### PR TITLE
Add tracking via Ahoy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 gem 'rails', '~> 4.2.6'
 
 gem 'activerecord-session_store'
+gem 'ahoy_matey'
 gem 'browserify-rails'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'devise', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,17 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    ahoy_matey (1.4.2)
+      addressable
+      browser (~> 2.0)
+      geocoder
+      rack-attack
+      railties
+      referer-parser (>= 0.3.0)
+      request_store
+      safely_block (>= 0.1.1)
+      user_agent_parser
+      uuidtools
     airbrussh (1.0.2)
       sshkit (>= 1.6.1, != 1.7.0)
     akami (1.3.1)
@@ -88,6 +99,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     brakeman (3.3.2)
+    browser (2.2.0)
     browserify-rails (3.1.0)
       railties (>= 4.0.0, < 5.1)
       sprockets (>= 3.5.2)
@@ -191,6 +203,7 @@ GEM
       mail (~> 2.6.3)
     encryptor (3.0.0)
     equalizer (0.0.11)
+    errbase (0.0.3)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
@@ -205,6 +218,7 @@ GEM
     figaro (1.1.1)
       thor (~> 0.14)
     formatador (0.2.5)
+    geocoder (1.3.7)
     get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -387,6 +401,8 @@ GEM
       codeclimate-engine-rb (~> 0.3.1)
       parser (~> 2.3.1, >= 2.3.1.2)
       rainbow (~> 2.0)
+    referer-parser (0.3.0)
+    request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rotp (3.1.0)
@@ -424,6 +440,8 @@ GEM
       nokogiri (>= 1.5.10)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
+    safely_block (0.1.1)
+      errbase
     saml_idp (0.3.2)
       activesupport
       builder
@@ -538,9 +556,11 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.0)
     uniform_notifier (1.10.0)
+    user_agent_parser (2.3.0)
     useragent (0.16.7)
     uuid (2.3.8)
       macaddr (~> 1.0)
+    uuidtools (2.1.5)
     valid_email (0.0.13)
       activemodel
       mail (~> 2.6.1)
@@ -579,6 +599,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  ahoy_matey
   better_errors
   binding_of_caller
   brakeman

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def analytics
-    @analytics ||= Analytics.new(current_user, request_attributes)
+    @analytics ||= Analytics.new(current_user, request_attributes, ahoy)
   end
 
   private
@@ -74,5 +74,9 @@ class ApplicationController < ActionController::Base
       user_agent: request.user_agent,
       user_ip: request.remote_ip
     }
+  end
+
+  def ahoy
+    @ahoy ||= Rails.env.test? ? NullAhoyTracker.new : Ahoy::Tracker.new(request: request)
   end
 end

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -9,12 +9,16 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   before_action :check_already_authenticated
 
   def new
+    analytics.track_event('User requested a new OTP code')
+
     current_user.send_new_otp
     flash[:notice] = t('devise.two_factor_authentication.user.new_otp_sent')
     redirect_to user_two_factor_authentication_path(method: 'sms')
   end
 
   def show
+    analytics.track_pageview
+
     if use_totp?
       show_totp_prompt
     else
@@ -113,6 +117,8 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def handle_second_factor_locked_resource
+    analytics.track_event('User reached max 2FA attempts')
+
     render :max_login_attempts_reached
 
     sign_out

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,9 +6,11 @@ module Users
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def start
+      analytics.track_pageview
     end
 
     def new
+      analytics.track_pageview
       ab_finished(:demo)
       @register_user_email_form = RegisterUserEmailForm.new
     end
@@ -30,6 +32,7 @@ module Users
     end
 
     def edit
+      analytics.track_pageview
       @update_user_profile_form = UpdateUserProfileForm.new(resource)
     end
 
@@ -60,6 +63,8 @@ module Users
       updater.set_flash_message
 
       if @update_user_profile_form.mobile_changed?
+        analytics.track_event('User asked to update their phone number')
+
         prompt_to_confirm_mobile(@update_user_profile_form.mobile)
       elsif is_flashing_format?
         EmailNotifier.new(resource).send_password_changed_email

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,11 @@ module Users
       request.env['devise.skip_trackable'] = true
     end
 
+    def new
+      analytics.track_pageview
+      super
+    end
+
     def create
       track_authentication_attempt(params[:user][:email])
       super
@@ -20,6 +25,8 @@ module Users
     end
 
     def timeout
