### PR TITLE
Add support for signing in with a recovery code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,11 +49,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     analytics.track_event('Authentication Successful')
 
-    if decorated_user.should_acknowledge_recovery_code?(session)
-      settings_recovery_code_url
-    else
-      stored_location_for(resource) || session[:saml_request_url] || profile_path
-    end
+    stored_location_for(resource) || session[:saml_request_url] || profile_path
   end
 
   def render_401

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,12 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     analytics.track_event('Authentication Successful')
-    stored_location_for(resource) || session[:saml_request_url] || profile_path
+
+    if decorated_user.should_acknowledge_recovery_code?(session)
+      settings_recovery_code_url
+    else
+      stored_location_for(resource) || session[:saml_request_url] || profile_path
+    end
   end
 
   def render_401

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -43,9 +43,12 @@ module TwoFactorAuthenticatable
 
     current_user.update(second_factor_attempts_count: 0)
 
-    redirect_to after_sign_in_path_for(current_user)
+    redirect_to after_2fa_path
   end
 
+  # Method will be renamed in the next refactor.
+  # You can pass in any "type" with a corresponding I18n key in
+  # devise.two_factor_authentication.invalid_#{type}
   def handle_invalid_otp(type: 'otp')
     analytics.track_event('User entered invalid 2FA code')
 
@@ -69,5 +72,13 @@ module TwoFactorAuthenticatable
 
   def user_decorator
     @user_decorator ||= current_user.decorate
+  end
+
+  def after_2fa_path
+    if decorated_user.should_acknowledge_recovery_code?(session)
+      settings_recovery_code_url
+    else
+      after_sign_in_path_for(current_user)
+    end
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -46,12 +46,12 @@ module TwoFactorAuthenticatable
     redirect_to after_sign_in_path_for(current_user)
   end
 
-  def handle_invalid_otp
+  def handle_invalid_otp(type: 'otp')
     analytics.track_event('User entered invalid 2FA code')
 
     update_invalid_user if current_user.two_factor_enabled?
 
-    flash[:error] = t('devise.two_factor_authentication.attempt_failed')
+    flash[:error] = t("devise.two_factor_authentication.invalid_#{type}")
 
     if user_decorator.blocked_from_entering_2fa_code?
       handle_second_factor_locked_user

--- a/app/controllers/two_factor_authentication/recovery_code_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_controller.rb
@@ -1,0 +1,13 @@
+module TwoFactorAuthentication
+  class RecoveryCodeController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    def show
+      @code = RecoveryCodeGenerator.new(current_user).create
+    end
+
+    def acknowledge
+      redirect_to after_sign_in_path_for(current_user)
+    end
+  end
+end

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -1,0 +1,23 @@
+module TwoFactorAuthentication
+  class RecoveryCodeVerificationController < DeviseController
+    include ScopeAuthenticator
+    include TwoFactorAuthenticatable
+
+    prepend_before_action :authenticate_scope!
+
+    def show
+    end
+
+    def create
+      result = RecoveryCodeForm.new(current_user, params[:code]).submit
+
+      analytics.track_event(:recovery_code_authentication, result)
+
+      if result[:success?]
+        handle_valid_otp
+      else
+        handle_invalid_otp(type: 'recovery_code')
+      end
+    end
+  end
+end

--- a/app/controllers/users/phone_confirmation_controller.rb
+++ b/app/controllers/users/phone_confirmation_controller.rb
@@ -55,6 +55,8 @@ module Users
     def after_confirmation_path
       if @updating_existing_number
         profile_path
+      elsif decorated_user.should_acknowledge_recovery_code?(session)
+        settings_recovery_code_url
       else
         after_sign_in_path_for(current_user)
       end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -69,6 +69,10 @@ UserDecorator = Struct.new(:user) do
     user.second_factor_locked_at && blocked_from_2fa_period_expired?
   end
 
+  def should_acknowledge_recovery_code?(session)
+    user.recovery_code.blank? && !omniauthed?(session)
+  end
+
   private
 
   def omniauthed?(session)

--- a/app/forms/recovery_code_form.rb
+++ b/app/forms/recovery_code_form.rb
@@ -1,0 +1,28 @@
+class RecoveryCodeForm
+  def initialize(user, code)
+    @user = user
+    @code = code
+  end
+
+  def submit
+    @success = valid_recovery_code?
+
+    user.update!(recovery_code: nil) if @success
+
+    result
+  end
+
+  private
+
+  attr_reader :user, :code, :success
+
+  def valid_recovery_code?
+    Devise::Encryptor.compare(User, user.recovery_code, code)
+  end
+
+  def result
+    {
+      success?: success
+    }
+  end
+end

