### PR TITLE
Pass full GET params to SLO handler

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -159,7 +159,11 @@ module SamlIdpLogoutConcern
   end
 
   def prepare_saml_logout_response
-    @saml_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse])
+    @saml_response = OneLogin::RubySaml::Logoutresponse.new(
+      params[:SAMLResponse],
+      nil,
+      { get_params: params }
+    )
   end
 
   def prepare_saml_logout_request


### PR DESCRIPTION
**Why**:

SLO request may not embed signature within the SAMLResponse param
so must explicitly pass all params to the Logoutresponse constructor.