### PR TITLE
Update Code Climate add linter configs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,12 +1,12 @@
 engines:
   brakeman:
-    enabled: false
+    enabled: true
   bundler-audit:
-    enabled: false
+    enabled: true
   coffeelint:
     enabled: true
   csslint:
-    enabled: false
+    enabled: true
   duplication:
     enabled: true
     config:
@@ -21,7 +21,7 @@ engines:
   rubocop:
     enabled: true
   scss-lint:
-    enabled: false
+    enabled: true
 
 ratings:
   paths:
@@ -29,8 +29,3 @@ ratings:
   - lib/**
   - '**.rb'
   - '**.go'
-
-exclude_paths:
-- spec/**/*
-- 'vendor/assets/stylesheets/uswds.css'
-- 'db/migrate/20160405212342_initial_schema.rb'

--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,1 @@
+--exclude-list=vendor/assets/stylesheets/uswds.css

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+public/build/bundle.js

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'bin/**/*'
     - 'config/initializers/devise.rb'
     - 'db/migrate/20160405212342_initial_schema.rb'
-  UseCache: false
+  UseCache: true
 
 Lint/AssignmentInCondition:
   Description: Don't use assignment in conditions.

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,3 @@
+exclude:
+  - 'vendor/assets/stylesheets/basscss/*.scss'
+  - 'vendor/assets/stylesheets/uswds.css'


### PR DESCRIPTION
**Why**:
Some engines that we care about were turned off, and Code Climate was
not properly ignoring certain files that we want to exclude from
analysis.

**How**:
Remove the `exclude_paths` directive from the Code Climate config, and
use the individual linter configs to exclude files.