### PR TITLE
Don't use Warden for session timeout tests

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -151,7 +151,7 @@ feature 'Sign in' do
       allow(Rails.application.config).to receive(:session_check_delay).and_return(1)
       allow(Devise).to receive(:timeout_in).and_return(1.second)
 
-      user = sign_in_and_2fa_user
+      user = sign_in_user(create(:user, :signed_up))
       sleep 3
       visit '/'
 


### PR DESCRIPTION
**Why**: I believe we need to simulate an actual sign in event to
properly test session timeout with a JS driver.