### PR TITLE
Refactor specs related to Active Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ group :test do
   gem 'poltergeist'
   gem 'rack_session_access'
   gem 'rack-test'
-  gem 'rspec-activejob'
   gem 'shoulda-matchers', '~> 2.8', require: false
   gem 'sms-spec', git: 'https://github.com/monfresh/sms-spec.git', require: 'sms_spec'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,9 +470,6 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
-    rspec-activejob (0.6.1)
-      activejob (>= 4.2)
-      rspec-mocks
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -667,7 +664,6 @@ DEPENDENCIES
   rails_layout
   responders (~> 2.0)
   rotp (~> 3.0)
-  rspec-activejob
   rspec-rails (~> 3.3)
   rubocop
   ruby-saml!

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -30,7 +30,6 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   private
 
   def authenticate_scope!
-    send(:"authenticate_#{resource_name}!", force: true)
     self.resource = send(:"current_#{resource_name}")
   end
 

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -4,6 +4,18 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
   describe 'update' do
     let(:user) { create(:user, :tfa_confirmed) }
 
+    context 'when user only has email 2FA' do
+      it 'does not perform SmsSenderNumberChangeJob' do
+        sign_in user
+        user.send_two_factor_authentication_code
+
+        expect(SmsSenderNumberChangeJob).
+          to_not receive(:perform_later).with(user)
+
+        patch :update, code: user.otp_code
+      end
+    end
+
     context 'when resource is no longer OTP locked out' do
       before do
         sign_in user
@@ -23,6 +35,38 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         patch :update, code: user.otp_code
 
         expect(user.reload.second_factor_locked_at).to be_nil
+      end
+    end
+  end
+
+  describe 'show' do
+    context 'when resource is not fully authenticated yet' do
+      it 'renders the show view' do
+        sign_in_before_2fa
+        get :show
+
+        expect(response).to_not be_redirect
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when resource is fully authenticated and does not have unconfirmed mobile' do
+      it 'redirects to the dashboard' do
+        user = create(:user, :signed_up)
+        sign_in user
+        get :show
+
+        expect(response).to redirect_to dashboard_index_path
+      end
+    end
+
+    context 'when resource is fully authenticated but has unconfirmed mobile' do
+      it 'renders the show view' do
+        user = create(:user, :signed_up, unconfirmed_mobile: '202-555-1212')
+        sign_in user
+        get :show
+
+        expect(response).to render_template(:show)
       end
     end
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1,0 +1,17 @@
+describe SamlIdpController do
+  render_views
+
+  describe '/api/saml/logout' do
+    it 'calls UserOtpSender#reset_otp_state' do
+      user = create(:user, :signed_up)
+      sign_in user
+
+      otp_sender = instance_double(UserOtpSender)
+      allow(UserOtpSender).to receive(:new).with(user).and_return(otp_sender)
+
+      expect(otp_sender).to receive(:reset_otp_state)
+
+      delete :logout
+    end
+  end
+end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -85,4 +85,26 @@ describe Users::SessionsController, devise: true do
       expect(response).to redirect_to(root_url)
     end
   end
+
+  describe 'POST /' do
+    it 'calls User#send_two_factor_authentication_code' do
+      create(:user, :signed_up, email: 'user@example.com')
+
+      expect_any_instance_of(User).to receive(:send_two_factor_authentication_code)
+
+      post :create, user: { email: 'user@example.com', password: '!1aZ' * 32 }
+    end
+
+    it 'calls UserOtpSender#reset_otp_state' do
+      user = create(:user, :signed_up, email: 'user@example.com')
+
+      otp_sender = instance_double(UserOtpSender)
+      allow(UserOtpSender).to receive(:new).with(user).and_return(otp_sender)
+
+      expect(otp_sender).to receive(:reset_otp_state)
+      expect(otp_sender).to receive(:send_otp)
+
+      post :create, user: { email: 'user@example.com', password: '!1aZ' * 32 }
+    end
+  end
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -75,11 +75,6 @@ feature 'Sign Up', devise: true do
   #   When I sign up, confirm email, and setup 2FA
   #   Then I see the dashboard
   context 'visitor can sign up and confirm a valid email for OTP', email: true do
