### PR TITLE
Add agency login info to profile

### DIFF
--- a/.reek
+++ b/.reek
@@ -6,6 +6,7 @@ IrresponsibleModule:
 TooManyMethods:
   exclude:
     - Users::ConfirmationsController
+    - ServiceProvider
 UnusedPrivateMethod:
   enabled: true
   exclude:

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -9,4 +9,8 @@ class Identity < ActiveRecord::Base
   def sp_metadata
     ServiceProvider.new(service_provider).metadata
   end
+
+  def display_name
+    sp_metadata[:friendly_name] || sp_metadata[:agency] || service_provider
+  end
 end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -3,32 +3,42 @@
 
 h1.heading = t('headings.profile.main')
 
-.mb4
-  h2.h5.mt4.mb2 = t('headings.profile.account_settings')
-  .py2.border-top
-    .clearfix.mxn1
-      .sm-col.sm-col-4.px1 = 'Email address'
-      .sm-col.sm-col-6.px1 = current_user.email
-      .sm-col.sm-col-2.px1.sm-right-align
-        = link_to 'Edit', edit_user_registration_path, \
-          class: 'btn btn-primary bg-light-blue gray px1 py0 h6 regular'
-  .py2.border-top
-    .clearfix.mxn1
-      .sm-col.sm-col-4.px1 = 'Mobile'
-      .sm-col.sm-col-6.px1 = current_user.mobile
-      .sm-col.sm-col-2.px1.sm-right-align
-        = link_to 'Edit', edit_user_registration_path, \
-          class: 'btn btn-primary bg-light-blue gray px1 py0 h6 regular'
-  .py2.border-top.border-bottom
-    .clearfix.mxn1
-      .sm-col.sm-col-8.px1 = 'Authenticator App'
-      .sm-col.sm-col-4.px1.sm-right-align
-        - if current_user.totp_enabled?
-          = button_to 'Disable', disable_totp_url, method: :delete, \
-            class: 'btn btn-primary bg-silver gray px2 py1 h5'
-        - else
-          = button_to 'Enable', users_totp_url, method: :get, \
-            class: 'btn btn-primary bg-silver gray px2 py1 h5'
+h2.h5.mt4.mb2 = t('headings.profile.account_settings')
+.py2.border-top
+  .clearfix.mxn1
+    .sm-col.sm-col-4.px1 = 'Email address'
+    .sm-col.sm-col-6.px1 = current_user.email
+    .sm-col.sm-col-2.px1.sm-right-align
+      = link_to 'Edit', edit_user_registration_path, \
+        class: 'btn btn-primary bg-light-blue gray px1 py0 h6 regular'
+.py2.border-top
+  .clearfix.mxn1
+    .sm-col.sm-col-4.px1 = 'Mobile'
+    .sm-col.sm-col-6.px1 = current_user.mobile
+    .sm-col.sm-col-2.px1.sm-right-align
+      = link_to 'Edit', edit_user_registration_path, \
+        class: 'btn btn-primary bg-light-blue gray px1 py0 h6 regular'
+.py2.border-top.border-bottom
+  .clearfix.mxn1
+    .sm-col.sm-col-8.px1 = 'Authenticator App'
+    .sm-col.sm-col-4.px1.sm-right-align
+      - if current_user.totp_enabled?
+        = button_to 'Disable', disable_totp_url, method: :delete, \
+          class: 'btn btn-primary bg-silver gray px2 py1 h5'
+      - else
+        = button_to 'Enable', users_totp_url, method: :get, \
+          class: 'btn btn-primary bg-silver gray px2 py1 h5'
+
+- unless current_user.active_identities.empty?
+  h2.h5.mt4.mb2 = t('headings.profile.agencies')
+  - current_user.active_identities.each do |i|
+    .py2.border-top
+      .clearfix.mxn1
+        .sm-col.sm-col-8.px1
+          .h3.truncate = i.display_name
+        .sm-col.sm-col-4.px1
+          .h6.bold = 'Last login'
+          .h5 = i.last_authenticated_at.to_s(:date_pretty)
 
 h2.h5.mt4.mb2 = t('headings.profile.advanced_settings')
 .py2.border-top.border-bottom

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,1 @@
-Time::DATE_FORMATS[:admin_date_and_time] = '%m-%d-%Y %H:%M'
+Time::DATE_FORMATS[:date_pretty] = '%B %e, %Y'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,9 +70,10 @@ en:
       change: Change your password
       forgot: Forgot password?
     profile:
