### PR TITLE
Removes password confirmation step

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -94,7 +94,7 @@ module Users
 
     def permitted_params
       params.require(:password_form).
-        permit(:confirmation_token, :password, :password_confirmation)
+        permit(:confirmation_token, :password)
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -96,7 +96,7 @@ module Users
 
     def user_params
       params.require(:password_form).
-        permit(:password, :password_confirmation, :reset_password_token)
+        permit(:password, :reset_password_token)
     end
 
     def form_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -79,7 +79,7 @@ module Users
 
     def user_params
       params.require(:update_user_profile_form).
-        permit(:mobile, :email, :password, :password_confirmation, :current_password)
+        permit(:mobile, :email, :password, :current_password)
     end
   end
 end

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -11,7 +11,6 @@ class PasswordForm
 
   def submit(params)
     self.password = params[:password]
-    self.password_confirmation = params[:password_confirmation]
 
     if valid? && user_valid?
       @user.password = params[:password]

--- a/app/forms/update_user_profile_form.rb
+++ b/app/forms/update_user_profile_form.rb
@@ -49,7 +49,6 @@ class UpdateUserProfileForm
     self.email = params[:email]
     self.current_password = params[:current_password]
     self.password = params[:password]
-    self.password_confirmation = params[:password_confirmation]
   end
 
   def attribute_taken?

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -24,6 +24,6 @@ module FormPasswordValidator
   end
 
   def user_updating_password?
-    password.present? || password_confirmation.present?
+    password.present?
   end
 end

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -14,7 +14,6 @@
         = f.error_notification
         = f.input :password, required: true, input_html: { autofocus: true }
         = render 'devise/shared/password_strength'
-        = f.input :password_confirmation, required: true
         = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
         = f.button :submit, 'Submit'
 

--- a/app/views/devise/password_expired/show.html.slim
+++ b/app/views/devise/password_expired/show.html.slim
@@ -9,5 +9,4 @@
         = f.error_notification
         = f.input :current_password, required: true, autofocus: true
         = f.input :password, label: 'New password', required: true
-        = f.input :password_confirmation, label: 'Confirm your new password', required: true
         = f.button :submit, 'Change my password'

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -15,7 +15,6 @@
         = f.full_error :reset_password_token
         = f.input :password, label: 'New password', required: true, autofocus: true
         = render 'devise/shared/password_strength'
-        = f.input :password_confirmation, label: 'Confirm your new password', required: true
         = f.button :submit, 'Change my password'
       = render 'devise/shared/links'
 

--- a/app/views/devise/registrations/_form.html.slim
+++ b/app/views/devise/registrations/_form.html.slim
@@ -5,5 +5,4 @@
 .mb3
   h4 Password
   = f.input :password, required: false
-  = f.input :password_confirmation, required: false
 .py2

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -17,8 +17,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: second_user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -27,8 +26,7 @@ describe Users::RegistrationsController, devise: true do
       email: new_email,
       mobile: '555-555-5555',
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -37,8 +35,7 @@ describe Users::RegistrationsController, devise: true do
       email: second_user.email,
       mobile: '555-555-5555',
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -47,8 +44,7 @@ describe Users::RegistrationsController, devise: true do
       email: second_user.email,
       mobile: '',
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -57,8 +53,7 @@ describe Users::RegistrationsController, devise: true do
       email: second_user.email,
       mobile: second_user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -67,8 +62,7 @@ describe Users::RegistrationsController, devise: true do
       email: new_email,
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -77,8 +71,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: second_user.mobile,
       current_password: '',
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -87,8 +80,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: user.mobile,
       current_password: 'foo',
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -97,8 +89,7 @@ describe Users::RegistrationsController, devise: true do
       email: '',
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -107,8 +98,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '@Aaaaaa1',
-      password_confirmation: '@Aaaaaa1'
+      password: '@Aaaaaa1'
     }
   end
 
@@ -117,18 +107,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '123',
-      password_confirmation: '123'
-    }
-  end
-
-  let(:attrs_with_invalid_password_confirmation) do
-    {
-      email: user.email,
-      mobile: user.mobile,
-      current_password: '!1aZ' * 32,
-      password: '@Aaaaaa1',
-      password_confirmation: '@Aaaaaa11'
+      password: '123'
     }
   end
 
@@ -137,8 +116,7 @@ describe Users::RegistrationsController, devise: true do
       email: user.email,
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: '@Aaaaaa11'
+      password: ''
     }
   end
 
@@ -420,27 +398,15 @@ describe Users::RegistrationsController, devise: true do
     end
   end
 
-  context 'invalid password confirmation' do
-    render_views
-
-    it 'displays invalid password confirmation error' do
-      sign_in(user)
-      put :update, update_user_profile_form: attrs_with_invalid_password_confirmation
-
-      expect(response.body).to have_content("doesn't match Password")
-      expect(user.reload.encrypted_password).to eq old_encrypted_password
-    end
-  end
-
   context 'blank new password' do
     render_views
 
