### PR TITLE
Remove use of hardcoded application name

### DIFF
--- a/app/views/devise/registrations/destroy_confirm.html.slim
+++ b/app/views/devise/registrations/destroy_confirm.html.slim
@@ -1,7 +1,7 @@
 - title t('titles.registrations.destroy_confirm')
 
 
-h1.heading = t('headings.delete_account')
+h1.heading = t('headings.delete_account', app_name: APP_NAME)
 p = t('devise.registrations.destroy_confirm')
 div
   = button_to t('forms.buttons.delete_account_confirm'), \

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -2,7 +2,7 @@
 
 
 h1.heading = t('headings.registrations.enter_email')
-p Enter the email address you’d like to associate with #{APP_NAME.downcase}
+p Enter the email address you’d like to associate with #{APP_NAME}
 = simple_form_for(@register_user_email_form,
     html: { autocomplete: 'off', role: 'form' },
     url: user_registration_path) do |f|

--- a/app/views/devise/registrations/start.html.slim
+++ b/app/views/devise/registrations/start.html.slim
@@ -11,12 +11,13 @@
   .col.col-2.center
     = image_tag(asset_url('shield.svg'), class: 'mt1')
   .col.col-10
-    p.pb2.sm-pb3.mb2.sm-mb3.border-bottom = t('devise.registrations.start.bullet_2')
+    p.pb2.sm-pb3.mb2.sm-mb3.border-bottom = t('devise.registrations.start.bullet_2',
+                                              app_name: APP_NAME)
   .clearfix
   .col.col-2.center
     = image_tag(asset_url('dot-gov.svg'), class: 'mt1')
   .col.col-10
-    p.pb2.sm-pb3.mb2 = t('devise.registrations.start.bullet_3')
+    p.pb2.sm-pb3.mb2 = t('devise.registrations.start.bullet_3', app_name: APP_NAME)
 .py1.sm-p0
   - ab_test(:demo) do |variant, _|
     = link_to t(variant), new_user_registration_path, class: 'btn btn-primary'

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -67,7 +67,7 @@ html lang="#{I18n.locale}"
             h3.mt1.caps Secure
             hr.max-width-1.bw2.border-red.ml0
             div
-              ' You can use login.gov to securely login to government
+              ' You can use #{APP_NAME} to securely login to government
               ' agency websites.
           .sm-col.sm-col-4.px2.sm-px3.mb2
             = image_tag(asset_url('home/ico-2.png'), alt: APP_NAME, width: 125,
@@ -75,7 +75,7 @@ html lang="#{I18n.locale}"
             h3.mt1.caps Easy
             hr.max-width-1.bw2.border-red.ml0
             div
-              ' login.gov is a service used by multiple U.S. government
+              ' #{APP_NAME} is a service used by multiple U.S. government
               ' agencies to make interacting with the government easier.
           .sm-col.sm-col-4.px2.sm-px3.mb2
             = image_tag(asset_url('home/ico-3.png'), alt: APP_NAME, width: 125,
@@ -83,7 +83,7 @@ html lang="#{I18n.locale}"
             h3.mt1.caps Inclusive
             hr.max-width-1.bw2.border-red.ml0
             div
-              ' You can use your login.gov account to access all
+              ' You can use your #{APP_NAME} account to access all
               ' participating U.S. government agencies.
 
     .bg-light-blue

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -43,7 +43,7 @@ h2.h5.mt4.mb2 = t('headings.profile.account_settings')
 h2.h5.mt4.mb2 = t('headings.profile.advanced_settings')
 .py2.border-top.border-bottom
   .clearfix.mxn1
-    .sm-col.sm-col-8.px1 = t('headings.delete_account')
+    .sm-col.sm-col-8.px1 = t('headings.delete_account', app_name: APP_NAME)
     .sm-col.sm-col-4.px1.sm-right-align
       = button_to t('forms.buttons.delete_account'), user_destroy_confirm_path, \
         method: :get, class: 'btn btn-primary px1 py0 h6 regular'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -46,10 +46,10 @@ en:
       start:
         bullet_1: Please use this site to securely log in to your participating government agency.
         bullet_2: >
-          login.gov is a central login platform used by multiple U.S. government
+          %{app_name} is a central login platform used by multiple U.S. government
           agencies to make interacting with the government easier.
         bullet_3: >
-          You can use your login.gov account to access all participating
+          You can use your ${app_name} account to access all participating
           U.S. government agencies.
       destroy_confirm: >
         Deleting your account cannot be undone. All data associated with your

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
       index: Admin Interface
     confirmations:
       new: Resend confirmation instructions
-    delete_account: Delete my login.gov account
+    delete_account: Delete my %{app_name} account
     log_in: Log in
     passwords:
       change: Change your password

--- a/spec/views/profile/index.html.slim_spec.rb
+++ b/spec/views/profile/index.html.slim_spec.rb
@@ -24,7 +24,7 @@ describe 'profile/index.html.slim' do
     it 'contains link to delete account' do
       render
 
-      expect(rendered).to have_content t('headings.delete_account')
+      expect(rendered).to have_content t('headings.delete_account', app_name: APP_NAME)
       expect(rendered).
         to have_xpath("//input[@value='#{t('forms.buttons.delete_account')}']")
     end


### PR DESCRIPTION
**Why**: We want the user visible app name to be
centrally controlled.