### PR TITLE
Remove body from unimplemented specs

### DIFF
--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -541,48 +541,30 @@ describe SamlIdpController do
       # a <saml:Conditions> element, which gives the conditions under which
       # the assertion is to be considered valid
       context 'Conditions' do
-        it 'has a saml:Conditions element' do
-          skip
-        end
+        it 'has a saml:Conditions element'
 
-        it 'has a NotBefore attribute' do
-          skip
-        end
+        it 'has a NotBefore attribute'
 
-        it 'has a NotOnOrAfter attribute' do
-          skip
-        end
+        it 'has a NotOnOrAfter attribute'
       end
 
       # a <saml:AuthnStatement> element, which describes the act of
       # authentication at the identity provider
       context 'AuthnStatement' do
-        it 'has a saml:AuthnStatement element' do
-          skip
-        end
+        it 'has a saml:AuthnStatement element'
 
-        it 'has an AuthnInstant attribute' do
-          skip
-        end
+        it 'has an AuthnInstant attribute'
 
-        it 'has a SessionIndex attribute' do
-          skip
-        end
+        it 'has a SessionIndex attribute'
       end
 
       context 'AuthnContext' do
-        it 'has a saml:AuthnContext element' do
-          skip
-        end
+        it 'has a saml:AuthnContext element'
 
         context 'AuthnContextClassRef' do
-          it 'has a saml:AuthnContextClassRef element' do
-            skip
-          end
+          it 'has a saml:AuthnContextClassRef element'
 
-          it 'has contents set to the loa of the ial?' do
-            skip
-          end
+          it 'has contents set to the loa of the ial?'
         end
       end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -102,17 +102,11 @@ feature 'saml api', devise: true, sms: true do
         expect(xmldoc.signature_nodeset.length).to eq(1)
       end
 
-      it 'applies xmldsig enveloped signature correctly' do
-        skip
-        # Verify
-        #   http://www.w3.org/2000/09/xmldsig#enveloped-signature
-      end
+      # Verify http://www.w3.org/2000/09/xmldsig#enveloped-signature
+      it 'applies xmldsig enveloped signature correctly'
 
-      it 'applies canonicalization method correctly' do
-        skip
-        # Verify
-        #   http://www.w3.org/2001/10/xml-exc-c14n#
-      end
+      # Verify http://www.w3.org/2001/10/xml-exc-c14n#
+      it 'applies canonicalization method correctly'
 
       it 'contains a signature method nodeset with SHA256 algorithm' do
         expect(xmldoc.signature_method_nodeset.length).to eq(1)


### PR DESCRIPTION
**Why**: It gives a more meaningful output: `Not yet implemented`
vs `No reason given`.