### PR TITLE
Fix support links in mailers

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -6,7 +6,7 @@ p = "Please note that this confirmation link expires in #{@confirmation_period} 
 
 p
   'If you would like additional assistance, please contact the #{APP_NAME} Customer Contact Center via the web form at
-  = link_to nil, Figaro.env.support_url
+  = link_to Figaro.env.support_url, Figaro.env.support_url
 
 p
   strong PLEASE DO NOT REPLY TO THIS MESSAGE

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -7,7 +7,7 @@ p = "Please note that this confirmation link expires in #{Devise.reset_password_
 
 p
   'If you would like additional assistance, please contact the #{APP_NAME} Customer Contact Center via the web form at
-  = link_to nil, Figaro.env.support_url
+  = link_to Figaro.env.support_url, Figaro.env.support_url
 
 p
   strong PLEASE DO NOT REPLY TO THIS MESSAGE

--- a/app/views/email_second_factor_mailer/your_code_is.html.slim
+++ b/app/views/email_second_factor_mailer/your_code_is.html.slim
@@ -6,7 +6,7 @@ html
     p = "Please enter this secure one-time password: #{@code} "
     p
       'If you are not attempting to log into #{APP_NAME}, please contact the Customer Contact Center by filling out the web form at
-      = link_to nil, Figaro.env.support_url
+      = link_to Figaro.env.support_url, Figaro.env.support_url
       |  for assistance.
     p Please be aware that this update might require your immediate attention.
     p

--- a/app/views/user_mailer/email_changed.html.slim
+++ b/app/views/user_mailer/email_changed.html.slim
@@ -7,7 +7,7 @@ html
 
     p
       'If you did not change your email address, please contact the #{APP_NAME} Customer Contact Center via the web form at
-      = link_to nil, Figaro.env.support_url
+      = link_to Figaro.env.support_url, Figaro.env.support_url
 
     p
       strong PLEASE DO NOT REPLY TO THIS MESSAGE

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -7,6 +7,6 @@ html
 
     p
       'If you did not change your password, please contact the #{APP_NAME} Customer Contact Center via the web form at
-      = link_to nil, Figaro.env.support_url
+      = link_to Figaro.env.support_url, Figaro.env.support_url
     p
       strong PLEASE DO NOT REPLY TO THIS MESSAGE

--- a/app/views/user_mailer/signup_with_your_email.html.slim
+++ b/app/views/user_mailer/signup_with_your_email.html.slim
@@ -13,7 +13,7 @@ html
 
     p
       'If you did not request a new account or suspect an error, please contact the #{APP_NAME} Customer Contact Center via the web form at
-      = link_to nil, Figaro.env.support_url
+      = link_to Figaro.env.support_url, Figaro.env.support_url
 
     p Please be aware that this update might require your immediate attention.
 


### PR DESCRIPTION
**Why**: The `link_to` helper must always include an argument for the
link text. This is what was causing emails to fail in production.