+      analytics.track_anonymous_event('Session Timed Out')
+
       flash[:notice] = t(
         'session_timedout',
         session_timeout: distance_of_time_in_words(Devise.timeout_in)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,24 +1,39 @@
 class Analytics
-  def initialize(user, request_attributes)
+  def initialize(user, request_attributes, ahoy)
     @user = user
     @request_attributes = request_attributes
+    @ahoy = ahoy
   end
 
   def track_event(event, subject = user)
+    uuid = subject.uuid
+
     AnalyticsEventJob.perform_later(
-      common_options.merge(action: event, user_id: subject.uuid)
+      common_options.merge(action: event, user_id: uuid)
     )
+
+    Rails.logger.info("#{event} by #{uuid}")
+
+    ahoy.track(event)
   end
 
   def track_anonymous_event(event, attribute = nil)
     AnalyticsEventJob.perform_later(
       common_options.merge(action: event, value: attribute)
     )
+
+    Rails.logger.info("#{event}: #{attribute}")
+
+    ahoy.track(event, value: attribute)
+  end
+
+  def track_pageview
+    ahoy.track_visit
   end
 
   private
 
-  attr_reader :user
+  attr_reader :user, :ahoy
 
   def common_options
     @common_options ||= @request_attributes.merge(

--- a/app/services/null_ahoy_tracker.rb
+++ b/app/services/null_ahoy_tracker.rb
@@ -1,0 +1,21 @@
+class NullAhoyTracker
+  def set_visitor_cookie
+    # no-op
+  end
+
+  def set_visit_cookie
+    # no-op
+  end
+
+  def new_visit?
+    true
+  end
+
+  def track_visit(_options = {})
+    # no-op
+  end
+
+  def track(_name, _properties = {}, _options = {})
+    # no-op
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :warn
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,4 @@
+module Ahoy
+  class Store < Ahoy::Stores::LogStore
+  end
+end

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -57,6 +57,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         stub_analytics(subject.current_user)
         expect(@analytics).to receive(:track_event).with('User entered invalid 2FA code')
+        expect(@analytics).to receive(:track_pageview)
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
         expect(subject.current_user).to receive(:authenticate_otp).and_return(false)
@@ -214,6 +215,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         expect(response).to render_template(:show)
       end
 
+      it 'tracks the pageview' do
+        stub_analytics(subject.current_user)
+        expect(@analytics).to receive(:track_pageview)
+
+        get :show
+      end
+
       context 'when user is TOTP enabled' do
         before do
           allow(subject.current_user).to receive(:totp_enabled?).and_return(true)
@@ -272,6 +280,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         with(subject.current_user.direct_otp, subject.current_user.mobile)
       expect(subject.current_user.direct_otp).not_to eq(old_otp)
       expect(subject.current_user.direct_otp).not_to be_nil
+    end
+
+    it 'tracks the event' do
+      stub_analytics(subject.current_user)
+      expect(@analytics).to receive(:track_event).with('User requested a new OTP code')
+
+      get :new
     end
   end
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -181,6 +181,16 @@ describe Users::RegistrationsController, devise: true do
       end
     end
 
+    it 'tracks the phone number update event' do
+      sign_in(second_user)
+
+      stub_analytics(second_user)
+      expect(@analytics).to receive(:track_event).
+        with('User asked to update their phone number')
+
+      patch :update, update_user_profile_form: attrs_for_new_mobile
+    end
+
     # Scenario: User updates both email and number
     #   Given I am signed in and editing my profile
     #   When I update both my mobile and email
@@ -384,6 +394,13 @@ describe Users::RegistrationsController, devise: true do
       expect(subject).to receive(:ab_finished).with(:demo)
       get :new
     end
+
+    it 'tracks the pageview' do
+      stub_analytics
+      expect(@analytics).to receive(:track_pageview)
+
+      get :new
+    end
   end
 
   describe '#create' do
@@ -426,6 +443,27 @@ describe Users::RegistrationsController, devise: true do
         with('User Registration: invalid email', 'invalid@')
 
       post :create, user: { email: 'invalid@' }
+    end
+  end
+
+  describe '#start' do
+    it 'tracks the pageview' do
+      stub_analytics
+      expect(@analytics).to receive(:track_pageview)
+
+      get :start
+    end
+  end
+
+  describe '#edit' do
+    it 'tracks the pageview' do
+      user = create(:user, :signed_up)
+      sign_in(user)
+
+      stub_analytics(subject.current_user)
+      expect(@analytics).to receive(:track_pageview)
+
+      get :edit
     end
   end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -85,6 +85,13 @@ describe Users::SessionsController, devise: true do
 
       expect(response).to redirect_to(root_url)
     end
+
+    it 'tracks the timeout' do
+      stub_analytics
+      expect(@analytics).to receive(:track_anonymous_event).with('Session Timed Out')
+
+      get :timeout
+    end
   end
 
   describe 'POST /' do
@@ -111,8 +118,18 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_anonymous_event).
         with('Authentication Attempt with nonexistent user')
       expect(@analytics).to_not receive(:track_event).with('Authentication Successful')
+      expect(@analytics).to receive(:track_pageview)
 
       post :create, user: { email: 'foo@example.com', password: 'password' }
+    end
+  end
+
+  describe '#new' do
+    it 'tracks the pageview' do
+      stub_analytics
+      expect(@analytics).to receive(:track_pageview)
+
+      get :new
     end
   end
 end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -114,6 +114,13 @@ feature 'Two Factor Authentication' do
     scenario 'user who enters OTP incorrectly 3 times is locked out for OTP validity period' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
+
+      stub_analytics(user)
+      expect(@analytics).to receive(:track_pageview).exactly(3).times
+      expect(@analytics).to receive(:track_event).exactly(3).times.
+        with('User entered invalid 2FA code')
+      expect(@analytics).to receive(:track_event).with('User reached max 2FA attempts')
+
       3.times do
         fill_in('code', with: 'bad-code')
         click_button('Submit')

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -261,6 +261,7 @@ feature 'Password Recovery' do
 
         stub_analytics
         expect(@analytics).to receive(:track_event).with('Password reset', @user.reload)
+        expect(@analytics).to receive(:track_pageview).twice
 
         click_button 'Change my password'
 

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -32,15 +32,9 @@ feature 'Sign Up', devise: true do
   scenario 'visitor can sign up and confirm a valid email' do
     sign_up_with('test@example.com')
 
-    analytics = instance_double(Analytics)
-    request_attributes = {
-      user_agent: nil,
-      user_ip: '127.0.0.1'
-    }
-
-    expect(Analytics).to receive(:new).twice.with(nil, request_attributes).and_return(analytics)
-    expect(analytics).to receive(:track_event).with('Email Confirmation: valid token', User.last)
-    expect(analytics).to receive(:track_event).
+    stub_analytics
+    expect(@analytics).to receive(:track_event).with('Email Confirmation: valid token', User.last)
+    expect(@analytics).to receive(:track_event).
       with('Password Created and User Confirmed', User.last)
 
     confirm_last_user

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -8,16 +8,20 @@ describe Analytics do
     }
   end
 
