### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -27,7 +27,7 @@ module Devise
 
     def authorize_otp_setup
       if user_fully_authenticated?
-        redirect_to(request.referrer || root_url)
+        redirect_to(request.referer || root_url)
       elsif resource.two_factor_enabled?
         redirect_to user_two_factor_authentication_path
       end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,8 +1,8 @@
 class Profile < ActiveRecord::Base
   belongs_to :user
 
-  validates_uniqueness_of :active, scope: :user_id, if: :active?
-  validates_uniqueness_of :ssn, scope: :active, if: :active?
+  validates :active, uniqueness: { scope: :user_id, if: :active? }
+  validates :ssn, uniqueness: { scope: :active, if: :active? }
 
   scope :active, -> { where(active: true) }
   scope :verified, -> { where.not(verified_at: nil) }

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -181,7 +181,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       before do
         sign_in_before_2fa
         subject.current_user.update(
-          second_factor_locked_at: Time.zone.now - Devise.direct_otp_valid_for - 1.seconds,
+          second_factor_locked_at: Time.zone.now - Devise.direct_otp_valid_for - 1.second,
           second_factor_attempts_count: 3
         )
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
 
     trait :with_phone do
       phone '+1 (202) 555-1212'
-      phone_confirmed_at Time.new
+      phone_confirmed_at Time.zone.now
     end
 
     trait :admin do

--- a/spec/support/features/active_job_helper.rb
+++ b/spec/support/features/active_job_helper.rb
@@ -5,14 +5,6 @@ module Features
       adapter.performed_jobs = []
     end
 
-    def enqueued_jobs
-      adapter.enqueued_jobs
-    end
-
-    def performed_jobs
-      adapter.performed_jobs
-    end
-
     def adapter
       ActiveJob::Base.queue_adapter
     end

--- a/spec/support/totp_helper.rb
+++ b/spec/support/totp_helper.rb
@@ -1,3 +1,3 @@
 def generate_totp_code(secret)
-  ROTP::TOTP.new(secret).at(Time.now, true)
+  ROTP::TOTP.new(secret).at(Time.zone.now, true)
 end


### PR DESCRIPTION
**Why**: We had some lingering Rails-specific offenses that you can
check for by adding the `-R` flag, as in `rubocop -R`.