### PR TITLE
Fix /sidekiq infinite redirect when signed out

### DIFF
--- a/config/initializers/devise_override.rb
+++ b/config/initializers/devise_override.rb
@@ -15,21 +15,17 @@ module Devise
     end
 
     def scope_url
-      opts  = {}
+      opts = {}
+
+      opts[:script_name] = nil
 
       route = route(scope, session[:route_to_registration])
 
       opts[:format] = request_format unless skip_format?
 
-      config = Rails.application.config
-
-      if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
-        opts[:script_name] = config.relative_url_root
-      end
-
       context = send(Devise.available_router_name)
 
-      context.send(route, opts) if context.respond_to?(route)
+      context.send(route, opts)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
-require 'sidekiq/web'
-
 Rails.application.routes.draw do
   authenticate :user, ->(u) { u.admin? } do
+    require 'sidekiq/web'
     mount Sidekiq::Web => '/sidekiq'
   end
 


### PR DESCRIPTION
Due to a bug in Devise, attempting to access the /sidekiq route while
signed out was causing an infinite redirect loop. This is because the
endpoint attempts to authenticate the user first to see if they are
an admin.

There is a pull request open that fixes this in Devise's FailureApp,
but since we are already overriding it, we can apply the fix directly.

Eventually, we might want to use basic HTTP auth instead of relying
on Devise and forcing developers to be both signed in and an admin.

Either way, this change is beneficial since it removes unecessary
conditionals in the FailureApp.