### PR TITLE
Add accessibility to password strength component

### DIFF
--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -8,7 +8,8 @@ p.italic Your password must be at least 8 characters.
     method: :patch,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.error_notification
-  = f.input :password, required: true, input_html: { autofocus: true }
+  = f.input :password, required: true,
+      input_html: { autofocus: true, 'aria-described-by': 'pw-strength-cntnr' }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.button :submit, 'Submit'

--- a/app/views/devise/shared/_password_strength.html.slim
+++ b/app/views/devise/shared/_password_strength.html.slim
@@ -1,4 +1,4 @@
-#pw-strength-cntnr.hide
+#pw-strength-cntnr.hide aria-live='polite' aria-atomic='true'
   .mb3
     .clearfix
       .pw-bar


### PR DESCRIPTION
**Why**: Used aria-live attributes to communicate strength and feedback to screen readers a la https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions