### PR TITLE
Rename some of our routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ class ApplicationController < ActionController::Base
   end
 
   def prompt_to_set_up_2fa
-    redirect_to users_otp_url
+    redirect_to phone_setup_url
   end
 
   def prompt_to_enter_otp

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -107,7 +107,7 @@ module Users
       elsif resource.two_factor_enabled?
         profile_path
       else
-        users_otp_url
+        phone_setup_url
       end
     end
 

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -11,7 +11,7 @@ module Users
       @reenter_phone_number_path = if current_user.mobile.present?
                                      edit_user_registration_path
                                    else
-                                     users_otp_path
+                                     phone_setup_path
                                    end
     end
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -41,7 +41,7 @@ module Users
 
     def process_invalid_code
       flash[:error] = t('errors.invalid_totp')
-      redirect_to users_totp_path
+      redirect_to authenticator_setup_path
     end
   end
 end

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -7,7 +7,7 @@ p
 p
   'Each code is valid for #{otp_valid_for_in_words}.
   'If you do not receive a code within this time, please
-  '#{link_to 'request a new one', users_otp_new_path, data: { 'no-turbolink' => true }}.
+  '#{link_to 'request a new one', otp_new_path, data: { 'no-turbolink' => true }}.
 
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2

--- a/app/views/devise/two_factor_authentication/show_totp.html.slim
+++ b/app/views/devise/two_factor_authentication/show_totp.html.slim
@@ -15,4 +15,4 @@ p
 hr
 p
   'If you don't have access to your authenticator app you can choose to
-  '#{link_to 'receive a code via SMS', users_otp_new_path}.
+  '#{link_to 'receive a code via SMS', otp_new_path}.

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -5,7 +5,7 @@ h1.heading = t('devise.two_factor_authentication.two_factor_setup')
 = simple_form_for(@two_factor_setup_form,
     html: { autocomplete: 'off', role: 'form' },
     method: :patch,
-    url: users_otp_path) do |f|
+    url: phone_setup_path) do |f|
   = f.error_notification
   p = t('devise.two_factor_authentication.otp_setup')
   = f.input :mobile, as: :tel, autofocus: true, label: 'Mobile Number', required: true

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -26,7 +26,7 @@ h2.h5.mt4.mb2 = t('headings.profile.account_settings')
         = button_to 'Disable', disable_totp_url, method: :delete, \
           class: 'btn btn-primary px1 py0 h6 regular'
       - else
-        = button_to 'Enable', users_totp_url, method: :get, \
+        = button_to 'Enable', authenticator_setup_url, method: :get, \
           class: 'btn btn-primary px1 py0 h6 regular'
 
 - unless current_user.active_identities.empty?

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -4,7 +4,7 @@ h1.heading = t('forms.totp_setup.header_text')
 p.mb0 = t('forms.totp_setup.totp_info')
 .py1.center
   = image_tag @qrcode, alt: 'QR Code for Authenticator App'
-= form_tag(confirm_totp_path, method: :patch, role: 'form') do
+= form_tag(authenticator_setup_path, method: :patch, role: 'form') do
   .mb2
     = label_tag 'code', t('forms.totp_setup.code'), class: 'hide'
     = number_field_tag :code, '', autofocus: true, class: 'block col-12 field mfa', required: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,9 +27,10 @@ Rails.application.routes.draw do
 
     patch '/confirm' => 'users/confirmations#confirm'
 
-    get '/users/otp' => 'devise/two_factor_authentication_setup#index'
-    patch '/users/otp' => 'devise/two_factor_authentication_setup#set'
-    get '/users/otp/new' => 'devise/two_factor_authentication#new'
+    get '/phone_setup' => 'devise/two_factor_authentication_setup#index'
+    patch '/phone_setup' => 'devise/two_factor_authentication_setup#set'
+
+    get '/otp/new' => 'devise/two_factor_authentication#new'
   end
 
   unless Figaro.env.domain_name.include?('superb.legit.domain.gov')
@@ -62,9 +63,9 @@ Rails.application.routes.draw do
   put '/phone_confirmation' => 'users/phone_confirmation#confirm'
   get '/profile' => 'profile#index'
   get '/splash' => 'home#index'
