### PR TITLE
Track GET request events via after_action

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -18,8 +18,6 @@ module Devise
     end
 
     def show
-      analytics.track_pageview
-
       if use_totp?
         show_totp_prompt
       else

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -4,8 +4,6 @@ module Users
     before_action :check_for_unconfirmed_phone
 
     def show
-      analytics.track_pageview
-
       @code_value = confirmation_code if FeatureManagement.prefill_otp_codes?
       @unconfirmed_phone = unconfirmed_phone
       @reenter_phone_number_path = if current_user.phone.present?

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,11 +6,9 @@ module Users
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def start
-      analytics.track_pageview
     end
 
     def new
-      analytics.track_pageview
       ab_finished(:demo)
       @register_user_email_form = RegisterUserEmailForm.new
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,6 @@ module Users
     end
 
     def new
-      analytics.track_pageview
       super
     end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -1,0 +1,5 @@
+class AnonymousUser
+  def uuid
+    'anonymous-uuid'
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -26,10 +26,6 @@ class Analytics
     ahoy.track(event, request_attributes.merge(value: attribute))
   end
 
-  def track_pageview
-    ahoy.track_visit
-  end
-
   private
 
   attr_reader :user, :request

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -57,7 +57,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         stub_analytics
         expect(@analytics).to receive(:track_event).with('User entered invalid 2FA code')
-        expect(@analytics).to receive(:track_pageview)
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
         expect(subject.current_user).to receive(:authenticate_otp).and_return(false)
@@ -226,14 +225,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       it 'renders the :show view' do
         get :show
         expect(response).to_not be_redirect
-        expect(response).to render_template(:show)
-      end
-
-      it 'tracks the pageview' do
-        stub_analytics
-        expect(@analytics).to receive(:track_pageview)
-
-        get :show
       end
 
       context 'when user is TOTP enabled' do
@@ -298,6 +289,8 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
     it 'tracks the event' do
       stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with('GET request for two_factor_authentication#new')
       expect(@analytics).to receive(:track_event).with('User requested a new OTP code')
 
       get :new

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -43,6 +43,7 @@ describe Users::ConfirmationsController, devise: true do
 
       stub_analytics
 
+      expect(@analytics).to receive(:track_event).with('GET request for confirmations#show')
       expect(@analytics).to receive(:track_event).
         with('Email Confirmation: User Already Confirmed', user)
 
@@ -55,6 +56,7 @@ describe Users::ConfirmationsController, devise: true do
 
       stub_analytics
 
+      expect(@analytics).to receive(:track_event).with('GET request for confirmations#show')
       expect(@analytics).to receive(:track_event).
         with('Email Confirmation: token expired', user)
 
@@ -69,6 +71,7 @@ describe Users::ConfirmationsController, devise: true do
 
       stub_analytics
 
+      expect(@analytics).to receive(:track_event).with('GET request for confirmations#show')
       expect(@analytics).to receive(:track_event).
         with('Email Confirmation: valid token', user)
 
@@ -113,6 +116,7 @@ describe Users::ConfirmationsController, devise: true do
 
       stub_analytics
 
+      expect(@analytics).to receive(:track_event).with('GET request for confirmations#show')
       expect(@analytics).to receive(:track_event).
         with('Email changed and confirmed', user)
 

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -167,13 +167,6 @@ describe Users::PhoneConfirmationController, devise: true do
       expect(response).to render_template(:show)
     end
 
-    it 'tracks the pageview' do
-      stub_analytics
-      expect(@analytics).to receive(:track_pageview)
-
-      get :show
-    end
-
     context 'when updating an existing phone number' do
       it 'sets @reenter_phone_number_path to profile edit path' do
         get :show

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -10,13 +10,6 @@ describe Users::RegistrationsController, devise: true do
       expect(subject).to receive(:ab_finished).with(:demo)
       get :new
     end
-
-    it 'tracks the pageview' do
-      stub_analytics
-      expect(@analytics).to receive(:track_pageview)
-
-      get :new
-    end
   end
 
   describe '#create' do
@@ -59,15 +52,6 @@ describe Users::RegistrationsController, devise: true do
         with('User Registration: invalid email', 'invalid@')
 
       post :create, user: { email: 'invalid@' }
-    end
-  end
-
-  describe '#start' do
-    it 'tracks the pageview' do
-      stub_analytics
-      expect(@analytics).to receive(:track_pageview)
-
-      get :start
     end
   end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -122,13 +122,4 @@ describe Users::SessionsController, devise: true do
       post :create, user: { email: 'foo@example.com', password: 'password' }
     end
   end
-
-  describe '#new' do
-    it 'tracks the pageview' do
-      stub_analytics
-      expect(@analytics).to receive(:track_pageview)
-
-      get :new
-    end
-  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -64,14 +64,4 @@ describe Analytics do
       analytics.track_anonymous_event('Anonymous Event', 'foo')
     end
   end
-
-  describe '#track_pageview' do
-    it 'logs the pageview' do
-      analytics = Analytics.new(nil, FakeRequest.new)
-
-      expect(ahoy).to receive(:track_visit)
-
-      analytics.track_pageview
-    end
-  end
 end

--- a/spec/support/fake_ahoy_tracker.rb
+++ b/spec/support/fake_ahoy_tracker.rb
@@ -1,8 +1,4 @@
 class FakeAhoyTracker
-  def track_visit(_options = {})
-    # no-op
-  end
-
   def track(_name, _properties = {}, _options = {})
     # no-op
   end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -1,4 +1,5 @@
 class FakeAnalytics
-  def track_pageview
+  def track_event(_event, _user = nil)
+    # no-op
   end
 end


### PR DESCRIPTION
**Why**: To complement the events we track, which are mostly the
result of PUT requests. I was misusing Ahoy's `track_visit` method.
It's not meant to be used to track page views. Instead, we need to use
the same `track_event` method we've been using, and instead of placing
a `track_event` call in every controller, we can add an `after_action`
in `ApplicationController` and automatically track all GET requests.