### PR TITLE
Make JS session timeout test less brittle

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -147,12 +147,12 @@ feature 'Sign in' do
 
   context 'signed in, session times out, sign back in', js: true do
     it 'prompts to enter OTP' do
-      allow(Rails.application.config).to receive(:session_check_frequency).and_return(0.01)
-      allow(Rails.application.config).to receive(:session_check_delay).and_return(0.01)
+      allow(Rails.application.config).to receive(:session_check_frequency).and_return(1)
+      allow(Rails.application.config).to receive(:session_check_delay).and_return(1)
       allow(Devise).to receive(:timeout_in).and_return(1.second)
 
       user = sign_in_and_2fa_user
-      Timecop.travel(1.minute)
+      sleep 3
       visit '/'
 
       fill_in 'Email', with: user.email
@@ -160,7 +160,6 @@ feature 'Sign in' do
       click_button 'Log in'
 
       expect(current_path).to eq user_two_factor_authentication_path
-      Timecop.return
     end
   end
 


### PR DESCRIPTION
**Why**: To eliminate intermittent failures.

**How**: Set the delay and frequency to 1 second, and sleep for 3
seconds to ensure the session has timed out. `sleep` is generally
discouraged, but I can't think of a more robust way to test this.