### PR TITLE
Remove need for domain entries in service_providers.yml

### DIFF
--- a/app/services/service_provider_config.rb
+++ b/app/services/service_provider_config.rb
@@ -4,15 +4,7 @@ class ServiceProviderConfig
   end
 
   def sp_attributes
-    SERVICE_PROVIDERS['valid_hosts'].fetch(issuer, {}).symbolize_keys
-  end
-
-  def self.fetch_providers_from_domain_name_or_rails_env
-    if Figaro.env.domain_name == 'superb.legit.domain.gov'
-      SERVICE_PROVIDERS.merge!(SERVICE_PROVIDERS.fetch('superb.legit.domain.gov', {}))
-    else
-      SERVICE_PROVIDERS.merge!(SERVICE_PROVIDERS.fetch(Rails.env, {}))
-    end
+    SERVICE_PROVIDERS.fetch(issuer, {}).symbolize_keys
   end
 
   private

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -33,6 +33,7 @@ development:
   session_timeout_in: '15'
   telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
+  valid_service_providers: '["https://rp1.serviceprovider.com/auth/saml/metadata", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails", "https://dashboard.login.gov"]'
 
 production:
   allow_third_party_auth: 'yes'
@@ -55,6 +56,7 @@ production:
   session_timeout_in: '8'
   smtp_settings: '{"address":"smtp.mandrillapp.com", "port":587, "authentication":"login", "enable_starttls_auto":true, "user_name":"user@gmail.com","password":"xxx"}'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
+  valid_service_providers: '["https://upaya-dev.18f.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo", "https://dashboard.demo.login.gov", "https://dashboard.qa.login.gov", "https://dashboard.dev.login.gov"]'
 
 test:
   allow_third_party_auth: 'yes'
@@ -77,3 +79,4 @@ test:
   secret_key_base: 'test_secret_key_base'
   session_timeout_in: '8'
   twilio_accounts: '[{"sid":"sid1", "auth_token":"token1", "number":"9999999999"}, {"sid":"sid2", "auth_token":"token2", "number":"2222222222"}]'
+  valid_service_providers: '["http://localhost:3000", "https://rp1.serviceprovider.com/auth/saml/metadata", "https://rp2.serviceprovider.com/auth/saml/metadata", "http://test.host"]'

--- a/config/initializers/_service_providers.rb
+++ b/config/initializers/_service_providers.rb
@@ -1,0 +1,4 @@
+SERVICE_PROVIDERS = YAML.load_file("#{Rails.root}/config/service_providers.yml").
+                    fetch(Rails.env, {})
+
+VALID_SERVICE_PROVIDERS = JSON.parse(Figaro.env.valid_service_providers)

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,5 +3,5 @@ Figaro.require_keys(
   'logins_per_ip_limit', 'logins_per_ip_period', 'otp_delivery_blocklist_bantime',
   'otp_delivery_blocklist_findtime', 'otp_delivery_blocklist_maxretry',
   'requests_per_ip_limit', 'requests_per_ip_period', 'saml_passphrase',
-  'secret_key_base', 'session_timeout_in', 'twilio_accounts'
+  'secret_key_base', 'session_timeout_in', 'twilio_accounts', 'valid_service_providers'
 )

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -43,11 +43,7 @@ SecureHeaders::Configuration.default do |config|
 end
 
 SecureHeaders::Configuration.override(:saml) do |config|
-  providers = YAML.load_file("#{Rails.root}/config/service_providers.yml")
-  providers = providers.fetch(Rails.env, {})
-  providers.symbolize_keys!
-
-  provider_attributes = providers[:valid_hosts].values
+  provider_attributes = SERVICE_PROVIDERS.values
 
   acs_urls = provider_attributes.map { |hash| hash['acs_url'] }
 

--- a/config/initializers/service_providers.rb
+++ b/config/initializers/service_providers.rb
@@ -1,3 +1,0 @@
-SERVICE_PROVIDERS = YAML.load_file("#{Rails.root}/config/service_providers.yml")
-
-ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -1,165 +1,150 @@
 test:
-  valid_hosts:
-    'http://localhost:3000':
-      acs_url: 'http://localhost:3000/test/saml/decode_assertion'
-      assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
-      sp_initiated_login_url: 'http://localhost:3000/test/saml'
-      block_encryption: 'none'
-      cert: 'saml_test_sp'
-      agency: 'test_agency'
-      friendly_name: 'test_friendly_name'
-      attribute_bundle:
-        - email
-        - phone
+  'http://localhost:3000':
+    acs_url: 'http://localhost:3000/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'http://localhost:3000/test/saml'
+    block_encryption: 'none'
+    cert: 'saml_test_sp'
+    agency: 'test_agency'
+    friendly_name: 'test_friendly_name'
+    attribute_bundle:
+      - email
+      - phone
 
