### PR TITLE
Require 2FA for admin to access constrained route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ sudo: false
 script:
   - make test
   - bundle exec slim-lint app/views
+services:
+  - redis-server

--- a/app/services/admin_constraint.rb
+++ b/app/services/admin_constraint.rb
@@ -1,0 +1,15 @@
+class AdminConstraint
+  def matches?(request)
+    user_is_admin?(request) && user_is_2fa_authenticated?(request)
+  end
+
+  private
+
+  def user_is_admin?(request)
+    request.env['warden'].user&.admin?
+  end
+
+  def user_is_2fa_authenticated?(request)
+    request.env['warden'].session(:user)['need_two_factor_authentication'] == false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
-  authenticate :user, ->(u) { u.admin? } do
-    require 'sidekiq/web'
-    mount Sidekiq::Web => '/sidekiq'
-    mount Split::Dashboard => '/split'
-  end
+  require 'sidekiq/web'
+  mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new
+  mount Split::Dashboard => '/split', constraints: AdminConstraint.new
 
   # Devise handles login itself. It's first in the chain to avoid a redirect loop during
   # authentication failure.

--- a/spec/requests/constrained_route_spec.rb
+++ b/spec/requests/constrained_route_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'routes that require admin + 2FA' do
+  def sign_in_user(user)
+    post_via_redirect(
+      new_user_session_path,
+      'user[email]' => user.email,
+      'user[password]' => user.password
+    )
+    get_via_redirect otp_send_path(otp_delivery_selection_form: { otp_method: 'sms' })
+    post_via_redirect(
+      login_two_factor_path(delivery_method: 'sms'),
+      'code' => user.reload.direct_otp
+    )
+  end
+
+  shared_examples 'constrained route' do |endpoint|
+    context 'user is signed in via 2FA but is not an admin' do
+      it 'does not allow access' do
+        user = create(:user, :signed_up)
+        sign_in_user(user)
+
+        expect { get endpoint }.to raise_error ActionController::RoutingError
+      end
+    end
+
+    context 'user is an admin but is not signed in via 2FA' do
+      it 'does not allow access' do
+        user = create(:user, :signed_up, :admin)
+
+        post_via_redirect(
+          new_user_session_path,
+          'user[email]' => user.email,
+          'user[password]' => user.password
+        )
+
+        expect { get endpoint }.to raise_error ActionController::RoutingError
+      end
+    end
+
+    context 'user is an admin and is signed in via 2FA' do
+      it 'allows access' do
+        user = create(:user, :signed_up, :admin)
+        sign_in_user(user)
+
+        expect { get endpoint }.to_not raise_error
+      end
+    end
+  end
+
+  it_behaves_like 'constrained route', '/sidekiq'
+  it_behaves_like 'constrained route', '/split'
+end


### PR DESCRIPTION
**Why**: To better protect access to dashboards such as Sidekiq and
Split.