### PR TITLE
Enforce SSN uniqueness constraints

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,6 +2,7 @@ class Profile < ActiveRecord::Base
   belongs_to :user
 
   validates_uniqueness_of :active, scope: :user_id, if: :active?
+  validates_uniqueness_of :ssn, scope: :active, if: :active?
 
   # rubocop:disable MethodLength
   def self.create_from_proofer_applicant(applicant, user)

--- a/db/migrate/20160727165624_add_profiles_ssn_unique.rb
+++ b/db/migrate/20160727165624_add_profiles_ssn_unique.rb
@@ -1,0 +1,5 @@
+class AddProfilesSsnUnique < ActiveRecord::Migration
+  def change
+    add_index :profiles, [:ssn, :active], unique: true, where: "(active = true)", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160719164239) do
+ActiveRecord::Schema.define(version: 20160727165624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20160719164239) do
     t.string   "vendor"
   end
 
+  add_index "profiles", ["ssn", "active"], name: "index_profiles_on_ssn_and_active", unique: true, where: "(active = true)", using: :btree
   add_index "profiles", ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)", using: :btree
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Profile do
   let(:user) { create(:user, :signed_up) }
+  let(:another_user) { create(:user, :signed_up) }
   let(:profile) do
     Profile.create(
       user_id: user.id
@@ -26,6 +27,36 @@ describe Profile do
       profile.save!
       expect do
         another_profile = Profile.new(user_id: user.id, active: true)
+        another_profile.save!(validate: false)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe 'allows one unique SSN per user' do
+    it 'allows multiple records per user if only one is active' do
+      profile.active = true
+      profile.ssn = '1234'
+      profile.save!
+      expect do
+        user.profiles.create(ssn: '1234')
+      end.to_not raise_error
+    end
+
+    it 'prevents create! via ActiveRecord uniqueness validation' do
+      profile.active = true
+      profile.ssn = '1234'
+      profile.save!
+      expect do
+        Profile.create!(user_id: another_user.id, active: true, ssn: '1234')
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'prevents save! via psql unique partial index' do
+      profile.active = true
+      profile.ssn = '1234'
+      profile.save!
+      expect do
+        another_profile = Profile.new(user_id: another_user.id, active: true, ssn: '1234')
         another_profile.save!(validate: false)
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end


### PR DESCRIPTION
**Why**: Disallow SSN from being used by multiple users.