-    'https://rp1.serviceprovider.com/auth/saml/metadata':
-      acs_url: 'http://example.com/test/saml/decode_assertion'
-      assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
-      block_encryption: 'aes256-cbc'
-      sp_initiated_login_url: 'https://example.com/auth/saml/login'
-      cert: 'saml_test_sp'
-      attribute_bundle:
-        - first_name
-        - last_name
-        - ssn
-        - zipcode
+  'https://rp1.serviceprovider.com/auth/saml/metadata':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    cert: 'saml_test_sp'
+    attribute_bundle:
+      - first_name
+      - last_name
+      - ssn
+      - zipcode
 
-    'https://rp2.serviceprovider.com/auth/saml/metadata':
-      acs_url: 'http://example.com/test/saml/decode_assertion'
-      assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
-      block_encryption: 'aes256-cbc'
-      cert: 'saml_test_sp'
+  'https://rp2.serviceprovider.com/auth/saml/metadata':
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    cert: 'saml_test_sp'
 
-    'http://test.host':
-      acs_url: 'http://test.host/test/saml/decode_assertion'
-      block_encryption: 'aes256-cbc'
-      metadata_url: 'http://test.host/test/saml/metadata'
-      sp_initiated_login_url: 'http://test.host/test/saml'
+  'http://test.host':
+    acs_url: 'http://test.host/test/saml/decode_assertion'
+    block_encryption: 'aes256-cbc'
+    metadata_url: 'http://test.host/test/saml/metadata'
+    sp_initiated_login_url: 'http://test.host/test/saml'
 
 development:
-  valid_hosts:
-    'https://rp1.serviceprovider.com/auth/saml/metadata':
-      metadata_url: 'http://localhost:3000/test/saml/metadata'
-      acs_url: 'http://localhost:3000/test/saml/decode_assertion'
-      assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
-      block_encryption: 'aes256-cbc'
-      sp_initiated_login_url: 'http://localhost:3000/test/saml'
-      cert: 'saml_test_sp'
-      fingerprint: '08:79:F5:B1:B8:CC:EC:8F:5C:2A:58:03:30:14:C9:E6:F1:67:78:F1:97:E8:3A:88:EB:8E:70:92:25:D2:2F:32'
+  'https://rp1.serviceprovider.com/auth/saml/metadata':
+    metadata_url: 'http://localhost:3000/test/saml/metadata'
+    acs_url: 'http://localhost:3000/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
+    block_encryption: 'aes256-cbc'
+    sp_initiated_login_url: 'http://localhost:3000/test/saml'
+    cert: 'saml_test_sp'
+    fingerprint: '08:79:F5:B1:B8:CC:EC:8F:5C:2A:58:03:30:14:C9:E6:F1:67:78:F1:97:E8:3A:88:EB:8E:70:92:25:D2:2F:32'
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
-      acs_url: 'http://localhost:4567/consume'
-      sp_initiated_login_url: 'http://localhost:4567/test/saml'
-      assertion_consumer_logout_service_url: 'http://localhost:4567/slo_logout'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_sinatra_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
+    acs_url: 'http://localhost:4567/consume'
+    sp_initiated_login_url: 'http://localhost:4567/test/saml'
+    assertion_consumer_logout_service_url: 'http://localhost:4567/slo_logout'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_sinatra_demo'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
-      acs_url: 'http://localhost:3003/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'http://localhost:3003/auth/saml/logout'
-      sp_initiated_login_url: 'http://localhost:3003/login'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_rails_demo'
-      agency: '18F'
-      friendly_name: '18F Test Service Provider'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails':
+    acs_url: 'http://localhost:3003/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'http://localhost:3003/auth/saml/logout'
+    sp_initiated_login_url: 'http://localhost:3003/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    agency: '18F'
+    friendly_name: '18F Test Service Provider'
+    attribute_bundle:
+      - email
 
-    'https://dashboard.login.gov':
-      acs_url: 'http://localhost:3001/users/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
-      sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'identity_dashboard_cert'
+  'https://dashboard.login.gov':
+    acs_url: 'http://localhost:3001/users/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
+    sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'identity_dashboard_cert'
 
 production:
