### PR TITLE
Fix minor Rubocop style offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,11 @@ Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
   Enabled: true
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+  SupportedStyles:
+    - nested
+    - compact
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -62,7 +62,8 @@ module SamlIdpLogoutConcern
       message: slo_request_builder(
         slo_identity.sp_metadata,
         resource.uuid,
-        slo_identity.session_uuid).signed,
+        slo_identity.session_uuid
+      ).signed,
       action_url: slo_identity.sp_metadata[:assertion_consumer_logout_service_url],
       message_type: 'SAMLRequest'
     }

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -1,6 +1,8 @@
 require 'feature_management'
 
+# rubocop:disable Style/ClassAndModuleChildren
 class Devise::TwoFactorAuthenticationController < DeviseController
+  # rubocop:enable Style/ClassAndModuleChildren
   prepend_before_action :authenticate_scope!
   before_action :verify_user_is_not_second_factor_locked
   before_action :handle_two_factor_authentication

--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -30,13 +30,15 @@ module Test
         UUID.generate,       # name_id
         'bogus_fuzzy_lambs', # name_qualifier
         UUID.generate,       # session_index
-        signature_opts)
+        signature_opts
+      )
 
       render template: 'saml_idp/shared/saml_post_binding.html.slim',
              locals: {
                action_url: '/api/saml/logout',
                message: Base64.encode64(logout_request_builder.build.to_xml),
-               type: :SAMLRequest },
+               type: :SAMLRequest
+             },
              layout: false
     end
     # rubocop:enable AbcSize, MethodLength

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -30,7 +30,8 @@ module Users
 
     def with_unconfirmed_confirmable
       @confirmable = User.find_or_initialize_with_error_by(
-        :confirmation_token, params[:confirmation_token])
+        :confirmation_token, params[:confirmation_token]
+      )
 
       if @confirmable.confirmed?
         @confirmable = User.confirm_by_token(params[:confirmation_token])

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -9,7 +9,8 @@ module Users
       # recover passwords. However, we always want to return success.
       flash[:success] = t('upaya.notices.password_reset')
       redirect_to after_sending_reset_password_instructions_path_for(
-        resource_name)
+        resource_name
+      )
     end
 
     def create
@@ -22,12 +23,14 @@ module Users
                           # If the account has not been confirmed, password reset should resend
                           # the confirmation email instructions
                           resource_class.send_confirmation_instructions(
-                            resource_params)
+                            resource_params
+                          )
                         else
                           # only send_reset_password_instructions if resource is matched above.
                           # this disallows other roles from using the password recovery form.
                           resource_class.send_reset_password_instructions(
-                            resource_params)
+                            resource_params
+                          )
                         end
       end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -7,7 +7,8 @@ UserDecorator = Struct.new(:user) do
 
   def lockout_time_remaining_in_words
     distance_of_time_in_words(
-      Time.zone.now, Time.zone.now + lockout_time_remaining, true, highest_measures: 2)
+      Time.zone.now, Time.zone.now + lockout_time_remaining, true, highest_measures: 2
+    )
   end
 
   def confirmation_period_expired_error
