### PR TITLE
Upgrades to latest stable node version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
     packages:
       - jq
 before_install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
   - npm install
 before_script:
   - cp config/application.yml.example config/application.yml


### PR DESCRIPTION
### Why
npm install fails intermittently with node v0.10, the default version in Travis

### How
Have the latest stable node version installed prior to
installing packages
source: http://entulho.fiatjaf.alhur.es/guias/how-to-use-node-along-with-other-language-on-travis-ci/

[No more `WARN`ings](https://travis-ci.org/18F/identity-idp/builds/151311740#L188)