### PR TITLE
Add sp-demo to IdP's provider list

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -57,6 +57,11 @@ production:
       acs_url: 'https://identity-rp-dev.apps.cloud.gov/consume'
       sp_initiated_login_url: 'https://identity-rp-dev.apps.cloud.gov/test/saml'
       cert: 'demo_sp'
+    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo':
+      metadata_url: 'https://identity-rp-demo.apps.cloud.gov/saml/metadata'
+      acs_url: 'https://identity-rp-demo.apps.cloud.gov/consume'
+      sp_initiated_login_url: 'https://identity-rp-demo.apps.cloud.gov/test/saml'
+      cert: 'demo_sp'
 
 superb.legit.domain.gov:
   valid_hosts:


### PR DESCRIPTION
Why:
 - mismatch between idp-demo and sp-dev made things hard to maintain.

How:
 - Add sp-demo entry to `service_providers.yml`

Necessary to fix 370