### PR TITLE
Store verified user attributes in db

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -34,6 +34,10 @@ module IdvSession
     idv_session[:applicant] = applicant
   end
 
+  def set_idv_pii(applicant)
+    idv_session[:pii_id] = PII.create_from_proofer_applicant(applicant, current_user).id
+  end
+
   def set_idv_resolution(resolution)
     idv_session[:resolution] = resolution
   end
@@ -50,9 +54,14 @@ module IdvSession
     idv_session[:applicant]
   end
 
+  def pii_id
+    idv_session[:pii_id]
+  end
+
   def clear_idv_session
     idv_session.delete(:vendor)
     idv_session.delete(:applicant)
+    idv_session.delete(:pii_id)
     idv_session.delete(:resolution)
     idv_session.delete(:question_number)
   end

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -22,7 +22,11 @@ module Idv
       agent = Proofer::Agent.new(vendor: idv_vendor, applicant: idv_applicant)
       @idv_vendor = idv_vendor
       @confirmation = agent.submit_answers(idv_resolution.questions, idv_resolution.session_id)
-      # HANDWAVING actually alter the user
+      if @confirmation.success?
+        pii = PII.find(pii_id)
+        pii.verified = true
+        pii.activate!
+      end
       clear_idv_session
     end
   end

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -12,6 +12,7 @@ module Idv
       if resolution.success
         set_idv_resolution(resolution)
         set_idv_question_number(0)
+        set_idv_pii(idv_applicant)
         redirect_to idv_questions_path
       else
         flash[:error] = I18n.t('idv.titles.fail')

--- a/app/models/pii.rb
+++ b/app/models/pii.rb
@@ -1,0 +1,37 @@
+class PII < ActiveRecord::Base
+  belongs_to :user
+
+  validates_uniqueness_of :active, scope: :user_id, if: :active?
+
+  # rubocop:disable AbcSize, MethodLength
+  def self.create_from_proofer_applicant(applicant, user)
+    create(
+      user: user,
+      first_name: applicant.first_name,
+      middle_name: applicant.middle_name,
+      last_name: applicant.last_name,
+      gen: applicant.gen,
+      address1: applicant.address1,
+      address2: applicant.address2,
+      city: applicant.city,
+      state: applicant.state,
+      zipcode: applicant.zipcode,
+      dob: applicant.dob,
+      ssn: applicant.ssn,
+      phone: applicant.phone,
+      drivers_license_state: applicant.drivers_license_state,
+      drivers_license_id: applicant.drivers_license_id,
+      passport_id: applicant.passport_id,
+      military_id: applicant.military_id
+    )
+  end
+  # rubocop:enable AbcSize, MethodLength
+
+  def activate!
+    transaction do
+      PII.where('user_id=?', user_id).update_all(active: false)
+      self.active = true
+      save!
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ActiveRecord::Base
 
   has_many :authorizations, dependent: :destroy
   has_many :identities, dependent: :destroy
+  has_many :piis, dependent: :destroy, class_name: PII
 
   def set_default_role
     self.role ||= :user
@@ -82,6 +83,10 @@ class User < ActiveRecord::Base
 
   def multiple_identities?
     active_identities.size > 1
+  end
+
+  def active_pii
+    piis.where(active: true).first
   end
 
   # To send emails asynchronously via ActiveJob.

