### PR TITLE
Cleanup phone confirmation event tracking

### DIFF
--- a/app/controllers/concerns/phone_confirmation_flow.rb
+++ b/app/controllers/concerns/phone_confirmation_flow.rb
@@ -12,10 +12,8 @@ module PhoneConfirmationFlow
 
   def confirm
     if params['code'] == confirmation_code
-      analytics.track_event('User confirmed their phone number')
       process_valid_code
     else
-      analytics.track_event('User entered invalid phone confirmation code')
       process_invalid_code
     end
   end
@@ -32,6 +30,7 @@ module PhoneConfirmationFlow
   end
 
   def process_invalid_code
+    analytics.track_event('User entered invalid phone confirmation code')
     flash[:error] = t('errors.invalid_confirmation_code')
     redirect_to this_phone_confirmation_path
   end

--- a/app/controllers/idv/phone_confirmation_controller.rb
+++ b/app/controllers/idv/phone_confirmation_controller.rb
@@ -27,20 +27,8 @@ module Idv
     end
 
     def assign_phone
-      if current_active_profile && unconfirmed_phone != current_active_profile.phone
-        track_existing_phone_change
-      end
+      analytics.track_event('User confirmed their verified phone number')
       idv_params['phone_confirmed_at'] = Time.current
-    end
-
-    def current_active_profile
-      current_user.active_profile
-    end
-
-    def track_existing_phone_change
-      old_phone = current_active_profile.phone
-      analytics.track_event('User changed and confirmed their verified phone number')
-      SmsSenderNumberChangeJob.perform_later(old_phone)
     end
 
     def after_confirmation_path

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -33,11 +33,12 @@ module Users
       old_phone = current_user.phone
       @updating_existing_number = old_phone.present?
       if @updating_existing_number
-        analytics.track_event('User changed and confirmed their phone number')
+        analytics.track_event('User changed their phone number')
         SmsSenderNumberChangeJob.perform_later(old_phone)
+      else
+        analytics.track_event('User confirmed their phone number')
       end
-      current_user.update(phone: unconfirmed_phone,
-                          phone_confirmed_at: Time.current)
+      current_user.update(phone: unconfirmed_phone, phone_confirmed_at: Time.current)
     end
 
     def after_confirmation_path

--- a/spec/controllers/idv/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/idv/phone_confirmation_controller_spec.rb
@@ -115,11 +115,10 @@ describe Idv::PhoneConfirmationController, devise: true do
         end
       end
 
-      it 'tracks the update and confirmation event' do
+      it 'tracks the confirmation event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('User confirmed their phone number')
         expect(@analytics).to receive(:track_event).
-          with('User changed and confirmed their verified phone number')
+          with('User confirmed their verified phone number')
 
         post :confirm, code: '123'
       end

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -113,11 +113,9 @@ describe Users::PhoneConfirmationController, devise: true do
         end
       end
 
-      it 'tracks the update and confirmation event' do
+      it 'tracks the update event' do
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('User confirmed their phone number')
-        expect(@analytics).to receive(:track_event).
-          with('User changed and confirmed their phone number')
+        expect(@analytics).to receive(:track_event).with('User changed their phone number')
 
         post :confirm, code: '123'
       end


### PR DESCRIPTION
**Why**: We were previously generating two different events
when the user confirmed their phone and they already had
one on record.  Instead we want to track a single event
which is either an initial confirmation or an update.

Also, while making this change I notices we were
pointlessly handling this distinction in the IdV phone
confirmation.