### PR TITLE
[Issue #591] Install latest PhantomJS in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ addons:
       - jq
 before_install:
   - npm install
+  # Install PhantomJS 2.1.1 manually
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
 before_script:
   - cp config/application.yml.example config/application.yml
   - cp certs/saml.crt.example certs/saml.crt


### PR DESCRIPTION
Why
The older version of PhantomJS is causing intermittent errors in our CI pipeline:

Tested 100 spec runs in fresh Ubuntu 12.04.5 LTS
7% failure rate with v1.9.8
0% failure rate with v2.1.1

How
Manually install PhantomJS 2.1.1 in Travis