### PR TITLE
Switch SmsSenderOtpJob to take PORO rather than User model

### DIFF
--- a/app/jobs/sms_sender_existing_mobile_job.rb
+++ b/app/jobs/sms_sender_existing_mobile_job.rb
@@ -2,8 +2,7 @@ class SmsSenderExistingMobileJob < ActiveJob::Base
   queue_as :sms
 
   def perform(mobile)
-    twilio_service = TwilioService.new
-    send(:existing_mobile, twilio_service, mobile)
+    existing_mobile(TwilioService.new, mobile)
   end
 
   private

--- a/app/jobs/sms_sender_number_change_job.rb
+++ b/app/jobs/sms_sender_number_change_job.rb
@@ -2,8 +2,7 @@ class SmsSenderNumberChangeJob < ActiveJob::Base
   queue_as :sms
 
   def perform(mobile)
-    twilio_service = TwilioService.new
-    send(:number_change, twilio_service, mobile)
+    number_change(TwilioService.new, mobile)
   end
 
   private

--- a/app/jobs/sms_sender_otp_job.rb
+++ b/app/jobs/sms_sender_otp_job.rb
@@ -1,22 +1,17 @@
 class SmsSenderOtpJob < ActiveJob::Base
   queue_as :sms
 
-  def perform(user)
-    twilio_service = TwilioService.new
-    send(:otp, twilio_service, user)
+  def perform(code, mobile)
+    send_otp(TwilioService.new, code, mobile)
   end
 
   private
 
-  def otp(twilio_service, user)
+  def send_otp(twilio_service, code, mobile)
     twilio_service.send_sms(
-      to: target_number_for(user),
-      body: otp_message(user.otp_code)
+      to: mobile,
+      body: otp_message(code)
     )
-  end
-
-  def target_number_for(user)
-    UserDecorator.new(user).two_factor_phone_number
   end
 
   def otp_message(code)

--- a/app/services/user_otp_sender.rb
+++ b/app/services/user_otp_sender.rb
@@ -8,7 +8,7 @@ class UserOtpSender
 
     generate_new_otp if @user.unconfirmed_mobile.present?
 
-    SmsSenderOtpJob.perform_later(@user)
+    SmsSenderOtpJob.perform_later(@user.otp_code, target_number)
   end
 
   # This method is executed by the two_factor_authentication gem upon login
@@ -18,6 +18,10 @@ class UserOtpSender
   end
 
   private
+
+  def target_number
+    UserDecorator.new(@user).two_factor_phone_number
+  end
 
   def generate_new_otp
     @user.update_columns(otp_secret_key: ROTP::Base32.random_base32)

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -167,12 +167,15 @@ describe Users::RegistrationsController, devise: true do
     before { sign_in(user) }
 
     it 'sends an OTP to unconfirmed mobile after update' do
-      expect(SmsSenderOtpJob).to receive(:perform_later).with(user)
+      allow(SmsSenderOtpJob).to receive(:perform_later)
 
       put(
         :update,
         update_user_profile_form: attrs_with_new_email_and_mobile
       )
+
+      expect(SmsSenderOtpJob).to have_received(:perform_later).
+        with(user.reload.otp_code, '+1 (555) 555-5555')
     end
   end
 

--- a/spec/jobs/sms_sender_existing_mobile_job_spec.rb
+++ b/spec/jobs/sms_sender_existing_mobile_job_spec.rb
@@ -1,15 +1,13 @@
 require 'rails_helper'
 
 describe SmsSenderExistingMobileJob, sms: true do
-  let(:user) { build_stubbed(:user, :with_mobile, otp_secret_key: 'lzmh6ekrnc5i6aaq') }
-
   describe '.perform' do
-    it 'sends existing mobile message to user.mobile' do
-      SmsSenderExistingMobileJob.perform_now(user.mobile)
+    it 'sends existing mobile message to mobile number' do
+      SmsSenderExistingMobileJob.perform_now('1234')
 
       expect(messages.size).to eq(1)
       msg = messages.first
