### PR TITLE
Fix rubocop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,15 +182,6 @@ Style/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail'
-  EnforcedStyle: only_raise
-  SupportedStyles:
-    - only_raise
-    - only_fail
-    - semantic
-
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -32,10 +32,7 @@ module Users
       token = params[:confirmation_token]
 
       @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, token)
-
-      if @confirmable.confirmed?
-        @confirmable = User.confirm_by_token(token)
-      end
+      @confirmable = User.confirm_by_token(token) if @confirmable.confirmed?
 
       @password_form = PasswordForm.new(@confirmable)
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -8,11 +8,10 @@ module Users
       # We are utilizing Pundit's policy for verifying which user can
       # recover passwords. However, we always want to return success.
       flash[:success] = t('notices.password_reset')
-      redirect_to after_sending_reset_password_instructions_path_for(
-        resource_name
-      )
+      redirect_to after_sending_reset_password_instructions_path_for(resource_name)
     end
 
+    # rubocop:disable AbcSize,MethodLength
     def create
       resource = resource_class.find_by_email(resource_params[:email])
 
@@ -35,8 +34,9 @@ module Users
       end
 
       flash[:success] = t('notices.password_reset')
-      respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+      redirect_to after_sending_reset_password_instructions_path_for(resource_name)
     end
+    # rubocop:enable AbcSize,MethodLength
 
     def edit
       resource = User.new

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -21,8 +21,8 @@ module Users
     def disable
       if current_user.otp_secret_key.present?
         current_user.update(otp_secret_key: nil)
+        flash[:success] = t('notices.totp_disabled')
       end
-      flash[:success] = t('notices.totp_disabled')
       redirect_to edit_user_registration_path
     end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -24,7 +24,7 @@ UserDecorator = Struct.new(:user) do
   def first_sentence_for_confirmation_email
     if user.reset_requested_at
       "Your #{APP_NAME} account has been reset by a tech support representative. " \
-      'In order to continue, you must confirm your email address.'
+      "In order to continue, you must confirm your email address."
     else
       "To #{user.confirmed_at ? 'finish updating' : 'continue creating'} your " \
       "#{APP_NAME} Account, you must confirm your email address."

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,6 @@
 class ApplicationPolicy
   def initialize(user, record)
-    fail Pundit::NotAuthorizedError, 'must be logged in' unless user
+    raise Pundit::NotAuthorizedError, 'must be logged in' unless user
     @user = user
     @record = record
   end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( misc/*.js email.css )
+Rails.application.config.assets.precompile += %w(misc/*.js email.css)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,6 +5,7 @@ SecureHeaders::Configuration.default do |config|
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
+  # rubocop:disable PercentStringArray
   config.csp = {
     default_src: %w('self'),
     report_only: Rails.env.development? ? true : false,
@@ -22,6 +23,7 @@ SecureHeaders::Configuration.default do |config|
     style_src: %w('self'),
     base_uri: %w('self')
   }
+  # rubocop:enable PercentStringArray
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationController do
   describe 'handling InvalidAuthenticityToken exceptions' do
     controller do
       def index
-        fail ActionController::InvalidAuthenticityToken
+        raise ActionController::InvalidAuthenticityToken
       end
     end
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -55,7 +55,7 @@ describe UserDecorator do
 
         expect(user_decorator.first_sentence_for_confirmation_email).
           to eq "Your #{APP_NAME} account has been reset by a tech support representative. " \
-                'In order to continue, you must confirm your email address.'
+                "In order to continue, you must confirm your email address."
       end
     end
 
@@ -75,10 +75,8 @@ describe UserDecorator do
         user_decorator = UserDecorator.new(user)
 
         expect(user_decorator.first_sentence_for_confirmation_email).
-          to eq(
-            "To continue creating your #{APP_NAME} Account, " \
-            'you must confirm your email address.'
-          )
+          to eq "To continue creating your #{APP_NAME} Account, " \
+                "you must confirm your email address."
       end
     end
   end


### PR DESCRIPTION
- Fix all rubocop warnings and errors
- Remove `Style/SignalException` from .rubocop.yml since it
  did not differ from upstream rubocop defaults.
- Remove only remaining use use of `#respond_with`