### PR TITLE
Fix OTP lockout logic to match new 2fa gem changes

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -112,11 +112,9 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def handle_second_factor_locked_resource
-    sign_out
+    @user_decorator = UserDecorator.new(current_user)
+    render :max_login_attempts_reached
 
-    render(
-      :max_login_attempts_reached,
-      locals: { user_decorator: UserDecorator.new(resource) }
-    )
+    sign_out
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -2,7 +2,7 @@ include ActionView::Helpers::DateHelper
 
 UserDecorator = Struct.new(:user) do
   def lockout_time_remaining
-    (Devise.allowed_otp_drift_seconds - (Time.zone.now - user.second_factor_locked_at)).to_i
+    (Devise.direct_otp_valid_for - (Time.zone.now - user.second_factor_locked_at)).to_i
   end
 
   def lockout_time_remaining_in_words

--- a/app/helpers/devise/two_factor_authentication_helper.rb
+++ b/app/helpers/devise/two_factor_authentication_helper.rb
@@ -1,7 +1,7 @@
 module Devise
   module TwoFactorAuthenticationHelper
-    def otp_drift_time_in_minutes
-      Devise.allowed_otp_drift_seconds / 60
+    def otp_valid_for_in_words
+      distance_of_time_in_words(Devise.direct_otp_valid_for)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ActiveRecord::Base
 
   def otp_time_lockout?
     return false if second_factor_locked_at.nil?
-    (Time.current - second_factor_locked_at) < Devise.allowed_otp_drift_seconds
+    (Time.current - second_factor_locked_at) < Devise.direct_otp_valid_for
   end
 
   def lock_access!(opts = {})

--- a/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
+++ b/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
@@ -1,6 +1,6 @@
 - title t('upaya.titles.account_locked')
 
-
-h2 = t('upaya.titles.account_locked')
-p
-  = raw(t('devise.two_factor_authentication.max_login_attempts_reached', time_remaining: user_decorator.lockout_time_remaining_in_words))
+h1.heading = t('upaya.titles.account_locked')
+p = t('devise.two_factor_authentication.max_login_attempts_reached')
+p = t('devise.two_factor_authentication.please_try_again',
+      time_remaining: @user_decorator.lockout_time_remaining_in_words)

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -1,11 +1,13 @@
 - title t('upaya.titles.enter_2fa_code')
 
-
 h1.heading = t('devise.two_factor_authentication.header_text')
 p
   'A one-time passcode has been sent to <strong>#{@phone_number}</strong>.
   'Please enter the code that you received.
-  'If you do not receive the code in #{otp_drift_time_in_minutes} minutes, please #{link_to 'request a new passcode', users_otp_new_path, data: { 'no-turbolink' => true }}.
+p
+  'Each code is valid for #{otp_valid_for_in_words}.
+  'If you do not receive a code within this time, please
+  '#{link_to 'request a new one', users_otp_new_path, data: { 'no-turbolink' => true }}.
 
 - if current_user.unconfirmed_mobile.present? && !current_user.two_factor_enabled?
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,8 +263,9 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
   # ==> Two Factor Authentication
-  config.allowed_otp_drift_seconds = 600
+  config.allowed_otp_drift_seconds = 30
   config.max_login_attempts = 3 # max OTP login attemps, not devise strategies (e.g. pw auth)
   config.otp_length = 6
   config.direct_otp_length = 6
+  config.direct_otp_valid_for = 5.minutes
 end

--- a/config/locales/devise.two_factor_authentication.en.yml
+++ b/config/locales/devise.two_factor_authentication.en.yml
@@ -5,9 +5,9 @@ en:
       contact_administrator: Please contact your system administrator.
       header_text: Enter your one-time passcode
       max_login_attempts_reached: >
-        Your account is temporarily locked because you have entered the one-time passcode
-        incorrectly too many times.<br /><br />
-        Please try again in %{time_remaining}.
+        Your account is temporarily locked because you have entered the
+        one-time passcode incorrectly too many times.
+      please_try_again: Please try again in %{time_remaining}.
       otp_setup: >
         Every time you log in, a one-time passcode will be sent to your phone via SMS.
         Please enter the phone number you would like to use to receive these messages.

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -119,7 +119,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         sign_in_before_2fa
         subject.current_user.send_new_otp
         subject.current_user.update(
-          second_factor_locked_at: Time.zone.now - (Devise.allowed_otp_drift_seconds + 1).seconds,
+          second_factor_locked_at: Time.zone.now - Devise.direct_otp_valid_for - 1.seconds,
           second_factor_attempts_count: 3
         )
       end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -6,7 +6,7 @@ describe UserDecorator do
       Timecop.freeze(Time.zone.now) do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 180)
         user_decorator = UserDecorator.new(user)
-        allow(Devise).to receive(:allowed_otp_drift_seconds).and_return(535)
+        allow(Devise).to receive(:direct_otp_valid_for).and_return(535)
 
         expect(user_decorator.lockout_time_remaining).to eq 355
       end
@@ -18,7 +18,7 @@ describe UserDecorator do
       Timecop.freeze(Time.zone.now) do
         user = build_stubbed(:user, second_factor_locked_at: Time.zone.now - 180)
         user_decorator = UserDecorator.new(user)
-        allow(Devise).to receive(:allowed_otp_drift_seconds).and_return(535)
+        allow(Devise).to receive(:direct_otp_valid_for).and_return(535)
 
         expect(user_decorator.lockout_time_remaining_in_words).
           to eq '5 minutes and 55 seconds'

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -95,8 +95,8 @@ feature 'Sign Up', devise: true do
       expect(page).
         to have_content(
           'A one-time passcode has been sent to ***-***-5555. ' \
-          'Please enter the code that you received. ' \
-          'If you do not receive the code in 10 minutes, please request a new passcode.'
+          'Please enter the code that you received. Each code is valid for 5 minutes. ' \
+          'If you do not receive a code within this time, please request a new one.'
         )
     end
 

--- a/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
@@ -3,16 +3,14 @@ require 'rails_helper'
 describe 'devise/two_factor_authentication/max_login_attempts_reached.html.slim' do
   context 'locked out account' do
     it 'includes localized error message with time remaining' do
-      user_decorator = instance_double(UserDecorator)
-      allow(view).to receive(:user_decorator).and_return(user_decorator)
-      allow(user_decorator).to receive(:lockout_time_remaining_in_words).and_return('10 minutes')
+      @user_decorator = instance_double(UserDecorator)
+      allow(@user_decorator).to receive(:lockout_time_remaining_in_words).and_return('1000 years')
 
       render
 
-      expect(rendered).to include(
-        t('devise.two_factor_authentication.max_login_attempts_reached',
-          time_remaining: '10 minutes')
-      )
+      expect(rendered).to include(t('upaya.titles.account_locked'))
+      expect(rendered).to include(t('devise.two_factor_authentication.max_login_attempts_reached'))
+      expect(rendered).to include('1000 years')
     end
   end
 end


### PR DESCRIPTION
**Why**: We were previously the totp dirft period to determine
how long to lock people out of they attempt too many bad OTP
logins.  Now we have a seperate direct_otp_valid_for period
which is differnt and longer than the TOTP drift period.
This longer period is the one that should dermine how long to
lock people out for.