### PR TITLE
Fix Capybara selector queries in view specs

### DIFF
--- a/spec/views/devise/registrations/new.html.slim_spec.rb
+++ b/spec/views/devise/registrations/new.html.slim_spec.rb
@@ -12,7 +12,7 @@ describe 'devise/registrations/new.html.slim' do
   it 'has a localized h2' do
     render
 
-    expect(rendered).to have_selector('h2', t('upaya.headings.registrations.new'))
+    expect(rendered).to have_selector('h2', text: t('upaya.headings.registrations.new'))
   end
 
   it 'sets form autocomplete to off' do

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -16,15 +16,14 @@ describe 'devise/sessions/new.html.slim' do
   it 'has a localized h2 headings' do
     render
 
-    expect(rendered).to have_selector('h2', t('upaya.headings.log_in'))
-    expect(rendered).
-      to have_selector('h2', t('upaya.headings.visitors.new_account'))
+    expect(rendered).to have_selector('h2', text: t('upaya.headings.log_in'))
   end
 
   it 'includes a link to create a new account' do
     render
 
     expect(rendered).
-      to have_link('create an account', href: new_user_registration_path)
+      to have_link(
+        t('upaya.links.create_new_account'), href: new_user_registration_path)
   end
 end


### PR DESCRIPTION
**Why**: Some view specs were passing in the expected `h2` text as a
second parameter to `have_selector`, which is not what Capybara
expects. In version 2.7.0, Capyara introduced a warning when unused
parameters are passed to a selector query. In this case, the specs
weren't actually testing that the correct text was present, so the
tests were passing even when the text was not present.

**How**: Pass in a hash as the second parameter, with `text` as the key
and the expected text as the value.