### PR TITLE
Register dashboard service providers

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -89,6 +89,20 @@ production:
       assertion_consumer_logout_service_url: 'https://identity-sp-rails-demo.apps.cloud.gov/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-sp-rails-demo.apps.cloud.gov/login'
       cert: 'demo_sp'
+    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dashboard-dev':
+      metadata_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml/metadata'
+      acs_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml/callback'
+      assertion_consumer_logout_service_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml/logout'
+      sp_initiated_login_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml'
+      cert: 'identity_dashboard_cert'
+      block_encryption: 'aes256-cbc'
+    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dashboard-demo':
+      metadata_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/metadata'
+      acs_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/callback'
+      assertion_consumer_logout_service_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/logout'
+      sp_initiated_login_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml'
+      cert: 'identity_dashboard_cert'
+      block_encryption: 'aes256-cbc'
 
 superb.legit.domain.gov:
   valid_hosts:


### PR DESCRIPTION
**Why**:

Adds entries for identity-dashboard -dev and -demo applications.