### PR TITLE
Let users update their password while signed in

### DIFF
--- a/.reek
+++ b/.reek
@@ -58,6 +58,7 @@ UtilityFunction:
       - raw_xml_response
       - sign_in_user
       - stub_auth
+      - stub_sign_in
   FeatureEnvy:
     enabled: false
   NestedIterators:

--- a/app/assets/javascripts/app/pw-toggle.js
+++ b/app/assets/javascripts/app/pw-toggle.js
@@ -1,23 +1,27 @@
 function togglePw() {
-  const input = document.querySelectorAll('input[type="password"]')[0];
+  const inputs = document.querySelectorAll('input[type="password"]');
 
-  if (input) {
-    input.parentNode.className += ' relative';
+  if (inputs) {
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i];
 
-    const el = `
-      <div class="top-0 right-0 absolute">
-        <label class="checkbox">
-          <input id="pw-toggle" type="checkbox">
-          <span class="indicator"></span>
-          Show password
-        </label>
-      </div>`;
-    input.insertAdjacentHTML('afterend', el);
+      input.parentNode.className += ' relative';
 
-    const toggle = document.getElementById('pw-toggle');
-    toggle.addEventListener('change', function() {
-      input.type = toggle.checked ? 'text' : 'password';
-    });
+      const el = `
+        <div class="top-0 right-0 absolute">
+          <label class="checkbox">
+            <input id="pw-toggle-${i}" type="checkbox">
+            <span class="indicator"></span>
+            Show password
+          </label>
+        </div>`;
+      input.insertAdjacentHTML('afterend', el);
+
+      const toggle = document.getElementById(`pw-toggle-${i}`);
+      toggle.addEventListener('change', function() {
+        input.type = toggle.checked ? 'text' : 'password';
+      });
+    }
   }
 }
 

