### PR TITLE
Fix SAML logout test

### DIFF
--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -209,9 +209,11 @@ feature 'saml api', devise: true, sms: true do
         settings.name_identifier_value = user.uuid
 
         visit request.create(settings)
+        user.reload
       end
 
       it 'signs out the user from IdP' do
+        pending "current_sign_in_at is not being set to nil during logout"
         expect(user.current_sign_in_at).to be_nil
 
         visit edit_user_registration_path


### PR DESCRIPTION
**What**: Update the SAML logout test such that the redirect the
logout request is actually sent to the IdP.  Also reload the user
model before testing its current_sign_in_at.

**Why**: SAML logout seems to be broken but the test was not reporting
it as such.