### PR TITLE
Remove autofocus from form fields

### DIFF
--- a/app/views/users/edit_info/email.html.slim
+++ b/app/views/users/edit_info/email.html.slim
@@ -5,5 +5,5 @@ h1.heading = t('headings.edit_info.email')
 = simple_form_for(@update_form, url: edit_email_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification
-  = f.input :email, autofocus: true, required: true
+  = f.input :email, required: true
   = f.button :submit, 'Update'

--- a/app/views/users/edit_info/mobile.html.slim
+++ b/app/views/users/edit_info/mobile.html.slim
@@ -5,5 +5,5 @@ h1.heading = t('headings.edit_info.mobile')
 = simple_form_for(@update_form, url: edit_mobile_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification
-  = f.input :mobile, as: :tel, autofocus: true, required: true
+  = f.input :mobile, as: :tel, required: true
   = f.button :submit, 'Update'


### PR DESCRIPTION
**Why**: we made decision to remove these across app
for accessibility reasons (these were the lingering ones)