### PR TITLE
Simplify authentication before_action logic

### DIFF
--- a/app/controllers/concerns/account_state_checker.rb
+++ b/app/controllers/concerns/account_state_checker.rb
@@ -1,9 +1,0 @@
-module AccountStateChecker
-  extend ActiveSupport::Concern
-
-  included do
-    before_action :authenticate_user!
-    before_action :confirm_two_factor_setup
-    before_action :confirm_two_factor_authenticated
-  end
-end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < ApplicationController
   include SpRedirect
 
-  include AccountStateChecker
+  before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_status
 
   def index

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -30,6 +30,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   private
 
   def authenticate_scope!
+    send(:"authenticate_#{resource_name}!", force: true)
     self.resource = send(:"current_#{resource_name}")
   end
 

--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -26,7 +26,6 @@ module Devise
       if user_fully_authenticated?
         redirect_to(request.referrer || root_url)
       elsif resource.two_factor_enabled?
-        flash[:error] = t('devise.errors.messages.user_not_authenticated')
         redirect_to user_two_factor_authentication_path
       end
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -13,8 +13,6 @@ class SamlIdpController < ApplicationController
   before_action :validate_saml_request, only: :auth
   before_action :validate_saml_logout_param, only: :logout
   before_action :store_sp_data, only: :auth
-  before_action :authenticate_user!, except: [:metadata, :logout]
-  before_action :confirm_two_factor_setup, only: :auth
   before_action :confirm_two_factor_authenticated, except: [:metadata, :logout]
 
   def auth

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,5 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    before_action :confirm_two_factor_setup, only: [:edit, :update]
     before_action :confirm_two_factor_authenticated, only: [:edit, :update]
     prepend_before_action :disable_account_creation, only: [:new, :create]
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -33,8 +33,8 @@ UserDecorator = Struct.new(:user) do
     user.unconfirmed_mobile.present? && user.mobile.present?
   end
 
-  def may_bypass_two_factor_setup?(session = {})
-    omniauthed?(session) || user.two_factor_enabled?
+  def may_bypass_2fa?(session = {})
+    omniauthed?(session)
   end
 
   private

--- a/config/locales/devise.two_factor_authentication.en.yml
+++ b/config/locales/devise.two_factor_authentication.en.yml
@@ -3,7 +3,6 @@ en:
     errors:
       messages:
         select_two_factor: You must select a two factor authenticaton preference.
-        user_not_authenticated: Access denied. Please confirm your one-time passcode to continue.
 
     two_factor_authentication:
       attempt_failed: Secure one-time passcode is invalid. Please try again or request a new one-time passcode.

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -57,8 +57,6 @@ describe DashboardController do
     it 'includes before_actions from AccountStateChecker' do
       expect(subject).to have_filters(
         :before,
-        :authenticate_user!,
-        :confirm_two_factor_setup,
         :confirm_two_factor_authenticated,
         :confirm_idv_status
       )

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -80,41 +80,22 @@ describe UserDecorator do
     end
   end
 
-  describe '#may_bypass_two_factor_setup?' do
-    it 'returns true when the user is omniauthed and two_factor_enabled' do
+  describe '#may_bypass_2fa?' do
+    it 'returns true when the user is omniauthed' do
       user = instance_double(User)
       allow(user).to receive(:two_factor_enabled?).and_return(true)
 
       user_decorator = UserDecorator.new(user)
       session = { omniauthed: true }
 
-      expect(user_decorator.may_bypass_two_factor_setup?(session)).to eq true
+      expect(user_decorator.may_bypass_2fa?(session)).to eq true
     end
 
-    it 'returns true when the user is omniauthed and not two_factor_enabled' do
+    it 'returns false when the user is not omniauthed' do
       user = instance_double(User)
-      allow(user).to receive(:two_factor_enabled?).and_return(false)
-
-      user_decorator = UserDecorator.new(user)
-      session = { omniauthed: true }
-
-      expect(user_decorator.may_bypass_two_factor_setup?(session)).to eq true
-    end
-
-    it 'returns false when the user is neither omniauthed nor two_factor_enabled' do
-      user = instance_double(User)
-      allow(user).to receive(:two_factor_enabled?).and_return(false)
       user_decorator = UserDecorator.new(user)
 
-      expect(user_decorator.may_bypass_two_factor_setup?).to eq false
-    end
-
-    it 'returns true when the user is not omniauthed but is two_factor_enabled' do
-      user = instance_double(User)
-      allow(user).to receive(:two_factor_enabled?).and_return(true)
-      user_decorator = UserDecorator.new(user)
-
-      expect(user_decorator.may_bypass_two_factor_setup?).to eq true
+      expect(user_decorator.may_bypass_2fa?).to eq false
     end
   end
 end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -266,13 +266,12 @@ feature 'Two Factor Authentication', devise: true do
       expect(page).to have_content I18n.t('devise.two_factor_authentication.user.new_otp_sent')
     end
 
-    scenario 'user attempts to circumnavigate OTP setup' do
-      second_factor = SecondFactor.find_by_name 'Email'
-      user = create(:user, :signed_up, second_factor_ids: second_factor.id)
+    scenario 'user attempts to bypass 2FA' do
+      user = create(:user, :signed_up)
       sign_in_user(user)
       visit edit_user_registration_path
 
-      expect(page).to have_content I18n.t('devise.errors.messages.user_not_authenticated')
+      expect(current_path).to eq user_two_factor_authentication_path
     end
 
     scenario 'user disables 2FA method' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -18,10 +18,9 @@ module ControllerHelper
     sign_in create(:user, :signed_up, :tech_support)
   end
 
-  def sign_in_before_2fa(user = create(:user, :signed_up))
-    allow(warden).to receive(:authenticated?).with(:user).and_return(true)
-    allow(controller).to receive(:current_user).and_return(user)
-    warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
+  def sign_in_before_2fa
+    sign_in_as_user
+    allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end
 end
 


### PR DESCRIPTION
**Why**:
After removing the account type and security questions controllers,
we introduced a bug that allowed SAML-authed users to bypass 2FA.
This is because the `before_action` that checked if a user had set up
their 2FA was only present in the account type and security questions
controllers, but not in `TwoFactorAuthenticationController`. Since
SamlIdpController had a before_action that made sure a user had set
up their security questions, a user would eventually end up being
prompted to set up their 2FA. However, after removing those
controllers, we exposed the brittleness of our gatekeepers.

**How**:
Instead of duplicating various before_actions throughout controllers,
we can modify the `confirm_two_factor_authenticated` `before_action`
to check that a user is signed in, that they have set up their 2FA,
and that they have entered a valid OTP before being considered fully
signed in. This allows us to reduce 3 `before_action`s in several controllers down
to one.

I also updated the flash on the OTP page to a notice instead of an
error and made the message more user-friendly.