### PR TITLE
Add delete account confirm step

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    before_action :confirm_two_factor_authenticated, only: [:edit, :update]
+    before_action :confirm_two_factor_authenticated, only: [:edit, :update, :destroy_confirm]
+    prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy, :destroy_confirm]
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def start
@@ -40,6 +41,9 @@ module Users
         clean_up_passwords resource
         render :edit
       end
+    end
+
+    def destroy_confirm
     end
 
     protected

--- a/app/views/devise/registrations/destroy_confirm.html.slim
+++ b/app/views/devise/registrations/destroy_confirm.html.slim
@@ -1,0 +1,10 @@
+- title t('titles.registrations.destroy_confirm')
+
+
+h1.heading = t('headings.delete_account')
+p = t('devise.registrations.destroy_confirm')
+div
+  = button_to t('forms.buttons.delete_account_confirm'), \
+            { controller: 'users/registrations', action: :destroy, id: current_user.id }, \
+            method: :delete, \
+            class: 'btn btn-primary'

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -35,8 +35,5 @@ h2.h5.mt4.mb2 = t('headings.profile.advanced_settings')
   .clearfix.mxn1
     .sm-col.sm-col-8.px1 = t('headings.delete_account')
     .sm-col.sm-col-4.px1.sm-right-align
-      = button_to t('forms.buttons.delete_account'), \
-                { controller: 'users/registrations', action: :destroy, id: current_user.id }, \
-                method: :delete, \
-                data: { confirm: 'Are you sure?' }, \
-                class: 'btn btn-primary bg-silver gray px2 py1 h5'
+      = button_to t('forms.buttons.delete_account'), user_destroy_confirm_path, \
+        method: :get, class: 'btn btn-primary bg-silver gray px2 py1 h5'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -51,6 +51,9 @@ en:
         bullet_3: >
           You can use your login.gov account to access all participating
           U.S. government agencies.
+      destroy_confirm: >
+        Deleting your account cannot be undone. All data associated with your
+        account will be removed. Are you sure you'd like to delete your account?
       destroyed: "Your account has been successfully deleted."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
     buttons:
       continue_browsing: Continue Browsing
       delete_account: Delete
+      delete_account_confirm: Yes, delete account
       resend_confirmation: Resend confirmation instructions
       reset_password: Send reset password instructions
     required_field: Indicates a required field.
@@ -48,6 +49,7 @@ en:
       forgot: Reset the password for your account
     profile: Profile
     registrations:
+      destroy_confirm: Delete your account
       edit: Edit your account
       new: Sign up for a account
       start: Get started

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     post '/' => 'users/sessions#create', as: :user_session
 
     get '/start' => 'users/registrations#start', as: :new_user_start
+    get '/delete' => 'users/registrations#destroy_confirm', as: :user_destroy_confirm
 
     get 'active'  => 'users/sessions#active'
     get 'timeout' => 'users/sessions#timeout'

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -10,6 +10,7 @@ feature 'User profile' do
       visit profile_index_path
       click_button t('forms.buttons.delete_account')
 
+      click_button t('forms.buttons.delete_account_confirm')
       expect(page).to have_content t('devise.registrations.destroyed')
       expect(current_path).to eq root_path
       expect(User.count).to eq 0

--- a/spec/views/devise/registrations/destroy_confirm.html.slim_spec.rb
+++ b/spec/views/devise/registrations/destroy_confirm.html.slim_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'devise/registrations/destroy_confirm.html.slim' do
+  before do
+    user = build_stubbed(:user, :signed_up)
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.registrations.destroy_confirm'))
+
+    render
+  end
+
+  it 'contains link to delete account' do
+    render
+
+    expect(rendered).to have_content t('devise.registrations.destroy_confirm')
+
+    expect(rendered).
+      to have_xpath("//input[@value='#{t('forms.buttons.delete_account_confirm')}']")
+  end
+end


### PR DESCRIPTION
**Why**: adding one more step (without javascript) to make sure user
wants to do this thing that can't be undone