### PR TITLE
Refactor ServiceProvider and related code

### DIFF
--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -70,7 +70,7 @@ class AttributeAsserter
 
   def bundle
     @_bundle ||= (
-      authn_request_bundle || service_provider.attribute_bundle || DEFAULT_BUNDLE
+      authn_request_bundle || service_provider.metadata[:attribute_bundle] || DEFAULT_BUNDLE
     ).map(&:to_sym)
   end
 

--- a/app/services/service_provider_config.rb
+++ b/app/services/service_provider_config.rb
@@ -1,22 +1,21 @@
 class ServiceProviderConfig
-  def initialize(filename:, issuer:)
+  def initialize(issuer:)
     @issuer = issuer
-    @data = YAML.load_file("#{Rails.root}/config/#{filename}")
   end
 
   def sp_attributes
-    data_hash['valid_hosts'].fetch(issuer, {}).symbolize_keys
+    SERVICE_PROVIDERS['valid_hosts'].fetch(issuer, {}).symbolize_keys
+  end
+
+  def self.fetch_providers_from_domain_name_or_rails_env
+    if Figaro.env.domain_name == 'superb.legit.domain.gov'
+      SERVICE_PROVIDERS.merge!(SERVICE_PROVIDERS.fetch('superb.legit.domain.gov', {}))
+    else
+      SERVICE_PROVIDERS.merge!(SERVICE_PROVIDERS.fetch(Rails.env, {}))
+    end
   end
 
   private
 
-  attr_reader :data, :issuer
-
-  def data_hash
-    if Figaro.env.domain_name == 'superb.legit.domain.gov'
-      data.merge!(data.fetch('superb.legit.domain.gov', {}))
-    else
-      data.merge!(data.fetch(Rails.env, {}))
-    end
-  end
+  attr_reader :issuer
 end

--- a/app/services/service_provider_config.rb
+++ b/app/services/service_provider_config.rb
@@ -1,0 +1,22 @@
+class ServiceProviderConfig
+  def initialize(filename:, issuer:)
+    @issuer = issuer
+    @data = YAML.load_file("#{Rails.root}/config/#{filename}")
+  end
+
+  def sp_attributes
+    data_hash['valid_hosts'].fetch(issuer, {}).symbolize_keys
+  end
+
+  private
+
+  attr_reader :data, :issuer
+
+  def data_hash
+    if Figaro.env.domain_name == 'superb.legit.domain.gov'
+      data.merge!(data.fetch('superb.legit.domain.gov', {}))
+    else
+      data.merge!(data.fetch(Rails.env, {}))
+    end
+  end
+end

--- a/config/initializers/service_providers.rb
+++ b/config/initializers/service_providers.rb
@@ -1,0 +1,3 @@
+SERVICE_PROVIDERS = YAML.load_file("#{Rails.root}/config/service_providers.yml")
+
+ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -15,16 +15,24 @@ test:
     'https://rp1.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+      block_encryption: 'aes256-cbc'
       sp_initiated_login_url: 'https://example.com/auth/saml/login'
       cert: 'saml_test_sp'
+      attribute_bundle:
+        - first_name
+        - last_name
+        - ssn
+        - zipcode
 
     'https://rp2.serviceprovider.com/auth/saml/metadata':
       acs_url: 'http://example.com/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
 
     'http://test.host':
       acs_url: 'http://test.host/test/saml/decode_assertion'
+      block_encryption: 'aes256-cbc'
       metadata_url: 'http://test.host/test/saml/metadata'
       sp_initiated_login_url: 'http://test.host/test/saml'
 
@@ -34,24 +42,25 @@ development:
       metadata_url: 'http://localhost:3000/test/saml/metadata'
       acs_url: 'http://localhost:3000/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
+      block_encryption: 'aes256-cbc'
       sp_initiated_login_url: 'http://localhost:3000/test/saml'
       cert: 'saml_test_sp'
       fingerprint: '08:79:F5:B1:B8:CC:EC:8F:5C:2A:58:03:30:14:C9:E6:F1:67:78:F1:97:E8:3A:88:EB:8E:70:92:25:D2:2F:32'
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
-      metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
       sp_initiated_login_url: 'http://localhost:4567/test/saml'
       assertion_consumer_logout_service_url: 'http://localhost:4567/slo_logout'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_sinatra_demo'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
