### PR TITLE
Fix form validation on IDV

### DIFF
--- a/app/views/idv/index.html.slim
+++ b/app/views/idv/index.html.slim
@@ -30,4 +30,4 @@ p
     | You will not be charged any money and are not sharing any account balances
      or other financial information with us.
 
-= link_to 'Continue', idv_sessions_path
+= link_to 'Continue', idv_sessions_path, data: { no_turbolink: true }


### PR DESCRIPTION
**Why**: Turbolink causes the javascript not to initialize correctly.  Fixes https://github.com/18F/identity-private/issues/533