-  valid_hosts:
-    'https://upaya-dev.18f.gov':
-      metadata_url: 'https://upaya-dev.18f.gov/api/saml/metadata'
-      acs_url: 'https://upaya-dev.18f.gov/test/saml/decode_assertion'
-      assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
-      sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'saml_test_sp'
-      attribute_bundle:
-        - email
+  'https://upaya-dev.18f.gov':
+    metadata_url: 'https://upaya-dev.18f.gov/api/saml/metadata'
+    acs_url: 'https://upaya-dev.18f.gov/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'https://upaya-dev.18f.gov/test/saml/decode_logoutresponse'
+    sp_initiated_login_url: 'https://upaya-dev.18f.gov/test/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'saml_test_sp'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
-      acs_url: 'http://localhost:4567/consume'
-      sp_initiated_login_url: 'http://localhost:4567/test/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_sinatra_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost':
+    acs_url: 'http://localhost:4567/consume'
+    sp_initiated_login_url: 'http://localhost:4567/test/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_sinatra_demo'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev':
-      acs_url: 'https://sp-sinatra.dev.login.gov/consume'
-      assertion_consumer_logout_service_url: 'https://sp-sinatra.dev.login.gov/slo_logout'
-      sp_initiated_login_url: 'https://sp-sinatra.dev.login.gov/test/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_sinatra_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev':
+    acs_url: 'https://sp-sinatra.dev.login.gov/consume'
+    assertion_consumer_logout_service_url: 'https://sp-sinatra.dev.login.gov/slo_logout'
+    sp_initiated_login_url: 'https://sp-sinatra.dev.login.gov/test/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_sinatra_demo'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo':
-      acs_url: 'https://sp-sinatra.demo.login.gov/consume'
-      assertion_consumer_logout_service_url: 'https://sp-sinatra.demo.login.gov/slo_logout'
-      sp_initiated_login_url: 'https://sp-sinatra.demo.login.gov/test/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_sinatra_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo':
+    acs_url: 'https://sp-sinatra.demo.login.gov/consume'
+    assertion_consumer_logout_service_url: 'https://sp-sinatra.demo.login.gov/slo_logout'
+    sp_initiated_login_url: 'https://sp-sinatra.demo.login.gov/test/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_sinatra_demo'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev':
-      acs_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/logout'
-      sp_initiated_login_url: 'https://identity-sp-rails-dev.apps.cloud.gov/login'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_rails_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev':
+    acs_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://identity-sp-rails-dev.apps.cloud.gov/auth/saml/logout'
+    sp_initiated_login_url: 'https://identity-sp-rails-dev.apps.cloud.gov/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    attribute_bundle:
+      - email
 
-    'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo':
-      acs_url: 'https://sp.demo.login.gov/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://sp.demo.login.gov/auth/saml/logout'
-      sp_initiated_login_url: 'https://sp.demo.login.gov/login'
-      block_encryption: 'aes256-cbc'
-      cert: 'sp_rails_demo'
-      attribute_bundle:
-        - email
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo':
+    acs_url: 'https://sp.demo.login.gov/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://sp.demo.login.gov/auth/saml/logout'
+    sp_initiated_login_url: 'https://sp.demo.login.gov/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    attribute_bundle:
+      - email
 
-    # Dashboard
-    'https://dashboard.demo.login.gov':
-      acs_url: 'https://dashboard.demo.login.gov/users/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://dashboard.demo.login.gov/users/auth/saml/logout'
-      sp_initiated_login_url: 'https://dashboard.demo.login.gov/users/auth/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'identity_dashboard_cert'
+  # Dashboard
+  'https://dashboard.demo.login.gov':
+    acs_url: 'https://dashboard.demo.login.gov/users/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://dashboard.demo.login.gov/users/auth/saml/logout'
+    sp_initiated_login_url: 'https://dashboard.demo.login.gov/users/auth/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'identity_dashboard_cert'
 
-    'https://dashboard.qa.login.gov':
-      acs_url: 'https://dashboard.qa.login.gov/users/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://dashboard.qa.login.gov/users/auth/saml/logout'
-      sp_initiated_login_url: 'https://dashboard.qa.login.gov/users/auth/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'identity_dashboard_cert'
+  'https://dashboard.qa.login.gov':
+    acs_url: 'https://dashboard.qa.login.gov/users/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://dashboard.qa.login.gov/users/auth/saml/logout'
+    sp_initiated_login_url: 'https://dashboard.qa.login.gov/users/auth/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'identity_dashboard_cert'
 