-    def success_notice
-      t('upaya.notices.account_created',
-        date: (Time.current + 1.year).strftime('%B %d, %Y'))
-    end
-
     before do
       sign_up_with_and_set_password_for('test@example.com')
       check 'Email'
@@ -101,7 +96,7 @@ feature 'Sign Up', devise: true do
 
       expect(current_path).to eq dashboard_index_path
       expect(User.find_by_email('test@example.com').second_factor_confirmed_at).to be_present
-      expect(page).to have_content(success_notice)
+      expect(page).to have_content(successful_account_creation_notice)
     end
 
     it 'does not include a link to enter a number again' do

--- a/spec/mailers/email_second_factor_mailer_spec.rb
+++ b/spec/mailers/email_second_factor_mailer_spec.rb
@@ -16,5 +16,10 @@ describe EmailSecondFactorMailer do
     it 'uses a default from address' do
       expect(mail.from).to eq ['upaya@18f.gov']
     end
+
+    it 'includes a link to customer service in the email' do
+      expect(mail.body).
+        to include 'at <a href="https://upaya.18f.gov/contact">'
+    end
   end
 end

--- a/spec/models/mobile_second_factor_spec.rb
+++ b/spec/models/mobile_second_factor_spec.rb
@@ -2,17 +2,14 @@ require 'rails_helper'
 
 include Features::ActiveJobHelper
 
-describe MobileSecondFactor, sms: true do
-  before do
-    reset_job_queues
-  end
-
+describe MobileSecondFactor do
   describe '.transmit' do
     it 'calls SmsSenderOtpJob' do
       user = build_stubbed(:user, :with_mobile, otp_secret_key: 'lzmh6ekrnc5i6aaq')
-      MobileSecondFactor.transmit(user)
 
-      expect(SmsSenderOtpJob).to have_been_enqueued.with(global_id(user))
+      expect(SmsSenderOtpJob).to receive(:perform_later).with(user)
+
+      MobileSecondFactor.transmit(user)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,6 @@ require 'rspec/rails'
 require 'email_spec'
 require 'factory_girl'
 require 'shoulda/matchers'
-require 'rspec/active_job'
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe TwilioService, sms: true do
+describe TwilioService do
   describe 'proxy configuration' do
     it 'ignores the proxy configuration if not set' do
       expect(Figaro.env).to receive(:proxy_addr).and_return(nil)
@@ -24,7 +24,7 @@ describe TwilioService, sms: true do
     end
   end
 
