### PR TITLE
Add error icon to invalid form field

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -4,7 +4,7 @@ import h5f from 'h5f';
 
 const validate = {
   msgs: {
-    missing: 'Please fill in all required fields.',
+    missing: 'Please fill in this field.',
     mismatch: 'Please match the requested format.',
   },
 
@@ -67,7 +67,7 @@ const validate = {
 
     f.insertAdjacentHTML(
       'afterend',
-      `<div role='alert' class='error-message red h5' id='alert_${f.id}'>
+      `<div role='alert' class='error-message red h6' id='alert_${f.id}'>
         ${f.validationMessage}
       </div>`
     );

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -6,11 +6,6 @@ $radio-checkbox-space: 1.5rem;
   font-weight: $bold-font-weight;
 }
 
-.invalid,
-.interacted.required:invalid {
-  border-color: $red;
-}
-
 .radio,
 .checkbox {
   padding-left: $radio-checkbox-space;
@@ -26,6 +21,20 @@ $radio-checkbox-space: 1.5rem;
 .radio-extra {
   margin-left: $radio-checkbox-space;
 }
+
+
+// error states
+.invalid,
+.interacted.required:invalid {
+  background-image: $form-icon-error;
+  background-position: center right .5rem;
+  background-repeat: no-repeat;
+  background-size: 1rem 1rem;
+  border-color: $red;
+}
+
+.error-message { margin-top: 2px; }
+
 
 // hide number field input spin box as per:
 // http://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box

--- a/app/assets/stylesheets/variables/_web.scss
+++ b/app/assets/stylesheets/variables/_web.scss
@@ -37,6 +37,9 @@ $form-field-height: 2.25rem !default;
 $form-field-padding-y: .5rem !default;
 $form-field-padding-x: .5rem !default;
 
+$form-icon-success: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%235cb85c' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E") !default;
+$form-icon-error: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23d9534f' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E") !default;
+
 $button-font-size: inherit !default;
 $button-font-weight: bold !default;
 $button-line-height: 1.125rem !default;

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -98,7 +98,7 @@ feature 'Two Factor Authentication' do
           fill_in 'code', with: ''
           click_button 'Submit'
 
-          expect(page).to have_content('Please fill in all required fields')
+          expect(page).to have_content('Please fill in this field')
         end
       end
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -31,13 +31,13 @@ feature 'Sign in' do
   scenario 'user cannot sign in with empty email', js: true do
     signin('', 'foo')
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 
   scenario 'user cannot sign in with empty password', js: true do
     signin('test@example.com', '')
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 
   # Scenario: User cannot sign in with wrong password

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -12,7 +12,7 @@ feature 'User edit' do
     fill_in 'Email', with: ''
     click_button 'Update'
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 
   scenario 'user sees error message if form is submitted without phone number', js: true do
@@ -22,6 +22,6 @@ feature 'User edit' do
     fill_in 'Mobile', with: ''
     click_button 'Update'
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 end

--- a/spec/features/visitors/confirmation_instructions_spec.rb
+++ b/spec/features/visitors/confirmation_instructions_spec.rb
@@ -75,7 +75,7 @@ feature 'Confirmation Instructions', devise: true do
     fill_in 'Email', with: ''
     click_button 'Resend confirmation instructions'
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 
   scenario 'user enters empty email' do

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -217,7 +217,7 @@ feature 'Password Recovery' do
     visit new_user_password_path
     click_button t('forms.buttons.reset_password')
 
-    expect(page).to have_content 'Please fill in all required fields'
+    expect(page).to have_content 'Please fill in this field'
   end
 
   # Scenario: User is unable to determine if someone else's account exists
@@ -273,7 +273,7 @@ feature 'Password Recovery' do
     it 'displays error when password fields are empty & JS is on', js: true do
       click_button 'Change my password'
 
-      expect(page).to have_content 'Please fill in all required fields'
+      expect(page).to have_content 'Please fill in this field'
     end
 
     it 'displays field validation error when password fields are empty' do

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -140,7 +140,7 @@ feature 'Sign Up', devise: true do
       fill_in 'password_form_password', with: ''
       click_button 'Submit'
 
-      expect(page).to have_content 'Please fill in all required fields'
+      expect(page).to have_content 'Please fill in this field'
     end
   end
 
@@ -225,7 +225,7 @@ feature 'Sign Up', devise: true do
   scenario 'visitor cannot sign up with empty email address', js: true do
     sign_up_with('')
 
-    expect(page).to have_content('Please fill in all required fields')
+    expect(page).to have_content('Please fill in this field')
   end
 
   scenario 'visitor cannot sign up with email with invalid domain name' do


### PR DESCRIPTION
**Why**: better indication of something user needs to address

Preview:
![image](https://cloud.githubusercontent.com/assets/1060893/17493761/c04087f8-5d7f-11e6-900e-0fdb5f4dddf0.png)
