### PR TITLE
Remove unused I18n translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'i18n-tasks'
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.3'
   gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
     dotiw (3.1.1)
       actionpack (>= 3)
       i18n
+    easy_translate (0.5.0)
+      json
+      thread
+      thread_safe
     email_spec (2.1.0)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -196,11 +200,22 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     heapy (0.1.2)
+    highline (1.7.8)
     htmlentities (4.3.4)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    i18n-tasks (0.9.5)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      easy_translate (>= 0.5.0)
+      erubis
+      highline (>= 1.7.3)
+      i18n
+      parser (>= 2.2.3.0)
+      term-ansicolor (>= 1.3.2)
+      terminal-table (>= 1.5.1)
     iniparse (1.4.2)
     json (1.8.3)
     jwt (1.5.4)
@@ -436,6 +451,9 @@ GEM
     sysexits (1.2.0)
     systemu (2.6.5)
     temple (0.7.7)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    terminal-table (1.6.0)
     test_after_commit (1.0.0)
       activerecord (>= 3.2)
     thin (1.5.1)
@@ -443,9 +461,11 @@ GEM
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
     thor (0.19.1)
+    thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.4)
     timecop (0.8.1)
+    tins (1.10.2)
     turbolinks (2.5.3)
       coffee-rails
     twilio-ruby (4.11.1)
@@ -512,6 +532,7 @@ DEPENDENCIES
   faker
   figaro
   guard-rspec
+  i18n-tasks
   lograge
   mailcatcher
   newrelic_rpm

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -9,7 +9,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
 
   def new
     current_user.send_new_otp
-    set_flash_message :success, 'new_otp_sent'
+    flash[:notice] = t('devise.two_factor_authentication.user.new_otp_sent')
     redirect_to user_two_factor_authentication_path
   end
 
@@ -52,7 +52,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
 
     sign_in resource_name, resource, bypass: true
-    set_flash_message :notice, :success
+    flash[:notice] = t('devise.two_factor_authentication.success')
 
     send_number_change_sms_if_needed
 
@@ -91,7 +91,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   def handle_invalid_otp
     update_invalid_resource if resource.two_factor_enabled?
 
-    flash.now[:error] = find_message(:attempt_failed)
+    flash.now[:error] = t('devise.two_factor_authentication.attempt_failed')
 
     if resource.second_factor_locked?
       handle_second_factor_locked_resource

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -71,7 +71,7 @@ module Users
         flash[:error] = UserDecorator.new(resource).confirmation_period_expired_error
         render :new
       else
-        set_flash_message :notice, :confirmed
+        flash[:notice] = t('devise.confirmations.confirmed')
         render :show
       end
     end
@@ -85,7 +85,7 @@ module Users
     end
 
     def process_confirmed_user
-      set_flash_message :notice, :confirmed
+      flash[:notice] = t('devise.confirmations.confirmed')
       redirect_to after_confirmation_path_for(resource_name, resource)
       EmailNotifier.new(@confirmable).send_email_changed_email
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,11 +19,11 @@ module Users
 
     def process_valid_authorization
       sign_in_and_redirect @user
-      set_flash_message(:notice, :success)
+      flash[:notice] = t('devise.omniauth_callbacks.success')
     end
 
     def process_invalid_authorization
-      set_flash_message(:alert, :failure, reason: 'Invalid email')
+      flash[:alert] = t('devise.omniauth_callbacks.failure', reason: 'Invalid email')
       redirect_to root_url
     end
   end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -81,7 +81,7 @@ module Users
     end
 
     def handle_successful_password_reset_for(resource)
-      set_flash_message(:notice, :updated_not_active) if is_flashing_format?
+      flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
 
       redirect_to new_user_session_path
 
@@ -89,7 +89,7 @@ module Users
     end
 
     def handle_expired_reset_password_token
-      set_flash_message(:error, :token_expired) if is_flashing_format?
+      flash[:error] = t('devise.passwords.token_expired') if is_flashing_format?
 
       redirect_to new_user_password_path
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -63,9 +63,8 @@ module Users
 
     def process_successful_creation
       if is_flashing_format?
