### PR TITLE
Remove top level 'upaya' key from en.yml

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
 
   def invalid_auth_token
     logger.info 'Rescuing InvalidAuthenticityToken'
-    flash[:error] = t('upaya.errors.invalid_authenticity_token')
+    flash[:error] = t('errors.invalid_authenticity_token')
     sign_out
     redirect_to root_url
   end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -7,7 +7,7 @@ module Users
     rescue_from Pundit::NotAuthorizedError do |_exception|
       # We are utilizing Pundit's policy for verifying which user can
       # recover passwords. However, we always want to return success.
-      flash[:success] = t('upaya.notices.password_reset')
+      flash[:success] = t('notices.password_reset')
       redirect_to after_sending_reset_password_instructions_path_for(
         resource_name
       )
@@ -34,7 +34,7 @@ module Users
                         end
       end
 
-      flash[:success] = t('upaya.notices.password_reset')
+      flash[:success] = t('notices.password_reset')
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ module Users
 
     def timeout
       flash[:notice] = t(
-        'upaya.session_timedout',
+        'session_timedout',
         session_timeout: distance_of_time_in_words(Devise.timeout_in)
       )
       redirect_to root_url

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -22,7 +22,7 @@ module Users
       if current_user.otp_secret_key.present?
         current_user.update(otp_secret_key: nil)
       end
-      flash[:success] = t('upaya.notices.totp_disabled')
+      flash[:success] = t('notices.totp_disabled')
       redirect_to edit_user_registration_path
     end
 
@@ -34,13 +34,13 @@ module Users
     end
 
     def process_valid_code
-      flash[:success] = t('upaya.notices.totp_configured')
+      flash[:success] = t('notices.totp_configured')
       redirect_to edit_user_registration_path
       user_session.delete(:new_totp_secret)
     end
 
     def process_invalid_code
-      flash[:error] = t('upaya.errors.invalid_totp')
+      flash[:error] = t('errors.invalid_totp')
       redirect_to users_totp_path
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def required_form_field(*args, &block)
-    content_tag(:p, "* #{t('upaya.forms.required_field')}", class: 'italic') +
+    content_tag(:p, "* #{t('forms.required_field')}", class: 'italic') +
       simple_form_for(*args, &block)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,13 +2,13 @@ class UserMailer < ActionMailer::Base
   default from: 'upaya@18f.gov'
 
   def email_changed(old_email)
-    mail(to: old_email, subject: t('upaya.mailer.email_change_notice.subject'))
+    mail(to: old_email, subject: t('mailer.email_change_notice.subject'))
   end
 
   def signup_with_your_email(email)
     @root_url = root_url
     @new_user_password_url = new_user_password_url
-    mail(to: email, subject: t('upaya.mailer.email_reuse_notice.subject'))
+    mail(to: email, subject: t('mailer.email_reuse_notice.subject'))
   end
 
   def password_changed(user)

--- a/app/views/dashboard/admin/_navigation.html.slim
+++ b/app/views/dashboard/admin/_navigation.html.slim
@@ -1,6 +1,6 @@
 .clearfix.p1
   .sm-col-right
     = link_to 'Accessibility Statement',
