### PR TITLE
Improve email confirmation UX

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -26,7 +26,7 @@ UserDecorator = Struct.new(:user) do
       "Your #{APP_NAME} account has been reset by a tech support representative. " \
       'In order to continue, you must confirm your email address.'
     else
-      "To finish #{user.confirmed_at ? 'updating' : 'creating'} your " \
+      "To #{user.confirmed_at ? 'finish updating' : 'continue creating'} your " \
       "#{APP_NAME} Account, you must confirm your email address."
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,15 @@
 class UserMailer < ActionMailer::Base
   default from: 'upaya@18f.gov'
 
+  def already_confirmed(user)
+    @root_url = root_url
+    @new_user_password_url = new_user_password_url
+    mail(
+      to: user.email,
+      subject: t('upaya.mailer.already_confirmed.subject', app_name: APP_NAME)
+    )
+  end
+
   def email_changed(old_email)
     mail(to: old_email, subject: t('upaya.mailer.email_change_notice.subject'))
   end

--- a/app/views/user_mailer/already_confirmed.html.slim
+++ b/app/views/user_mailer/already_confirmed.html.slim
@@ -1,0 +1,12 @@
+html
+  head
+    meta content='text/html; charset=UTF-8' http-equiv='Content-Type'
+  body
+
+    p= t('upaya.mailer.already_confirmed.sign_in', app_name: APP_NAME)
+
+    p= link_to @root_url, @root_url, target: '_blank'
+
+    p= t('upaya.mailer.already_confirmed.forgot_password')
+
+    p= link_to @new_user_password_url, @new_user_password_url, target: '_blank'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,11 @@
 en:
   devise:
     confirmations:
+      already_confirmed: "Your email address has already been confirmed. %{action}"
       confirmed: "Your email address has been successfully confirmed."
+      confirmed_but_must_set_password: >
+        Your email address has been successfully confirmed.
+        To continue creating your account, please set a password.
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,15 @@ en:
         show: User Details
 
     mailer:
+      already_confirmed:
+        forgot_password: >
+          If you cannot remember your password, request reset password
+          instructions by clicking the link below:
+        sign_in: >
+          A request was made to resend confirmation instructions to this email.
+          This email address has already been confirmed. You can sign in with
+          your %{app_name} account by clicking the link below:
+        subject: Your %{app_name} account has already been confirmed
       password_expires_soon:
         subject: Password expiration notice
       email_reuse_notice:

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -75,7 +75,10 @@ describe UserDecorator do
         user_decorator = UserDecorator.new(user)
 
         expect(user_decorator.first_sentence_for_confirmation_email).
-          to eq "To finish creating your #{APP_NAME} Account, you must confirm your email address."
+          to eq(
+            "To continue creating your #{APP_NAME} Account, " \
+            'you must confirm your email address.'
+          )
       end
     end
   end

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -52,7 +52,7 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     render
 
     expect(rendered).
-      to have_content "To finish creating your #{APP_NAME} Account, you must confirm your email"
+      to have_content "To continue creating your #{APP_NAME} Account"
   end
 
   it 'mentions resetting the account when account has been reset by tech support' do


### PR DESCRIPTION
**Why**:
To address the following issues:

- When a user who is already confirmed clicks on the link in their
confirmation email again, they remain on the "Resend confirmation
instructions" screen with an error message that their email has already
been confirmed and they should try signing in. A better UX would be to
redirect them to the appropriate place depending on whether or not they
are signed in.

- If a user confirms, then signs out, and comes back to the site after
a while, forgetting they already confirmed, then clicks "Didn't receive
confirmation instructions?", and resends confirmation instructions to
that same email, they will never receive an email.

**How**:

- If a user is already confirmed and clicks the confirmation link again
while signed out, they are redirected to the sign in page, with the
following flash error message: `Your email address has already been
confirmed. Please sign in.`. If they are already signed in, they are
redirected to the dashboard (which in turn might redirect them to the
part of the account creation process they haven't completed yet).

- If a user is already confirmed and resends confirmation instructions
to their confirmed email, they will receive an email letting them know
their email is already confirmed, with a link to sign in or reset their
password if they forgot it.

- When a user first clicks the confirmation link, the flash notice says
`Your email address has been successfully confirmed. To continue
creating your account, please set a password.` as opposed to just
`Your email address has been successfully confirmed.`. This indicates
that the account is not fully created yet.

- The confirmation email now says `to continue creating your account`,
as opposed to `to finish creating ...` because clicking the confirmation
link does not finish creating the account.