### PR TITLE
Fix throttling intermittent test failures

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -51,7 +51,7 @@ test:
   sp_url: ''
   idp_sso_target_url: 'http://identityprovider.example.com/saml/auth'
   logins_per_ip_limit: '2'
-  logins_per_ip_period: '2'
+  logins_per_ip_period: '60'
   newrelic_license_key: 'xxx'
   proofing_kbv: 'true'
   proofing_vendors: 'mock'

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -92,7 +92,7 @@ describe 'throttling requests' do
     it 'uses an exponential backoff' do
       3.times do
         post '/', { user: { email: 'test@example.com' } }, 'HTTP_X_FORWARDED_FOR' => '1.2.3.4'
-        Timecop.travel(4.seconds)
+        Timecop.travel(120.seconds)
       end
 
       (1..5).each do |level|


### PR DESCRIPTION
**Why**: So Travis can be green all the time

**How**: Increase the `logins_per_ip_period` to 60 seconds