### PR TITLE
Update Overcommit settings

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -31,6 +31,7 @@ PreCommit:
     required_executable: 'slim-lint'
     install_command: 'gem install slim_lint'
     include: '**/*.slim'
+    problem_on_unmodified_line: ignore
 
 CommitMsg:
   MessageFormat:
@@ -42,6 +43,7 @@ CommitMsg:
       See our contribution guidelines:
       https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#commit-message-style-guide
     sample_message: '**Why**: To eliminate unnecessary database calls.'
+    on_fail: warn
 
   TextWidth:
     enabled: true


### PR DESCRIPTION
**Why**: So that it only warns you when the commit message is not
properly formatted. Otherwise, you lose your commit message and have
to type everything all over again.

I also set SlimLint to ignore problems on unmodified lines because we
only care about newly-introduced issues. We can fix existing style
issues in a separate PR.