### PR TITLE
Don't use Twilio during performance testing mode

### DIFF
--- a/app/services/null_twilio_client.rb
+++ b/app/services/null_twilio_client.rb
@@ -1,0 +1,9 @@
+class NullTwilioClient
+  def messages
+    self
+  end
+
+  def create(params = {})
+    # noop
+  end
+end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,9 +1,6 @@
 class TwilioService
-  # https://www.twilio.com/docs/api/rest/test-credentials#test-incoming-phone-numbers-parameters-PhoneNumber
-  TWILIO_TEST_NUMBER = '+15005550006'.freeze
-
   def initialize
-    return twilio_test_client if FeatureManagement.pt_mode?
+    return null_twilio_client if FeatureManagement.pt_mode?
     return twilio_proxy_client if proxy_addr.present?
     twilio_client
   end
@@ -20,19 +17,16 @@ class TwilioService
     @account ||= self.class.random_account
   end
 
+  def null_twilio_client
+    @client ||= NullTwilioClient.new
+  end
+
   def twilio_proxy_client
     @client ||= Twilio::REST::Client.new(
       account['sid'],
       account['auth_token'],
       proxy_addr: proxy_addr,
       proxy_port: proxy_port
-    )
-  end
-
-  def twilio_test_client
-    @client ||= Twilio::REST::Client.new(
-      Figaro.env.twilio_test_account_sid,
-      Figaro.env.twilio_test_auth_token
     )
   end
 
@@ -49,7 +43,6 @@ class TwilioService
   end
 
   def from_number
-    return TWILIO_TEST_NUMBER if FeatureManagement.pt_mode?
     "+1#{account['number']}"
   end
 

--- a/bin/setup
+++ b/bin/setup
@@ -14,9 +14,7 @@ Dir.chdir APP_ROOT do
 
   puts "== Copying sample files =="
   %w(database.yml saml.key.enc secrets.yml application.yml).each do |file|
-    unless File.exist?("config/#{file}")
-      run "cp config/#{file}.example config/#{file}"
-    end
+    run "cp config/#{file}.example config/#{file}"
   end
 
   if ARGV.shift == "--docker" then

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -18,12 +18,6 @@ development:
   newrelic_license_key: 'xxx'
   pt_mode: 'on'
   saml_passphrase: 'secret'
-  # Configure Twilio Test Account keys for Performance Testing to avoid
-  # spamming real phone numbers.
-  # https://www.twilio.com/user/account/settings
-  # https://www.twilio.com/user/account/developer-tools/test-credentials
-  twilio_test_account_sid: 'xxx'
-  twilio_test_auth_token: 'xxx'
 
 production:
   allow_third_party_auth: 'yes'
@@ -41,8 +35,6 @@ production:
   twilio_account_sid: 'sid'
   twilio_auth_token: 'token'
   twilio_number: '8888888888'
-  twilio_test_account_sid: 'xxx'
-  twilio_test_auth_token: 'xxx'
 
 test:
   allow_third_party_auth: 'yes'
@@ -58,5 +50,3 @@ test:
   twilio_account_sid: 'sid'
   twilio_auth_token: 'token'
   twilio_number: '8888888888'
-  twilio_test_account_sid: 'test_sid'
-  twilio_test_auth_token: 'test_token'


### PR DESCRIPTION
**Why**:
When `pt_mode` is on, SMS sending is disabled, and any OTP code is
considered valid. The way we were disabling SMS was by using Twilio's
Test Credentials, but those are meant for testing the API. Being able
to use the test Twilio client requires actual secret Twilio test
credentials in application.yml. This is overkill when we can prevent
an SMS from being sent in ways that don't invoke Twilio.

**How**:
Create a NullTwilioClient class that doesn't do anything, and call it
when pt_mode is on.

An added benefit is that we can update bin/setup so that the example
files are always copied over so that developers can make sure they
have the latest configuration. The only reason we used to prevent the
files from being overwritten was to allow developers to keep their
secret Twilio test credentials, but those are no longer needed.