### PR TITLE
Fix UnusedParameters Reek offenses

### DIFF
--- a/app/services/null_twilio_client.rb
+++ b/app/services/null_twilio_client.rb
@@ -3,7 +3,7 @@ class NullTwilioClient
     self
   end
 
-  def create(params = {})
+  def create(_params)
     # noop
   end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -1,10 +1,4 @@
 class FakeAnalytics
-  def track_event(event, subject = user)
-  end
-
-  def track_anonymous_event(event, attribute = nil)
-  end
-
   def track_pageview
   end
 end


### PR DESCRIPTION
**Why**: To clean up methods.