### PR TITLE
Add more events to track

### DIFF
--- a/.reek
+++ b/.reek
@@ -50,6 +50,7 @@ UtilityFunction:
       - sign_up_and_2fa
       - raw_xml_response
       - sign_in_user
+      - stub_auth
   FeatureEnvy:
     enabled: false
   NestedIterators:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -149,7 +149,7 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: true
-  MaxLineLength: 100
+  MaxLineLength: 80
 
 # Checks the indentation of the first element in an array literal.
 Style/IndentArray:

--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -18,6 +18,7 @@ module Devise
       if @two_factor_setup_form.submit(params[:two_factor_setup_form])
         process_valid_form
       else
+        analytics.track_event('2FA setup: invalid phone number')
         render :index
       end
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -15,7 +15,11 @@ class SamlIdpController < ApplicationController
   def auth
     link_identity_from_session_data
 
-    return redirect_to idv_url if identity_needs_verification?
+    needs_idv = identity_needs_verification?
+
+    analytics.track_event("SAML Auth (idv=#{needs_idv})")
+
+    return redirect_to idv_url if needs_idv
 
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
   end

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -21,7 +21,8 @@ module Users
     end
 
     def disable
-      if current_user.otp_secret_key.present?
+      if current_user.totp_enabled?
+        analytics.track_event('User Disabled TOTP')
         current_user.update(otp_secret_key: nil)
         flash[:success] = t('notices.totp_disabled')
       end
@@ -36,12 +37,14 @@ module Users
     end
 
     def process_valid_code
+      analytics.track_event('TOTP Setup: valid code')
       flash[:success] = t('notices.totp_configured')
       redirect_to profile_path
       user_session.delete(:new_totp_secret)
     end
 
     def process_invalid_code
+      analytics.track_event('TOTP Setup: invalid code')
       flash[:error] = t('errors.invalid_totp')
       redirect_to authenticator_setup_path
     end

--- a/app/models/nonexistent_user.rb
+++ b/app/models/nonexistent_user.rb
@@ -1,0 +1,9 @@
+class NonexistentUser
+  def uuid
+    'nonexistent-uuid'
+  end
+
+  def role
+    'nonexistent'
+  end
+end

--- a/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
@@ -26,6 +26,18 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
 
       expect(response).to redirect_to(phone_confirmation_send_path)
     end
+
+    it 'tracks an event when the number is invalid' do
+      allow(subject).to receive(:authenticate_scope!).and_return(true)
+      allow(subject).to receive(:authorize_otp_setup).and_return(true)
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).with('2FA setup: invalid phone number')
+
+      patch :set, two_factor_setup_form: { phone: '703-555-010' }
+
+      expect(response).to render_template(:index)
+    end
   end
 
   describe 'before_actions' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,25 +1,173 @@
 require 'rails_helper'
 
 describe Users::PasswordsController, devise: true do
-  describe 'Resetting password with valid password' do
-    it 'tracks valid password reset event' do
-      user = create(:user, :signed_up)
+  describe '#edit' do
+    context 'no user matches token' do
+      it 'redirects to page where user enters email for password reset token' do
+        stub_analytics
+        allow(@analytics).to receive(:track_anonymous_event)
 
-      raw_reset_token, db_confirmation_token =
-        Devise.token_generator.generate(User, :reset_password_token)
-      user.update(
-        reset_password_token: db_confirmation_token,
-        reset_password_sent_at: Time.zone.now
-      )
+        get :edit, reset_password_token: 'foo'
 
-      stub_analytics
+        expect(@analytics).to have_received(:track_anonymous_event).
+          with('Reset password: invalid token', 'foo')
 
-      expect(@analytics).to receive(:track_event).with('Password reset', user)
+        expect(response).to redirect_to new_user_password_path
+        expect(flash[:error]).to eq t('devise.passwords.invalid_token')
+      end
+    end
 
