### PR TITLE
Add capistrano for deployment and setup dev/qa stages

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,24 @@
+# Load DSL and Setup Up Stages
+require 'capistrano/setup'
+
+# Includes default deployment tasks
+require 'capistrano/deploy'
+
+# support for bundler, rails/assets and rails/migrations
+require 'capistrano/rails'
+
+# support for rbenv
+require 'capistrano/rbenv'
+
+# support for sidekiq
+require 'capistrano/sidekiq'
+require 'capistrano/sidekiq/monit'
+
+# support for new relic deploy updates
+require 'new_relic/recipes'
+
+# support for whenever
+# require 'whenever/capistrano'
+
+# Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,13 @@ gem 'kaminari-bootstrap', '~> 3.0.1'
 gem 'lograge'
 gem 'newrelic_rpm'
 gem 'omniauth-saml', github: 'amoose/omniauth-saml', branch: 'feature/internal_idp'
-gem 'phony_rails'
+gem 'phony_rails', '~> 0.13.1'
 gem 'pg'
 gem 'pundit'
 gem 'valid_email'
 gem 'rack-attack'
 gem 'responders', '~> 2.0'
+gem 'rotp', '~> 2.1.1'
 gem 'ruby-saml', github: 'amoose/ruby-saml'
 # gem 'nokogiri-xmlsec-me-harder', '~> 0.9.1', require: 'xmlsec'
 gem 'saml_idp', github: '18F/saml_idp'
@@ -30,6 +31,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'secure_headers', '~> 3.0.0'
 gem 'sidekiq'
 gem 'simple_form', github: 'amoose/simple_form', branch: 'feature/aria-invalid'
+gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'turbolinks'
 gem 'twilio-ruby'
@@ -43,11 +45,7 @@ group :deploy do
   gem 'capistrano' # , '~> 3.4'
   gem 'capistrano-rails' # , '~> 1.1', require: false
   gem 'capistrano-rbenv' # , '~> 2.0', require: false
-  gem 'capistrano-resque' # , '~> 0.2.1', require: false
-  gem 'chef', '~> 12.0.1'
-  gem 'knife-ec2'
-  gem 'knife-solo', github: 'matschaffer/knife-solo', submodules: true
-  gem 'knife-solo_data_bag'
+  gem 'capistrano-sidekiq'
 end
 
 group :development do
@@ -87,7 +85,6 @@ group :test do
   gem 'rspec-activejob'
   gem 'rubocop'
   gem 'shoulda-matchers', '~> 2.8', require: false
-  gem 'sinatra', require: false
   gem 'sms-spec', git: 'https://github.com/monfresh/sms-spec.git', require: 'sms_spec'
   gem 'timecop'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,16 +34,6 @@ GIT
       activemodel (~> 4.0)
 
 GIT
-  remote: git://github.com/matschaffer/knife-solo.git
-  revision: 3b3fa546f24fcee291ef73315e0e9729894f6500
-  submodules: true
-  specs:
-    knife-solo (0.5.2)
-      chef (>= 10.20)
-      erubis (~> 2.7.0)
-      net-ssh (>= 2.7, < 4.0)
-
-GIT
   remote: https://github.com/Houdini/two_factor_authentication
   revision: 675f651929b7a09bb59169bf4206a10895c2b9d9
   specs:
@@ -64,7 +54,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.2)
     actionmailer (4.2.6)
       actionpack (= 4.2.6)
       actionview (= 4.2.6)
@@ -106,6 +95,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    airbrussh (1.0.1)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     ast (2.2.0)
     attr_encrypted (3.0.1)
@@ -113,17 +104,17 @@ GEM
     autoprefixer-rails (5.2.1.3)
       execjs
       json
-    aws-sdk (2.2.31)
-      aws-sdk-resources (= 2.2.31)
-    aws-sdk-core (2.2.31)
+    aws-sdk (2.2.37)
+      aws-sdk-resources (= 2.2.37)
+    aws-sdk-core (2.2.37)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.31)
-      aws-sdk-core (= 2.2.31)
+    aws-sdk-resources (2.2.37)
+      aws-sdk-core (= 2.2.37)
     bcrypt (3.1.11)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
-    benchmark-ips (2.5.0)
-    berkshelf (4.3.1)
+    benchmark-ips (2.6.1)
+    berkshelf (4.3.2)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
       buff-config (~> 1.0)
