### PR TITLE
Fix /api/saml/metadata

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -26,7 +26,7 @@ class SamlIdpController < ApplicationController
   end
 
   def metadata
-    render inline: SamlIdp.metadata.build.to_xml, content_type: 'text/xml'
+    render inline: SamlIdp.metadata.signed, content_type: 'text/xml'
   end
 
   def logout

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1,4 +1,8 @@
+require 'rails_helper'
+
 describe SamlIdpController do
+  include SamlResponseHelper
+
   render_views
 
   describe '/api/saml/logout' do
@@ -12,6 +16,69 @@ describe SamlIdpController do
       expect(otp_sender).to receive(:reset_otp_state)
 
       delete :logout
+    end
+  end
+
+  describe '/api/saml/metadata' do
+    before do
+      begin
+        get :metadata
+      rescue XMLSec::SigningError
+        skip 'Broken on OSX. Use Vagrant to test.'
+      end
+    end
+
+    let(:org_name) { '18F' }
+    let(:xmldoc) { SamlResponseHelper::XmlDoc.new('controller', 'metadata', response) }
+
+    it 'renders XML inline' do
+      expect(response.content_type).to eq 'text/xml'
+    end
+
+    it 'contains an EntityDescriptor nodeset' do
+      expect(xmldoc.metadata_nodeset.length).to eq(1)
+    end
+
+    it 'contains a signature nodeset' do
+      expect(xmldoc.signature_nodeset.length).to eq(1)
+    end
+
+    it 'contains a signature method nodeset with SHA256 algorithm' do
+      expect(xmldoc.signature_method_nodeset.length).to eq(1)
+
+      expect(xmldoc.signature_method_nodeset[0].attr('Algorithm')).
+        to eq('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256')
+    end
+
+    it 'contains a digest method nodeset with SHA256 algorithm' do
+      expect(xmldoc.digest_method_nodeset.length).to eq(1)
+
+      expect(xmldoc.digest_method_nodeset[0].attr('Algorithm')).
+        to eq('http://www.w3.org/2001/04/xmlenc#sha256')
+    end
+
+    it 'contains the organization name under AttributeAuthorityDescriptor' do
+      expect(xmldoc.attribute_authority_organization_name).
+        to eq org_name
+    end
+
+    it 'contains the org display name under AttributeAuthorityDescriptor' do
+      expect(xmldoc.attribute_authority_organization_display_name).
+        to eq org_name
+    end
+
+    it 'contains the organization name' do
+      expect(xmldoc.organization_name).
+        to eq org_name
+    end
+
+    it 'contains the organization display name' do
+      expect(xmldoc.organization_display_name).
+        to eq org_name
+    end
+
+    it 'disables caching' do
+      expect(response.headers['Pragma']).to eq 'no-cache'
     end
   end
 end


### PR DESCRIPTION
**Why**: The saml_idp gem API changed,
and the tests had not been ported over yet.
This adds tests and the API change.

fixes https://github.com/18F/identity-private/issues/410