### PR TITLE
Raise error when keys are missing from secrets

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -46,17 +46,8 @@ class TwilioService
     "+1#{account['number']}"
   end
 
-  def self.singular_account
-    Rails.logger.warn('Please set up the `twilio_accounts` entry in config/secrets.yml')
-    {
-      'sid' => Figaro.env.twilio_account_sid,
-      'auth_token' => Figaro.env.twilio_auth_token,
-      'number' => Figaro.env.twilio_number
-    }
-  end
-
   def self.accounts
-    Rails.application.secrets.twilio_accounts || [singular_account]
+    Rails.application.secrets.twilio_accounts
   end
 
   def self.random_account

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -32,9 +32,6 @@ production:
   proxy_port: '80'
   pt_mode: 'off'
   saml_passphrase: 'secret'
-  twilio_account_sid: 'sid'
-  twilio_auth_token: 'token'
-  twilio_number: '8888888888'
 
 test:
   allow_third_party_auth: 'yes'
@@ -47,6 +44,3 @@ test:
   newrelic_license_key: 'xxx'
   pt_mode: 'off'
   saml_passphrase: 'secret'
-  twilio_account_sid: 'sid'
-  twilio_auth_token: 'token'
-  twilio_number: '8888888888'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,4 +1,20 @@
+module Figaro
+  # rubocop:disable Style/RaiseArgs
+  def require_keys(*keys)
+    missing_keys = keys.flatten - (::ENV.keys + secret_keys)
+    fail MissingKeys.new(missing_keys) if missing_keys.any?
+  end
+  # rubocop:enable Style/RaiseArgs
+
+  private
+
+  def secret_keys
+    ::Rails.application.secrets.keys.map(&:to_s)
+  end
+end
+
 Figaro.require_keys(
   'allow_third_party_auth', 'domain_name', 'idp_sso_target_url', 'pt_mode',
-  'saml_passphrase'
+  'saml_passphrase', 'saml_cert', 'saml_idp_cert', 'saml_client_private_key',
+  'saml_private_key', 'twilio_accounts'
 )

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -151,18 +151,6 @@ describe TwilioService do
   end
 
   describe '.random_account' do
-    context 'twilio_accounts setting is missing' do
-      it 'falls back to using deprecated Twilio settings' do
-        allow(Rails.application.secrets).to receive(:twilio_accounts).and_return(nil)
-
-        expect(TwilioService.random_account).to eq(
-          'sid' => 'sid',
-          'auth_token' => 'token',
-          'number' => '8888888888'
-        )
-      end
-    end
-
     context 'twilio_accounts has multiple entries' do
       it 'randomly samples one of the accounts' do
         expect(Rails.application.secrets.twilio_accounts).to receive(:sample)


### PR DESCRIPTION
**Why**:
When certain SAML-related keys are missing from secrets.yml, it causes
tests to fail, but without a clear explanation that the reason is due
to missing certs or RSA keys. A better developer experience would be
to raise an error right away during runtime if a required key is
missing, just like we've already been doing for Figaro keys.

**How**:
Override Figaro's `require_keys` method to also check secrets.yml, and
add the saml certs and RSA keys to the list of required keys.

An additional benefit of doing this is that we can get rid of the
`singular_account` fallback in `TwilioService` by adding
`twilio_accounts` to the list of required keys, and removing the
`twilio_account_sid`, `twilio_auth_token`, and `twilio_number` keys.