### PR TITLE
Move two_factor_authentication gem to upstream version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'turbolinks'
 gem 'twilio-ruby'
-gem 'two_factor_authentication', github: 'sbc100/two_factor_authentication', branch: 'direct_codes'
+gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', require: false
 gem 'xmlenc', '~> 0.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,6 @@
 GIT
-  remote: https://github.com/monfresh/sms-spec.git
-  revision: 786238c1924c055d16a4963abb329c9b985ce104
-  specs:
-    sms-spec (0.2.0)
-      rspec (~> 3.1)
-
-GIT
-  remote: https://github.com/sbc100/two_factor_authentication.git
-  revision: 06c67df575d99fd51a62427d696d6e1211d4b7b5
-  branch: direct_codes
+  remote: https://github.com/Houdini/two_factor_authentication.git
+  revision: 9d7d3472f4d272f70c2357ca4bced6f32ec2fbc9
   specs:
     two_factor_authentication (1.1.5)
       devise
@@ -16,6 +8,13 @@ GIT
       rails (>= 3.1.1)
       randexp
       rotp
+
+GIT
+  remote: https://github.com/monfresh/sms-spec.git
+  revision: 786238c1924c055d16a4963abb329c9b985ce104
+  specs:
+    sms-spec (0.2.0)
+      rspec (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -331,7 +330,7 @@ GEM
     redis (3.3.0)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
-    rotp (3.0.1)
+    rotp (3.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)


### PR DESCRIPTION
Our changes are now upstream so we no longer need to
point at our own branch.