### PR TITLE
Disallow more than 3 IdV attempts in 24 hours

### DIFF
--- a/.reek
+++ b/.reek
@@ -53,6 +53,7 @@ UtilityFunction:
   DuplicateMethodCall:
     exclude:
       - complete_idv_profile
+      - stub_subject
       - saml_settings
       - sign_up_and_2fa
       - raw_xml_response

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -12,11 +12,36 @@ module IdvSession
     redirect_to idv_session_url unless idv_session[:params].present?
   end
 
+  def confirm_idv_attempts_allowed
+    if idv_attempter.exceeded?
+      flash[:error] = t('idv.errors.hardfail')
+      redirect_to idv_fail_url
+    elsif idv_attempter.reset_attempts?
+      self.idv_attempts = 0
+    end
+  end
+
   def idv_session
     user_session[:idv] ||= {}
   end
 
   protected
+
+  def idv_attempts=(num)
+    current_user.update!(idv_attempts: num)
+  end
+
+  def idv_attempts
+    current_user.idv_attempts
+  end
+
+  def idv_attempter
+    @_attempter ||= IdvAttempter.new(current_user)
+  end
+
+  def idv_flag_user_attempt
+    current_user.update!(idv_attempted_at: Time.zone.now)
+  end
 
   def idv_question_number
     idv_session[:question_number] ||= 0

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -52,9 +52,17 @@ module Idv
       # do not store PII that failed.
       idv_profile.destroy
       analytics.track_event('IdV Failed')
+      if idv_attempter.exceeded?
+        idv_flag_user_attempt
+        redirect_to idv_fail_url
+      else
+        redirect_to idv_retry_url
+      end
     end
 
     def finish_proofing_success
+      idv_flag_user_attempt
+      self.idv_attempts = 0
       complete_idv_profile
       flash[:success] = I18n.t('idv.titles.complete')
       analytics.track_event('IdV Successful')

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -3,6 +3,7 @@ module Idv
     include IdvSession
 
     before_action :confirm_two_factor_authenticated
+    before_action :confirm_idv_attempts_allowed
 
     helper_method :idv_profile_form
 

--- a/app/controllers/idv/step_controller.rb
+++ b/app/controllers/idv/step_controller.rb
@@ -6,5 +6,6 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_session_started
+    before_action :confirm_idv_attempts_allowed
   end
 end

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -10,4 +10,11 @@ class IdvController < ApplicationController
 
   def cancel
   end
+
+  def fail
+  end
+
+  def retry
+    flash.now[:error] = I18n.t('idv.errors.fail')
+  end
 end

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -48,7 +48,7 @@ module Idv
     end
 
     def dob_in_the_past?(date)
-      date < Date.today
+      date < Time.zone.today
     end
 
     def parsed_dob

--- a/app/services/idv_attempter.rb
+++ b/app/services/idv_attempter.rb
@@ -1,0 +1,41 @@
+class IdvAttempter
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def exceeded?
+    return false if window_expired?
+
+    # too many attempts in the window
+    idv_attempts >= idv_max_attempts && !window_expired?
+  end
+
+  def window_expired?
+    # never attempted
+    attempted_at = current_user.idv_attempted_at
+    return true unless attempted_at.present?
+
+    # last attempted in the past outside the window
+    attempted_at + idv_attempt_window < Time.zone.now
+  end
+
+  def reset_attempts?
+    idv_attempts >= idv_max_attempts && window_expired?
+  end
+
+  private
+
+  attr_reader :current_user
+
+  def idv_attempts
+    current_user.idv_attempts
+  end
+
+  def idv_max_attempts
+    (Figaro.env.idv_max_attempts || 3).to_i
+  end
+
+  def idv_attempt_window
+    (Figaro.env.idv_attempt_window_in_hours || 24).to_i.hours
+  end
+end

--- a/app/views/idv/cancel.html.slim
+++ b/app/views/idv/cancel.html.slim
@@ -1,5 +1,5 @@
-- title t('idv.titles.hardfail')
+- title t('idv.titles.cancel')
 
