### PR TITLE
Do not track GET requests to the /active endpoint

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,7 @@ module Users
     include ::ActionView::Helpers::DateHelper
 
     skip_before_action :session_expires_at, only: [:active]
+    skip_after_action :track_get_requests, only: [:active]
 
     def create
       track_authentication_attempt(params[:user][:email])

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -85,6 +85,15 @@ describe Users::SessionsController, devise: true do
         expect(session[:pinged_at]).to_not eq(now)
       end
     end
+
+    it 'does not track analytics event' do
+      stub_sign_in
+      stub_analytics
+
+      expect(@analytics).to_not receive(:track_event)
+
+      get :active
+    end
   end
 
   describe 'GET /timeout' do


### PR DESCRIPTION
**Why**: To keep our analytics logs free of noise. The `/active`
endpoint currently gets hit every 30 seconds as part of the session
timeout feature.