### PR TITLE
Add password strength to edit page

### DIFF
--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -14,6 +14,9 @@
         = f.input :reset_password_token, as: :hidden
         = f.full_error :reset_password_token
         = f.input :password, label: 'New password', required: true, autofocus: true
+        = render 'devise/shared/password_strength'
         = f.input :password_confirmation, label: 'Confirm your new password', required: true
         = f.button :submit, 'Change my password'
       = render 'devise/shared/links'
+
+== javascript_include_tag 'misc/pw-strength'


### PR DESCRIPTION
**Why**: to inform user of password strength if they need to create new one