### PR TITLE
Update Devise to 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 4.2.6'
 
 gem 'browserify-rails'
 gem 'coffee-rails', '~> 4.1.0'
-gem 'devise', '~> 3.5'
+gem 'devise', '~> 4.1'
 gem 'dotiw'
 gem 'figaro'
 gem 'lograge'
@@ -75,6 +75,7 @@ group :test do
   gem 'rack-test'
   gem 'shoulda-matchers', '~> 2.8', require: false
   gem 'sms-spec', git: 'https://github.com/monfresh/sms-spec.git', require: 'sms_spec'
+  gem 'test_after_commit'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,12 +164,11 @@ GEM
       rack (>= 1)
       rake (> 10, < 12)
       thor (~> 0.19)
-    devise (3.5.10)
+    devise (4.1.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 5.1)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -446,6 +445,8 @@ GEM
     sysexits (1.2.0)
     systemu (2.6.5)
     temple (0.7.7)
+    test_after_commit (1.0.0)
+      activerecord (>= 3.2)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -505,7 +506,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   derailed
-  devise (~> 3.5)
+  devise (~> 4.1)
   dotiw
   email_spec
   factory_girl_rails
@@ -546,6 +547,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen
+  test_after_commit
   thin
   timecop
   turbolinks
@@ -557,4 +559,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -12,5 +12,8 @@
       = render 'devise/sessions/form'
       h2.m0.py3.text-over-line
         span or use your
-      = button_to 'Existing Credential', user_omniauth_authorize_path(:saml), title: 'Existing Credential',
-        class: 'btn btn-primary col-12 bg-navy mb1', method: :get
+      = button_to 'Existing Credential',
+                  user_saml_omniauth_authorize_path,
+                  title: 'Existing Credential',
+                  class: 'btn btn-primary col-12 bg-navy mb1',
+                  method: :get


### PR DESCRIPTION
**Why**:
To take advantage of a fix that waits until the user has been committed
to the database before sending the confirmation email, which will
resolve the Sidekiq crashes we've been seeing.

**How**
- Update the gem
- Replace the deprecated `user_omniauth_authorize_path(:saml)` route
path with the new one. See: https://git.io/vrhnJ
- Add the `test_after_commit` gem to be able to test Devise
confirmation emails. See: https://git.io/vrhnI