### PR TITLE
Simply OTP method selection

### DIFF
--- a/app/controllers/concerns/otp_delivery_fallback.rb
+++ b/app/controllers/concerns/otp_delivery_fallback.rb
@@ -29,11 +29,8 @@ module OtpDeliveryFallback
 
   def current_otp_method
     query_method = params[:otp_method]
-    query_method.to_sym if
-      %w(sms voice totp).include? query_method
-  end
-
-  def use_sms_or_voice_otp_delivery?
-    %i(sms voice).include? current_otp_method
+    return query_method.to_sym if %w(sms voice totp rescue_code).include? query_method
+    return :totp if current_user.totp_enabled?
+    return :sms
   end
 end

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -19,7 +19,7 @@ module Devise
     end
 
     def show
-      if use_totp?
+      if current_otp_method == :totp
         show_totp_prompt
       else
         @phone_number = user_decorator.masked_two_factor_phone_number
@@ -51,12 +51,6 @@ module Devise
 
     def check_already_authenticated
       redirect_to profile_path if user_fully_authenticated?
-    end
-
-    def use_totp?
-      # Present the TOTP entry screen to users who are TOTP enabled,
-      # unless the user explictly selects SMS or voice
-      current_user.totp_enabled? && !use_sms_or_voice_otp_delivery?
     end
 
     def verify_user_is_not_second_factor_locked


### PR DESCRIPTION
**Why**: The logic for OTP method was split between
`current_otp_method` and `use_totp`.  This change means that
`current_otp_method` contains all the logic and will never
return nil.