### PR TITLE
Warn user when leaving page with unfinished IdV

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -26,7 +26,15 @@ const validate = {
   },
 
   validateForm(e) {
-    if (!this.form.checkValidity()) e.preventDefault();
+    if (!this.form.checkValidity()) {
+      if (this.pageUnloader) {
+        window.onbeforeunload = this.pageUnloader;
+      }
+      e.preventDefault();
+    } else {
+      this.pageUnloader = window.onbeforeunload;
+      window.onbeforeunload = false;
+    }
 
     const fields = this.form.querySelectorAll('.field');
     for (let i = 0; i < fields.length; i++) {

--- a/app/assets/javascripts/misc/page-unload-warning.js
+++ b/app/assets/javascripts/misc/page-unload-warning.js
@@ -1,0 +1,5 @@
+function pageUnloadWarning() {
+  return true;
+}
+
+window.onbeforeunload = pageUnloadWarning;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,9 @@ class ApplicationController < ActionController::Base
   layout 'card'
 
   def session_expires_at
-    session[:session_expires_at] = Time.zone.now + Devise.timeout_in
+    now = Time.zone.now
+    session[:session_expires_at] = now + Devise.timeout_in
+    session[:pinged_at] ||= now
   end
 
   def append_info_to_payload(payload)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,11 +3,9 @@ module Users
     include ValidEmailParameter
 
     def create
-      email = params[:user][:email]
+      RequestPasswordReset.new(downcased_email).perform
 
-      RequestPasswordReset.new(email).perform
-
-      analytics_user = User.find_by_email(email) || NonexistentUser.new
+      analytics_user = User.find_by_email(downcased_email) || NonexistentUser.new
       analytics.track_event(
         'Password Reset Request', user_id: analytics_user.uuid, role: analytics_user.role
       )
@@ -93,6 +91,10 @@ module Users
 
     def form_params
       params.fetch(:password_form, {})
+    end
+
+    def downcased_email
+      params[:user][:email].downcase
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,8 @@ module Users
 
     def active
       response.headers['Etag'] = '' # clear etags to prevent caching
-      Rails.logger.debug("alive?:#{alive?} expires_at:#{expires_at} now:#{Time.zone.now}")
+      session[:pinged_at] = now
+      Rails.logger.debug("alive?:#{alive?} expires_at:#{expires_at} now:#{now}")
       render json: { live: alive?, timeout: expires_at }
     end
 
@@ -25,18 +26,22 @@ module Users
 
     private
 
+    def now
+      @_now ||= Time.zone.now
+    end
+
     def expires_at
-      @_expires_at ||= (session[:session_expires_at] || (Time.zone.now - 1))
+      @_expires_at ||= (session[:session_expires_at] || (now - 1))
     end
 
     def alive?
       return false unless session && expires_at
-      session_alive = expires_at > Time.zone.now
+      session_alive = expires_at > now
       current_user.present? && session_alive
     end
 
     def track_authentication_attempt(email)
-      existing_user = User.find_by_email(email)
+      existing_user = User.find_by_email(email.downcase)
 
       if existing_user
         return analytics.track_event('Authentication Attempt', user_id: existing_user.uuid)

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -13,7 +13,7 @@ class RegisterUserEmailForm
   end
 
   def submit(params)
-    user.email = params[:email]
+    user.email = params[:email].downcase
 
     if valid_form?
       user.save!
@@ -22,15 +22,15 @@ class RegisterUserEmailForm
     end
   end
 
-  def valid_form?
-    valid? && !email_taken?
-  end
-
   def email_taken?
     @email_taken == true
   end
 
   private
+
+  def valid_form?
+    valid? && !email_taken?
+  end
 
   def process_errors
     # To prevent discovery of existing emails, we check to see if the email is

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -15,7 +15,8 @@ class UpdateUserEmailForm
   end
 
   def submit(params)
-    email = params[:email]
+    email = params[:email].downcase
+
     if email != @user.email
       @email_changed = true
       self.email = email
@@ -24,7 +25,7 @@ class UpdateUserEmailForm
     if valid_form?
       @user.update(params)
     else
-      process_errors(params)
+      process_errors
     end
   end
 
@@ -42,11 +43,11 @@ class UpdateUserEmailForm
 
   private
 
-  def process_errors(params)
+  def process_errors
     return false unless email_taken? && valid?
 
     @user.skip_confirmation_notification!
     UserMailer.signup_with_your_email(email).deliver_later
-    @user.update(params)
+    true
   end
 end

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -1,14 +1,14 @@
 module SessionTimeoutWarningHelper
   def frequency
-    Rails.application.config.session_check_frequency
+    (Figaro.env.session_check_frequency || 150).to_i
   end
 
   def start
-    Rails.application.config.session_check_delay
+    (Figaro.env.session_check_delay || 30).to_i
   end
 
   def warning
-    Rails.application.config.session_timeout_warning_seconds
+    (Figaro.env.session_timeout_warning_seconds || 30).to_i
   end
 
   def auto_session_timeout_js

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -13,3 +13,5 @@ p.italic Please provide only one of the following:
   .mt4.mb1
     = link_to 'Cancel', idv_cancel_path, class: 'btn btn-primary bg-gray mr2'
     = f.button :submit, 'Continue', class: 'btn btn-primary'
+
+== javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -23,3 +23,5 @@
   .mt4.mb1
     = link_to 'Cancel', idv_cancel_path, class: 'btn btn-primary bg-gray mr2'
     = f.button :submit, 'Continue', class: 'btn btn-primary'
+
+== javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/review/new.html.slim
+++ b/app/views/idv/review/new.html.slim
@@ -35,3 +35,5 @@ p.italic Please review your information and ensure it is correct.
   .mt4.mb1
     = link_to 'Cancel', idv_cancel_path, class: 'btn btn-primary bg-gray mr2'
     button type='submit' class='btn btn-primary' = 'Submit'
+
+== javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -32,3 +32,5 @@ p.italic Please provide all of the following:
   .mt3.mb2
     = link_to 'Cancel', idv_cancel_path, class: 'btn btn-primary bg-gray mr2'
     button type='submit' class='btn btn-primary' = 'Continue'
+
+== javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -26,7 +26,11 @@ function success(data) {
 
   if (show_warning & !el) cntnr.insertAdjacentHTML('afterbegin', warning_info);
   if (!show_warning & el) el.remove();
-  if (data.live == false) window.location.href = '/timeout';
+  if (data.live == false) {
+    window.onbeforeunload = null;
+    window.onunload = null;
+    window.location.href = '/timeout';
+  }
 }
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,18 +25,6 @@ module Upaya
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Set the number of seconds the timeout warning should occur before
-    # login session is timed out.
-    config.session_timeout_warning_seconds = 120
-    # Set the number of seconds in which to delay the start of the
-    # PeriodicalQuery() call. Make sure the sum of this value and
-    # session_timeout_warning_seconds is a multiple of 60 seconds.
-    config.session_check_delay             = 60
-    # Set the frequency of the PeriodicalQuery() call in seconds.
-    # Make sure the sum of this value and session_timeout_warning_seconds
-    # is a multiple of 60 seconds.
-    config.session_check_frequency         = 60
-
     config.middleware.use Rack::Attack
 
     # Configure Browserify to use babelify to compile ES6

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -10,6 +10,20 @@
 
 email_from: 'no-reply@login.gov'
 mailer_domain_name: 'http://localhost:3000'
+
+# Set the number of seconds the timeout warning should occur before
+# login session is timed out.
+session_timeout_warning_seconds: '150'
+# Set the number of seconds in which to delay the start of the
+# PeriodicalQuery() call. Make sure the sum of this value and
+# session_timeout_warning_seconds is a multiple of 60 seconds.
+session_check_delay: '30'
+# Set the frequency of the PeriodicalQuery() call in seconds.
+# Make sure the sum of this value and session_timeout_warning_seconds
+# is a multiple of 60 seconds.
+session_check_frequency: '30'
+
+stale_session_window: '180'
 support_url: 'https://18f.gov/contact'
 
 development:

--- a/lib/tasks/check_sessions.rake
+++ b/lib/tasks/check_sessions.rake
@@ -1,0 +1,41 @@
+#
+# usage:
+#   % rake check_stale_sessions [DEBUG=1] [PURGE=1]
+#
+desc 'check for stale sessions'
+task check_stale_sessions: :environment do
+  puts "now:               #{Time.zone.now}" if debug
+  puts "stale_window_time: #{stale_window_time}" if debug
+  ActiveRecord::SessionStore::Session.where('updated_at < ?', stale_window_time).each do |session|
+    next unless session.data.keys.any?
+    session.data.symbolize_keys!
+    puts "pinged_at:         #{session.data[:pinged_at]}" if debug
+    puts session.data.pretty_inspect if debug
+    if stale?(session.data)
+      puts " ----------> stale!" if debug
+      session.destroy! if purge
+    end
+  end
+end
+
+def purge
+  ENV['PURGE'] == '1'
+end
+
+def debug
+  ENV['DEBUG'] == '1'
+end
+
+def stale_window
+  @_stale_window ||= Figaro.env.stale_session_window.to_i
+end
+
+def stale_window_time
+  Time.zone.now - stale_window
+end
+
+def stale?(session_data)
+  return false unless session_data[:session_expires_at].present?
+  return true if session_data[:session_expires_at] < Time.zone.now
+  return true if session_data[:pinged_at].present? && session_data[:pinged_at] < stale_window_time
+end

--- a/spec/controllers/users/edit_email_controller_spec.rb
+++ b/spec/controllers/users/edit_email_controller_spec.rb
@@ -42,17 +42,16 @@ describe Users::EditEmailController do
 
     context "user changes email to another user's email address" do
       it 'lets user know they need to confirm their new email' do
-        sign_in(user)
+        stub_sign_in
 
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, update_user_email_form: { email: second_user.email }
+        put :update, update_user_email_form: { email: second_user.email.upcase }
 
         expect(response).to redirect_to profile_url
         expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
         expect(response).to render_template('user_mailer/signup_with_your_email')
-        expect(user.reload.email).to eq 'old_email@example.com'
         expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
         expect(@analytics).to have_received(:track_event).
           with('User attempted to change their email to an existing email')

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -151,7 +151,7 @@ describe Users::PasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with('Password Reset Request', user_id: tech_user.uuid, role: 'tech')
 
-        put :create, user: { email: 'tech@example.com' }
+        put :create, user: { email: 'TECH@example.com' }
       end
     end
 
@@ -165,7 +165,7 @@ describe Users::PasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with('Password Reset Request', user_id: admin.uuid, role: 'admin')
 
-        put :create, user: { email: 'admin@example.com' }
+        put :create, user: { email: 'ADMIN@example.com' }
       end
     end
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -72,6 +72,18 @@ describe Users::SessionsController, devise: true do
 
         expect(json['live']).to eq false
       end
+
+      it 'updates pinged_at session key' do
+        stub_sign_in
+        now = Time.current
+        session[:pinged_at] = now
+
+        Timecop.travel(Time.current + 10)
+        get :active
+        Timecop.return
+
+        expect(session[:pinged_at]).to_not eq(now)
+      end
     end
   end
 
@@ -114,7 +126,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).with('Authentication Attempt', user_id: user.uuid)
       expect(@analytics).to receive(:track_event).with('Authentication Successful')
 
-      post :create, user: { email: user.email, password: user.password }
+      post :create, user: { email: user.email.upcase, password: user.password }
     end
 
     it 'tracks the authentication attempt for nonexistent user' do

--- a/spec/features/idv/interrupted_session_spec.rb
+++ b/spec/features/idv/interrupted_session_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+feature 'Interrupted IdV session' do
+  include IdvHelper
+
+  describe 'Closing the browser while on the first form', js: true do
+    before do
+      allow(FeatureManagement).to receive(:proofing_requires_kbv?).and_return(false)
+
+      sign_in_and_2fa_user
+      visit idv_session_path
+    end
+
+    context 'when the alert is dismissed' do
+      it 'does not display an alert when submitting the form' do
+        # dismiss the alert that appears when the user closes the browser window
+        # dismiss means the user clicked on "Stay on Page"
+        page.driver.browser.dismiss_confirm do
+          page.driver.close_window(page.driver.current_window_handle)
+        end
+
+        fill_out_idv_form_ok
+        click_button 'Continue'
+
+        expect(page).to have_content(t('idv.form.ccn'))
+      end
+    end
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -75,9 +75,9 @@ feature 'Sign in' do
 
   context 'session approaches timeout', js: true do
     before :each do
-      allow(Rails.application.config).to receive(:session_check_frequency).and_return(1)
-      allow(Rails.application.config).to receive(:session_check_delay).and_return(1)
-      allow(Rails.application.config).to receive(:session_timeout_warning_seconds).
+      allow(Figaro.env).to receive(:session_check_frequency).and_return(1)
+      allow(Figaro.env).to receive(:session_check_delay).and_return(1)
+      allow(Figaro.env).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in)
     end
 

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -3,44 +3,5 @@ require 'rails_helper'
 describe RegisterUserEmailForm do
   subject { RegisterUserEmailForm.new }
 
