### PR TITLE
Minor deploy fixes

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,6 +2,7 @@
 # GLOBAL CONFIG
 #################
 set :application, 'idp'
+set :assets_roles, [:web, :worker]
 # set branch based on env var or ask with the default set to the current local branch
 set :branch, ENV['branch'] || ENV['BRANCH'] || ask(:branch, `git branch`.match(/\* (\S+)\s/m)[1])
 set :bundle_without, 'deploy development doc test'
@@ -16,7 +17,7 @@ set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public
 set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-idp.git'
 set :sidekiq_options, ''
-set :sidekiq_queue, [:mailers, :sms, :voice, :analytics]
+set :sidekiq_queue, [:analytics, :mailers, :sms, :voice]
 set :sidekiq_monit_use_sudo, true
 set :sidekiq_user, 'ubuntu'
 set :ssh_options, forward_agent: false, user: 'ubuntu'

--- a/config/deploy/templates/sidekiq_monit.erb
+++ b/config/deploy/templates/sidekiq_monit.erb
@@ -7,10 +7,3 @@ check process <%= sidekiq_service_name(idx) %>
   stop program = "/bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" as uid ubuntu and gid ubuntu with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq
 <% end %>
-
-# check process sidekiq_idp_production0
-#   with pidfile "/var/www/idp/shared/tmp/pids/sidekiq-0.pid"
-#   start program = "/bin/bash -c 'cd /var/www/idp/current && /opt/ruby_build/builds/2.3.1/bin/bundle exec sidekiq  --index 0 --pidfile /var/www/idp/shared/tmp/pids/sidekiq-0.pid --environment production  --logfile /var/www/idp/shared/log/sidekiq.log --queue mailers --queue sms --queue analytics'" as uid ubuntu and gid ubuntu with timeout 30 seconds
-# 
-#   stop program = "/bin/bash -c 'cd /var/www/idp/current && /opt/ruby_build/builds/2.3.1/bin/bundle exec sidekiqctl stop /var/www/idp/shared/tmp/pids/sidekiq-0.pid'" as uid ubuntu and gid ubuntu with timeout 20 seconds
-#   group idp-sidekiq


### PR DESCRIPTION
Override the assets_roles var to include the worker host

__Why__
Although it's a worker host it still needs to compile assets in order to send
html formatted email.

__How__
Override the default values for asset_roles used by capistrano-rails to include
the worker host.

This also removes the commented portion of the sidekiq monit config template. Eventually we can remove that piece all together since we have chef handling that part now.