### PR TITLE
Add IdV tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: dc90ed5476bfec52cffb2afbe6151a3f84a2ec1c
+  revision: 282bbd7ee7878ab0b01ab04acb329ac7d961bb6e
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/views/idv/confirmations/index.html.slim
+++ b/app/views/idv/confirmations/index.html.slim
@@ -6,4 +6,4 @@
     div = t('idv.titles.hardfail')
 
 - if @idv_vendor == :mock && !@confirmation.success?
-  pre.mt2.p2.bg-silver.ws-pre-line = @confirmation.vendor_resp.pretty_inspect
+  pre.mt2.p2.bg-silver.ws-pre-line = @confirmation.vendor_resp.inspect

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe Idv::ConfirmationsController do
+  render_views
+
+  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+  let(:applicant) { Proofer::Applicant.new first_name: 'Some', last_name: 'One' }
+  let(:agent) { Proofer::Agent.new vendor: :mock }
+  let(:resolution) { agent.start applicant }
+
+  describe 'before_actions' do
+    it 'includes before_actions from AccountStateChecker' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated
+      )
+    end
+  end
+
+  context 'session started' do
+    before do
+      init_idv_session
+    end
+
+    describe 'all questions answered correctly' do
+      it 'shows success' do
+        init_idv_session
+        complete_idv_session(true)
+
+        get :index
+
+        expect(response.status).to eq 200
+        expect(response.body).to include(t('idv.titles.complete'))
+      end
+    end
+
+    describe 'some answers incorrect' do
+      it 'shows error' do
+        init_idv_session
+        complete_idv_session(false)
+
+        get :index
+
+        expect(response.status).to eq 200
+        expect(response.body).to include(t('idv.titles.hardfail'))
+      end
+    end
+
+    describe 'questions incomplete' do
+      it 'redirects to /idv/questions' do
+        init_idv_session
+
+        get :index
+
+        expect(response).to redirect_to(idv_questions_path)
+      end
+    end
+  end
+
+  describe 'session not yet started' do
+    it 'redirects to /idv/sessions' do
+      sign_in(user)
+
+      get :index
+
+      expect(response).to redirect_to(idv_sessions_path)
+    end
+  end
+
+  def init_idv_session
+    sign_in(user)
+    subject.user_session[:idv] = {
+      vendor: :mock,
+      applicant: applicant,
+      resolution: resolution,
+      question_number: 0
+    }
+  end
+
+  def complete_idv_session(answer_correctly)
+    Proofer::Vendor::Mock::ANSWERS.each do |ques, answ|
+      resolution.questions.find_by_key(ques).answer = answer_correctly ? answ : 'wrong'
+      subject.user_session[:idv][:question_number] += 1
+    end
+  end
+end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -43,5 +43,14 @@ describe Idv::SessionsController do
       expect(flash).to be_empty
       expect(response).to redirect_to(idv_questions_path)
     end
+
+    it 'shows failure on intentionally bad values' do
+      sign_in(user)
+
+      post :create, first_name: 'Bad', ssn: '6666'
+
+      expect(response).to redirect_to(idv_sessions_path)
+      expect(flash[:error]).to eq t('idv.titles.fail')
+    end
   end
 end

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'IdV session' do
-  let(:mock_questions) { Proofer::Agent.new(vendor: :mock).start.questions }
+  let(:mock_questions) { Proofer::Vendor::Mock.new.build_question_set(nil) }
 
   scenario 'KBV with all answers correct' do
     sign_in_and_2fa_user
@@ -36,5 +36,60 @@ feature 'IdV session' do
     end
 
     expect(page).to have_content(t('idv.titles.complete'))
+  end
+
+  scenario 'KBV with some incorrect answers' do
+    sign_in_and_2fa_user
+
+    visit '/idv/sessions'
+
+    expect(page).to have_content(t('idv.form.first_name'))
+
+    fill_in :first_name, with: 'Some'
+    fill_in :last_name, with: 'One'
+    fill_in :ssn, with: '666661234'
+    fill_in :dob, with: '19800102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+    click_button 'Continue'
+
+    expect(page).to have_content('Where did you live')
+
+    %w(city bear quest color speed).each do |answer_key|
+      question = mock_questions.find_by_key(answer_key)
+      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
+      if question.choices.nil?
+        fill_in :answer, with: 'wrong'
+      else
+        choice = question.choices.detect { |c| c.key == answer_text }
+        el_id = "#choice_#{choice.key_html_safe}"
+        find(el_id).set(true)
+      end
+      click_button 'Next'
+    end
+
+    expect(page).to have_content(t('idv.titles.hardfail'))
+  end
+
+  scenario 'un-resolvable PII' do
+    sign_in_and_2fa_user
+
+    visit '/idv/sessions'
+
+    expect(page).to have_content(t('idv.form.first_name'))
+
+    fill_in :first_name, with: 'Bad'
+    fill_in :last_name, with: 'User'
+    fill_in :ssn, with: '6666'
+    fill_in :dob, with: '19000102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+    click_button 'Continue'
+
+    expect(page).to have_content(t('idv.titles.fail'))
   end
 end


### PR DESCRIPTION
**Why**: IdV controllers lacked some test coverage,
particularly for failure cases.

**How**: Updates the identity-proofer gem to support
mock vendor failure triggers.