### PR TITLE
Re-render the TOTP entry screen on invalid code

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -16,11 +16,10 @@ class Devise::TwoFactorAuthenticationController < DeviseController
 
   def show
     if use_totp?
-      render :show_totp
-      return
+      show_totp_prompt
+    else
+      show_direct_otp_prompt
     end
-
-    @phone_number = UserDecorator.new(current_user).masked_two_factor_phone_number
   end
 
   def update
@@ -102,6 +101,15 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     )
   end
 
+  def show_direct_otp_prompt
+    @phone_number = UserDecorator.new(current_user).masked_two_factor_phone_number
+    render :show
+  end
+
+  def show_totp_prompt
+    render :show_totp
+  end
+
   def handle_invalid_otp
     update_invalid_resource if resource.two_factor_enabled?
 
@@ -110,8 +118,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     if resource.second_factor_locked?
       handle_second_factor_locked_resource
     else
-      @user_decorator = UserDecorator.new(current_user)
-      render :show
+      show
     end
   end
 

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -16,5 +16,6 @@ p
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2
     = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.two_factor.code')
+    = hidden_field_tag('method', 'sms')
     = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true
   = submit_tag 'Submit', class: 'btn btn-primary'

--- a/app/views/devise/two_factor_authentication/show_totp.html.slim
+++ b/app/views/devise/two_factor_authentication/show_totp.html.slim
@@ -5,7 +5,7 @@ p
   'Please enter the code from your authenticator app.
   'If you have several accounts set up in your app, enter the code
   'corresponding to <strong>#{current_user.email}</strong> at
-  '<strong>Login.gov</strong>.
+  '<strong>#{APP_NAME}</strong>.
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2
     = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.two_factor.code')

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -140,8 +140,8 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
           expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
         end
 
-        it 're-renders the OTP entry screen' do
-          expect(response).to render_template(:show)
+        it 're-renders the TOTP entry screen' do
+          expect(response).to render_template(:show_totp)
         end
 
         it 'displays flash error message' do

--- a/spec/views/devise/two_factor_authentication/show_totp.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/show_totp.html.slim_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'devise/two_factor_authentication/show_totp.html.slim' do
+  it 'prompts to enter code from app' do
+    user = build_stubbed(:user, :signed_up, otp_secret_key: 123)
+    allow(view).to receive(:current_user).and_return(user)
+
+    render
+
+    expect(rendered).to have_content 'Please enter the code from your authenticator app'
+    expect(rendered).to have_content "enter the code corresponding to #{user.email}"
+  end
+end


### PR DESCRIPTION
**Why**: We were rendering the regular SMS OTP entry
screen.

fixes https://github.com/18F/identity-private/issues/487