### PR TITLE
Remove remaining user-visible references to Upaya

### DIFF
--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.dashboard')
+- title t('upaya.titles.dashboard', app_name: APP_NAME)
 
 table.table-light.border.bg-white.mb3
   tbody

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.confirmations.new')
+- title t('upaya.titles.confirmations.new', app_name: APP_NAME)
 
 
 h1.heading = t('upaya.headings.confirmations.new')

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.confirmations.show')
+- title t('upaya.titles.confirmations.show', app_name: APP_NAME)
 
 
 h1.heading = t('upaya.forms.confirmation.show_hdr')

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.passwords.forgot')
+- title t('upaya.titles.passwords.forgot', app_name: APP_NAME)
 
 
 h1.heading = t('upaya.headings.passwords.forgot')

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.registrations.new')
+- title t('upaya.titles.registrations.new', app_name: APP_NAME)
 
 
 h1.heading = t('upaya.headings.registrations.enter_email')

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.registrations.edit')
+- title t('upaya.titles.registrations.edit', app_name: APP_NAME)
 
 
 h1.heading = 'Update information'

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.enter_2fa_code')
+- title t('upaya.titles.enter_2fa_code', app_name: APP_NAME)
 
 h1.heading = t('upaya.forms.totp_setup.header_text')
 p= t('upaya.forms.totp_setup.totp_info')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,17 +39,17 @@ en:
     session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
     titles:
       confirmations:
-        new: Resend confirmation instructions for your Upaya Account
-        show: Create a Password for your Upaya Account
-      dashboard: Your Upaya Account
-      enter_2fa_code: Enter the secure one-time password to log in to your Upaya Account
+        new: Resend confirmation instructions for your %{app_name} Account
+        show: Create a Password for your %{app_name} Account
+      dashboard: Your %{app_name} Account
+      enter_2fa_code: Enter the secure one-time password to log in to your %{app_name} Account
       account_locked: Account Locked
       passwords:
-        change: Change your password for your Upaya Account
-        forgot: Reset your password for your Upaya Account
+        change: Change your password for your %{app_name} Account
+        forgot: Reset your password for your %{app_name} Account
       registrations:
-        edit: Edit your Upaya Account
-        new: Sign up for a Upaya Account
+        edit: Edit your %{app_name} Account
+        new: Sign up for a %{app_name} Account
         start: Get started
       two_factor_setup: Two-factor Authentication Setup
       users:

--- a/spec/features/visitors/confirmation_instructions_spec.rb
+++ b/spec/features/visitors/confirmation_instructions_spec.rb
@@ -86,10 +86,10 @@ feature 'Confirmation Instructions', devise: true do
   end
 
   scenario 'confirmations new page has localized title' do
-    expect(page).to have_title t('upaya.titles.confirmations.new')
+    expect(page).to have_title t('upaya.titles.confirmations.new', app_name: APP_NAME)
   end
 
   scenario 'confirmations new page has localized heading' do
-    expect(page).to have_title t('upaya.headings.confirmations.new')
+    expect(page).to have_title t('upaya.headings.confirmations.new', app_name: APP_NAME)
   end
 end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -374,7 +374,7 @@ feature 'Password Recovery' do
   end
 
   scenario 'passwords new view has a localized title' do
-    expect(page).to have_title t('upaya.titles.passwords.forgot')
+    expect(page).to have_title t('upaya.titles.passwords.forgot', app_name: APP_NAME)
   end
 
   scenario 'passwords new view has a localized heading' do

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -35,7 +35,7 @@ feature 'Sign Up', devise: true do
     confirm_last_user
 
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
-    expect(page).to have_title t('upaya.titles.confirmations.show')
+    expect(page).to have_title t('upaya.titles.confirmations.show', app_name: APP_NAME)
     expect(page).to have_content t('upaya.forms.confirmation.show_hdr')
 
     fill_in 'password_form_password', with: VALID_PASSWORD

--- a/spec/views/devise/registrations/new.html.slim_spec.rb
+++ b/spec/views/devise/registrations/new.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'devise/registrations/new.html.slim' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('upaya.titles.registrations.new'))
+    expect(view).to receive(:title).with(t('upaya.titles.registrations.new', app_name: APP_NAME))
 
     render
   end

--- a/spec/views/users/registrations/edit.html.slim_spec.rb
+++ b/spec/views/users/registrations/edit.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'users/registrations/edit.html.slim' do
     end
 
     it 'has a localized title' do
-      expect(view).to receive(:title).with(t('upaya.titles.registrations.edit'))
+      expect(view).to receive(:title).with(t('upaya.titles.registrations.edit', app_name: APP_NAME))
 
       render
     end


### PR DESCRIPTION
**Why**: The application name as seen by the user should be
configurable

**How**: Use the APP_NAME constant rather than hardcoding Upaya.