### PR TITLE
Update SP config for localhost SP app

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -41,7 +41,7 @@ development:
       cert: 'demo_sp'
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
       metadata_url: 'http://localhost:3003/saml/metadata'
-      acs_url: 'http://localhost:3003/consume'
+      acs_url: 'http://localhost:3003/auth/saml/callback'
       sp_initiated_login_url: 'http://localhost:3003/login'
       cert: 'demo_sp'
     'https://dashboard.login.gov':


### PR DESCRIPTION
**Why**: The acs_url for the SP app has changed now that we are using
Omniauth and Rails versus straight-up ruby-saml and Sinatra.