### PR TITLE
Symlink New Relic config across deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,6 +12,7 @@ set :keep_releases, 5
 set :linked_files, %w(certs/saml.crt
                       config/application.yml
                       config/database.yml
+                      config/newrelic.yml
                       keys/saml.key.enc)
 set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
 set :rails_env, :production


### PR DESCRIPTION
__Why__
This is needed to add the .gitignored New Relic config to the remote server across deploys.

__How__
Add to Capistrano's list of linked files.