### PR TITLE
Fix inline form validation

### DIFF
--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -8,8 +8,8 @@ p Please enter the code sent to <strong>#{@phone_number}</strong>.
   = label_tag 'code', \
     raw(t('simple_form.required.html')) + t('forms.two_factor.code'), \
     class: 'block caps ls-05 bold'
-  = number_field_tag(:code, '', required: true, value: @code_value, \
-                     class: 'col-12 sm-col-5 mb4 sm-mb0 sm-mr-20p field mfa')
-  = submit_tag 'Submit', class: 'btn btn-primary'
+  .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
+    = number_field_tag(:code, '', required: true, value: @code_value, class: 'col-12 field mfa')
+  = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 p.mt2.mb0 Didn't receive a code? #{link_to 'Resend', otp_new_path}

--- a/app/views/users/phone_confirmation/show.html.slim
+++ b/app/views/users/phone_confirmation/show.html.slim
@@ -5,11 +5,12 @@ p.m0 Please enter the code sent to <strong>#{@unconfirmed_phone}</strong>.
 
 = form_tag([:phone_confirmation], method: :put, role: 'form', class: 'mt4') do
   = label_tag 'code', 'One-time passcode', class: 'block caps ls-05 bold'
-  = number_field_tag(:code, \
-                     '', required: true, \
-                     value: @code_value, \
-                     class: 'col-12 sm-col-5 mb4 sm-mb0 sm-mr-20p field mfa')
-  = submit_tag 'Submit', class: 'btn btn-primary'
+  .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
+    = number_field_tag(:code, \
+                       '', required: true, \
+                       value: @code_value, \
+                       class: 'col-12 field mfa')
+  = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 - resend_link = link_to('Resend', \
                         phone_confirmation_send_path)

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -6,6 +6,6 @@ p.mb0 = t('forms.totp_setup.totp_info')
   = image_tag @qrcode, alt: 'QR Code for Authenticator App'
 = form_tag(authenticator_setup_path, method: :patch, role: 'form', class: 'mb1') do
   = label_tag 'code', t('forms.totp_setup.code'), class: 'block caps ls-05 bold'
-  = number_field_tag :code, '', required: true, \
-    class: 'col-12 sm-col-5 mb4 sm-mb0 sm-mr-20p field mfa'
-  = submit_tag 'Submit', class: 'btn btn-primary'
+  .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
+    = number_field_tag :code, '', required: true, class: 'col-12 field mfa'
+  = submit_tag 'Submit', class: 'btn btn-primary align-top'


### PR DESCRIPTION
**Why**: Moves validation message to end of form instead of after input on inline forms in order to preserve submit button location https://github.com/18F/identity-private/issues/654