### PR TITLE
Fix default action mailer hostname for development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # ActionMailer Config
   config.action_mailer.default_url_options = {
-    host: 'localhost',
+    host: Figaro.env.domain_name,
     protocol: 'http'
   }
 


### PR DESCRIPTION
This was recently changes from 'localhost:3000' to 'localhost'
which broken the links in the emails generated by action
mailer.  This change should mean that the URLs are correct
regardless of the host or port that we run on.