-    'https://dashboard.dev.login.gov':
-      acs_url: 'https://dashboard.dev.login.gov/users/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://dashboard.dev.login.gov/users/auth/saml/logout'
-      sp_initiated_login_url: 'https://dashboard.dev.login.gov/users/auth/saml'
-      block_encryption: 'aes256-cbc'
-      cert: 'identity_dashboard_cert'
-
-superb.legit.domain.gov:
-  valid_hosts:
-    'urn:govheroku:serviceprovider':
-      acs_url: 'https://vets.gov/users/auth/saml/callback'
-      assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout'
-      block_encryption: 'aes256-cbc'
-      cert: 'saml_test_sp'
-      agency: 'test_agency'
-      attribute_bundle:
-        - email
-        - phone
+  'https://dashboard.dev.login.gov':
+    acs_url: 'https://dashboard.dev.login.gov/users/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://dashboard.dev.login.gov/users/auth/saml/logout'
+    sp_initiated_login_url: 'https://dashboard.dev.login.gov/users/auth/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'identity_dashboard_cert'

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -20,6 +20,10 @@ class ServiceProvider
     }
   end
 
+  def valid?
+    VALID_SERVICE_PROVIDERS.include?(issuer)
+  end
+
   private
 
   def sp_attributes

--- a/spec/services/service_provider_config_spec.rb
+++ b/spec/services/service_provider_config_spec.rb
@@ -2,46 +2,17 @@ require 'rails_helper'
 
 describe ServiceProviderConfig do
   describe '#sp_attributes' do
-    context 'when the domain_name is superb.legit.domain.gov' do
-      before do
-        allow(Figaro.env).to receive(:domain_name).and_return('superb.legit.domain.gov')
-        ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env
-      end
+    it 'returns the issuer attributes for the Rails.env entry in the YAML file' do
+      config = ServiceProviderConfig.new(issuer: 'http://test.host')
 
-      after do
-        allow(Figaro.env).to receive(:domain_name).and_return('')
-        ServiceProviderConfig.fetch_providers_from_domain_name_or_rails_env
-      end
+      yaml_hash = {
+        acs_url: 'http://test.host/test/saml/decode_assertion',
+        block_encryption: 'aes256-cbc',
+        metadata_url: 'http://test.host/test/saml/metadata',
+        sp_initiated_login_url: 'http://test.host/test/saml'
+      }
 
-      it 'returns the issuer attributes for the superb.legit.domain.gov entry in the YAML file' do
-        config = ServiceProviderConfig.new(issuer: 'urn:govheroku:serviceprovider')
-
-        yaml_hash = {
-          acs_url: 'https://vets.gov/users/auth/saml/callback',
-          assertion_consumer_logout_service_url: 'https://vets.gov/api/saml/logout',
-          block_encryption: 'aes256-cbc',
-          cert: 'saml_test_sp',
-          agency: 'test_agency',
-          attribute_bundle: %w(email phone)
-        }
-
-        expect(config.sp_attributes).to eq yaml_hash
-      end
-    end
-
-    context 'when the domain_name is not superb.legit.domain.gov' do
-      it 'returns the issuer attributes for the Rails.env entry in the YAML file' do
-        config = ServiceProviderConfig.new(issuer: 'http://test.host')
-
-        yaml_hash = {
-          acs_url: 'http://test.host/test/saml/decode_assertion',
-          block_encryption: 'aes256-cbc',
-          metadata_url: 'http://test.host/test/saml/metadata',
-          sp_initiated_login_url: 'http://test.host/test/saml'
-        }
-
-        expect(config.sp_attributes).to eq yaml_hash
-      end
+      expect(config.sp_attributes).to eq yaml_hash
     end
   end
 end

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -1,0 +1,9 @@
+class FakeSamlRequest
+  def service_provider
+    self
+  end
+
+  def identifier
+    'http://localhost:3000'
+  end
+end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -76,6 +76,12 @@ module SamlAuthHelper
     settings
   end
 
+  def invalid_service_provider_settings
+    settings = saml_settings.dup
+    settings.issuer = 'invalid_provider'
+    settings
+  end
+
   def sp1_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'


### PR DESCRIPTION
**Why**: The list of authorized service providers should be configurable
on each server, so that the live production server can have a different
list than our demo servers for example.

**How**: Per the Twelve Factor App principles, use ENV vars to allow
this kind of configuration. Hence, I've added a
`valid_service_providers` entry to `application.yml` that can be
customized on each server.

- Rename the `service_providers` initializer to `_service_providers`
to allow the `secure_headers` initializer to use the `SERVICE_PROVIDERS`
constant. Initializers get loaded alphabetically.

- Remove the `valid_hosts` key from `service_providers.yml` since it's
redundant.

- Add a `before_action` to SamlIdpController#auth to validate the
service provider, in case someone tries to send a SAML request with
a service provider that is not approved. Capture this event in our
analytics.