-h1.heading = t('idv.titles.hardfail')
-p.mb1 = t('idv.messages.hardfail', app_name: APP_NAME)
+h1.heading = t('idv.titles.cancel')
+p.mb1 = t('idv.messages.cancel', app_name: APP_NAME)
 = link_to 'Back', idv_url, class: 'underline'

--- a/app/views/idv/confirmations/index.html.slim
+++ b/app/views/idv/confirmations/index.html.slim
@@ -1,9 +1,0 @@
-- if @confirmation.success?
-  .alert.alert-success.p2
-    div = t('idv.titles.complete')
-- else
-  .alert.alert-danger.p2
-    div = t('idv.titles.hardfail')
-
-- if @idv_vendor == :mock && !@confirmation.success?
-  pre.mt2.p2.bg-silver.ws-pre-line = @confirmation.vendor_resp.inspect

--- a/app/views/idv/fail.html.slim
+++ b/app/views/idv/fail.html.slim
@@ -1,0 +1,8 @@
+- title t('idv.titles.hardfail')
+
+h1.heading = t('idv.titles.hardfail')
+
+p.mb1 = t('idv.messages.hardfail')
+p.mb1 = t('idv.messages.hardfail2', hours: Figaro.env.idv_attempt_window_in_hours)
+p.mb1 = t('idv.messages.hardfail3')
+p.mb1 = t('idv.messages.hardfail4')

--- a/app/views/idv/retry.html.slim
+++ b/app/views/idv/retry.html.slim
@@ -1,0 +1,7 @@
+- title t('idv.titles.fail')
+
+h1.heading = t('idv.titles.fail')
+
+p.mb1 = t('idv.messages.fail')
+
+= link_to t('idv.messages.review_and_continue'), idv_session_path, class: 'btn btn-primary'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -9,6 +9,8 @@
 # Figaro requires all values to be explicit strings.
 
 email_from: 'no-reply@login.gov'
+idv_max_attempts: '3'
+idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
 support_url: 'https://18f.gov/contact'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,11 +187,30 @@ en:
     errors:
       duplicate_ssn: >
         An account already exists using the information you provided.
+      fail: >
+        Sorry, we were unable to verify your identity based on the information you provided.
+      hardfail: >
+        We were unable to verify your identity at this time.
       missing_finance: You must provide a financial account ID.
       invalid_ccn: Credit card number should be only last 8 digits.
       bad_dob: Your date of birth must be a valid date.
     messages:
+      fail: >
+        Please check that the personal and financial information you provided is accurate.
+        To learn more about the information we need from you and how it’s used to verify your identity,
+        please see our troubleshooting page.
       hardfail: >
+        Your login.gov account can’t be used to access information with 
+        participating agencies until you successfully complete this process.
+      hardfail2: >
+        You can try to complete the verification process again in %{hours} hours.
+      hardfail3: >
+        If you’re unable to verify your identity through this process there might
+        be other options available to you. Please see our troubleshooting page to learn about those options.
+      hardfail4: >
+        You can also return to the agency website that directed you here to try to log in there
+        for the services you are attempting to access.
+      cancel: >
         To access your information with the participating agency’s website,
         %{app_name} needs to verify your identity. We need to collect some basic
         personal information as well as some financial information from you to
@@ -204,14 +223,16 @@ en:
       dupe_ssn2_link: sign out now and sign back in
       dupe_ssn3: If you can't remember your original login information, you can %{link}.
       dupe_ssn3_link: try recovering it here
+      review_and_continue: Review my info and try again
     titles:
       intro: Help us identify you
       expectations: We need some information from you
       welcome: Verify your identity
       phone: Phone number of record
       question: Answer a few questions
-      fail: Identity verification unsuccessful
-      hardfail: We cannot verify your identity
+      fail: We were unable to verify your identity
+      cancel: We cannot verify your identity
+      hardfail: We were unable to verify your identity
       complete: Identity verification complete
       review: Review and submit
       dupe: "Error: An account may already exist"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,8 @@ Rails.application.routes.draw do
 
   get '/idv' => 'idv#index'
   get '/idv/cancel' => 'idv#cancel'
