### PR TITLE
Don't buffer stdout when running under foreman/docker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: env bin/rails s
+web: bundle exec rails server
 worker: bundle exec sidekiq -q sms -q mailers
 mail: bundle exec mailcatcher -f

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,10 @@
 # This file is used by Rack-based servers to start the application.
 
+# Don't buffer stdout.  We want logs to be available in real time.
+# See: https://devcenter.heroku.com/articles/logging#writing-to-your-log
+# If we end up using the rails_12factor gem, we can remove this, as it provides
+# this functionality.
+STDOUT.sync = true
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application


### PR DESCRIPTION
Without this change stdout is buffered making it very
hard to debug when running under foreman/docker.