### PR TITLE
Send email when registering with existing email

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -35,7 +35,10 @@ class RegisterUserEmailForm
   def process_errors
     # To prevent discovery of existing emails, we check to see if the email is
     # already taken and if so, we act as if the user registration was successful.
-    return true if email_taken?
+    if email_taken?
+      UserMailer.signup_with_your_email(email).deliver_later
+      return true
+    end
 
     false
   end

--- a/app/views/devise/registrations/verify_email.html.slim
+++ b/app/views/devise/registrations/verify_email.html.slim
@@ -4,10 +4,10 @@
 h1.heading = t('headings.registrations.verify_email')
 .mt4.mb3.p2.alert.alert-success
   p
-    | #{t('devise.registrations.signed_up_but_unconfirmed.message_start')}
+    | #{t('notices.signed_up_but_unconfirmed.first_paragraph_start')}
       <strong>#{email}</strong>
-      #{t('devise.registrations.signed_up_but_unconfirmed.message_end')}
+      #{t('notices.signed_up_but_unconfirmed.first_paragraph_end')}
   p.m0
-    | Didn't receive an email?
+    | #{t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')}
       #{link_to t('links.resend'), new_user_confirmation_path}
 p.italic = t('devise.registrations.close_window')

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -57,11 +57,6 @@ en:
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed:
-        message_start: We sent an email to
-        message_end: >
-          with a link to confirm your email address. Please click on the
-          link in your email to continue signing up.
       email_update_needs_confirmation: >
         You updated your account successfully, but we need to verify your new
         email address. Please check your email and follow the confirm link to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
       password: Your new password must be at least %{min_length} characters.
 
   links:
-    resend: Resend
+    resend: Try resending the confirmation instructions.
     sign_out: Sign out
     sign_in: Log in
     sign_up: Sign up
@@ -69,6 +69,12 @@ en:
     send_code:
       voice: You will be called with your one-time passcode.
       sms: Your one-time passcode has been sent via text message.
+    signed_up_but_unconfirmed:
+      first_paragraph_start: We sent an email to
+      first_paragraph_end: >
+        with a link to confirm your email address. Please click on the
+        link in your email to continue signing up.
+      no_email_sent_explanation_start: Didn't receive an email?
   session_timedout: >
     For your security, you’ve been logged out due to inactivity. Please log in again.
   session_timeout_warning: >-

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -16,11 +16,13 @@ feature 'Sign Up', devise: true do
   scenario 'visitor can sign up with valid email address' do
     email = 'test@example.com'
     sign_up_with(email)
-    expect(page).to have_content(
-      t('devise.registrations.signed_up_but_unconfirmed.message_start') +
-      " #{email} " +
-      t('devise.registrations.signed_up_but_unconfirmed.message_end')
-    )
+
+    expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_start')
+    expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_end')
+    expect(page).
+      to have_content t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')
+    expect(page).to have_content email
+    expect(page).to have_link(t('links.resend'), href: new_user_confirmation_path)
   end
 
   # Scenario: Visitor can sign up and confirm with valid email address and password
@@ -253,12 +255,13 @@ feature 'Sign Up', devise: true do
     user = create(:user, email: 'existing_user@example.com')
     sign_up_with('existing_user@example.com')
 
-    expect(page).to have_content(
-      t('devise.registrations.signed_up_but_unconfirmed.message_start') +
-      " #{user.email} " +
-      t('devise.registrations.signed_up_but_unconfirmed.message_end')
-    )
-    expect(number_of_emails_sent).to eq 0
+    expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_start')
+    expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_end')
+    expect(page).
+      to have_content t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')
+    expect(page).to have_content user.email
+    expect(page).to have_link(t('links.resend'), href: new_user_confirmation_path)
+    expect(last_email.html_part.body).to have_content 'This email address is already in use.'
   end
 
   # Scenario: Visitor signs up but confirms with an expired token


### PR DESCRIPTION
**Why**: Some users might forget that they've already created an
account, and might attempt to register with their existing email
address. If that happens, we send them an email to let them know
they already have an account. In addition, I've updated the flash
message to explain the various scenarios in which a user might not
have received an email after registering, and suggested courses of
action.