### PR TITLE
Remove broken link in admin nav

### DIFF
--- a/app/views/dashboard/admin/_navigation.html.slim
+++ b/app/views/dashboard/admin/_navigation.html.slim
@@ -1,5 +1,4 @@
 nav.navbar.navbar-admin[role='navigation']
   .navbar-collapse
     ul.horizontal-menu
-      li= link_to 'Manage Users', users_path
       li= link_to 'Accessibility Statement','https://upaya.18f.gov/accessibility'


### PR DESCRIPTION
**Why**: We currently don't have the UsersController from save-ferris,
so `users_path` in the admin nav is causing an exception when signing
in as an admin. Signing in as an admin is required to be able to view
the `/sidekiq` route to troubleshoot Sidekiq issues in production.