### PR TITLE
Add signup/login navigation

### DIFF
--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -2,10 +2,10 @@
 
 .clearfix.mxn2
   .sm-col-6.px2.mx-auto
+    = render 'devise/shared/auth_nav'
     .panel
       .panel-heading
         h2.m0 = t('upaya.headings.registrations.new')
-
       = simple_form_for(@register_user_email_form,
           html: { autocomplete: 'off', role: 'form' },
           url: user_registration_path) do |f|
@@ -15,7 +15,3 @@
                   autofocus: true,
                   input_html: { 'aria-describedby' => 'email_description' }
         = f.button :submit, 'Sign up'
-        div
-          = t('upaya.forms.registration.already_have_account_html')
-          '
-          = link_to 'Log in', new_user_session_path

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -2,13 +2,10 @@
 
 .clearfix.mxn2
   .sm-col-6.px2.mx-auto
+    = render 'devise/shared/auth_nav'
     .panel
       .panel-heading
         h2.m0 = t('upaya.headings.log_in')
-        div
-          = 'or '
-          = link_to t('upaya.links.create_new_account'), \
-              new_user_registration_path
       = render 'devise/sessions/form'
       h2.m0.py3.text-over-line
         span or use your

--- a/app/views/devise/shared/_auth_nav.html.slim
+++ b/app/views/devise/shared/_auth_nav.html.slim
@@ -1,0 +1,10 @@
+.clearfix.mxn1.mb1
+  - login_page = controller_name == 'sessions'
+  .sm-col.sm-col-6.px1.mb1
+    = link_to t('upaya.links.sign_up'), new_user_registration_path, \
+      class: 'btn btn-primary border-box col-12 center ' \
+             "#{login_page ? 'bg-gray' : 'bg-navy'}"
+  .sm-col.sm-col-6.px1.mb1
+    = link_to t('upaya.links.sign_in'), new_user_session_path, \
+      class: 'btn btn-primary border-box col-12 center ' \
+             "#{login_page ? 'bg-navy' : 'bg-gray'}"

--- a/app/views/shared/_branding.html.slim
+++ b/app/views/shared/_branding.html.slim
@@ -1,4 +1,4 @@
-.py3.center
+.py3.mb2.center
   img {
     src="#{ asset_url('logo.svg') }"
     alt="login.gov logo"

--- a/app/views/shared/_navigation_links.html.slim
+++ b/app/views/shared/_navigation_links.html.slim
@@ -9,6 +9,6 @@
 - else
   .clearfix.p2
     .sm-col-right.h5
-      = link_to t('upaya.links.sign_in'), new_user_session_path
+      = link_to t('upaya.links.sign_up'), new_user_registration_path, class: 'navy bold'
       '&nbsp;&middot;&nbsp;
-      = link_to t('upaya.links.sign_up'), new_user_registration_path
+      = link_to t('upaya.links.sign_in'), new_user_session_path, class: 'navy bold'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,6 @@ en:
         resend_confirmation: Resend confirmation instructions
       required_field: Indicates a required field.
       registration:
-        already_have_account_html: Already have an account?
         need_password: Please verify your current password to confirm changes.
       two_factor:
         code: Secure one-time password
@@ -18,7 +17,6 @@ en:
         show_hdr: Create a Password
 
     links:
-      create_new_account: create an account
       sign_out: 'Sign out'
       sign_in: 'Log in'
       sign_up: 'Sign up'

--- a/spec/features/app_settings/registrations_enabled_spec.rb
+++ b/spec/features/app_settings/registrations_enabled_spec.rb
@@ -19,7 +19,7 @@ feature 'RegistrationsEnabled', devise: true do
 
       expect(page).
         to have_link(
-          t('upaya.links.create_new_account'), href: new_user_registration_path
+          t('upaya.links.sign_up'), href: new_user_registration_path
         )
     end
   end

--- a/spec/views/devise/registrations/new.html.slim_spec.rb
+++ b/spec/views/devise/registrations/new.html.slim_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'devise/registrations/new.html.slim' do
   before do
     @register_user_email_form = RegisterUserEmailForm.new
+    allow(view).to receive(:controller_name).and_return('registrations')
   end
 
   it 'has a localized title' do
@@ -15,6 +16,20 @@ describe 'devise/registrations/new.html.slim' do
     render
 
     expect(rendered).to have_selector('h2', text: t('upaya.headings.registrations.new'))
+  end
+
+  it 'has proper css classes for log in / sign up nav' do
+    render
+
+    base_class = 'btn btn-primary border-box col-12 center'
+
+    sign_up_class = "#{base_class} bg-navy"
+    expect(rendered).
+      to have_xpath("//a[@class='#{sign_up_class}' and @href='#{new_user_registration_path}']")
+
+    log_in_class = "#{base_class} bg-gray"
+    expect(rendered).
+      to have_xpath("//a[@class='#{log_in_class}' and @href='#{new_user_session_path}']")
   end
 
   it 'sets form autocomplete to off' do

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'devise/sessions/new.html.slim' do
     allow(view).to receive(:resource).and_return(build_stubbed(:user))
     allow(view).to receive(:resource_name).and_return(:user)
     allow(view).to receive(:devise_mapping).and_return(Devise.mappings[:user])
+    allow(view).to receive(:controller_name).and_return('sessions')
   end
 
   it 'has a localized title' do
@@ -19,12 +20,26 @@ describe 'devise/sessions/new.html.slim' do
     expect(rendered).to have_selector('h2', text: t('upaya.headings.log_in'))
   end
 
+  it 'has proper css classes for log in / sign up nav' do
+    render
+
+    base_class = 'btn btn-primary border-box col-12 center'
+
+    sign_up_class = "#{base_class} bg-gray"
+    expect(rendered).
+      to have_xpath("//a[@class='#{sign_up_class}' and @href='#{new_user_registration_path}']")
+
+    log_in_class = "#{base_class} bg-navy"
+    expect(rendered).
+      to have_xpath("//a[@class='#{log_in_class}' and @href='#{new_user_session_path}']")
+  end
+
   it 'includes a link to create a new account' do
     render
 
     expect(rendered).
       to have_link(
-        t('upaya.links.create_new_account'), href: new_user_registration_path
+        t('upaya.links.sign_up'), href: new_user_registration_path
       )
   end
 end


### PR DESCRIPTION
**Why**: to make it easy to see where you are
and navigate between sign up & log in pages

preview:
![image](https://cloud.githubusercontent.com/assets/1060893/16055511/a6e5985e-323f-11e6-9a71-6af9b10bf329.png)