-      put(
-        :update,
-        password_form: { password: 'NewVal!dPassw0rd', reset_password_token: raw_reset_token }
-      )
+    context 'token expired' do
+      it 'redirects to page where user enters email for password reset token' do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        user = instance_double('User')
+        allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
+        allow(user).to receive(:reset_password_period_valid?).and_return(false)
+
+        get :edit, reset_password_token: 'foo'
+
+        expect(@analytics).to have_received(:track_event).
+          with('Reset password: token expired', user)
+
+        expect(response).to redirect_to new_user_password_path
+        expect(flash[:error]).to eq t('devise.passwords.token_expired')
+      end
+    end
+
+    context 'token is valid' do
+      it 'displays the form to enter a new password' do
+        stub_analytics
+
+        user = instance_double('User')
+        allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
+
+        get :edit, reset_password_token: 'foo'
+
+        expect(response).to render_template :edit
+        expect(flash.keys).to be_empty
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'user submits new password after token expires' do
+      it 'redirects to page where user enters email for password reset token' do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        params = { password: 'password', reset_password_token: 'foo' }
+
+        user = instance_double('User')
+        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
+        allow(user).to receive(:reset_password_token).and_return('foo')
+        allow(user).to receive(:errors).and_return(reset_password_token: 'token expired')
+
+        put :update, password_form: params
+
+        expect(@analytics).to have_received(:track_event).
+          with('Reset password: token expired', user)
+
+        expect(response).to redirect_to new_user_password_path
+        expect(flash[:error]).to eq t('devise.passwords.token_expired')
+      end
+    end
+
+    context 'user submits invalid new password' do
+      it 'renders edit' do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        params = { password: 'pass', reset_password_token: 'foo' }
+
+        user = instance_double('User')
+        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
+        allow(user).to receive(:reset_password_token).and_return('foo')
+        allow(user).to receive(:errors).and_return({})
+
+        put :update, password_form: params
+
+        expect(@analytics).to have_received(:track_event).
+          with('Reset password: invalid password', user)
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context 'user submits valid new password' do
+      it 'redirects to sign in page' do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        params = { password: 'password', reset_password_token: 'foo' }
+
+        user = instance_double('User')
+        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
+        allow(user).to receive(:reset_password_token).and_return('foo')
+        allow(user).to receive(:errors).and_return({})
+        allow(user).to receive(:password=).with('password')
+
+        notifier = instance_double(EmailNotifier)
+        allow(EmailNotifier).to receive(:new).with(user).and_return(notifier)
+
+        expect(notifier).to receive(:send_password_changed_email)
+
+        put :update, password_form: params
+
+        expect(@analytics).to have_received(:track_event).
+          with('Password reset', user)
+
+        expect(response).to redirect_to new_user_session_path
+        expect(flash[:notice]).to eq t('devise.passwords.updated_not_active')
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'no user matches email' do
+      it 'tracks event using anonymous user' do
+        stub_analytics
+
+        nonexistent_user = instance_double(NonexistentUser)
+        allow(NonexistentUser).to receive(:new).and_return(nonexistent_user)
+
+        expect(nonexistent_user).to receive(:role).and_return('nonexistent')
+
+        expect(@analytics).to receive(:track_event).
+          with('Password Reset Requested for nonexistent role', nonexistent_user)
+
+        put :create, user: { email: 'nonexistent@example.com' }
+      end
+    end
+
+    context 'matched email belongs to a tech support user' do
+      it 'tracks event using tech user' do
+        stub_analytics
+
+        tech_user = build_stubbed(:user, :tech_support)
+        allow(User).to receive(:find_by_email).with('tech@example.com').and_return(tech_user)
+
+        expect(@analytics).to receive(:track_event).
+          with('Password Reset Requested for tech role', tech_user)
+
+        put :create, user: { email: 'tech@example.com' }
+      end
+    end
+
+    context 'matched email belongs to an admin user' do
+      it 'tracks event using tech user' do
+        stub_analytics
+
+        admin = build_stubbed(:user, :admin)
+        allow(User).to receive(:find_by_email).with('admin@example.com').and_return(admin)
+
+        expect(@analytics).to receive(:track_event).
+          with('Password Reset Requested for admin role', admin)
+
+        put :create, user: { email: 'admin@example.com' }
+      end
     end
   end
 end

--- a/spec/models/nonexistent_user_spec.rb
+++ b/spec/models/nonexistent_user_spec.rb
@@ -1,0 +1,17 @@
+describe NonexistentUser do
+  describe 'uuid' do
+    it 'is set to nonexistent-uuid' do
+      nonexistent_user = NonexistentUser.new
+
+      expect(nonexistent_user.uuid).to eq 'nonexistent-uuid'
+    end
+  end
+
+  describe 'role' do
+    it 'is set to nonexistent' do
+      nonexistent_user = NonexistentUser.new
+
+      expect(nonexistent_user.role).to eq 'nonexistent'
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To have more complete analytics

Note that the refactoring of `PasswordsController` was necessary in
order to add event tracking without introducing new Rubocop and Reek
offenses.

Some tests were refactored as well to avoid slowing them down even more
by adding a new `it` block for the new tracking test. For tests that
use the database, it's best to combine all expectations in the same
`it` block to avoid hitting the DB more than once.