### PR TITLE
Use passphrase when loading SAML Private Key

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,7 +10,8 @@ DEFAULT_OPTIONS = {
   allowed_clock_drift: 60.seconds,
   certificate: Rails.application.secrets.saml_cert,
   private_key: OpenSSL::PKey::RSA.new(
-    File.read(Rails.root + 'config/saml.key.enc')).to_pem,
+    File.read(Rails.root + 'config/saml.key.enc'),
+    Figaro.env.saml_passphrase).to_pem,
   assertion_consumer_service_url: "https://#{Figaro.env.domain_name}/users/auth/saml/callback",
   assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
   authn_context: 'http://idmanagement.gov/ns/assurance/loa/2',


### PR DESCRIPTION
__Why__
The app would not load in prod since we did not have a way of providing the
passphrase for the SAML private key.

__How__
Provide the passphrase when loading the key in the omniauth initializer.