### PR TITLE
Replace `have_filters` with `have_actions`

### DIFF
--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Users::PhoneConfirmationController, devise: true do
   describe 'before_actions' do
     it 'includes authentication checks' do
-      expect(subject).to have_filters(
+      expect(subject).to have_actions(
         :before,
         :authenticate_user!,
         :check_for_unconfirmed_mobile


### PR DESCRIPTION
**Why**: A previous PR had replaced `filter` with `action`, but somehow
this use of `have_filters` was not flagged by Travis in Sam's PR.

This fix allows tests to pass again.