### PR TITLE
Update bummr setup

### DIFF
--- a/.bummr-build.sh
+++ b/.bummr-build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-bundle exec rspec
+bundle exec rspec --fail-fast

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.2.6'
 
 gem 'browserify-rails'
 gem 'coffee-rails', '~> 4.1.0'
-gem 'devise'
+gem 'devise', '~> 3.5'
 gem 'dotiw'
 gem 'figaro'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   derailed
-  devise
+  devise (~> 3.5)
   dotiw
   email_spec
   factory_girl_rails


### PR DESCRIPTION
**Why**:
Bummr only works from a clean branch off of master, and recommends that a few things be true before running `bummr update`, namely that RSpec be configured to fail fast, and that any gems that we don't want Bummr to update should be version-restrained in the Gemfile.

This PR makes those recommended changes.