### PR TITLE
Adds pa11y Section 508 scan to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ addons:
   code_climate:
     repo_token:
       secure: '0RG6L9Sfur37NAB4X9rZypo6tffcWQtTcTpuSi08SfLN9jgiG2nHArVvw0nfNcSg7EmJ27ZnQxQqRjXlG76ufndlmoxgVX6xs96VyDyCOEFzRecE+wziNis+B3ACZb5OHaoMpomzsYFA73nYoCnPkgKUPAQFReTIqW7IB2Z1t7auTZe6kYBkKP7yB37wAVD4HMUDwm0spT0U2ur2GzSi86EqFEXR4NfhzGu5o7Y/hzWPxyyz+CRrujXhdWZl1FNtMj0mUM0/zSEEgUuCRRClGkD31RECjDKQQrXUkgQ1b3O/Nbih/8EjDqs4udLGnBYbtoahZ0ogZ/SV5xj7n2umNBJeLLTZO/qhWyQA4YDPuAZCw61VK1jpyQE1uZKxawYkgXBScmTWCJeAwEqZ4V8z4H4W2y1ZgegAoBCYOhv2+Dq4d9IaBUaeH3ukhEKX9H38yF1DEkp2sXKfXOxyEgpr0g0IIII9YVYQ89WExNmnZnfgd6lBqMFlP4wj8pQkCAeMG8+e+O0QsewzwlVgDDp5pQCgHEYq5X3quvWv0bRJDBL68/4fU9kEjv+RAo8Wx99x3nrZSzJglBrSaPt2/+eoVf3VTIJX4p8oO3aC/gcpbrWZrsfcGfLgKCEiu/ggzhicYhWY+Aa+pdeOefrO51ki9BIu84PoMrP2I7EREp2s1vw='
+    addons:
+  apt:
+    packages:
+      - jq
 before_install:
   - npm install
 before_script:
@@ -10,6 +14,8 @@ before_script:
   - cp keys/saml.key.enc.example keys/saml.key.enc
   - bin/rake db:setup --trace
   - bin/rake assets:precompile
+after_script:
+  - npm run pa11y-ci
 bundler_args: "--deployment --jobs=3 --retry=3 --without deploy development doc"
 cache: bundler
 language: ruby

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Identity-IdP (Upaya)
 [![Code Climate](https://codeclimate.com/github/18F/identity-idp/badges/gpa.svg)](https://codeclimate.com/github/18F/identity-idp)
 [![Test Coverage](https://codeclimate.com/github/18F/identity-idp/badges/coverage.svg)](https://codeclimate.com/github/18F/identity-idp/coverage)
 [![security](https://hakiri.io/github/18F/identity-idp/master.svg)](https://hakiri.io/github/18F/identity-idp/master)
+[![accessibility](https://continua11y.18f.gov/18F/identity-idp.svg?branch=master)](https://continua11y.18f.gov/18F/identity-idp)
 
 A proof-of-concept Identity Management System.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "upaya",
   "version": "0.0.1",
   "private": true,
-  "scripts": {},
+  "scripts": {
+    "pa11y-ci": "pa11y-crawl --run \"bundle exec rails s\" --ci -w 10 --standard Section508 http://localhost:3000",
+    "pa11y-local": "pa11y-crawl --run \"rails s -p 4545\" -w 10 --standard Section508 http://localhost:4545"
+  },
   "engines": {
     "node": "~4.4.x",
     "npm": "~3.8.x"
@@ -17,6 +20,9 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",
-    "browserify-incremental": "^3.1.1"
+    "browserify-incremental": "^3.1.1",
+    "pa11y": "^4.0.0",
+    "pa11y-crawl": "^0.2.3",
+    "pa11y-reporter-full-json": "^0.0.1"
   }
 }


### PR DESCRIPTION
**Why** To enable tracking of Section 508 violations in our app over time with [continua11y](https://continua11y.18f.gov).

This currently only crawls pages without authentication, next iteration will include authenticated and splash pages. 

Fixes https://github.com/18F/identity-private/issues/378