### PR TITLE
Only show the last 4 digits of the phone number

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -18,7 +18,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
       redirect_to dashboard_index_url
     end
 
-    @phone_number = UserDecorator.new(current_user).two_factor_phone_number
+    @phone_number = UserDecorator.new(current_user).masked_two_factor_phone_number
   end
 
   def update

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -45,6 +45,12 @@ UserDecorator = Struct.new(:user) do
     user.mobile
   end
 
+  def masked_two_factor_phone_number
+    return masked_number(user.unconfirmed_mobile) if user.unconfirmed_mobile.present?
+
+    masked_number(user.mobile)
+  end
+
   def identity_not_verified?
     user.identities.pluck(:ial).uniq == [1]
   end
@@ -55,5 +61,9 @@ UserDecorator = Struct.new(:user) do
     return false if session[:omniauthed] != true
 
     session.delete(:omniauthed)
+  end
+
+  def masked_number(number)
+    "***-***-#{number[13..16]}"
   end
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -90,7 +90,7 @@ feature 'Sign Up', devise: true do
     it 'informs the user that the OTP code is sent to the mobile' do
       expect(page).
         to have_content(
-          "A one-time passcode has been sent to #{@user.unconfirmed_mobile}. " \
+          'A one-time passcode has been sent to ***-***-5555. ' \
           'Please enter the code that you received. ' \
           'If you do not receive the code in 10 minutes, please request a new passcode.'
         )
@@ -117,7 +117,7 @@ feature 'Sign Up', devise: true do
     it 'pretends the mobile is valid and prompts to confirm the number' do
       expect(current_path).to eq user_two_factor_authentication_path
       expect(page).
-        to have_content("A one-time passcode has been sent to #{@existing_user.mobile}.")
+        to have_content('A one-time passcode has been sent to ***-***-1212.')
     end
 
     it 'does not confirm the new number with an invalid OTP' do

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -124,8 +124,7 @@ describe 'user edits their account', email: true do
 
       expect(response.body).
         to include(
-          'A one-time passcode has been sent to ' \
-          "<strong>#{user.reload.unconfirmed_mobile}</strong>."
+          'A one-time passcode has been sent to <strong>***-***-1213</strong>.'
         )
       expect(flash[:notice]).to eq t('devise.registrations.mobile_update_needs_confirmation')
 
@@ -161,8 +160,7 @@ describe 'user edits their account', email: true do
 
       expect(response.body).
         to include(
-          'A one-time passcode has been sent to ' \
-          "<strong>#{user.reload.unconfirmed_mobile}</strong>."
+          'A one-time passcode has been sent to <strong>***-***-1213</strong>.'
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq '+1 (202) 555-1212'
@@ -199,8 +197,7 @@ describe 'user edits their account', email: true do
     it 'lets user know they need to confirm both their new mobile and email' do
       expect(response.body).
         to include(
-          'A one-time passcode has been sent to ' \
-          "<strong>#{user.reload.unconfirmed_mobile}</strong>."
+          'A one-time passcode has been sent to <strong>***-***-1213</strong>.'
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(last_email.subject).to eq 'Email confirmation instructions'
@@ -233,8 +230,7 @@ describe 'user edits their account', email: true do
 
       expect(response.body).
         to include(
-          'A one-time passcode has been sent to ' \
-          "<strong>#{user.reload.unconfirmed_mobile}</strong>."
+          'A one-time passcode has been sent to <strong>***-***-5555</strong>.'
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq '+1 (202) 555-1212'

--- a/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 describe 'devise/two_factor_authentication/show.html.slim' do
   context 'user has unconfirmed_mobile' do
     it 'sends OTP to unconfirmed mobile' do
-      user = build_stubbed(:user, unconfirmed_mobile: '5005550999')
+      user = build_stubbed(:user, unconfirmed_mobile: '+1 (500) 555-0999')
       allow(view).to receive(:current_user).and_return(user)
-      @phone_number = UserDecorator.new(user).two_factor_phone_number
+      @phone_number = UserDecorator.new(user).masked_two_factor_phone_number
 
       render
 
       expect(rendered).
-        to have_content "A one-time passcode has been sent to #{user.unconfirmed_mobile}"
+        to have_content 'A one-time passcode has been sent to ***-***-0999'
     end
   end
 
@@ -18,12 +18,12 @@ describe 'devise/two_factor_authentication/show.html.slim' do
     it 'sends OTP to mobile and prompts to enter the OTP' do
       user = build_stubbed(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(user)
-      @phone_number = UserDecorator.new(user).two_factor_phone_number
+      @phone_number = UserDecorator.new(user).masked_two_factor_phone_number
 
       render
 
       expect(rendered).
-        to have_content "A one-time passcode has been sent to #{user.mobile}"
+        to have_content 'A one-time passcode has been sent to ***-***-1212'
 
       expect(rendered).
         to have_content t('devise.two_factor_authentication.header_text')


### PR DESCRIPTION
**Why**: For privacy and security reasons, we don't want to display
the user's full phone number when letting them know where the OTP was
sent. The last 4 digits should be enough for them to recognize the
number.