### PR TITLE
Add the :web role to the list of hosts to be restarted

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,7 @@ set :whenever_roles, [:app]
 namespace :deploy do
   desc 'Restart application'
   task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
+    on roles(:app, :web), in: :sequence, wait: 5 do
       execute :touch, release_path.join('tmp/restart.txt')
     end
   end


### PR DESCRIPTION
__Why__
Capistrano was only restarting the worker hosts and not the web role hosts that
have are serving the app.

__How__
Add the :web role to the list of hosts to be restarted in the deploy.rb