### PR TITLE
Add Google Analytics and DAP scripts

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,6 +26,9 @@ html lang="#{I18n.locale}"
       <script src='https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js'></script>
     <![endif]-->
 
+    - if Figaro.env.google_analytics_key.present?
+      = render 'shared/google_analytics/page_tracking'
+
   body class="#{Rails.env}-env site"
     .site-wrap
       = render 'shared/usa_banner'
@@ -36,3 +39,9 @@ html lang="#{I18n.locale}"
   - if current_user
     #session-timeout-cntnr
     = auto_session_timeout_js
+
+  - if Figaro.env.participate_in_dap == 'yes'
+    <!-- We participate in the US government's analytics program. -->
+    <!-- See the data at analytics.usa.gov. -->
+    - dap_source = 'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA'
+    <script async type='text/javascript' src='#{dap_source}' id='_fed_an_ua_tag'></script>

--- a/app/views/shared/google_analytics/_page_tracking.html.slim
+++ b/app/views/shared/google_analytics/_page_tracking.html.slim
@@ -1,0 +1,10 @@
+javascript:
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '#{Figaro.env.google_analytics_key}', 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+  ga('send', 'pageview');

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -45,6 +45,7 @@ production:
   otp_delivery_blocklist_bantime: '10'
   otp_delivery_blocklist_findtime: '5'
   otp_delivery_blocklist_maxretry: '5'
+  participate_in_dap: 'no'
   proxy_addr: '123.456.789'
   proxy_port: '80'
   redis_url: 'redis://localhost:6379/0'


### PR DESCRIPTION
**Why**: To enable tracking of page views on our 18F Google Analytics,
as well as the Digital Analytics Program (analytics.usa.gov).

Both are opt-in via ENV vars defined in application.yml, which can be
set or unset on individual servers.