-      'https://upaya.18f.gov/accessibility', class: 'btn p1 h6 navy'
-    = link_to t('upaya.links.sign_out'),
+      'https://18f.gov/accessibility', class: 'btn p1 h6 navy'
+    = link_to t('links.sign_out'),
       destroy_user_session_path, method: 'delete', class: 'btn p1 h6 navy'

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.dashboard')
+- title t('titles.dashboard')
 
 table.table-light.border.bg-white.mb3
   tbody

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,7 +1,7 @@
-- title t('upaya.titles.confirmations.new')
+- title t('titles.confirmations.new')
 
 
-h1.heading = t('upaya.headings.confirmations.new')
+h1.heading = t('headings.confirmations.new')
 = simple_form_for(resource,
                   as: resource_name,
                   url: confirmation_path(resource_name),
@@ -10,4 +10,4 @@ h1.heading = t('upaya.headings.confirmations.new')
     = f.error_notification
     = f.full_error :confirmation_token
   = f.input :email, required: true, autofocus: true
-  = f.button :submit, t('upaya.forms.buttons.resend_confirmation')
+  = f.button :submit, t('forms.buttons.resend_confirmation')

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -1,7 +1,7 @@
-- title t('upaya.titles.confirmations.show')
+- title t('titles.confirmations.show')
 
 
-h1.heading = t('upaya.forms.confirmation.show_hdr')
+h1.heading = t('forms.confirmation.show_hdr')
 p.italic Your password must be at least 8 characters.
 = simple_form_for(@password_form,
     url: confirm_path,

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,7 +1,7 @@
-- title t('upaya.titles.passwords.change')
+- title t('titles.passwords.change')
 
 
-h1.heading = t('upaya.headings.passwords.change')
+h1.heading = t('headings.passwords.change')
 = simple_form_for(@password_form,
     url: password_path(resource_name),
     html: { autocomplete: 'off',

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,11 +1,11 @@
-- title t('upaya.titles.passwords.forgot')
+- title t('titles.passwords.forgot')
 
 
-h1.heading = t('upaya.headings.passwords.forgot')
+h1.heading = t('headings.passwords.forgot')
 = simple_form_for(resource,
                   as: resource_name,
                   url: password_path(resource_name),
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.error_notification
   = f.input :email, required: true, autofocus: true
-  = f.button :submit, t('upaya.forms.buttons.reset_password')
+  = f.button :submit, t('forms.buttons.reset_password')

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,7 +1,7 @@
-- title t('upaya.titles.registrations.new')
+- title t('titles.registrations.new')
 
 
-h1.heading = t('upaya.headings.registrations.enter_email')
+h1.heading = t('headings.registrations.enter_email')
 p.italic Enter the email address you’d like to associate with login.gov
 = simple_form_for(@register_user_email_form,
     html: { autocomplete: 'off', role: 'form' },

--- a/app/views/devise/registrations/start.html.slim
+++ b/app/views/devise/registrations/start.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.registrations.start')
+- title t('titles.registrations.start')
 
 
 = render 'devise/shared/auth_nav'

--- a/app/views/devise/registrations/verify_email.html.slim
+++ b/app/views/devise/registrations/verify_email.html.slim
@@ -1,7 +1,7 @@
-- title t('upaya.titles.registrations.edit')
+- title t('titles.registrations.edit')
 
 
-h1.heading = t('upaya.headings.registrations.verify_email')
+h1.heading = t('headings.registrations.verify_email')
 p
   '#{t('devise.registrations.signed_up_but_unconfirmed.message_start')}
   '<strong>#{email}</strong>.

--- a/app/views/devise/sessions/_form.html.slim
+++ b/app/views/devise/sessions/_form.html.slim
@@ -5,8 +5,8 @@
   = f.input :email, required: true, autofocus: true
   = f.input :password,
             required: true,
-            hint: link_to(t('upaya.headings.passwords.forgot'),
+            hint: link_to(t('headings.passwords.forgot'),
                           new_password_path(resource_name)),
             hint_html: { class: 'py1 line-height-1 right-align' }
-  = f.button :submit, t('upaya.headings.log_in')
+  = f.button :submit, t('headings.log_in')
 = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.visitors.index')
+- title t('titles.visitors.index')
 
 
 = render 'devise/shared/auth_nav'

--- a/app/views/devise/shared/_auth_nav.html.slim
+++ b/app/views/devise/shared/_auth_nav.html.slim
@@ -1,10 +1,10 @@
 .clearfix.mb3
   - login_page = controller_name == 'sessions'
   .col.col-6
-    = link_to t('upaya.links.sign_in'),
+    = link_to t('links.sign_in'),
               new_user_session_path,
               class: 'btn-auth' + (login_page ? ' btn-auth--active' : '')
   .col.col-6
-    = link_to t('upaya.links.sign_up'),
+    = link_to t('links.sign_up'),
               new_user_start_path,
               class: 'btn-auth' + (login_page ? '' : ' btn-auth--active')

--- a/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
+++ b/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim
@@ -1,6 +1,6 @@
-- title t('upaya.titles.account_locked')
+- title t('titles.account_locked')
 
-h1.heading = t('upaya.titles.account_locked')
+h1.heading = t('titles.account_locked')
 p = t('devise.two_factor_authentication.max_login_attempts_reached')
 p = t('devise.two_factor_authentication.please_try_again',
       time_remaining: @user_decorator.lockout_time_remaining_in_words)

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.enter_2fa_code')
+- title t('titles.enter_2fa_code')
 
 h1.heading = t('devise.two_factor_authentication.header_text')
 p
@@ -20,7 +20,7 @@ p
 
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2
-    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.two_factor.code')
+    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('forms.two_factor.code')
     = hidden_field_tag('method', 'sms')
     = number_field_tag(:code, \
                        '', \

--- a/app/views/devise/two_factor_authentication/show_totp.html.slim
+++ b/app/views/devise/two_factor_authentication/show_totp.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.enter_2fa_code')
+- title t('titles.enter_2fa_code')
 
 h1.heading = t('devise.two_factor_authentication.totp_header_text')
 p
@@ -8,7 +8,7 @@ p
   '<strong>#{APP_NAME}</strong>.
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2
-    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.two_factor.code')
+    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('forms.two_factor.code')
     = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true
   = submit_tag 'Submit', class: 'btn btn-primary'
 

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.two_factor_setup')
+- title t('titles.two_factor_setup')
 
 
 h1.heading = t('devise.two_factor_authentication.two_factor_setup')

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -1,9 +1,9 @@
 #session-timeout-msg
   .p2.bg-white.border
-    .h3.bold.mb1 = t('upaya.headings.session_timeout_warning')
-    p = t('upaya.session_timeout_warning',
+    .h3.bold.mb1 = t('headings.session_timeout_warning')
+    p = t('session_timeout_warning',
           time_left_in_session: time_left_in_session,
-          continue_text: t('upaya.forms.buttons.continue_browsing'))
-    = link_to t('upaya.forms.buttons.continue_browsing'),
+          continue_text: t('forms.buttons.continue_browsing'))
+    = link_to t('forms.buttons.continue_browsing'),
               request.original_url,
               class: 'btn btn-primary'

--- a/app/views/shared/_navigation_links.html.slim
+++ b/app/views/shared/_navigation_links.html.slim
@@ -4,5 +4,5 @@
   - else
     .clearfix.p2
       .sm-col-right.h5
-        = link_to t('upaya.links.sign_out'),
+        = link_to t('links.sign_out'),
           destroy_user_session_path, method: 'delete', class: 'navy bold'

--- a/app/views/shared/_user_search.html.slim
+++ b/app/views/shared/_user_search.html.slim
@@ -3,7 +3,7 @@
   = form_tag support_find_path, class: 'form-horizontal', method: 'post', role: 'form' do
     .panel-body
       fieldset.form-group
-        legend.solo-legend= t('upaya.headings.search')
+        legend.solo-legend= t('headings.search')
         hr
         = label_tag :email, nil, class: 'col-md-2 control-label'
         .col-md-10

--- a/app/views/user_mailer/signup_with_your_email.html.slim
+++ b/app/views/user_mailer/signup_with_your_email.html.slim
@@ -1,7 +1,7 @@
 p
   'A request was made to use this email address as a username for a #{APP_NAME}
   'account. This email address is already in use. If you requested this change,
-  'please use the following link to #{t('upaya.headings.log_in').downcase}
+  'please use the following link to #{t('headings.log_in').downcase}
   'to #{APP_NAME}:
 
 p= link_to @root_url, @root_url, target: '_blank'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,6 +1,6 @@
-- title t('upaya.titles.users.edit', user: @user.email)
+- title t('titles.users.edit', user: @user.email)
 
-h3 = t('upaya.headings.users.edit')
+h3 = t('headings.users.edit')
 = required_form_field(@user, html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.error_notification
   = f.input :email, required: true, autofocus: true

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,9 +1,9 @@
-- title t('upaya.titles.users.index')
+- title t('titles.users.index')
 
-h2 = t('upaya.headings.admin.index')
+h2 = t('headings.admin.index')
 = render 'shared/user_search'
 
-h3 = t('upaya.headings.users.index')
+h3 = t('headings.users.index')
 table.table
   tbody
     - @users.each do |user|

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-- title t('upaya.titles.registrations.edit')
+- title t('titles.registrations.edit')
 
 
 h1.heading = 'Update information'
@@ -7,7 +7,7 @@ h1.heading = 'Update information'
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification
   = render 'devise/registrations/form', f: f
-  p.italic = t('upaya.forms.registration.need_password')
+  p.italic = t('forms.registration.need_password')
   = f.input(:current_password, required: true)
   = f.button :submit, 'Update'
 
@@ -17,8 +17,8 @@ h1.heading = 'Authenticator App'
 - else
   = button_to 'Enable', users_totp_url, method: :get, class: 'btn btn-primary'
 
-h1.heading = t('upaya.headings.delete_account')
-= button_to t('upaya.forms.buttons.delete_account'), \
+h1.heading = t('headings.delete_account')
+= button_to t('forms.buttons.delete_account'), \
           { action: :destroy, id: current_user.id }, \
           method: :delete, \
           data: { confirm: 'Are you sure?' }, \

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
-- title t('upaya.titles.users.show', user: @user.email)
+- title t('titles.users.show', user: @user.email)
 
-h3 = t('upaya.headings.users.show')
+h3 = t('headings.users.show')
 
 table.table
   tr

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -1,11 +1,11 @@
-- title t('upaya.titles.enter_2fa_code')
+- title t('titles.enter_2fa_code')
 
-h1.heading = t('upaya.forms.totp_setup.header_text')
-p= t('upaya.forms.totp_setup.totp_info')
+h1.heading = t('forms.totp_setup.header_text')
+p= t('forms.totp_setup.totp_info')
 .center
   = image_tag @qrcode, alt: 'QR Code for Authenticator App'
 = form_tag(confirm_totp_path, method: :patch, role: 'form') do
   .mb2
-    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('upaya.forms.totp_setup.code')
+    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('forms.totp_setup.code')
     = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true
   = submit_tag 'Submit', class: 'btn btn-primary'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -9,7 +9,7 @@
 # Figaro requires all values to be explicit strings.
 
 mailer_domain_name: 'http://localhost:3000'
-support_url: 'https://upaya.18f.gov/contact'
+support_url: 'https://18f.gov/contact'
 
 development:
   allow_third_party_auth: 'yes'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -93,7 +93,7 @@ ignore_unused:
 - 'activerecord.errors.*'
 - 'errors.messages.*'
 - '{devise,simple_form}.*'
-- 'upaya.errors.not_authorized'
+- 'errors.not_authorized'
 - 'experiments.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,88 +1,89 @@
 en:
-  upaya:
-    errors:
-      invalid_totp: 'Invalid code entered.  Please try again.'
-      not_authorized: 'You are not authorized to perform this action.'
-      invalid_authenticity_token: 'Oops, something went wrong. Please sign in again.'
+  errors:
+    invalid_totp: Invalid code entered.  Please try again.
+    not_authorized: You are not authorized to perform this action.
+    invalid_authenticity_token: Oops, something went wrong. Please sign in again.
+    messages:
+      improbable_phone: Mobile number is invalid. Please make sure you enter a 10-digit phone number.
 
-    forms:
-      buttons:
-        continue_browsing: Continue Browsing
-        delete_account: Delete My Account
-        resend_confirmation: Resend confirmation instructions
-        reset_password: Send reset password instructions
-      required_field: Indicates a required field.
-      registration:
-        need_password: Please verify your current password to confirm changes.
-      two_factor:
-        code: Secure one-time password
-      totp_setup:
-        header_text: Authenticator App Setup
-        totp_info: >
-          To enable app-based authentication, use your TOTP-compatible mobile
-          app to scan the QR code below, then enter the app-generated code
-          in the box below.
-        code: App-generated code
-      confirmation:
-        show_hdr: Create a Password
+  forms:
+    buttons:
+      continue_browsing: Continue Browsing
+      delete_account: Delete My Account
+      resend_confirmation: Resend confirmation instructions
+      reset_password: Send reset password instructions
+    required_field: Indicates a required field.
+    registration:
+      need_password: Please verify your current password to confirm changes.
+    two_factor:
+      code: Secure one-time password
+    totp_setup:
+      header_text: Authenticator App Setup
+      totp_info: >
+        To enable app-based authentication, use your TOTP-compatible mobile
+        app to scan the QR code below, then enter the app-generated code
+        in the box below.
+      code: App-generated code
+    confirmation:
+      show_hdr: Create a Password
 
-    links:
-      sign_out: 'Sign out'
-      sign_in: 'Log in'
-      sign_up: 'Sign up'
-    notices:
-      totp_configured: Authenticator app successfully configured
-      totp_disabled: Authenticator app disabled
-      password_reset: 'You will receive an email with instructions on how to reset your password in a few minutes.'
-    session_timedout: "For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again."
-    session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
-    titles:
-      confirmations:
-        new: Resend confirmation instructions for your account
-        show: Create a password for your account
-      dashboard: Dashboard
-      enter_2fa_code: Enter the secure one-time password to log in to your account
-      account_locked: Account locked
-      passwords:
-        change: Change the password for your account
-        forgot: Reset the password for your account
-      registrations:
-        edit: Edit your account
-        new: Sign up for a account
-        start: Get started
-      two_factor_setup: Two-factor Authentication Setup
-      users:
-        edit: Editing User - %{user}
-        index: Manage Users
-        show: User - %{user}
-      visitors:
-        index: Welcome
+  links:
+    sign_out: 'Sign out'
+    sign_in: 'Log in'
+    sign_up: 'Sign up'
+  notices:
+    totp_configured: Authenticator app successfully configured
+    totp_disabled: Authenticator app disabled
+    password_reset: 'You will receive an email with instructions on how to reset your password in a few minutes.'
+  session_timedout: "For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again."
+  session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
+  titles:
+    confirmations:
+      new: Resend confirmation instructions for your account
+      show: Create a password for your account
+    dashboard: Dashboard
+    enter_2fa_code: Enter the secure one-time password to log in to your account
+    account_locked: Account locked
+    passwords:
+      change: Change the password for your account
+      forgot: Reset the password for your account
+    registrations:
+      edit: Edit your account
+      new: Sign up for a account
+      start: Get started
+    two_factor_setup: Two-factor Authentication Setup
+    users:
+      edit: Editing User - %{user}
+      index: Manage Users
+      show: User - %{user}
+    visitors:
+      index: Welcome
 
-    headings:
-      admin:
-        index: Admin Interface
-      confirmations:
-        new: Resend confirmation instructions
-      delete_account: Delete Account
-      log_in: Log in
-      passwords:
-        change: Change your password
-        forgot: Forgot password?
-      registrations:
-        enter_email: Email address
-        verify_email: Verify email address
-      search: Search for a user
-      session_timeout_warning: Session Timeout
-      users:
-        edit: Edit User
-        index: Users
-        show: User Details
+  headings:
+    admin:
+      index: Admin Interface
+    confirmations:
+      new: Resend confirmation instructions
+    delete_account: Delete Account
+    log_in: Log in
+    passwords:
+      change: Change your password
+      forgot: Forgot password?
+    registrations:
+      enter_email: Email address
+      verify_email: Verify email address
+    search: Search for a user
+    session_timeout_warning: Session Timeout
+    users:
+      edit: Edit User
+      index: Users
+      show: User Details
 
-    mailer:
-      email_reuse_notice:
-        subject: Email confirmation notification
-      email_change_notice:
-        subject: Email change notification
+  mailer:
+    email_reuse_notice:
+      subject: Email confirmation notification
+    email_change_notice:
+      subject: Email change notification
 
   activerecord:
     errors:
@@ -126,6 +127,3 @@ en:
         ssn: Social Security Number (SSN)
         address: Mailing address
         finance: Financial information
-  errors:
-    messages:
-      improbable_phone: 'Mobile number is invalid. Please make sure you enter a 10-digit phone number.'

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -292,7 +292,7 @@ describe Users::RegistrationsController, devise: true do
       expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
       expect(response).to render_template('user_mailer/signup_with_your_email')
       expect(user.reload.email).to eq 'old_email@example.com'
-      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
+      expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
     end
   end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -72,7 +72,7 @@ describe Users::SessionsController, devise: true do
 
       expect(response.request.env['rack.session']['flash']['flashes']).to(
         have_text(
-          t('upaya.session_timedout',
+          t('session_timedout',
             session_timeout: distance_of_time_in_words(Devise.timeout_in))
         )
       )

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -51,7 +51,7 @@ describe Users::TotpSetupController, devise: true do
       end
 
       it 'sets flash[:error] message' do
-        expect(flash[:error]).to eq t('upaya.errors.invalid_totp')
+        expect(flash[:error]).to eq t('errors.invalid_totp')
       end
 
       it 'does not enable TOTP for the current user' do
@@ -72,7 +72,7 @@ describe Users::TotpSetupController, devise: true do
       end
 
       it 'sets flash[:success] message' do
-        expect(flash[:success]).to eq t('upaya.notices.totp_configured')
+        expect(flash[:success]).to eq t('notices.totp_configured')
       end
 
       it 'enables totp for the current user' do

--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :identity do
-    service_provider 'https://upaya.serviceprovider.com'
+    service_provider 'https://serviceprovider.com'
   end
 
   trait :active do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -167,7 +167,7 @@ feature 'Two Factor Authentication', devise: true do
         click_button('Submit')
       end
 
-      expect(page).to have_content t('upaya.titles.account_locked')
+      expect(page).to have_content t('titles.account_locked')
 
       # let 10 minutes (otp validity period) magically pass
       user.update(second_factor_locked_at: Time.zone.now - (Devise.direct_otp_valid_for + 1.second))

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -129,9 +129,9 @@ feature 'Sign in' do
 
     scenario 'user sees warning before session times out' do
       def warning_content
-        t('upaya.session_timeout_warning',
+        t('session_timeout_warning',
           time_left_in_session: time_left_in_session,
-          continue_text: t('upaya.forms.buttons.continue_browsing'))
+          continue_text: t('forms.buttons.continue_browsing'))
       end
 
       sign_in_and_2fa_user
@@ -177,7 +177,7 @@ feature 'Sign in' do
 
     it 'successfully signs in the user' do
       user = sign_in_user
-      click_link(t('upaya.links.sign_out'))
+      click_link(t('links.sign_out'))
 
       Timecop.travel(Devise.timeout_in + 1.minute)
 
@@ -185,7 +185,7 @@ feature 'Sign in' do
       fill_in 'Password', with: user.password
       click_button 'Log in'
 
-      expect(page).to_not have_content t('upaya.errors.invalid_authenticity_token')
+      expect(page).to_not have_content t('errors.invalid_authenticity_token')
       expect(current_path).to eq users_otp_path
     end
   end

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -11,7 +11,7 @@ feature 'Sign out', devise: true do
   #   Then I see a signed out message
   scenario 'user signs out successfully' do
     sign_in_user
-    click_link(t('upaya.links.sign_out'))
+    click_link(t('links.sign_out'))
 
     expect(page).to have_content t('devise.sessions.signed_out')
   end

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -52,7 +52,7 @@ feature 'User edit' do
     it 'deletes the account and signs the user out with a flash message' do
       sign_in_and_2fa_user
       visit edit_user_registration_path
-      click_button t('upaya.forms.buttons.delete_account')
+      click_button t('forms.buttons.delete_account')
 
       expect(page).to have_content t('devise.registrations.destroyed')
       expect(current_path).to eq root_path

--- a/spec/features/visitors/confirmation_instructions_spec.rb
+++ b/spec/features/visitors/confirmation_instructions_spec.rb
@@ -86,10 +86,10 @@ feature 'Confirmation Instructions', devise: true do
   end
 
   scenario 'confirmations new page has localized title' do
-    expect(page).to have_title t('upaya.titles.confirmations.new')
+    expect(page).to have_title t('titles.confirmations.new')
   end
 
   scenario 'confirmations new page has localized heading' do
-    expect(page).to have_title t('upaya.headings.confirmations.new')
+    expect(page).to have_title t('headings.confirmations.new')
   end
 end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -15,7 +15,7 @@ feature 'Password Recovery' do
 
   before(:each) do
     visit root_path
-    click_link t('upaya.headings.passwords.forgot')
+    click_link t('headings.passwords.forgot')
   end
 
   # Scenario: User can request a password reset link be sent to them
@@ -26,7 +26,7 @@ feature 'Password Recovery' do
     before do
       user = create(:user, :signed_up)
       fill_in 'Email', with: user.email
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
     end
 
     it 'uses a relevant email subject' do
@@ -39,7 +39,7 @@ feature 'Password Recovery' do
     end
 
     it 'displays a localized notice' do
-      expect(page).to have_content t('upaya.notices.password_reset')
+      expect(page).to have_content t('notices.password_reset')
     end
 
     it 'includes a link to reset the password in the email' do
@@ -68,15 +68,15 @@ feature 'Password Recovery' do
       click_email_link_matching(/confirmation_token/)
       reset_email
       visit root_path
-      click_link t('upaya.headings.passwords.forgot')
+      click_link t('headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
       open_last_email
       click_email_link_matching(/confirmation_token/)
     end
 
     it 'shows the password form' do
-      expect(page).to have_content t('upaya.forms.confirmation.show_hdr')
+      expect(page).to have_content t('forms.confirmation.show_hdr')
     end
   end
 
@@ -99,7 +99,7 @@ feature 'Password Recovery' do
     end
 
     it 'shows the password form' do
-      expect(page).to have_content t('upaya.forms.confirmation.show_hdr')
+      expect(page).to have_content t('forms.confirmation.show_hdr')
     end
   end
 
@@ -111,17 +111,17 @@ feature 'Password Recovery' do
   context 'user with password confirmation resets password', email: true do
     before do
       sign_up_with_and_set_password_for('email@example.com')
-      click_link(t('upaya.links.sign_out'))
+      click_link(t('links.sign_out'))
       visit root_path
-      click_link t('upaya.headings.passwords.forgot')
+      click_link t('headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
       open_last_email
       click_email_link_matching(/reset_password_token/)
     end
 
     it 'shows the password form' do
-      expect(page).to have_content t('upaya.headings.passwords.change')
+      expect(page).to have_content t('headings.passwords.change')
     end
 
     it 'keeps user signed out after they successfully reset their password' do
@@ -141,11 +141,11 @@ feature 'Password Recovery' do
   context 'user with invalid token cannot reset password', email: true do
     before do
       sign_up_with_and_set_password_for('email@example.com')
-      click_link(t('upaya.links.sign_out'))
+      click_link(t('links.sign_out'))
       visit root_path
-      click_link t('upaya.headings.passwords.forgot')
+      click_link t('headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
       visit edit_user_password_path(reset_password_token: 'invalid_token')
     end
 
@@ -169,17 +169,17 @@ feature 'Password Recovery' do
       click_button 'Submit'
       fill_in 'code', with: User.last.direct_otp
       click_button 'Submit'
-      click_link(t('upaya.links.sign_out'))
+      click_link(t('links.sign_out'))
       visit root_path
-      click_link t('upaya.headings.passwords.forgot')
+      click_link t('headings.passwords.forgot')
       fill_in 'Email', with: 'email@example.com'
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
       open_last_email
       click_email_link_matching(/reset_password_token/)
     end
 
     it 'shows the password form' do
-      expect(page).to have_content t('upaya.headings.passwords.change')
+      expect(page).to have_content t('headings.passwords.change')
     end
 
     it 'redirects user to dashboard after signing back in' do
@@ -204,7 +204,7 @@ feature 'Password Recovery' do
 
     invalid_addresses.each do |email|
       fill_in 'Email', with: email
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
 
       expect(page).to have_content t('valid_email.validations.email.invalid')
     end
@@ -219,20 +219,20 @@ feature 'Password Recovery' do
 
     invalid_addresses.each do |email|
       fill_in 'Email', with: email
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
 
       expect(page).to have_content t('valid_email.validations.email.invalid')
     end
   end
 
   scenario 'user submits blank email address' do
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(page).to have_content t('valid_email.validations.email.invalid')
   end
 
   scenario 'user submits blank email address and has JS turned on', js: true do
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(page).to have_content 'Please fill in all required fields'
   end
@@ -243,7 +243,7 @@ feature 'Password Recovery' do
   #   Then I still don't know if an account exists
   scenario 'user is unable to determine if account exists' do
     fill_in 'Email', with: 'no_account_exists@gmail.com'
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
     expect(page).to have_content(t('devise.passwords.send_instructions'))
   end
 
@@ -256,7 +256,7 @@ feature 'Password Recovery' do
       @user = create(:user, :signed_up)
 
       fill_in 'Email', with: @user.email
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
 
       raw_reset_token, db_confirmation_token =
         Devise.token_generator.generate(User, :reset_password_token)
@@ -312,7 +312,7 @@ feature 'Password Recovery' do
     user = create(:user, :signed_up)
 
     fill_in 'Email', with: user.email
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     user.reset_password_sent_at =
       Time.zone.now - Devise.reset_password_within - 1.hour
@@ -337,7 +337,7 @@ feature 'Password Recovery' do
     user = create(:user, :signed_up)
 
     fill_in 'Email', with: user.email
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     raw_reset_token, db_confirmation_token =
       Devise.token_generator.generate(User, :reset_password_token)
@@ -365,20 +365,20 @@ feature 'Password Recovery' do
     user.update(confirmed_at: nil)
 
     visit root_path
-    click_link t('upaya.headings.passwords.forgot')
+    click_link t('headings.passwords.forgot')
     fill_in 'Email', with: user.email
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(last_email.subject).
       to eq t('devise.mailer.confirmation_instructions.subject')
   end
 
   scenario 'passwords new view has a localized title' do
-    expect(page).to have_title t('upaya.titles.passwords.forgot')
+    expect(page).to have_title t('titles.passwords.forgot')
   end
 
   scenario 'passwords new view has a localized heading' do
-    expect(page).to have_content t('upaya.headings.passwords.forgot')
+    expect(page).to have_content t('headings.passwords.forgot')
   end
 
   # Scenario: User enters non-existent email address into password reset form
@@ -387,7 +387,7 @@ feature 'Password Recovery' do
   #   Then I see 'email sent'
   scenario 'user enters non-existent email address into password reset form' do
     fill_in 'user_email', with: 'ThisEmailAddressShall@NeverExist.com'
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(page).to have_content t('devise.passwords.send_instructions')
     expect(page).not_to(have_content('not found'))
@@ -403,7 +403,7 @@ feature 'Password Recovery' do
     user = create(:user, :signed_up, :tech_support)
 
     fill_in 'user_email', with: user.email
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(page).to have_content t('devise.passwords.send_instructions')
     expect(ActionMailer::Base.deliveries).to be_empty
@@ -418,7 +418,7 @@ feature 'Password Recovery' do
     user = create(:user, :signed_up, :admin)
 
     fill_in 'user_email', with: user.email
-    click_button t('upaya.forms.buttons.reset_password')
+    click_button t('forms.buttons.reset_password')
 
     expect(page).to have_content t('devise.passwords.send_instructions')
     expect(ActionMailer::Base.deliveries).to be_empty

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -35,8 +35,8 @@ feature 'Sign Up', devise: true do
     confirm_last_user
 
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
-    expect(page).to have_title t('upaya.titles.confirmations.show')
-    expect(page).to have_content t('upaya.forms.confirmation.show_hdr')
+    expect(page).to have_title t('titles.confirmations.show')
+    expect(page).to have_content t('forms.confirmation.show_hdr')
 
     fill_in 'password_form_password', with: VALID_PASSWORD
     click_button 'Submit'
@@ -88,7 +88,7 @@ feature 'Sign Up', devise: true do
         click_button 'Submit'
       end
 
-      expect(page).to_not have_content t('upaya.titles.account_locked')
+      expect(page).to_not have_content t('titles.account_locked')
       visit user_two_factor_authentication_path
       expect(current_path).to eq user_two_factor_authentication_path
     end
@@ -105,7 +105,7 @@ feature 'Sign Up', devise: true do
     # JJG - I think we should go as far as making sure the user enters
     # a new number and that the OTP is sent to the new number.
     it 'allows user to enter new number if they Sign Out before confirming' do
-      click_link(t('upaya.links.sign_out'))
+      click_link(t('links.sign_out'))
       signin(@user.reload.email, VALID_PASSWORD)
       expect(current_path).to eq users_otp_path
     end

--- a/spec/lib/rails_logger_spec.rb
+++ b/spec/lib/rails_logger_spec.rb
@@ -88,7 +88,7 @@ describe 'Rails.logger', type: :feature do
       visit new_user_password_path
 
       fill_in 'Email', with: user.email
-      click_button t('upaya.forms.buttons.reset_password')
+      click_button t('forms.buttons.reset_password')
 
       raw_reset_token, db_confirmation_token =
         Devise.token_generator.generate(User, :reset_password_token)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -11,7 +11,7 @@ describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eq t('upaya.mailer.email_change_notice.subject')
+      expect(mail.subject).to eq t('mailer.email_change_notice.subject')
     end
 
     it 'renders the body' do
@@ -51,7 +51,7 @@ describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
+      expect(mail.subject).to eq t('mailer.email_reuse_notice.subject')
     end
 
     it 'renders the body' do

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -163,7 +163,7 @@ describe 'user edits their account', email: true do
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq '+1 (202) 555-1212'
-      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
+      expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
       expect(number_of_emails_sent).to eq 1
     end
 
@@ -231,7 +231,7 @@ describe 'user edits their account', email: true do
         )
       expect(flash[:notice]).to eq t('devise.registrations.email_and_mobile_need_confirmation')
       expect(user.reload.mobile).to eq '+1 (202) 555-1212'
-      expect(last_email.subject).to eq t('upaya.mailer.email_reuse_notice.subject')
+      expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
       expect(number_of_emails_sent).to eq 1
     end
 

--- a/spec/views/devise/registrations/new.html.slim_spec.rb
+++ b/spec/views/devise/registrations/new.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'devise/registrations/new.html.slim' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('upaya.titles.registrations.new'))
+    expect(view).to receive(:title).with(t('titles.registrations.new'))
 
     render
   end

--- a/spec/views/devise/registrations/start.html.slim_spec.rb
+++ b/spec/views/devise/registrations/start.html.slim_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'devise/registrations/start.html.slim' do
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('upaya.titles.registrations.start'))
+    expect(view).to receive(:title).with(t('titles.registrations.start'))
 
     render
   end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'devise/sessions/new.html.slim' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('upaya.titles.visitors.index'))
+    expect(view).to receive(:title).with(t('titles.visitors.index'))
 
     render
   end
@@ -29,7 +29,7 @@ describe 'devise/sessions/new.html.slim' do
 
     expect(rendered).
       to have_link(
-        t('upaya.links.sign_up'), href: new_user_start_path
+        t('links.sign_up'), href: new_user_start_path
       )
   end
 end

--- a/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/max_login_attempts_reached.html.slim_spec.rb
@@ -8,7 +8,7 @@ describe 'devise/two_factor_authentication/max_login_attempts_reached.html.slim'
 
       render
 
-      expect(rendered).to include(t('upaya.titles.account_locked'))
+      expect(rendered).to include(t('titles.account_locked'))
       expect(rendered).to include(t('devise.two_factor_authentication.max_login_attempts_reached'))
       expect(rendered).to include('1000 years')
     end

--- a/spec/views/users/registrations/edit.html.slim_spec.rb
+++ b/spec/views/users/registrations/edit.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'users/registrations/edit.html.slim' do
     end
 
     it 'has a localized title' do
-      expect(view).to receive(:title).with(t('upaya.titles.registrations.edit'))
+      expect(view).to receive(:title).with(t('titles.registrations.edit'))
 
       render
     end
@@ -30,9 +30,9 @@ describe 'users/registrations/edit.html.slim' do
     it 'contains link to delete account' do
       render
 
-      expect(rendered).to have_content t('upaya.headings.delete_account')
+      expect(rendered).to have_content t('headings.delete_account')
       expect(rendered).
-        to have_xpath("//input[@value='#{t('upaya.forms.buttons.delete_account')}']")
+        to have_xpath("//input[@value='#{t('forms.buttons.delete_account')}']")
     end
   end
 


### PR DESCRIPTION
**Why** It doesn't serve any useful purpose and
removing it resulting in shorter strings which
means less typing and reading for us hard working
developers.