### PR TITLE
Add git commit hooks via overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,40 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/brigade/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/brigade/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/brigade/overcommit#configuration
+
+PreCommit:
+  BundleCheck:
+    enabled: true
+    description: 'Check Gemfile dependencies'
+    required_executable: 'bundle'
+    flags: ['check']
+    install_command: 'gem install bundler'
+    include:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+
+  SlimLint:
+    enabled: true
+    description: 'Analyze with slim-lint'
+    required_executable: 'slim-lint'
+    install_command: 'gem install slim_lint'
+    include: '**/*.slim'
+
+CommitMsg:
+  TextWidth:
+    enabled: true
+    description: 'Check text width'
+    max_subject_width: 50
+    max_body_width: 72

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,15 @@ Database Cleaner to ignore those static tables.
 Fixes #123
 ```
 
+Note that we use [Overcommit] to enforce some of the commit message rules.
+If this is your first time contributing to this repo, you will need to
+sign your Overcommit configuration by running `overcommit --sign` before
+being able to run `git commit`. See the [Security] section in the Overcommit
+README for more details.
+
+[Overcommit]: https://github.com/brigade/overcommit
+[Security]: https://github.com/brigade/overcommit#security
+
 ### Additional notes on pull requests and code reviews
 
 - Prioritize code reviews above your other work

--- a/Gemfile
+++ b/Gemfile
@@ -55,9 +55,12 @@ group :development do
   gem 'derailed'
   gem 'binding_of_caller'
   gem 'guard-rspec', require: false
+  gem 'overcommit'
   gem 'quiet_assets'
   gem 'rack-mini-profiler'
   gem 'rails_layout'
+  gem 'rubocop'
+  gem 'slim_lint'
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen'
@@ -67,9 +70,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.3'
   gem 'thin'
-  gem 'brakeman'
   gem 'bullet'
-  gem 'dawnscanner', require: false
   gem 'mailcatcher', '0.6.3'
 end
 
@@ -84,7 +85,6 @@ group :test do
   gem 'rack_session_access'
   gem 'rack-test'
   gem 'rspec-activejob'
-  gem 'rubocop'
   gem 'shoulda-matchers', '~> 2.8', require: false
   gem 'sms-spec', git: 'https://github.com/monfresh/sms-spec.git', require: 'sms_spec'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,8 +111,6 @@ GEM
     aws-sdk-resources (2.2.37)
       aws-sdk-core (= 2.2.37)
     bcrypt (3.1.11)
-    bcrypt-ruby (3.1.5)
-      bcrypt (>= 3.1.3)
     benchmark-ips (2.6.1)
     berkshelf (4.3.2)
       addressable (~> 2.3, >= 2.3.4)
@@ -141,16 +139,6 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    brakeman (3.2.1)
-      erubis (~> 2.6)
-      haml (>= 3.0, < 5.0)
-      highline (>= 1.6.20, < 2.0)
-      ruby2ruby (~> 2.3.0)
-      ruby_parser (~> 3.8.1)
-      safe_yaml (>= 1.0)
-      sass (~> 3.0)
-      slim (>= 1.3.6, < 4.0)
-      terminal-table (~> 1.4)
     browserify-rails (3.0.1)
       railties (>= 4.0.0, < 5.0)
       sprockets (>= 3.5.2)
@@ -205,6 +193,8 @@ GEM
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     cleanroom (1.0.0)
     cliver (0.3.2)
@@ -222,33 +212,8 @@ GEM
     connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    cvss (0.99.0)
     daemons (1.2.3)
-    data_mapper (1.2.0)
-      dm-aggregates (~> 1.2.0)
-      dm-constraints (~> 1.2.0)
-      dm-core (~> 1.2.0)
-      dm-migrations (~> 1.2.0)
-      dm-serializer (~> 1.2.0)
-      dm-timestamps (~> 1.2.0)
-      dm-transactions (~> 1.2.0)
-      dm-types (~> 1.2.0)
-      dm-validations (~> 1.2.0)
-    data_objects (0.10.17)
-      addressable (~> 2.1)
     database_cleaner (1.5.3)
-    dawnscanner (1.6.2)
-      cvss
-      data_mapper
-      dm-sqlite-adapter
-      haml
-      justify
-      logger-colors
-      ptools
-      ruby_parser
-      sqlite3
-      sys-uname
-      terminal-table
     debug_inspector (0.0.2)
     derailed (0.1.0)
       derailed_benchmarks
@@ -271,42 +236,6 @@ GEM
       devise (>= 3.0.0, < 4.0)
       railties (>= 3.2.6, < 5.0)
     diff-lcs (1.2.5)
-    dm-aggregates (1.2.0)
-      dm-core (~> 1.2.0)
-    dm-constraints (1.2.0)
-      dm-core (~> 1.2.0)
-    dm-core (1.2.1)
-      addressable (~> 2.3)
-    dm-do-adapter (1.2.0)
-      data_objects (~> 0.10.6)
-      dm-core (~> 1.2.0)
-    dm-migrations (1.2.0)
-      dm-core (~> 1.2.0)
-    dm-serializer (1.2.2)
-      dm-core (~> 1.2.0)
-      fastercsv (~> 1.5)
-      json (~> 1.6)
-      json_pure (~> 1.6)
-      multi_json (~> 1.0)
-    dm-sqlite-adapter (1.2.0)
-      dm-do-adapter (~> 1.2.0)
-      do_sqlite3 (~> 0.10.6)
-    dm-timestamps (1.2.0)
-      dm-core (~> 1.2.0)
-    dm-transactions (1.2.0)
-      dm-core (~> 1.2.0)
-    dm-types (1.2.2)
-      bcrypt-ruby (~> 3.0)
-      dm-core (~> 1.2.0)
-      fastercsv (~> 1.5)
-      json (~> 1.6)
-      multi_json (~> 1.0)
-      stringex (~> 1.4)
-      uuidtools (~> 2.1)
-    dm-validations (1.2.0)
-      dm-core (~> 1.2.0)
-    do_sqlite3 (0.10.17)
-      data_objects (= 0.10.17)
     docile (1.1.5)
     dotiw (3.1.1)
       actionpack (>= 3)
@@ -328,7 +257,6 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fastercsv (1.5.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -351,12 +279,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    haml (4.0.7)
-      tilt
     hashdiff (0.3.0)
     hashie (3.4.3)
     heapy (0.1.2)
-    highline (1.7.8)
     hitimes (1.2.3)
     htmlentities (4.3.4)
     httparty (0.13.7)
@@ -364,6 +289,7 @@ GEM
       multi_xml (>= 0.5.2)
     httpclient (2.7.2)
     i18n (0.7.0)
+    iniparse (1.4.2)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -377,7 +303,6 @@ GEM
       railties (>= 3.2.16)
     json (1.8.3)
     json_pure (1.8.3)
-    justify (1.0.2)
     jwt (1.5.4)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
@@ -390,7 +315,6 @@ GEM
     listen (3.1.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
-    logger-colors (1.0.0)
     lograge (0.3.6)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -447,6 +371,9 @@ GEM
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     orm_adapter (0.5.0)
+    overcommit (0.33.0)
+      childprocess (~> 0.5.8)
+      iniparse (~> 1.4)
     parser (2.3.1.0)
       ast (~> 2.2)
     pg (0.18.4)
@@ -467,7 +394,6 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
-    ptools (1.3.3)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
@@ -569,11 +495,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.0)
-    ruby2ruby (2.3.0)
-      ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
-    ruby_parser (3.8.1)
-      sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
@@ -588,7 +509,6 @@ GEM
     secure_headers (3.0.3)
       useragent
     semverse (1.2.1)
-    sexp_processor (4.7.0)
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -617,6 +537,11 @@ GEM
       activesupport (>= 3.1, < 5.0)
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
+    slim_lint (0.7.2)
+      rake (>= 10, < 12)
+      rubocop (>= 0.36.0)
+      slim (~> 3.0)
+      sysexits (~> 1.1)
     slop (3.6.0)
     solve (2.0.3)
       molinillo (~> 0.4.2)
@@ -638,12 +563,9 @@ GEM
     sshkit (1.10.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stringex (1.5.1)
-    sys-uname (1.0.2)
-      ffi (>= 1.0.0)
+    sysexits (1.2.0)
     systemu (2.6.5)
     temple (0.7.6)
-    terminal-table (1.5.2)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -669,7 +591,6 @@ GEM
     useragent (0.16.7)
     uuid (2.3.8)
       macaddr (~> 1.0)
-    uuidtools (2.1.5)
     valid_email (0.0.13)
       activemodel
       mail (~> 2.6.1)
@@ -701,7 +622,6 @@ DEPENDENCIES
   berkshelf
   better_errors
   binding_of_caller
-  brakeman
   browserify-rails
   bullet
   capistrano
@@ -712,7 +632,6 @@ DEPENDENCIES
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   database_cleaner
-  dawnscanner
   derailed
   devise
   devise_security_extension
@@ -730,6 +649,7 @@ DEPENDENCIES
   mailcatcher (= 0.6.3)
   newrelic_rpm
   omniauth-saml!
+  overcommit
   pg
   phony_rails (~> 0.13.1)
   poltergeist
@@ -756,6 +676,7 @@ DEPENDENCIES
   simple_form!
   sinatra
   slim-rails
+  slim_lint
   sms-spec!
   spring
   spring-commands-rspec

--- a/bin/setup
+++ b/bin/setup
@@ -36,6 +36,9 @@ Dir.chdir APP_ROOT do
   run "rm -f log/*"
   run "rm -rf tmp/cache"
 
+  puts "\n== Adding git hooks via Overcommit =="
+  run 'overcommit --install'
+
   puts "\n== Restarting application server =="
   run "mkdir -p tmp"
   run "touch tmp/restart.txt"


### PR DESCRIPTION
**Why**:
- To enforce our commit message style guide rules
- To run the Slim linter before commits are pushed since Code Climate
does not have a Slim linting engine yet.