### PR TITLE
Catch duplicate SSN attempt during IdV

### DIFF
--- a/.reek
+++ b/.reek
@@ -33,6 +33,7 @@ UnusedPrivateMethod:
     - ActiveJob::Logging::LogSubscriber
     - SamlIdpController
     - Users::PhoneConfirmationController
+    - ssn_is_unique
 UtilityFunction:
   public_methods_only: true
   exclude:

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -7,19 +7,19 @@ module Idv
 
     def index
       @using_mock_vendor = pick_a_vendor == :mock
+      @profile = IdvProfileForm.new
     end
 
     def show
     end
 
     def create
-      self.idv_params = applicant_params.delete_if { |_key, value| value.blank? }
-      idv_form = IdvProfileForm.new(current_user)
-      if idv_form.submit(idv_params)
+      self.idv_params = profile_params
+      @profile = IdvProfileForm.new
+      if @profile.submit(profile_params, current_user.id)
         redirect_to idv_session_url(1)
       else
-        flash[:error] = idv_form.errors
-        redirect_to idv_sessions_path
+        render :index
       end
     end
 
@@ -60,8 +60,8 @@ module Idv
 
     # rubocop:disable MethodLength
     # This method is single statement spread across many lines for readability
-    def applicant_params
-      params.slice(
+    def profile_params
+      params.require(:profile).permit(
         :first_name,
         :last_name,
         :phone,

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -14,7 +14,13 @@ module Idv
 
     def create
       self.idv_params = applicant_params.delete_if { |_key, value| value.blank? }
-      redirect_to idv_session_url(1)
+      idv_form = IdvProfileForm.new(current_user)
+      if idv_form.submit(idv_params)
+        redirect_to idv_session_url(1)
+      else
+        flash[:error] = idv_form.errors
+        redirect_to idv_sessions_path
+      end
     end
 
     def update

--- a/app/forms/idv_profile_form.rb
+++ b/app/forms/idv_profile_form.rb
@@ -1,44 +1,36 @@
 class IdvProfileForm
-  attr_reader :user, :errors, :params
+  include ActiveModel::Model
 
-  def initialize(user)
-    @user = user
-    @errors = []
+  def self.model_name
+    ActiveModel::Name.new(self, nil, 'Profile')
   end
 
-  def submit(params)
-    @params = params
-    error_required_params if required_params_blank?
-    error_duplicate_ssn if ssn_taken?
-    @errors.blank?
+  validates :first_name, :last_name, :dob, :ssn, :address1, :city, :state, :zipcode, presence: true
+
+  validate :ssn_is_unique
+
+  delegate :user_id, :first_name, :last_name, :phone, :email, :dob, :ssn, :address1,
+           :address2, :city, :state, :zipcode, to: :profile
+
+  def profile
+    @profile ||= Profile.new
+  end
+
+  def submit(params, user_id)
+    @user_id = user_id
+    @ssn = params[:ssn]
+    profile.attributes = params
+    valid?
   end
 
   private
 
-  def required_params
-    [:first_name, :last_name, :dob, :ssn, :address1, :city, :state, :zipcode]
-  end
+  attr_writer :first_name, :last_name, :phone, :email, :dob, :ssn, :address1,
+              :address2, :city, :state, :zipcode
 
-  def required_params_blank?
-    required_params.any? { |param| !params.key?(param) || params[param].blank? }
-  end
-
-  def error_required_params
-    required_params.each do |param|
-      next if params[param].present?
-      field_name = I18n.t("idv.form.#{param}")
-      err_msg = "#{field_name} is required"
-      @errors << err_msg
+  def ssn_is_unique
+    if Profile.where.not(user_id: @user_id).where(ssn: @ssn).any?
+      errors.add :ssn, I18n.t('idv.errors.duplicate_ssn')
     end
-  end
-
-  def error_duplicate_ssn
-    @errors << I18n.t('idv.errors.duplicate_ssn')
-  end
-
-  def ssn_taken?
-    ssn = params[:ssn]
-    return false unless ssn.present?
-    Profile.where.not(user: user.id).where(ssn: ssn).any?
   end
 end

--- a/app/forms/idv_profile_form.rb
+++ b/app/forms/idv_profile_form.rb
@@ -1,0 +1,44 @@
+class IdvProfileForm
+  attr_reader :user, :errors, :params
+
+  def initialize(user)
+    @user = user
+    @errors = []
+  end
+
+  def submit(params)
+    @params = params
+    error_required_params if required_params_blank?
+    error_duplicate_ssn if ssn_taken?
+    @errors.blank?
+  end
+
+  private
+
+  def required_params
+    [:first_name, :last_name, :dob, :ssn, :address1, :city, :state, :zipcode]
+  end
+
+  def required_params_blank?
+    required_params.any? { |param| !params.key?(param) || params[param].blank? }
+  end
+
+  def error_required_params
+    required_params.each do |param|
+      next if params[param].present?
+      field_name = I18n.t("idv.form.#{param}")
+      err_msg = "#{field_name} is required"
+      @errors << err_msg
+    end
+  end
+
+  def error_duplicate_ssn
+    @errors << I18n.t('idv.errors.duplicate_ssn')
+  end
+
+  def ssn_taken?
+    ssn = params[:ssn]
+    return false unless ssn.present?
+    Profile.where.not(user: user.id).where(ssn: ssn).any?
+  end
+end

--- a/app/views/idv/sessions/index.html.slim
+++ b/app/views/idv/sessions/index.html.slim
@@ -5,40 +5,44 @@
     | Do not use real personal information. This is for demo purposes only.
 
 .mb3.h6.caps.red = t('idv.titles.welcome')
-= form_tag(idv_sessions_path, method: 'post')
+= simple_form_for(@profile, url: idv_sessions_path, html: { method: :post, role: 'form' }) do |f|
+  = f.error_notification
+
   h2.heading = t('idv.titles.session.basic')
+
   p Please provide all of the following:
   .mb4.sm-col-7
     .mb2
       = label_tag 'first_name', t('idv.form.first_name')
-      = block_text_field_tag 'first_name', nil, required: true
+      = f.input :first_name, required: true, class: 'block col-12 field'
     .mb2
       = label_tag 'last_name', t('idv.form.last_name')
-      = block_text_field_tag 'last_name', nil, required: true
+      = f.input :last_name, required: true, class: 'block col-12 field'
   h2.heading = t('idv.titles.session.dob')
   .mb4.sm-col-5
     = label_tag 'dob', t('idv.form.dob'), class: 'hide'
-    = block_date_field_tag 'dob', nil, required: true
+    = f.input :dob, as: :date, html5: true, required: true, class: 'block col-12 field'
   h2.heading = t('idv.titles.session.ssn')
   .mb4.sm-col-5
     = label_tag 'ssn', t('idv.form.ssn'), class: 'hide'
-    = block_text_field_tag 'ssn', nil, required: true, pattern: '[0-9]*'
+    = f.input :ssn, required: true, pattern: '[0-9]*'
   h2.heading = t('idv.titles.session.address')
   .mb4.sm-col-7
     .mb2
       = label_tag 'address1', t('idv.form.address1')
-      = block_text_field_tag 'address1', nil, required: true
+      = f.input :address1, required: true, class: 'block col-12 field'
     .mb2
       = label_tag 'address2', t('idv.form.address2')
-      = block_text_field_tag 'address2', nil
+      = f.input :address2, class: 'block col-12 field'
     .mb2
       = label_tag 'city', t('idv.form.city')
-      = block_text_field_tag 'city', nil, required: true
+      = f.input :city, required: true, class: 'block col-12 field'
     .clearfix.mxn1
       .sm-col.sm-col-6.px1
         = label_tag 'state', t('idv.form.state')
-        = us_states_territories_select_tag required: true
+        = f.input :state,
+                  collection: us_states_territories, required: true, class: 'block col-12 field'
       .sm-col.sm-col-6.px1
         = label_tag 'zipcode', t('idv.form.zipcode')
-        = block_text_field_tag 'zipcode', nil, required: true, pattern: '[0-9]*'
+        = f.input :zipcode, required: true, class: 'block col-12 field', pattern: '[0-9]*'
   button type='submit' class='btn btn-primary' = 'Continue verifying'

--- a/app/views/shared/_messages.html.slim
+++ b/app/views/shared/_messages.html.slim
@@ -1,12 +1,10 @@
 - unless flash.empty?
-  - flash.each do |name, message|
-    - if message.present? && (message.is_a?(String) || message.is_a?(Array))
-      - messages = message.is_a?(Array) ? message : [message]
+  - flash.each do |name, msg|
+    - if msg.present? && msg.is_a?(String)
       - msg_type = name.to_s =~ /notice|success/ ? 'success' : 'danger'
-      - messages.each do |msg|
-        .mxn2.sm-m0
-          div class="mb3 p2 alert alert-#{msg_type}"
-            = image_tag(asset_url("alert/ico-#{msg_type}.svg"), class: 'alert-ico')
-            div class="#{msg.length < 50 ? 'center bold' : ''}" = msg
+      .mxn2.sm-m0
+        div class="mb3 p2 alert alert-#{msg_type}"
+          = image_tag(asset_url("alert/ico-#{msg_type}.svg"), class: 'alert-ico')
+          div class="#{msg.length < 50 ? 'center bold' : ''}" = msg
 
 #session-timeout-cntnr

--- a/app/views/shared/_messages.html.slim
+++ b/app/views/shared/_messages.html.slim
@@ -1,10 +1,12 @@
 - unless flash.empty?
-  - flash.each do |name, msg|
-    - if msg.present? && msg.is_a?(String)
+  - flash.each do |name, message|
+    - if message.present? && (message.is_a?(String) || message.is_a?(Array))
+      - messages = message.is_a?(Array) ? message : [message]
       - msg_type = name.to_s =~ /notice|success/ ? 'success' : 'danger'
-      .mxn2.sm-m0
-        div class="mb3 p2 alert alert-#{msg_type}"
-          = image_tag(asset_url("alert/ico-#{msg_type}.svg"), class: 'alert-ico')
-          div class="#{msg.length < 50 ? 'center bold' : ''}" = msg
+      - messages.each do |msg|
+        .mxn2.sm-m0
+          div class="mb3 p2 alert alert-#{msg_type}"
+            = image_tag(asset_url("alert/ico-#{msg_type}.svg"), class: 'alert-ico')
+            div class="#{msg.length < 50 ? 'center bold' : ''}" = msg
 
 #session-timeout-cntnr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,10 @@ en:
       city: City
       state: State
       zipcode: ZIP Code
+    errors:
+      duplicate_ssn: >
+        You may already have an account, please use that one.
+        You can always change your email address in your existing account.
     titles:
       intro: Help us identify you
       expectations: We need some information from you

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -45,7 +45,7 @@ describe Idv::SessionsController do
       end
 
       it 'creates proofing applicant' do
-        post :create, user_attrs
+        post :create, profile: user_attrs
         post :update, id: 1, ccn: '12341234'
 
         expect(flash).to be_empty
@@ -54,7 +54,7 @@ describe Idv::SessionsController do
       end
 
       it 'shows failure on intentionally bad values' do
-        post :create, first_name: 'Bad', ssn: '6666'
+        post :create, profile: user_attrs.merge(first_name: 'Bad', ssn: '6666')
         post :update, id: 1, ccn: '12341234'
 
         expect(response).to redirect_to(idv_sessions_path)
@@ -64,20 +64,20 @@ describe Idv::SessionsController do
       it 'disallows duplicate SSN' do
         create(:profile, ssn: '1234')
 
-        post :create, ssn: '1234'
+        post :create, profile: user_attrs.merge(ssn: '1234')
 
-        expect(response).to redirect_to(idv_sessions_path)
-        expect(flash[:error]).to include t('idv.errors.duplicate_ssn')
+        expect(response).to render_template(:index)
+        expect(response.body).to match t('idv.errors.duplicate_ssn')
       end
 
       it 'checks for required fields' do
         partial_attrs = user_attrs.dup
         partial_attrs.delete :first_name
 
-        post :create, partial_attrs
+        post :create, profile: partial_attrs
 
-        expect(response).to redirect_to(idv_sessions_path)
-        expect(flash[:error]).to include "#{t('idv.form.first_name')} is required"
+        expect(response).to render_template(:index)
+        expect(response.body).to match 'can&#39;t be blank'
       end
     end
 
@@ -87,14 +87,14 @@ describe Idv::SessionsController do
       end
 
       it 'skips questions creation' do
-        post :create, user_attrs
+        post :create, profile: user_attrs
         post :update, id: 1, ccn: '12341234'
 
         expect(subject.user_session[:idv][:resolution].questions).to be_nil
       end
 
       it 'shows failure on intentionally bad values' do
-        post :create, first_name: 'Bad', ssn: '6666'
+        post :create, profile: user_attrs.merge(first_name: 'Bad', ssn: '6666')
         post :update, id: 1, ccn: '12341234'
 
         expect(response).to redirect_to(idv_sessions_path)

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -60,6 +60,25 @@ describe Idv::SessionsController do
         expect(response).to redirect_to(idv_sessions_path)
         expect(flash[:error]).to eq t('idv.titles.fail')
       end
+
+      it 'disallows duplicate SSN' do
+        create(:profile, ssn: '1234')
+
+        post :create, ssn: '1234'
+
+        expect(response).to redirect_to(idv_sessions_path)
+        expect(flash[:error]).to include t('idv.errors.duplicate_ssn')
+      end
+
+      it 'checks for required fields' do
+        partial_attrs = user_attrs.dup
+        partial_attrs.delete :first_name
+
+        post :create, partial_attrs
+
+        expect(response).to redirect_to(idv_sessions_path)
+        expect(flash[:error]).to include "#{t('idv.form.first_name')} is required"
+      end
     end
 
     context 'KBV off' do

--- a/spec/forms/idv_profile_form_spec.rb
+++ b/spec/forms/idv_profile_form_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe IdvProfileForm do
+  let(:user) { create(:user, :signed_up) }
+  let(:subject) { IdvProfileForm.new(user) }
+  let(:user_attrs) do
+    {
+      first_name: 'Some',
+      last_name: 'One',
+      ssn: '666661234',
+      dob: '19720329',
+      address1: '123 Main St',
+      address2: '',
+      city: 'Somewhere',
+      state: 'KS',
+      zipcode: '66044'
+    }
+  end
+
+  describe '#submit' do
+    it 'returns true on success' do
+      expect(subject.submit(user_attrs)).to eq true
+    end
+
+    it 'checks required fields' do
+      expect(subject.submit(ssn: '1234', first_name: 'Joe')).to eq false
+      expect(subject.errors).to include "#{t('idv.form.last_name')} is required"
+    end
+
+    it 'checks duplicate SSN' do
+      create(:profile, ssn: '1234')
+
+      expect(subject.submit(ssn: '1234', first_name: 'Joe')).to eq false
+      expect(subject.errors).to include t('idv.errors.duplicate_ssn')
+    end
+  end
+end

--- a/spec/forms/idv_profile_form_spec.rb
+++ b/spec/forms/idv_profile_form_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 describe IdvProfileForm do
-  let(:user) { create(:user, :signed_up) }
-  let(:subject) { IdvProfileForm.new(user) }
-  let(:user_attrs) do
+  let(:subject) { IdvProfileForm.new }
+  let(:profile_attrs) do
     {
       first_name: 'Some',
       last_name: 'One',
@@ -17,21 +16,72 @@ describe IdvProfileForm do
     }
   end
 
+  it do
+    is_expected.
+      to validate_presence_of(:first_name).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:last_name).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:ssn).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:dob).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:address1).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:city).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:state).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.
+      to validate_presence_of(:zipcode).with_message("can't be blank")
+  end
+
+  describe 'snn uniqueness' do
+    context 'when ssn is already taken by another profile' do
+      it 'is invalid' do
+        create(:profile, ssn: '1234')
+
+        expect(subject.submit(profile_attrs.merge(ssn: '1234'), 123)).to eq false
+        expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
+      end
+    end
+
+    context 'when ssn is already taken by same profile' do
+      it 'is valid' do
+        create(:profile, ssn: '1234', user_id: 456)
+
+        expect(subject.submit(profile_attrs.merge(ssn: '1234'), 456)).to eq true
+      end
+    end
+  end
+
   describe '#submit' do
     it 'returns true on success' do
