### PR TITLE
Add small cert fingerprinting tool

### DIFF
--- a/bin/fingerprint
+++ b/bin/fingerprint
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+#
+# Print out the sha256 fingerprint for a x509 certificate.
+# Uses both the Fingerprinter Ruby library used by the app,
+# and the equivalent openssl command, just for comparison.
+# Usage:
+#  bin/fingerprint path/to/file.cert
+#
+
+require_relative '../lib/fingerprinter'
+
+ARGV.each do |cert|
+  cert_pem = File.read(cert)
+  fprint = Fingerprinter.fingerprint_cert(cert_pem)
+  puts "#{cert} => #{fprint.upcase.split(/(..)/).reject {|c| c.length == 0 }.join(':')}"
+  system("openssl x509 -sha256 -noout -fingerprint -in #{cert}")
+end

--- a/lib/fingerprinter.rb
+++ b/lib/fingerprinter.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 class Fingerprinter
   def self.fingerprint_cert(cert_pem)
     return nil unless cert_pem


### PR DESCRIPTION
**Why**: Easy CLI for fingerprinting a x509 certificate.