@@ -16,7 +17,8 @@ UserDecorator = Struct.new(:user) do
 
   def confirmation_period
     distance_of_time_in_words(
-      Time.zone.now, Time.zone.now + Devise.confirm_within, true, accumulate_on: :hours)
+      Time.zone.now, Time.zone.now + Devise.confirm_within, true, accumulate_on: :hours
+    )
   end
 
   def first_sentence_for_confirmation_email

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -11,7 +11,8 @@ DEFAULT_OPTIONS = {
   certificate: File.read("#{Rails.root}/certs/saml_cert.crt"),
   private_key: OpenSSL::PKey::RSA.new(
     File.read(Rails.root + 'keys/saml.key.enc'),
-    Figaro.env.saml_passphrase).to_pem,
+    Figaro.env.saml_passphrase
+  ).to_pem,
   assertion_consumer_service_url: "https://#{Figaro.env.domain_name}/users/auth/saml/callback",
   assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
   authn_context: 'http://idmanagement.gov/ns/assurance/loa/2',

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -7,7 +7,8 @@ SamlIdp.configure do |config|
   config.x509_certificate = File.read("#{Rails.root}/certs/saml_cert.crt")
   config.secret_key = OpenSSL::PKey::RSA.new(
     File.read(Rails.root + 'keys/saml.key.enc'),
-    Figaro.env.saml_passphrase).to_pem
+    Figaro.env.saml_passphrase
+  ).to_pem
 
   config.algorithm = OpenSSL::Digest::SHA256
   # config.signature_alg = 'rsa-sha256'

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -21,7 +21,8 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         sign_in user
         user.send_two_factor_authentication_code
         user.update(
-          second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds)
+          second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds
+        )
         user.update(second_factor_attempts_count: 3)
       end
 

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -409,7 +409,8 @@ describe Users::RegistrationsController, devise: true do
       put(
         :update,
         update_user_profile_form: attrs_with_already_taken_mobile.merge!(
-          email: second_user.email, mobile: '703')
+          email: second_user.email, mobile: '703'
+        )
       )
 
       expect(flash).to be_empty

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -73,7 +73,8 @@ describe Users::SessionsController, devise: true do
       expect(response.request.env['rack.session']['flash']['flashes']).to(
         have_text(
           t('upaya.session_timedout',
-            session_timeout: distance_of_time_in_words(Devise.timeout_in)))
+            session_timeout: distance_of_time_in_words(Devise.timeout_in))
+        )
       )
     end
 

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -289,7 +289,8 @@ feature 'Sign Up', devise: true do
 
     expect(current_path).to eq user_confirmation_path
     expect(page).to have_content t(
-      'errors.messages.confirmation_period_expired', period: '24 hours')
+      'errors.messages.confirmation_period_expired', period: '24 hours'
+    )
   end
 
   # Scenario: Visitor signs up but confirms with an invalid token
@@ -301,7 +302,8 @@ feature 'Sign Up', devise: true do
     raw_confirmation_token = Devise.token_generator.generate(User, :confirmation_token)
 
     User.last.update(
-      confirmation_token: raw_confirmation_token, confirmation_sent_at: Time.current)
+      confirmation_token: raw_confirmation_token, confirmation_sent_at: Time.current
+    )
     visit '/users/confirmation?confirmation_token=invalid_token'
 
     expect(page).to have_content 'Confirmation token is invalid'

--- a/spec/jobs/sms_sender_otp_job_spec.rb
+++ b/spec/jobs/sms_sender_otp_job_spec.rb
@@ -22,7 +22,8 @@ describe SmsSenderOtpJob, sms: true do
           :user,
           :with_mobile,
           otp_secret_key: 'lzmh6ekrnc5i6aaq',
-          unconfirmed_mobile: '7035551212')
+          unconfirmed_mobile: '7035551212'
+        )
 
         SmsSenderOtpJob.perform_now(user)
 
@@ -39,7 +40,8 @@ describe SmsSenderOtpJob, sms: true do
         user = build_stubbed(
           :user,
           otp_secret_key: 'lzmh6ekrnc5i6aaq',
-          unconfirmed_mobile: '7035551212')
+          unconfirmed_mobile: '7035551212'
+        )
 
         SmsSenderOtpJob.perform_now(user)
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -18,7 +18,8 @@ describe UserMailer, type: :mailer do
       expect(mail.body).
         to have_content(
           'You have asked Upaya to change the email address currently associated with your ' \
-          'Upaya Account')
+          'Upaya Account'
+        )
     end
   end
 
@@ -37,7 +38,8 @@ describe UserMailer, type: :mailer do
       expect(mail.body).
         to have_content(
           'You have asked Upaya to change the password currently associated with your ' \
-          'Upaya Account')
+          'Upaya Account'
+        )
     end
   end
 

--- a/spec/services/otp_sender_spec.rb
+++ b/spec/services/otp_sender_spec.rb
@@ -17,7 +17,8 @@ describe UserOtpSender do
     context 'when user is two_factor_enabled and has an unconfirmed_mobile' do
       it 'generates a new OTP and only sends OTP to unconfirmed_mobile' do
         user = build_stubbed(
-          :user, unconfirmed_mobile: '5005550006', otp_secret_key: 'lzmh6ekrnc5i6aaq')
+          :user, unconfirmed_mobile: '5005550006', otp_secret_key: 'lzmh6ekrnc5i6aaq'
+        )
 
         allow(user).to receive(:two_factor_enabled?).and_return(true)
 

--- a/spec/support/fake_idpaas.rb
+++ b/spec/support/fake_idpaas.rb
@@ -30,7 +30,9 @@ class FakeIdpaas < Sinatra::Base
         ],
         helpMessage: 'This is the help message',
         helpImageUrl: 'http://localhost:8080/idpaas/help-image/'\