--- a/db/migrate/20160627152327_add_pii_table.rb
+++ b/db/migrate/20160627152327_add_pii_table.rb
@@ -1,0 +1,39 @@
+class AddPiiTable < ActiveRecord::Migration
+  # rubocop:disable AbcSize, MethodLength
+  def up
+    create_table :piis do |tbl|
+      tbl.integer :user_id, null: false
+      tbl.boolean :active, null: false, default: false
+      tbl.boolean :verified, null: false, default: false
+      tbl.timestamps null: false
+
+      tbl.string :first_name
+      tbl.string :middle_name
+      tbl.string :last_name
+      tbl.string :gen
+      tbl.string :address1
+      tbl.string :address2
+      tbl.string :city
+      tbl.string :state
+      tbl.string :zipcode
+      tbl.string :ssn
+      tbl.string :dob
+      tbl.string :phone
+      tbl.string :drivers_license_state
+      tbl.string :drivers_license_id
+      tbl.string :passport_id
+      tbl.string :military_id
+    end
+
+    add_index :piis, :user_id
+    # https://www.postgresql.org/docs/current/static/indexes-partial.html
+    execute('create unique index piis_active_user_idx on piis(user_id, active) where active=true')
+  end
+  # rubocop:enable AbcSize, MethodLength
+
+  def down
+    remove_index :piis, :user_id
+    execute('drop index piis_active_user_idx')
+    drop_table :piis
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524231157) do
+ActiveRecord::Schema.define(version: 20160627152327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,33 @@ ActiveRecord::Schema.define(version: 20160524231157) do
   add_index "identities", ["service_provider", "authn_context"], name: "index_identities_on_service_provider_and_authn_context", using: :btree
   add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
+
+  create_table "piis", force: :cascade do |t|
+    t.integer  "user_id",                               null: false
+    t.boolean  "active",                default: false, null: false
+    t.boolean  "verified",              default: false, null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.string   "first_name"
+    t.string   "middle_name"
+    t.string   "last_name"
+    t.string   "gen"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zipcode"
+    t.string   "ssn"
+    t.string   "dob"
+    t.string   "phone"
+    t.string   "drivers_license_state"
+    t.string   "drivers_license_id"
+    t.string   "passport_id"
+    t.string   "military_id"
+  end
+
+  add_index "piis", ["user_id", "active"], name: "piis_active_user_idx", unique: true, where: "(active = true)", using: :btree
+  add_index "piis", ["user_id"], name: "index_piis_on_user_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
     t.string   "session_id", limit: 255, null: false

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+require 'proofer/vendor/mock'
+
+describe Idv::ConfirmationsController do
+  render_views
+
+  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+  let(:applicant) { Proofer::Applicant.new first_name: 'Some', last_name: 'One' }
+  let(:agent) { Proofer::Agent.new vendor: :mock }
+  let(:resolution) { agent.start applicant }
+  let(:pii) { PII.create_from_proofer_applicant(applicant, user) }
+
+  describe 'before_actions' do
+    it 'includes before_actions from AccountStateChecker' do
+      expect(subject).to have_filters(
+        :before,
+        :confirm_two_factor_authenticated
+      )
+    end
+  end
+
+  describe '#index' do
+    before(:each) do
+      init_idv_session
+    end
+
+    it 'verifies and activates PII on successful confirmation' do
+      get :index
+
+      expect(response.body).to include(t('idv.titles.complete'))
+      pii.reload
+      expect(pii).to be_active
+      expect(pii).to be_verified
+    end
+  end
+
+  def init_idv_session
+    sign_in(user)
+    answer_all_questions
+    subject.user_session[:idv] = {
+      vendor: :mock,
+      applicant: applicant,
+      pii_id: pii.id,
+      resolution: resolution,
+      question_number: resolution.questions.count + 1
+    }
+  end
+
+  def answer_all_questions
+    Proofer::Vendor::Mock::ANSWERS.each do |ques, answ|
+      resolution.questions.find_by_key(ques).answer = answ
+    end
+  end
+end

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -4,7 +4,7 @@ feature 'IdV session' do
   let(:mock_questions) { Proofer::Agent.new(vendor: :mock).start.questions }
 
   scenario 'KBV with all answers correct' do
-    sign_in_and_2fa_user
+    user = sign_in_and_2fa_user
 
     visit '/idv'
 
@@ -36,5 +36,9 @@ feature 'IdV session' do
     end
 
     expect(page).to have_content(t('idv.titles.complete'))
+
+    expect(user.active_pii).to be_a(PII)
+    expect(user.active_pii.verified).to eq true
+    expect(user.active_pii.ssn).to eq '666661234'
   end
 end

--- a/spec/models/pii_spec.rb
+++ b/spec/models/pii_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe PII do
+  let(:user) { create(:user, :signed_up) }
+  let(:pii) do
+    PII.create(
+      user_id: user.id
+    )
+  end
+
+  subject { pii }
+
+  it { is_expected.to belong_to(:user) }
+
+  describe 'allows only one active PII per user' do
+    it 'prevents create! via ActiveRecord uniqueness validation' do
+      pii.active = true
+      pii.save!
+      expect do
+        PII.create!(user_id: user.id, active: true)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'prevents save! via psql unique partial index' do
+      pii.active = true
+      pii.save!
+      expect do
+        another_pii = PII.new(user_id: user.id, active: true)
+        another_pii.save!(validate: false)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe '#activate!' do
+    it 'activates current PII, de-activates all other PII for the user' do
+      active_pii = PII.create(user: user, active: true)
+      pii.activate!
+      active_pii.reload
+      expect(active_pii).to_not be_active
+      expect(pii).to be_active
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,12 @@ require 'saml_idp_constants'
 MAX_GOOD_PASSWORD = '!1aZ' * 32
 
 describe User do
+  describe 'Associations' do
+    it { should have_many(:authorizations) }
+    it { should have_many(:identities) }
+    it { should have_many(:piis) }
+  end
+
   it 'should only send one email during creation' do
     expect do
       User.create(email: 'nobody@nobody.com')


### PR DESCRIPTION
**Why**:

PII is generated for every proofing session, and a user
may proof more than once. It is to the user's benefit
and convenience that PII is preserved, for
(a) passing to relying parties as required, and
(b) pre-populating forms when re-proofing.

**How**:

Per https://github.com/18F/identity-private/issues/479
PII is stored on its own table, with a one-to-many relationship
to users table.