--- a/app/services/recovery_code_generator.rb
+++ b/app/services/recovery_code_generator.rb
@@ -1,0 +1,28 @@
+class RecoveryCodeGenerator
+  def initialize(user, length: 16)
+    @user = user
+    @length = length
+  end
+
+  def create
+    user.update!(recovery_code: hashed_code)
+
+    raw_recovery_code
+  end
+
+  private
+
+  attr_reader :length, :user
+
+  def hashed_code
+    Devise::Encryptor.digest(User, raw_recovery_code)
+  end
+
+  def raw_recovery_code
+    @raw_recovery_code ||= SecureRandom.hex(recovery_code_length / 2)
+  end
+
+  def recovery_code_length
+    Figaro.env.recovery_code_length.to_i || length
+  end
+end

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -21,3 +21,7 @@ p#2fa-description
       = t('devise.two_factor_authentication.otp_method.voice')
   = f.button :submit, t('forms.buttons.submit'), class: 'btn btn-primary btn-wide mb2'
 p.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')
+
+- link = link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),
+  login_two_factor_recovery_code_path)
+p.mt2.mb0.italic == t('devise.two_factor_authentication.recovery_code_fallback.text', link: link)

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -60,7 +60,7 @@ h2.heading = t('headings.profile.login_info')
       .sm-col.sm-col-2.px1.sm-right-align
         = link_to 'Edit', edit_phone_path, \
           class: btn_cls
-  .py-12p.border-top.border-bottom
+  .py-12p.border-top
     .clearfix.mxn1
       .sm-col.sm-col-10.px1 = 'Authentication app'
       .sm-col.sm-col-2.px1.sm-right-align
@@ -70,6 +70,12 @@ h2.heading = t('headings.profile.login_info')
         - else
           = link_to 'Enable', authenticator_start_url, \
             class: btn_cls
+  .py-12p.border-top.border-bottom
+    .clearfix.mxn1
+      .sm-col.sm-col-10.px1 =  t('profile.items.recovery_code')
+      .sm-col.sm-col-2.px1.sm-right-align
+        = link_to t('profile.links.regenerate_recovery_code'), \
+          settings_recovery_code_url, class: btn_cls
 
 h2.heading = t('headings.profile.agencies')
 .mt3.mb4

--- a/app/views/two_factor_authentication/recovery_code/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code/show.html.slim
@@ -1,0 +1,11 @@
+- title t('titles.recovery_code')
+
+h1.heading = t('headings.recovery_code')
+p= t('instructions.recovery_code')
+
+.mt3.mb4.monospace
+  = @code
+
+.mt3.mb4
+  = button_to(t('forms.buttons.acknowledge_recovery_code'), \
+    acknowledge_recovery_code_path, class: 'btn btn-primary')

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -1,0 +1,10 @@
+- title t('titles.enter_2fa_code')
+
+h1.heading = t('devise.two_factor_authentication.recovery_code_header_text')
+p = t('devise.two_factor_authentication.recovery_code_prompt')
+
+= form_tag(:login_two_factor_recovery_code, method: :post, role: 'form') do
+  .mb2
+    = label_tag 'code', raw(t('simple_form.required.html')) + t('forms.two_factor.recovery_code')
+    = block_text_field_tag :code, '', class: 'block col-12 field mfa', required: true
+  = submit_tag t('forms.buttons.submit'), class: 'btn btn-primary'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -12,6 +12,8 @@ email_from: 'no-reply@login.gov'
 idv_max_attempts: '3'
 idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
+
+# Must be an even number. 16 seems to be what most sites use.
 recovery_code_length: '16'
 
 # Set the number of seconds the timeout warning should occur before

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -12,6 +12,7 @@ email_from: 'no-reply@login.gov'
 idv_max_attempts: '3'
 idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
+recovery_code_length: '16'
 
 # Set the number of seconds the timeout warning should occur before
 # login session is timed out.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -2,7 +2,7 @@ Figaro.require_keys(
   'allow_third_party_auth', 'domain_name', 'enable_test_routes', 'idp_sso_target_url',
   'logins_per_ip_limit', 'logins_per_ip_period', 'otp_delivery_blocklist_bantime',
   'otp_delivery_blocklist_findtime', 'otp_delivery_blocklist_maxretry',