-      main: My account
       account_settings: Account settings
       advanced_settings: Advanced settings
+      agencies: Agencies I've logged into
+      main: My account
     registrations:
       enter_email: Email address
       verify_email: Verify email address

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -6,6 +6,8 @@ test:
       sp_initiated_login_url: 'http://localhost:3000/test/saml'
       block_encryption: 'none'
       cert: 'saml_test_sp'
+      agency: 'test_agency'
+      friendly_name: 'test_friendly_name'
 
     'https://rp1.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
@@ -45,6 +47,8 @@ development:
       assertion_consumer_logout_service_url: 'http://localhost:3003/auth/saml/logout'
       sp_initiated_login_url: 'http://localhost:3003/login'
       cert: 'demo_sp'
+      agency: '18F'
+      friendly_name: '18F Test Service Provider'
     'https://dashboard.login.gov':
       metadata_url: 'http://localhost:3001/users/auth/saml/metadata'
       acs_url: 'http://localhost:3001/users/auth/saml/callback'
@@ -110,3 +114,4 @@ superb.legit.domain.gov:
       acs_url: 'https://vets.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout'
       cert: 'saml_test_sp'
+      agency: 'test_agency'

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -33,6 +33,14 @@ class ServiceProvider
     host_attributes['metadata_url']
   end
 
+  def agency
+    host_attributes['agency']
+  end
+
+  def friendly_name
+    host_attributes['friendly_name']
+  end
+
   def cert
     return if host_attributes['cert'].blank?
 

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -15,7 +15,9 @@ describe ServiceProvider do
           block_encryption: 'none',
           key_transport: 'rsa-oaep-mgf1p',
           fingerprint: nil,
-          double_quote_xml_attribute_values: true
+          double_quote_xml_attribute_values: true,
+          agency: nil,
+          friendly_name: nil
         }
 
         expect(@service_provider.metadata).to eq attributes
@@ -35,7 +37,9 @@ describe ServiceProvider do
           block_encryption: 'none',
           key_transport: 'rsa-oaep-mgf1p',
           fingerprint: fingerprint,
-          double_quote_xml_attribute_values: true
+          double_quote_xml_attribute_values: true,
+          agency: 'test_agency',
+          friendly_name: 'test_friendly_name'
         }
 
         expect(service_provider.metadata).to eq attributes
@@ -73,7 +77,9 @@ describe ServiceProvider do
             fingerprint: fingerprint,
             key_transport: 'rsa-oaep-mgf1p',
             metadata_url: nil,
-            sp_initiated_login_url: nil
+            sp_initiated_login_url: nil,
+            agency: 'test_agency',
+            friendly_name: nil
           }
 
           expect(service_provider.metadata).to eq attributes
@@ -147,6 +153,44 @@ describe ServiceProvider do
 
         expect(service_provider.metadata_url).
           to eq 'http://test.host/test/saml/metadata'
+      end
+    end
+  end
+
+  describe '#agency' do
+    context 'when value is not specified in YAML' do
+      it 'returns nil' do
+        service_provider = ServiceProvider.new('http://test.host')
+
+        expect(service_provider.agency).to be_nil
+      end
+    end
+
+    context 'when value is specified in YAML' do
+      it 'returns the value from YAML' do
+        service_provider = ServiceProvider.new('http://localhost:3000')
+
+        expect(service_provider.agency).
+          to eq 'test_agency'
+      end
+    end
+  end
+
+  describe '#friendly_name' do
+    context 'when value is not specified in YAML' do
+      it 'returns nil' do
+        service_provider = ServiceProvider.new('http://test.host')
+
+        expect(service_provider.friendly_name).to be_nil
+      end
+    end
+
+    context 'when value is specified in YAML' do
+      it 'returns the value from YAML' do
+        service_provider = ServiceProvider.new('http://localhost:3000')
+
+        expect(service_provider.friendly_name).
+          to eq 'test_friendly_name'
       end
     end
   end


### PR DESCRIPTION
**Why**: provide users with information
about which agencies they're connected with
and when the last login date was

**Preview**:
<img width="462" alt="demo" src="https://cloud.githubusercontent.com/assets/1060893/16781761/b474b56a-484a-11e6-9b65-533eadb3ec86.png">

