### PR TITLE
Add brakeman to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'rails', '~> 4.2.6'
 
@@ -17,7 +18,7 @@ gem 'valid_email'
 gem 'rack-attack'
 gem 'ruby-saml'
 gem 'nokogiri-xmlsec-me-harder', '~> 0.9.1', require: 'xmlsec'
-gem 'saml_idp', git: 'https://github.com/pkarman/saml_idp', branch: 'logout-request-builder'
+gem 'saml_idp', github: 'pkarman/saml_idp', branch: 'logout-request-builder'
 gem 'sass-rails', '~> 5.0'
 gem 'secure_headers', '~> 3.0'
 gem 'sidekiq'
@@ -26,7 +27,7 @@ gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'turbolinks'
 gem 'twilio-ruby'
-gem 'two_factor_authentication', git: 'https://github.com/Houdini/two_factor_authentication'
+gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', require: false
 gem 'activerecord-session_store', '1.0.0.pre'
@@ -40,15 +41,16 @@ end
 
 group :development do
   gem 'better_errors'
-  gem 'bummr'
+  gem 'brakeman', require: false
+  gem 'bummr', require: false
   gem 'derailed'
   gem 'binding_of_caller'
   gem 'guard-rspec', require: false
-  gem 'overcommit'
+  gem 'overcommit', require: false
   gem 'quiet_assets'
   gem 'rack-mini-profiler'
   gem 'rails_layout'
-  gem 'rubocop'
+  gem 'rubocop', require: false
   gem 'slim_lint'
   gem 'spring'
   gem 'spring-commands-rspec'
@@ -60,12 +62,12 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.3'
   gem 'thin'
   gem 'bullet'
-  gem 'mailcatcher'
+  gem 'mailcatcher', require: false
 end
 
 group :test do
   gem 'capybara-screenshot'
-  gem 'codeclimate-test-reporter', require: nil
+  gem 'codeclimate-test-reporter', require: false
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'factory_girl_rails'
@@ -74,7 +76,7 @@ group :test do
   gem 'rack_session_access'
   gem 'rack-test'
   gem 'shoulda-matchers', '~> 2.8', require: false
-  gem 'sms-spec', git: 'https://github.com/monfresh/sms-spec.git', require: 'sms_spec'
+  gem 'sms-spec', github: 'monfresh/sms-spec', require: 'sms_spec'
   gem 'test_after_commit'
   gem 'timecop'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,5 @@
 GIT
-  remote: git://github.com/amoose/omniauth-saml.git
-  revision: 06c019e451db4eb769bf40fcba2b092091fe7d4a
-  branch: feature/internal_idp
-  specs:
-    omniauth-saml (1.3.0)
-      omniauth (~> 1.2)
-
-GIT
-  remote: https://github.com/Houdini/two_factor_authentication
+  remote: https://github.com/Houdini/two_factor_authentication.git
   revision: 675f651929b7a09bb59169bf4206a10895c2b9d9
   specs:
     two_factor_authentication (1.1.5)
@@ -18,6 +10,14 @@ GIT
       rotp
 
 GIT
+  remote: https://github.com/amoose/omniauth-saml.git
+  revision: 06c019e451db4eb769bf40fcba2b092091fe7d4a
+  branch: feature/internal_idp
+  specs:
+    omniauth-saml (1.3.0)
+      omniauth (~> 1.2)
+
+GIT
   remote: https://github.com/monfresh/sms-spec.git
   revision: 786238c1924c055d16a4963abb329c9b985ce104
   specs:
@@ -25,7 +25,7 @@ GIT
       rspec (~> 3.1)
 
 GIT
-  remote: https://github.com/pkarman/saml_idp
+  remote: https://github.com/pkarman/saml_idp.git
   revision: 693ef99be920e4bc7ca57c6a764d1c740e154094
   branch: logout-request-builder
   specs:
@@ -92,6 +92,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    brakeman (3.3.1)
     browserify-rails (3.1.0)
       railties (>= 4.0.0, < 5.1)
       sprockets (>= 3.5.2)
@@ -494,6 +495,7 @@ DEPENDENCIES
   activerecord-session_store (= 1.0.0.pre)
   better_errors
   binding_of_caller
+  brakeman
   browserify-rails
   bullet
   bummr

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ To run all the tests:
 See RSpec [docs](https://relishapp.com/rspec/rspec-core/docs/command-line) for
 more information.
 
+Run security scanner
+
+    $ bundle exec brakeman
+
 ### Deploying
 
 We currently run `dev` and `qa` environments at https://upaya-idp-dev.18f.gov


### PR DESCRIPTION
**Why**: So developers can run brakeman locally

Also, add `require: false` to several gems that are
not need at runtime (e.g. command line tools).