### PR TITLE
Update Overcommit config to fail on warnings

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -33,6 +33,19 @@ PreCommit:
     include: '**/*.slim'
 
 CommitMsg:
+  ALL:
+    on_warn: 'fail'
+
+  MessageFormat:
+    enabled: true
+    description: 'Check commit message matches expected pattern'
+    pattern: '\*\*Why\*\*:'
+    expected_pattern_message: >
+      Body of commit message must include a reason for the change.
+      See our contribution guidelines:
+      https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#commit-message-style-guide
+    sample_message: '**Why**: To eliminate unnecessary database calls.'
+
   TextWidth:
     enabled: true
     description: 'Check text width'


### PR DESCRIPTION
**Why**: To be able to enforce our commit message style guide rules.
Before, Overcommit would just output warnings, but would still allow
the commit message to be saved.

**How**: Add the `on_warn: fail` directive so that commit messages
cannot be saved until they pass all the rules, including the presence
of a `**Why**:` section that provides justification for the change.