### PR TITLE
Nit typo fix

### DIFF
--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -593,7 +593,7 @@ describe SamlIdpController do
             expect(subject).to_not be_nil
           end
 
-          it 'has contents set to the loa of the ial?' do
+          it 'has contents set to the loa of the ial' do
             expect(subject.content).to eq Saml::Idp::Constants::LOA1_AUTHNCONTEXT_CLASSREF
           end
         end


### PR DESCRIPTION
**Why**: Because tests should declare, not ask