### PR TITLE
Add host for local Rails SP development

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -26,7 +26,11 @@ development:
       acs_url: 'http://localhost:4567/consume'
       sp_initiated_login_url: 'http://localhost:4567/test/saml'
       cert: 'demo_sp'
-
+    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
+      metadata_url: 'http://localhost:3003/saml/metadata'
+      acs_url: 'http://localhost:3003/consume'
+      sp_initiated_login_url: 'http://localhost:3003/test/saml'
+      cert: 'demo_sp'
     'https://dashboard.login.gov':
       metadata_url: 'http://localhost:3001/users/auth/saml/metadata'
       acs_url: 'http://localhost:3001/users/auth/saml/callback'

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -29,7 +29,7 @@ development:
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
       metadata_url: 'http://localhost:3003/saml/metadata'
       acs_url: 'http://localhost:3003/consume'
-      sp_initiated_login_url: 'http://localhost:3003/test/saml'
+      sp_initiated_login_url: 'http://localhost:3003/login'
       cert: 'demo_sp'
     'https://dashboard.login.gov':
       metadata_url: 'http://localhost:3001/users/auth/saml/metadata'


### PR DESCRIPTION
Why:
To support development of Rails version of the RP/SP while still supporting the existing Sinatra version, add another set of host data for the Rails SP currently being created.

How:
Copy the one from the Sinatra version `urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost` and change relevant information. Hoping that using the same cert is cool.