### PR TITLE
Limit number of history events stored per user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,14 @@ class ApplicationController < ActionController::Base
   end
 
   def create_user_event(event_type, user = current_user)
-    Event.create(user_id: user.id, event_type: event_type)
+    Event.transaction do
+      Event.create!(user_id: user.id, event_type: event_type)
+      # Keep total number of events per user under MAX_EVENTS_PER_USER
+      events = Event.where(user_id: user.id).order('created_at ASC')
+      if events.count > Event::MAX_EVENTS_PER_USER
+        events.first.destroy
+      end
+    end
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 class Event < ActiveRecord::Base
   belongs_to :user
 
+  MAX_EVENTS_PER_USER = 10
+
   enum event_type: {
     account_created: 1,
     phone_confirmed: 2,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -206,5 +206,17 @@ describe ApplicationController do
         subject.create_user_event(:account_created, user)
       end
     end
+
+    it 'limits the number of events per user' do
+      real_user = build(:user)
+      real_user.save!
+      allow(subject).to receive(:current_user).and_return(real_user)
+      (0..Event::MAX_EVENTS_PER_USER*2).each do |i|
+        subject.create_user_event(:account_created)
+      end
+
+      events = Event.where(user_id: real_user.id)
+      expect(events.count).to eq(Event::MAX_EVENTS_PER_USER)
+    end
   end
 end


### PR DESCRIPTION
**Why** We don't want this table to grow unbounded
or create a UI for multiple pages of events.