### PR TITLE
Add .byebug_history to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.sassc
 **.orig
 .bundle
+.byebug_history
 .coveralls.yml
 .databag_secret
 .env


### PR DESCRIPTION
**Why**: This file is autognerated when debugging with byebug
but was not being ignored by git.