+  get '/idv/fail' => 'idv#fail'
+  get '/idv/retry' => 'idv#retry'
   get '/idv/phone_confirmation' => 'idv/phone_confirmation#show'
   get '/idv/phone_confirmation/send' => 'idv/phone_confirmation#send_code'
   put '/idv/phone_confirmation' => 'idv/phone_confirmation#confirm'

--- a/db/migrate/20160908163322_add_users_idv_attempted_at.rb
+++ b/db/migrate/20160908163322_add_users_idv_attempted_at.rb
@@ -1,0 +1,5 @@
+class AddUsersIdvAttemptedAt < ActiveRecord::Migration
+  def change
+    add_column :users, :idv_attempted_at, :datetime
+  end
+end

--- a/db/migrate/20160914155344_add_idv_attempts_to_user.rb
+++ b/db/migrate/20160914155344_add_idv_attempts_to_user.rb
@@ -1,0 +1,5 @@
+class AddIdvAttemptsToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :idv_attempts, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160908195301) do
+ActiveRecord::Schema.define(version: 20160914155344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,8 @@ ActiveRecord::Schema.define(version: 20160908195301) do
     t.string   "encrypted_otp_secret_key_salt", limit: 255
     t.string   "direct_otp"
     t.datetime "direct_otp_sent_at"
+    t.datetime "idv_attempted_at"
+    t.integer  "idv_attempts",                              default: 0
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/controllers/idv/finance_controller_spec.rb
+++ b/spec/controllers/idv/finance_controller_spec.rb
@@ -6,7 +6,8 @@ describe Idv::FinanceController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started
+        :confirm_idv_session_started,
+        :confirm_idv_attempts_allowed
       )
     end
   end
@@ -15,6 +16,7 @@ describe Idv::FinanceController do
     before do
       allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
       allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
       allow(subject).to receive(:idv_session).and_return(params: {})
     end
 

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -7,7 +7,8 @@ describe Idv::PhoneController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started
+        :confirm_idv_session_started,
+        :confirm_idv_attempts_allowed
       )
     end
   end
@@ -18,10 +19,7 @@ describe Idv::PhoneController do
 
       it 'renders #new' do
         user = User.new(phone: '+1 (415) 555-0130')
-        allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
-        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-        allow(subject).to receive(:idv_session).and_return(params: {})
-        allow(subject).to receive(:current_user).and_return(user)
+        stub_subject(user)
 
         put :create, idv_phone_form: { phone: '703' }
 
