### PR TITLE
Always run db:setup with explicit RAILS_ENV

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -28,7 +28,7 @@ Dir.chdir APP_ROOT do
   run "npm install"
 
   puts "\n== Preparing database =="
-  run "bin/rake db:setup"
+  run "bin/rake db:setup RAILS_ENV=development"
   run 'bin/rake db:setup RAILS_ENV=test'
 
   puts "\n== Removing old logs and tempfiles =="


### PR DESCRIPTION
Without RAILS_ENV set db:setup tries to create both development and test
databases, but only honors DATABASE_URL for the first.  This means that you
cannot use DATABASE_URL in combination with db:setup unless you explicitly set
RAILS_ENV.