-  'requests_per_ip_limit', 'requests_per_ip_period', 'saml_passphrase',
-  'secret_key_base', 'session_timeout_in', 'support_email',
+  'recovery_code_length', 'requests_per_ip_limit', 'requests_per_ip_period',
+  'saml_passphrase', 'secret_key_base', 'session_timeout_in', 'support_email',
   'twilio_accounts', 'valid_service_providers'
 )

--- a/config/locales/devise.two_factor_authentication.en.yml
+++ b/config/locales/devise.two_factor_authentication.en.yml
@@ -1,14 +1,21 @@
 en:
   devise:
     two_factor_authentication:
-      attempt_failed: Secure one-time passcode is invalid. Please try again or request a new one-time passcode.
       contact_administrator: Please contact your system administrator.
       header_text: Enter your one-time passcode
+      invalid_otp: Secure one-time passcode is invalid. Please try again or request a new one-time passcode.
+      invalid_recovery_code: Invalid recovery code. Please try again.
       totp_header_text: Enter your Authenticator code
       max_login_attempts_reached: >
         Your account is temporarily locked because you have entered the
         one-time passcode incorrectly too many times.
       please_try_again: Please try again in %{time_remaining}.
+      recovery_code_header_text: Enter a recovery code
+      recovery_code_prompt: >
+        Please enter your recovery code. Once used, a new one will be generated for you.
+      recovery_code_fallback:
+        text: Don't have access to your phone? Use a %{link} instead.
+        link: recovery code
       otp_setup: >
         Every time you log in, a one-time passcode will be sent to your phone via SMS or with a
         phone call.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
 
   forms:
     buttons:
+      acknowledge_recovery_code: Continue
       continue_browsing: Continue browsing
       resend_confirmation: Resend confirmation instructions
       reset_password: Send reset password instructions
@@ -29,6 +30,7 @@ en:
       header_text: Confirm your phone number
     two_factor:
       code: One-time passcode
+      recovery_code: Recovery code
     totp_setup:
       code: One-time passcode
       totp_info: >
@@ -45,6 +47,10 @@ en:
   instructions:
     edit_info:
       password: Your new password must be at least %{min_length} characters.
+    recovery_code: >
+      Below is the recovery code that we have generated for you. You can use
+      this code to access your account in case you lose access to your phone.
+      Make sure to print and/or write down this code and keep it in a safe place.
 
   links:
     resend: Try resending the confirmation instructions.
@@ -99,6 +105,7 @@ en:
       change: Change the password for your account
       forgot: Reset the password for your account
     profile: Profile
+    recovery_code: Your Recovery Code
     registrations:
       new: Sign up for a account
       start: Get started
@@ -138,6 +145,7 @@ en:
       login_info: Login information
       main: My account
       two_factor: Two-factor Authentication
+    recovery_code: Your Recovery Code
     registrations:
       enter_email: Email address
       verify_email: Verify email address
@@ -213,7 +221,7 @@ en:
         To learn more about the information we need from you and how it’s used to verify your identity,
         please see our troubleshooting page.
       hardfail: >
-        Your login.gov account can’t be used to access information with 
+        Your login.gov account can’t be used to access information with
         participating agencies until you successfully complete this process.
       hardfail2: >
         You can try to complete the verification process again in %{hours} hours.
@@ -267,6 +275,12 @@ en:
       comments_note: Optional, but very helpful
     messages:
       thanks: Thanks! We'll be in touch soon.
+
+  profile:
+    items:
+      recovery_code: Recovery code
+    links:
+      regenerate_recovery_code: Regenerate
 
   voice:
     otp_confirmation: >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,10 @@ Rails.application.routes.draw do
     get '/otp/send' => 'devise/two_factor_authentication#send_code'
     get '/login/two-factor/authenticator' => 'two_factor_authentication/totp_verification#show'
     post '/login/two-factor/authenticator' => 'two_factor_authentication/totp_verification#create'
