### PR TITLE
Fix page reflow on idv intro

### DIFF
--- a/app/views/idv/index.html.slim
+++ b/app/views/idv/index.html.slim
@@ -5,7 +5,7 @@ h1.heading = t('idv.titles.expectations')
 
 .mt3.mb3.overflow-hidden.border-bottom
   .left.pr1.sm-pr2
-    = image_tag(asset_url('circle-1.svg'), alt: '1')
+    = image_tag(asset_url('circle-1.svg'), width: 30, alt: '1')
   .overflow-hidden
     div
       | Please have the following basic information
@@ -19,7 +19,7 @@ h1.heading = t('idv.titles.expectations')
 
 .mb3.overflow-hidden.border-bottom
   .left.pr1.sm-pr2
-    = image_tag(asset_url('circle-2.svg'), alt: '2')
+    = image_tag(asset_url('circle-2.svg'), width: 30, alt: '2')
   .overflow-hidden
     div
       | Additionally, we need a number from
@@ -36,7 +36,7 @@ h1.heading = t('idv.titles.expectations')
 
 .mb3.overflow-hidden.border-bottom
   .left.pr1.sm-pr2
-    = image_tag(asset_url('circle-3.svg'), alt: '3')
+    = image_tag(asset_url('circle-3.svg'), width: 30, alt: '3')
   .overflow-hidden
     div Finally, we need your official phone number which can be:
     ul.mt2.mb3.red-dots


### PR DESCRIPTION
**Why**: content was sometimes jumping to the right
before number images finished loading; setting image width
attributes solves this ([reference](https://www.codecaptain.io/blog/web-development/responsive-images-and-preventing-page-reflow/474))