### PR TITLE
Update top nav links

### DIFF
--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -15,11 +15,10 @@ nav.bg-white
         - if signed_in?
           .h4 Welcome <strong>#{current_user.email}</strong>
           .mt1.sm-mt2.h5
-            = link_to t('links.my_account'), profile_path, \
-              class: 'bold underline'
+            = link_to t('links.my_account'), profile_path,
+              class: current_page?(profile_path) ? 'bold gray' : 'underline'
             span.px1.silver = '|'
-            = link_to t('links.sign_out'), destroy_user_session_path, \
-              class: 'bold underline'
+            = link_to t('links.sign_out'), destroy_user_session_path, class: 'underline'
         - else
           .h4.sm-show &nbsp;
           .mt1.sm-mt2.h5


### PR DESCRIPTION
**Why**: As per visual design, my account link in top nav  should be disabled when you are on the actual account overview page