### PR TITLE
Restore link to IdV cancel message

### DIFF
--- a/app/views/idv/cancel.html.slim
+++ b/app/views/idv/cancel.html.slim
@@ -1,4 +1,5 @@
 - title t('idv.titles.hardfail')
 
 h1.heading = t('idv.titles.hardfail')
-p.mb1 = t('idv.messages.hardfail', app_name: APP_NAME)
+p.mb1 = t('idv.messages.hardfail', app_name: APP_NAME,
+        link: link_to(t('idv.messages.hardfail_link'), idv_url)).html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,7 +151,8 @@ en:
         %{app_name} needs to verify your identity. We need to collect some basic
         personal information as well as some financial information from you to
         complete this process. If you don’t have the information we need at this
-        time you can continue later.
+        time you can %{link}.
+      hardfail_link: continue later
     titles:
       intro: Help us identify you
       expectations: We need some information from you


### PR DESCRIPTION
**Why**: Anchor link got dropped in the text update.