### PR TITLE
Enables color in rspec output

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,10 @@ ENV['RAILS_ENV'] ||= 'test'
 
 RSpec.configure do |config|
   # see more settings at spec/rails_helper.rb
-
   config.raise_errors_for_deprecations!
   config.order = :random
+  config.color = true
+
   # allows you to run only the failures from the previous run:
   # rspec --only-failures
   config.example_status_persistence_file_path = './tmp/rspec-examples.txt'


### PR DESCRIPTION
### Why
The default output from rspec does not include color

### How
Adds `config.color = true` to spec_helper.rb