### PR TITLE
Use number and tel types for OTP and mobile fields

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -16,3 +16,18 @@
   margin-left: .5rem;
   vertical-align: baseline;
 }
+
+// hide number field input spin box as per:
+// http://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box
+// and added .mfa class selector as per CodeClimate warning to:
+// 'Avoid qualifying attribute selectors with an element.'
+.mfa {
+  -moz-appearance: textfield;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  // display: none; <- Crashes Chrome on hover
+  -webkit-appearance: none;
+  margin: 0; // <-- Apparently some margin are still there even though it's hidden
+}

--- a/app/views/devise/registrations/_form.html.slim
+++ b/app/views/devise/registrations/_form.html.slim
@@ -1,7 +1,8 @@
 .mb3
   h4 = t('upaya.forms.registration.contact_info')
-  = f.input :email, required: true, autofocus: true, input_html: { 'data-tooltip' => true, :title => t('upaya.forms.registration.email_field') }
-  = f.input :mobile, required: false, input_html: { 'data-tooltip' => true, :title => t('upaya.forms.registration.mobile_field') }
+  = f.input :email, autofocus: true, input_html: { 'data-tooltip' => true, title: t('upaya.forms.registration.email_field') }, required: true
+  = f.input :mobile, as: :tel, input_html: { 'data-tooltip' => true, title: t('upaya.forms.registration.mobile_field') }, required: false
+
 .mb3
   h4 Password
   = f.input :password, required: false

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -17,5 +17,5 @@
       = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
         .mb2
           = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.two_factor.code')
-          = text_field_tag :code, '', required: true, autofocus: true, class: 'block col-12 field'
+          = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true
         = submit_tag 'Submit', class: 'btn btn-primary'

--- a/app/views/devise/two_factor_authentication_setup/confirm.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/confirm.html.slim
@@ -2,5 +2,5 @@
 
 h2 = t('devise.two_factor_authentication.enter_auth_code')
 = form_tag([resource_name, :two_factor_authentication], method: :put, role: 'form') do
-  = text_field_tag :code
+  = number_field_tag :code, autofocus: true
   = submit_tag 'Submit', class: 'usa-button'

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -11,6 +11,6 @@
           url: users_otp_path) do |f|
         = f.error_notification
         p = t('devise.two_factor_authentication.otp_setup')
-        = f.input :mobile, label: 'Mobile Number', required: true, autofocus: true
+        = f.input :mobile, as: :tel, autofocus: true, label: 'Mobile Number', required: true
         = f.button :submit, 'Submit'
         p = t('devise.two_factor_authentication.otp_sms_disclaimer')

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -4,6 +4,6 @@ h3 = t('upaya.headings.users.edit')
 = required_form_field(@user, html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.error_notification
   = f.input :email, required: true, autofocus: true
-  = f.input :mobile, required: false, readonly: true
+  = f.input :mobile, as: :tel, readonly: true, required: false
   = f.input :role, collection: User.roles.keys.map { |role| [role.titleize, role] }
   = f.button :submit, 'Update', class: 'usa-button'


### PR DESCRIPTION
This makes it easier for mobile users to enter their OTP and phone numbers since it provides keyboard options for numerical input or a customized phone input.

![img_2040](https://cloud.githubusercontent.com/assets/24955/15756508/69ff8090-28b6-11e6-8a40-ec8d83da47ac.PNG)

![img_2043](https://cloud.githubusercontent.com/assets/24955/15756521/78b29898-28b6-11e6-9e46-d76eae584fee.PNG)
