### PR TITLE
Update two_factor_auth gem and enable direct OTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'turbolinks'
 gem 'twilio-ruby'
-gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication'
+gem 'two_factor_authentication', github: 'sbc100/two_factor_authentication', branch: 'direct_codes'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', require: false
 gem 'xmlenc', '~> 0.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,14 @@
 GIT
-  remote: https://github.com/Houdini/two_factor_authentication.git
-  revision: 675f651929b7a09bb59169bf4206a10895c2b9d9
+  remote: https://github.com/monfresh/sms-spec.git
+  revision: 786238c1924c055d16a4963abb329c9b985ce104
+  specs:
+    sms-spec (0.2.0)
+      rspec (~> 3.1)
+
+GIT
+  remote: https://github.com/sbc100/two_factor_authentication.git
+  revision: 06c67df575d99fd51a62427d696d6e1211d4b7b5
+  branch: direct_codes
   specs:
     two_factor_authentication (1.1.5)
       devise
@@ -8,13 +16,6 @@ GIT
       rails (>= 3.1.1)
       randexp
       rotp
-
-GIT
-  remote: https://github.com/monfresh/sms-spec.git
-  revision: 786238c1924c055d16a4963abb329c9b985ce104
-  specs:
-    sms-spec (0.2.0)
-      rspec (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -322,7 +323,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.1.2)
+    rake (11.2.2)
     randexp (0.1.7)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -8,7 +8,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   before_action :handle_two_factor_authentication
 
   def new
-    current_user.send_two_factor_authentication_code
+    current_user.send_new_otp
     set_flash_message :success, 'new_otp_sent'
     redirect_to user_two_factor_authentication_path
   end

--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -34,7 +34,7 @@ module Devise
     def process_valid_form
       update_metrics
 
-      resource.send_two_factor_authentication_code
+      resource.send_new_otp
 
       flash[:success] = t('devise.two_factor_authentication.please_confirm')
       redirect_to user_two_factor_authentication_path

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -56,7 +56,7 @@ module Users
     end
 
     def process_redirection(resource)
-      resource.send_two_factor_authentication_code unless @update_user_profile_form.mobile_taken?
+      resource.send_new_otp unless @update_user_profile_form.mobile_taken?
 
       redirect_to user_two_factor_authentication_path
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
     mobile_confirmed_at.present?
   end
 
-  def send_two_factor_authentication_code
+  def send_two_factor_authentication_code(_code)
     UserOtpSender.new(self).send_otp
   end
 

--- a/app/services/user_otp_sender.rb
+++ b/app/services/user_otp_sender.rb
@@ -6,9 +6,9 @@ class UserOtpSender
   def send_otp
     return if @user.second_factor_locked?
 
-    generate_new_otp if @user.unconfirmed_mobile.present?
+    @user.create_direct_otp if @user.unconfirmed_mobile.present?
 
-    SmsSenderOtpJob.perform_later(@user.otp_code, target_number)
+    SmsSenderOtpJob.perform_later(@user.direct_otp, target_number)
   end
 
   # This method is executed by the two_factor_authentication gem upon login
@@ -21,9 +21,5 @@ class UserOtpSender
 
   def target_number
     UserDecorator.new(@user).two_factor_phone_number
-  end
-
-  def generate_new_otp
-    @user.update_columns(otp_secret_key: ROTP::Base32.random_base32)
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,4 +266,5 @@ Devise.setup do |config|
   config.allowed_otp_drift_seconds = 600
   config.max_login_attempts = 3 # max OTP login attemps, not devise strategies (e.g. pw auth)
   config.otp_length = 8
+  config.direct_otp_length = 8
 end

--- a/db/migrate/20160517184709_add_direct_otp_to_users.rb
+++ b/db/migrate/20160517184709_add_direct_otp_to_users.rb
@@ -1,0 +1,6 @@
+class AddDirectOtpToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :direct_otp, :string
+    add_column :users, :direct_otp_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,8 @@ ActiveRecord::Schema.define(version: 20160524231157) do
     t.string   "encrypted_otp_secret_key",      limit: 255
     t.string   "encrypted_otp_secret_key_iv",   limit: 255
     t.string   "encrypted_otp_secret_key_salt", limit: 255
+    t.string   "direct_otp"
+    t.datetime "direct_otp_sent_at"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -7,19 +7,19 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
     context 'when user has not changed their number' do
       it 'does not perform SmsSenderNumberChangeJob' do
         sign_in user
-        user.send_two_factor_authentication_code
+        user.send_new_otp
 
         expect(SmsSenderNumberChangeJob).
           to_not receive(:perform_later).with(user)
 
