### PR TITLE
Make session_timeout_in ENV var required

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,5 +3,5 @@ Figaro.require_keys(
   'logins_per_ip_limit', 'logins_per_ip_period', 'otp_delivery_blocklist_bantime',
   'otp_delivery_blocklist_findtime', 'otp_delivery_blocklist_maxretry',
   'requests_per_ip_limit', 'requests_per_ip_period', 'saml_passphrase',
-  'secret_key_base', 'twilio_accounts'
+  'secret_key_base', 'session_timeout_in', 'twilio_accounts'
 )


### PR DESCRIPTION
**Why**: So that the app crashes right away if the key is missing.
This makes it very easy to find out that a required key is missing,
which is crucial since we don't yet have an automated way to update
`application.yml` in production.