+    # rubocop:disable LineLength
+    get '/login/two-factor/recovery-code' => 'two_factor_authentication/recovery_code_verification#show'
+    post '/login/two-factor/recovery-code' => 'two_factor_authentication/recovery_code_verification#create'
+    # rubocop:enable LineLength
     get(
       '/login/two-factor/:delivery_method' => 'two_factor_authentication/otp_verification#show',
       as: :login_two_factor
@@ -74,6 +78,8 @@ Rails.application.routes.draw do
   match '/edit/phone' => 'users/edit_phone#update', via: [:patch, :put]
   get '/settings/password' => 'users/edit_password#edit'
   patch '/settings/password' => 'users/edit_password#update'
+  get '/settings/recovery-code' => 'two_factor_authentication/recovery_code#show'
+  post '/acknowledge_recovery_code' => 'two_factor_authentication/recovery_code#acknowledge'
 
   get '/idv' => 'idv#index'
   get '/idv/cancel' => 'idv#cancel'

--- a/db/migrate/20160915202036_add_recovery_code_to_user.rb
+++ b/db/migrate/20160915202036_add_recovery_code_to_user.rb
@@ -1,0 +1,5 @@
+class AddRecoveryCodeToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :recovery_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160914155344) do
+ActiveRecord::Schema.define(version: 20160915202036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20160914155344) do
     t.datetime "direct_otp_sent_at"
     t.datetime "idv_attempted_at"
     t.integer  "idv_attempts",                              default: 0
+    t.string   "recovery_code"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -49,7 +49,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
       end
 
       it 'displays flash error message' do
-        expect(flash[:error]).to eq t('devise.two_factor_authentication.attempt_failed')
+        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_otp')
       end
     end
 

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe TwoFactorAuthentication::RecoveryCodeController do
+  describe '#show' do
+    it 'generates a new recovery code' do
+      stub_sign_in
+      generator = instance_double(RecoveryCodeGenerator)
+      allow(RecoveryCodeGenerator).to receive(:new).
+        with(subject.current_user).and_return(generator)
+
+      expect(generator).to receive(:create)
+
+      get :show
+    end
+
+    it 'redirects to the profile page' do
+      stub_sign_in
+      subject.current_user.recovery_code = 'foo'
+
+      post :acknowledge
+
+      expect(response).to redirect_to profile_path
+    end
+  end
+end

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: true do
+  describe '#create' do
+    context 'when the user enters a valid recovery code' do
+      before do
+        stub_sign_in_before_2fa(User.new(recovery_code: 'foo'))
+        form = instance_double(RecoveryCodeForm)
+        allow(RecoveryCodeForm).to receive(:new).
+          with(subject.current_user, 'foo').and_return(form)
+        allow(form).to receive(:submit).and_return(success?: true)
+      end
+
+      it 'redirects to the profile' do
+        post :create, code: 'foo'
+
+        expect(response).to redirect_to profile_path
+      end
+
+      it 'calls handle_valid_otp' do
+        expect(subject).to receive(:handle_valid_otp).and_call_original
+
+        post :create, code: 'foo'
+      end
+
+      it 'tracks the valid authentication event' do
+        stub_analytics
+        analytics_hash = { success?: true }
+
+        expect(@analytics).to receive(:track_event).
+          with(:recovery_code_authentication, analytics_hash).ordered
+        expect(@analytics).to receive(:track_event).with('User 2FA successful').ordered
+        expect(@analytics).to receive(:track_event).with('Authentication Successful').ordered
+
+        post :create, code: 'foo'
+      end
+    end
+
+    context 'when the user enters an invalid recovery code' do
+      before do
+        stub_sign_in_before_2fa
+        form = instance_double(RecoveryCodeForm)
+        allow(RecoveryCodeForm).to receive(:new).
+          with(subject.current_user, 'foo').and_return(form)
+        allow(form).to receive(:submit).and_return(success?: false)
+      end
+
+      it 'calls handle_invalid_otp' do
+        expect(subject).to receive(:handle_invalid_otp).and_call_original
+
+        post :create, code: 'foo'
+      end
+
+      it 're-renders the recovery code entry screen' do
+        post :create, code: 'foo'
+
+        expect(response).to render_template(:show)
+        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_recovery_code')
+      end
+    end
+  end
+end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -51,7 +51,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
       end
 
       it 'displays flash error message' do
-        expect(flash[:error]).to eq t('devise.two_factor_authentication.attempt_failed')
+        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_otp')
       end
     end
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -115,4 +115,27 @@ describe UserDecorator do
       expect(user_decorator.active_identity_for(sp)).to eq user.last_identity
     end
   end
