### PR TITLE
Track active SP session with session_uuid

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -5,7 +5,7 @@ class Identity < ActiveRecord::Base
   validates :service_provider, presence: true
 
   def deactivate
-    update!(last_authenticated_at: nil)
+    update!(session_uuid: nil)
   end
 
   def sp_metadata

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ActiveRecord::Base
 
   def active_identities
     identities.where(
-      'last_authenticated_at IS NOT ?',
+      'session_uuid IS NOT ?',
       nil
     ).order(
       last_authenticated_at: :asc

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -107,7 +107,7 @@ describe UserDecorator do
       user.identities << create(
         :identity,
         service_provider: sp.issuer,
-        last_authenticated_at: Time.current
+        session_uuid: SecureRandom.uuid
       )
 
       user_decorator = UserDecorator.new(user)

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -301,7 +301,7 @@ feature 'saml api', devise: true do
         click_button 'Submit' # logout request for second SP
 
         logout_user.identities.each do |ident|
-          expect(ident.last_authenticated_at).to be_nil
+          expect(ident.session_uuid).to be_nil
         end
 
         expect(logout_user.active_identities).to be_empty

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -120,10 +120,10 @@ describe User do
   context 'when identities are present' do
     let(:user) { create(:user, :signed_up) }
     let(:active_identity) do
-      Identity.create(service_provider: 'entity_id', last_authenticated_at: Time.current - 1.hour)
+      Identity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
     end
     let(:inactive_identity) do
-      Identity.create(service_provider: 'entity_id', last_authenticated_at: nil)
+      Identity.create(service_provider: 'entity_id', session_uuid: nil)
     end
 
     describe '#active_identities' do
@@ -141,11 +141,13 @@ describe User do
     before do
       user.identities << Identity.create(
         service_provider: 'first',
-        last_authenticated_at: Time.current - 1.hour
+        last_authenticated_at: Time.current - 1.hour,
+        session_uuid: SecureRandom.uuid
       )
       user.identities << Identity.create(
         service_provider: 'last',
-        last_authenticated_at: Time.current
+        last_authenticated_at: Time.current,
+        session_uuid: SecureRandom.uuid
       )
     end
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -9,7 +9,7 @@ describe AttributeAsserter do
     build(
       :identity,
       service_provider: service_provider.issuer,
-      last_authenticated_at: Time.current
+      session_uuid: SecureRandom.uuid
     )
   end
   let(:service_provider) do


### PR DESCRIPTION
**Why**: Distinguish a SP (Identity) history as
*ever* logged in vs *currently* logged in by using
`session_uuid` to indicate current status.