### PR TITLE
Update have_filters matcher to check for options

### DIFF
--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -221,18 +221,6 @@ describe SamlIdpController do
       end
     end
 
-    describe 'before_actions' do
-      it 'includes the appropriate before_actions' do
-        expect(subject).to have_filters(
-          :before,
-          :validate_saml_request,
-          :verify_authn_context,
-          :store_saml_request_in_session,
-          :confirm_two_factor_authenticated
-        )
-      end
-    end
-
     context 'SAML Response' do
       let(:xmldoc) { SamlResponseHelper::XmlDoc.new('controller', 'auth', response) }
 
@@ -633,6 +621,21 @@ describe SamlIdpController do
           expect(mobile['FriendlyName']).to eq('mobile')
         end
       end
+    end
+  end
+
+  describe 'before_actions' do
+    it 'includes the appropriate before_actions' do
+      expect(subject).to have_filters(
+        :before,
+        :disable_caching,
+        [:apply_secure_headers_override, only: [:auth, :logout]],
+        [:validate_saml_request, only: :auth],
+        [:verify_authn_context, only: :auth],
+        [:store_saml_request_in_session, only: :auth],
+        [:confirm_two_factor_authenticated, only: :auth],
+        [:validate_saml_logout_param, only: :logout]
+      )
     end
   end
 end

--- a/spec/support/matchers/have_filters.rb
+++ b/spec/support/matchers/have_filters.rb
@@ -1,6 +1,74 @@
+# Usage in a controller spec:
+#
+# it 'includes the appropriate before_actions' do
+#   expect(subject).to have_filters(
+#     :before,
+#     :authenticate_scope!,
+#     :verify_user_is_not_second_factor_locked,
+#     :handle_two_factor_authentication,
+#     :check_already_authenticated
+#   )
+# end
+#
+# The first parameter passed to the `have_filter` method is the kind of filter,
+# such as :before for `before_action`. The rest of the parameters represent an
+# array of the expected filters.
+# If any of the filters have only: or except: options, such as:
+# before_action :check_already_authenticated, only: :new,
+# you can test it like this:
+#
+# it 'includes the appropriate before_actions' do
+#   expect(subject).to have_filters(
+#     :before,
+#     :authenticate_scope!,
+#     :verify_user_is_not_second_factor_locked,
+#     :handle_two_factor_authentication,
+#     [:check_already_authenticated, only: :new]
+#   )
+# end
+
 RSpec::Matchers.define :have_filters do |kind, *names|
   match do |controller|
-    filters = controller._process_action_callbacks.select { |f| f.kind == kind }.map(&:filter)
+    callbacks = controller._process_action_callbacks.select { |callback| callback.kind == kind }
+
+    filters = callbacks.each_with_object([]) do |f, result|
+      result << f.filter unless filter_has_only_option?(f) || filter_has_except_option?(f)
+      result << [f.filter, only: symbolized_only_action(f)] if filter_has_only_option?(f)
+      result << [f.filter, except: symbolized_except_action(f)] if filter_has_except_option?(f)
+    end
+
     names.all? { |name| filters.include?(name) }
   end
+end
+
+def filter_has_only_option?(filter)
+  if_option_for(filter).present?
+end
+
+def filter_has_except_option?(filter)
+  unless_option_for(filter).present?
+end
+
+def if_option_for(filter)
+  filter.instance_variable_get(:@if)
+end
+
+def unless_option_for(filter)
+  filter.instance_variable_get(:@unless)
+end
+
+def symbol_from_string(string)
+  if string.include?('||')
+    string.split('||').map { |s| s.split('==')[1].strip.tr("'", '').to_sym }
+  else
+    string.split('==')[1].strip.tr("'", '').to_sym
+  end
+end
+
+def symbolized_only_action(filter)
+  symbol_from_string(if_option_for(filter)[0])
+end
+
+def symbolized_except_action(filter)
+  symbol_from_string(unless_option_for(filter)[0])
 end


### PR DESCRIPTION
**Why**: The RSpec `have_filters` matcher was only verifying the names
of the filters, but was ignoring `only:` and `except:` options. This
means that we couldn't test that a `before_action` was only applied
to certain actions with this matcher.

**How**: Update the matcher to include `only:` and `except:` options
to allow them to be specified in the test.