### PR TITLE
Add explicit sign_out in /users/sessions/timeout

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,16 +2,7 @@ module Users
   class SessionsController < Devise::SessionsController
     include ::ActionView::Helpers::DateHelper
 
-    prepend_before_action :skip_timeout, only: [:active]
     skip_before_action :session_expires_at, only: [:active]
-
-    def skip_timeout
-      request.env['devise.skip_trackable'] = true
-    end
-
-    def new
-      super
-    end
 
     def create
       track_authentication_attempt(params[:user][:email])
@@ -20,17 +11,29 @@ module Users
 
     def active
       response.headers['Etag'] = '' # clear etags to prevent caching
-      render json: { live: current_user.present?, timeout: session[:session_expires_at] }
+      Rails.logger.debug("alive?:#{alive?} expires_at:#{expires_at} now:#{Time.zone.now}")
+      render json: { live: alive?, timeout: expires_at }
     end
 
     def timeout
-      analytics.track_anonymous_event('Session Timed Out')
-
-      flash[:timeout] = t('session_timedout')
+      if sign_out
+        analytics.track_anonymous_event('Session Timed Out')
+        flash[:timeout] = t('session_timedout')
+      end
       redirect_to root_url
     end
 
     private
+
+    def expires_at
+      @_expires_at ||= (session[:session_expires_at] || (Time.zone.now - 1))
+    end
+
+    def alive?
+      return false unless session && expires_at
+      session_alive = expires_at > Time.zone.now
+      current_user.present? && session_alive
+    end
 
     def track_authentication_attempt(email)
       existing_user = User.find_by_email(email)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -147,10 +147,10 @@ feature 'Sign in' do
     it 'prompts to enter OTP' do
       allow(Rails.application.config).to receive(:session_check_frequency).and_return(1)
       allow(Rails.application.config).to receive(:session_check_delay).and_return(1)
-      allow(Devise).to receive(:timeout_in).and_return(1.second)
+      allow(Devise).to receive(:timeout_in).and_return(2.seconds)
 
       user = sign_in_user(create(:user, :signed_up))
-      sleep 3
+      sleep 4
       visit '/'
 
       fill_in 'Email', with: user.email


### PR DESCRIPTION
**Why**: Devise was not always signing out the current_user
in sync with session[:session_expires_at]. The explicit
sign_out call prevents automatic session extension on redirect
to root_path.