### PR TITLE
Assert SP-requested verified profile attributes in SAMLResponse

### DIFF
--- a/.reek
+++ b/.reek
@@ -28,6 +28,7 @@ UnusedPrivateMethod:
     - ActiveJob::Logging::LogSubscriber
     - Users::PhoneConfirmationController
 UtilityFunction:
+  public_methods_only: true
   exclude:
     - AnalyticsEventJob#perform
     - SmsSenderConfirmationJob

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,11 @@ gem 'pundit'
 gem 'valid_email'
 gem 'rack-attack'
 gem 'rqrcode'
-gem 'ruby-saml'
-gem 'saml_idp', '~> 0.3.1'
+
+# unreleased feature via: https://github.com/onelogin/ruby-saml/pull/345
+gem 'ruby-saml', github: 'onelogin/ruby-saml', branch: 'master'
+
+gem 'saml_idp', '~> 0.4.0'
 gem 'sass-rails', '~> 5.0'
 gem 'savon'
 gem 'secure_headers', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,14 @@ GIT
     sms-spec (0.2.0)
       rspec (~> 3.1)
 
+GIT
+  remote: https://github.com/onelogin/ruby-saml.git
+  revision: 709b4c09a06ab7a299a512eaa166a56ddc50290a
+  branch: master
+  specs:
+    ruby-saml (1.3.1)
+      nokogiri (>= 1.5.10)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -437,13 +445,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    ruby-saml (1.3.0)
-      nokogiri (>= 1.5.10)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
     safely_block (0.1.1)
       errbase
-    saml_idp (0.3.2)
+    saml_idp (0.4.0)
       activesupport
       builder
       httparty
@@ -649,8 +655,8 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 3.3)
   rubocop
-  ruby-saml
-  saml_idp (~> 0.3.1)
+  ruby-saml!
+  saml_idp (~> 0.4.0)
   sass-rails (~> 5.0)
   savon
   secure_headers (~> 3.0)

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -49,6 +49,16 @@ module SamlIdpAuthConcern
     current_user.last_identity
   end
 
