### PR TITLE
Fix OTP lockout logic to match new 2fa gem changes

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -2,7 +2,7 @@ include ActionView::Helpers::DateHelper
 
 UserDecorator = Struct.new(:user) do
   def lockout_time_remaining
-    (Devise.allowed_otp_drift_seconds - (Time.zone.now - user.second_factor_locked_at)).to_i
+    (Devise.direct_otp_valid_for - (Time.zone.now - user.second_factor_locked_at)).to_i
   end
 
   def lockout_time_remaining_in_words

--- a/app/helpers/devise/two_factor_authentication_helper.rb
+++ b/app/helpers/devise/two_factor_authentication_helper.rb
@@ -1,7 +1,7 @@
 module Devise
   module TwoFactorAuthenticationHelper
-    def otp_drift_time_in_minutes
-      Devise.allowed_otp_drift_seconds / 60
+    def otp_valid_for_in_words
+      distance_of_time_in_words(Devise.direct_otp_valid_for)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ActiveRecord::Base
 
   def otp_time_lockout?
     return false if second_factor_locked_at.nil?
-    (Time.current - second_factor_locked_at) < Devise.allowed_otp_drift_seconds
+    (Time.current - second_factor_locked_at) < Devise.direct_otp_valid_for
   end
 
   def lock_access!(opts = {})

--- a/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
+++ b/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
@@ -1,5 +1,11 @@
 - title t('upaya.titles.account_locked')
 
-h2 =  t('upaya.titles.account_locked')
-p
-  = raw(t('devise.two_factor_authentication.max_login_attempts_reached', time_remaining: user_decorator.lockout_time_remaining_in_words))
+.clearfix.mxn2
+  .sm-col-6.px2.mx-auto
+    .panel
+      .panel-heading
+        h2.m0 = t('upaya.titles.account_locked')
+      p
+        'Your account is temporarily locked because you have entered the
+        'one-time passcode incorrectly too many times.
+      p Please try again in #{user_decorator.lockout_time_remaining_in_words}.

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -8,7 +8,7 @@
       p
         'A one-time passcode has been sent to <strong>#{@phone_number}</strong>.
         'Please enter the code that you received.
-        'If you do not receive the code in #{otp_drift_time_in_minutes} minutes, please #{link_to 'request a new passcode', users_otp_new_path, data: { 'no-turbolink' => true }}.
+        'If you do not receive the code in #{otp_valid_for_in_words}, please #{link_to 'request a new passcode', users_otp_new_path, data: { 'no-turbolink' => true }}.
 
       - if current_user.unconfirmed_mobile.present? && !current_user.two_factor_enabled?
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,8 +263,9 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
   # ==> Two Factor Authentication
-  config.allowed_otp_drift_seconds = 600
+  config.allowed_otp_drift_seconds = 30
   config.max_login_attempts = 3 # max OTP login attemps, not devise strategies (e.g. pw auth)
   config.otp_length = 8
   config.direct_otp_length = 8
+  config.direct_otp_valid_for = 10.minutes
 end

--- a/config/locales/devise.two_factor_authentication.en.yml
+++ b/config/locales/devise.two_factor_authentication.en.yml
@@ -4,10 +4,6 @@ en:
       attempt_failed: Secure one-time passcode is invalid. Please try again or request a new one-time passcode.
       contact_administrator: Please contact your system administrator.
       header_text: Enter your one-time passcode
-      max_login_attempts_reached: >
-        Your account is temporarily locked because you have entered the one-time passcode
-        incorrectly too many times.<br /><br />
-        Please try again in %{time_remaining}.
       otp_setup: >
         Every time you log in, a one-time passcode will be sent to your phone via SMS.
         Please enter the phone number you would like to use to receive these messages.

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -78,9 +78,9 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         sign_in_before_2fa
         subject.current_user.send_new_otp
         subject.current_user.update(
-          second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds
+          second_factor_locked_at: Time.zone.now - Devise.direct_otp_valid_for - 1.seconds,
+          second_factor_attempts_count: 3
         )
-        subject.current_user.update(second_factor_attempts_count: 3)
       end
 
       it 'resets attempts count when user submits bad code' do

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -6,7 +6,7 @@ describe UserDecorator do
       Timecop.freeze(Time.zone.now) do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 180)
         user_decorator = UserDecorator.new(user)
-        allow(Devise).to receive(:allowed_otp_drift_seconds).and_return(535)
+        allow(Devise).to receive(:direct_otp_valid_for).and_return(535)
 
         expect(user_decorator.lockout_time_remaining).to eq 355
       end
@@ -18,7 +18,7 @@ describe UserDecorator do
       Timecop.freeze(Time.zone.now) do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 180)
         user_decorator = UserDecorator.new(user)
-        allow(Devise).to receive(:allowed_otp_drift_seconds).and_return(535)
+        allow(Devise).to receive(:direct_otp_valid_for).and_return(535)
 
         expect(user_decorator.lockout_time_remaining_in_words).
           to eq '5 minutes and 55 seconds'

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -155,9 +155,8 @@ feature 'Two Factor Authentication', devise: true do
     scenario 'user is displayed the time remaining until their otp expires' do
       my_user = create(:user, :signed_up)
       sign_in_user(my_user)
-      otp_drift_minutes = Devise.allowed_otp_drift_seconds / 60
 
-      expect(page).to have_content "#{otp_drift_minutes} minutes"
+      expect(page).to have_content distance_of_time_in_words(Devise.direct_otp_valid_for)
     end
 
     scenario 'user can resend one-time password (OTP)' do
@@ -168,7 +167,7 @@ feature 'Two Factor Authentication', devise: true do
       expect(page).to have_content t('devise.two_factor_authentication.user.new_otp_sent')
     end
 
-    scenario 'user enters OTP incorrectly 3 times and is locked out for otp drift period' do
+    scenario 'user enters OTP incorrectly 3 times and is locked out for otp validitiy period' do
       user = create(:user, :signed_up)
       signin(user.email, user.password)
       3.times do
@@ -178,8 +177,8 @@ feature 'Two Factor Authentication', devise: true do
 
       expect(page).to have_content t('upaya.titles.account_locked')
 
-      # let 10 minutes (otp drift time) magically pass
-      user.update(second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1))
+      # let 10 minutes (otp validity period) magically pass
+      user.update(second_factor_locked_at: Time.zone.now - (Devise.direct_otp_valid_for + 1.second))
 
       signin(user.email, user.password)
 

--- a/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
@@ -5,14 +5,12 @@ describe 'devise/two_factor_authentication/max_login_attempts_reached.html.slim'
     it 'includes localized error message with time remaining' do
       user_decorator = instance_double(UserDecorator)
       allow(view).to receive(:user_decorator).and_return(user_decorator)
-      allow(user_decorator).to receive(:lockout_time_remaining_in_words).and_return('10 minutes')
+      allow(user_decorator).to receive(:lockout_time_remaining_in_words).and_return('1000 years')
 
       render
 
-      expect(rendered).to include(
-        t('devise.two_factor_authentication.max_login_attempts_reached',
-          time_remaining: '10 minutes')
-      )
+      expect(rendered).to include(t('upaya.titles.account_locked'))
+      expect(rendered).to include('1000 years')
     end
   end
 end


### PR DESCRIPTION
**Why**: We were previously the totp dirft period to determine
how long to lock people out of they attempt too many bad OTP
logins.  Now we have a seperate direct_otp_valid_for period
which is differnt and longer than the TOTP drift period.
This longer period is the one that should dermine how long to
lock people out for.