-      expect(msg.number).to eq(user.mobile)
+      expect(msg.number).to eq('1234')
       expect(msg.body).to include('This number is already set up to receive one-time passwords')
     end
   end

--- a/spec/jobs/sms_sender_number_change_job_spec.rb
+++ b/spec/jobs/sms_sender_number_change_job_spec.rb
@@ -1,15 +1,13 @@
 require 'rails_helper'
 
 describe SmsSenderNumberChangeJob, sms: true do
-  let(:user) { build_stubbed(:user, :with_mobile, otp_secret_key: 'lzmh6ekrnc5i6aaq') }
-
   describe '.perform' do
-    it 'sends number change message to user.mobile' do
-      SmsSenderNumberChangeJob.perform_now(user.mobile)
+    it 'sends number change message to the mobile number' do
+      SmsSenderNumberChangeJob.perform_now('1234')
 
       expect(messages.size).to eq(1)
       msg = messages.first
-      expect(msg.number).to eq(user.mobile)
+      expect(msg.number).to eq('1234')
       expect(msg.body).to include('You have changed the phone number')
     end
   end

--- a/spec/jobs/sms_sender_otp_job_spec.rb
+++ b/spec/jobs/sms_sender_otp_job_spec.rb
@@ -1,56 +1,15 @@
 require 'rails_helper'
 
 describe SmsSenderOtpJob, sms: true do
-  let(:user) { build_stubbed(:user, :with_mobile, otp_secret_key: 'lzmh6ekrnc5i6aaq') }
-
   describe '.perform' do
-    context 'when the user has a mobile number and no unconfirmed number' do
-      it 'sends OTP message to the confirmed number' do
-        SmsSenderOtpJob.perform_now(user)
+    it 'sends a message containing the OTP code to the mobile number' do
+      SmsSenderOtpJob.perform_now('1234', '555-5555')
 
-        expect(messages.size).to eq(1)
-        msg = messages.first
-        expect(msg.number).to eq(user.mobile)
-        expect(msg.body).to include('secure one-time password')
-        expect(msg.body).to include(user.otp_code)
-      end
-    end
-
-    context 'when the user has a mobile number and an unconfirmed number' do
-      it 'sends OTP message to the unconfirmed number' do
-        user = build_stubbed(
-          :user,
-          :with_mobile,
-          otp_secret_key: 'lzmh6ekrnc5i6aaq',
-          unconfirmed_mobile: '7035551212'
-        )
-
-        SmsSenderOtpJob.perform_now(user)
-
-        expect(messages.size).to eq(1)
-        msg = messages.first
-        expect(msg.number).to eq('7035551212')
-        expect(msg.body).to include('secure one-time password')
-        expect(msg.body).to include(user.otp_code)
-      end
-    end
-
-    context 'when the user only has an unconfirmed number' do
-      it 'sends OTP message to the unconfirmed number' do
-        user = build_stubbed(
-          :user,
-          otp_secret_key: 'lzmh6ekrnc5i6aaq',
-          unconfirmed_mobile: '7035551212'
-        )
-
-        SmsSenderOtpJob.perform_now(user)
-
-        expect(messages.size).to eq(1)
-        msg = messages.first
-        expect(msg.number).to eq('7035551212')
-        expect(msg.body).to include('secure one-time password')
-        expect(msg.body).to include(user.otp_code)
-      end
+      expect(messages.size).to eq(1)
+      msg = messages.first
+      expect(msg.number).to eq('555-5555')
+      expect(msg.body).to include('secure one-time password')
+      expect(msg.body).to include('1234')
     end
   end
 end

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -244,7 +244,7 @@ describe 'user edits their account', email: true do
     it 'calls SmsSenderOtpJob but not SmsSenderExistingMobileJob' do
       sign_in_as_a_valid_user(user)
 
-      expect(SmsSenderOtpJob).to receive(:perform_later).with(user)
+      allow(SmsSenderOtpJob).to receive(:perform_later)
       expect(SmsSenderExistingMobileJob).
         to_not receive(:perform_later).with(user_with_mobile.mobile)
 
