### PR TITLE
Add table to hold user visible account activity

### DIFF
--- a/.reek
+++ b/.reek
@@ -20,6 +20,8 @@ NilCheck:
     - user_not_found?
 TooManyStatements:
   max_statements: 6
+  exclude:
+    - Users::PhoneConfirmationController
 TooManyMethods:
   exclude:
     - Devise::TwoFactorAuthenticationController

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
     @analytics ||= Analytics.new(user, request)
   end
 
+  def create_user_event(event_type, user = current_user)
+    Event.create(user_id: user.id, event_type: event_type)
+  end
+
   private
 
   def decorated_user

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -113,6 +113,7 @@ module Users
 
     def process_confirmed_user
       analytics.track_event('Email changed and confirmed', @confirmable)
+      create_user_event(:email_changed, @confirmable)
 
       flash[:notice] = t('devise.confirmations.confirmed')
       redirect_to after_confirmation_path_for(@confirmable)

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -29,17 +29,22 @@ module Users
       :unconfirmed_phone
     end
 
+    # TODO(sbc): refactor to reduce method length
+    # rubocop:disable MethodLength
     def assign_phone
       old_phone = current_user.phone
       @updating_existing_number = old_phone.present?
       if @updating_existing_number
+        create_user_event(:phone_changed)
         analytics.track_event('User changed their phone number')
         SmsSenderNumberChangeJob.perform_later(old_phone)
       else
+        create_user_event(:phone_confirmed)
         analytics.track_event('User confirmed their phone number')
       end
       current_user.update(phone: unconfirmed_phone, phone_confirmed_at: Time.current)
     end
+    # rubocop:enable MethodLength
 
     def after_confirmation_path
       if @updating_existing_number

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -43,10 +43,14 @@ module Users
     end
 
     def track_registration(form)
-      return analytics.track_event('Account Created', form.user) unless form.email_taken?
-
-      existing_user = User.find_by_email(form.email)
-      analytics.track_event('Registration Attempt with existing email', existing_user)
+      if form.email_taken?
+        existing_user = User.find_by_email(form.email)
+        analytics.track_event('Registration Attempt with existing email', existing_user)
+      else
+        user = form.user
+        analytics.track_event('Account Created', user)
+        create_user_event(:account_created, user)
+      end
     end
   end
 end

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -23,6 +23,7 @@ module Users
     def disable
       if current_user.totp_enabled?
         analytics.track_event('User Disabled TOTP')
+        create_user_event(:authenticator_disabled)
         current_user.update(otp_secret_key: nil)
         flash[:success] = t('notices.totp_disabled')
       end
@@ -38,6 +39,7 @@ module Users
 
     def process_valid_code
       analytics.track_event('TOTP Setup: valid code')
+      create_user_event(:authenticator_enabled)
       flash[:success] = t('notices.totp_configured')
       redirect_to profile_path
       user_session.delete(:new_totp_secret)

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,0 +1,5 @@
+EventDecorator = Struct.new(:event) do
+  def pretty_event_type
+    I18n.t("event_types.#{event.event_type}")
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,19 @@
+class Event < ActiveRecord::Base
+  belongs_to :user
+
+  enum event_type: {
+    account_created: 1,
+    phone_confirmed: 2,
+    password_changed: 3,
+    phone_changed: 4,
+    email_changed: 5,
+    authenticator_enabled: 6,
+    authenticator_disabled: 7
+  }
+
+  validates :event_type, presence: true
+
+  def decorate
+    EventDecorator.new(self)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ActiveRecord::Base
   has_many :authorizations, dependent: :destroy
   has_many :identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
+  has_many :events, dependent: :destroy
 
   attr_accessor :asserted_attributes
 

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -76,3 +76,18 @@ h2.heading = t('headings.profile.agencies')
           .sm-col.sm-col-4.px1
             .h6.bold = 'Last login'
             .h5 = i.last_authenticated_at.to_s(:date_pretty)
+
+h2.heading = t('headings.profile.account_history')
+.mt3.mb2
+  .py-12p.border-top
+    .clearfix.mxn1
+      .sm-col.sm-col-6.px1
+        .h6.bold Event
+      .sm-col.sm-col-6.px1
+        .h6.bold When
+    - current_user.events.each do |event|
+      .clearfix.mxn1
+        .sm-col.sm-col-6.px1
+          .h4.truncate = event.decorate.pretty_event_type
+        .sm-col.sm-col-6.px1
+          .h5 = event.created_at.to_formatted_s(:long)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -95,6 +95,7 @@ ignore_unused:
 - '{devise,simple_form}.*'
 - 'errors.not_authorized'
 - 'experiments.*'
+- 'event_types.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,14 @@ en:
     messages:
       improbable_phone: Phone number is invalid. Please make sure you enter a 10-digit phone number.
 
+  event_types:
+    account_created: Account created
+    phone_confirmed: Phone confirmed
+    phone_changed: Phone changed
+    email_changed: Email changed
+    authenticator_enabled: Authenticator app enabled
+    authenticator_disabled: Authenticator app disabled
+
   forms:
     buttons:
       continue_browsing: Continue browsing
@@ -87,6 +95,7 @@ en:
     profile:
       agencies: Agencies I've logged into
       profile_info: Profile information
+      account_history: Account history
       login_info: Login information
       main: My account
       two_factor: Two-factor Authentication
@@ -125,6 +134,7 @@ en:
     validations:
       email:
         invalid: Please enter a valid email in the format of user@domain.com
+
   idv:
     form:
       first_name: First name

