### PR TITLE
Allow all users to reset their passwords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'bin/**/*'
     - 'config/initializers/devise.rb'
     - 'db/migrate/20160405212342_initial_schema.rb'
+  TargetRubyVersion: 2.3
   UseCache: true
 
 Lint/AssignmentInCondition:
@@ -159,6 +160,11 @@ Style/FileName:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: true
   Exclude: []
+Style/FrozenStringLiteralComment:
+  Description: >-
+                 Add the frozen_string_literal comment to the top of files
+                 to help transition from Ruby 2.3.0 to Ruby 3.0.
+  Enabled: false
 Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,0 +1,9 @@
+class NullUser
+  def confirmed?
+    false
+  end
+
+  def send_confirmation_instructions
+    # noop
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -35,8 +35,4 @@ class UserPolicy
     return false if @user.admin? || @user.tech?
     @current_user.tech? || @current_user.admin?
   end
-
-  def recover_password?
-    @user.role == 'user'
-  end
 end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -397,34 +397,4 @@ feature 'Password Recovery' do
     expect(page).not_to(have_content('not found'))
     expect(page).not_to(have_content('Please review the problems below:'))
   end
-
-  # Scenario: Tech support user requests password reset
-  #   Given I am not signed in
-  #   When I enter my email address
-  #   Then I see 'email sent' but do not receive recovery email.
-  scenario 'tech user enters email address into password reset form' do
-    reset_email
-    user = create(:user, :signed_up, :tech_support)
-
-    fill_in 'user_email', with: user.email
-    click_button t('forms.buttons.reset_password')
-
-    expect(page).to have_content t('devise.passwords.send_instructions')
-    expect(ActionMailer::Base.deliveries).to be_empty
-  end
-
-  # Scenario: Admin user requests password reset
-  #   Given I am not signed in
-  #   When I enter my email address
-  #   Then I see 'email sent' but do not receive recovery email.
-  scenario 'admin user enters email address into password reset form' do
-    reset_email
-    user = create(:user, :signed_up, :admin)
-
-    fill_in 'user_email', with: user.email
-    click_button t('forms.buttons.reset_password')
-
-    expect(page).to have_content t('devise.passwords.send_instructions')
-    expect(ActionMailer::Base.deliveries).to be_empty
-  end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -94,25 +94,4 @@ describe UserPolicy do
 
     it { is_expected.to_not permit_action(:tech_reset_password) }
   end
-
-  context 'recover password for a normal user' do
-    let(:current_user) { nil }
-    let(:user) { create :user }
-
-    it { is_expected.to permit_action(:recover_password) }
-  end
-
-  context 'recover password for a tech user' do
-    let(:current_user) { nil }
-    let(:user) { build_stubbed :user, :tech_support }
-
-    it { is_expected.to_not permit_action(:recover_password) }
-  end
-
-  context 'recover password for an admin user' do
-    let(:current_user) { nil }
-    let(:user) { build_stubbed :user, :admin }
-
-    it { is_expected.to_not permit_action(:recover_password) }
-  end
 end


### PR DESCRIPTION
**Why**: Disallowing admin and tech roles from resetting passwords was
a relic from save-ferris because those roles were always authenticating
via Omniauth. This is not the case for login.gov.