### PR TITLE
Use named CSP override in SamlIdpController#auth

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -18,6 +18,8 @@ class SamlIdpController < ApplicationController
   before_action :confirm_two_factor_authenticated, except: [:metadata, :logout]
 
   def auth
+    use_secure_headers_override(:saml)
+
     unless valid_authn_contexts.include?(requested_authn_context)
       process_invalid_authn_context
       return

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -35,7 +35,7 @@ production:
 
 test:
   allow_third_party_auth: 'yes'
-  domain_name: 'example.com'
+  domain_name: ''
   ducksboard_uid: '8VEQre2c8b62mQV0sa'
   sp_url: ''
   idp_sso_target_url: 'http://identityprovider.example.com/saml/auth'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -33,3 +33,12 @@ SecureHeaders::Configuration.default do |config|
   #   ]
   # }
 end
+
+SecureHeaders::Configuration.override(:saml) do |config|
+  providers = YAML.load_file("#{Rails.root}/config/service_providers.yml")
+  providers = providers.fetch(Rails.env, {})
+  providers.symbolize_keys!
+  whitelisted_urls = providers[:valid_hosts].values.map { |k, _| k['acs_url'] }
+
+  whitelisted_urls.each { |url| config.csp[:form_action] << url }
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -38,7 +38,13 @@ SecureHeaders::Configuration.override(:saml) do |config|
   providers = YAML.load_file("#{Rails.root}/config/service_providers.yml")
   providers = providers.fetch(Rails.env, {})
   providers.symbolize_keys!
-  whitelisted_urls = providers[:valid_hosts].values.map { |k, _| k['acs_url'] }
+
+  provider_attributes = providers[:valid_hosts].values
+
+  acs_urls = provider_attributes.map { |hash| hash['acs_url'] }
+  acls_urls = provider_attributes.map { |hash| hash['assertion_consumer_logout_service_url'] }
+
+  whitelisted_urls = (acs_urls + acls_urls)
 
   whitelisted_urls.each { |url| config.csp[:form_action] << url }
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -146,6 +146,16 @@ feature 'saml api', devise: true, sms: true do
       expect(current_path).to eq(users_otp_path)
       expect(page).to have_content(I18n.t('devise.two_factor_authentication.otp_setup'))
     end
+
+    it 'adds acs_urls for current Rails env to CSP form_action' do
+      visit '/test/saml'
+      authenticate_user(user)
+
+      expect(page.response_headers['Content-Security-Policy']).
+        to include(
+          'form-action \'self\' localhost:3000/test/saml/decode_assertion ' \
+          'example.com/test/saml/decode_assertion;')
+    end
   end
 
   context 'visiting /api/saml/logout' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -147,14 +147,17 @@ feature 'saml api', devise: true, sms: true do
       expect(page).to have_content(I18n.t('devise.two_factor_authentication.otp_setup'))
     end
 
-    it 'adds acs_urls for current Rails env to CSP form_action' do
+    it 'adds unique ACS and ACLS URLs for current Rails env to CSP form_action' do
+      # ACS = acs_url, ACLS = assertion_consumer_logout_service_url
       visit '/test/saml'
       authenticate_user(user)
 
       expect(page.response_headers['Content-Security-Policy']).
         to include(
           'form-action \'self\' localhost:3000/test/saml/decode_assertion ' \
-          'example.com/test/saml/decode_assertion;')
+          'example.com/test/saml/decode_assertion ' \
+          'localhost:3000/test/saml/decode_slo_request ' \
+          'example.com/test/saml/decode_slo_request;')
     end
   end
 


### PR DESCRIPTION
**Why**:
After a SAML-authed user finishes signing in, they get redirected to
the `acs_url` defined in `service_providers.yml` for the current
Service Provider in the current Rails environment. This redirect
happens via submitting a form in `saml_post_binding.html.slim`, which
is tied to the `auth` action of `SamlIdpController`.

Our default CSP config restricts form submissions to the current host,
but we need to whitelist approved URLs in this scenario.

**How**:
The `secure_headers` gem provides a way to define named overrides that
can then be called in controller actions. I've defined a `:saml`
override that parses `service_providers.yml` and adds all the
`acs_url`s for the current Rails env to the `form_action` directive.

Note that for the SamlTestController to redirect to `/api/saml/auth` in
specs, the `domain_name` in the test environment needs to be set to an
empty string. Hence, I've updated `application.yml.example`.