### PR TITLE
Use #user_session rather than #session for storing state

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -53,7 +53,7 @@ module SamlIdpLogoutConcern
     return generate_slo_request(resource) if resource_in_slo?(resource)
 
     # no SLO messages to generate; finish logout at IdP
-    return nil if session[:logout_response].nil?
+    return nil if user_session[:logout_response].nil?
 
     response = slo_response_from_session
 
@@ -65,7 +65,7 @@ module SamlIdpLogoutConcern
   def resource_in_slo?(resource)
     return true if resource && resource.multiple_identities?
     return true if
-      resource && resource.active_identities.present? && session[:logout_response].nil?
+      resource && resource.active_identities.present? && user_session[:logout_response].nil?
     false
   end
 
@@ -97,8 +97,8 @@ module SamlIdpLogoutConcern
     # The response was generated with the originating request
     # and stored in session
     {
-      message: session[:logout_response],
-      action_url: session[:logout_response_url],
+      message: user_session[:logout_response],
+      action_url: user_session[:logout_response_url],
       message_type: 'SAMLResponse'
     }
   end
@@ -164,11 +164,11 @@ module SamlIdpLogoutConcern
 
   def prepare_saml_logout_request
     validate_saml_request
-    return if session[:logout_response]
+    return if user_session[:logout_response]
     # store originating SP's logout response in the user session
     # for final step in SLO
-    session[:logout_response] = logout_response_builder.signed
-    session[:logout_response_url] = saml_request.response_url
+    user_session[:logout_response] = logout_response_builder.signed
+    user_session[:logout_response_url] = saml_request.response_url
   end
 
   def finish_slo_at_idp

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -52,7 +52,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def handle_valid_otp
-    warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+    user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
 
     sign_in resource_name, resource, bypass: true
     flash[:notice] = t('devise.two_factor_authentication.success')


### PR DESCRIPTION
**Why**: Variables stored in the top level #session are shared
between all 'scopes', so they persist between two different users
logging in.  Any user-specific session storage should be in
`user_session` (a Devise method) which is only accessible to that 
particular logged-in user.