-  describe 'test client', sms: true do
+  describe 'test client' do
     let(:user) { build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq') }
 
     it 'uses the test client when pt_mode is true' do
@@ -50,28 +50,28 @@ describe TwilioService, sms: true do
       TwilioService.new
     end
 
-    it 'sends an OTP from the test number when pt_mode is true' do
+    it 'sends an OTP from the test number when pt_mode is true', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(true)
       SmsSenderOtpJob.perform_now(user)
 
       expect(messages.first.from).to eq '+15005550006'
     end
 
-    it 'sends an OTP from the real number when pt_mode is false' do
+    it 'sends an OTP from the real number when pt_mode is false', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(false)
       SmsSenderOtpJob.perform_now(user)
 
       expect(messages.first.from).to eq '+19999999999'
     end
 
-    it 'sends number change SMS from test # when pt_mode is true' do
+    it 'sends number change SMS from test # when pt_mode is true', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(true)
       SmsSenderNumberChangeJob.perform_now(user)
 
       expect(messages.first.from).to eq '+15005550006'
     end
 
-    it 'sends number change SMS from real # when pt_mode is false' do
+    it 'sends number change SMS from real # when pt_mode is false', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(false)
       SmsSenderNumberChangeJob.perform_now(user)
 
@@ -80,7 +80,7 @@ describe TwilioService, sms: true do
   end
 
   describe '#send_sms' do
-    it 'uses the same account for every call in a single instance' do
+    it 'uses the same account for every call in a single instance', sms: true do
       expect(Rails.application.secrets).to receive(:twilio_accounts).
         and_return(
           [
@@ -109,7 +109,7 @@ describe TwilioService, sms: true do
       end
     end
 
-    it 'uses a different Twilio account for different instances' do
+    it 'uses a different Twilio account for different instances', sms: true do
       expect(Rails.application.secrets).to receive(:twilio_accounts).
         and_return(
           [{

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -17,6 +17,12 @@ module ControllerHelper
     @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in create(:user, :signed_up, :tech_support)
   end
+
+  def sign_in_before_2fa(user = create(:user, :signed_up))
+    allow(warden).to receive(:authenticated?).with(:user).and_return(true)
+    allow(controller).to receive(:current_user).and_return(user)
+    warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -81,5 +81,10 @@ module Features
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current)
       visit "/users/confirmation?confirmation_token=#{@raw_confirmation_token}"
     end
+
+    def successful_account_creation_notice
+      t('upaya.notices.account_created',
+        date: (Time.current + 1.year).strftime('%B %d, %Y'))
+    end
   end
 end

--- a/spec/support/sms.rb
+++ b/spec/support/sms.rb
@@ -2,9 +2,8 @@ SmsSpec.driver = :'twilio-ruby'
 
 RSpec.configure do |config|
   config.include SmsSpec::Helpers, sms: true
-  config.include(RSpec::ActiveJob, sms: true)
 
-  config.after(:each, sms: true) do
+  config.before(:each, sms: true) do
     clear_messages
     ActiveJob::Base.queue_adapter.enqueued_jobs = []
     ActiveJob::Base.queue_adapter.performed_jobs = []
@@ -16,6 +15,14 @@ module Features
     def reset_job_queues
       ActiveJob::Base.queue_adapter.enqueued_jobs = []
       ActiveJob::Base.queue_adapter.performed_jobs = []
+    end
+
+    def enqueued_jobs
+      ActiveJob::Base.queue_adapter.enqueued_jobs
+    end
+
+    def performed_jobs
+      ActiveJob::Base.queue_adapter.performed_jobs
     end
   end
 end

--- a/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
@@ -37,6 +37,15 @@ describe 'devise/two_factor_authentication/show.html.slim' do
 
       expect(rendered).to have_content 'A one-time passcode has been sent to foo@bar.com.'
     end
+
+    it 'prompts the user to enter an OTP' do
+      allow(view).to receive(:current_user).and_return(create(:user, :signed_up))
+
+      render
+
+      expect(rendered).
+        to have_content t('devise.two_factor_authentication.header_text')
+    end
   end
 
   context 'user only has mobile second factor and no unconfirmed email' do


### PR DESCRIPTION
**Why**:
- To make them more robust and less prone to intermittent failures

**How**:
- Instead of relying on a gem to check if a job was enqueued, check
that a specific method was called on an object, since those objects are
already unit tested separately
- Replace feature specs with controller and view specs
- Make sure Active Job queues are cleared **before** specs that
interact with them, as opposed to **after**.

For example, when a user signs in, they get sent an OTP via the
`send_two_factor_authentication_code` method. That method then
instantiates the `UserOtpSender` class, which contains logic that
determines which devices the OTP should be sent to. That logic is unit
tested separately in `otp_sender_spec`. So, instead of writing various
slow feature tests for all the different scenarios while signing in, we
just need to write one `SessionsController` test that verifies that
when a user signs in, the `send_two_factor_authentication_code` is
called on the current user.