### PR TITLE
Throw exceptions if IdentityLinker fails

### DIFF
--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -4,7 +4,7 @@ IdentityLinker = Struct.new(:user, :provider, :authn_context) do
   def link_identity
     find_or_create_identity
 
-    identity.update(identity_attributes)
+    identity.update!(identity_attributes)
   end
 
   private

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe IdentityLinker do
   describe '#link_identity' do
-    it "updates user's last authenticated identity" do
-      user = create(:user)
+    let(:user) { create(:user) }
 
+    it "updates user's last authenticated identity" do
       IdentityLinker.new(user, 'test.host', 'LOA1').link_identity
       user.reload
 
@@ -24,6 +24,11 @@ describe IdentityLinker do
       expect(last_identity.session_uuid).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)
       expect(last_identity.last_authenticated_at).to be_present
       expect(identity_attributes).to eq new_attributes
+    end
+
+    it 'fails when given a nil provider' do
+      linker = IdentityLinker.new(user, nil, 'LOA1')
+      expect { linker.link_identity }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end


### PR DESCRIPTION
**Why**: Without the `!` both `find_or_create_by`
and `update` can fail without detection. This issue
was detected when passed a nil provider and the identity
linker failed to create valid identiry model in the
database but the error went unnoticed.

Fixes https://github.com/18F/identity-private/issues/559