### PR TITLE
Rename current_otp_delivery_method -> current_otp_method

### DIFF
--- a/app/controllers/concerns/otp_delivery_fallback.rb
+++ b/app/controllers/concerns/otp_delivery_fallback.rb
@@ -11,29 +11,29 @@ module OtpDeliveryFallback
 
   def fallback_confirmation_link
     if sms_enabled?
-      otp_send_path(delivery_method: :voice)
+      otp_send_path(otp_method: :voice)
     else
-      otp_send_path(delivery_method: :sms)
+      otp_send_path(otp_method: :sms)
     end
   end
 
   def set_fallback_vars
     @fallback_confirmation_link = fallback_confirmation_link
     @sms_enabled = sms_enabled?
-    @current_otp_delivery_method = current_otp_delivery_method
+    @current_otp_method = current_otp_method
   end
 
   def sms_enabled?
-    current_otp_delivery_method == :sms
+    current_otp_method == :sms
   end
 
-  def current_otp_delivery_method
-    query_method = params[:delivery_method]
+  def current_otp_method
+    query_method = params[:otp_method]
     query_method.to_sym if
       %w(sms voice totp).include? query_method
   end
 
   def use_sms_or_voice_otp_delivery?
-    %i(sms voice).include? current_otp_delivery_method
+    %i(sms voice).include? current_otp_method
   end
 end

--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -1,12 +1,12 @@
 module PhoneConfirmation
-  def prompt_to_confirm_phone(phone, delivery_method = nil)
+  def prompt_to_confirm_phone(phone, otp_method = nil)
     user_session[:unconfirmed_phone] = phone
     # If the user selected delivery method, the code is sent and user is
     # prompted to confirm.
-    prompt_to_choose_delivery_method and return unless delivery_method
+    prompt_to_choose_delivery_method and return unless otp_method
 
     redirect_to phone_confirmation_send_path(
-      delivery_method: delivery_method
+      otp_method: otp_method
     )
   end
 

--- a/app/controllers/concerns/phone_confirmation_flow.rb
+++ b/app/controllers/concerns/phone_confirmation_flow.rb
@@ -72,18 +72,18 @@ module PhoneConfirmationFlow
     # user's session. Re-sending the confirmation code doesn't generate a new one.
     self.confirmation_code = generate_confirmation_code unless confirmation_code
 
-    if current_otp_delivery_method == :voice
+    if current_otp_method == :voice
       VoiceSenderOtpJob.perform_later(confirmation_code, unconfirmed_phone)
     else
       SmsSenderOtpJob.perform_later(confirmation_code, unconfirmed_phone)
     end
-    flash[:success] = t("notices.send_code.#{current_otp_delivery_method}")
+    flash[:success] = t("notices.send_code.#{current_otp_method}")
   end
 
   def set_fallback_vars
     @fallback_confirmation_link = fallback_confirmation_link
     @sms_enabled = sms_enabled?
-    @current_otp_delivery_method = current_otp_delivery_method
+    @current_otp_method = current_otp_method
   end
 
   def fallback_confirmation_link
@@ -112,11 +112,11 @@ module PhoneConfirmationFlow
   end
 
   def sms_enabled?
-    current_otp_delivery_method == :sms
+    current_otp_method == :sms
   end
 
-  def current_otp_delivery_method
-    query_method = params[:delivery_method]
+  def current_otp_method
+    query_method = params[:otp_method]
     query_method.to_sym if
       %w(sms voice totp).include? query_method
   end

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -32,9 +32,9 @@ module Devise
     end
 
     def send_code
-      analytics.track_event("User requested #{current_otp_delivery_method} OTP delivery")
+      analytics.track_event("User requested #{current_otp_method} OTP delivery")
       send_user_otp
-      flash[:success] = t("notices.send_code.#{current_otp_delivery_method}")
+      flash[:success] = t("notices.send_code.#{current_otp_method}")
     end
 
     def update
@@ -87,7 +87,7 @@ module Devise
     end
 
     def show_direct_otp_prompt
-      redirect_to otp_confirm_path(delivery_method: current_otp_delivery_method)
+      redirect_to otp_confirm_path(otp_method: current_otp_method)
     end
 
     def show_totp_prompt
