### PR TITLE
Use SameSite=Lax setting for cookies

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -25,8 +25,10 @@ SecureHeaders::Configuration.default do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
+    # We need to set the SameSite setting to "Lax", not "Strict" until this bug
+    # is fixed in Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=619603
     samesite: {
-      strict: true # mark all cookies as SameSite=Strict
+      lax: true # mark all cookies as SameSite=Lax.
     }
   }
   # Temporarily disabled until we configure pinning. See GitHub issue #1895.


### PR DESCRIPTION
**Why**: Using the SameSite=Strict setting was breaking our app due to
this Chrome bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=619603

Sessions were not properly being set and persisting, which was causing
the SAML auth flow to end prematurely in production because we rely on
the `session[:saml_request_url]` variable to continue the auth after
the user signs in.