### PR TITLE
Always display the last 4 when masking phone numbers

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -64,6 +64,6 @@ UserDecorator = Struct.new(:user) do
   end
 
   def masked_number(number)
-    "***-***-#{number[13..16]}"
+    "***-***-#{number[-4..-1]}"
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,14 +6,12 @@ end
 if Rails.env.development?
   # Create a few dummy accounts for use during development.  These accounts all
   # have 'password' as password and are setup for mobile OTP delivery.
-  mobile = 4_155_555_555
-  %w(test1@test.com test2@test.com).each do |email|
+  %w(test1@test.com test2@test.com).each_with_index do |email, index|
     User.find_or_create_by!(email: email) do |user|
       user.skip_confirmation!
       user.reset_password('password', 'password')
-      user.unconfirmed_mobile = mobile.to_s
+      user.unconfirmed_mobile = format('+1 (415) 555-01%02d', index)
       user.mobile_confirm
     end
-    mobile += 1
   end
 end


### PR DESCRIPTION
**Why**: Seems like to good idea not to rely on the
absolute length of the phone number.  Also it was
breaking the seeded phone numbers which were not being
stored formatting in the DB (fixed that too).