@@ -124,7 +124,7 @@ module Devise
     end
 
     def prompt_for_otp_reentry
-      if current_otp_delivery_method == :totp
+      if current_otp_method == :totp
         show_totp_prompt
       else
         show_direct_otp_prompt
@@ -132,7 +132,7 @@ module Devise
     end
 
     def send_user_otp
-      current_user.send_new_otp(delivery_method: current_otp_delivery_method)
+      current_user.send_new_otp(otp_method: current_otp_method)
       show_direct_otp_prompt
     end
 

--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -37,7 +37,7 @@ module Devise
       update_metrics
       prompt_to_confirm_phone(
         @two_factor_setup_form.phone,
-        @two_factor_setup_form.delivery_method
+        @two_factor_setup_form.otp_method
       )
     end
 

--- a/app/controllers/idv/phone_confirmation_controller.rb
+++ b/app/controllers/idv/phone_confirmation_controller.rb
@@ -15,11 +15,11 @@ module Idv
     private
 
     def this_phone_confirmation_path
-      idv_phone_confirmation_path(delivery_method: current_otp_delivery_method)
+      idv_phone_confirmation_path(otp_method: current_otp_method)
     end
 
-    def this_send_confirmation_code_path(delivery_method)
-      idv_phone_confirmation_send_path(delivery_method: delivery_method)
+    def this_send_confirmation_code_path(otp_method)
+      idv_phone_confirmation_send_path(otp_method: otp_method)
     end
 
     def confirmation_code_session_key

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -19,12 +19,12 @@ module Users
 
     def this_phone_confirmation_path
       phone_confirmation_path(
-        delivery_method: current_otp_delivery_method
+        otp_method: current_otp_method
       )
     end
 
-    def this_send_confirmation_code_path(delivery_method)
-      phone_confirmation_send_path(delivery_method: delivery_method)
+    def this_send_confirmation_code_path(otp_method)
+      phone_confirmation_send_path(otp_method: otp_method)
     end
 
     def confirmation_code_session_key

--- a/app/forms/two_factor_setup_form.rb
+++ b/app/forms/two_factor_setup_form.rb
@@ -2,7 +2,7 @@ class TwoFactorSetupForm
   include ActiveModel::Model
   include FormPhoneValidator
 
-  attr_accessor :phone, :delivery_method
+  attr_accessor :phone, :otp_method
 
   def initialize(user)
     @user = user
@@ -12,7 +12,7 @@ class TwoFactorSetupForm
     self.phone = params[:phone].phony_formatted(
       format: :international, normalize: :US, spaces: ' '
     )
-    self.delivery_method = params[:voice].present? ? :voice : :sms
+    self.otp_method = params[:voice].present? ? :voice : :sms
 
     valid?
   end

--- a/app/services/user_otp_sender.rb
+++ b/app/services/user_otp_sender.rb
@@ -7,7 +7,7 @@ class UserOtpSender
     return if user_decorator.blocked_from_entering_2fa_code?
 
     phone_number = @user.phone
-    if options[:delivery_method] == :voice
+    if options[:otp_method] == :voice
       VoiceSenderOtpJob.perform_later(code, phone_number)
     else
       SmsSenderOtpJob.perform_later(code, phone_number)

--- a/app/views/devise/two_factor_authentication/confirm.html.slim
+++ b/app/views/devise/two_factor_authentication/confirm.html.slim
@@ -4,7 +4,7 @@ h1.heading = t('devise.two_factor_authentication.header_text')
 p Please enter the code sent to <strong>#{@phone_number}</strong>.
 
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form', class: 'mt4') do
-  = hidden_field_tag(:delivery_method, @current_otp_delivery_method)
+  = hidden_field_tag(:otp_method, @current_otp_method)
   = label_tag 'code', \
     raw(t('simple_form.required.html')) + t('forms.two_factor.code'), \
     class: 'block caps ls-05 bold'
@@ -15,4 +15,4 @@ p Please enter the code sent to <strong>#{@phone_number}</strong>.
 p.mt2.mb0
   = render 'users/phone_confirmation/phone_confirmation_fallback'
   p.mb0== "Didn't receive a code? #{link_to 'Resend',