+  let(:ahoy) { NullAhoyTracker.new }
+
   let(:common_options) { request_attributes.merge(anonymize_ip: true) }
 
   describe '#track_event' do
     it 'identifies the user and sends the event to the backend' do
       user = build_stubbed(:user, uuid: '123')
 
-      analytics = Analytics.new(user, request_attributes)
+      analytics = Analytics.new(user, request_attributes, ahoy)
 
       expect(AnalyticsEventJob).to receive(:perform_later).
         with(common_options.merge(action: 'Trackable Event', user_id: user.uuid))
+      expect(ahoy).to receive(:track).with('Trackable Event')
+      expect(Rails.logger).to receive(:info).with("Trackable Event by #{user.uuid}")
 
       analytics.track_event('Trackable Event')
     end
@@ -26,10 +30,12 @@ describe Analytics do
       current_user = build_stubbed(:user, uuid: '123')
       tracked_user = build_stubbed(:user, uuid: '456')
 
-      analytics = Analytics.new(current_user, request_attributes)
+      analytics = Analytics.new(current_user, request_attributes, ahoy)
 
       expect(AnalyticsEventJob).to receive(:perform_later).
         with(common_options.merge(user_id: tracked_user.uuid, action: 'Trackable Event'))
+      expect(ahoy).to receive(:track).with('Trackable Event')
+      expect(Rails.logger).to receive(:info).with("Trackable Event by #{tracked_user.uuid}")
 
       analytics.track_event('Trackable Event', tracked_user)
     end
@@ -37,12 +43,24 @@ describe Analytics do
 
   describe '#track_anonymous_event' do
     it 'sends the event and attribute value' do
-      analytics = Analytics.new(nil, request_attributes)
+      analytics = Analytics.new(nil, request_attributes, ahoy)
 
       expect(AnalyticsEventJob).to receive(:perform_later).
         with(common_options.merge(action: 'Anonymous Event', value: 'foo'))
+      expect(ahoy).to receive(:track).with('Anonymous Event', value: 'foo')
+      expect(Rails.logger).to receive(:info).with('Anonymous Event: foo')
 
       analytics.track_anonymous_event('Anonymous Event', 'foo')
+    end
+  end
+
+  describe '#track_pageview' do
+    it 'logs the pageview' do
+      analytics = Analytics.new(nil, request_attributes, ahoy)
+
+      expect(ahoy).to receive(:track_visit)
+
+      analytics.track_pageview
     end
   end
 end

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,6 +1,7 @@
 module AnalyticsHelper
   def stub_analytics(user = nil)
     @analytics = instance_double(Analytics)
+    ahoy = instance_double(NullAhoyTracker)
 
     allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).
       and_return('127.0.0.1')
@@ -12,6 +13,12 @@ module AnalyticsHelper
       user_ip: '127.0.0.1'
     }
 
-    expect(Analytics).to receive(:new).with(user, request_attributes).and_return(@analytics)
+    expect(NullAhoyTracker).to receive(:new).at_least(:once).and_return(ahoy)
+    expect(ahoy).to receive(:set_visitor_cookie).at_least(:once)
+    expect(ahoy).to receive(:set_visit_cookie).at_least(:once)
+    expect(ahoy).to receive(:new_visit?).at_least(:once)
+
+    expect(Analytics).to receive(:new).at_least(:once).with(user, request_attributes, ahoy).
+      and_return(@analytics)
   end
 end


### PR DESCRIPTION
**Why**: To compare the kind of analysis and fraud detection we can run
using Google Analytics versus one of the many data stores supported by
Ahoy: https://github.com/ankane/ahoy#choose-a-data-store

For simplicity, the data store is currently set to `LogStore`, which
will log events to `log/events.log`, and pageviews to `log/visits.log`.

I also added tracking for a few more events and pageviews.