-      metadata_url: 'http://localhost:3003/saml/metadata'
       acs_url: 'http://localhost:3003/auth/saml/callback'
       assertion_consumer_logout_service_url: 'http://localhost:3003/auth/saml/logout'
       sp_initiated_login_url: 'http://localhost:3003/login'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_rails_demo'
       agency: '18F'
       friendly_name: '18F Test Service Provider'
@@ -59,10 +68,10 @@ development:
         - email
 
     'https://dashboard.login.gov':
-      metadata_url: 'http://localhost:3001/users/auth/saml/metadata'
       acs_url: 'http://localhost:3001/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
       sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'identity_dashboard_cert'
 
 production:
@@ -72,74 +81,75 @@ production:
       acs_url: 'https://upaya-dev.18f.gov/test/saml/decode_assertion'
       assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
       sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
-      metadata_url: 'http://localhost:4567/saml/metadata'
       acs_url: 'http://localhost:4567/consume'
       sp_initiated_login_url: 'http://localhost:4567/test/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_sinatra_demo'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev':
-      metadata_url: 'https://sp-sinatra.dev.login.gov/saml/metadata'
       acs_url: 'https://sp-sinatra.dev.login.gov/consume'
       assertion_consumer_logout_service_url: 'https://sp-sinatra.dev.login.gov/slo_logout'
       sp_initiated_login_url: 'https://sp-sinatra.dev.login.gov/test/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_sinatra_demo'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo':
-      metadata_url: 'https://sp-sinatra.demo.login.gov/saml/metadata'
       acs_url: 'https://sp-sinatra.demo.login.gov/consume'
       assertion_consumer_logout_service_url: 'https://sp-sinatra.demo.login.gov/slo_logout'
       sp_initiated_login_url: 'https://sp-sinatra.demo.login.gov/test/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_sinatra_demo'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev':
-      metadata_url: 'https://identity-sp-rails-dev.apps.cloud.gov/saml/metadata'
       acs_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/logout'
       sp_initiated_login_url: 'https://identity-sp-rails-dev.apps.cloud.gov/login'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_rails_demo'
       attribute_bundle:
         - email
 
     'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo':
-      metadata_url: 'https://sp.demo.login.gov/saml/metadata'
       acs_url: 'https://sp.demo.login.gov/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://sp.demo.login.gov/auth/saml/logout'
       sp_initiated_login_url: 'https://sp.demo.login.gov/login'
+      block_encryption: 'aes256-cbc'
       cert: 'sp_rails_demo'
       attribute_bundle:
         - email
 
     # Dashboard
     'https://dashboard.demo.login.gov':
-      metadata_url: 'https://dashboard.demo.login.gov/users/auth/saml/metadata'
       acs_url: 'https://dashboard.demo.login.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://dashboard.demo.login.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://dashboard.demo.login.gov/users/auth/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'identity_dashboard_cert'
 
     'https://dashboard.qa.login.gov':
-      metadata_url: 'https://dashboard.qa.login.gov/users/auth/saml/metadata'
       acs_url: 'https://dashboard.qa.login.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://dashboard.qa.login.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://dashboard.qa.login.gov/users/auth/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'identity_dashboard_cert'
 
     'https://dashboard.dev.login.gov':
-      metadata_url: 'https://dashboard.dev.login.gov/users/auth/saml/metadata'
       acs_url: 'https://dashboard.dev.login.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://dashboard.dev.login.gov/users/auth/saml/logout'
       sp_initiated_login_url: 'https://dashboard.dev.login.gov/users/auth/saml'
+      block_encryption: 'aes256-cbc'
       cert: 'identity_dashboard_cert'
 
 superb.legit.domain.gov:
@@ -147,6 +157,7 @@ superb.legit.domain.gov:
     'urn:govheroku:serviceprovider':
       acs_url: 'https://vets.gov/users/auth/saml/callback'
       assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout'
+      block_encryption: 'aes256-cbc'
       cert: 'saml_test_sp'
       agency: 'test_agency'
       attribute_bundle:

--- a/lib/fingerprinter.rb
+++ b/lib/fingerprinter.rb
@@ -1,7 +1,6 @@
 class Fingerprinter