@@ -172,25 +163,27 @@ GEM
     bullet (5.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
-    byebug (8.2.2)
-    capistrano (3.4.0)
+    byebug (8.2.4)
+    capistrano (3.5.0)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
+      sshkit (>= 1.9.0)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
+    capistrano-harrow (0.3.2)
     capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-rbenv (2.0.4)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
-    capistrano-resque (0.2.2)
+    capistrano-sidekiq (0.5.4)
       capistrano
-      resque
-      resque-scheduler
-    capybara (2.6.2)
+      sidekiq (>= 3.4)
+    capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -205,31 +198,10 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef (12.0.3)
-      chef-zero (~> 3.2)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi-yajl (~> 1.2)
-      highline (~> 1.6, >= 1.6.9)
-      mixlib-authentication (~> 1.3)
-      mixlib-cli (~> 1.4)
-      mixlib-config (~> 2.0)
-      mixlib-log (~> 1.3)
-      mixlib-shellout (>= 2.0.0.rc.0, < 3.0)
-      net-ssh (~> 2.6)
-      net-ssh-multi (~> 1.1)
-      ohai (~> 8.0)
-      plist (~> 3.1.0)
-      pry (~> 0.9)
-    chef-config (12.8.1)
+    chef-config (12.9.38)
+      fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-zero (3.2.1)
-      ffi-yajl (~> 1.1)
-      hashie (~> 2.0)
-      mixlib-log (~> 1.3)
-      rack
-      uuidtools (~> 2.1)
     chronic (0.10.2)
     cleanroom (1.0.0)
     cliver (0.3.2)
@@ -261,7 +233,7 @@ GEM
       dm-validations (~> 1.2.0)
     data_objects (0.10.17)
       addressable (~> 2.1)
-    database_cleaner (1.5.1)
+    database_cleaner (1.5.3)
     dawnscanner (1.6.2)
       cvss
       data_mapper
@@ -285,7 +257,7 @@ GEM
       rack (>= 1)
       rake (> 10, < 12)
       thor (~> 0.19)
-    devise (3.5.6)
+    devise (3.5.8)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -343,12 +315,11 @@ GEM
     encryptor (3.0.0)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
-    excon (0.49.0)
     execjs (2.6.0)
-    factory_girl (4.5.0)
+    factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.6.0)
-      factory_girl (~> 4.5.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
     faker (1.6.3)
       i18n (~> 0.5)
@@ -356,105 +327,13 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.10)
-    ffi-yajl (1.4.0)
-      ffi (~> 1.5)
-      libyajl2 (~> 1.2)
     figaro (1.1.1)
       thor (~> 0.14)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.29.0)
-      fog-atmos
-      fog-aws (~> 0.0)
-      fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.4)
-      fog-ecloud
-      fog-json
-      fog-local
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.9.2)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.10.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-core (1.37.0)
-      builder
-      excon (~> 0.45)
-      formatador (~> 0.2)
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-local (0.3.0)
-      fog-core (~> 1.27)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.0)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
+    fuzzyurl (0.8.0)
     get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    gssapi (1.2.0)
-      ffi (>= 1.0.1)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -469,12 +348,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    gyoku (1.3.1)
-      builder (>= 2.1.2)
     haml (4.0.7)
       tilt
     hashdiff (0.3.0)
-    hashie (2.1.2)
+    hashie (3.4.3)
     heapy (0.1.2)
     highline (1.7.8)
     hitimes (1.2.3)
@@ -482,14 +359,12 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    httpclient (2.7.1)
+    httpclient (2.7.2)
     i18n (0.7.0)