@@ -254,6 +254,8 @@ describe 'user edits their account', email: true do
           email: user_with_mobile.email
         )
       )
+      expect(SmsSenderOtpJob).to have_received(:perform_later).
+        with(user.reload.otp_code, '+1 (555) 555-5555')
     end
   end
 end

--- a/spec/services/otp_sender_spec.rb
+++ b/spec/services/otp_sender_spec.rb
@@ -2,29 +2,28 @@ require 'rails_helper'
 
 describe UserOtpSender do
   describe '#send_otp' do
-    context 'when user is two_factor_enabled and does not have unconfirmed_mobile' do
+    context 'when user does not have unconfirmed_mobile' do
       it 'sends OTP to mobile' do
-        user = build_stubbed(:user)
+        user = build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq')
 
-        allow(user).to receive(:two_factor_enabled?).and_return(true)
-
-        expect(SmsSenderOtpJob).to receive(:perform_later).with(user)
+        expect(SmsSenderOtpJob).to receive(:perform_later).with(user.otp_code, user.mobile)
 
         UserOtpSender.new(user).send_otp
       end
     end
 
-    context 'when user is two_factor_enabled and has an unconfirmed_mobile' do
-      it 'generates a new OTP and only sends OTP to unconfirmed_mobile' do
+    context 'when user has an unconfirmed_mobile' do
+      it 'generates a new otp_secret_key and sends OTP to unconfirmed_mobile' do
         user = build_stubbed(
           :user, unconfirmed_mobile: '5005550006', otp_secret_key: 'lzmh6ekrnc5i6aaq'
         )
 
-        allow(user).to receive(:two_factor_enabled?).and_return(true)
-
-        expect(SmsSenderOtpJob).to receive(:perform_later).with(user)
+        allow(SmsSenderOtpJob).to receive(:perform_later)
 
         UserOtpSender.new(user).send_otp
+
+        expect(SmsSenderOtpJob).to have_received(:perform_later).
+          with(user.otp_code, user.unconfirmed_mobile)
 
         expect(user.otp_secret_key).to_not eq 'lzmh6ekrnc5i6aaq'
       end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -25,8 +25,6 @@ describe TwilioService do
   end
 
   describe 'performance testing mode' do
-    let(:user) { build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq') }
-
     it 'uses NullTwilioClient when pt_mode is on' do
       expect(FeatureManagement).to receive(:pt_mode?).and_return(true)
       expect(NullTwilioClient).to receive(:new)
@@ -54,28 +52,28 @@ describe TwilioService do
 
     it 'does not send any OTP when pt_mode is true', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(true)
-      SmsSenderOtpJob.perform_now(user)
+      SmsSenderOtpJob.perform_now('1234', '555-5555')
 
       expect(messages.size).to eq 0
     end
 
     it 'sends an OTP when pt_mode is false', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(false)
-      SmsSenderOtpJob.perform_now(user)
+      SmsSenderOtpJob.perform_now('1234', '555-5555')
 
       expect(messages.size).to eq 1
     end
 
     it 'does not send a number change SMS when pt_mode is true', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(true)
-      SmsSenderNumberChangeJob.perform_now(user)
+      SmsSenderNumberChangeJob.perform_now('555-5555')
 
       expect(messages.size).to eq 0
     end
 
     it 'sends number change SMS when pt_mode is false', sms: true do
       expect(FeatureManagement).to receive(:pt_mode?).at_least(:once).and_return(false)
-      SmsSenderNumberChangeJob.perform_now(user)
+      SmsSenderNumberChangeJob.perform_now('555-5555')
 
       expect(messages.size).to eq 1
     end


### PR DESCRIPTION
**Why**: Removes the need for sidekiq to do database access.
This matches the behaviour of the other jobs.  Also allows
us the remove some redunant specs.  It also moves the logic
for deciding which number to send to out of async job which
is required another change I'm working to store unconfirmed
mobile number in the session rather than in the database.