### PR TITLE
Remove redundant license info from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,3 @@ more information.
 ### Why 'Upaya'?
 
 "skill in means" https://en.wikipedia.org/wiki/Upaya
-
-## License
-
-[The project is in the public domain](LICENSE.md), and all contributions will
-also be released in the public domain. By submitting a pull request, you are
-agreeing to waive all rights to your contribution under the terms of the [CC0
-Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
-
-This project constitutes an original work of the United States Government.


### PR DESCRIPTION
We have a more thorough [`LICENSE.md`](https://github.com/18F/identity-idp/blob/master/LICENSE.md)