+  def build_asserted_attributes(principal)
+    asserter = AttributeAsserter.new(principal, current_service_provider, saml_request)
+    asserter.build
+  end
+
+  def encode_authn_response(principal, opts)
+    build_asserted_attributes(principal)
+    super(principal, opts)
+  end
+
   def saml_response
     encode_response(
       current_user,

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -40,7 +40,7 @@ UserDecorator = Struct.new(:user) do
   end
 
   def identity_not_verified?
-    user.active_profile ? false : true
+    !user.active_profile.present?
   end
 
   def qrcode(otp_secret_key)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,6 +4,9 @@ class Profile < ActiveRecord::Base
   validates_uniqueness_of :active, scope: :user_id, if: :active?
   validates_uniqueness_of :ssn, scope: :active, if: :active?
 
+  scope :active, -> { where(active: true) }
+  scope :verified, -> { where.not(verified_at: nil) }
+
   # rubocop:disable MethodLength
   def self.create_from_proofer_applicant(applicant, user)
     create(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ActiveRecord::Base
   has_many :identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
 
+  attr_accessor :asserted_attributes
+
   def set_default_role
     self.role ||= :user
   end
@@ -66,7 +68,7 @@ class User < ActiveRecord::Base
   end
 
   def active_profile
-    profiles.where(active: true).first
+    profiles.find(&:active?)
   end
 
   # To send emails asynchronously via ActiveJob.

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -1,0 +1,94 @@
+class AttributeAsserter
+  attr_accessor :user, :service_provider, :authn_request
+
+  DEFAULT_BUNDLE = [
+    :first_name,
+    :middle_name,
+    :last_name,
+    :address1,
+    :address2,
+    :city,
+    :state,
+    :zipcode,
+    :dob,
+    :ssn,
+    :phone
+  ].freeze
+
+  def initialize(user, service_provider, authn_request)
+    self.user = user
+    self.service_provider = service_provider
+    self.authn_request = authn_request
+  end
+
+  def build
+    attrs = default_attrs
+    add_email(attrs) if bundle.include? :email
+    add_mobile(attrs) if bundle.include? :mobile
+    add_bundle(attrs) if user.active_profile.present?
+    user.asserted_attributes = attrs
+  end
+
+  private
+
+  def default_attrs
+    {
+      uuid: {
+        getter: :uuid,
+        name_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT,
+        name_id_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
+      }
+    }
+  end
+
+  def add_bundle(attrs)
+    bundle.each do |attr|
+      next unless DEFAULT_BUNDLE.include? attr
+      attrs[attr] = { getter: attribute_getter_function(attr) }
+    end
+  end
+
+  def attribute_getter_function(attr)
+    -> (principal) { principal.active_profile[attr] }
+  end
+
+  def add_email(attrs)
+    attrs[:email] = {
+      getter: :email,
+      name_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
+      name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS
+    }
+  end
+
+  def add_mobile(attrs)
+    attrs[:mobile] = { getter: :mobile }
+  end
+
+  def bundle
+    @_bundle ||= (
+      authn_request_bundle || service_provider.attribute_bundle || DEFAULT_BUNDLE
+    ).map(&:to_sym)
+  end
+
+  def uri_pattern
+    Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF
+  end
+
+  def authn_request_bundle
+    return unless authn_context_attr_nodes.any?
+    authn_context_attr_nodes.join(':').gsub(uri_pattern, '').split(/\W+/).compact.uniq
+  end
+
+  def authn_context_attr_nodes
+    @_attr_node_contents ||= begin
+      doc = Saml::XML::Document.parse(authn_request.raw_xml)
+      doc.xpath(
+        '//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef',
+        samlp: Saml::XML::Namespaces::PROTOCOL,
+        saml: Saml::XML::Namespaces::ASSERTION
+      ).select do |node|
+        node.content =~ /#{Regexp.escape(uri_pattern)}/
+      end
+    end
+  end
+end

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -33,21 +33,6 @@ SamlIdp.configure do |config|
       email_address: -> (principal) { principal.email }
     }
 
-  # Attributes
-  config.attributes = {
-    uuid: {
-      getter: :uuid,
-      name_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT,
-      name_id_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
-    },
-    email: {
-      getter: :email,
-      name_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
-      name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS
-    },
-    mobile: { getter: :mobile }
-  }
-
   ## Technical contact ##
   # config.technical_contact.company = "Example"
   # config.technical_contact.given_name = "Jonny"

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -8,6 +8,7 @@ test:
       cert: 'saml_test_sp'
       agency: 'test_agency'
       friendly_name: 'test_friendly_name'
+      attribute_bundle: ['email', 'mobile']
 
     'https://rp1.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
@@ -112,3 +113,4 @@ superb.legit.domain.gov:
       assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout'
       cert: 'saml_test_sp'
       agency: 'test_agency'
+      attribute_bundle: ['email', 'mobile']

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -4,6 +4,7 @@ module Saml
     module Constants
       LOA1_AUTHNCONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'.freeze
       LOA3_AUTHNCONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'.freeze
+      REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
       VALID_AUTHNCONTEXTS = [
         LOA1_AUTHNCONTEXT_CLASSREF,

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -41,6 +41,10 @@ class ServiceProvider
     host_attributes['friendly_name']
   end
 
+  def attribute_bundle
+    host_attributes['attribute_bundle']
+  end
+
   def cert
     return if host_attributes['cert'].blank?
 

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :profile do
+    association :user, factory: [:user, :signed_up]
+
+    trait :active do
+      active true
+      activated_at Time.current
+    end
+
+    trait :verified do
+      verified_at Time.current
+    end
+  end
+end

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -12,6 +12,7 @@ describe ServiceProvider do
           assertion_consumer_logout_service_url: nil,
           sp_initiated_login_url: nil,
           metadata_url: nil,
+          attribute_bundle: nil,
           cert: nil,
           block_encryption: 'aes256-cbc',
           key_transport: 'rsa-oaep-mgf1p',
@@ -34,6 +35,7 @@ describe ServiceProvider do
           assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request',
           sp_initiated_login_url: 'http://localhost:3000/test/saml',
           metadata_url: nil,
+          attribute_bundle: %w(email mobile),
           cert: File.read("#{Rails.root}/certs/sp/saml_test_sp.crt"),
           block_encryption: 'none',
           key_transport: 'rsa-oaep-mgf1p',
@@ -80,7 +82,8 @@ describe ServiceProvider do
             metadata_url: nil,
             sp_initiated_login_url: nil,
             agency: 'test_agency',
-            friendly_name: nil
+            friendly_name: nil,
+            attribute_bundle: %w(email mobile)
           }
 
           expect(service_provider.metadata).to eq attributes

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 describe Profile do
   let(:user) { create(:user, :signed_up) }
   let(:another_user) { create(:user, :signed_up) }
-  let(:profile) do
-    Profile.create(
-      user_id: user.id
-    )
-  end
+  let(:profile) { create(:profile, user: user) }
 
   subject { profile }
 
@@ -69,6 +65,24 @@ describe Profile do
       active_profile.reload
       expect(active_profile).to_not be_active
       expect(profile).to be_active
+    end
+  end
+
+  describe 'scopes' do
+    describe '#active' do
+      it 'returns only active Profiles' do
+        user.profiles.create(active: false)
+        user.profiles.create(active: true)
+        expect(user.profiles.active.count).to eq 1
+      end
+    end
+
+    describe '#verified' do
+      it 'returns only verified Profiles' do
+        user.profiles.create(verified_at: Time.current)
+        user.profiles.create(verified_at: nil)
+        expect(user.profiles.verified.count).to eq 1
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -193,6 +193,21 @@ describe User do
     end
   end
 
+  context 'when user has multiple profiles' do
+    let(:user) { create(:user, :signed_up) }
+
+    before do
+      create(:profile, :active, :verified, first_name: 'Jane', user: user)
+      create(:profile, :verified, first_name: 'Susan', user: user)
+    end
+
+    describe '#active_profile' do
+      it 'returns the only active profile' do
+        expect(user.active_profile.first_name).to eq 'Jane'
+      end
+    end
+  end
+
   describe '#send_two_factor_authentication_code' do
     it 'calls UserOtpSender#send_otp' do
       user = build_stubbed(:user)

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe AttributeAsserter do
+  include SamlAuthHelper
+
+  let(:loa1_user) { create(:user, :signed_up) }
+  let(:user) { create(:profile, :active, :verified, first_name: 'Jane').user }
+  let(:service_provider) { ServiceProvider.new(sp1_saml_settings.issuer) }
+  let(:raw_authn_request) { URI.decode loa3_authnrequest.split('SAMLRequest').last }
+  let(:authn_request) do
+    SamlIdp::Request.from_deflated_request(raw_authn_request)
+  end
+
+  describe '#build' do
+    context 'verified user' do
+      let(:subject) { described_class.new(user, service_provider, authn_request) }
+
+      context 'custom bundle includes email, mobile' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+            %w(email mobile first_name)
+          )
+          subject.build
+        end
+
+        it 'includes all defined attributes' do
+          expect(user.asserted_attributes).to have_key :email
+          expect(user.asserted_attributes).to have_key :mobile
+          expect(user.asserted_attributes).to have_key :first_name
+          expect(user.asserted_attributes).to_not have_key :last_name
+        end
+
+        it 'creates getter function' do
+          expect(user.asserted_attributes[:first_name][:getter].call(user)).to eq 'Jane'
+        end
+      end
+
+      context 'Service Provider does not specify bundle' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(nil)
+          subject.build
+        end
+
+        context 'authn request does not specify bundle' do
+          it 'contains DEFAULT_BUNDLE' do
+            expect(user.asserted_attributes.keys).to match_array(
+              AttributeAsserter::DEFAULT_BUNDLE + [:uuid]
+            )
+          end
+        end
+
+        context 'authn request specifies bundle' do
+          let(:raw_authn_request) do
+            URI.decode auth_request.create(loa3_with_bundle_saml_settings).split('SAMLRequest').last
+          end
+
+          it 'uses authn request bundle' do
+            expect(user.asserted_attributes).to have_key :email
+            expect(user.asserted_attributes).to have_key :mobile
+            expect(user.asserted_attributes).to have_key :first_name
+            expect(user.asserted_attributes).to have_key :last_name
+            expect(user.asserted_attributes).to have_key :ssn
+            expect(user.asserted_attributes).to_not have_key :dob
+          end
+        end
+      end
+
+      context 'Service Provider specifies empty bundle' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return([])
+          subject.build
+        end
+
+        it 'contains UUID only' do
+          expect(user.asserted_attributes.keys).to eq([:uuid])
+        end
+      end
+
+      context 'custom bundle has invalid attribute name' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+            %w(email foo)
+          )
+          subject.build
+        end
+
+        it 'silently skips invalid attribute name' do
+          expect(user.asserted_attributes).to have_key :email
+          expect(user.asserted_attributes).to_not have_key :foo
+        end
+      end
+    end
+
+    context 'un-verified user' do
+      let(:subject) { described_class.new(loa1_user, service_provider, authn_request) }
+
+      context 'custom bundle does not include email, mobile' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+            %w(first_name last_name)
+          )
+          subject.build
+        end
+
+        it 'includes only UUID' do
+          expect(loa1_user.asserted_attributes).to have_key :uuid
+          expect(loa1_user.asserted_attributes).to_not have_key :email
+          expect(loa1_user.asserted_attributes).to_not have_key :mobile
+          expect(loa1_user.asserted_attributes).to_not have_key :first_name
+          expect(loa1_user.asserted_attributes).to_not have_key :last_name
+        end
+      end
+
+      context 'custom bundle includes email, mobile' do
+        before do
+          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+            %w(first_name last_name email mobile)
+          )
+          subject.build
+        end
+
+        it 'includes UUID, email, mobile only' do
+          expect(loa1_user.asserted_attributes).to have_key :uuid
+          expect(loa1_user.asserted_attributes).to have_key :email
+          expect(loa1_user.asserted_attributes).to have_key :mobile
+          expect(loa1_user.asserted_attributes).to_not have_key :first_name
+          expect(loa1_user.asserted_attributes).to_not have_key :last_name
+        end
+      end
+    end
+  end
+end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -81,6 +81,16 @@ module SamlAuthHelper
     settings
   end
 
+  def loa3_with_bundle_saml_settings
+    settings = loa3_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}mobile"
+    ]
+    settings
+  end
+
   def sp1_authnrequest
     auth_request.create(sp1_saml_settings)
   end

--- a/spec/support/saml_response_helper.rb
+++ b/spec/support/saml_response_helper.rb
@@ -177,6 +177,13 @@ module SamlResponseHelper
       )
     end
 
+    def attribute_value_for(name)
+      response_doc.at(
+        %(//ds:Attribute[@Name="#{name}"]),
+        ds: Saml::XML::Namespaces::ASSERTION
+      ).children.children.to_s
+    end
+
     def assertion_statement_node
       response_doc.xpath(
         '//samlp:Response/saml:Assertion/saml:AuthnStatement',


### PR DESCRIPTION
Assert SP-requested verified profile attributes in SAMLResponse
    
**Why**: Service Providers should define their own attribute bundles. We should not respond with any PII that the SP has not explicitly requested.
    
**How**: AttributeAsserter service class builds assertion config for SamlIdp::AssertionBuilder, which can now delegate to the principal (user) for attributes rather than using global SamlIdp::Config.