### PR TITLE
Make rack_mini_profiler optional in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'overcommit', require: false
   gem 'quiet_assets'
-  gem 'rack-mini-profiler'
+  gem 'rack-mini-profiler', require: false
   gem 'rails_layout'
   gem 'reek'
   gem 'rubocop', require: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ locally, `make test` will run the rspec tests.
 
 ### Dependencies
 
-- Ruby 2.3.0
+- Ruby 2.3.1
 - [Postgresql](http://www.postgresql.org/download/)
 - [Redis 2.8+](http://redis.io/)
 - [Node.js v4.4.x](https://nodejs.org)
@@ -75,10 +75,15 @@ more information.
         $ make run
 
 If you want to develop without and internet connection, you can set
-`RAILS_OFFLINE=1` in your envrionment.  This disables the `mx` record
-check on emails addresses.
+`RAILS_OFFLINE=1` in your environment.  This disables the `mx` record
+check on email addresses.
+
+If you want to measure the app's performance in development, set the
+`rack_mini_profiler` option to `'on'` in `config/application.yml` and
+restart the server. See the [rack_mini_profiler] gem for more details.
 
 [Laptop]: https://github.com/18F/laptop
+[rack_mini_profiler]: https://github.com/MiniProfiler/rack-mini-profiler
 
 ### Running Tests
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -24,6 +24,7 @@ development:
   otp_delivery_blocklist_maxretry: '5'
   proofing_kbv: 'false'
   proofing_vendors: 'mock'
+  rack_mini_profiler: 'off'
   redis_url: 'redis://localhost:6379/0'
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,5 @@
+if Rails.env.development? && Figaro.env.rack_mini_profiler == 'on'
+  require 'rack-mini-profiler'
+
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
**Why**: To reduce noise in the browser developer tools console
due to the CSP issues caused by the gem using inline scripts.