### PR TITLE
Localize email subject lines

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,13 +2,13 @@ class UserMailer < ActionMailer::Base
   default from: 'upaya@18f.gov'
 
   def email_changed(old_email)
-    mail(to: old_email, subject: 'Email change notification')
+    mail(to: old_email, subject: t('upaya.mailer.email_change_notice.subject'))
   end
 
   def signup_with_your_email(user)
     @root_url = root_url
     @new_user_password_url = new_user_password_url
-    mail(to: user.email, subject: 'Email Confirmation Notification')
+    mail(to: user.email, subject: t('upaya.mailer.email_reuse_notice.subject'))
   end
 
   def password_changed(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,11 @@ en:
 
     mailer:
       password_expires_soon:
-        subject: Password Expiration Notice
+        subject: Password expiration notice
+      email_reuse_notice:
+        subject: Email confirmation notification
+      email_change_notice:
+        subject: Email change notification
 
   activerecord:
     errors:

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -281,7 +281,7 @@ describe Users::RegistrationsController, devise: true do
       expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
       expect(response).to render_template('user_mailer/signup_with_your_email')
       expect(user.reload.email).to eq 'old_email@example.com'
-      expect(last_email.subject).to eq 'Email Confirmation Notification'
+      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
     end
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -11,7 +11,7 @@ describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eq('Email change notification')
+      expect(mail.subject).to eq t('upaya.mailer.email_change_notice.subject')
     end
 
     it 'renders the body' do
@@ -65,7 +65,7 @@ describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eq 'Email Confirmation Notification'
+      expect(mail.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
     end
 
     it 'renders the body' do

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -49,7 +49,7 @@ describe 'user edits their account', email: true do
     it 'displays a notice informing the user their email has been confirmed when user confirms' do
       get_via_redirect links_in_email(last_email).first
 
-      expect(flash[:notice]).to eq t 'devise.confirmations.confirmed'
+      expect(flash[:notice]).to eq t('devise.confirmations.confirmed')
       expect(response).to render_template('user_mailer/email_changed')
     end
 
@@ -66,7 +66,7 @@ describe 'user edits their account', email: true do
       delete_via_redirect destroy_user_session_path
       get_via_redirect links_in_email(last_email).first
 
-      expect(flash[:notice]).to eq t 'devise.confirmations.confirmed'
+      expect(flash[:notice]).to eq t('devise.confirmations.confirmed')
     end
   end
 
@@ -188,7 +188,7 @@ describe 'user edits their account', email: true do
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq old_mobile
-      expect(last_email.subject).to eq 'Email Confirmation Notification'
+      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
     end
 
     it 'calls SmsSenderExistingMobileJob but not SmsSenderOtpJob' do
@@ -263,7 +263,7 @@ describe 'user edits their account', email: true do
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq old_mobile
-      expect(last_email.subject).to eq 'Email Confirmation Notification'
+      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
     end
 
     it 'calls SmsSenderOtpJob but not SmsSenderExistingMobileJob' do


### PR DESCRIPTION
**Why** To achieve localization of email subject lines and avoid
duplication of strings in test cases.