### PR TITLE
Add per-field edit forms

### DIFF
--- a/app/controllers/users/edit_info_controller.rb
+++ b/app/controllers/users/edit_info_controller.rb
@@ -1,0 +1,57 @@
+module Users
+  class EditInfoController < ApplicationController
+    include PhoneConfirmation
+
+    before_action :confirm_two_factor_authenticated
+
+    def email
+      @update_form = UpdateUserEmailForm.new(current_user)
+      handle_request
+    end
+
+    def mobile
+      @update_form = UpdateUserMobileForm.new(current_user)
+      handle_request
+    end
+
+    private
+
+    def handle_request
+      if request.put?
+        attempt_submit
+      else
+        render
+      end
+    end
+
+    def attempt_submit
+      if @update_form.submit(user_params)
+        process_successful_update(current_user)
+      else
+        render
+      end
+    end
+
+    def user_params
+      form = @update_form.class.name.underscore.to_sym
+      params.require(form).permit(:email, :mobile)
+    end
+
+    def process_successful_update(resource)
+      process_updates(resource)
+      bypass_sign_in resource
+    end
+
+    def process_updates(resource)
+      updater = UserFlashUpdater.new(@update_form, flash)
+      updater.set_flash_message
+
+      if @update_form.mobile_changed?
+        prompt_to_confirm_mobile(@update_form.mobile)
+      elsif is_flashing_format?
+        EmailNotifier.new(resource).send_password_changed_email
+        redirect_to profile_url
+      end
+    end
+  end
+end

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -65,7 +65,7 @@ module Users
 
     def after_confirmation_path
       if @updating_existing_number
-        edit_user_registration_path
+        profile_path
       else
         after_sign_in_path_for(current_user)
       end

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -1,0 +1,48 @@
+class UpdateUserEmailForm
+  include ActiveModel::Model
+  include FormEmailValidator
+
+  attr_accessor :email
+  attr_reader :user
+
+  def persisted?
+    true
+  end
+
+  def initialize(user)
+    @user = user
+    self.email = @user.email
+  end
+
+  def submit(params)
+    self.email = params[:email]
+
+    if valid_form?
+      @user.update(params)
+    else
+      process_errors(params)
+    end
+  end
+
+  def valid_form?
+    valid? && !email_taken?
+  end
+
+  def mobile_changed?
+    false
+  end
+
+  private
+
+  def email_taken?
+    @email_taken == true
+  end
+
+  def process_errors(params)
+    return false unless email_taken? && valid?
+
+    @user.skip_confirmation_notification!
+    UserMailer.signup_with_your_email(email).deliver_later
+    @user.update(params)
+  end
+end

--- a/app/forms/update_user_mobile_form.rb
+++ b/app/forms/update_user_mobile_form.rb
@@ -1,0 +1,33 @@
+class UpdateUserMobileForm
+  include ActiveModel::Model
+  include FormMobileValidator
+
+  attr_accessor :mobile
+  attr_reader :user
+
+  def persisted?
+    true
+  end
+
+  def initialize(user)
+    @user = user
+    self.mobile = @user.mobile
+  end
+
+  def submit(params)
+    formatted_mobile = params[:mobile].phony_formatted(
+      format: :international, normalize: :US, spaces: ' '
+    )
+
+    if formatted_mobile != @user.mobile
+      @mobile_changed = true
+      self.mobile = formatted_mobile
+    end
+
+    valid?
+  end
+
+  def mobile_changed?
+    @mobile_changed == true
+  end
+end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -9,14 +9,14 @@ h2.h5.mt4.mb2 = t('headings.profile.account_settings')
     .sm-col.sm-col-4.px1 = 'Email address'
     .sm-col.sm-col-6.px1 = current_user.email
     .sm-col.sm-col-2.px1.sm-right-align
-      = link_to 'Edit', edit_user_registration_path, \
+      = link_to 'Edit', edit_email_path, \
         class: 'btn btn-primary px1 py0 h6 regular'
 .py2.border-top
   .clearfix.mxn1
     .sm-col.sm-col-4.px1 = 'Mobile'
     .sm-col.sm-col-6.px1 = current_user.mobile
     .sm-col.sm-col-2.px1.sm-right-align
-      = link_to 'Edit', edit_user_registration_path, \
+      = link_to 'Edit', edit_mobile_path, \
         class: 'btn btn-primary px1 py0 h6 regular'
 .py2.border-top.border-bottom
   .clearfix.mxn1