-  def self.fingerprint_cert(cert_pem)
-    return nil unless cert_pem
-    cert = OpenSSL::X509::Certificate.new(cert_pem)
-    OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest
+  def self.fingerprint_cert(ssl_cert)
+    return nil unless ssl_cert
+    OpenSSL::Digest::SHA256.new(ssl_cert.to_der).hexdigest
   end
 end

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -1,9 +1,6 @@
 require 'fingerprinter'
 
 class ServiceProvider
-  # currently acceptable encryption values are 'none' and 'aes256-cbc'
-  DEFAULT_ENCRYPTION = 'aes256-cbc'.freeze
-
   attr_reader :issuer
 
   def initialize(issuer)
@@ -11,95 +8,56 @@ class ServiceProvider
   end
 
   def metadata
-    ignored_methods = [:metadata, :encrypt_responses?, :encryption_opts, :issuer]
-    metadata_methods = self.class.instance_methods(false) - ignored_methods
-
-    @metadata ||= metadata_methods.inject({}) do |hash, method|
-      hash.merge(:"#{method}" => send(method))
-    end
-  end
-
-  def acs_url
-    sp_attributes['acs_url']
-  end
-
-  def assertion_consumer_logout_service_url
-    sp_attributes['assertion_consumer_logout_service_url']
-  end
-
-  def sp_initiated_login_url
-    sp_attributes['sp_initiated_login_url']
-  end
-
-  def metadata_url
-    sp_attributes['metadata_url']
-  end
-
-  def agency
-    sp_attributes['agency']
-  end
-
-  def friendly_name
-    sp_attributes['friendly_name']
-  end
-
-  def attribute_bundle
-    sp_attributes['attribute_bundle']
-  end
-
-  def cert
-    sp_cert = sp_attributes['cert']
-    return if sp_cert.blank?
-
-    cert_dir = "#{Rails.root}/certs/sp/"
-
-    @cert ||= File.read("#{cert_dir}#{sp_cert}.crt")
-  end
-
-  def block_encryption
-    sp_attributes['block_encryption'] || DEFAULT_ENCRYPTION
-  end
-
-  def key_transport
-    'rsa-oaep-mgf1p'
+    sp_attributes.merge(shared_attributes)
   end
 
   def encryption_opts
     return nil unless encrypt_responses?
     {
-      cert: OpenSSL::X509::Certificate.new(cert),
+      cert: ssl_cert,
       block_encryption: block_encryption,
-      key_transport: key_transport
+      key_transport: 'rsa-oaep-mgf1p'
     }
-  end
-
-  def fingerprint
-    @fingerprint ||= ::Fingerprinter.fingerprint_cert(cert)
-  end
-
-  def double_quote_xml_attribute_values
-    true
   end
 
   private
 
-  def config
-    @config ||= YAML.load_file("#{Rails.root}/config/service_providers.yml")
-
-    if Figaro.env.domain_name == 'superb.legit.domain.gov'
-      @config.merge!(@config.fetch('superb.legit.domain.gov', {}))
-    else
-      @config.merge!(@config.fetch(Rails.env, {}))
-    end
-
-    @config.symbolize_keys!
+  def sp_attributes
+    @sp_attributes ||= config.sp_attributes
   end
 
-  def sp_attributes
-    config[:valid_hosts].fetch(@issuer, {})
+  def config
+    ServiceProviderConfig.new(filename: 'service_providers.yml', issuer: issuer)
+  end
+
+  def shared_attributes
+    {
+      fingerprint: fingerprint
+    }
+  end
+
+  def ssl_cert
+    @ssl_cert ||= begin
+      sp_cert = sp_attributes[:cert]
+      return if sp_cert.blank?
+
+      cert_dir = "#{Rails.root}/certs/sp/"
+
+      cert_file = File.read("#{cert_dir}#{sp_cert}.crt")
+
+      OpenSSL::X509::Certificate.new(cert_file)
+    end
+  end
+
+  def fingerprint
+    @fingerprint ||= Fingerprinter.fingerprint_cert(ssl_cert)
   end
 
   def encrypt_responses?
     block_encryption != 'none'
+  end
+
+  def block_encryption
+    sp_attributes[:block_encryption]
   end
 end

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -8,7 +8,7 @@ class ServiceProvider
   end
 
   def metadata
-    sp_attributes.merge(shared_attributes)
+    sp_attributes.merge!(fingerprint: fingerprint)
   end
 
   def encryption_opts
@@ -27,13 +27,7 @@ class ServiceProvider
   end
 
   def config
