### PR TITLE
Adds helper method for determining Service Provider endpoints

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -35,15 +35,5 @@ SecureHeaders::Configuration.default do |config|
 end
 
 SecureHeaders::Configuration.override(:saml) do |config|
-  providers = YAML.load_file("#{Rails.root}/config/service_providers.yml")
-  providers = providers.fetch(Rails.env, {})
-  providers.symbolize_keys!
-
-  provider_attributes = providers[:valid_hosts].values
-
-  acs_urls = provider_attributes.map { |hash| hash['acs_url'] }
-
-  whitelisted_domains = acs_urls.map { |url| url.split('//')[1].split('/')[0] }
-
-  whitelisted_domains.each { |domain| config.csp[:form_action] << domain }
+  ServiceProvider.domain_endpoints.each { |domain| config.csp[:form_action] << domain }
 end

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -1,4 +1,19 @@
 class ServiceProvider
+  def self.domain_endpoints
+    providers = YAML.load_file("#{Rails.root}/config/service_providers.yml")
+    providers = providers.fetch(Rails.env, {})
+    providers.symbolize_keys!
+
+    provider_attributes = providers[:valid_hosts].values
+
+    acs_urls = provider_attributes.map { |hash| hash['acs_url'] }
+
+    whitelisted_domains = acs_urls.map do |url|
+      host = URI.parse(url).host.downcase
+    end
+    whitelisted_domains.uniq
+  end
+
   def initialize(host)
     @host = host
   end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -152,9 +152,8 @@ feature 'saml api', devise: true, sms: true do
     it 'adds acs_url domain names for current Rails env to CSP form_action' do
       visit '/test/saml'
       authenticate_user(user)
-
       expect(page.response_headers['Content-Security-Policy']).
-        to include('form-action \'self\' localhost:3000 example.com')
+        to include("form-action \'self\' #{ServiceProvider.domain_endpoints.join(' ')}")
     end
   end
 
@@ -192,7 +191,7 @@ feature 'saml api', devise: true, sms: true do
 
       it 'adds acs_url domain names for current Rails env to CSP form_action' do
         expect(page.response_headers['Content-Security-Policy']).
-          to include('form-action \'self\' localhost:3000 example.com')
+          to include("form-action \'self\' #{ServiceProvider.domain_endpoints.join(' ')}")
       end
     end
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -189,7 +189,9 @@ module SamlAuthHelper
   end
 
   def authenticate_user(user = create(:user, :signed_up))
-    sign_in_user(user)
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
     fill_in 'code', with: user.otp_code
     click_button 'Submit'
   rescue XMLSec::SigningError


### PR DESCRIPTION
Why
The local service provider configuration may differ between development environments

How
This permits the config to pull from the local yml file.