-    otp_new_path(delivery_method: params[:delivery_method])}"
+    otp_new_path(otp_method: params[:otp_method])}"

--- a/app/views/devise/two_factor_authentication/confirm_totp.html.slim
+++ b/app/views/devise/two_factor_authentication/confirm_totp.html.slim
@@ -8,7 +8,7 @@ p
   '<strong>#{APP_NAME}</strong>.
 = form_tag([:user, :two_factor_authentication], method: :put, role: 'form') do
   .mb2
-    = hidden_field_tag(:delivery_method, :totp)
+    = hidden_field_tag(:otp_method, :totp)
     = label_tag 'code', raw(t('simple_form.required.html')) + t('forms.two_factor.code')
     = number_field_tag :code, '', class: 'block col-12 field mfa', required: true
   = submit_tag 'Submit', class: 'btn btn-primary'
@@ -16,9 +16,9 @@ p
 hr
 p
  - sms_link = link_to t('devise.two_factor_authentication.totp_fallback.' \
-    'sms_link_text'), otp_send_path(delivery_method: :sms)
+    'sms_link_text'), otp_send_path(otp_method: :sms)
  - voice_link = link_to t('devise.two_factor_authentication.totp_fallback.' \
-    'voice_link_text'), otp_send_path(delivery_method: :voice)
+    'voice_link_text'), otp_send_path(otp_method: :voice)
 
  == t('devise.two_factor_authentication.totp_fallback.text', sms_link: sms_link,
     voice_link: voice_link)

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -5,8 +5,8 @@ h1.heading = t('headings.choose_otp_delivery')
 p#2fa-description = t('devise.two_factor_authentication.choose_otp_delivery', phone: @phone_number)
 
 = button_to t('devise.two_factor_authentication.buttons.confirm_with_sms'),
-  otp_send_path, class: 'btn btn-primary mb2', method: :get, params: { delivery_method: :sms }
+  otp_send_path, class: 'btn btn-primary mb2', method: :get, params: { otp_method: :sms }
 = button_to t('devise.two_factor_authentication.buttons.confirm_with_voice'),
-  otp_send_path, class: 'btn btn-primary mb2', method: :get, params: { delivery_method: :voice }
+  otp_send_path, class: 'btn btn-primary mb2', method: :get, params: { otp_method: :voice }
 
 p.mt2.mb0.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')

--- a/app/views/shared/choose_delivery_method.html.slim
+++ b/app/views/shared/choose_delivery_method.html.slim
@@ -7,9 +7,9 @@ p#2fa-description = t('devise.two_factor_authentication.choose_delivery_confirma
 
 = button_to t('devise.two_factor_authentication.buttons.' \
   'confirm_with_sms'), phone_confirmation_send_path,
-  class: 'btn btn-primary mb2', method: :get, params: { delivery_method: :sms }
+  class: 'btn btn-primary mb2', method: :get, params: { otp_method: :sms }
 = button_to t('devise.two_factor_authentication.buttons.' \
   'confirm_with_voice'), phone_confirmation_send_path,
-  class: 'btn btn-primary mb2', method: :get, params: { delivery_method: :voice }
+  class: 'btn btn-primary mb2', method: :get, params: { otp_method: :voice }
 
 p.mt2.mb0.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')

--- a/app/views/users/phone_confirmation/show.html.slim
+++ b/app/views/users/phone_confirmation/show.html.slim
@@ -13,7 +13,7 @@ p.m0 Please enter the code sent to <strong>#{@unconfirmed_phone}</strong>.
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 - resend_link = link_to('Resend', \
-                        phone_confirmation_send_path(delivery_method: params[:delivery_method]))
+                        phone_confirmation_send_path(otp_method: params[:otp_method]))
 - update_number_link = link_to('Try again', \
                                @reenter_phone_number_path)
 

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -60,7 +60,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
         expect(subject.current_user).to receive(:authenticate_otp).and_return(false)
-        patch :update, code: '12345', delivery_method: :sms
+        patch :update, code: '12345', otp_method: :sms
       end
 
       it 'increments second_factor_attempts_count' do