-    ServiceProviderConfig.new(filename: 'service_providers.yml', issuer: issuer)
-  end
-
-  def shared_attributes
-    {
-      fingerprint: fingerprint
-    }
+    ServiceProviderConfig.new(issuer: issuer)
   end
 
   def ssl_cert

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -114,12 +114,6 @@ describe SamlIdpController do
     let(:xmldoc) { SamlResponseDoc.new('controller', 'response_assertion', response) }
 
     context 'with LOA3 and the identity is already verified' do
-      before do
-        allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
-          %w(first_name last_name ssn zipcode)
-        )
-      end
-
       it 'calls AttributeAsserter#build' do
         settings = loa3_saml_settings
         user = create(:user, :signed_up)
@@ -203,21 +197,24 @@ describe SamlIdpController do
     end
 
     describe 'HEAD /api/saml/auth', type: :request do
-      it 'responds with "400 Forbidden" with unknown bindings' do
+      it 'responds with "403 Forbidden"' do
         head '/api/saml/auth?SAMLRequest=bang!'
 
         expect(response.status).to eq(403)
       end
     end
 
-    context 'with invalid requests' do
-      it 'responds with "403 Forbidden" to GET requests without SAML request params' do
+    context 'with missing SAMLRequest params' do
+      it 'responds with "403 Forbidden"' do
         get :auth
+
         expect(response.status).to eq(403)
       end
+    end
 
-      it 'responds with a 403 error' do
-        get(:auth, SAMLRequest: 'bang!')
+    context 'with invalid SAMLRequest param' do
+      it 'responds with "403 Forbidden"' do
+        get :auth
 
         expect(response.status).to eq(403)
       end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -366,7 +366,7 @@ feature 'saml api', devise: true, sms: true do
 
         sp2 = ServiceProvider.new(sp2_saml_settings.issuer)
 
-        expect(current_url).to eq(sp2.assertion_consumer_logout_service_url)
+        expect(current_url).to eq(sp2.metadata[:assertion_consumer_logout_service_url])
         expect(user.active_identities.size).to eq(0)
 
         visit profile_path

--- a/spec/lib/fingerprinter_spec.rb
+++ b/spec/lib/fingerprinter_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'fingerprinter'
+
+describe Fingerprinter do
+  describe '.fingerprint_cert' do
+    context 'ssl_cert is nil' do
+      it 'returns nil' do
+        expect(Fingerprinter.fingerprint_cert(nil)).to be_nil
+      end
+    end
+
+    context 'ssl_cert is present' do
+      it 'returns a hexdigest of the cert' do
+        cert =
+          "-----BEGIN CERTIFICATE-----\n" \
+          "MIIDAjCCAeoCCQDnptBMGdfBIjANBgkqhkiG9w0BAQsFADBCMQswCQYDVQQGEwJV\n" \
+          "UzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2VhdHRsZTEMMAoGA1UE\n" \
+          "ChMDMThGMCAXDTE0MTAwODIzMzkzMVoYDzIxMDYwMTEyMjMzOTMxWjBCMQswCQYD\n" \
+          "VQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2VhdHRsZTEM\n" \
+          "MAoGA1UEChMDMThGMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1zps\n" \
+          "ODzA7AHnls/NaICXSuBjyRbmEmDsoAl6YC/3ljBfG8POZre5wTeSjkPaj/h70ai5\n" \
+          "DEWrG3PyEJ0D6QqwNjReChq3AFSSnPLZeRu11N4UVvScJwCpRMs2LD93BBfFy8VU\n" \
+          "SQIOsPdrpy9ct31aNzYhi7LF3GBgIwcwq3SLxaF+YYDbbGqHZ8XkjrQlQlRGOPc8\n" \
+          "dcKcl0azNqSP4jAp83sw2NsKNPgDpI3PCs3H4C2q0RV/V+A4EIXi/3brAmnwKSOA\n" \
+          "JZ2ZAUIjHkv/Y1kk1TzAcy6s/V5f5Mxb4BjXxdAB18umI+EnfHLupV2fScOYY833\n" \
+          "AHSpuBiY+b7UfYPU5QIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCrjv4rCw3Qhpyv\n" \
+          "konOP/Yufxj/SwkaZdanJCnbOvndRk2qO57FQU9qPwUJOu8kws8Xat+A+4ow2hQl\n" \
+          "C0b4OlifwrYcnBK/hDOcMOOH/d8na2bzOSg7lkHMOK3luELxPqsnkrszwtqAYs6K\n" \
+          "cLk2AEacrkAG0DVfOqYOGtUGUrx5QDYutX2kz24VcZ10so4IfRYI4EJX/tF46lqy\n" \
+          "dp6KaRxeVNQo21CGhfzeBSqgd0tRicu9uHzI57nxCLIzSQoLT5c6geCl5LJ7DxS2\n" \
+          "kaNiHglqe6GyLbbp3Y5q45xyBGPtJVT6kR6XqK4sEJPRgznbDn2NDx0Ef9mxHdVP\n" \
+          "e0sZY2CS\n-----END CERTIFICATE-----\n"
+
+        ssl_cert = OpenSSL::X509::Certificate.new(cert)
+
+        digest = instance_double(OpenSSL::Digest::SHA256)
+        expect(OpenSSL::Digest::SHA256).to receive(:new).with(ssl_cert.to_der).and_return(digest)
+        expect(digest).to receive(:hexdigest)
+
+        Fingerprinter.fingerprint_cert(ssl_cert)
+      end
+    end
+  end
+end

