### PR TITLE
Revert "Update Overcommit config to fail on warnings"

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -33,9 +33,6 @@ PreCommit:
     include: '**/*.slim'
 
 CommitMsg:
-  ALL:
-    on_warn: 'fail'
-
   MessageFormat:
     enabled: true
     description: 'Check commit message matches expected pattern'


### PR DESCRIPTION
This reverts commit ef39ba3ec2576dce55c9bdd16f52db96d2bbf5a1.

**Why**: Turning warnings into errors for every commit
had some unindented consequences.
a) It makes it impossible to commit localy changes without a
fully formed commit message.
b) It makes it hard/impossible to use tools that generate
or work with commits.
c) Invalid commit messages are disgarded so its easy to loose
work when writing commit messages.

In an ideal world these rules would be enforced only when
pushing commits to the remote and not at local commit time,
but I'm not sure there is way to enfore commit checks at
push time with overcommit.