### PR TITLE
Shorten SMS message

### DIFF
--- a/app/jobs/sms_sender_otp_job.rb
+++ b/app/jobs/sms_sender_otp_job.rb
@@ -15,10 +15,6 @@ class SmsSenderOtpJob < ActiveJob::Base
   end
 
   def otp_message(code)
-    <<-END.strip_heredoc
-      You requested a secure one-time password to log in to your #{APP_NAME} Account.
-
-      Please enter this secure one-time password: #{code}
-    END
+    "#{code} is your #{APP_NAME} one-time password."
   end
 end

--- a/spec/jobs/sms_sender_otp_job_spec.rb
+++ b/spec/jobs/sms_sender_otp_job_spec.rb
@@ -8,7 +8,7 @@ describe SmsSenderOtpJob, sms: true do
       expect(messages.size).to eq(1)
       msg = messages.first
       expect(msg.number).to eq('555-5555')
-      expect(msg.body).to include('secure one-time password')
+      expect(msg.body).to include('one-time password')
       expect(msg.body).to include('1234')
     end
   end


### PR DESCRIPTION
**Why**: so one-time password is visible via phone notifications