+
+  describe '#should_acknowledge_recovery_code?' do
+    it 'returns true when the user has no recovery code and is not omniauthed' do
+      user_decorator = UserDecorator.new(User.new)
+      session = { omniauthed: false }
+
+      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
+    end
+
+    it 'returns false when the user has a recovery code' do
+      user_decorator = UserDecorator.new(User.new(recovery_code: 'foo'))
+      session = { omniauthed: false }
+
+      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+    end
+
+    it 'returns false when the user is omniauthed' do
+      user_decorator = UserDecorator.new(User.new)
+      session = { omniauthed: true }
+
+      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,7 @@ FactoryGirl.define do
 
     trait :signed_up do
       with_phone
+      recovery_code '$2a$10$vOkU3l3j0aYgWbXVdwJA5.FICxwydpvPrzBuzjFZUXDnPeXkMHeLe'
     end
 
     trait :unconfirmed do

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -43,4 +43,19 @@ feature 'User profile' do
       expect(current_path).to eq profile_path
     end
   end
+
+  describe 'Regenerating recovery code' do
+    it 'displays new code and takes user back to profile page after continuing' do
+      user = sign_in_and_2fa_user
+      old_code = user.recovery_code
+
+      click_link t('profile.links.regenerate_recovery_code')
+
+      expect(user.reload.recovery_code).to_not eq old_code
+
+      click_button t('forms.buttons.acknowledge_recovery_code')
+
+      expect(current_path).to eq profile_path
+    end
+  end
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -62,11 +62,11 @@ feature 'Sign Up', devise: true do
       click_button t('forms.buttons.submit')
     end
 
-    it 'updates phone_confirmed_at and redirects to profile after confirmation' do
+    it 'updates phone_confirmed_at and redirects to acknowledge recovery code' do
       click_button 'Submit'
 
       expect(@user.reload.phone_confirmed_at).to be_present
-      expect(current_path).to eq profile_path
+      expect(current_path).to eq settings_recovery_code_path
     end
 
     it 'allows user to resend confirmation code' do

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -67,6 +67,10 @@ feature 'Sign Up', devise: true do
 
       expect(@user.reload.phone_confirmed_at).to be_present
       expect(current_path).to eq settings_recovery_code_path
+
+      click_button t('forms.buttons.acknowledge_recovery_code')
+
+      expect(current_path).to eq profile_path
     end
 
     it 'allows user to resend confirmation code' do

--- a/spec/forms/recovery_code_form_spec.rb
+++ b/spec/forms/recovery_code_form_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe RecoveryCodeForm do
+  describe '#submit' do
+    context 'when the form is valid' do
+      it 'returns true for success?' do
+        user = create(:user)
+        raw_code = RecoveryCodeGenerator.new(user).create
+
+        result = RecoveryCodeForm.new(user, raw_code).submit
+
+        result_hash = {
+          success?: true
+        }
+
+        expect(result).to eq result_hash
+        expect(user.recovery_code).to be_nil
+      end
+    end
+
+    context 'when the form is invalid' do
+      it 'returns false for success?' do
+        user = build_stubbed(:user, :signed_up)
+
+        result = RecoveryCodeForm.new(user, 'foo').submit
+
+        result_hash = {
+          success?: false
+        }
+
+        expect(result).to eq result_hash
+        expect(user.recovery_code).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/services/recovery_code_generator_spec.rb
+++ b/spec/services/recovery_code_generator_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe RecoveryCodeGenerator do
+  describe '#create' do
+    it 'returns the raw recovery code' do
+      generator = RecoveryCodeGenerator.new(User.new)
+
+      allow(SecureRandom).to receive(:hex).with(8).and_return('a1b2c3d4e5f6g7h8')
+
+      expect(generator.create).to eq 'a1b2c3d4e5f6g7h8'
+    end
+
+    it 'hashes the raw recovery code' do
+      user = create(:user)
+
+      generator = RecoveryCodeGenerator.new(user)
+
+      allow(SecureRandom).to receive(:hex).with(8).and_return('a1b2c3d4e5f6g7h8')
+
+      generator.create
+
+      expect(user.recovery_code).to_not eq 'a1b2c3d4e5f6g7h8'
+    end
+
+    it 'generates an alphanumeric string of length 16 by default' do
+      generator = RecoveryCodeGenerator.new(User.new)
+
+      expect(generator.create).to match(/\A[a-zA-Z0-9]{16}\z/)
+    end
+
+    it 'allows length to be configured via ENV var' do
+      allow(Figaro.env).to receive(:recovery_code_length).and_return('14')
+      generator = RecoveryCodeGenerator.new(User.new)
+
+      expect(generator.create).to match(/\A[a-zA-Z0-9]{14}\z/)
+    end
+  end
+end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -32,6 +32,8 @@ module ControllerHelper
   end
 
   def stub_sign_in_before_2fa(user = User.new)
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+    allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -1,5 +1,5 @@
 class FakeAnalytics