--- a/spec/lib/fingerprinter_spec.rb
+++ b/spec/lib/fingerprinter_spec.rb
@@ -1,5 +1,4 @@
-require 'spec_helper'
-require 'fingerprinter'
+require 'rails_helper'
 
 describe Fingerprinter do
   describe '.fingerprint_cert' do

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -12,7 +12,13 @@ describe AttributeAsserter do
       last_authenticated_at: Time.current
     )
   end
-  let(:service_provider) { ServiceProvider.new(sp1_saml_settings.issuer) }
+  let(:service_provider) do
+    instance_double(
+      ServiceProvider,
+      issuer: 'http://localhost:3000',
+      metadata: {}
+    )
+  end
   let(:raw_authn_request) { URI.decode loa3_authnrequest.split('SAMLRequest').last }
   let(:authn_request) do
     SamlIdp::Request.from_deflated_request(raw_authn_request)
@@ -25,9 +31,8 @@ describe AttributeAsserter do
       context 'custom bundle includes email, phone' do
         before do
           user.identities << identity
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
-            %w(email phone first_name)
-          )
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+            and_return(%w(email phone first_name))
           subject.build
         end
 
@@ -50,7 +55,8 @@ describe AttributeAsserter do
 
       context 'Service Provider does not specify bundle' do
         before do
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(nil)
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+            and_return(nil)
           subject.build
         end
 
@@ -80,7 +86,8 @@ describe AttributeAsserter do
 
       context 'Service Provider specifies empty bundle' do
         before do
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return([])
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+            and_return([])
           subject.build
         end
 
@@ -91,7 +98,7 @@ describe AttributeAsserter do
 
       context 'custom bundle has invalid attribute name' do
         before do
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
             %w(email foo)
           )
           subject.build
@@ -109,7 +116,7 @@ describe AttributeAsserter do
 
       context 'custom bundle does not include email, phone' do
         before do
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
             %w(first_name last_name)
           )
           subject.build
@@ -126,7 +133,7 @@ describe AttributeAsserter do
 
       context 'custom bundle includes email, phone' do
         before do
-          allow_any_instance_of(ServiceProvider).to receive(:attribute_bundle).and_return(
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
             %w(first_name last_name email phone)
           )
           subject.build

--- a/spec/services/service_provider_config_spec.rb
+++ b/spec/services/service_provider_config_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe ServiceProviderConfig do
+  describe '#sp_attributes' do
+    context 'when the domain_name is superb.legit.domain.gov' do
+      it 'returns the issuer attributes for the superb.legit.domain.gov entry in the YAML file' do
+        allow(Figaro.env).to receive(:domain_name).and_return('superb.legit.domain.gov')
+
+        config = ServiceProviderConfig.new(
+          filename: 'service_providers.yml', issuer: 'urn:govheroku:serviceprovider'
+        )
+
+        yaml_hash = {
+          acs_url: 'https://vets.gov/users/auth/saml/callback',
+          assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout',
+          block_encryption: 'aes256-cbc',
+          cert: 'saml_test_sp',
+          agency: 'test_agency',
+          attribute_bundle: %w(email phone)
+        }
+
+        expect(config.sp_attributes).to eq yaml_hash
+      end
+    end
+
+    context 'when the domain_name is not superb.legit.domain.gov' do
+      it 'returns the issuer attributes for the Rails.env entry in the YAML file' do
+        config = ServiceProviderConfig.new(
+          filename: 'service_providers.yml', issuer: 'http://test.host'
+        )
+
+        yaml_hash = {
+          acs_url: 'http://test.host/test/saml/decode_assertion',
+          block_encryption: 'aes256-cbc',
+          metadata_url: 'http://test.host/test/saml/metadata',
+          sp_initiated_login_url: 'http://test.host/test/saml'
+        }
+
+        expect(config.sp_attributes).to eq yaml_hash
+      end
+    end
+  end
+end

