### PR TITLE
Store PII on its own table

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'db/schema.rb'
     - 'bin/**/*'
     - 'config/initializers/devise.rb'
-    - 'db/migrate/20160405212342_initial_schema.rb'
+    - 'db/migrate/*'
   TargetRubyVersion: 2.3
   UseCache: true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: dc90ed5476bfec52cffb2afbe6151a3f84a2ec1c
+  revision: 282bbd7ee7878ab0b01ab04acb329ac7d961bb6e
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -26,20 +26,24 @@ module IdvSession
       idv_resolution.questions.any?
   end
 
-  def set_idv_vendor(vendor)
+  def idv_vendor=(vendor)
     idv_session[:vendor] = vendor
   end
 
-  def set_idv_applicant(applicant)
+  def idv_applicant=(applicant)
     idv_session[:applicant] = applicant
   end
 
-  def set_idv_resolution(resolution)
+  def idv_profile_from_applicant(applicant)
+    idv_session[:profile_id] = Profile.create_from_proofer_applicant(applicant, current_user).id
+  end
+
+  def idv_resolution=(resolution)
     idv_session[:resolution] = resolution
   end
 
-  def set_idv_question_number(n)
-    idv_session[:question_number] = n
+  def idv_question_number=(num)
+    idv_session[:question_number] = num
   end
 
   def idv_vendor
@@ -50,14 +54,29 @@ module IdvSession
     idv_session[:applicant]
   end
 
+  def idv_profile_id
+    idv_session[:profile_id]
+  end
+
+  def idv_profile
+    @_profile ||= Profile.find(idv_profile_id)
+  end
+
   def clear_idv_session
     idv_session.delete(:vendor)
     idv_session.delete(:applicant)
+    idv_session.delete(:profile_id)
     idv_session.delete(:resolution)
     idv_session.delete(:question_number)
   end
 
   def idv_session
     user_session[:idv] ||= {}
+  end
+
+  def complete_idv_profile
+    idv_profile.verified_at = Time.zone.now
+    idv_profile.vendor = idv_vendor
+    idv_profile.activate
   end
 end

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -22,7 +22,7 @@ module Idv
       agent = Proofer::Agent.new(vendor: idv_vendor, applicant: idv_applicant)
       @idv_vendor = idv_vendor
       @confirmation = agent.submit_answers(idv_resolution.questions, idv_resolution.session_id)
-      # HANDWAVING actually alter the user
+      complete_idv_profile if @confirmation.success?
       clear_idv_session
     end
   end

--- a/app/controllers/idv/questions_controller.rb
+++ b/app/controllers/idv/questions_controller.rb
@@ -14,7 +14,7 @@ module Idv
 
     def create
       idv_resolution.questions[idv_question_number].answer = params.require('answer')
-      set_idv_question_number(idv_question_number + 1)
+      self.idv_question_number += 1
       redirect_to idv_questions_path
     end
 

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -8,10 +8,9 @@ module Idv
     end
 
     def create
-      resolution = setup_idv_session
+      resolution = start_idv_session
       if resolution.success
-        set_idv_resolution(resolution)
-        set_idv_question_number(0)
+        init_questions_and_profile(resolution)
         redirect_to idv_questions_path
       else
         flash[:error] = I18n.t('idv.titles.fail')
@@ -21,13 +20,22 @@ module Idv
 
     private
 
-    def setup_idv_session
+    def start_idv_session
       agent = Proofer::Agent.new(vendor: pick_a_vendor)
+      self.idv_applicant = applicant_from_params
+      self.idv_vendor = agent.vendor
+      agent.start(idv_applicant)
+    end
+
+    def applicant_from_params
       app_vars = applicant_params.delete_if { |_key, value| value.blank? }
-      applicant = Proofer::Applicant.new(app_vars)
-      set_idv_applicant(applicant)
-      set_idv_vendor(agent.vendor)
-      agent.start(applicant)
+      Proofer::Applicant.new(app_vars)
+    end
+
+    def init_questions_and_profile(resolution)
+      self.idv_resolution = resolution
+      self.idv_question_number = 0
+      idv_profile_from_applicant(idv_applicant)
     end
 
     # rubocop:disable MethodLength

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,35 @@
+class Profile < ActiveRecord::Base
+  belongs_to :user
+
+  validates_uniqueness_of :active, scope: :user_id, if: :active?
+
+  # rubocop:disable AbcSize, MethodLength
+  def self.create_from_proofer_applicant(applicant, user)
+    create(
+      user: user,
+      first_name: applicant.first_name,
+      middle_name: applicant.middle_name,
+      last_name: applicant.last_name,
+      address1: applicant.address1,
+      address2: applicant.address2,
+      city: applicant.city,
+      state: applicant.state,
+      zipcode: applicant.zipcode,
+      dob: applicant.dob,
+      ssn: applicant.ssn,
+      phone: applicant.phone
+    )
+  end
+  # rubocop:enable AbcSize, MethodLength
+
+  def activate
+    transaction do
+      Profile.where('user_id=?', user_id).update_all(active: false)
+      update!(active: true, activated_at: Time.zone.now)
+    end
+  end
+
+  def verified?
+    verified_at.present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ActiveRecord::Base
 
   has_many :authorizations, dependent: :destroy
   has_many :identities, dependent: :destroy
