### PR TITLE
Remove unused fields from identities table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,10 +52,6 @@ class User < ActiveRecord::Base
     active_identities[-1] unless active_identities.empty?
   end
 
-  def last_quizzed_identity
-    identities.order(updated_at: :desc).detect(&:quiz_started)
-  end
-
   def active_identities
     identities.where(
       'last_authenticated_at IS NOT ?',

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -19,13 +19,8 @@ IdentityLinker = Struct.new(:user, :provider, :authn_context) do
   def identity_attributes
     {
       authn_context: authn_context,
-      session_index: session_index,
       last_authenticated_at: Time.current,
       session_uuid: SecureRandom.uuid
     }
-  end
-
-  def session_index
-    user.active_identities.size + 1
   end
 end

--- a/db/migrate/20160719164239_remove_unused_identity_fields.rb
+++ b/db/migrate/20160719164239_remove_unused_identity_fields.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedIdentityFields < ActiveRecord::Migration
+  def change
+    remove_column :identities, :quiz_started
+    remove_column :identities, :session_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718152327) do
+ActiveRecord::Schema.define(version: 20160719164239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,9 +44,7 @@ ActiveRecord::Schema.define(version: 20160718152327) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "session_index"
     t.string   "session_uuid",          limit: 255
-    t.boolean  "quiz_started",                      default: false
     t.integer  "ial",                               default: 1
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -193,67 +193,6 @@ describe User do
     end
   end
 
-  describe '#last_quizzed identity' do
-    let(:user) { create(:user, :signed_up) }
-
-    context 'when the most recent identity is active and has started a quiz' do
-      it 'returns the most recent identity' do
-        user.identities.create(
-          service_provider: 'first',
-          last_authenticated_at: nil,
-          quiz_started: true,
-          updated_at: 5.seconds.ago
-        )
-        user.identities.create(
-          service_provider: 'last',
-          last_authenticated_at: Time.current,
-          quiz_started: true,
-          updated_at: Time.current
-        )
-
-        expect(user.last_quizzed_identity.service_provider).to eq('last')
-      end
-    end
-
-    context 'when the most recent identity is inactive and has started a quiz' do
-      it 'returns the most recent identity' do
-        user.identities.create(
-          service_provider: 'first',
-          last_authenticated_at: 5.seconds.ago,
-          quiz_started: true,
-          updated_at: 5.seconds.ago
-        )
-        user.identities.create(
-          service_provider: 'last',
-          last_authenticated_at: nil,
-          quiz_started: true,
-          updated_at: Time.current
-        )
-
-        expect(user.last_quizzed_identity.service_provider).to eq('last')
-      end
-    end
-
-    context 'when none of the identities have started a quiz' do
-      it 'does not return any identity' do
-        user.identities.create(
-          service_provider: 'first',
-          last_authenticated_at: nil,
-          quiz_started: false,
-          updated_at: 5.seconds.ago
-        )
-        user.identities.create(
-          service_provider: 'last',
-          last_authenticated_at: Time.current,
-          quiz_started: false,
-          updated_at: Time.current
-        )
-
-        expect(user.last_quizzed_identity).to be_nil
-      end
-    end
-  end
-
   describe '#send_two_factor_authentication_code' do
     it 'calls UserOtpSender#send_otp' do
       user = build_stubbed(:user)

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -13,13 +13,12 @@ describe IdentityLinker do
       new_attributes = {
         service_provider: 'test.host',
         authn_context: 'LOA1',
-        session_index: 1,
         user_id: user.id,
         ial: 1
       }
 
       identity_attributes = last_identity.attributes.symbolize_keys.
-                            except(:created_at, :updated_at, :id, :quiz_started, :session_uuid,
+                            except(:created_at, :updated_at, :id, :session_uuid,
                                    :last_authenticated_at)
 
       expect(last_identity.session_uuid).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)


### PR DESCRIPTION
**Why**: These fields were not used anywhere.