-  describe 'email validation' do
-    it 'uses the valid_email gem with mx and ban_disposable options' do
-      email_validator = subject._validators.values.flatten.first
-
-      expect(email_validator.class).to eq EmailValidator
-      expect(email_validator.options).
-        to eq(mx: true, ban_disposable_email: true)
-    end
-  end
-
-  describe 'email uniqueness' do
-    context 'when email is already taken' do
-      it 'is not valid' do
-        second_user = build_stubbed(:user, :signed_up, email: 'taken@gmail.com')
-        allow(User).to receive(:exists?).with(email: second_user.email).and_return(true)
-
-        subject.user.email = second_user.email
-
-        expect(subject.valid_form?).to be false
-      end
-    end
-
-    context 'when email is not already taken' do
-      it 'is valid' do
-        subject.user.email = 'not_taken@gmail.com'
-
-        expect(subject.valid_form?).to be true
-      end
-    end
-
-    context 'when email is nil' do
-      it 'does not add already taken errors' do
-        subject.user.email = nil
-
-        expect(subject.valid_form?).to be false
-        expect(subject.errors[:email]).
-          to eq [t('valid_email.validations.email.invalid')]
-      end
-    end
-  end
+  it_behaves_like 'email validation'
 end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe SessionTimeoutWarningHelper do
   describe '#time_left_in_session' do
     it 'describes time left based on when the timeout warning appears' do
