### PR TITLE
Make rack-attack specs less brittle.

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -62,11 +62,12 @@ describe 'throttling requests' do
       end
 
       it 'returns a custom body' do
-        expect(last_response.body).to eq(File.read('public/429.html'))
+        expect(last_response.body).
+          to include('Your request was denied because of unusual activity.')
       end
 
       it 'returns text/html for Content-type' do
-        expect(last_response.header['Content-type']).to eq('text/html')
+        expect(last_response.header['Content-type']).to include('text/html')
       end
 
       it 'logs the throttle' do
@@ -143,11 +144,12 @@ describe 'throttling requests' do
       end
 
       it 'returns a custom body' do
-        expect(last_response.body).to eq(File.read('public/429.html'))
+        expect(last_response.body).
+          to include('Your request was denied because of unusual activity.')
       end
 
       it 'returns text/html for Content-type' do
-        expect(last_response.header['Content-type']).to eq('text/html')
+        expect(last_response.header['Content-type']).to include('text/html')
       end
 
       it 'logs the throttle' do


### PR DESCRIPTION
**Why**: We've been getting intermittent failures for some rack-attack specs.

**How**:
- Instead of reading the 429.html file, look for some expected text
inside the file.
- Instead of verifying that the Content Type is exactly `text/html`,
only make sure it includes `text/html`, to allow for the scenario
where the `charset` gets added to the header.