### PR TITLE
Speed up session timeout specs

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -16,7 +16,7 @@ describe Users::SessionsController, devise: true do
   describe 'GET /active' do
     context 'when user is present' do
       before do
-        sign_in_as_user
+        stub_sign_in
 
         get :active
       end
@@ -54,7 +54,7 @@ describe Users::SessionsController, devise: true do
 
     context 'when user is present' do
       it 'sets live key to true' do
-        sign_in_as_user
+        stub_sign_in
         session[:session_expires_at] = Time.current + 10
         get :active
 
@@ -64,7 +64,7 @@ describe Users::SessionsController, devise: true do
       end
 
       it 'respects session_expires_at' do
-        sign_in_as_user
+        stub_sign_in
         session[:session_expires_at] = Time.current - 1
         get :active
 
@@ -88,7 +88,7 @@ describe Users::SessionsController, devise: true do
     end
 
     it 'redirects to the homepage' do
-      sign_in_as_user
+      stub_sign_in
 
       get :timeout
 


### PR DESCRIPTION
**Why**: To shave a few seconds off our test suite

**How**:
- Use `stub_sign_in` to avoid creating a user in the DB in controller
specs that don't need it

- Check the request headers for the proper AJAX headers instead of
having a feature test with a sleep of 4 seconds. That spec was written
to test a bug that was due to not setting the proper AJAX headers.
If we can test that the headers are present, then we can be confident
the bug does not exist.