### PR TITLE
Decrease idle session timeout to 8 minutes

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -27,9 +27,10 @@ development:
   redis_url: 'redis://localhost:6379/0'
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'
-  telephony_disabled: 'true'
   saml_passphrase: 'trust-but-verify'
   secret_key_base: 'development_secret_key_base'
+  session_timeout_in: '15'
+  telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
 
 production:
@@ -50,7 +51,7 @@ production:
   requests_per_ip_period: '300'
   saml_passphrase: 'trust-but-verify'
   secret_key_base: 'rake secret'
-  redis_url: 'redis://localhost:6379/0'
+  session_timeout_in: '8'
   smtp_settings: '{"address":"smtp.mandrillapp.com", "port":587, "authentication":"login", "enable_starttls_auto":true, "user_name":"user@gmail.com","password":"xxx"}'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
 
@@ -73,5 +74,5 @@ test:
   requests_per_ip_period: '60'
   saml_passphrase: 'trust-but-verify'
   secret_key_base: 'test_secret_key_base'
-  redis_url: 'redis://localhost:6379/0'
+  session_timeout_in: '8'
   twilio_accounts: '[{"sid":"sid1", "auth_token":"token1", "number":"9999999999"}, {"sid":"sid2", "auth_token":"token2", "number":"2222222222"}]'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -152,7 +152,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 15.minutes
+  config.timeout_in = Figaro.env.session_timeout_in.to_i.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
**Why**: Mitigate session vulnerability.

NOTE this also alphabetizes the application.yml settings
and removes a couple of duplicates.