### PR TITLE
Reduce OTP length from 8 to 6

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,6 +265,6 @@ Devise.setup do |config|
   # ==> Two Factor Authentication
   config.allowed_otp_drift_seconds = 600
   config.max_login_attempts = 3 # max OTP login attemps, not devise strategies (e.g. pw auth)
-  config.otp_length = 8
-  config.direct_otp_length = 8
+  config.otp_length = 6
+  config.direct_otp_length = 6
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -293,11 +293,11 @@ describe User do
       expect(user.direct_otp.length).to eq 6
     end
 
-    it 'is set to 8' do
+    it 'is set to 6' do
       user = build(:user)
       user.send_new_otp
 
-      expect(user.direct_otp.length).to eq 8
+      expect(user.direct_otp.length).to eq 6
     end
   end
 end


### PR DESCRIPTION
**Why**: Given that we will only be allowing a small number of
failures attempts per OTP there is no need to an 8 digit
code here.