### PR TITLE
Remove unused columns from identities table

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -32,9 +32,8 @@ module SamlIdpAuthConcern
 
   def link_identity_from_session_data
     provider = saml_request.service_provider.identifier
-    authn_context = requested_authn_context
 
-    IdentityLinker.new(current_user, provider, authn_context).link_identity
+    IdentityLinker.new(current_user, provider).link_identity
   end
 
   def identity_needs_verification?

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -1,4 +1,4 @@
-IdentityLinker = Struct.new(:user, :provider, :authn_context) do
+IdentityLinker = Struct.new(:user, :provider) do
   attr_reader :identity
 
   def link_identity
@@ -18,7 +18,6 @@ IdentityLinker = Struct.new(:user, :provider, :authn_context) do
 
   def identity_attributes
     {
-      authn_context: authn_context,
       last_authenticated_at: Time.current,
       session_uuid: SecureRandom.uuid
     }

--- a/db/migrate/20160803174440_cleanup_identities_table.rb
+++ b/db/migrate/20160803174440_cleanup_identities_table.rb
@@ -1,0 +1,7 @@
+class CleanupIdentitiesTable < ActiveRecord::Migration
+  def change
+    remove_column :identities, :ial
+    remove_column :identities, :authn_context
+    add_index 'identities', ['user_id', 'service_provider']
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727165624) do
+ActiveRecord::Schema.define(version: 20160803174440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,18 +39,15 @@ ActiveRecord::Schema.define(version: 20160727165624) do
 
   create_table "identities", force: :cascade do |t|
     t.string   "service_provider",      limit: 255
-    t.string   "authn_context",         limit: 255
     t.datetime "last_authenticated_at"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "session_uuid",          limit: 255
-    t.integer  "ial",                               default: 1
   end
 
-  add_index "identities", ["ial"], name: "index_identities_on_ial", using: :btree
-  add_index "identities", ["service_provider", "authn_context"], name: "index_identities_on_service_provider_and_authn_context", using: :btree
   add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree
+  add_index "identities", ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", using: :btree
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
 
   create_table "profiles", force: :cascade do |t|

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -248,11 +248,7 @@ describe SamlIdpController do
         linker = instance_double(IdentityLinker)
 
         expect(IdentityLinker).to receive(:new).
-          with(
-            controller.current_user,
-            saml_settings.issuer,
-            'http://idmanagement.gov/ns/assurance/loa/1'
-          ).and_return(linker)
+          with(controller.current_user, saml_settings.issuer).and_return(linker)
 
         expect(linker).to receive(:link_identity)
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -135,10 +135,6 @@ feature 'saml api', devise: true, sms: true do
         expect(user.last_identity.service_provider).to eq saml_spec_settings.issuer
       end
 
-      it 'stores authn_context in Identity model' do
-        expect(user.last_identity.authn_context).to eq saml_settings.authn_context
-      end
-
       it 'stores last_authenticated_at in Identity model' do
         expect(user.last_identity.last_authenticated_at).to be_present
       end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -5,16 +5,14 @@ describe IdentityLinker do
     let(:user) { create(:user) }
 
     it "updates user's last authenticated identity" do
-      IdentityLinker.new(user, 'test.host', 'LOA1').link_identity
+      IdentityLinker.new(user, 'test.host').link_identity
       user.reload
 
       last_identity = user.last_identity
 
       new_attributes = {
         service_provider: 'test.host',
-        authn_context: 'LOA1',
-        user_id: user.id,
-        ial: 1
+        user_id: user.id
       }
 
       identity_attributes = last_identity.attributes.symbolize_keys.
@@ -27,7 +25,7 @@ describe IdentityLinker do
     end
 
     it 'fails when given a nil provider' do
-      linker = IdentityLinker.new(user, nil, 'LOA1')
+      linker = IdentityLinker.new(user, nil)
       expect { linker.link_identity }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end


### PR DESCRIPTION
The IAL of a given user is now signaled by an active
proofing record in the `profiles` table. This field
is unused.