### PR TITLE
Render view after email registration

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -62,14 +62,7 @@ module Users
     end
 
     def process_successful_creation
-      if is_flashing_format?
-        flash[:notice] = t(
-          'devise.registrations.signed_up_but_unconfirmed',
-          email: @register_user_email_form.user.email
-        )
-      end
-
-      redirect_to root_path
+      render :verify_email, locals: { email: @register_user_email_form.user.email }
     end
 
     def disable_account_creation

--- a/app/views/devise/registrations/verify_email.html.slim
+++ b/app/views/devise/registrations/verify_email.html.slim
@@ -1,0 +1,10 @@
+- title t('upaya.titles.registrations.edit')
+
+
+h1.heading = t('upaya.headings.registrations.verify_email')
+p
+  '#{t('devise.registrations.signed_up_but_unconfirmed.message_start')}
+  '<strong>#{email}</strong>.
+  '#{t('devise.registrations.signed_up_but_unconfirmed.message_end')}
+p Didn't receive an email? #{link_to 'Resend', '/'}
+p = t('devise.registrations.close_window')

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -47,11 +47,12 @@ en:
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: >
-        A confirmation email has been sent to %{email}. Please follow
-        the instructions in the email to confirm your account. If you do not receive
-        the confirmation email within the next 10 minutes, please return to this page
-        and request your confirmation instructions again.
+      signed_up_but_unconfirmed:
+        message_start: A confirmation email has been sent to
+        message_end: >
+          Please follow the instructions in the email to confirm your account. If you do
+          not receive the confirmation email within the next 10 minutes, please return
+          to this page and request your confirmation instructions again.
       email_update_needs_confirmation: >
         You updated your account successfully, but we need to verify your new
         email address. Please check your email and follow the confirm link to
@@ -68,6 +69,7 @@ en:
         email and click the confirmation link to confirm your new email address.
       updated: "Your account has been updated successfully."
       enabled_twofactor: "Successfully enabled two-factor authentication."
+      close_window: "You can close this browser window once you have verified your email address."
     sessions:
       signed_in: ''
       signed_out: "You are now signed out."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,8 @@ en:
         change: Change your password
         forgot: Forgot password?
         update: Update your password
+      registrations:
+        verify_email: Verify email address
       search: Search for a user
       session_timeout_warning: Session Timeout
       users:

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -14,9 +14,12 @@ feature 'Sign Up', devise: true do
   #   When I sign up with a valid email address
   #   Then I see a message that I need to confirm my email address
   scenario 'visitor can sign up with valid email address' do
-    sign_up_with('test@example.com')
+    email = 'test@example.com'
+    sign_up_with(email)
     expect(page).to have_content(
-      t('devise.registrations.signed_up_but_unconfirmed', email: 'test@example.com')
+      t('devise.registrations.signed_up_but_unconfirmed.message_start') +
+      " #{email}. " +
+      t('devise.registrations.signed_up_but_unconfirmed.message_end')
     )
   end
 
@@ -266,7 +269,9 @@ feature 'Sign Up', devise: true do
     sign_up_with('existing_user@example.com')
 
     expect(page).to have_content(
-      t('devise.registrations.signed_up_but_unconfirmed', email: user.email)
+      t('devise.registrations.signed_up_but_unconfirmed.message_start') +
+      " #{user.email}. " +
+      t('devise.registrations.signed_up_but_unconfirmed.message_end')
     )
     expect(last_email.body).to have_content 'This email address is already in use.'
     expect(last_email.body).


### PR DESCRIPTION
**Why**: per latest designs and UX flow,
we want to have a separate screen after you
register a new email (vs a flash message coupled
with redirection to root)