### PR TITLE
Move from edit_user_registration_path to profile_path

### DIFF
--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -9,7 +9,7 @@ module Users
       @code_value = confirmation_code if FeatureManagement.prefill_otp_codes?
       @unconfirmed_mobile = unconfirmed_mobile
       @reenter_phone_number_path = if current_user.mobile.present?
-                                     edit_user_registration_path
+                                     profile_path
                                    else
                                      phone_setup_path
                                    end

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -23,7 +23,7 @@ module Users
         current_user.update(otp_secret_key: nil)
         flash[:success] = t('notices.totp_disabled')
       end
-      redirect_to edit_user_registration_path
+      redirect_to profile_path
     end
 
     private
@@ -35,7 +35,7 @@ module Users
 
     def process_valid_code
       flash[:success] = t('notices.totp_configured')
-      redirect_to edit_user_registration_path
+      redirect_to profile_path
       user_session.delete(:new_totp_secret)
     end
 

--- a/app/views/test/saml_test/decode_response.html.slim
+++ b/app/views/test/saml_test/decode_response.html.slim
@@ -3,7 +3,7 @@ div class='container'
     h3 Decoded SAML Response
     p
       | Visit the profile page to demo the SP iniated email change + redirect:
-      = link_to 'Profile page', edit_user_registration_path, role: 'menuitem'
+      = link_to 'Profile page', profile_path, role: 'menuitem'
     table border='2' width='80%'
       tbody
       tr

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -178,7 +178,7 @@ describe Users::PhoneConfirmationController, devise: true do
       it 'sets @reenter_phone_number_path to profile edit path' do
         get :show
 
-        expect(assigns(:reenter_phone_number_path)).to eq(edit_user_registration_path)
+        expect(assigns(:reenter_phone_number_path)).to eq(profile_path)
       end
     end
 

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -66,8 +66,8 @@ describe Users::TotpSetupController, devise: true do
         patch :confirm, code: generate_totp_code(subject.user_session[:new_totp_secret])
       end
 
-      it 'redirects to edit_user_registration_path' do
-        expect(response).to redirect_to(edit_user_registration_path)
+      it 'redirects to profile_path' do
+        expect(response).to redirect_to(profile_path)
       end
 
       it 'sets flash[:success] message' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -219,7 +219,7 @@ feature 'saml api', devise: true, sms: true do
       end
 
       it 'signs out the user from IdP' do
-        visit edit_user_registration_path
+        visit profile_path
 
         expect(page).to have_content t('devise.failure.unauthenticated')
       end
@@ -304,7 +304,7 @@ feature 'saml api', devise: true, sms: true do
 
         expect(logout_user.active_identities).to be_empty
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(page).to have_content t('devise.failure.unauthenticated')
       end
 
@@ -316,7 +316,7 @@ feature 'saml api', devise: true, sms: true do
 
         expect(request_xmldoc.asserted_session_index).to eq(@sp1_asserted_session_index)
         click_button 'Submit'
-        visit edit_user_registration_path
+        visit profile_path
         expect(page).to have_content t('devise.failure.unauthenticated')
       end
     end
@@ -366,7 +366,7 @@ feature 'saml api', devise: true, sms: true do
         expect(current_url).to eq(sp2.assertion_consumer_logout_service_url)
         expect(user.active_identities.size).to eq(0)
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(current_url).to eq root_url
       end
     end
@@ -401,7 +401,7 @@ feature 'saml api', devise: true, sms: true do
           to eq('urn:oasis:names:tc:SAML:2.0:status:Success')
         click_button 'Submit' # LogoutResponse for originating SP: sp1
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(page).to have_content t('devise.failure.unauthenticated')
 
         expect(user.active_identities.size).to eq(0)
@@ -438,7 +438,7 @@ feature 'saml api', devise: true, sms: true do
           to eq('urn:oasis:names:tc:SAML:2.0:status:Success')
         click_button 'Submit' # LogoutResponse for originating SP: sp2
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(page).to have_content t('devise.failure.unauthenticated')
 
         expect(user.active_identities.size).to eq(0)

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -25,7 +25,7 @@ feature 'Two Factor Authentication' do
     scenario 'user attempts to circumnavigate OTP setup' do
       sign_in_before_2fa
 
-      visit edit_user_registration_path
+      visit profile_path
 
       expect(current_path).to eq phone_setup_path
     end
@@ -89,7 +89,7 @@ feature 'Two Factor Authentication' do
         end
 
         it 'does not allow user to bypass entering OTP' do
-          visit edit_user_registration_path
+          visit profile_path
 
           expect(current_path).to eq user_two_factor_authentication_path
         end
@@ -145,7 +145,7 @@ feature 'Two Factor Authentication' do
 
         expect(page).to have_content 'Your account is temporarily locked'
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(current_path).to eq root_path
       end
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -62,12 +62,13 @@ feature 'Sign in' do
 
   scenario 'user session expires in amount of time specified by Devise config' do
     sign_in_and_2fa_user
-    visit edit_user_registration_path
-    expect(current_path).to eq edit_user_registration_path
+
+    visit profile_path
+    expect(current_path).to eq profile_path
 
     Timecop.travel(Devise.timeout_in + 1.minute)
-    visit edit_user_registration_path
 
+    visit profile_path
     expect(current_path).to eq root_path
 
     Timecop.return

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -269,7 +269,7 @@ feature 'Password Recovery' do
 
         expect(last_email.subject).to eq 'Password change notification'
 
-        visit edit_user_registration_path
+        visit profile_path
         expect(current_path).to eq new_user_session_path
       end
     end


### PR DESCRIPTION
**Why**: We are moving away form the devise way do editing the
user profile.

This change moves towards using our own profile controller.
A followup change will be needed finally remove the old user
edit MVC classes.