-    inflecto (0.0.2)
-    ipaddress (0.8.3)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jmespath (1.2.3)
+    jmespath (1.2.4)
       json_pure (>= 1.8.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
@@ -507,23 +382,12 @@ GEM
     kaminari-bootstrap (3.0.1)
       kaminari (>= 0.13.0)
       rails
-    knife-ec2 (0.12.0)
-      fog (~> 1.29.0)
-      knife-windows (~> 1.0)
-    knife-solo_data_bag (1.1.0)
-    knife-windows (1.4.0)
-      winrm (~> 1.7)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libyajl2 (1.2.0)
-    listen (3.0.6)
+    listen (3.1.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
-    little-plugger (1.1.4)
     logger-colors (1.0.0)
-    logging (2.1.0)
-      little-plugger (~> 1.1)
-      multi_json (~> 1.10)
     lograge (0.3.6)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -545,7 +409,9 @@ GEM
       thin (~> 1.5.0)
     memory_profiler (0.9.6)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (3.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitar (0.5.4)
     minitest (5.8.4)
@@ -554,58 +420,37 @@ GEM
       rspec-core (~> 3.2)
       rspec-expectations (~> 3.2)
       rspec-mocks (~> 3.2)
-    mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
     mixlib-log (1.6.0)
     mixlib-shellout (2.2.6)
     molinillo (0.4.4)
-    mono_logger (1.1.0)
-    multi_json (1.11.2)
+    multi_json (1.11.3)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.4)
-    net-ssh-gateway (1.2.0)
-      net-ssh (>= 2.6.5)
-    net-ssh-multi (1.2.1)
-      net-ssh (>= 2.6.5)
-      net-ssh-gateway (>= 1.2.0)
-    newrelic_rpm (3.15.1.316)
+    net-ssh (3.1.1)
+    newrelic_rpm (3.15.2.317)
     nio4r (1.2.1)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
-    nori (2.6.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.4.0)
-      ffi (~> 1.9)
-      ffi-yajl (>= 1.1, < 3.0)
-      ipaddress
-      mime-types (~> 2.0)
-      mixlib-cli
-      mixlib-config (~> 2.0)
-      mixlib-log
-      mixlib-shellout (~> 2.0)
-      rake (~> 10.1)
-      systemu (~> 2.6.4)
-      wmi-lite (~> 1.0)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     orm_adapter (0.5.0)
-    parser (2.3.0.7)
+    parser (2.3.1.0)
       ast (~> 2.2)
     pg (0.18.4)
-    phony (2.15.20)
+    phony (2.15.21)
     phony_rails (0.13.1)
       activesupport (>= 3.0)
       phony (~> 2.12)
-    plist (3.1.0)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -662,27 +507,14 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (10.5.0)
+    rake (11.1.2)
     randexp (0.1.7)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redis (3.2.2)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.3.0)
     responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
-    resque (1.26.0)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.3)
-      sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
-    resque-scheduler (4.1.0)
-      mono_logger (~> 1.0)
-      redis (~> 3.0)
-      resque (~> 1.25)
-      rufus-scheduler (~> 3.0)
     retryable (2.0.3)
     ridley (4.5.0)
       addressable
@@ -702,7 +534,7 @@ GEM
       retryable (~> 2.0)
       semverse (~> 1.1)
       varia_model (~> 0.4.0)
