### PR TITLE
Add PII disclaimer for IdV session in mock mode

### DIFF
--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -5,6 +5,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
 
     def index
+      @using_mock_vendor = pick_a_vendor == :mock
     end
 
     def show

--- a/app/views/idv/sessions/index.html.slim
+++ b/app/views/idv/sessions/index.html.slim
@@ -1,5 +1,8 @@
 - title t('idv.titles.welcome')
 
+- if @using_mock_vendor
+  .mb3.h6.caps.red
+    span = 'Do not use real personal information on this form. This is for demo purposes only.'
 
 .mb3.h6.caps.red = t('idv.titles.welcome')
 = form_tag(idv_sessions_path, method: 'post', novalidate: true)


### PR DESCRIPTION

<img width="572" alt="screen shot 2016-08-01 at 4 13 30 pm" src="https://cloud.githubusercontent.com/assets/1205061/17309127/eee9cdee-5802-11e6-8170-51a768ca9908.png">
**Why**: Discourage use of real PII when not using
a real proofing vendor.