@@ -68,7 +68,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'redirects to the OTP entry screen' do
-        expect(response).to redirect_to(otp_confirm_path(delivery_method: :sms))
+        expect(response).to redirect_to(otp_confirm_path(otp_method: :sms))
       end
 
       it 'displays flash error message' do
@@ -149,7 +149,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
       context 'when the user enters an invalid TOTP' do
         before do
-          patch :update, code: 'abc', delivery_method: :totp
+          patch :update, code: 'abc', otp_method: :totp
         end
 
         it 'increments second_factor_attempts_count' do
@@ -167,12 +167,12 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
       context 'user requests a direct OTP via SMS' do
         before do
-          get :new, delivery_method: :sms
+          get :new, otp_method: :sms
         end
 
         it 'redirects to the confirmation screen' do
           expect(response).to_not render_template(:confirm_totp)
-          expect(response).to redirect_to(otp_confirm_path(delivery_method: :sms))
+          expect(response).to redirect_to(otp_confirm_path(otp_method: :sms))
         end
 
         context 'when user enters correct OTP' do
@@ -184,16 +184,16 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         context 'when user enters incorrect OTP' do
           it 'redirects to the confirmation screen' do
-            patch :update, code: 'rrrr', delivery_method: :sms
+            patch :update, code: 'rrrr', otp_method: :sms
             expect(flash[:error]).to eq t('devise.two_factor_authentication.attempt_failed')
-            expect(response).to redirect_to(otp_confirm_path(delivery_method: :sms))
+            expect(response).to redirect_to(otp_confirm_path(otp_method: :sms))
           end
         end
       end
 
       context 'user requests a direct OTP via voice' do
         before do
-          get :new, delivery_method: :voice
+          get :new, otp_method: :voice
         end
 
         context 'when user enters correct OTP' do
@@ -205,9 +205,9 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         context 'when user enters incorrect OTP' do
           it 'redirects to the confirmation screen' do
-            patch :update, code: 'rrrr', delivery_method: :voice
+            patch :update, code: 'rrrr', otp_method: :voice
             expect(flash[:error]).to eq t('devise.two_factor_authentication.attempt_failed')
-            expect(response).to redirect_to(otp_confirm_path(delivery_method: :voice))
+            expect(response).to redirect_to(otp_confirm_path(otp_method: :voice))
           end
         end
       end
@@ -309,9 +309,9 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
     end
 
     it 'redirects to :show' do
-      get :new, delivery_method: :sms
+      get :new, otp_method: :sms
 
-      expect(response).to redirect_to(action: :confirm, delivery_method: :sms)
+      expect(response).to redirect_to(action: :confirm, otp_method: :sms)
     end
 
     it 'sends a new OTP' do
@@ -337,7 +337,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
     context 'when selecting an unsupported delivery method' do
       before do
         allow(SmsSenderOtpJob).to receive(:perform_later)
-        get :new, delivery_method: :email
+        get :new, otp_method: :email
       end
 
       it 'sends OTP via SMS' do
@@ -356,7 +356,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'sends OTP via SMS' do
-        get :send_code, delivery_method: :sms
+        get :send_code, otp_method: :sms
 
         expect(SmsSenderOtpJob).to have_received(:perform_later).
           with(subject.current_user.direct_otp, subject.current_user.phone)
@@ -371,11 +371,11 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         expect(@analytics).to receive(:track_event).with('GET request for ' \
           'two_factor_authentication#send_code')
 
-        get :send_code, delivery_method: :sms
+        get :send_code, otp_method: :sms
       end
 
       it 'notifies the user of OTP transmission' do
-        get :send_code, delivery_method: :sms
+        get :send_code, otp_method: :sms
 
         expect(flash[:success]).to eq t('notices.send_code.sms')
       end
@@ -389,7 +389,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'sends OTP via voice' do
-        get :send_code, delivery_method: :voice
+        get :send_code, otp_method: :voice
 
         expect(VoiceSenderOtpJob).to have_received(:perform_later).
           with(subject.current_user.direct_otp, subject.current_user.phone)
@@ -403,11 +403,11 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         expect(@analytics).to receive(:track_event).with('GET request for ' \
           'two_factor_authentication#send_code')
 
-        get :send_code, delivery_method: :voice
+        get :send_code, otp_method: :voice
       end
 
       it 'notifies the user of OTP transmission' do