-  get '/users/totp' => 'users/totp_setup#new'
-  delete '/users/totp' => 'users/totp_setup#disable', as: :disable_totp
-  patch '/users/totp' => 'users/totp_setup#confirm', as: :confirm_totp
+  get '/authenticator_setup' => 'users/totp_setup#new'
+  delete '/authenticator_setup' => 'users/totp_setup#disable', as: :disable_totp
+  patch '/authenticator_setup' => 'users/totp_setup#confirm'
 
   root to: 'users/sessions#new'
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -88,7 +88,7 @@ describe ApplicationController do
     end
 
     context 'when the user may not bypass 2FA and is not 2FA-enabled' do
-      it 'redirects to users_otp_url with a flash message' do
+      it 'redirects to phone_setup_url with a flash message' do
         user = create(:user)
         sign_in user
 
@@ -101,7 +101,7 @@ describe ApplicationController do
 
         get :index
 
-        expect(response).to redirect_to users_otp_url
+        expect(response).to redirect_to phone_setup_url
       end
     end
 

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -188,7 +188,7 @@ describe Users::PhoneConfirmationController, devise: true do
       it 'sets @reenter_phone_number_path to OTP setup path' do
         get :show
 
-        expect(assigns(:reenter_phone_number_path)).to eq(users_otp_path)
+        expect(assigns(:reenter_phone_number_path)).to eq(phone_setup_path)
       end
     end
 

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -45,8 +45,8 @@ describe Users::TotpSetupController, devise: true do
         patch :confirm, code: 123
       end
 
-      it 'redirects :new' do
-        expect(response).to redirect_to(users_totp_path)
+      it 'redirects back to authenticator_setup_path' do
+        expect(response).to redirect_to(authenticator_setup_path)
       end
 
       it 'sets flash[:error] message' do
@@ -74,7 +74,7 @@ describe Users::TotpSetupController, devise: true do
         expect(flash[:success]).to eq t('notices.totp_configured')
       end
 
-      it 'enables totp for the current user' do
+      it 'enables TOTP for the current user' do
         expect(subject.current_user.totp_enabled?).to be(true)
       end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -31,7 +31,7 @@ feature 'saml api', devise: true, sms: true do
       end
 
       it 'prompts the user to set up 2FA' do
-        expect(current_path).to eq users_otp_path
+        expect(current_path).to eq phone_setup_path
       end
 
       it 'prompts the user to confirm mobile after setting up 2FA' do
@@ -49,7 +49,7 @@ feature 'saml api', devise: true, sms: true do
       end
 
       it 'prompts user to set up 2FA after confirming email and setting password' do
-        expect(current_path).to eq users_otp_path
+        expect(current_path).to eq phone_setup_path
       end
 
       it 'prompts the user to confirm mobile after setting up 2FA' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -10,7 +10,7 @@ feature 'Two Factor Authentication' do
     scenario 'user is prompted to setup two factor authentication at first sign in' do
       sign_in_before_2fa
 
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
       expect(page).
         to have_content t('devise.two_factor_authentication.two_factor_setup')
     end
@@ -19,7 +19,7 @@ feature 'Two Factor Authentication' do
       sign_up_and_set_password
       click_button 'Submit'
 
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
     end
 
     scenario 'user attempts to circumnavigate OTP setup' do
@@ -27,7 +27,7 @@ feature 'Two Factor Authentication' do
 
       visit edit_user_registration_path
 
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
     end
 
     describe 'user selects Mobile' do

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -123,7 +123,7 @@ feature 'Password Recovery' do
     it 'prompts user to set up their 2FA options after signing back in' do
       reset_password_and_sign_back_in(@user)
 
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
     end
   end
 

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -46,7 +46,7 @@ feature 'Sign Up', devise: true do
     fill_in 'password_form_password', with: VALID_PASSWORD
     click_button 'Submit'
 
-    expect(current_url).to eq users_otp_url
+    expect(current_url).to eq phone_setup_url
     expect(page).to_not have_content t('devise.confirmations.confirmed')
     expect(page).to_not have_content t('devise.confirmations.confirmed_but_must_set_password')
   end
@@ -88,7 +88,7 @@ feature 'Sign Up', devise: true do
 
     it 'provides user with link to type in a phone number so they are not locked out' do
       click_link 'entering it again'
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
     end
 
     it 'informs the user that the OTP code is sent to the mobile' do
@@ -98,7 +98,7 @@ feature 'Sign Up', devise: true do
     it 'allows user to enter new number if they Sign Out before confirming' do
       click_link(t('links.sign_out'))
       signin(@user.reload.email, @user.password)
-      expect(current_path).to eq users_otp_path
+      expect(current_path).to eq phone_setup_path
     end
   end
 


### PR DESCRIPTION
**Why**: The naming of some of these routes was confusing
for developers and I guess for some users too.