-        patch :update, code: user.otp_code
+        patch :update, code: user.direct_otp
       end
     end
 
     context 'when resource is no longer OTP locked out' do
       before do
         sign_in user
-        user.send_two_factor_authentication_code
+        user.send_new_otp
         user.update(
           second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds
         )
@@ -33,7 +33,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'resets second_factor_locked_at when user submits correct code' do
-        patch :update, code: user.otp_code
+        patch :update, code: user.direct_otp
 
         expect(user.reload.second_factor_locked_at).to be_nil
       end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -175,7 +175,7 @@ describe Users::RegistrationsController, devise: true do
       )
 
       expect(SmsSenderOtpJob).to have_received(:perform_later).
-        with(user.reload.otp_code, '+1 (555) 555-5555')
+        with(user.reload.direct_otp, '+1 (555) 555-5555')
     end
   end
 

--- a/spec/features/app_settings/performance_testing_mode_spec.rb
+++ b/spec/features/app_settings/performance_testing_mode_spec.rb
@@ -21,7 +21,7 @@ feature 'Performance Testing Mode', devise: true do
 
     scenario 'allows user to enter their unique OTP during login' do
       sign_in_user(user)
-      fill_in 'code', with: user.otp_code
+      fill_in 'code', with: user.reload.direct_otp
       click_button 'Submit'
       expect(current_path).to eq dashboard_index_path
     end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -89,7 +89,7 @@ feature 'Two Factor Authentication', devise: true do
         end
 
         it 'does not allow user to access OTP setup page after entering valid OTP' do
-          fill_in 'code', with: @user.otp_code
+          fill_in 'code', with: @user.reload.direct_otp
           click_button 'Submit'
           visit users_otp_path
 
@@ -97,7 +97,7 @@ feature 'Two Factor Authentication', devise: true do
         end
 
         it 'does not allow user to access OTP prompt page after entering valid OTP' do
-          fill_in 'code', with: @user.otp_code
+          fill_in 'code', with: @user.reload.direct_otp
           click_button 'Submit'
           visit user_two_factor_authentication_path
 
@@ -132,18 +132,19 @@ feature 'Two Factor Authentication', devise: true do
         # With 2fa, you are signed in but blocked on an otp challenge.
         expect(page).to have_content I18n.t 'devise.sessions.signed_in'
         expect(page).to have_content 'A one-time passcode has been sent'
+        user.reload
 
         # Reach straight to the model to re-retrieve the OTP for testing
         # access checks of this feature. Lets us exclude testing the
         # sending logic.
-        fill_in 'code', with: user.otp_code + 'invalidate_me'
+        fill_in 'code', with: 'invalid_otp'
         click_button 'Submit'
         expect(page).to have_content I18n.t('devise.two_factor_authentication.attempt_failed')
         expect(page).to have_content I18n.t('devise.two_factor_authentication.header_text')
         user.reload
         expect(user.second_factor_attempts_count).to equal(1)
 
-        fill_in 'code', with: user.otp_code
+        fill_in 'code', with: user.direct_otp
         click_button 'Submit'
         user.reload
 

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -9,7 +9,7 @@ feature 'User edit' do
     user = create(:user, :signed_up)
 
     sign_in_user(user)
-    fill_in 'code', with: user.otp_code
+    fill_in 'code', with: user.reload.direct_otp
     click_button 'Submit'
 
     visit edit_user_registration_path
@@ -24,7 +24,7 @@ feature 'User edit' do
     user = create(:user, :signed_up)
 
     sign_in_user(user)
-    fill_in 'code', with: user.otp_code
+    fill_in 'code', with: user.reload.direct_otp
     click_button 'Submit'
 
     visit edit_user_registration_path

--- a/spec/features/users/user_show_spec.rb
+++ b/spec/features/users/user_show_spec.rb
@@ -16,7 +16,7 @@ feature 'User profile page', devise: true do
     expect(page).
       to have_content t('devise.two_factor_authentication.header_text')
 
-    fill_in 'code', with: user.otp_code
+    fill_in 'code', with: user.direct_otp
     click_button 'Submit'
 
     visit user_path(user)

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -166,7 +166,7 @@ feature 'Password Recovery' do
       sign_up_with_and_set_password_for('email@example.com')
       fill_in 'Mobile', with: '5555555555'
       click_button 'Submit'
-      fill_in 'code', with: User.last.otp_code
+      fill_in 'code', with: User.last.direct_otp
       click_button 'Submit'
       click_link(t('upaya.headings.log_out'), match: :first)
       visit root_path
@@ -183,7 +183,7 @@ feature 'Password Recovery' do
 
     it 'redirects user to dashboard after signing back in' do
       reset_password_and_sign_back_in
