### PR TITLE
Successful IdV redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: 282bbd7ee7878ab0b01ab04acb329ac7d961bb6e
+  revision: 3b44d294c9f12c4fb7ab89687f48d3453f8582a7
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -18,12 +18,16 @@ module IdvSession
     idv_session[:resolution]
   end
 
+  def idv_questions
+    idv_resolution.questions
+  end
+
   def proofing_session_started?
     idv_resolution.present? &&
       idv_applicant.present? &&
       idv_resolution.success &&
-      idv_resolution.questions &&
-      idv_resolution.questions.any?
+      idv_questions &&
+      idv_questions.any?
   end
 
   def idv_vendor=(vendor)

--- a/app/controllers/idv/questions_controller.rb
+++ b/app/controllers/idv/questions_controller.rb
@@ -21,9 +21,10 @@ module Idv
     private
 
     def render_next_question
-      if idv_question_number < idv_resolution.questions.count
+      questions = idv_resolution.questions
+      if idv_question_number < questions.count
         @question_sequence = idv_question_number + 1
-        @question = idv_resolution.questions[idv_question_number]
+        @question = questions[idv_question_number]
       else
         redirect_to idv_confirmations_path
       end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -40,7 +40,7 @@ UserDecorator = Struct.new(:user) do
   end
 
   def identity_not_verified?
-    user.identities.pluck(:ial).uniq == [1]
+    user.active_profile ? false : true
   end
 
   def qrcode(otp_secret_key)

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -27,26 +27,27 @@ describe Idv::SessionsController do
     end
   end
 
-  describe 'user has created account' do
-    it 'starts new proofing session' do
+  context 'user has created account' do
+    before do
       sign_in(user)
+    end
+
+    it 'starts new proofing session' do
       get :index
+
       expect(response.status).to eq 200
       expect(response.body).to include t('idv.form.first_name')
     end
 
-    it 'creates proofing session' do
-      sign_in(user)
-
+    it 'creates proofing applicant' do
       post :create, user_attrs
 
       expect(flash).to be_empty
       expect(response).to redirect_to(idv_questions_path)
+      expect(subject.user_session[:idv][:applicant]).to be_a Proofer::Applicant
     end
 
     it 'shows failure on intentionally bad values' do
-      sign_in(user)
-
       post :create, first_name: 'Bad', ssn: '6666'
 
       expect(response).to redirect_to(idv_sessions_path)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -117,7 +117,7 @@ describe SamlIdpController do
         user = create(:user, :signed_up)
         generate_saml_response(user, loa3_saml_settings)
 
-        user.last_identity.update(ial: 2)
+        user.profiles.create(verified_at: Time.current, active: true, activated_at: Time.current)
 
         generate_saml_response(user, loa3_saml_settings)
 

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'IdV session' do
-  let(:mock_questions) { Proofer::Vendor::Mock.new.build_question_set(nil) }
+  include IdvHelper
 
   scenario 'KBV with all answers correct' do
     user = sign_in_and_2fa_user
@@ -10,31 +10,11 @@ feature 'IdV session' do
 
     expect(page).to have_content(t('idv.form.first_name'))
 
-    fill_in :first_name, with: 'Some'
-    fill_in :last_name, with: 'One'
-    fill_in :ssn, with: '666661234'
-    fill_in :dob, with: '19800102'
-    fill_in :address1, with: '123 Main St'
-    fill_in :city, with: 'Nowhere'
-    select 'Kansas', from: :state
-    fill_in :zipcode, with: '66044'
+    fill_out_idv_form_ok
     click_button 'Continue'
-
     expect(page).to have_content('Where did you live')
 
-    %w(city bear quest color speed).each do |answer_key|
-      question = mock_questions.find_by_key(answer_key)
-      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
-      if question.choices.nil?
-        fill_in :answer, with: answer_text
-      else
-        choice = question.choices.detect { |c| c.key == answer_text }
-        el_id = "#choice_#{choice.key_html_safe}"
-        find(el_id).set(true)
-      end
-      click_button 'Next'
-    end
-
+    complete_idv_questions_ok
     expect(page).to have_content(t('idv.titles.complete'))
 
     expect(user.active_profile).to be_a(Profile)
