### PR TITLE
Adds handling for SPs who do not implement SLO

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -62,6 +62,9 @@ module SamlIdpLogoutConcern
 
   def generate_slo_request(resource)
     slo_identity = fetch_identity_for_slo(resource)
+    # The SP has not implemented SLO; do not generate a request!
+    return nil if
+      slo_identity.sp_metadata[:assertion_consumer_logout_service_url].nil?
     {
       message: slo_request_builder(
         slo_identity.sp_metadata,

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -450,6 +450,25 @@ feature 'saml api', devise: true, sms: true do
         expect(page.get_rack_session.keys & removed_keys).to eq []
       end
     end
+
+    context 'without SLO implemented at SP' do
+      let(:logout_user) { create(:user, :signed_up) }
+
+      before do
+        visit sp1_authnrequest
+        authenticate_user(logout_user)
+      end
+
+      it 'completes logout at IdP' do
+        allow_any_instance_of(ServiceProvider).to receive(:metadata).and_return(
+          service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata'
+        )
+
+        visit destroy_user_session_url
+
+        expect(current_path).to eq('/')
+      end
+    end
   end
 
   context 'visiting /api/saml/auth' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -457,6 +457,7 @@ feature 'saml api', devise: true, sms: true do
       before do
         visit sp1_authnrequest
         authenticate_user(logout_user)
+        click_button 'Submit'
       end
 
       it 'completes logout at IdP' do


### PR DESCRIPTION
Why
Some Service Providers do not have SLO, which causes unepexcted behavior
when logging out.

How
Permit sessions to expire externally and end session at the IdP as
normal.