### PR TITLE
Fix session timeout message padding

### DIFF
--- a/app/views/layouts/_messages.html.slim
+++ b/app/views/layouts/_messages.html.slim
@@ -9,4 +9,4 @@
               '&times;
             = msg
 
-#session-timeout-cntnr.p2
+#session-timeout-cntnr

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -1,4 +1,5 @@
-#session-timeout-msg.bg-white.border.p2
-  .h3.bold.mb1 = t('upaya.headings.session_timeout_warning')
-  p = t('upaya.session_timeout_warning', time_left_in_session: time_left_in_session, continue_text: t('upaya.forms.buttons.continue_browsing'))
-  = link_to t('upaya.forms.buttons.continue_browsing'), request.original_url, class: 'btn btn-primary'
+#session-timeout-msg.p2
+  .p2.bg-white.border
+    .h3.bold.mb1 = t('upaya.headings.session_timeout_warning')
+    p = t('upaya.session_timeout_warning', time_left_in_session: time_left_in_session, continue_text: t('upaya.forms.buttons.continue_browsing'))
+    = link_to t('upaya.forms.buttons.continue_browsing'), request.original_url, class: 'btn btn-primary'


### PR DESCRIPTION
**Why**: fixes superfluous padding when no timeout msg present,
(moves it within the container)