-    it 'displays invalid password confirmation error' do
+    it 'does not change password' do
       sign_in(user)
       put :update, update_user_profile_form: attrs_with_blank_new_password
 
-      expect(response.body).to have_content("can't be blank")
       expect(user.reload.encrypted_password).to eq old_encrypted_password
+      expect(response).to redirect_to edit_user_registration_url
     end
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     confirmed_at Time.current
     email { Faker::Internet.safe_email }
     password '!1aZ' * 32 # Maximum length password.
-    password_confirmation '!1aZ' * 32 # Maximum length password.
 
     trait :with_mobile do
       mobile '+1 (202) 555-1212'

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -59,7 +59,7 @@ feature 'Sign in' do
   context 'user fails login 3 times' do
     before do
       password = '1Validpass!'
-      @user = create(:user, password: password, password_confirmation: password)
+      @user = create(:user, password: password)
       signin(@user.email, 'invalidpass')
       signin(@user.email, 'invalidpass')
       signin(@user.email, 'invalidpass')

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -7,7 +7,6 @@ require 'rails_helper'
 feature 'Password Recovery' do
   def reset_password_and_sign_back_in
     fill_in 'New password', with: 'NewVal!dPassw0rd'
-    fill_in 'Confirm your new password', with: 'NewVal!dPassw0rd'
     click_button 'Change my password'
     fill_in 'Email', with: 'email@example.com'
     fill_in 'user_password', with: 'NewVal!dPassw0rd'
@@ -126,7 +125,6 @@ feature 'Password Recovery' do
 
     it 'keeps user signed out after they successfully reset their password' do
       fill_in 'New password', with: 'NewVal!dPassw0rd'
-      fill_in 'Confirm your new password', with: 'NewVal!dPassw0rd'
       click_button 'Change my password'
 
       expect(current_path).to eq new_user_session_path
@@ -273,7 +271,6 @@ feature 'Password Recovery' do
     context 'when password form values are valid' do
       it 'changes the password, sends an email about the change, and does not sign the user in' do
         fill_in 'New password', with: 'NewVal!dPassw0rd'
-        fill_in 'Confirm your new password', with: 'NewVal!dPassw0rd'
         click_button 'Change my password'
 
         expect(page).to have_content(I18n.t('devise.passwords.updated_not_active'))
@@ -350,7 +347,6 @@ feature 'Password Recovery' do
     Timecop.travel(Devise.reset_password_within + 1.minute)
 
     fill_in 'New password', with: 'NewVal!dPassw0rd'
-    fill_in 'Confirm your new password', with: 'NewVal!dPassw0rd'
     click_button 'Change my password'
 
     expect(page).to have_content t('devise.passwords.token_expired')

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -34,7 +34,6 @@ feature 'Sign Up', devise: true do
     expect(page).to have_content t('upaya.forms.confirmation.show_hdr')
 
     fill_in 'password_form_password', with: VALID_PASSWORD
-    fill_in 'Password confirmation', with: VALID_PASSWORD
     click_button 'Submit'
 
     expect(page).to have_content I18n.t('devise.two_factor_authentication.otp_setup')
@@ -131,75 +130,24 @@ feature 'Sign Up', devise: true do
     end
   end
 
-  scenario 'visitor is redirected back to password form when passwords do not match' do
-    sign_up_with('test@example.com')
-    confirm_last_user
-    fill_in 'password_form_password', with: VALID_PASSWORD
-    fill_in 'Password confirmation', with: 'gobilily-gook'
-    click_button 'Submit'
-
-    expect(page).to have_content "doesn't match Password"
-    expect(current_url).to eq confirm_url
-  end
-
   scenario 'visitor is redirected back to password form when password is blank' do
     sign_up_with('test@example.com')
     confirm_last_user
     fill_in 'password_form_password', with: ''
-    fill_in 'Password confirmation', with: 'gobilily-gook'
-    click_button 'Submit'
-
-    expect(page).to have_content "doesn't match Password"
-    expect(current_url).to eq confirm_url
-  end
-
-  scenario 'visitor is redirected back to password form when password_confirmation is blank' do
-    sign_up_with('test@example.com')
-    confirm_last_user
-    fill_in 'password_form_password', with: VALID_PASSWORD
-    fill_in 'password_form_password_confirmation', with: ''
-    click_button 'Submit'
-
-    expect(page).to have_content "doesn't match Password"
-    expect(current_url).to eq confirm_url
-  end
-
-  scenario 'visitor is redirected back to password form when both password fields are blank' do
-    sign_up_with('test@example.com')
-    confirm_last_user
-    fill_in 'password_form_password', with: ''
-    fill_in 'Password confirmation', with: ''
     click_button 'Submit'
 
     expect(page).to have_content "can't be blank"
     expect(current_url).to eq confirm_url
   end
 