+  has_many :profiles, dependent: :destroy
 
   def set_default_role
     self.role ||= :user
@@ -66,6 +67,10 @@ class User < ActiveRecord::Base
 
   def multiple_identities?
     active_identities.size > 1
+  end
+
+  def active_profile
+    profiles.where(active: true).first
   end
 
   # To send emails asynchronously via ActiveJob.

--- a/app/views/idv/confirmations/index.html.slim
+++ b/app/views/idv/confirmations/index.html.slim
@@ -6,4 +6,4 @@
     div = t('idv.titles.hardfail')
 
 - if @idv_vendor == :mock && !@confirmation.success?
-  pre.mt2.p2.bg-silver.ws-pre-line = @confirmation.vendor_resp.pretty_inspect
+  pre.mt2.p2.bg-silver.ws-pre-line = @confirmation.vendor_resp.inspect

--- a/db/migrate/20160718152327_add_profiles_table.rb
+++ b/db/migrate/20160718152327_add_profiles_table.rb
@@ -1,0 +1,27 @@
+class AddProfilesTable < ActiveRecord::Migration
+  def change
+    create_table :profiles do |tbl|
+      tbl.integer :user_id, null: false
+      tbl.boolean :active, null: false, default: false
+      tbl.datetime :verified_at
+      tbl.datetime :activated_at
+      tbl.timestamps null: false
+
+      tbl.string :first_name
+      tbl.string :middle_name
+      tbl.string :last_name
+      tbl.string :address1
+      tbl.string :address2
+      tbl.string :city
+      tbl.string :state
+      tbl.string :zipcode
+      tbl.string :ssn
+      tbl.string :dob
+      tbl.string :phone
+      tbl.string :vendor
+    end
+
+    add_index :profiles, :user_id
+    add_index "profiles", ["user_id", "active"], unique: true, where: "(active = true)", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715150022) do
+ActiveRecord::Schema.define(version: 20160718152327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,30 @@ ActiveRecord::Schema.define(version: 20160715150022) do
   add_index "identities", ["service_provider", "authn_context"], name: "index_identities_on_service_provider_and_authn_context", using: :btree
   add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
+
+  create_table "profiles", force: :cascade do |t|
+    t.integer  "user_id",                      null: false
+    t.boolean  "active",       default: false, null: false
+    t.datetime "verified_at"
+    t.datetime "activated_at"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.string   "first_name"
+    t.string   "middle_name"
+    t.string   "last_name"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zipcode"
+    t.string   "ssn"
+    t.string   "dob"
+    t.string   "phone"
+    t.string   "vendor"
+  end
+
+  add_index "profiles", ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)", using: :btree
+  add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
     t.string   "session_id", limit: 255, null: false

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe Idv::ConfirmationsController do
+  render_views
+
+  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+  let(:applicant) { Proofer::Applicant.new first_name: 'Some', last_name: 'One' }
+  let(:agent) { Proofer::Agent.new vendor: :mock }
+  let(:resolution) { agent.start applicant }
+
+  describe 'before_actions' do
+    it 'includes before_actions from AccountStateChecker' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated
+      )
+    end
+  end
+
+  context 'session started' do
+    before do
+      init_idv_session
+    end
+
+    describe 'all questions answered correctly' do
+      it 'shows success' do
+        init_idv_session
+        complete_idv_session(true)
+
+        get :index
+
+        expect(response.status).to eq 200
+        expect(response.body).to include(t('idv.titles.complete'))
+      end
+    end
+
+    describe 'some answers incorrect' do
+      it 'shows error' do
+        init_idv_session
+        complete_idv_session(false)
+
+        get :index
+
+        expect(response.status).to eq 200
+        expect(response.body).to include(t('idv.titles.hardfail'))
+      end
+    end
+
+    describe 'questions incomplete' do
+      it 'redirects to /idv/questions' do
+        init_idv_session
+
+        get :index
+
+        expect(response).to redirect_to(idv_questions_path)
+      end
+    end
+  end
+
+  describe 'session not yet started' do
+    it 'redirects to /idv/sessions' do
+      sign_in(user)
+
+      get :index
+
+      expect(response).to redirect_to(idv_sessions_path)
+    end
+  end
+
+  def init_idv_session
+    sign_in(user)
+    subject.user_session[:idv] = {
+      vendor: :mock,
+      applicant: applicant,
+      resolution: resolution,
+      question_number: 0
+    }
+  end
+
+  def complete_idv_session(answer_correctly)
+    Proofer::Vendor::Mock::ANSWERS.each do |ques, answ|
+      resolution.questions.find_by_key(ques).answer = answer_correctly ? answ : 'wrong'
+      subject.user_session[:idv][:question_number] += 1
+    end
+  end
+end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -43,5 +43,14 @@ describe Idv::SessionsController do
       expect(flash).to be_empty
       expect(response).to redirect_to(idv_questions_path)
     end
