### PR TITLE
Remove check of current_sign_in_at from saml logout spec

### DIFF
--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -212,8 +212,6 @@ feature 'saml api', devise: true, sms: true do
       end
 
       it 'signs out the user from IdP' do
-        expect(user.current_sign_in_at).to be_nil
-
         visit edit_user_registration_path
 
         expect(page).to have_content I18n.t 'devise.failure.unauthenticated'


### PR DESCRIPTION
Checking for current_sign_in_at being nil is not a
valid way to detect if logout occured since this
field is never set to nil.