### PR TITLE
Handle already authenticated users using before_action of 2fa controller

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -6,6 +6,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   prepend_before_action :authenticate_scope!
   before_action :verify_user_is_not_second_factor_locked
   before_action :handle_two_factor_authentication
+  before_action :check_already_authenticated
 
   def new
     current_user.send_new_otp
@@ -14,10 +15,6 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def show
-    if user_fully_authenticated? && current_user.unconfirmed_mobile.blank?
-      redirect_to dashboard_index_url
-    end
-
     @phone_number = UserDecorator.new(current_user).masked_two_factor_phone_number
   end
 
@@ -32,6 +29,12 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   private
+
+  def check_already_authenticated
+    if user_fully_authenticated? && current_user.unconfirmed_mobile.blank?
+      redirect_to dashboard_index_url
+    end
+  end
 
   def authenticate_scope!
     send(:"authenticate_#{resource_name}!", force: true)

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -1,7 +1,64 @@
 require 'rails_helper'
 
 describe Devise::TwoFactorAuthenticationController, devise: true do
-  describe 'update' do
+  describe 'before_actions' do
+    it 'includes the appropriate before_actions' do
+      expect(subject).to have_filters(
+        :before,
+        :authenticate_scope!,
+        :verify_user_is_not_second_factor_locked,
+        :handle_two_factor_authentication,
+        :check_already_authenticated
+      )
+    end
+  end
+
+  describe '#check_already_authenticated' do
+    controller do
+      before_filter :check_already_authenticated
+
+      def index
+        render text: 'Hello'
+      end
+    end
+
+    context 'when the user is already fully signed in' do
+      let(:user) { create(:user, :signed_up) }
+
+      before do
+        sign_in user
+      end
+
+      it 'redirects to the dashboard' do
+        get :index
+
+        expect(response).to redirect_to(dashboard_index_url)
+      end
+
+      it 'does not redirect if the user has an unconfirmed mobile' do
+        subject.current_user.unconfirmed_mobile = '123'
+        get :index
+
+        expect(response).not_to redirect_to(dashboard_index_url)
+        expect(response.code).to eq('200')
+      end
+    end
+
+    context 'when the user if not fully signed in' do
+      before do
+        sign_in_before_2fa
+      end
+
+      it 'does not redirect to the dashboard' do
+        get :index
+
+        expect(response).not_to redirect_to(dashboard_index_url)
+        expect(response.code).to eq('200')
+      end
+    end
+  end
+
+  describe '#update' do
     let(:user) { create(:user, :signed_up) }
 
     context 'when user has not changed their number' do
@@ -18,29 +75,29 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
     context 'when resource is no longer OTP locked out' do
       before do
-        sign_in user
-        user.send_new_otp
-        user.update(
+        sign_in_before_2fa
+        subject.current_user.send_new_otp
+        subject.current_user.update(
           second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds
         )
-        user.update(second_factor_attempts_count: 3)
+        subject.current_user.update(second_factor_attempts_count: 3)
       end
 
       it 'resets attempts count when user submits bad code' do
         patch :update, code: '12345'
 
-        expect(user.reload.second_factor_attempts_count).to eq 1
+        expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
       end
 
       it 'resets second_factor_locked_at when user submits correct code' do
-        patch :update, code: user.direct_otp
+        patch :update, code: subject.current_user.direct_otp
 
-        expect(user.reload.second_factor_locked_at).to be_nil
+        expect(subject.current_user.reload.second_factor_locked_at).to be_nil
       end
     end
   end
 
-  describe 'show' do
+  describe '#show' do
     context 'when resource is not fully authenticated yet' do
       it 'renders the show view' do
         sign_in_before_2fa
@@ -48,16 +105,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         expect(response).to_not be_redirect
         expect(response).to render_template(:show)
-      end
-    end
-
-    context 'when resource is fully authenticated and does not have unconfirmed mobile' do
-      it 'redirects to the dashboard' do
-        user = create(:user, :signed_up)
-        sign_in user
-        get :show
-
-        expect(response).to redirect_to dashboard_index_path
       end
     end
 


### PR DESCRIPTION
**Why**: All the actions in this controller should be accessible
only during authentication (technically also during mobile
update).