+
+    it 'shows failure on intentionally bad values' do
+      sign_in(user)
+
+      post :create, first_name: 'Bad', ssn: '6666'
+
+      expect(response).to redirect_to(idv_sessions_path)
+      expect(flash[:error]).to eq t('idv.titles.fail')
+    end
   end
 end

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -4,7 +4,7 @@ feature 'IdV session' do
   let(:mock_questions) { Proofer::Vendor::Mock.new.build_question_set(nil) }
 
   scenario 'KBV with all answers correct' do
-    sign_in_and_2fa_user
+    user = sign_in_and_2fa_user
 
     visit '/idv/sessions'
 
@@ -36,6 +36,10 @@ feature 'IdV session' do
     end
 
     expect(page).to have_content(t('idv.titles.complete'))
+
+    expect(user.active_profile).to be_a(Profile)
+    expect(user.active_profile.verified?).to eq true
+    expect(user.active_profile.ssn).to eq '666661234'
   end
 
   scenario 'KBV with some incorrect answers' do

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'IdV session' do
-  let(:mock_questions) { Proofer::Agent.new(vendor: :mock).start.questions }
+  let(:mock_questions) { Proofer::Vendor::Mock.new.build_question_set(nil) }
 
   scenario 'KBV with all answers correct' do
     sign_in_and_2fa_user
@@ -36,5 +36,60 @@ feature 'IdV session' do
     end
 
     expect(page).to have_content(t('idv.titles.complete'))
+  end
+
+  scenario 'KBV with some incorrect answers' do
+    sign_in_and_2fa_user
+
+    visit '/idv/sessions'
+
+    expect(page).to have_content(t('idv.form.first_name'))
+
+    fill_in :first_name, with: 'Some'
+    fill_in :last_name, with: 'One'
+    fill_in :ssn, with: '666661234'
+    fill_in :dob, with: '19800102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+    click_button 'Continue'
+
+    expect(page).to have_content('Where did you live')
+
+    %w(city bear quest color speed).each do |answer_key|
+      question = mock_questions.find_by_key(answer_key)
+      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
+      if question.choices.nil?
+        fill_in :answer, with: 'wrong'
+      else
+        choice = question.choices.detect { |c| c.key == answer_text }
+        el_id = "#choice_#{choice.key_html_safe}"
+        find(el_id).set(true)
+      end
+      click_button 'Next'
+    end
+
+    expect(page).to have_content(t('idv.titles.hardfail'))
+  end
+
+  scenario 'un-resolvable PII' do
+    sign_in_and_2fa_user
+
+    visit '/idv/sessions'
+
+    expect(page).to have_content(t('idv.form.first_name'))
+
+    fill_in :first_name, with: 'Bad'
+    fill_in :last_name, with: 'User'
+    fill_in :ssn, with: '6666'
+    fill_in :dob, with: '19000102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+    click_button 'Continue'
+
+    expect(page).to have_content(t('idv.titles.fail'))
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe Profile do
+  let(:user) { create(:user, :signed_up) }
+  let(:profile) do
+    Profile.create(
+      user_id: user.id
+    )
+  end
+
+  subject { profile }
+
+  it { is_expected.to belong_to(:user) }
+
+  describe 'allows only one active Profile per user' do
+    it 'prevents create! via ActiveRecord uniqueness validation' do
+      profile.active = true
+      profile.save!
+      expect do
+        Profile.create!(user_id: user.id, active: true)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'prevents save! via psql unique partial index' do
+      profile.active = true
+      profile.save!
+      expect do
+        another_profile = Profile.new(user_id: user.id, active: true)
+        another_profile.save!(validate: false)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe '#activate' do
+    it 'activates current Profile, de-activates all other Profile for the user' do
+      active_profile = Profile.create(user: user, active: true)
+      profile.activate
+      active_profile.reload
+      expect(active_profile).to_not be_active
+      expect(profile).to be_active
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,12 @@ require 'saml_idp_constants'
 MAX_GOOD_PASSWORD = '!1aZ' * 32
 
 describe User do
+  describe 'Associations' do
+    it { should have_many(:authorizations) }
+    it { should have_many(:identities) }
+    it { should have_many(:profiles) }
+  end
+
   it 'should only send one email during creation' do
     expect do
       User.create(email: 'nobody@nobody.com')


### PR DESCRIPTION
**Why**:

We collect PII for 2 reasons:

* identity resolution in proofing process,
* pass verified values to relying parties as required.

**How**:

Per https://github.com/18F/identity-private/issues/479
PII is stored on its own table, with a one-to-many relationship
to users table. The 'active' and 'verified' flags are tracked
in order to indicate the status of each profile record.