-        get :send_code, delivery_method: :voice
+        get :send_code, otp_method: :voice
 
         expect(flash[:success]).to eq t('notices.send_code.voice')
       end
@@ -421,7 +421,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'sends OTP via SMS' do
-        get :send_code, delivery_method: :pigeon
+        get :send_code, otp_method: :pigeon
 
         expect(SmsSenderOtpJob).to have_received(:perform_later).
           with(subject.current_user.direct_otp, subject.current_user.phone)

--- a/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
@@ -40,7 +40,7 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         )
 
         expect(response).to redirect_to(
-          phone_confirmation_send_path(delivery_method: :voice)
+          phone_confirmation_send_path(otp_method: :voice)
         )
       end
     end
@@ -59,7 +59,7 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         )
 
         expect(response).to redirect_to(
-          phone_confirmation_send_path(delivery_method: :sms)
+          phone_confirmation_send_path(otp_method: :sms)
         )
       end
     end
@@ -77,7 +77,7 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         )
 
         expect(response).to redirect_to(
-          phone_confirmation_send_path(delivery_method: :sms)
+          phone_confirmation_send_path(otp_method: :sms)
         )
       end
     end

--- a/spec/controllers/idv/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/idv/phone_confirmation_controller_spec.rb
@@ -95,7 +95,7 @@ describe Idv::PhoneConfirmationController, devise: true do
       end
 
       context 'user enters an invalid code' do
-        before { post :confirm, code: '999', delivery_method: :sms }
+        before { post :confirm, code: '999', otp_method: :sms }
 
         it 'does not clear session data' do
           expect(subject.user_session[:idv_unconfirmed_phone]).to eq('+1 (555) 555-5555')
@@ -108,7 +108,7 @@ describe Idv::PhoneConfirmationController, devise: true do
 
         it 'redirects back phone_confirmation_path' do
           expect(response).to redirect_to(
-            idv_phone_confirmation_path(delivery_method: :sms)
+            idv_phone_confirmation_path(otp_method: :sms)
           )
         end
 

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -51,7 +51,7 @@ describe Users::PhoneConfirmationController, devise: true do
 
       context 'when choosing SMS OTP delivery' do
         it 'notifies the user of OTP transmission' do
-          get :send_code, delivery_method: :sms
+          get :send_code, otp_method: :sms
 
           expect(flash[:success]).to eq t('notices.send_code.sms')
         end
@@ -59,7 +59,7 @@ describe Users::PhoneConfirmationController, devise: true do
 
       context 'when choosing voice OTP delivery' do
         it 'notifies the user of OTP transmission' do
-          get :send_code, delivery_method: :voice
+          get :send_code, otp_method: :voice
 
           expect(flash[:success]).to eq t('notices.send_code.voice')
         end
@@ -109,7 +109,7 @@ describe Users::PhoneConfirmationController, devise: true do
       end
 
       context 'user enters an invalid code' do
-        before { post :confirm, code: '999', delivery_method: :sms }
+        before { post :confirm, code: '999', otp_method: :sms }
 
         it 'does not clear session data' do
           expect(subject.user_session[:unconfirmed_phone]).to eq('+1 (555) 555-5555')
@@ -123,7 +123,7 @@ describe Users::PhoneConfirmationController, devise: true do
 
         it 'redirects back phone_confirmation_path' do
           expect(response).to redirect_to(
-            phone_confirmation_path(delivery_method: :sms)
+            phone_confirmation_path(otp_method: :sms)
           )
         end
 

--- a/spec/forms/two_factor_setup_form_spec.rb
+++ b/spec/forms/two_factor_setup_form_spec.rb
@@ -28,8 +28,8 @@ describe TwoFactorSetupForm do
                        voice: 'Confirm with voice message')
       end
 
-      it 'sets delivery_method to "voice"' do
-        expect(subject.delivery_method).to eq(:voice)
+      it 'sets otp_method to "voice"' do
+        expect(subject.otp_method).to eq(:voice)
       end
     end
 
@@ -39,8 +39,8 @@ describe TwoFactorSetupForm do
                        sms: 'Confirm with text message')
       end
 
