### PR TITLE
Disable Ahoy's throttling and routes

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,3 +1,6 @@
+Ahoy.mount = false
+Ahoy.throttle = false
+
 module Ahoy
   class Store < Ahoy::Stores::LogStore
   end


### PR DESCRIPTION
**Why**:
- We don't use Ahoy's routes since those are only used by Ahoy.js to
send POST requests to those endpoints so that events and views can be
recorded.

- Even if we don't use Ahoy.js, we should still disable the routes
since they are not protected in any way, which means that anyone can
spam our logs/DB 19 times every minute.

- Ahoy uses the rack-attack gem to throttle the aforementioned POST
requests, but it interferes with our usage of rack-attack. See these
issues:
https://github.com/ankane/ahoy/pull/204
https://github.com/kickstarter/rack-attack/issues/199