-      allow(Rails.application.config).
+      allow(Figaro.env).
         to receive(:session_check_frequency).and_return(1.minute)
-      allow(Rails.application.config).
+      allow(Figaro.env).
         to receive(:session_check_delay).and_return(2.minutes)
-      allow(Rails.application.config).
+      allow(Figaro.env).
         to receive(:session_timeout_warning_seconds).and_return(3.minutes)
 
       expect(helper.time_left_in_session).
@@ -17,5 +17,5 @@ describe SessionTimeoutWarningHelper do
 end
 
 def time_between_warning_and_timeout
-  Rails.application.config.session_timeout_warning_seconds
+  Figaro.env.session_timeout_warning_seconds
 end

--- a/spec/support/shared_examples_for_email_validation.rb
+++ b/spec/support/shared_examples_for_email_validation.rb
@@ -1,0 +1,40 @@
+shared_examples 'email validation' do
+  it 'uses the valid_email gem with mx and ban_disposable options' do
+    email_validator = subject._validators.values.flatten.
+                      detect { |v| v.class == EmailValidator }
+
+    expect(email_validator.options).
+      to eq(mx: true, ban_disposable_email: true)
+  end
+
+  describe '#submit' do
+    context 'when email is already taken' do
+      it 'returns true to prevent revealing account existence' do
+        create(:user, :signed_up, email: 'taken@gmail.com')
+
+        result = subject.submit(email: 'TAKEN@gmail.com')
+
+        expect(result).to be true
+        expect(subject.email).to eq 'taken@gmail.com'
+      end
+    end
+
+    context 'when email is not already taken' do
+      it 'is valid' do
+        result = subject.submit(email: 'not_taken@gmail.com')
+
+        expect(result).to be true
+      end
+    end
+
+    context 'when email is invalid' do
+      it 'returns false and adds errors to the form object' do
+        result = subject.submit(email: 'invalid_email')
+
+        expect(result).to be false
+        expect(subject.errors[:email]).
+          to eq [t('valid_email.validations.email.invalid')]
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Closing the browser window will lose IdV data
and creates security issue with still-open session.

**How**: Help prevent bad UX by warning the user if their
current IdV application will be lost if they leave the page.

Track each time the session is actively pinged and create a Rake
task to run against and clean up possibly stale sessions.