@@ -33,10 +31,7 @@ describe Idv::PhoneController do
     context 'when form is valid and submitted phone is same as user phone' do
       it 'redirects to review page and sets phone_confirmed_at' do
         user = User.new(phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
-        allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
-        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-        allow(subject).to receive(:idv_session).and_return(params: {})
-        allow(subject).to receive(:current_user).and_return(user)
+        stub_subject(user)
 
         put :create, idv_phone_form: { phone: '+1 (415) 555-0130' }
 
@@ -53,10 +48,7 @@ describe Idv::PhoneController do
     context 'when form is valid and submitted phone is different from user phone' do
       it 'redirects to review page and does not set phone_confirmed_at' do
         user = User.new(phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
-        allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
-        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-        allow(subject).to receive(:idv_session).and_return(params: {})
-        allow(subject).to receive(:current_user).and_return(user)
+        stub_subject(user)
 
         put :create, idv_phone_form: { phone: '+1 (415) 555-0160' }
 
@@ -68,5 +60,13 @@ describe Idv::PhoneController do
         expect(subject.idv_session[:params]).to eq expected_params
       end
     end
+  end
+
+  def stub_subject(user)
+    allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
+    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
+    allow(subject).to receive(:idv_session).and_return(params: {})
+    allow(subject).to receive(:current_user).and_return(user)
   end
 end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -20,7 +20,8 @@ describe Idv::SessionsController do
     it 'includes before_actions from AccountStateChecker' do
       expect(subject).to have_actions(
         :before,
-        :confirm_two_factor_authenticated
+        :confirm_two_factor_authenticated,
+        :confirm_idv_attempts_allowed
       )
     end
   end

--- a/spec/controllers/idv/step_controller_spec.rb
+++ b/spec/controllers/idv/step_controller_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe Idv::StepController do
+  let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
+
+  describe '#confirm_idv_attempts_allowed' do
+    controller do
+      before_action :confirm_idv_attempts_allowed
+
+      def show
+        render text: 'Hello'
+      end
+    end
+
+    before(:each) do
+      sign_in(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'user has exceeded IdV max attempts in a single session' do
+      before do
+        user.idv_attempts = 3
+        user.idv_attempted_at = Time.zone.now
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      end
+
+      it 'redirects to hardfail page' do
+        get :show
+
+        expect(response).to redirect_to idv_fail_url
+      end
+    end
+
+    context 'user has exceeded IdV max attempts in a single period' do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+        user.idv_attempts = 3
+        user.idv_attempted_at = Time.zone.now
+      end
+
+      it 'redirects to hardfail page' do
+        get :show
+
+        expect(response).to redirect_to idv_fail_url
+      end
+    end
+
+    context 'user attempts IdV after window has passed' do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+        user.idv_attempts = 3
+        user.idv_attempted_at = Time.zone.now - 25.hours
+        get :show
+      end
+
+      it 'allows request to proceed' do
+        expect(response.body).to eq 'Hello'
+      end
+
+      it 'resets user attempt count' do
+        expect(user.idv_attempts).to eq 0
+      end
+    end
+  end
+
+  describe '#confirm_idv_session_started' do
+    controller do
+      before_action :confirm_idv_session_started
+
+      def show
+        render text: 'Hello'
+      end
+    end
+
+    before(:each) do
+      sign_in(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'user has not started IdV session' do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
+      end
+
+      it 'redirects to idv session url' do
+        get :show
+
+        expect(response).to redirect_to(idv_session_url)
+      end
+    end
+
+    context 'user has started IdV session' do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:idv_session).and_return(params: { first_name: 'Jane' })
+      end
+
+      it 'allows request' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+      end
+    end
+  end
+end

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -88,7 +88,7 @@ describe Idv::ProfileForm do
     context 'when dob is in the future' do
       it 'is invalid' do
         expect(
-          subject.submit(profile_attrs.merge(dob: (Date.today + 1).strftime('%Y-%m-%d')))
+          subject.submit(profile_attrs.merge(dob: (Time.zone.today + 1).strftime('%Y-%m-%d')))
         ).to eq false
         expect(subject.errors[:dob]).to eq [t('idv.errors.bad_dob')]
       end

--- a/spec/services/idv_attempter_spec.rb
+++ b/spec/services/idv_attempter_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe IdvAttempter do
+  let(:current_user) { User.new }
+  let(:subject) { IdvAttempter.new(current_user) }
+
+  describe '#window_expired?' do
+    context 'inside window' do
+      before do
+        current_user.idv_attempted_at = Time.zone.now
+      end
+
+      it 'returns false' do
+        expect(subject.window_expired?).to eq false
+      end
+    end
+
+    context 'outside window' do
+      before do
+        current_user.idv_attempted_at = Time.zone.now - 25.hours
+      end
+
+      it 'returns true' do
+        expect(subject.window_expired?).to eq true
+      end
+    end
+  end
+
+  describe '#exceeded?' do
+    context 'no attempts yet made' do
+      context 'inside the window' do
+        before do
+          current_user.idv_attempted_at = Time.zone.now
+        end
+
+        it 'returns false' do
+          expect(subject.exceeded?).to eq false
+        end
+      end
+
+      context 'outside the window' do
+        before do
+          current_user.idv_attempted_at = Time.zone.now - 25.hours
+        end
+
+        it 'returns false' do
+          expect(subject.exceeded?).to eq false
+        end
+      end
+    end
+
+    context 'max attempts exceeded' do
+      before do
+        current_user.idv_attempts = 3
+      end
+
+      context 'inside the window' do
+        before do
+          current_user.idv_attempted_at = Time.zone.now
+        end
+
+        it 'returns true' do
+          expect(subject.exceeded?).to eq true
+        end
+      end
+
+      context 'outside the window' do
+        before do
+          current_user.idv_attempted_at = Time.zone.now - 25.hours
+        end
+
+        it 'returns false' do
+          expect(subject.exceeded?).to eq false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Throttling of IdV attempts helps keep costs down
and UX success rate high.