-    rotp (2.1.1)
+    rotp (2.1.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -733,14 +565,12 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.7.5)
+    ruby-progressbar (1.8.0)
     ruby2ruby (2.3.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
-    rubyntlm (0.6.0)
-    rufus-scheduler (3.2.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
@@ -788,13 +618,13 @@ GEM
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
-    spring (1.6.4)
+    spring (1.7.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
       spring (~> 1.2)
-    sprockets (3.5.2)
+    sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.0.4)
@@ -802,7 +632,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
-    sshkit (1.9.0)
+    sshkit (1.10.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stringex (1.5.1)
@@ -843,11 +673,9 @@ GEM
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)
-    vegas (0.1.11)
-      rack (>= 1.0.0)
     warden (1.2.6)
       rack (>= 1.0)
-    webmock (1.24.2)
+    webmock (2.0.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -856,15 +684,6 @@ GEM
     websocket-extensions (0.1.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
-    winrm (1.7.3)
-      builder (>= 2.1.2)
-      gssapi (~> 1.2)
-      gyoku (~> 1.0)
-      httpclient (~> 2.2, >= 2.2.0.2)
-      logging (>= 1.6.1, < 3.0)
-      nori (~> 2.0)
-      rubyntlm (~> 0.6.0)
-    wmi-lite (1.0.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -884,9 +703,8 @@ DEPENDENCIES
   capistrano
   capistrano-rails
   capistrano-rbenv
-  capistrano-resque
+  capistrano-sidekiq
   capybara-screenshot
-  chef (~> 12.0.1)
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   database_cleaner
@@ -904,15 +722,12 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   kaminari-bootstrap (~> 3.0.1)
-  knife-ec2
-  knife-solo!
-  knife-solo_data_bag
   lograge
   mailcatcher (= 0.6.3)
   newrelic_rpm
   omniauth-saml!
   pg
-  phony_rails
+  phony_rails (~> 0.13.1)
   poltergeist
   pry-byebug
   pundit
@@ -924,6 +739,7 @@ DEPENDENCIES
   rails (~> 4.2.6)
   rails_layout
   responders (~> 2.0)
+  rotp (~> 2.1.1)
   rspec-activejob
   rspec-rails (~> 3.3)
   rubocop

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ To run all the tests:
 See RSpec [docs](https://relishapp.com/rspec/rspec-core/docs/command-line) for
 more information.
 
+### Deploying
+
+We currently run `dev` and `qa` environments at https://upaya-idp-dev.18f.gov and https://upaya-idp-qa.18f.gov. Core developers can deploy to those hosts with [Capistrano](http://capistranorb.com) using the following command:
+
+```
+cap <env/stage> deploy
+```
+
+You will need to provide a copy of your SSH public key and you may need to provide your IP address if you are not in a GSA building or on the GSA VPN. Post a message in the slack channel if you need help.
+
 ## More Information
 
 **Notice:** This project is still in alpha.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,35 @@
+#################
+# GLOBAL CONFIG
+#################
+set :application, 'upaya'
+# set branch based on env var or ask with the default set to the current local branch
+set :branch, ENV['branch'] || ENV['BRANCH'] || ask(:branch, `git branch`.match(/\* (\S+)\s/m)[1])
+set :bundle_without, 'deploy development doc test'
+set :deploy_via, :remote_cache
+set :keep_releases, 5
+set :linked_files, %w(config/application.yml
+                      config/database.yml
+                      config/secrets.yml
+                      config/saml.key.enc)
+set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
+set :rails_env, :production
+set :rbenv_ruby, '2.3.0'
+set :rbenv_type, :user # or :system, depends on your rbenv setup
+set :repo_url, 'https://github.com/18F/identity-idp.git'
+set :sidekiq_queue, [:mailers, :sms]
+set :ssh_options, forward_agent: false, user: 'ubuntu'
+set :whenever_roles, [:app]
+
+#########
+# TASKS
+#########
+namespace :deploy do
+  desc 'Restart application'
+  task :restart do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :touch, release_path.join('tmp/restart.txt')
+    end
+  end
+
+  after :publishing, :restart
+end

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,0 +1,1 @@
+server 'upaya-idp-dev.18f.gov', roles: %w(web app db)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,1 @@
+server 'upaya-idp-qa.18f.gov', roles: %w(web app db)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  authenticate :user, ->(u) { u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   match '/dashboard' => 'dashboard#index', as: :dashboard_index, via: :get
 
   get 'terms' => 'terms#index'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,9 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+# Learn more: http://github.com/javan/whenever
+
+every :day, at: '3:00 am', roles: [:job_creator] do
+  rake 'clear_expired_sessions'
+end

--- a/lib/tasks/clear_expired_sessions.rake
+++ b/lib/tasks/clear_expired_sessions.rake
@@ -1,0 +1,9 @@
+# Rake task for clearing out expired or stale sessions.
+#
+#  - http://blog.brightbox.co.uk/posts/clearing-out-rails-sessions
+
+desc 'Clear expired sessions'
+task clear_expired_sessions: :environment do
+  ActiveRecord::SessionStore::Session.delete_all(
+    ['updated_at < ?', 1.day.ago])
+end


### PR DESCRIPTION
This adds capistrano3 support so we can deploy to remote servers. I setup `dev` and `qa` envs at https://upaya-dev.18f.gov and https://upaya-qa.18f.gov. They should be fully functional aside from SMS support; I need to setup a twilio subaccount and dev account to get that working.

To deploy to a remote server use `cap <env name> deploy`. We may need to whitelist your IP if you're not using the GSA VPN or in a GSA building. Similarly we'll need your ssh pub key (I have everyone from save-ferris). I created a base image with all of the OS deps and the app fully installed in case we need to spin up more envs. This should be converted to a cloud formation template if we're going to use this more often.