-  context 'password and/or password_confirmation fields are blank when JS is on', js: true do
+  context 'password field is blank when JS is on', js: true do
     before do
       User.create!(email: 'test@example.com')
       confirm_last_user
     end
 
-    it 'shows error message when password_confirmation is blank' do
-      fill_in 'password_form_password', with: VALID_PASSWORD
-      fill_in 'Password confirmation', with: ''
-      click_button 'Submit'
-
-      expect(page).to have_content 'Please fill in all required fields'
-    end
-
-    it 'shows error message when both password fields are blank' do
-      fill_in 'password_form_password', with: ''
-      fill_in 'Password confirmation', with: ''
-      click_button 'Submit'
-
-      expect(page).to have_content 'Please fill in all required fields'
-    end
-
     it 'shows error message when password is blank' do
       fill_in 'password_form_password', with: ''
-      fill_in 'Password confirmation', with: 'gobilily-gook'
       click_button 'Submit'
 
       expect(page).to have_content 'Please fill in all required fields'
@@ -238,7 +186,6 @@ feature 'Sign Up', devise: true do
     sign_up_with('test@example.com')
     confirm_last_user
     fill_in 'password_form_password', with: 'Q!2e'
-    fill_in 'Password confirmation', with: 'Q!2e'
     click_button 'Submit'
 
     expect(page).to have_content('characters')

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -59,7 +59,7 @@ describe PasswordForm do
 
         password = 'valid password'
 
-        expect(form.submit(password: password, password_confirmation: password)).
+        expect(form.submit(password: password)).
           to eq false
       end
     end
@@ -72,7 +72,7 @@ describe PasswordForm do
 
         password = 'invalid'
 
-        expect(form.submit(password: password, password_confirmation: password)).
+        expect(form.submit(password: password)).
           to eq false
       end
     end
@@ -85,7 +85,7 @@ describe PasswordForm do
 
         password = 'valid password'
 
-        form.submit(password: password, password_confirmation: password)
+        form.submit(password: password)
 
         expect(user.password).to eq password
       end

--- a/spec/lib/rails_logger_spec.rb
+++ b/spec/lib/rails_logger_spec.rb
@@ -30,7 +30,6 @@ describe 'Rails.logger', type: :feature do
       confirm_last_user
 
       fill_in 'password_form_password', with: 'ValidPassw0rd!'
-      fill_in 'password_form_password_confirmation', with: 'ValidPassw0rd!'
     end
 
     it 'logs [Password Created]' do
@@ -51,7 +50,6 @@ describe 'Rails.logger', type: :feature do
 
       fill_in 'update_user_profile_form_current_password', with: user.password
       fill_in 'update_user_profile_form_password', with: user_password
-      fill_in 'update_user_profile_form_password_confirmation', with: user_password
     end
 
     it 'logs [Password Changed]' do
@@ -101,7 +99,6 @@ describe 'Rails.logger', type: :feature do
 
     it 'logs the events' do
       fill_in 'New password', with: 'NewVal!dPassw0rd'
-      fill_in 'Confirm your new password', with: 'NewVal!dPassw0rd'
 
       expect(Rails.logger).to receive(:info).with("[#{user.uuid}] [Password Changed]")
       click_button 'Change my password'

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -28,8 +28,7 @@ describe 'user edits their account', email: true do
       email: new_email,
       mobile: user.mobile,
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 
@@ -38,8 +37,7 @@ describe 'user edits their account', email: true do
       email: @user.email,
       mobile: '555-555-5555',
       current_password: '!1aZ' * 32,
-      password: '',
-      password_confirmation: ''
+      password: ''
     }
   end
 

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -17,7 +17,7 @@ describe EmailNotifier do
     context 'when the password has changed' do
       it 'sends an email notifiying the user of the password change' do
         user = create(:user, :signed_up)
-        user.update!(password: 'newValidPass!!00', password_confirmation: 'newValidPass!!00')
+        user.update!(password: 'newValidPass!!00')
 
         expect(UserMailer).to receive(:password_changed).with(user).and_return(mailer)
         expect(mailer).to receive(:deliver_later)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -24,7 +24,6 @@ module Features
       Capybara.reset_session! if reset_session
       confirm_last_user
       fill_in 'password_form_password', with: VALID_PASSWORD
-      fill_in 'password_form_password_confirmation', with: VALID_PASSWORD
       click_button 'Submit'
       user
     end


### PR DESCRIPTION
**Why**: usability & efficiency (reduce steps & amount of typing required)

The next step (and next PR) is adding a 'Show password' toggle
so users can check what they typed into the single password input.

preview:
![image](https://cloud.githubusercontent.com/assets/1060893/15860769/636bab6a-2c98-11e6-989a-db9de0942a41.png)