--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -32,7 +32,9 @@ function getFeedback(z) {
 
 
 function analyzePw() {
-  const input = document.getElementById('password_form_password');
+  const input = document.querySelector(
+    '#password_form_password, #update_user_password_form_password'
+  );
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');
   const pwFeedback = document.getElementById('pw-strength-feedback');

--- a/app/controllers/users/edit_password_controller.rb
+++ b/app/controllers/users/edit_password_controller.rb
@@ -1,0 +1,37 @@
+module Users
+  class EditPasswordController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    def edit
+      @update_user_password_form = UpdateUserPasswordForm.new(current_user)
+    end
+
+    def update
+      @update_user_password_form = UpdateUserPasswordForm.new(current_user)
+
+      result = @update_user_password_form.submit(user_params)
+
+      analytics.track_event(:password_change, result)
+
+      if result[:success?]
+        handle_success
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def user_params
+      params.require(:update_user_password_form).permit(:password, :current_password)
+    end
+
+    def handle_success
+      bypass_sign_in current_user
+
+      redirect_to profile_url, notice: t('notices.password_changed')
+
+      EmailNotifier.new(current_user).send_password_changed_email
+    end
+  end
+end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -1,0 +1,39 @@
+class UpdateUserPasswordForm
+  include ActiveModel::Model
+  include FormPasswordValidator
+
+  validates :current_password, presence: true
+  validate :verify_current_password
+
+  def initialize(user)
+    @user = user
+  end
+
+  def submit(params)
+    self.password = params[:password]
+    self.current_password = params[:current_password]
+
+    @success = valid? && user.update_with_password(params)
+
+    result
+  end
+
+  private
+
+  attr_reader :user, :success
+
+  attr_accessor :password, :current_password
+
+  def verify_current_password
+    return if user.valid_password?(current_password)
+
+    errors.add(:current_password, I18n.t('errors.incorrect_password'))
+  end
+
+  def result
+    {
+      success?: success,
+      errors: errors.full_messages
+    }
+  end
+end

--- a/app/services/email_notifier.rb
+++ b/app/services/email_notifier.rb
@@ -1,6 +1,6 @@
 EmailNotifier = Struct.new(:user) do
   def send_password_changed_email
-    UserMailer.password_changed(user).deliver_later if password_changed?
+    UserMailer.password_changed(user).deliver_later
   end
 
   def send_email_changed_email
@@ -8,10 +8,6 @@ EmailNotifier = Struct.new(:user) do
   end
 
   private
-
-  def password_changed?
-    changed_attributes.fetch('encrypted_password', false)
-  end
 
   def email_changed?
     changed_attributes.fetch('email', false)

--- a/app/views/devise/confirmations/show.html.slim
+++ b/app/views/devise/confirmations/show.html.slim
@@ -2,7 +2,8 @@
 
 
 h1.heading = t('forms.confirmation.show_hdr')
-p.m0.italic#password-description Your password must be at least 8 characters.
+p.m0.italic#password-description
+  = t('instructions.edit_info.password', min_length: Devise.password_length.first)
 = simple_form_for(@password_form,
     url: confirm_path,
     method: :patch,

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -35,13 +35,18 @@
 
 h2.heading = t('headings.profile.login_info')
 .mt3.mb4
-  .py-12p.border-bottom.border-top
+  .py-12p.border-top
     .clearfix.mxn1
       .sm-col.sm-col-5.px1 = 'Email address'
       .sm-col.sm-col-5.px1.truncate = current_user.email
       .sm-col.sm-col-2.px1.sm-right-align
         = link_to 'Edit', edit_email_path, \
           class: btn_cls
+  .py-12p.border-top.border-bottom
+    .clearfix.mxn1
+      .sm-col.sm-col-10.px1 = 'Password'
+      .sm-col.sm-col-2.px1.sm-right-align
+        = link_to 'Edit', settings_password_path, class: btn_cls
   .mt3.mb1.h6.bold.caps.ls-0
     | #{t('headings.profile.two_factor')}#{tooltip(t('tooltips.placeholder'))}
   .py-12p.border-top

--- a/app/views/users/edit_password/edit.html.slim
+++ b/app/views/users/edit_password/edit.html.slim
@@ -1,0 +1,16 @@
+- title t('titles.edit_info.password')
+
+h1.heading = t('headings.edit_info.password')
+p.m0.italic#password-description
+  = t('instructions.edit_info.password', min_length: Devise.password_length.first)
+= simple_form_for(@update_user_password_form, url: settings_password_path,
+    html: { autocomplete: 'off', method: :patch, role: 'form' }) do |f|
+  = f.error_notification
+  = f.input :current_password, required: true
+  = f.input :password, label: 'New Password', required: true,
+            input_html: { 'aria-describedby': 'password-description' }
+  = render 'devise/shared/password_strength'
+  = f.button :submit, 'Update', class: 'mt2 mb1'
+= link_to 'Cancel', :back, class: 'underline'
+
+== javascript_include_tag 'misc/pw-strength'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   errors:
+    incorrect_password: is incorrect
     invalid_totp: Invalid code entered.  Please try again.
     not_authorized: You are not authorized to perform this action.
     invalid_authenticity_token: Oops, something went wrong. Please sign in again.
@@ -39,6 +40,10 @@ en:
     confirmation:
       show_hdr: Create a Password
 
+  instructions:
+    edit_info:
+      password: Your new password must be at least %{min_length} characters.
+
   links:
     resend: Resend
     sign_out: Sign out
@@ -53,11 +58,12 @@ en:
         text: Or, %{link}
         link_text: call me with the one-time passcode
   notices:
+    password_changed: Your password was successfully changed.
     totp_configured: Authenticator app successfully configured
     totp_disabled: Authenticator app disabled
     phone_confirmation_successful: Phone confirmation successful!
     password_reset: >
-      You will receive an email with instructions on how to reset your password 
+      You will receive an email with instructions on how to reset your password
       in a few minutes.
     send_code:
       voice: You will be called with your one-time passcode.
@@ -73,6 +79,7 @@ en:
       show: Create a password for your account
     edit_info:
       email: Edit your email
+      password: Edit your password
       phone: Edit your phone number
       confirm_phone: Confirm your phone number
     enter_2fa_code: Enter the secure one-time passcode
@@ -104,6 +111,7 @@ en:
       new: Resend confirmation instructions
     edit_info:
       email: Edit your email
+      password: Edit your password
       phone: Edit your phone number
     log_in: Log in
     choose_otp_delivery: Choose delivery method

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
   match '/edit/email' => 'users/edit_email#update', via: [:patch, :put]
   get '/edit/phone' => 'users/edit_phone#edit'
   match '/edit/phone' => 'users/edit_phone#update', via: [:patch, :put]
+  get '/settings/password' => 'users/edit_password#edit'
+  patch '/settings/password' => 'users/edit_password#update'
 
   get '/idv' => 'idv#index'
   get '/idv/cancel' => 'idv#cancel'

--- a/spec/controllers/users/edit_password_controller_spec.rb
+++ b/spec/controllers/users/edit_password_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+include Features::LocalizationHelper
+include Features::MailerHelper
+
+describe Users::EditPasswordController do
+  describe '#update' do
+    context 'form returns success' do
+      it 'redirects to profile and sends a password change email' do
+        stub_sign_in
+
+        user = controller.current_user
+
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        email_notifier = instance_double(EmailNotifier)
+        allow(EmailNotifier).to receive(:new).with(user).and_return(email_notifier)
+
+        expect(email_notifier).to receive(:send_password_changed_email)
+
+        params = { password: 'new password', current_password: 'password' }
+        patch :update, update_user_password_form: params
+
+        expect(@analytics).to have_received(:track_event).
+          with(:password_change, success?: true, errors: [])
+        expect(response).to redirect_to profile_url
+        expect(flash[:notice]).to eq t('notices.password_changed')
+      end
+    end
+
+    context 'form returns failure' do
+      it 'renders edit' do
+        stub_sign_in
+
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        expect(EmailNotifier).to_not receive(:new)
+
+        params = { password: 'new', current_password: 'current password' }
+        patch :update, update_user_password_form: params
+
+        errors = [
+          "Password #{t('errors.messages.too_short.other', count: Devise.password_length.first)}",
+          "Current password #{t('errors.incorrect_password')}"
+        ]
+
+        expect(@analytics).to have_received(:track_event).
+          with(:password_change, success?: false, errors: errors)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -53,9 +53,8 @@ feature 'Sign in' do
 
   scenario 'user can see and use password visibility toggle', js: true do
     visit new_user_session_path
-    expect(page).to have_css('#pw-toggle', visible: false)
 
-    find(:css, '#pw-toggle', visible: false).trigger('click')
+    find('#pw-toggle-0', visible: false).trigger('click')
 
     expect(page).to have_css('input.password[type="text"]')
   end

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -17,4 +17,30 @@ feature 'User profile' do
       expect(User.count).to eq 0
     end
   end
+
+  describe 'Editing the password' do
+    it 'includes the password strength indicator when JS is on', js: true do
+      user = sign_in_and_2fa_user
+      click_link 'Edit', href: settings_password_path
+
+      expect(page).to_not have_css('#pw-strength-cntnr.hide')
+      expect(page).to have_content '...'
+
+      fill_in 'update_user_password_form_current_password', with: user.password
+      expect(page).to_not have_content 'Weak'
+
+      fill_in 'update_user_password_form_password', with: 'this is a great sentence'
+      expect(page).to have_content 'Great'
+
+      find('#pw-toggle-0', visible: false).trigger('click')
+      find('#pw-toggle-1', visible: false).trigger('click')
+
+      expect(page).to_not have_css('input.password[type="password"]')
+      expect(page).to have_css('input.password[type="text"]')
+
+      click_button 'Update'
+
+      expect(current_path).to eq profile_path
+    end
+  end
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -181,10 +181,9 @@ feature 'Sign Up', devise: true do
     create(:user, :unconfirmed)
     confirm_last_user
 
-    expect(page).to have_css('#pw-toggle', visible: false)
     expect(page).to have_css('input.password[type="password"]')
 
-    find(:css, '#pw-toggle', visible: false).trigger('click')
+    find('#pw-toggle-0', visible: false).trigger('click')
 
     expect(page).to_not have_css('input.password[type="password"]')
     expect(page).to have_css('input.password[type="text"]')

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -3,39 +3,7 @@ require 'rails_helper'
 describe PasswordForm do
   subject { PasswordForm.new(build_stubbed(:user)) }
 
-  it do
-    is_expected.to validate_length_of(:password).
-      is_at_least(Devise.password_length.first)
-  end
-
-  it do
-    is_expected.to validate_length_of(:password).
-      is_at_most(Devise.password_length.last)
-  end
-
-  it do
-    is_expected.to allow_value('ValidPassword1!').for(:password)
-  end
-
-  it do
-    is_expected.to allow_value('ValidPassword1').for(:password)
-  end
-
-  it do
-    is_expected.to allow_value('validpassword1!').for(:password)
-  end
-
-  it do
-    is_expected.to allow_value('VALIDPASSWORD1!').for(:password)
-  end
-
-  it do
-    is_expected.to allow_value('ValidPASSWORD!').for(:password)
-  end
-
-  it do
-    is_expected.to allow_value('bear bull bat baboon').for(:password)
-  end
+  it_behaves_like 'password validation'
 
   it "is initialized with the user's reset_password_token" do
     user = build_stubbed(:user, reset_password_token: 'foo')

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe UpdateUserPasswordForm do
+  let(:user) { User.new(password: 'fancy password') }
+  subject { UpdateUserPasswordForm.new(user) }
+
+  it_behaves_like 'password validation'
+
+  describe '#submit' do
+    context 'when the form is valid but the current password is incorrect' do
+      it 'returns false' do
+        params = { password: 'new password', current_password: 'current password' }
+
+        result = subject.submit(params)
+
+        result_hash = {
+          success?: false,
+          errors: subject.errors.full_messages
+        }
+
+        expect(result).to eq result_hash
+      end
+    end
+
+    context 'when the form is invalid' do
+      it 'returns false' do
+        params = { password: 'new', current_password: 'fancy password' }
+
+        result = subject.submit(params)
+
+        result_hash = {
+          success?: false,
+          errors: subject.errors.full_messages
+        }
+
+        expect(result).to eq result_hash
+      end
+    end
+
+    context 'when both the form and user are valid' do
+      it 'sets the user password to the submitted password' do
+        params = { password: 'new password', current_password: 'fancy password' }
+
+        expect(subject.errors).to receive(:full_messages).and_call_original
+
+        result = subject.submit(params)
+
+        result_hash = {
+          success?: true,
+          errors: []
+        }
+
+        expect(result).to eq result_hash
+      end
+    end
+  end
+end

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -4,16 +4,6 @@ describe EmailNotifier do
   describe '#send_password_changed_email' do
     let(:mailer) { instance_double(ActionMailer::MessageDelivery) }
 
-    context 'when the password has not changed' do
-      it 'does not send an email' do
-        user = build_stubbed(:user, :signed_up)
-
-        expect(UserMailer).to_not receive(:password_changed).with(user)
-
-        EmailNotifier.new(user).send_password_changed_email
-      end
-    end
-
     context 'when the password has changed' do
       it 'sends an email notifiying the user of the password change' do
         user = create(:user, :signed_up)

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -24,6 +24,12 @@ module ControllerHelper
     controller.current_user.send_new_otp
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end
+
+  def stub_sign_in
+    user = User.new(password: 'password')
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/shared_examples_for_password_validation.rb
+++ b/spec/support/shared_examples_for_password_validation.rb
@@ -1,0 +1,39 @@
+shared_examples 'password validation' do
+  it do
+    is_expected.to validate_presence_of(:password).with_message("can't be blank")
+  end
+
+  it do
+    is_expected.to validate_length_of(:password).
+      is_at_least(Devise.password_length.first)
+  end
+
+  it do
+    is_expected.to validate_length_of(:password).
+      is_at_most(Devise.password_length.last)
+  end
+
+  it do
+    is_expected.to allow_value('ValidPassword1!').for(:password)
+  end
+
+  it do
+    is_expected.to allow_value('ValidPassword1').for(:password)
+  end
+
+  it do
+    is_expected.to allow_value('validpassword1!').for(:password)
+  end
+
+  it do
+    is_expected.to allow_value('VALIDPASSWORD1!').for(:password)
+  end
+
+  it do
+    is_expected.to allow_value('ValidPASSWORD!').for(:password)
+  end
+
+  it do
+    is_expected.to allow_value('bear bull bat baboon').for(:password)
+  end
+end

--- a/spec/views/users/edit_password/edit.html.slim_spec.rb
+++ b/spec/views/users/edit_password/edit.html.slim_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'users/edit_password/edit.html.slim' do
+  before do
+    user = User.new
+    allow(view).to receive(:current_user).and_return(user)
+    @update_user_password_form = UpdateUserPasswordForm.new(user)
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.edit_info.password'))
+
+    render
+  end
+
+  it 'has a localized heading' do
+    render
+
+    expect(rendered).to have_content t('headings.edit_info.password')
+  end
+
+  it 'sets form autocomplete to off' do
+    render
+
+    expect(rendered).to have_xpath("//form[@autocomplete='off']")
+  end
+
+  it 'contains minimum password length requirements' do
+    render
+
+    expect(rendered).to have_content t(
+      'instructions.edit_info.password', min_length: Devise.password_length.first
+    )
+  end
+end


### PR DESCRIPTION
**Why**: This is a required feature that we used to have when we used
a single form for updating various attributes. When we moved each
attribute to its own form, we only moved email and phone, so I'm
completing the move by adding a form for updating the password.