### PR TITLE
Configure reek for specs and fix offenses

### DIFF
--- a/.reek
+++ b/.reek
@@ -37,7 +37,36 @@ UtilityFunction:
   public_methods_only: true
   exclude:
     - AnalyticsEventJob#perform
-
+'spec':
+  ControlParameter:
+    exclude:
+      - complete_idv_session
+  DuplicateMethodCall:
+    exclude:
+      - saml_settings
+      - sign_up_and_2fa
+      - raw_xml_response
+  FeatureEnvy:
+    enabled: false
+  NestedIterators:
+    exclude:
+      - complete_idv_questions_fail
+      - complete_idv_questions_ok
+  NilCheck:
+    exclude:
+      - complete_idv_questions_fail
+      - complete_idv_questions_ok
+  TooManyInstanceVariables:
+    enabled: false
+  TooManyMethods:
+    enabled: false
+  TooManyStatements:
+    enabled: false
+  UncommunicativeVariableName:
+    exclude:
+      - complete_idv_questions_fail
+      - complete_idv_questions_ok
+  UtilityFunction:
+    enabled: false
 exclude_paths:
   - db/migrate
-  - spec/**/*

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -16,8 +16,9 @@ describe Users::OmniauthCallbacksController, devise: true do
   end
 
   def configure_request_env
-    request.env['devise.mapping'] = Devise.mappings[:user]
-    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:saml]
+    env = request.env
+    env['devise.mapping'] = Devise.mappings[:user]
+    env['omniauth.auth'] = OmniAuth.config.mock_auth[:saml]
   end
 
   describe 'GET /users/auth/saml/callback' do

--- a/spec/omniauth_spec_helper.rb
+++ b/spec/omniauth_spec_helper.rb
@@ -1,7 +1,7 @@
 module OmniAuthSpecHelper
   def self.valid_saml_login_setup(email_address, uuid)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.add_mock(
+    config.test_mode = true
+    config.add_mock(
       :saml,
       provider: 'saml',
       uid: uuid,
@@ -19,21 +19,25 @@ module OmniAuthSpecHelper
   end
 
   def self.invalid_credentials
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:saml] = :invalid_credentials
+    config.test_mode = true
+    config.mock_auth[:saml] = :invalid_credentials
   end
 
   def self.invalid_ticket
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:saml] = :invalid_ticket
+    config.test_mode = true
+    config.mock_auth[:saml] = :invalid_ticket
   end
 
   # http://stackoverflow.com/questions/19483367
   def self.silence_omniauth
-    previous_logger = OmniAuth.config.logger
-    OmniAuth.config.logger = Logger.new('/dev/null')
+    previous_logger = config.logger
+    config.logger = Logger.new('/dev/null')
     yield
   ensure
-    OmniAuth.config.logger = previous_logger
+    config.logger = previous_logger
+  end
+
+  def self.config
+    @config ||= OmniAuth.config
   end
 end

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -12,8 +12,10 @@ describe "GET '/users/auth/saml/callback'" do
     OmniAuthSpecHelper.silence_omniauth do
       get '/users/auth/saml/callback'
     end
-    request.env['devise.mapping'] = Devise.mappings[:user]
-    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:saml]
+
+    env = request.env
+    env['devise.mapping'] = Devise.mappings[:user]
+    env['omniauth.auth'] = OmniAuth.config.mock_auth[:saml]
   end
 
   context 'invalid credentials' do

--- a/spec/support/features/active_job_helper.rb
+++ b/spec/support/features/active_job_helper.rb
@@ -1,0 +1,20 @@
+module Features
+  module ActiveJobHelper
+    def reset_job_queues
+      adapter.enqueued_jobs = []
+      adapter.performed_jobs = []
+    end
+
+    def enqueued_jobs
+      adapter.enqueued_jobs
+    end
+
+    def performed_jobs
+      adapter.performed_jobs
+    end
+
+    def adapter
+      ActiveJob::Base.queue_adapter
+    end
+  end
+end

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -7,10 +7,12 @@ module IdvHelper
     %w(city bear quest color speed).each do |answer_key|
       question = mock_idv_questions.find_by_key(answer_key)
       answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
-      if question.choices.nil?
+      choices = question.choices
+
+      if choices.nil?
         fill_in :answer, with: answer_text
       else
-        choice = question.choices.detect { |c| c.key == answer_text }
+        choice = choices.detect { |c| c.key == answer_text }
         el_id = "#choice_#{choice.key_html_safe}"
         find(el_id).set(true)
       end
@@ -22,10 +24,12 @@ module IdvHelper
     %w(city bear quest color speed).each do |answer_key|
       question = mock_idv_questions.find_by_key(answer_key)
       answer_text = Proofer::Vendor::Mock::ANSWERS[answer_key]
-      if question.choices.nil?
+      choices = question.choices
+
+      if choices.nil?
         fill_in :answer, with: 'wrong'
       else
-        choice = question.choices.detect { |c| c.key == answer_text }
+        choice = choices.detect { |c| c.key == answer_text }
         el_id = "#choice_#{choice.key_html_safe}"
         find(el_id).set(true)
       end

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -59,7 +59,7 @@ end
 
 def symbol_from_string(string)
   if string.include?('||')
-    string.split('||').map { |s| s.split('==')[1].strip.tr("'", '').to_sym }
+    string.split('||').map { |str| str.split('==')[1].strip.tr("'", '').to_sym }
   else
     string.split('==')[1].strip.tr("'", '').to_sym
   end

--- a/spec/support/sms.rb
+++ b/spec/support/sms.rb
@@ -2,27 +2,10 @@ SmsSpec.driver = :'twilio-ruby'
 
 RSpec.configure do |config|
   config.include SmsSpec::Helpers, sms: true
+  config.include Features::ActiveJobHelper, sms: true
 
   config.before(:each, sms: true) do
     clear_messages
-    ActiveJob::Base.queue_adapter.enqueued_jobs = []
-    ActiveJob::Base.queue_adapter.performed_jobs = []
-  end
-end
-
-module Features
-  module ActiveJobHelper
-    def reset_job_queues
-      ActiveJob::Base.queue_adapter.enqueued_jobs = []
-      ActiveJob::Base.queue_adapter.performed_jobs = []
-    end
-
-    def enqueued_jobs
-      ActiveJob::Base.queue_adapter.enqueued_jobs
-    end
-
-    def performed_jobs
-      ActiveJob::Base.queue_adapter.performed_jobs
-    end
+    reset_job_queues
   end
 end


### PR DESCRIPTION
**Why**: To define offenses we don't care about in tests, and to fix
the ones we care about.