### PR TITLE
Remove unused localization

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,4 +242,3 @@ en:
   errors:
     messages:
       improbable_phone: 'Mobile number is invalid. Please make sure you enter a 10-digit phone number.'
-      taken: 'has already been taken'


### PR DESCRIPTION
**Why**:
The Form Objects refactor removed "already taken" errors altogether.
Either way, this error never needed to be localized since it would
never be shown to a user (because we don't want to reveal that an
email or phone number already exists.)