### PR TITLE
Add demo env to capistrano

### DIFF
--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,0 +1,1 @@
+server 'upaya-idp-demo.18f.gov', roles: %w(web app db)


### PR DESCRIPTION
Adds `-demo` env along with corresponding AWS resources.