-        set_flash_message(
-          :notice,
-          :signed_up_but_unconfirmed,
+        flash[:notice] = t(
+          'devise.registrations.signed_up_but_unconfirmed',
           email: @register_user_email_form.user.email
         )
       end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,123 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    - config/locales/%{locale}.yml
+    ## More files:
+    - config/locales/**/*.%{locale}.yml
+    ## Another gem (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: convervative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  relative_roots:
+  #   - app/controllers
+  - app/decorators
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Google Translate
+# translation:
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   api_key: "AbC-dEf5"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+ignore_unused:
+- 'activerecord.errors.*'
+- 'errors.messages.*'
+- '{devise,simple_form}.*'
+- 'upaya.errors.not_authorized'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%#= I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#        only: %w(*.html.haml *.html.slim),
+#        patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%#= I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#        patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/devise.two_factor_authentication.en.yml
+++ b/config/locales/devise.two_factor_authentication.en.yml
@@ -13,6 +13,7 @@ en:
         Please enter the phone number you would like to use to receive these messages.
       otp_sms_disclaimer: "Note: By accepting these terms and conditions, you acknowledge that Standard Messaging Rates or other charges related to these notifications may apply."
       please_confirm: Your phone number has been set. Please confirm it by entering the passcode below.
+      success: "Two factor authentication successful."
       two_factor_setup: Two-factor Authentication Setup
       user:
         new_otp_sent: A new one-time passcode has been sent.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,5 @@
 en:
   upaya:
-    alerts:
-      caution: Caution!
-      app_settings_caution: >
-        These settings affect the functionality of the application.
-        Take caution in updating any of the following settings.
     errors:
       not_authorized: 'You are not authorized to perform this action.'
       invalid_authenticity_token: 'Oops, something went wrong. Please sign in again.'
@@ -13,33 +8,14 @@ en:
       buttons:
         continue_browsing: Continue Browsing
         resend_confirmation: Resend confirmation instructions
-        no_accounts: Not accepting new accounts
       required_field: Indicates a required field.
       registration:
-        email_field: >
-          Your email address is used to log in to your Upaya Account.
-          All Upaya email communications will be sent to this address.
-        mobile_field: 'If you wish to have your secure one-time password sent to your mobile phone, enter the number here.'
-        contact_info: Contact information
         already_have_account_html: Already have an account?
         need_password: Please verify your current password to confirm changes.
       two_factor:
         code: Secure one-time password
-        make_selection: Please choose at least one delivery method.
       confirmation:
         show_hdr: Create a Password
-        show_instructions: Your password must be at least 8 characters in length and contain at least one upper case letter, at least one lower case letter, at least one number, and at least one special character.
-      session:
-        need: >
-          You need to create a new account if you want to:
-        need_list_html: |
-            <li></li>
-            <li></li>
-        advantage: >
-          Advantages of a Upaya online account:
-        advantage_list_html: >
-          <li></li>
-          <li></li>
 
     links:
       create_new_account: create an account
@@ -47,34 +23,18 @@ en:
       sign_in: 'Log in'
       sign_up: 'Sign up'
     notices:
-      app_setting_created: AppSetting was successfully created.
-      app_setting_updated: AppSetting was successfully updated.
       account_created: >
         You have successfully created your account.
       password_reset: 'You will receive an email with instructions on how to reset your password in a few minutes.'
-      user_email_changed_by_admin: >
-        The customer needs to confirm their email (%{email}) before it can be
-        changed. Please ask the customer to follow the instructions in the
-        email that was just sent to her or him.
     session_timedout: "For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again."
     session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
     titles:
-      app_settings:
-        edit: Editing %{app_setting}
-        index: Application Settings
-        new: New App Setting
-        show: Viewing %{app_setting}
       confirmations:
         new: Resend confirmation instructions for your Upaya Account
         show: Create a Password for your Upaya Account
       dashboard: Your Upaya Account
       enter_2fa_code: Enter the secure one-time password to log in to your Upaya Account
       account_locked: Account Locked
-      faqs:
-        edit: Editing FAQ
-        index: Frequently Asked Questions
-        new: Create a new FAQ
-        show: Viewing FAQ
       passwords:
         change: Change your password for your Upaya Account
         forgot: Reset your password for your Upaya Account
@@ -83,10 +43,6 @@ en:
         edit: Edit your Upaya Account
         new: Sign up for a Upaya Account
       two_factor_setup: Two-factor Authentication Setup
-      sign_in: Sign in to your Upaya Account
-      tech_support:
-        index: Tech Support
-        show: Tech Support
       users:
         edit: Editing User - %{user}
         index: Manage Users
@@ -97,40 +53,21 @@ en:
     headings:
       admin:
         index: Admin Interface
-      app_settings:
-        edit: Editing %{app_setting}
-        index: Application Settings
-        new: New App Setting
       confirmations:
         new: Resend confirmation instructions
-        show: "Instructions: Enter your password"
-      dashboard:
-        index: My Services
-      faqs:
-        edit: Editing FAQ
-        index: Frequently Asked Questions
-        new: New FAQ
       log_in: Log in
-      log_out: Sign out
       passwords:
         change: Change your password
         forgot: Forgot password?
         update: Update your password
       registrations:
-        edit: My Profile
         new: Sign up
       search: Search for a user
       session_timeout_warning: Session Timeout
-      tech_support:
-        index: Tech Support
-        show: Tech Support
       users:
         edit: Edit User
         index: Users
         show: User Details
-      visitors:
-        index: Upaya
-        new_account: Create a new account
 
     mailer:
       password_expires_soon:

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -169,7 +169,7 @@ feature 'Sign in' do
 
     it 'successfully signs in the user' do
       user = sign_in_user
-      click_link(t('upaya.headings.log_out'), match: :first)
+      click_link(t('upaya.links.sign_out'))
 
       Timecop.travel(Devise.timeout_in + 1.minute)
 

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -11,7 +11,7 @@ feature 'Sign out', devise: true do
   #   Then I see a signed out message
   scenario 'user signs out successfully' do
     sign_in_user
-    click_link(t('upaya.headings.log_out'), match: :first)
+    click_link(t('upaya.links.sign_out'))
 
     expect(page).to have_content t('devise.sessions.signed_out')
   end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -110,7 +110,7 @@ feature 'Password Recovery' do
   context 'user with password confirmation resets password', email: true do
     before do
       sign_up_with_and_set_password_for('email@example.com')
-      click_link(t('upaya.headings.log_out'), match: :first)
+      click_link(t('upaya.links.sign_out'))
       visit root_path
       click_link t('upaya.headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
@@ -140,7 +140,7 @@ feature 'Password Recovery' do
   context 'user with invalid token cannot reset password', email: true do
     before do
       sign_up_with_and_set_password_for('email@example.com')
-      click_link(t('upaya.headings.log_out'), match: :first)
+      click_link(t('upaya.links.sign_out'))
       visit root_path
       click_link t('upaya.headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
@@ -168,7 +168,7 @@ feature 'Password Recovery' do
       click_button 'Submit'
       fill_in 'code', with: User.last.direct_otp
       click_button 'Submit'
-      click_link(t('upaya.headings.log_out'), match: :first)
+      click_link(t('upaya.links.sign_out'))
       visit root_path
       click_link t('upaya.headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -99,7 +99,7 @@ feature 'Sign Up', devise: true do
     # JJG - I think we should go as far as making sure the user enters
     # a new number and that the OTP is sent to the new number.
     it 'allows user to enter new number if they Sign Out before confirming' do
-      click_link(t('upaya.headings.log_out'), match: :first)
+      click_link(t('upaya.links.sign_out'))
       signin(@user.reload.email, VALID_PASSWORD)
       expect(current_path).to eq users_otp_path
     end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'i18n/tasks'
+
+RSpec.describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to(
+      be_empty,
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    )
+  end
+
+  it 'does not have unused keys' do
+    expect(unused_keys).to(
+      be_empty,
+      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    )
+  end
+end


### PR DESCRIPTION
**Why**: To keep the app tidy

**How**:
- Install the i18n-tasks gem
- Run `i18n-tasks health` to see what the gem thinks is used and unused
- Add i18n-tasks configuration file to ignore translations that the gem
  thinks are unused but are actually used, and to tell it to look for
  translations in paths that it doesn't include by default
- Add i18n-tasks spec to check for unused translations
- Replace Devise-specific `set_flash_message` with the default Rails
  way of setting flash messages. This allows the gem to find those
  translations.
- Replace `upaya.headings.log_out` with `upaya.links.sign_out` since
  the former is not used.
- Run `i18n-tasks remove-unused` to remove unused translations