-          '22619919-2adb-5825-1cf4-06e1d4a9e11b.jpg' } }.to_json
+          '22619919-2adb-5825-1cf4-06e1d4a9e11b.jpg'
+      }
+    }.to_json
   end
 
   get '/idpaas/user/:user_uuid/' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -49,7 +49,8 @@ module Features
       @raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
 
       User.last.update(
-        confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current)
+        confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current
+      )
       visit "/users/confirmation?confirmation_token=#{@raw_confirmation_token}"
     end
   end

--- a/spec/support/idpaas_responses_helper.rb
+++ b/spec/support/idpaas_responses_helper.rb
@@ -68,9 +68,7 @@ module IdpaasResponsesHelper
           { key: 3, text: '21917' },
           { key: 4, text: '21802' },
           { key: 5, text: 'NONE OF THE ABOVE' }
-        ]
-      }
-    }.to_json
+        ] } }.to_json
   end
 
   def response_without_help_with_nulls
@@ -86,9 +84,7 @@ module IdpaasResponsesHelper
           ],
           helpMessage: nil,
           helpUuid: nil,
-          helpImageUrl: nil
-        }
-    }.to_json
+          helpImageUrl: nil } }.to_json
   end
 
   # Responses below return HTTP 404 status code

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -184,7 +184,8 @@ module SamlAuthHelper
       OneLogin::RubySaml::Response.new(
         Nokogiri::HTML(response.body).at_css('#SAMLResponse')['value'],
         private_key: key,
-        private_key_password: '').response
+        private_key_password: ''
+      ).response
     )
   end
 

--- a/spec/support/saml_response_helper.rb
+++ b/spec/support/saml_response_helper.rb
@@ -71,8 +71,7 @@ module SamlResponseHelper
     def logout_asserted_session_index
       response_doc.xpath('//samlp:LogoutRequest/samlp:SessionIndex',
                          samlp: Saml::XML::Namespaces::PROTOCOL,
-                         saml: Saml::XML::Namespaces::ASSERTION
-                        )[0].content
+                         saml: Saml::XML::Namespaces::ASSERTION)[0].content
     end
 
     def issuer_nodeset
@@ -164,8 +163,7 @@ module SamlResponseHelper
     def asserted_session_index
       response_doc.xpath('//samlp:LogoutRequest/samlp:SessionIndex',
                          samlp: Saml::XML::Namespaces::PROTOCOL,
-                         saml: Saml::XML::Namespaces::ASSERTION
-                        )[0].content
+                         saml: Saml::XML::Namespaces::ASSERTION)[0].content
     end
   end
 end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -13,7 +13,8 @@ shared_context 'rake' do
   before do
     Rake.application = rake
     Rake.application.rake_require(
-      task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+      task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file
+    )
 
     Rake::Task.define_task(:environment)
   end

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -15,7 +15,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     render
 
     expect(rendered).to have_link(
-      'https://upaya.18f.gov/contact', href: 'https://upaya.18f.gov/contact')
+      'https://upaya.18f.gov/contact', href: 'https://upaya.18f.gov/contact'
+    )
   end
 
   it 'includes a link to confirmation' do
@@ -25,7 +26,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
 
     expect(rendered).to have_link(
       'http://test.host/users/confirmation?confirmation_token=foo',
-      href: 'http://test.host/users/confirmation?confirmation_token=foo')
+      href: 'http://test.host/users/confirmation?confirmation_token=foo'
+    )
   end
 
   it 'includes a request to not reply to this messsage' do

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -24,6 +24,7 @@ describe 'devise/sessions/new.html.slim' do
 
     expect(rendered).
       to have_link(
-        t('upaya.links.create_new_account'), href: new_user_registration_path)
+        t('upaya.links.create_new_account'), href: new_user_registration_path
+      )
   end
 end

--- a/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
@@ -11,7 +11,8 @@ describe 'devise/two_factor_authentication/max_login_attempts_reached.html.slim'
 
       expect(rendered).to include(
         t('devise.two_factor_authentication.max_login_attempts_reached',
-          time_remaining: '10 minutes'))
+          time_remaining: '10 minutes')
+      )
     end
   end
 end


### PR DESCRIPTION
**Why**: To get rid of the noise when running rubocop. We recently
upgraded the Rubocop gem, which is now flagging style issues with the
placement of closing parentheses.