-  def track_event(_event, _user = nil)
+  def track_event(_event, _attributes = {})
     # no-op
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -69,8 +69,12 @@ module Features
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = sign_up_and_set_password
       fill_in 'Phone', with: '202-555-1212'
+      # Select SMS delivery
       click_button t('forms.buttons.submit')
+      # Enter 2FA code
       click_button t('forms.buttons.submit')
+      # Acknowledge recovery code
+      click_button 'Continue'
       user
     end
   end

--- a/spec/views/profile/index.html.slim_spec.rb
+++ b/spec/views/profile/index.html.slim_spec.rb
@@ -41,4 +41,15 @@ describe 'profile/index.html.slim' do
       expect(rendered).not_to have_link('Enable', href: authenticator_start_url)
     end
   end
+
+  it 'contains a recovery code section' do
+    user = User.new
+    allow(view).to receive(:current_user).and_return(user)
+
+    render
+
+    expect(rendered).to have_content t('profile.items.recovery_code')
+    expect(rendered).
+      to have_link(t('profile.links.regenerate_recovery_code'), href: settings_recovery_code_url)
+  end
 end

--- a/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'two_factor_authentication/recovery_code/show.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.recovery_code'))
+
+    render
+  end
+
+  it 'has a localized heading' do
+    render
+
+    expect(rendered).to have_content t('headings.recovery_code')
+  end
+
+  it 'informs the user of importance of keeping the recovery code in a safe place' do
+    render
+
+    expect(rendered).to have_content t('instructions.recovery_code')
+  end
+
+  it 'contains link to continue authenticating' do
+    render
+
+    expect(rendered).
+      to have_xpath("//input[@value='#{t('forms.buttons.acknowledge_recovery_code')}']")
+    expect(rendered).
+      to have_xpath("//form[@action='#{acknowledge_recovery_code_path}']")
+  end
+
+  it 'displays the recovery code' do
+    @code = 'foo'
+
+    render
+
+    expect(rendered).to have_content 'foo'
+  end
+end

--- a/spec/views/two_factor_authentication/recovery_code_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/recovery_code_verification/show.html.slim_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'two_factor_authentication/recovery_code_verification/show.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.enter_2fa_code'))
+
+    render
+  end
+
+  it 'has a localized heading' do
+    render
+
+    expect(rendered).
+      to have_content t('devise.two_factor_authentication.recovery_code_header_text')
+  end
+
+  it 'prompts the user to enter their recovery code' do
+    render
+
+    expect(rendered).
+      to have_content t('devise.two_factor_authentication.recovery_code_prompt')
+  end
+
+  it 'contains a form to submit the recovery code' do
+    render
+
+    expect(rendered).
+      to have_xpath("//input[@value='#{t('forms.buttons.submit')}']")
+    expect(rendered).
+      to have_xpath("//form[@action='#{login_two_factor_recovery_code_path}']")
+    expect(rendered).
+      to have_xpath("//form[@method='post']")
+  end
+end


### PR DESCRIPTION
**Why**: To allow users who lose access to their 2FA phone to recover
access to their account.

**How**:
- Follow the design pattern of keeping each method of authentication in
its own controller, and a form object to validate the code.
- Generate a 16-character alphanumeric random code and one-way encrypt
it in the database. This has the advantage of keeping the code secure,
but the disadvantage that it cannot be displayed to the user more than
once, which could be problematic if they generate multiple codes and
don't remember which one is the latest one.
- When a user first signs up, after they confirm their 2FA phone, they
will be presented with their recovery code with instructions for how
and where to keep it safe.
- Once signed in, a user can generate a new code. Note that this
currently doesn't include any messages about what that implies.
- When a user signs in with their recovery code, a new one is
immediately generated, which replaces their previous one.