### PR TITLE
Add HTML5 Constraints API validation

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -1,0 +1,16 @@
+import 'classlist.js';
+import gf from 'gentleform';
+
+
+function validateForm() {
+  const form = document.querySelector('form[novalidate]');
+
+  if (form) {
+    gf(form, function onSubmit(e) {
+      if (!this.isValid()) e.preventDefault();
+    });
+  }
+}
+
+
+document.addEventListener('DOMContentLoaded', validateForm);

--- a/app/assets/javascripts/app/utils.js
+++ b/app/assets/javascripts/app/utils.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 
-
 // Removing element from DOM (on click containing appropriate data attribute)
 const dismiss = '[data-dismiss="true"]';
 $(document).on('click', dismiss, (e) => { $(e.target).parent().remove(); });
@@ -9,11 +8,12 @@ $(document).on('click', dismiss, (e) => { $(e.target).parent().remove(); });
 // Safari & IE 8/9 do not support client side handling of `required` attribute on
 // form inputs; this adds basic messaging and styling fallback for these browsers
 // "page:load" event needed because of turbolinks, which overrides normal loading process
+
 $(document).on('ready page:load', () => {
   const message = '<div class="error-notify alert-danger p1 mt1 mb2">Please fill in all required' +
     ' fields.</div>';
 
-  $('form').on('submit', function(e) {
+  $('form:not([novalidate])').on('submit', function(e) {
     const $form = $(this);
     const $fields = $form.find('[required]').filter(function() { return this.value === ''; });
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,4 @@
 
 import 'app/utils';
 import 'app/pw-toggle';
+import 'app/form-validation';

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -4,6 +4,10 @@
   font-weight: $bold-font-weight;
 }
 
+.is-invalid {
+  border-color: $red;
+}
+
 [type="submit"] {
   @media #{$breakpoint-max-sm} {
     max-width: 100%;

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,3 +1,5 @@
+# rubocop:disable ModuleLength
+# :reek:DataClump
 module FormHelper
   def app_setting_value_field_for(app_setting, f)
     if app_setting.boolean?
@@ -7,20 +9,46 @@ module FormHelper
     end
   end
 
-  def block_text_field_tag(name, value)
-    text_field_tag(name, value, class: 'block col-12 mb2 field')
+  def block_text_field_tag(name, value, options = {})
+    text_field_tag(name, value, options.merge(class: 'block col-12 mb2 field')) +
+      form_input_error_messages(name, options)
   end
 
-  def block_date_field_tag(name, value)
-    date_field_tag(name, value, class: 'block col-12 mb2 field')
+  def block_date_field_tag(name, value, options = {})
+    date_field_tag(name, value, options.merge(class: 'block col-12 mb2 field')) +
+      form_input_error_messages(name, options)
   end
 
-  def us_states_territories_select_tag
+  # rubocop:disable MethodLength
+  def form_input_error_messages(name, options = {})
+    content_tag(:div, nil, class: 'bold red mb2', data: { 'errors-for' => name }) do
+      if options[:required]
+        concat content_tag(
+          :div,
+          t('forms.value_missing'),
+          style: 'display: none',
+          data: { 'errors-when' => 'valueMissing' }
+        )
+      end
+      if options[:pattern]
+        concat content_tag(
+          :div,
+          options[:'data-custom-message'] || t('forms.pattern_mismatch'),
+          style: 'display: none',
+          data: { 'errors-when' => 'patternMismatch' }
+        )
+      end
+    end
+  end
+  # rubocop:enable MethodLength
+
+  def us_states_territories_select_tag(options = {})
     select_tag(
       'state',
       options_for_select(us_states_territories),
-      class: 'block col-12 mb2 field'
-    )
+      options.merge(class: 'block col-12 mb2 field')
+    ) +
+      form_input_error_messages('state', options)
   end
 
   # rubocop:disable MethodLength, Style/WordArray

--- a/app/views/idv/questions/_text.html.slim
+++ b/app/views/idv/questions/_text.html.slim
@@ -1,3 +1,2 @@
 = hidden_field_tag('text_question', true)
-= text_field_tag 'answer', nil, required: true, autofocus: true, \
-  class: 'block col-12 mb2 field'
+= block_text_field_tag 'answer', nil, required: true, autofocus: true

--- a/app/views/idv/sessions/index.html.slim
+++ b/app/views/idv/sessions/index.html.slim
@@ -1,51 +1,52 @@
 - title t('idv.titles.welcome')
 
-
-= form_tag(idv_sessions_path, method: 'post')
+= form_tag(idv_sessions_path, method: 'post', novalidate: true)
   h1.heading = t('idv.titles.session.basic')
   .mb3
-    label = t('idv.form.first_name')
-    = block_text_field_tag 'first_name', nil
-    label = t('idv.form.last_name')
-    = block_text_field_tag 'last_name', nil
+    = label_tag 'first_name', t('idv.form.first_name')
+    = block_text_field_tag 'first_name', nil, required: true
+    = label_tag 'last_name', t('idv.form.last_name')
+    = block_text_field_tag 'last_name', nil, required: true
   h1.heading = t('idv.titles.session.dob')
   .mb3
-    label.hide = t('idv.form.dob')
-    = block_date_field_tag 'dob', nil
+    = label_tag 'dob', t('idv.form.dob'), class: 'hide'
+    = block_date_field_tag 'dob', nil, required: true
   h1.heading = t('idv.titles.session.ssn')
   .mb3
-    label.hide = t('idv.form.ssn')
-    = block_text_field_tag 'ssn', nil
+    = label_tag 'ssn', t('idv.form.ssn'), class: 'hide'
+    = block_text_field_tag 'ssn', nil, required: true, pattern: '[0-9]*', \
+      'data-custom-message': t('idv.errors.invalid_ssn')
   h1.heading = t('idv.titles.session.address')
   .mb3
-    label = t('idv.form.address1')
-    = block_text_field_tag 'address1', nil
-    label = t('idv.form.address2')
+    = label_tag 'address1', t('idv.form.address1')
+    = block_text_field_tag 'address1', nil, required: true
+    = label_tag 'address2', t('idv.form.address2')
     = block_text_field_tag 'address2', nil
-    label = t('idv.form.city')
-    = block_text_field_tag 'city', nil
+    = label_tag 'city', t('idv.form.city')
+    = block_text_field_tag 'city', nil, required: true
     .clearfix.mxn1
       .sm-col.sm-col-6.px1
-        label = t('idv.form.state')
-        = us_states_territories_select_tag
+        = label_tag 'state', t('idv.form.state')
+        = us_states_territories_select_tag required: true
       .sm-col.sm-col-6.px1
-        label = t('idv.form.zipcode')
-        = block_text_field_tag 'zipcode', nil
+        = label_tag 'zipcode', t('idv.form.zipcode')
+        = block_text_field_tag 'zipcode', nil, required: true, pattern: '[0-9]*', \
+          'data-custom-message': t('idv.errors.invalid_zipcode')
   h1.heading = t('idv.titles.session.finance')
   .mb3
-    label = t('idv.form.ccn')
-    = block_text_field_tag 'ccn', nil
-    label = t('idv.form.mortgage')
-    = block_text_field_tag 'mortgage', nil
-    label = t('idv.form.home_equity_line')
-    = block_text_field_tag 'home_equity_line', nil
-    label = t('idv.form.auto_loan')
-    = block_text_field_tag 'auto_loan', nil
+    = label_tag 'ccn', t('idv.form.ccn')
+    = block_text_field_tag 'ccn', nil, pattern: '[0-9]*'
+    = label_tag 'mortgage', t('idv.form.mortgage')
+    = block_text_field_tag 'mortgage', nil, pattern: '[0-9]*'
+    = label_tag 'home_equity_line', t('idv.form.home_equity_line')
+    = block_text_field_tag 'home_equity_line', nil, pattern: '[0-9]*'
+    = label_tag 'auto_loan', t('idv.form.auto_loan')
+    = block_text_field_tag 'auto_loan', nil, pattern: '[0-9]*'
     .clearfix.mxn1
       .sm-col.sm-col-6.px1
-        label = t('idv.form.bank_routing')
-        = block_text_field_tag 'bank_routing', nil
+        = label_tag 'bank_routing', t('idv.form.bank_routing')
+        = block_text_field_tag 'bank_routing', nil, pattern: '[0-9]*'
       .sm-col.sm-col-6.px1
-        label = t('idv.form.bank_acct')
-        = block_text_field_tag 'bank_acct', nil
+        = label_tag 'bank_acct', t('idv.form.bank_acct')
+        = block_text_field_tag 'bank_acct', nil, pattern: '[0-9]*'
   button type='submit' class='btn btn-primary' = 'Continue'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
       code: App-generated code
     confirmation:
       show_hdr: Create a Password
+    value_missing: This field is required
+    pattern_mismatch: Please enter information in the correct format
 
   links:
     sign_out: 'Sign out'
@@ -119,6 +121,9 @@ en:
       city: City
       state: State
       zipcode: ZIP Code
+    errors:
+      invalid_ssn: 'Please enter a valid SSN in the format of 123-45-6789'
+      invalid_zipcode: 'Please enter a valid Zip Code in the format of 20006'
     titles:
       welcome: Verify your identity
       question: Answer a few questions

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "npm": "~3.8.x"
   },
   "dependencies": {
+    "classlist.js": "^1.1.20150312",
+    "gentleform": "^2.0.1",
     "jquery": "^2.2.3",
     "zxcvbn": "^4.3.0"
   },


### PR DESCRIPTION
**Why**: Adds client side HTML5 validation using the constraints API, but displays errors using javascript for accessibility and wider browser support.  Included gem also provides built in support for adding proper ARIA attributes.  IE support is limited to 9+ so future PR can address IE specific fallback, or a server side solution.  Also, this PR only addresses the IDV section of the application, however the same validation can easily be applied to other forms.

Vote to close #238 in favor of this approach.

![screen recording 2016-07-08 at 01 41 pm](https://cloud.githubusercontent.com/assets/1178494/16696184/de2de9ee-4511-11e6-9f9b-7d8bcf37021b.gif)
