### PR TITLE
Add support for generating code coverage report locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 if ENV['TRAVIS']
   require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
+elsif ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start 'rails'
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
**Why**: Its useful to be able to run coverage locally
when fixing coverage regressions or working to improve
coverage.

**How**: Call SimpleCov.start in the spec_helper if run
with COVERAGE environment variable set.