### PR TITLE
Point to top level dir for assets in 429.html

### DIFF
--- a/public/429.html
+++ b/public/429.html
@@ -3,7 +3,7 @@
 <head>
   <title>Rate Limited | Login.gov</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="css/static.css">
+  <link rel="stylesheet" href="../css/static.css">
 </head>
 <body>
   <div class="site-wrapper">
@@ -11,7 +11,7 @@
       <div class="cover-container">
         <div class="masthead clearfix">
           <div class="inner">
-            <img class="masthead-brand" src="images/logo-white.svg" width="150">
+            <img class="masthead-brand" src="../images/logo-white.svg" width="150">
           </div>
         </div>
         <div class="inner cover">


### PR DESCRIPTION
**Why**: If throttling happens while you're in a path such as
`/users/two_factor_authentication`, and if the 429.html points
to css and images using relative paths, the app will look for
the assets under the `users` directory instead of at the root,
which will cause the page to render without assets.