### PR TITLE
Landing page for decline to verify identity

### DIFF
--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -8,4 +8,7 @@ class IdvController < ApplicationController
     # explore UX of this flow. disabled for now till we find the edge cases.
     # redirect_to idv_sessions_url if proofing_session_started?
   end
+
+  def cancel
+  end
 end

--- a/app/views/idv/cancel.html.slim
+++ b/app/views/idv/cancel.html.slim
@@ -1,0 +1,8 @@
+- title t('idv.titles.hardfail')
+
+h1.heading = t('idv.titles.hardfail')
+
+p
+  | In order to verify your identity we need to collect some basic contact
+    and financial information from you. If you do not have the necessary
+    information available to you at this time, you may #{link_to('continue later', idv_path)}.

--- a/app/views/idv/index.html.slim
+++ b/app/views/idv/index.html.slim
@@ -52,5 +52,5 @@ p
     this information and your identity.
 p.bold Do you have all of this information available?
 
-= link_to 'No', idv_sessions_path, class: 'btn btn-primary mr1'
+= link_to 'No', idv_cancel_path, class: 'btn btn-primary mr1'
 = link_to 'Yes', idv_sessions_path, class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   match '/edit/phone' => 'users/edit_phone#update', via: [:patch, :put]
 
   get '/idv' => 'idv#index'
+  get '/idv/cancel' => 'idv#cancel'
   namespace :idv do
     resources :questions, :sessions, :confirmations
   end

--- a/spec/features/idv/question_cycle_spec.rb
+++ b/spec/features/idv/question_cycle_spec.rb
@@ -3,6 +3,25 @@ require 'rails_helper'
 feature 'IdV session' do
   include IdvHelper
 
+  context 'landing page' do
+    before do
+      sign_in_and_2fa_user
+      visit idv_path
+    end
+
+    scenario 'decline to verify identity' do
+      click_link 'No'
+
+      expect(page).to have_content(t('idv.titles.hardfail'))
+    end
+
+    scenario 'proceed to verify identity' do
+      click_link 'Yes'
+
+      expect(page).to have_content(t('idv.titles.welcome'))
+    end
+  end
+
   context 'KBV off' do
     before do
       allow(FeatureManagement).to receive(:proofing_requires_kbv?).and_return(false)


### PR DESCRIPTION
**Why**: For users who lack or refuse to provide
verification data.