### PR TITLE
Remove use of turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'split', require: 'split/dashboard'
 gem 'staccato'
-gem 'turbolinks'
 gem 'twilio-ruby'
 gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/Houdini/two_factor_authentication.git
-  revision: 9d7d3472f4d272f70c2357ca4bced6f32ec2fbc9
+  revision: c3691f1a965d8e5d7d80948332222924235f54bb
   specs:
     two_factor_authentication (1.1.5)
       devise
@@ -545,8 +545,6 @@ GEM
     tilt (2.0.5)
     timecop (0.8.1)
     tins (1.10.2)
-    turbolinks (2.5.3)
-      coffee-rails
     twilio-ruby (4.11.1)
       builder (>= 2.1.2)
       jwt (~> 1.0)
@@ -671,7 +669,6 @@ DEPENDENCIES
   test_after_commit
   thin
   timecop
-  turbolinks
   twilio-ruby
   two_factor_authentication!
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/app/utils.js
+++ b/app/assets/javascripts/app/utils.js
@@ -7,8 +7,7 @@ $(document).on('click', dismiss, (e) => { $(e.target).parent().remove(); });
 
 // Safari & IE 8/9 do not support client side handling of `required` attribute on
 // form inputs; this adds basic messaging and styling fallback for these browsers
-// "page:load" event needed because of turbolinks, which overrides normal loading process
-$(document).on('ready page:load', () => {
+$(document).on('ready', () => {
   const message = '<div class="error-notify alert-danger p1 mt1 mb2">Please fill in all required' +
     ' fields.</div>';
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,3 @@
-//= require turbolinks
-
 import 'app/utils';
 import 'app/pw-toggle';
 import 'app/form-validation';

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -7,7 +7,7 @@ p
 p
   'Each code is valid for #{otp_valid_for_in_words}.
   'If you do not receive a code within this time, please
-  '#{link_to 'request a new one', otp_new_path, data: { 'no-turbolink' => true }}.
+  '#{link_to 'request a new one', otp_new_path}.
 
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,17 +11,17 @@ html lang="#{I18n.locale}"
     title
       = content_for?(:title) ? APP_NAME + ' - ' + yield(:title) : APP_NAME
 
-    == stylesheet_link_tag 'application', :media => 'all', 'data-turbolinks-track' => true
-    == javascript_include_tag 'application', 'data-turbolinks-track' => true
+    == stylesheet_link_tag 'application', media: 'all'
+    == javascript_include_tag 'application'
     == csrf_meta_tags
     link rel='icon' type='image/png' href="#{asset_url('favicon.png')}"
     link rel='icon' type='image/ico' href="#{asset_url('favicon.ico')}"
 
     <!--[if lt IE 10]>
-      = stylesheet_link_tag 'ie9.css', :media => 'all', 'data-turbolinks-track' => true
+      = stylesheet_link_tag 'ie9.css', media: 'all'
     <!--[elseif lt IE 9]>
       <script src='https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js'></script>
-      = stylesheet_link_tag 'ie8.css', :media => 'all', 'data-turbolinks-track' => true
+      = stylesheet_link_tag 'ie8.css', media: 'all'
       <script src='https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js'></script>
     <![endif]-->
 


### PR DESCRIPTION
**Why**: Trubolinks can supposedly increase performance
but in comes with certain costs. As well as adding
complexity for developers it apparently interferes
with screenreaders and therefore 508 compliance.