### PR TITLE
Honor argument to send_two_factor_authentication_code

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,8 @@ class User < ActiveRecord::Base
     mobile.present?
   end
 
-  def send_two_factor_authentication_code(_code)
-    UserOtpSender.new(self).send_otp
+  def send_two_factor_authentication_code(code)
+    UserOtpSender.new(self).send_otp(code)
   end
 
   def confirmation_period_expired?

--- a/app/services/user_otp_sender.rb
+++ b/app/services/user_otp_sender.rb
@@ -3,10 +3,10 @@ class UserOtpSender
     @user = user
   end
 
-  def send_otp
+  def send_otp(code)
     return if user_decorator.blocked_from_entering_2fa_code?
 
-    SmsSenderOtpJob.perform_later(@user.direct_otp, @user.mobile)
+    SmsSenderOtpJob.perform_later(code, @user.mobile)
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -199,7 +199,7 @@ describe User do
       otp_sender = instance_double(UserOtpSender)
 
       expect(UserOtpSender).to receive(:new).with(user).and_return(otp_sender)
-      expect(otp_sender).to receive(:send_otp)
+      expect(otp_sender).to receive(:send_otp).with(123)
 
       user.send_two_factor_authentication_code(123)
     end

--- a/spec/services/otp_sender_spec.rb
+++ b/spec/services/otp_sender_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe UserOtpSender do
   describe '#send_otp' do
     it 'sends OTP via SMS' do
-      user = build_stubbed(:user, otp_secret_key: 'lzmh6ekrnc5i6aaq')
+      user = build_stubbed(:user)
 
-      expect(SmsSenderOtpJob).to receive(:perform_later).with(user.direct_otp, user.mobile)
+      expect(SmsSenderOtpJob).to receive(:perform_later).with('123', user.mobile)
 
-      UserOtpSender.new(user).send_otp
+      UserOtpSender.new(user).send_otp('123')
     end
   end
 end


### PR DESCRIPTION
**Why**: Cleanup UserOtpSender such that it takes that
required code to send rather than using knowledge of the
user model.