--- a/spec/services/service_provider_config_spec.rb
+++ b/spec/services/service_provider_config_spec.rb
@@ -3,12 +3,18 @@ require 'rails_helper'
 describe ServiceProviderConfig do
   describe '#sp_attributes' do
     context 'when the domain_name is superb.legit.domain.gov' do
-      it 'returns the issuer attributes for the superb.legit.domain.gov entry in the YAML file' do
+      before do
         allow(Figaro.env).to receive(:domain_name).and_return('superb.legit.domain.gov')
+        ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env
+      end
 
-        config = ServiceProviderConfig.new(
-          filename: 'service_providers.yml', issuer: 'urn:govheroku:serviceprovider'
-        )
+      after do
+        allow(Figaro.env).to receive(:domain_name).and_return('')
+        ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env
+      end
+
+      it 'returns the issuer attributes for the superb.legit.domain.gov entry in the YAML file' do
+        config = ServiceProviderConfig.new(issuer: 'urn:govheroku:serviceprovider')
 
         yaml_hash = {
           acs_url: 'https://vets.gov/users/auth/saml/callback',
@@ -25,9 +31,7 @@ describe ServiceProviderConfig do
 
     context 'when the domain_name is not superb.legit.domain.gov' do
       it 'returns the issuer attributes for the Rails.env entry in the YAML file' do
-        config = ServiceProviderConfig.new(
-          filename: 'service_providers.yml', issuer: 'http://test.host'
-        )
+        config = ServiceProviderConfig.new(issuer: 'http://test.host')
 
         yaml_hash = {
           acs_url: 'http://test.host/test/saml/decode_assertion',

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -31,11 +31,15 @@ module SamlAuthHelper
   end
 
   def sp_fingerprint
-    @sp_fingerprint ||= Fingerprinter.fingerprint_cert(saml_test_sp_cert)
+    @sp_fingerprint ||= Fingerprinter.fingerprint_cert(
+      OpenSSL::X509::Certificate.new(saml_test_sp_cert)
+    )
   end
 
   def idp_fingerprint
-    @idp_fingerprint ||= Fingerprinter.fingerprint_cert(saml_test_idp_cert)
+    @idp_fingerprint ||= Fingerprinter.fingerprint_cert(
+      OpenSSL::X509::Certificate.new(saml_test_idp_cert)
+    )
   end
 
   def saml_test_sp_key


### PR DESCRIPTION
**Why**: To simplify it and remove unused code. The main purpose of
this class is to provide a hash of service provider attributes based
on the contents of the `service_providers.yml` file. This means that
all we need to do is parse the file, symbolize the keys, process some
of the values, such as the cert, and generate a fingerprint from the
cert.

The only instance methods needed are `metadata`, which returns the
hash of attributes, and `encryption opts`. All the instance methods
based on the YAML keys that we used to have are not needed. They were
never called (or didn't need to be called) directly. I'm not sure what
I was thinking when I wrote that code. Note that `encryption_opts`
could be merged into the `metadata` hash as well, but it's much easier
to test when it's a separate method.

**How**:
- Remove all instance methods based on YAML file keys.
- To return the proper hash in the `metadata` method, parse the YAML
file, symbolize the keys, and merge any other attributes that aren't
read from the YAML file, such as the fingerprint.
- Make the `block_encryption` key required in the YAML file as opposed
to using a conditional in the code.
- Remove `metadata_url` entries from the YAML file since those are not
used. None of those URLs exist.
- Pass in the `OpenSSL::X509::Certificate` instance of the cert to the
Fingerprinter class, as opposed to creating two instances, one in the
ServiceProvider class, and one in the Fingerprinter class.
- Raise an error if the issuer is invalid (i.e not present in the YAML
file).