--- a/app/views/users/edit_info/email.html.slim
+++ b/app/views/users/edit_info/email.html.slim
@@ -1,0 +1,9 @@
+- title t('titles.edit_info.email')
+
+
+h1.heading = t('headings.edit_info.email')
+= simple_form_for(@update_form, url: edit_email_path,
+    html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
+  = f.error_notification
+  = f.input :email, autofocus: true, required: true
+  = f.button :submit, 'Update'

--- a/app/views/users/edit_info/mobile.html.slim
+++ b/app/views/users/edit_info/mobile.html.slim
@@ -1,0 +1,9 @@
+- title t('titles.edit_info.mobile')
+
+
+h1.heading = t('headings.edit_info.mobile')
+= simple_form_for(@update_form, url: edit_mobile_path,
+    html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
+  = f.error_notification
+  = f.input :mobile, as: :tel, autofocus: true, required: true
+  = f.button :submit, 'Update'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,9 @@ en:
     confirmations:
       new: Resend confirmation instructions for your account
       show: Create a password for your account
+    edit_info:
+      email: Edit your email
+      mobile: Edit your phone number
     enter_2fa_code: Enter the secure one-time password to log in to your account
     account_locked: Account locked
     passwords:
@@ -73,6 +76,9 @@ en:
     confirmations:
       new: Resend confirmation instructions
     delete_account: Delete my %{app_name} account
+    edit_info:
+      email: Edit your email
+      mobile: Edit your phone number
     log_in: Log in
     passwords:
       change: Change your password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Rails.application.routes.draw do
 
     patch '/confirm' => 'users/confirmations#confirm'
 
+    match '/edit/email' => 'users/edit_info#email', via: [:get, :put], as: :edit_email
+    match '/edit/mobile' => 'users/edit_info#mobile', via: [:get, :put], as: :edit_mobile
+
     get '/phone_setup' => 'devise/two_factor_authentication_setup#index'
     patch '/phone_setup' => 'devise/two_factor_authentication_setup#set'
 

--- a/spec/controllers/users/edit_info_controller_spec.rb
+++ b/spec/controllers/users/edit_info_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+include Features::MailerHelper
+include Features::LocalizationHelper
+
+describe Users::EditInfoController, devise: true do
+  describe '#email' do
+    let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+    let(:second_user) { create(:user, :signed_up, email: 'another@example.com') }
+    let(:new_email) { 'new_email@example.com' }
+
+    context 'user changes email' do
+      before do
+        sign_in(user)
+        put :email, update_user_email_form: { email: new_email }
+      end
+
+      it 'lets user know they need to confirm their new email' do
+        expect(response).to redirect_to profile_url
+        expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
+        expect(response).to render_template('devise/mailer/confirmation_instructions')
+        expect(user.reload.email).to eq 'old_email@example.com'
+      end
+    end
+
+    context 'user attempts to remove email address' do
+      render_views
+
+      it 'displays an error message and does not delete the email' do
+        sign_in(user)
+        put :email, update_user_email_form: { email: '' }
+
+        expect(response.body).to have_content invalid_email_message
+        expect(user.reload.email).to be_present
+      end
+    end
+
+    context "user changes email to another user's email address" do
+      it 'lets user know they need to confirm their new email' do
+        sign_in(user)
+        put :email, update_user_email_form: { email: second_user.email }
+
+        expect(response).to redirect_to profile_url
+        expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
+        expect(response).to render_template('user_mailer/signup_with_your_email')
+        expect(user.reload.email).to eq 'old_email@example.com'
+        expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
+      end
+    end
+
+    context 'user updates with invalid email' do
+      render_views
+
+      it 'displays error about invalid email' do
+        sign_in(user)
+        put :email, update_user_email_form: { email: 'foo' }
+
+        expect(response.body).to have_content('Please enter a valid email')
+      end
+    end
+  end
+
+  describe '#mobile' do
+    let(:user) { create(:user, :signed_up, mobile: '+1 (202) 555-1234') }
+    let(:second_user) { create(:user, :signed_up, mobile: '+1 (202) 555-5678') }
+    let(:new_mobile) { '555-555-5555' }
+
+    context 'user changes mobile' do
+      before do
+        sign_in(user)
+        put :mobile, update_user_mobile_form: { mobile: new_mobile }
+      end
+
+      it 'redirects to phone confirmation page with success message' do
+        expect(response).to redirect_to(phone_confirmation_send_path)
+        expect(flash[:notice]).to eq t('devise.registrations.mobile_update_needs_confirmation')
+        expect(user.reload.mobile).to_not eq '+1 (555) 555-5555'
+      end
+    end
+
+    context 'user attempts to remove mobile number' do
+      render_views
+
+      it 'displays error message and does not remove mobile' do
+        sign_in(user)
+        put :mobile, update_user_mobile_form: { mobile: '' }
+
+        expect(response.body).to have_content invalid_mobile_message
+        expect(second_user.reload.mobile).to be_present
+      end
+    end
+
+    context "user changes mobile to another user's mobile" do
+      it 'redirects to phone confirmation page with success message' do
+        sign_in(user)
+        put :mobile, update_user_mobile_form: { mobile: second_user.mobile }
+
+        expect(response).to redirect_to(phone_confirmation_send_path)
+        expect(flash[:notice]).to eq t('devise.registrations.mobile_update_needs_confirmation')
+        expect(user.reload.mobile).to_not eq second_user.mobile
+      end
+    end
+
+    context 'user updates with invalid mobile' do
+      render_views
+
+      it 'displays error about invalid mobile' do
+        sign_in(user)
+        put :mobile, update_user_mobile_form: { mobile: '123' }
+
+        expect(response.body).to have_content('number is invalid')
+      end
+    end
+  end
+end

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -82,8 +82,8 @@ describe Users::PhoneConfirmationController, devise: true do
           expect(subject.current_user.mobile_confirmed_at).to_not eq(@previous_mobile_confirmed_at)
         end
 
-        it 'redirects to edit_user_registration_path' do
-          expect(response).to redirect_to(edit_user_registration_path)
+        it 'redirects to profile_path' do
+          expect(response).to redirect_to(profile_path)
         end
 
         it 'displays success flash notice' do

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe UpdateUserEmailForm do
+  let(:user) { build_stubbed(:user, :signed_up) }
+  subject { UpdateUserEmailForm.new(user) }
+
+  it do
+    is_expected.
+      to validate_presence_of(:email).
+      with_message(t('valid_email.validations.email.invalid'))
+  end
+
+  describe 'email validation' do
+    it 'uses the valid_email gem with mx and ban_disposable options' do
+      email_validator = subject._validators.values.flatten.
+                        detect { |v| v.class == EmailValidator }
+
+      expect(email_validator.options).
+        to eq(mx: true, ban_disposable_email: true)
+    end
+  end
+
+  describe 'email uniqueness' do
+    context 'when email is already taken' do
+      it 'is invalid' do
+        second_user = build_stubbed(:user, :signed_up, email: 'taken@gmail.com')
+        allow(User).to receive(:exists?).with(email: second_user.email).and_return(true)
+
+        subject.email = second_user.email
+
+        expect(subject.valid_form?).to be false
+      end
+    end
+
+    context 'when email is not already taken' do
+      it 'is valid' do
+        subject.email = 'not_taken@gmail.com'
+
+        expect(subject.valid_form?).to be true
+      end
+    end
+
+    context 'when email is same as current user' do
+      it 'is valid' do
+        subject.email = user.email
+
+        expect(subject.valid_form?).to be true
+      end
+    end
+
+    context 'when email is nil' do
+      it 'does not add already taken errors' do
+        subject.email = nil
+
+        expect(subject.valid_form?).to be false
+        expect(subject.errors[:email].uniq).
+          to eq [t('valid_email.validations.email.invalid')]
+      end
+    end
+  end
+end

--- a/spec/forms/update_user_mobile_form_spec.rb
+++ b/spec/forms/update_user_mobile_form_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe UpdateUserMobileForm do
+  let(:user) { build_stubbed(:user, :signed_up) }
+  subject { UpdateUserMobileForm.new(user) }
+
+  it do
+    is_expected.
+      to validate_presence_of(:mobile).
+      with_message(t('errors.messages.improbable_phone'))
+  end
+
+  describe 'mobile validation' do
+    it 'uses the phony_rails gem with country option set to US' do
+      mobile_validator = subject._validators.values.flatten.
+                         detect { |v| v.class == PhonyPlausibleValidator }
+
+      expect(mobile_validator.options).
+        to eq(country_code: 'US', presence: true, message: :improbable_phone)
+    end
+  end
+
+  def format_phone(mobile)
+    mobile.phony_formatted(
+      format: :international, normalize: :US, spaces: ' '
+    )
+  end
+
+  describe 'mobile uniqueness' do
+    context 'when mobile is already taken' do
+      it 'is valid' do
+        second_user = build_stubbed(:user, :signed_up, mobile: '+1 (202) 555-1213')
+        allow(User).to receive(:exists?).with(email: 'new@gmail.com').and_return(false)
+        allow(User).to receive(:exists?).with(mobile: second_user.mobile).and_return(true)
+
+        subject.mobile = second_user.mobile
+
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context 'when mobile is not already taken' do
+      it 'is valid' do
+        subject.mobile = '+1 (703) 555-1212'
+
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context 'when mobile is same as current user' do
+      it 'is valid' do
+        subject.mobile = user.mobile
+
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context 'when mobile is nil' do
+      it 'does not add already taken errors' do
+        subject.mobile = nil
+
+        expect(subject.valid?).to be false
+        expect(subject.errors[:mobile].uniq).
+          to eq [t('errors.messages.improbable_phone')]
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: make it simpler & easier for user to edit their info

in a future PR, i think we can remove the older update_user_profile
code bits (contains all fields, requires re-typing current password)