### PR TITLE
Refactor use of UserDecorator

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def decorated_user
+    UserDecorator.new(current_user)
+  end
+
   def after_sign_in_path_for(resource)
     analytics.track_event('Authentication Successful')
     stored_location_for(resource) || session[:saml_request_url] || profile_path
@@ -52,9 +56,7 @@ class ApplicationController < ActionController::Base
   def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 
-    user_decorator = UserDecorator.new(current_user)
-
-    return if user_decorator.may_bypass_2fa?(session) || user_fully_authenticated?
+    return if decorated_user.may_bypass_2fa?(session) || user_fully_authenticated?
 
     return prompt_to_set_up_2fa unless current_user.two_factor_enabled?
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -38,15 +38,11 @@ module SamlIdpAuthConcern
   end
 
   def identity_needs_verification?
-    loa3_requested? && identity_not_verified?
+    loa3_requested? && decorated_user.identity_not_verified?
   end
 
   def loa3_requested?
     requested_authn_context == Saml::Idp::Constants::LOA3_AUTHNCONTEXT_CLASSREF
-  end
-
-  def identity_not_verified?
-    UserDecorator.new(current_user).identity_not_verified?
   end
 
   def active_identity

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -6,7 +6,7 @@ module Users
       if user_session[:new_totp_secret].nil?
         user_session[:new_totp_secret] = current_user.generate_totp_secret
       end
-      @qrcode = UserDecorator.new(current_user).qrcode(user_session[:new_totp_secret])
+      @qrcode = decorated_user.qrcode(user_session[:new_totp_secret])
     end
 
     def confirm


### PR DESCRIPTION
**Why**: We want to keep the User model slim, so make it easier for controllers to access `decorated_user` just like `current_user`.