### PR TITLE
Add browserify npm package before compiling assets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,5 +31,15 @@ namespace :deploy do
     end
   end
 
+  desc 'Install npm packages required for asset compilation with browserify'
+  task :browserify do
+    on roles(:app), in: :sequence do
+      within release_path do
+        execute :npm, 'install'
+      end
+    end
+  end
+
+  before 'assets:precompile', :browserify
   after :publishing, :restart
 end


### PR DESCRIPTION
__Why__
Capistrano deploys were failing since the browserify package is not installed.

__How__
Create a deploy hook that runs before the assets:precompile deploy step to install the npm deps from package.json.

__To do__
See if we can improve this by not having to `npm install` with each deploy if there were no changes to package.json. Also look into the necessity of the `in: :sequence` statement, I just copied that from the other task.