@@ -49,31 +29,12 @@ feature 'IdV session' do
 
     expect(page).to have_content(t('idv.form.first_name'))
 
-    fill_in :first_name, with: 'Some'
-    fill_in :last_name, with: 'One'
-    fill_in :ssn, with: '666661234'
-    fill_in :dob, with: '19800102'
-    fill_in :address1, with: '123 Main St'
-    fill_in :city, with: 'Nowhere'
-    select 'Kansas', from: :state
-    fill_in :zipcode, with: '66044'
+    fill_out_idv_form_ok
     click_button 'Continue'
 
     expect(page).to have_content('Where did you live')
 
-    %w(city bear quest color speed).each do |answer_key|
-      question = mock_questions.find_by_key(answer_key)
-      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
-      if question.choices.nil?
-        fill_in :answer, with: 'wrong'
-      else
-        choice = question.choices.detect { |c| c.key == answer_text }
-        el_id = "#choice_#{choice.key_html_safe}"
-        find(el_id).set(true)
-      end
-      click_button 'Next'
-    end
-
+    complete_idv_questions_fail
     expect(page).to have_content(t('idv.titles.hardfail'))
   end
 
@@ -84,14 +45,7 @@ feature 'IdV session' do
 
     expect(page).to have_content(t('idv.form.first_name'))
 
-    fill_in :first_name, with: 'Bad'
-    fill_in :last_name, with: 'User'
-    fill_in :ssn, with: '6666'
-    fill_in :dob, with: '19000102'
-    fill_in :address1, with: '123 Main St'
-    fill_in :city, with: 'Nowhere'
-    select 'Kansas', from: :state
-    fill_in :zipcode, with: '66044'
+    fill_out_idv_form_fail
     click_button 'Continue'
 
     expect(page).to have_content(t('idv.titles.fail'))

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -1,0 +1,57 @@
+module IdvHelper
+  def mock_idv_questions
+    @_mock_idv_questions ||= Proofer::Vendor::Mock.new.build_question_set(nil)
+  end
+
+  def complete_idv_questions_ok
+    %w(city bear quest color speed).each do |answer_key|
+      question = mock_idv_questions.find_by_key(answer_key)
+      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
+      if question.choices.nil?
+        fill_in :answer, with: answer_text
+      else
+        choice = question.choices.detect { |c| c.key == answer_text }
+        el_id = "#choice_#{choice.key_html_safe}"
+        find(el_id).set(true)
+      end
+      click_button 'Next'
+    end
+  end
+
+  def complete_idv_questions_fail
+    %w(city bear quest color speed).each do |answer_key|
+      question = mock_idv_questions.find_by_key(answer_key)
+      answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
+      if question.choices.nil?
+        fill_in :answer, with: 'wrong'
+      else
+        choice = question.choices.detect { |c| c.key == answer_text }
+        el_id = "#choice_#{choice.key_html_safe}"
+        find(el_id).set(true)
+      end
+      click_button 'Next'
+    end
+  end
+
+  def fill_out_idv_form_ok
+    fill_in :first_name, with: 'Some'
+    fill_in :last_name, with: 'One'
+    fill_in :ssn, with: '666661234'
+    fill_in :dob, with: '19800102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+  end
+
+  def fill_out_idv_form_fail
+    fill_in :first_name, with: 'Bad'
+    fill_in :last_name, with: 'User'
+    fill_in :ssn, with: '6666'
+    fill_in :dob, with: '19000102'
+    fill_in :address1, with: '123 Main St'
+    fill_in :city, with: 'Nowhere'
+    select 'Kansas', from: :state
+    fill_in :zipcode, with: '66044'
+  end
+end


### PR DESCRIPTION
**Why**: LOA2+ authn requires IdV proofing if not
previously performed. On successful IdV, redirect
to the originating SP, just as normal sign-in does.