### PR TITLE
Default to encrypting SAML tokens

### DIFF
--- a/app/views/test/saml_test/decode_response.html.slim
+++ b/app/views/test/saml_test/decode_response.html.slim
@@ -13,18 +13,20 @@ div class='container'
         td Issuer
         td = response.issuers.first
       tr
-        td Document
+        td XML Document
         td
-          = link_to 'Open XML in New Window',
-                    "data:text/xml;charset=utf-8;base64,#{Base64.encode64(response.document.to_s)}",
+          - xml_doc = Base64.encode64(response.document.to_s)
+          = link_to 'Open in New Window',
+                    "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                     target: '_blank'
 
       tr
-        td Encrypted Document
+        td Decrypted XML Document
         - if response.decrypted_document.present?
           td
-            = link_to 'Open Raw XML in New Window',
-                      "data:text/xml;charset=utf-8;base64,#{params[:SAMLResponse]}",
+            - xml_doc = Base64.encode64(response.decrypted_document.to_s)
+            = link_to 'Open in New Window',
+                      "data:text/xml;charset=utf-8;base64,#{xml_doc}",
                       target: '_blank'
 
         - else

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -13,13 +13,11 @@ test:
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
       sp_initiated_login_url: 'https://example.com/auth/saml/login'
-      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
 
     'https://rp2.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
-      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
 
     'http://test.host':
@@ -56,7 +54,6 @@ development:
       assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
       sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
 
 production:
   valid_hosts:
@@ -66,7 +63,6 @@ production:
       assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
       sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
       cert: 'saml_test_sp'
-      block_encryption: 'aes256-cbc'
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
       metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
@@ -102,14 +98,12 @@ production:
       assertion_consumer_logout_service_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-dashboard-dev.apps.cloud.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dashboard-demo':
       metadata_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/metadata'
       acs_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-dashboard-demo.apps.cloud.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
-      block_encryption: 'aes256-cbc'
 
 superb.legit.domain.gov:
   valid_hosts:

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -2,7 +2,7 @@ require 'fingerprinter'
 
 class ServiceProvider
   # currently acceptable encryption values are 'none' and 'aes256-cbc'
-  DEFAULT_ENCRYPTION = 'none'.freeze
+  DEFAULT_ENCRYPTION = 'aes256-cbc'.freeze
 
   def initialize(host)
     @host = host

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 require 'service_provider'
 
 describe ServiceProvider do
@@ -12,7 +13,7 @@ describe ServiceProvider do
           sp_initiated_login_url: nil,
           metadata_url: nil,
           cert: nil,
-          block_encryption: 'none',
+          block_encryption: 'aes256-cbc',
           key_transport: 'rsa-oaep-mgf1p',
           fingerprint: nil,
           double_quote_xml_attribute_values: true,
@@ -71,7 +72,7 @@ describe ServiceProvider do
           attributes = {
             acs_url: 'https://vets.gov/users/auth/saml/callback',
             assertion_consumer_logout_service_url: acls_url,
-            block_encryption: 'none',
+            block_encryption: 'aes256-cbc',
             cert: File.read("#{Rails.root}/certs/sp/saml_test_sp.crt"),
             double_quote_xml_attribute_values: true,
             fingerprint: fingerprint,
@@ -211,10 +212,10 @@ describe ServiceProvider do
 
   describe '#block_encryption' do
     context 'when no value is specified in YAML' do
-      it 'returns "none"' do
+      it 'returns "aes256-cbc"' do
         service_provider = ServiceProvider.new('http://test.host')
 
-        expect(service_provider.block_encryption).to eq 'none'
+        expect(service_provider.block_encryption).to eq 'aes256-cbc'
       end
     end
 

--- a/spec/support/saml_response_helper.rb
+++ b/spec/support/saml_response_helper.rb
@@ -193,11 +193,19 @@ module SamlResponseHelper
   end
 
   def decrypted_saml_response
-    @decrypted_saml_response ||= Saml::XML::Document.parse(saml_response.document.to_s)
+    @decrypted_saml_response ||= Saml::XML::Document.parse(saml_response_string(saml_response))
+  end
+
+  def saml_response_string(response)
+    if response.decrypted_document.present?
+      response.decrypted_document.to_s
+    else
+      response.document.to_s
+    end
   end
 
   def saml_response
-    OneLogin::RubySaml::Response.new(
+    @saml_response ||= OneLogin::RubySaml::Response.new(
       Nokogiri::HTML(response.body).at_css('#SAMLResponse')['value'],
       settings: saml_settings
     )


### PR DESCRIPTION
**Why**: We want to enable encryption by default and
in particular be consistent between dev and prod.