### PR TITLE
Enable SAML encyption by default

### DIFF
--- a/app/views/test/saml_test/decode_response.html.slim
+++ b/app/views/test/saml_test/decode_response.html.slim
@@ -13,18 +13,20 @@ div class='container'
         td Issuer
         td = response.issuers.first
       tr
-        td Document
+        td XML Document
         td
-          = link_to 'Open XML in New Window',
-                    "data:text/xml;charset=utf-8;base64,#{Base64.encode64(response.document.to_s)}",
+          - xml_doc = Base64.encode64(response.document.to_s)
+          = link_to 'Open in New Window',
+                    "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                     target: '_blank'
 
       tr
-        td Encrypted Document
+        td Decrypted XML Document
         - if response.decrypted_document.present?
           td
-            = link_to 'Open Raw XML in New Window',
-                      "data:text/xml;charset=utf-8;base64,#{params[:SAMLResponse]}",
+            - xml_doc = Base64.encode64(response.decrypted_document.to_s)
+            = link_to 'Open in New Window',
+                      "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                       target: '_blank'
 
         - else

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -4,7 +4,6 @@ test:
       acs_url: 'http://localhost:3000/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
       sp_initiated_login_url: 'http://localhost:3000/test/saml'
-      block_encryption: 'none'
       cert: 'saml_test_sp'
       agency: 'test_agency'
       friendly_name: 'test_friendly_name'
@@ -13,13 +12,11 @@ test:
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
       sp_initiated_login_url: 'https://example.com/auth/saml/login'
-      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
 
     'https://rp2.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
-      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
 
     'http://test.host':
@@ -56,7 +53,6 @@ development:
       assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
       sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
 
 production:
   valid_hosts:
@@ -66,7 +62,6 @@ production:
       assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
       sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
       cert: 'saml_test_sp'
-      block_encryption: 'aes256-cbc'
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
       metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
@@ -102,14 +97,12 @@ production:
       assertion_consumer_logout_service_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dashboard-demo':
       metadata_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/metadata'
       acs_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
 
 superb.legit.domain.gov:
   valid_hosts:

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -3,6 +3,10 @@ class FeatureManagement
     Figaro.env.sms_disabled == 'true'
   end
 
+  def self.saml_encryption_disabled?
+    Figaro.env.saml_encryption_disabled == 'true'
+  end
+
   def self.allow_third_party_auth?
     Figaro.env.allow_third_party_auth == 'yes'
   end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -72,6 +72,20 @@ feature 'saml api', devise: true, sms: true do
       end
     end
 
+    context 'saml encryption is disabled' do
+      before do
+        expect(FeatureManagement).to receive(:saml_encryption_disabled?).and_return('true')
+        sign_in_and_2fa_user(user)
+        visit authnrequest_get
+      end
+
+      let(:xmldoc) { SamlResponseHelper::XmlDoc.new('feature', 'response_assertion') }
+
+      it 'does not encrypt SAML response' do
+        expect(xmldoc.original_encrypted?).to eq false
+      end
+    end
+
     context 'user can get a well-formed signed Assertion' do
       before do
         sign_in_and_2fa_user(user)
@@ -88,8 +102,8 @@ feature 'saml api', devise: true, sms: true do
         expect(xmldoc.response_assertion_nodeset.length).to eq(1)
       end
 
-      it 'respects service provider explicitly disabling encryption' do
-        expect(xmldoc.original_encrypted?).to eq false
+      it 'encrypts responses by default' do
+        expect(xmldoc.original_encrypted?).to eq true
       end
 
       it 'populates issuer with the idp name' do

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -12,8 +12,6 @@ describe ServiceProvider do
           sp_initiated_login_url: nil,
           metadata_url: nil,
           cert: nil,
-          block_encryption: 'none',
-          key_transport: 'rsa-oaep-mgf1p',
           fingerprint: nil,
           double_quote_xml_attribute_values: true,
           agency: nil,
@@ -34,8 +32,6 @@ describe ServiceProvider do
           sp_initiated_login_url: 'http://localhost:3000/test/saml',
           metadata_url: nil,
           cert: File.read("#{Rails.root}/certs/sp/saml_test_sp.crt"),
-          block_encryption: 'none',
-          key_transport: 'rsa-oaep-mgf1p',
           fingerprint: fingerprint,
           double_quote_xml_attribute_values: true,
           agency: 'test_agency',
@@ -71,11 +67,9 @@ describe ServiceProvider do
           attributes = {
             acs_url: 'https://vets.gov/users/auth/saml/callback',
             assertion_consumer_logout_service_url: acls_url,
-            block_encryption: 'none',
             cert: File.read("#{Rails.root}/certs/sp/saml_test_sp.crt"),
             double_quote_xml_attribute_values: true,
             fingerprint: fingerprint,
-            key_transport: 'rsa-oaep-mgf1p',
             metadata_url: nil,
             sp_initiated_login_url: nil,
             agency: 'test_agency',
@@ -206,34 +200,6 @@ describe ServiceProvider do
       service_provider = ServiceProvider.new('http://localhost:3000')
 
       expect(service_provider.cert).to eq File.read("#{Rails.root}/certs/sp/saml_test_sp.crt")
-    end
-  end
-
-  describe '#block_encryption' do
-    context 'when no value is specified in YAML' do
-      it 'returns "none"' do
-        service_provider = ServiceProvider.new('http://test.host')
-
-        expect(service_provider.block_encryption).to eq 'none'
-      end
-    end
-
-    context 'when value is specified in YAML' do
-      it 'returns the value from YAML' do
-        service_provider = ServiceProvider.new(
-          'https://rp1.serviceprovider.com/auth/saml/metadata'
-        )
-
-        expect(service_provider.block_encryption).to eq 'aes256-cbc'
-      end
-    end
-  end
-
-  describe '#key_transport' do
-    it 'returns a hardcoded value' do
-      service_provider = ServiceProvider.new('http://localhost:3000')
-
-      expect(service_provider.key_transport).to eq 'rsa-oaep-mgf1p'
     end
   end
 

--- a/spec/support/saml_response_helper.rb
+++ b/spec/support/saml_response_helper.rb
@@ -193,11 +193,19 @@ module SamlResponseHelper
   end
 
   def decrypted_saml_response
-    @decrypted_saml_response ||= Saml::XML::Document.parse(saml_response.document.to_s)
+    @decrypted_saml_response ||= Saml::XML::Document.parse(saml_response_string(saml_response))
+  end
+
+  def saml_response_string(response)
+    if response.decrypted_document.present?
+      response.decrypted_document.to_s
+    else
+      response.document.to_s
+    end
   end
 
   def saml_response
-    OneLogin::RubySaml::Response.new(
+    @saml_response ||= OneLogin::RubySaml::Response.new(
       Nokogiri::HTML(response.body).at_css('#SAMLResponse')['value'],
       settings: saml_settings
     )


### PR DESCRIPTION
**Why**: We want to enable encryption by default.  This
change also removes some un-used complexity around the
setting of key_transport and block_encryption.  We currently
only support single value for these setting so the simplest
option is just to hardcode them.

Disabling of saml encryption is done in application.yml
so that it can be overridden by the environment if
needed.