### PR TITLE
Add password strength indicator js (zxcvbn)

### DIFF
--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -1,0 +1,41 @@
+import zxcvbn from 'zxcvbn';
+
+
+// zxcvbn returns a strength score from 0 to 4
+// we map those scores to:
+// 1. a CSS class to the pw strength module
+// 2. text describing the score
+const scale = {
+  0: ['pw-very-weak', 'Very weak'],
+  1: ['pw-weak', 'Weak'],
+  2: ['pw-so-so', 'So-so'],
+  3: ['pw-good', 'Good'],
+  4: ['pw-great', 'Great'],
+};
+
+// fallback result if pw field is empty or zxcvbn lookup fails
+const fallback = ['pw-na', 'Password strength'];
+
+
+function analyzePw() {
+  const input = document.getElementById('password_form_password');
+  const pwCntnr = document.getElementById('pw-strength-cntnr');
+  const pwTxt = document.getElementById('pw-feedback');
+
+  // the pw strength module is hidden by default ("hide" CSS class)
+  // (so that javascript disabled browsers won't see it)
+  // thus, first step is unhiding it
+  pwCntnr.className = '';
+
+  input.addEventListener('keyup', function(e) {
+    const val = e.target.value;
+    const z = zxcvbn(val);
+    const result = val.length && z ? scale[z.score] : fallback;
+
+    pwCntnr.className = result[0];
+    pwTxt.innerHTML = result[1];
+  });
+}
+
+
+document.addEventListener('DOMContentLoaded', analyzePw);

--- a/app/assets/stylesheets/components/_password.scss
+++ b/app/assets/stylesheets/components/_password.scss
@@ -1,0 +1,36 @@
+$weak: #e80e0e;
+$so-so: #ffac00;
+$good: #9ac056;
+$great: #00b200;
+
+// scss-lint:disable IdSelector
+#pw-strength-cntnr { margin-top: -.75rem; }
+
+.pw-bar {
+  background-color: #e9e9e9;
+  border: 2px solid #fff;
+  box-sizing: border-box;
+  float: left;
+  height: 12px;
+  width: 25%;
+}
+
+.pw-weak {
+  color: $weak;
+  .pw-bar:nth-child(-n+1) { background-color: $weak; }
+}
+
+.pw-so-so {
+  color: $so-so;
+  .pw-bar:nth-child(-n+2) { background-color: $so-so; }
+}
+
+.pw-good {
+  color: $good;
+  .pw-bar:nth-child(-n+3) { background-color: $good; }
+}
+
+.pw-great {
+  color: $great;
+  .pw-bar { background-color: $great; }
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -5,4 +5,5 @@
 @import 'form';
 @import 'override';
 @import 'panel';
+@import 'password';
 @import 'util';

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -13,6 +13,9 @@
           html: { role: 'form', autocomplete: 'off' }) do |f|
         = f.error_notification
         = f.input :password, required: true, input_html: { autofocus: true }
+        = render 'devise/shared/password_strength'
         = f.input :password_confirmation, required: true
         = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
         = f.button :submit, 'Submit'
+
+== javascript_include_tag 'misc/pw-strength'

--- a/app/views/devise/shared/_password_strength.html.slim
+++ b/app/views/devise/shared/_password_strength.html.slim
@@ -1,0 +1,8 @@
+#pw-strength-cntnr.hide
+  .mb2
+    .clearfix
+      .pw-bar
+      .pw-bar
+      .pw-bar
+      .pw-bar
+    #pw-feedback.h6.right-align = 'Password strength'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(misc/saml-post.js)
+Rails.application.config.assets.precompile += %w(misc/*.js)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "npm": "~3.8.x"
   },
   "dependencies": {
-    "jquery": "^2.2.3"
+    "jquery": "^2.2.3",
+    "zxcvbn": "^4.3.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -206,6 +206,34 @@ feature 'Sign Up', devise: true do
     end
   end
 
+  scenario 'password strength indicator hidden when JS is off' do
+    sign_up_with('test@example.com')
+    confirm_last_user
+
+    expect(page).to have_css('#pw-strength-cntnr.hide')
+  end
+
+  context 'password strength indicator when JS is on', js: true do
+    before do
+      User.create!(email: 'test@example.com')
+      confirm_last_user
+    end
+
+    it 'is visible on page (not have "hide" class)' do
+      expect(page).to_not have_css('#pw-strength-cntnr.hide')
+    end
+
+    it 'updates as password changes' do
+      expect(page).to have_content 'Password strength'
+
+      fill_in 'password_form_password', with: 'password'
+      expect(page).to have_content 'Very weak'
+
+      fill_in 'password_form_password', with: 'this is a great sentence'
+      expect(page).to have_content 'Great'
+    end
+  end
+
   scenario 'visitor is redirected back to password form when password is invalid' do
     sign_up_with('test@example.com')
     confirm_last_user


### PR DESCRIPTION
**Why**:
To inform the user about the strength / guessability
of their password as they type it

**How**:
Uses https://github.com/dropbox/zxcvbn library;
js file is only loaded on relevant page and after
main content (since file is large [800kb uncompressed])

**Preview**:
![demo](http://f.cl.ly/items/1a1o120J1s3w1p1p3X07/Screen%20Recording%202016-06-03%20at%2003.02%20PM.gif)