-      fill_in 'code', with: User.last.otp_code
+      fill_in 'code', with: User.last.direct_otp
       click_button 'Submit'
 
       expect(current_path).to eq dashboard_index_path

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -56,7 +56,7 @@ feature 'Sign Up', devise: true do
     end
 
     it 'updates mobile_confirmed_at and redirects to dashboard after confirmation' do
-      fill_in 'Secure one-time password', with: @user.otp_code
+      fill_in 'Secure one-time password', with: @user.direct_otp
       click_button 'Submit'
 
       expect(@user.reload.mobile_confirmed_at).to be_present

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require 'saml_idp_constants'
 
 MAX_GOOD_PASSWORD = '!1aZ' * 32
@@ -271,23 +272,32 @@ describe User do
       expect(UserOtpSender).to receive(:new).with(user).and_return(otp_sender)
       expect(otp_sender).to receive(:send_otp)
 
-      user.send_two_factor_authentication_code
+      user.send_two_factor_authentication_code(123)
     end
   end
 
   describe 'OTP length' do
     it 'uses Devise setting when set' do
-      allow(Devise).to receive(:otp_length).and_return(10)
-      user = build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq')
+      allow(Devise).to receive(:direct_otp_length).and_return(10)
+      user = build(:user)
+      user.send_new_otp
 
-      expect(user.otp_code.length).to eq 10
+      expect(user.direct_otp.length).to eq 10
     end
 
     it 'defaults to 6 when Devise setting is not set' do
-      allow(Devise).to receive(:otp_length).and_return(nil)
-      user = build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq')
+      allow(Devise).to receive(:direct_otp_length).and_return(nil)
+      user = build(:user)
+      user.send_new_otp
 
-      expect(user.otp_code.length).to eq 6
+      expect(user.direct_otp.length).to eq 6
+    end
+
+    it 'is set to 8' do
+      user = build(:user)
+      user.send_new_otp
+
+      expect(user.direct_otp.length).to eq 8
     end
   end
 end

--- a/spec/services/otp_sender_spec.rb
+++ b/spec/services/otp_sender_spec.rb
@@ -4,18 +4,18 @@ describe UserOtpSender do
   describe '#send_otp' do
     context 'when user does not have unconfirmed_mobile' do
       it 'sends OTP to mobile' do
-        user = build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq')
+        user = build_stubbed(:user, direct_otp: '1234')
 
-        expect(SmsSenderOtpJob).to receive(:perform_later).with(user.otp_code, user.mobile)
+        expect(SmsSenderOtpJob).to receive(:perform_later).with('1234', user.mobile)
 
         UserOtpSender.new(user).send_otp
       end
     end
 
     context 'when user has an unconfirmed_mobile' do
-      it 'generates a new otp_secret_key and sends OTP to unconfirmed_mobile' do
-        user = build_stubbed(
-          :user, unconfirmed_mobile: '5005550006', otp_secret_key: 'lzmh6ekrnc5i6aaq'
+      it 'generates a new OTP and only sends OTP to unconfirmed_mobile' do
+        user = build(
+          :user, unconfirmed_mobile: '5005550006', direct_otp: '1234'
         )
 
         allow(SmsSenderOtpJob).to receive(:perform_later)
@@ -23,9 +23,9 @@ describe UserOtpSender do
         UserOtpSender.new(user).send_otp
 
         expect(SmsSenderOtpJob).to have_received(:perform_later).
-          with(user.otp_code, user.unconfirmed_mobile)
+          with(user.direct_otp, user.unconfirmed_mobile)
 
-        expect(user.otp_secret_key).to_not eq 'lzmh6ekrnc5i6aaq'
+        expect(user.direct_otp).to_not eq '1234'
       end
     end
   end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -57,7 +57,7 @@ module Features
       user = sign_up_with_and_set_password_for(email, reset_session)
       fill_in 'Mobile', with: '202-555-1212'
       click_button 'Submit'
-      fill_in 'code', with: user.reload.otp_code
+      fill_in 'code', with: user.reload.direct_otp
       click_button 'Submit'
       user
     end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -142,7 +142,7 @@ module SamlAuthHelper
 
   def authenticate_user(user = create(:user, :signed_up))
     sign_in_user(user)
-    fill_in 'code', with: user.otp_code
+    fill_in 'code', with: user.reload.direct_otp
     click_button 'Submit'
   end
 end


### PR DESCRIPTION
**Why**: Basic OTP delivery via SMS or Voice doesn't require
the use of TOTP.  In fact using TOTP for these
complicates things and forces us to use a high drift factor.
After this change, we can separate the use of TOTP from regular
direct OTPs.