### PR TITLE
Remove unnecessary require statement

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,3 @@
-require 'omniauth_authorizer'
-
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     skip_before_action :verify_authenticity_token


### PR DESCRIPTION
**Why**: It was causing a warning in the logs that the
OmniauthAuthorizer constant was already defined.