### PR TITLE
Make email lookups case-insensitive

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,11 +3,9 @@ module Users
     include ValidEmailParameter
 
     def create
-      email = params[:user][:email]
+      RequestPasswordReset.new(downcased_email).perform
 
-      RequestPasswordReset.new(email).perform
-
-      analytics_user = User.find_by_email(email) || NonexistentUser.new
+      analytics_user = User.find_by_email(downcased_email) || NonexistentUser.new
       analytics.track_event(
         'Password Reset Request', user_id: analytics_user.uuid, role: analytics_user.role
       )
@@ -93,6 +91,10 @@ module Users
 
     def form_params
       params.fetch(:password_form, {})
+    end
+
+    def downcased_email
+      params[:user][:email].downcase
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -36,7 +36,7 @@ module Users
     end
 
     def track_authentication_attempt(email)
-      existing_user = User.find_by_email(email)
+      existing_user = User.find_by_email(email.downcase)
 
       if existing_user
         return analytics.track_event('Authentication Attempt', user_id: existing_user.uuid)

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -13,7 +13,7 @@ class RegisterUserEmailForm
   end
 
   def submit(params)
-    user.email = params[:email]
+    user.email = params[:email].downcase
 
     if valid_form?
       user.save!
@@ -22,15 +22,15 @@ class RegisterUserEmailForm
     end
   end
 
-  def valid_form?
-    valid? && !email_taken?
-  end
-
   def email_taken?
     @email_taken == true
   end
 
   private
+
+  def valid_form?
+    valid? && !email_taken?
+  end
 
   def process_errors
     # To prevent discovery of existing emails, we check to see if the email is

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -15,7 +15,8 @@ class UpdateUserEmailForm
   end
 
   def submit(params)
-    email = params[:email]
+    email = params[:email].downcase
+
     if email != @user.email
       @email_changed = true
       self.email = email
@@ -24,7 +25,7 @@ class UpdateUserEmailForm
     if valid_form?
       @user.update(params)
     else
-      process_errors(params)
+      process_errors
     end
   end
 
@@ -42,11 +43,11 @@ class UpdateUserEmailForm
 
   private
 
-  def process_errors(params)
+  def process_errors
     return false unless email_taken? && valid?
 
     @user.skip_confirmation_notification!
     UserMailer.signup_with_your_email(email).deliver_later
-    @user.update(params)
+    true
   end
 end

--- a/spec/controllers/users/edit_email_controller_spec.rb
+++ b/spec/controllers/users/edit_email_controller_spec.rb
@@ -42,17 +42,16 @@ describe Users::EditEmailController do
 
     context "user changes email to another user's email address" do
       it 'lets user know they need to confirm their new email' do
-        sign_in(user)
+        stub_sign_in
 
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, update_user_email_form: { email: second_user.email }
+        put :update, update_user_email_form: { email: second_user.email.upcase }
 
         expect(response).to redirect_to profile_url
         expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
         expect(response).to render_template('user_mailer/signup_with_your_email')
-        expect(user.reload.email).to eq 'old_email@example.com'
         expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
         expect(@analytics).to have_received(:track_event).
           with('User attempted to change their email to an existing email')

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -151,7 +151,7 @@ describe Users::PasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with('Password Reset Request', user_id: tech_user.uuid, role: 'tech')
 
-        put :create, user: { email: 'tech@example.com' }
+        put :create, user: { email: 'TECH@example.com' }
       end
     end
 
@@ -165,7 +165,7 @@ describe Users::PasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with('Password Reset Request', user_id: admin.uuid, role: 'admin')
 
-        put :create, user: { email: 'admin@example.com' }
+        put :create, user: { email: 'ADMIN@example.com' }
       end
     end
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -122,7 +122,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).with('Authentication Attempt', user_id: user.uuid)
       expect(@analytics).to receive(:track_event).with('Authentication Successful')
 
-      post :create, user: { email: user.email, password: user.password }
+      post :create, user: { email: user.email.upcase, password: user.password }
     end
 
     it 'tracks the authentication attempt for nonexistent user' do

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -3,44 +3,5 @@ require 'rails_helper'
 describe RegisterUserEmailForm do
   subject { RegisterUserEmailForm.new }
 
-  describe 'email validation' do
-    it 'uses the valid_email gem with mx and ban_disposable options' do
-      email_validator = subject._validators.values.flatten.first
-
-      expect(email_validator.class).to eq EmailValidator
-      expect(email_validator.options).
-        to eq(mx: true, ban_disposable_email: true)
-    end
-  end
-
-  describe 'email uniqueness' do
-    context 'when email is already taken' do
-      it 'is not valid' do
-        second_user = build_stubbed(:user, :signed_up, email: 'taken@gmail.com')
-        allow(User).to receive(:exists?).with(email: second_user.email).and_return(true)
-
-        subject.user.email = second_user.email
-
-        expect(subject.valid_form?).to be false
-      end
-    end
-
-    context 'when email is not already taken' do
-      it 'is valid' do
-        subject.user.email = 'not_taken@gmail.com'
-
-        expect(subject.valid_form?).to be true
-      end
-    end
-
-    context 'when email is nil' do
-      it 'does not add already taken errors' do
-        subject.user.email = nil
-
-        expect(subject.valid_form?).to be false
-        expect(subject.errors[:email]).
-          to eq [t('valid_email.validations.email.invalid')]
-      end
-    end
-  end
+  it_behaves_like 'email validation'
 end

--- a/spec/support/shared_examples_for_email_validation.rb
+++ b/spec/support/shared_examples_for_email_validation.rb
@@ -1,0 +1,40 @@
+shared_examples 'email validation' do
+  it 'uses the valid_email gem with mx and ban_disposable options' do
+    email_validator = subject._validators.values.flatten.
+                      detect { |v| v.class == EmailValidator }
+
+    expect(email_validator.options).
+      to eq(mx: true, ban_disposable_email: true)
+  end
+
+  describe '#submit' do
+    context 'when email is already taken' do
+      it 'returns true to prevent revealing account existence' do
+        create(:user, :signed_up, email: 'taken@gmail.com')
+
+        result = subject.submit(email: 'TAKEN@gmail.com')
+
+        expect(result).to be true
+        expect(subject.email).to eq 'taken@gmail.com'
+      end
+    end
+
+    context 'when email is not already taken' do
+      it 'is valid' do
+        result = subject.submit(email: 'not_taken@gmail.com')
+
+        expect(result).to be true
+      end
+    end
+
+    context 'when email is invalid' do
+      it 'returns false and adds errors to the form object' do
+        result = subject.submit(email: 'invalid_email')
+
+        expect(result).to be false
+        expect(subject.errors[:email]).
+          to eq [t('valid_email.validations.email.invalid')]
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Because case should not matter when comparing email
addresses. If we make lookups case sensitive, the same email,
but with different capitalizations, will not be considered as
"already taken", which will lead to various errors.