-      expect(subject.submit(user_attrs)).to eq true
+      expect(subject.submit(profile_attrs, 1000)).to eq true
     end
 
-    it 'checks required fields' do
-      expect(subject.submit(ssn: '1234', first_name: 'Joe')).to eq false
-      expect(subject.errors).to include "#{t('idv.form.last_name')} is required"
-    end
-
-    it 'checks duplicate SSN' do
-      create(:profile, ssn: '1234')
-
-      expect(subject.submit(ssn: '1234', first_name: 'Joe')).to eq false
-      expect(subject.errors).to include t('idv.errors.duplicate_ssn')
+    it 'returns false on failure' do
+      expect(subject.submit({ ssn: '1234', first_name: 'Joe' }, 1000)).to eq false
     end
   end
 end

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -38,25 +38,25 @@ module IdvHelper
   end
 
   def fill_out_idv_form_ok
-    fill_in :first_name, with: 'Some'
-    fill_in :last_name, with: 'One'
-    fill_in :ssn, with: '666661234'
-    fill_in :dob, with: '19800102'
-    fill_in :address1, with: '123 Main St'
-    fill_in :city, with: 'Nowhere'
-    select 'Kansas', from: :state
-    fill_in :zipcode, with: '66044'
+    fill_in 'profile_first_name', with: 'Some'
+    fill_in 'profile_last_name', with: 'One'
+    fill_in 'profile_ssn', with: '666661234'
+    fill_in 'profile_dob', with: '19800102'
+    fill_in 'profile_address1', with: '123 Main St'
+    fill_in 'profile_city', with: 'Nowhere'
+    select 'Kansas', from: 'profile_state'
+    fill_in 'profile_zipcode', with: '66044'
   end
 
   def fill_out_idv_form_fail
-    fill_in :first_name, with: 'Bad'
-    fill_in :last_name, with: 'User'
-    fill_in :ssn, with: '6666'
-    fill_in :dob, with: '19000102'
-    fill_in :address1, with: '123 Main St'
-    fill_in :city, with: 'Nowhere'
-    select 'Kansas', from: :state
-    fill_in :zipcode, with: '66044'
+    fill_in 'profile_first_name', with: 'Bad'
+    fill_in 'profile_last_name', with: 'User'
+    fill_in 'profile_ssn', with: '6666'
+    fill_in 'profile_dob', with: '19000102'
+    fill_in 'profile_address1', with: '123 Main St'
+    fill_in 'profile_city', with: 'Nowhere'
+    select 'Kansas', from: 'profile_state'
+    fill_in 'profile_zipcode', with: '66044'
   end
 
   def fill_out_financial_form_ok


### PR DESCRIPTION
**Why**: SSN must be unique, so alert the user
as early as possible of the problem.