-      it 'sets delivery_method to "sms"' do
-        expect(subject.delivery_method).to eq(:sms)
+      it 'sets otp_method to "sms"' do
+        expect(subject.otp_method).to eq(:sms)
       end
     end
   end

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -16,7 +16,7 @@ describe 'user edits their account', email: true do
       'user[email]' => user.email,
       'user[password]' => user.password
     )
-    get_via_redirect otp_send_path(delivery_method: :sms)
+    get_via_redirect otp_send_path(otp_method: :sms)
     if user.reload.direct_otp
       patch_via_redirect(
         user_two_factor_authentication_path,
@@ -60,7 +60,7 @@ describe 'user edits their account', email: true do
       sign_in_as_a_valid_user
       @old_otp_code = user.direct_otp
       put_via_redirect edit_phone_path, update_user_phone_form: { phone: '555-555-5555' }
-      get_via_redirect phone_confirmation_send_path(delivery_method: :sms)
+      get_via_redirect phone_confirmation_send_path(otp_method: :sms)
     end
 
     it 'does not allow the OTP to be used for confirmation' do

--- a/spec/services/otp_sender_spec.rb
+++ b/spec/services/otp_sender_spec.rb
@@ -13,7 +13,7 @@ describe UserOtpSender do
     end
 
     context 'with voice delivery method' do
-      let(:options) { { delivery_method: :voice } }
+      let(:options) { { otp_method: :voice } }
 
       it 'sends OTP via voice delivery' do
         expect(VoiceSenderOtpJob).to receive(:perform_later).with('123', user.phone)
@@ -23,7 +23,7 @@ describe UserOtpSender do
     end
 
     context 'with SMS delivery method' do
-      let(:options) { { delivery_method: :sms } }
+      let(:options) { { otp_method: :sms } }
 
       it 'sends OTP via voice delivery' do
         expect(SmsSenderOtpJob).to receive(:perform_later).with('123', user.phone)

--- a/spec/views/devise/two_factor_authentication/confirm_totp.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/confirm_totp.html.slim_spec.rb
@@ -18,8 +18,8 @@ describe 'devise/two_factor_authentication/confirm_totp.html.slim' do
     render
 
     expect(rendered).to have_link('receive a code via SMS',
-                                  href: otp_send_path(delivery_method: :sms))
+                                  href: otp_send_path(otp_method: :sms))
     expect(rendered).to have_link('with a phone call',
-                                  href: otp_send_path(delivery_method: :voice))
+                                  href: otp_send_path(otp_method: :voice))
   end
 end

--- a/spec/views/users/phone_confirmation/show.html.slim_spec.rb
+++ b/spec/views/users/phone_confirmation/show.html.slim_spec.rb
@@ -51,28 +51,28 @@ describe 'users/phone_confirmation/show.html.slim' do
   context 'when choosing to receive OTP via SMS' do
     before do
       @sms_enabled = true
-      @fallback_confirmation_link = '/users/phone_confirmation/send?delivery_method=voice'
+      @fallback_confirmation_link = '/users/phone_confirmation/send?otp_method=voice'
     end
 
     it 'has a link to send confirmation with voice' do
       render
 
       expect(rendered).to have_link('call me with the one-time passcode',
-                                    href: '/users/phone_confirmation/send?delivery_method=voice')
+                                    href: '/users/phone_confirmation/send?otp_method=voice')
     end
   end
 
   context 'when choosing to receive OTP via voice' do
     before do
       @sms_enabled = false
-      @fallback_confirmation_link = '/users/phone_confirmation/send?delivery_method=sms'
+      @fallback_confirmation_link = '/users/phone_confirmation/send?otp_method=sms'
     end
 
     it 'has a link to send confirmation as SMS' do
       render
 
       expect(rendered).to have_link('send me a text message with the one-time ' \
-        'passcode', href: '/users/phone_confirmation/send?delivery_method=sms')
+        'passcode', href: '/users/phone_confirmation/send?otp_method=sms')
     end
   end
 end


### PR DESCRIPTION
**Why**: Since :totp and soon :rescue_code will be valid
options I think its clearer to call just simply an "OTP method"
since there is no delivery involved in those types of OTP.

This was split out of a my larger change to add rescue
codes.