### PR TITLE
Remove unused password validation code

### DIFF
--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -4,26 +4,6 @@ module FormPasswordValidator
   included do
     validates :password,
               presence: true,
-              length: Devise.password_length,
-              confirmation: true,
-              if: :password_required?
-  end
-
-  private
-
-  def password_required?
-    new_user? || user_resetting_password? || user_updating_password?
-  end
-
-  def new_user?
-    @user.encrypted_password.blank?
-  end
-
-  def user_resetting_password?
-    @user.reset_password_token.present?
-  end
-
-  def user_updating_password?
-    password.present?
+              length: Devise.password_length
   end
 end

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -4,10 +4,6 @@ describe PasswordForm do
   subject { PasswordForm.new(build_stubbed(:user)) }
 
   it do
-    is_expected.to validate_confirmation_of(:password)
-  end
-
-  it do
     is_expected.to validate_length_of(:password).
       is_at_least(Devise.password_length.first)
   end


### PR DESCRIPTION
**Why**:
- The logic around when the password field is required no longer
applies now that we've moved individual editable attributes to their
own page. Now, whenever a password field is displayed, it will always
be required.
- The confirmation validation no longer applies now that we no longer
ask the user to type in their password twice.