### PR TITLE
Update ruby-saml from 1.2.0 to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    ruby-saml (1.2.0)
+    ruby-saml (1.3.0)
       nokogiri (>= 1.5.10)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)


### PR DESCRIPTION
**Why**: To address a security vulnerability that was recently disclosed: https://groups.google.com/forum/#!topic/ruby-security-ann/vnFoMsy6VE0