### PR TITLE
Remove unused `addons` key from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ addons:
   code_climate:
     repo_token:
       secure: '0RG6L9Sfur37NAB4X9rZypo6tffcWQtTcTpuSi08SfLN9jgiG2nHArVvw0nfNcSg7EmJ27ZnQxQqRjXlG76ufndlmoxgVX6xs96VyDyCOEFzRecE+wziNis+B3ACZb5OHaoMpomzsYFA73nYoCnPkgKUPAQFReTIqW7IB2Z1t7auTZe6kYBkKP7yB37wAVD4HMUDwm0spT0U2ur2GzSi86EqFEXR4NfhzGu5o7Y/hzWPxyyz+CRrujXhdWZl1FNtMj0mUM0/zSEEgUuCRRClGkD31RECjDKQQrXUkgQ1b3O/Nbih/8EjDqs4udLGnBYbtoahZ0ogZ/SV5xj7n2umNBJeLLTZO/qhWyQA4YDPuAZCw61VK1jpyQE1uZKxawYkgXBScmTWCJeAwEqZ4V8z4H4W2y1ZgegAoBCYOhv2+Dq4d9IaBUaeH3ukhEKX9H38yF1DEkp2sXKfXOxyEgpr0g0IIII9YVYQ89WExNmnZnfgd6lBqMFlP4wj8pQkCAeMG8+e+O0QsewzwlVgDDp5pQCgHEYq5X3quvWv0bRJDBL68/4fU9kEjv+RAo8Wx99x3nrZSzJglBrSaPt2/+eoVf3VTIJX4p8oO3aC/gcpbrWZrsfcGfLgKCEiu/ggzhicYhWY+Aa+pdeOefrO51ki9BIu84PoMrP2I7EREp2s1vw='
-    addons:
   apt:
     packages:
       - jq


### PR DESCRIPTION
**Why**: There was an extra `addons` entry