--- a/db/migrate/20160815174550_add_events_table.rb
+++ b/db/migrate/20160815174550_add_events_table.rb
@@ -1,0 +1,9 @@
+class AddEventsTable < ActiveRecord::Migration
+  def change
+    create_table :events do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+      t.integer  :event_type,     limit: 4,   null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160809195935) do
+ActiveRecord::Schema.define(version: 20160815174550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,15 @@ ActiveRecord::Schema.define(version: 20160809195935) do
 
   add_index "authorizations", ["provider", "uid"], name: "index_authorizations_on_provider_and_uid", using: :btree
   add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
+
+  create_table "events", force: :cascade do |t|
+    t.integer  "user_id",                    null: false
+    t.integer  "event_type",                 null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
 
   create_table "identities", force: :cascade do |t|
     t.string   "service_provider",      limit: 255
@@ -131,4 +140,5 @@ ActiveRecord::Schema.define(version: 20160809195935) do
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", using: :btree
   add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
 
+  add_foreign_key "events", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ if Rails.env.development?
       user.reset_password('password', 'password')
       user.phone = format('+1 (415) 555-01%02d', index)
       user.phone_confirmed_at = Time.current
+      Event.create(user_id: user.id, event_type: :account_created)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -185,4 +185,26 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#create_user_event' do
+    let(:user) { build_stubbed(:user) }
+
+    context 'when the user is not specified' do
+      it 'creates an Event object for the current_user' do
+        allow(subject).to receive(:current_user).and_return(user)
+
+        expect(Event).to receive(:create).with(user_id: user.id, event_type: :account_created)
+
+        subject.create_user_event(:account_created)
+      end
+    end
+
+    context 'when the user is specified' do
+      it 'creates an Event object for the specified user' do
+        expect(Event).to receive(:create).with(user_id: user.id, event_type: :account_created)
+
+        subject.create_user_event(:account_created, user)
+      end
+    end
+  end
 end

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -66,6 +66,9 @@ describe Users::PhoneConfirmationController, devise: true do
       subject.user_session[:unconfirmed_phone] = '+1 (555) 555-5555'
       subject.user_session[:phone_confirmation_code] = '123'
       @previous_phone_confirmed_at = subject.current_user.phone_confirmed_at
+      stub_analytics
+      allow(@analytics).to receive(:track_event)
+      allow(subject).to receive(:create_user_event)
     end
 
     context 'user has an existing phone number' do
@@ -89,6 +92,13 @@ describe Users::PhoneConfirmationController, devise: true do
         it 'displays success flash notice' do
           expect(flash[:success]).to eq t('notices.phone_confirmation_successful')
         end
+
+        it 'tracks the update event' do
+          expect(@analytics).to have_received(:track_event).with('User changed their phone number')
+
+          expect(subject).to have_received(:create_user_event).with(:phone_changed)
+          expect(subject).to have_received(:create_user_event).exactly(:once)
+        end
       end
 
       context 'user enters an invalid code' do
@@ -111,21 +121,11 @@ describe Users::PhoneConfirmationController, devise: true do
         it 'displays error flash notice' do
           expect(flash[:error]).to eq t('errors.invalid_confirmation_code')
         end
-      end
 
-      it 'tracks the update event' do
-        stub_analytics
-        expect(@analytics).to receive(:track_event).with('User changed their phone number')
-
-        post :confirm, code: '123'
-      end
-
-      it 'tracks an event when the user enters an invalid code' do
-        stub_analytics
-        expect(@analytics).to receive(:track_event).
-          with('User entered invalid phone confirmation code')
-
-        post :confirm, code: '999'
+        it 'tracks an event' do
+          expect(@analytics).to have_received(:track_event).
+            with('User entered invalid phone confirmation code')
+        end
       end
     end
 
@@ -141,14 +141,15 @@ describe Users::PhoneConfirmationController, devise: true do
         it 'redirects to profile page' do
           expect(response).to redirect_to(profile_path)
         end
-      end
 
-      it 'tracks the confirmation event' do
-        stub_analytics
-        expect(@analytics).to receive(:track_event).with('User confirmed their phone number')
-        expect(@analytics).to receive(:track_event).with('Authentication Successful')
+        it 'tracks the confirmation event' do
+          expect(@analytics).to have_received(:track_event).
+            with('User confirmed their phone number')
+          expect(@analytics).to have_received(:track_event).with('Authentication Successful')
 
-        post :confirm, code: '123'
+          expect(subject).to have_received(:create_user_event).with(:phone_confirmed)
+          expect(subject).to have_received(:create_user_event).exactly(:once)
+        end
       end
     end
   end

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe EventDecorator do
+  describe '#pretty_event_type' do
+    it 'returns the localized text corresponding to the event type' do
+      event = build_stubbed(:event, event_type: :email_changed)
+      decorator = EventDecorator.new(event)
+
+      expect(decorator.pretty_event_type).to eq t('event_types.email_changed')
+    end
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :event do
+    user_id 1
+    event_type :account_created
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Event do
+  it { is_expected.to belong_to(:user) }
+
+  describe 'validations' do
+    let(:event) { build_stubbed(:event) }
+
+    it { is_expected.to validate_presence_of(:event_type) }
+
+    it 'factory built event is valid' do
+      expect(event).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,7 @@ describe User do
     it { is_expected.to have_many(:authorizations) }
     it { is_expected.to have_many(:identities) }
     it { is_expected.to have_many(:profiles) }
+    it { is_expected.to have_many(:events) }
   end
 
   it 'should only send one email during creation' do


### PR DESCRIPTION
**Why**: We want to give the user some visibility into
the history of the activity on their account.  The precise
subset of events and the retention schedule are not final
but this gives us a simple framework for managing them.

This is only the first part of this feature.  Still to come
is the ability to limit the number of events stored per user
and perhaps storing the location and user agent information
about the request that triggerd each event.