### PR TITLE
Improve saml form auto-submit js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
   },
   'rules': {
     'func-names': 0,
-    'space-before-function-paren': 0
+    'space-before-function-paren': 0,
+    'prefer-arrow-callback': 0
   },
   'parserOptions': {
     'ecmaVersion': 6,

--- a/app/assets/javascripts/app/saml_post_binding.js
+++ b/app/assets/javascripts/app/saml_post_binding.js
@@ -1,7 +1,0 @@
-document.addEventListener('DOMContentLoaded', function() {
-  var samlForm = document.getElementById('saml-post-binding');
-  if (samlForm) {
-    document.body.className += ' hidden';
-    samlForm.submit();
-  }
-});

--- a/app/assets/javascripts/misc/saml-post.js
+++ b/app/assets/javascripts/misc/saml-post.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.body.className += ' hide';
+  document.getElementById('saml-post-binding').submit();
+});

--- a/app/views/saml_idp/shared/saml_post_binding.html.slim
+++ b/app/views/saml_idp/shared/saml_post_binding.html.slim
@@ -3,24 +3,23 @@ html
   head
     meta charset='utf-8'
     meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'
-    == stylesheet_link_tag 'application', :media => 'all'
-    == javascript_include_tag 'application'
     == csrf_meta_tags
+    == stylesheet_link_tag 'application', media: 'all'
+    == javascript_include_tag 'misc/saml-post'
   body
-    .container(tabindex="-1" )
-      .site-content-wrapper#start-of-content(tabindex="-1" )
-        .panel.panel-default
-          .panel-body
-            h2= 'Submit to continue'
-            hr
+    .container.px2.py3
+      .clearfix.mxn2
+        .sm-col-6.px2.mx-auto
+          .panel
+            .panel-heading
+              h2.m0 = 'Submit to continue'
             p
               'JavaScript seems to be turned off in your browser. Normally this
-              'step happens automatically, but because you have JavaScript turned
-              'off, please click the submit button to continue signing in or
-              'signing out.
-
+              'step happens automatically, but because you have JavaScript
+              'turned off, please click the submit button to continue signing
+              'in or signing out.
             form action=action_url method='POST' id='saml-post-binding'
               = hidden_field_tag(type, message)
               - if params.has_key?(:RelayState)
                 = hidden_field_tag("RelayState", params[:RelayState])
-              = submit_tag 'Submit', class: 'usa-button'
+              = submit_tag 'Submit', class: 'btn btn-primary'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(favicons/* small-flag.png)
+Rails.application.config.assets.precompile += %w(misc/saml-post.js)


### PR DESCRIPTION
__Why__
Before, we were adding the javascript snippet that auto submits saml form to every page. This is now improved by simply inlining this bit on the relevant page (and not including the other non-necessary application JS).

Also, the style of the page if JS is disabled is improved:
![image](https://cloud.githubusercontent.com/assets/1060893/15304910/f803641e-1b8d-11e6-89f9-6dd56e574b5d.png)
