### PR TITLE
Add default attribute bundle for demo apps

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -8,7 +8,9 @@ test:
       cert: 'saml_test_sp'
       agency: 'test_agency'
       friendly_name: 'test_friendly_name'
-      attribute_bundle: ['email', 'phone']
+      attribute_bundle:
+        - email
+        - phone
 
     'https://rp1.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
@@ -35,12 +37,16 @@ development:
       sp_initiated_login_url: 'http://localhost:3000/test/saml'
       cert: 'saml_test_sp'
       fingerprint: '08:79:F5:B1:B8:CC:EC:8F:5C:2A:58:03:30:14:C9:E6:F1:67:78:F1:97:E8:3A:88:EB:8E:70:92:25:D2:2F:32'
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
       metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
       sp_initiated_login_url: 'http://localhost:4567/test/saml'
       assertion_consumer_logout_service_url: 'http://localhost:4567/slo_logout'
       cert: 'sp_sinatra_demo'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
       metadata_url: 'http://localhost:3003/saml/metadata'
       acs_url: 'http://localhost:3003/auth/saml/callback'
@@ -49,6 +55,9 @@ development:
       cert: 'sp_rails_demo'
       agency: '18F'
       friendly_name: '18F Test Service Provider'
+      attribute_bundle:
+        - email
+
     'https://dashboard.login.gov':
       metadata_url: 'http://localhost:3001/users/auth/saml/metadata'
       acs_url: 'http://localhost:3001/users/auth/saml/callback'
@@ -64,35 +73,53 @@ production:
       assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
       sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
       cert: 'saml_test_sp'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
       metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
       sp_initiated_login_url: 'http://localhost:4567/test/saml'
       cert: 'sp_sinatra_demo'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev':
       metadata_url: 'https://sp-sinatra.dev.login.gov/saml/metadata'
       acs_url: 'https://sp-sinatra.dev.login.gov/consume'
       assertion_consumer_logout_service_url: 'https://sp-sinatra.dev.login.gov/slo_logout'
       sp_initiated_login_url: 'https://sp-sinatra.dev.login.gov/test/saml'
       cert: 'sp_sinatra_demo'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo':
       metadata_url: 'https://sp-sinatra.demo.login.gov/saml/metadata'
       acs_url: 'https://sp-sinatra.demo.login.gov/consume'
       assertion_consumer_logout_service_url: 'https://sp-sinatra.demo.login.gov/slo_logout'
       sp_initiated_login_url: 'https://sp-sinatra.demo.login.gov/test/saml'
       cert: 'sp_sinatra_demo'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev':
       metadata_url: 'https://identity-sp-rails-dev.apps.cloud.gov/saml/metadata'
       acs_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-sp-rails-dev.apps.cloud.gov/login'
       cert: 'sp_rails_demo'
+      attribute_bundle:
+        - email
+
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo':
       metadata_url: 'https://sp.demo.login.gov/saml/metadata'
       acs_url: 'https://sp.demo.login.gov/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://sp.demo.login.gov/auth/saml/logout'
       sp_initiated_login_url: 'https://sp.demo.login.gov/login'
       cert: 'sp_rails_demo'
+      attribute_bundle:
+        - email
+
     # Dashboard
     'https://dashboard.demo.login.gov':
       metadata_url: 'https://dashboard.demo.login.gov/users/auth/saml/metadata'
@@ -100,12 +127,14 @@ production:
       assertion_consumer_logout_service_url: 'https://dashboard.demo.login.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://dashboard.demo.login.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
+
     'https://dashboard.qa.login.gov':
       metadata_url: 'https://dashboard.qa.login.gov/users/auth/saml/metadata'
       acs_url: 'https://dashboard.qa.login.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://dashboard.qa.login.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://dashboard.qa.login.gov/users/auth/saml'
       cert: 'identity_dashboard_cert'
+
     'https://dashboard.dev.login.gov':
       metadata_url: 'https://dashboard.dev.login.gov/users/auth/saml/metadata'
       acs_url: 'https://dashboard.dev.login.gov/users/auth/saml/callback'
@@ -120,4 +149,6 @@ superb.legit.domain.gov:
       assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout'
       cert: 'saml_test_sp'
       agency: 'test_agency'
-      attribute_bundle: ['email', 'phone']
+      attribute_bundle:
+        - email
+        - phone


### PR DESCRIPTION
**Why**: All demo apps require at least email for LOA1,
so include that attribute by default.