### PR TITLE
Fix confirm_two_factor_authenticated when used in Devise controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
   end
 
   def confirm_two_factor_authenticated
-    authenticate_user!
+    authenticate_user!(force: true)
 
     user_decorator = UserDecorator.new(current_user)
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,6 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
     before_action :confirm_two_factor_authenticated, only: [:edit, :update, :destroy_confirm]
-    prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy, :destroy_confirm]
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def start


### PR DESCRIPTION
We use confirm_two_factor_authenticated in RegistrationsController
which is a devise controller, but authenticate_user! doesn't actually
do anything inside a devise controller unless `force: true` is passed.

**Why**: authenticate_user! was returning rather then throwing an
exception which was causing a nil crash in confirm_two_factor_authenticated
when used from a Devise controller.

Fixes https://github.com/18F/identity-private/issues/530