### PR TITLE
Fix JavaScript form submission in SAML auth flow

### DIFF
--- a/app/assets/javascripts/app/saml_post_binding.js
+++ b/app/assets/javascripts/app/saml_post_binding.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var samlForm = document.getElementById('saml-post-binding');
+  if (samlForm) {
+    document.body.className += ' hidden';
+    samlForm.submit();
+  }
+});


### PR DESCRIPTION
We were missing the JavaScript code that performs the form
submission in the HTTP Post SAML flow.