### PR TITLE
Only use domain names in CSP form_action

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -14,10 +14,9 @@ class SamlIdpController < ApplicationController
   before_action :validate_saml_logout_param, only: :logout
   before_action :store_sp_data, only: :auth
   before_action :confirm_two_factor_authenticated, except: [:metadata, :logout]
+  before_action :apply_secure_headers_override, only: [:auth, :logout]
 
   def auth
-    use_secure_headers_override(:saml)
-
     unless valid_authn_contexts.include?(requested_authn_context)
       process_invalid_authn_context
       return
@@ -185,6 +184,10 @@ class SamlIdpController < ApplicationController
       requested_authn_context,
       true
     )
+  end
+
+  def apply_secure_headers_override
+    use_secure_headers_override(:saml)
   end
 end
 # rubocop:enable ClassLength

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -42,9 +42,8 @@ SecureHeaders::Configuration.override(:saml) do |config|
   provider_attributes = providers[:valid_hosts].values
 
   acs_urls = provider_attributes.map { |hash| hash['acs_url'] }
-  acls_urls = provider_attributes.map { |hash| hash['assertion_consumer_logout_service_url'] }
 
-  whitelisted_urls = (acs_urls + acls_urls)
+  whitelisted_domains = acs_urls.map { |url| url.split('//')[1].split('/')[0] }
 
-  whitelisted_urls.each { |url| config.csp[:form_action] << url }
+  whitelisted_domains.each { |domain| config.csp[:form_action] << domain }
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -149,17 +149,12 @@ feature 'saml api', devise: true, sms: true do
       expect(page).to have_content(I18n.t('devise.two_factor_authentication.otp_setup'))
     end
 
-    it 'adds unique ACS and ACLS URLs for current Rails env to CSP form_action' do
-      # ACS = acs_url, ACLS = assertion_consumer_logout_service_url
+    it 'adds acs_url domain names for current Rails env to CSP form_action' do
       visit '/test/saml'
       authenticate_user(user)
 
       expect(page.response_headers['Content-Security-Policy']).
-        to include(
-          'form-action \'self\' localhost:3000/test/saml/decode_assertion ' \
-          'example.com/test/saml/decode_assertion ' \
-          'localhost:3000/test/saml/decode_slo_request ' \
-          'example.com/test/saml/decode_slo_request;')
+        to include('form-action \'self\' localhost:3000 example.com')
     end
   end
 
@@ -193,6 +188,11 @@ feature 'saml api', devise: true, sms: true do
       it 'generates logout request with Issuer' do
         expect(xmldoc.issuer_nodeset.length).to eq(1)
         expect(xmldoc.issuer_nodeset[0].content).to eq "https://#{Figaro.env.domain_name}/api/saml"
+      end
+
+      it 'adds acs_url domain names for current Rails env to CSP form_action' do
+        expect(page.response_headers['Content-Security-Policy']).
+          to include('form-action \'self\' localhost:3000 example.com')
       end
     end
 


### PR DESCRIPTION
**Why**:
The final Service Provider URL where the user will end up might not
necessarily be listed in service_providers.yml. For example,
`https://identity-rp-dev.apps.cloud.gov/consume` redirects to
`https://identity-rp-dev.apps.cloud.gov/success`. If the final URL
is not listed in the CSP form_action directive, any browser that
supports the `form_action` directive will prevent the form from being
submitted.

**How**:
- Instead of using specific full URLs, use only the domain names.
- Add the controller override to the `logout` action to support
SLO.