### PR TITLE
Make UI tweaks to app auth page

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -62,7 +62,7 @@ UserDecorator = Struct.new(:user) do
     }
     url = user.provisioning_uri(nil, options)
     qrcode = RQRCode::QRCode.new(url)
-    qrcode.as_png(size: 166).to_data_url
+    qrcode.as_png(size: 300).to_data_url
   end
 
   private

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -1,11 +1,11 @@
 - title t('titles.enter_2fa_code')
 
 h1.heading = t('forms.totp_setup.header_text')
-p= t('forms.totp_setup.totp_info')
-.center
+p.mb0 = t('forms.totp_setup.totp_info')
+.py1.center
   = image_tag @qrcode, alt: 'QR Code for Authenticator App'
 = form_tag(confirm_totp_path, method: :patch, role: 'form') do
   .mb2
-    = label_tag 'code', raw('<abbr title="required">*</abbr> ') + t('forms.totp_setup.code')
+    = label_tag 'code', t('forms.totp_setup.code'), class: 'hide'
     = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true
   = submit_tag 'Submit', class: 'btn btn-primary'


### PR DESCRIPTION
**Why**: tiny bump in usability / look

**How**: bigger img, removed unneeded input label, minor spacing

**Preview**:
![image](https://cloud.githubusercontent.com/assets/1060893/16670608/01652cb4-4469-11e6-8296-5b290b095083.png)
