### PR TITLE
Prevent redundant IdV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,6 @@ Metrics/ClassLength:
   - spec/**/*
   - app/controllers/users/confirmations_controller.rb
   - app/controllers/devise/two_factor_authentication_controller.rb
-  - app/controllers/idv/sessions_controller.rb
 
 Metrics/LineLength:
   Description: Limit lines to 80 characters.
@@ -62,6 +61,8 @@ Metrics/ModuleLength:
   Enabled: true
   Exclude:
   - spec/**/*
+# idv_session should be removed after https://github.com/18F/identity-idp/pull/489 merged
+  - app/controllers/concerns/idv_session.rb
 
 Rails/TimeZone:
   # The value `strict` means that `Time` should be used with `zone`.

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -21,6 +21,10 @@ module IdvSession
     end
   end
 
+  def confirm_idv_needed
+    redirect_to idv_activated_url if current_user.active_profile.present?
+  end
+
   def idv_session
     user_session[:idv] ||= {}
   end

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -4,6 +4,7 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_attempts_allowed
+    before_action :confirm_idv_needed
 
     helper_method :idv_profile_form
 

--- a/app/controllers/idv/step_controller.rb
+++ b/app/controllers/idv/step_controller.rb
@@ -5,6 +5,7 @@ module Idv
     helper_method :idv_params
 
     before_action :confirm_two_factor_authenticated
+    before_action :confirm_idv_needed
     before_action :confirm_idv_session_started
     before_action :confirm_idv_attempts_allowed
   end

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -17,4 +17,7 @@ class IdvController < ApplicationController
   def retry
     flash.now[:error] = I18n.t('idv.errors.fail')
   end
+
+  def activated
+  end
 end

--- a/app/views/idv/activated.html.slim
+++ b/app/views/idv/activated.html.slim
@@ -1,0 +1,6 @@
+- title t('idv.titles.activated')
+
+h1.heading = t('idv.titles.activated')
+- activated_link = link_to(t('idv.messages.activated_link'), Figaro.env.support_url)
+p.mb1 = t('idv.messages.activated', link: activated_link).html_safe
+= link_to 'Back', idv_url, class: 'underline'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,10 @@ en:
         Please check that the personal and financial information you provided is accurate.
         To learn more about the information we need from you and how it’s used to verify your identity,
         please see our troubleshooting page.
+      activated: >
+        Your identity has been verified. If you need to change your verified information,
+        please %{link}.
+      activated_link: contact us
       hardfail: >
         Your login.gov account can’t be used to access information with
         participating agencies until you successfully complete this process.
@@ -246,6 +250,7 @@ en:
       dupe_ssn3_link: try recovering it here
       review_and_continue: Review my info and try again
     titles:
+      activated: Your identity has already been verified
       intro: Help us identify you
       expectations: We need some information from you
       welcome: Verify your identity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
   post '/acknowledge_recovery_code' => 'two_factor_authentication/recovery_code#acknowledge'
 
   get '/idv' => 'idv#index'
+  get '/idv/activated' => 'idv#activated'
   get '/idv/cancel' => 'idv#cancel'
   get '/idv/fail' => 'idv#fail'
   get '/idv/retry' => 'idv#retry'

--- a/spec/controllers/idv/finance_controller_spec.rb
+++ b/spec/controllers/idv/finance_controller_spec.rb
@@ -14,7 +14,7 @@ describe Idv::FinanceController do
 
   describe '#create' do
     before do
-      allow(subject).to receive(:confirm_two_factor_authenticated).and_return(true)
+      stub_sign_in
       allow(subject).to receive(:confirm_idv_session_started).and_return(true)
       allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
       allow(subject).to receive(:idv_session).and_return(params: {})

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -21,7 +21,8 @@ describe Idv::SessionsController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_attempts_allowed
+        :confirm_idv_attempts_allowed,
+        :confirm_idv_needed
       )
     end
   end

--- a/spec/controllers/idv/step_controller_spec.rb
+++ b/spec/controllers/idv/step_controller_spec.rb
@@ -110,4 +110,52 @@ describe Idv::StepController do
       end
     end
   end
+
+  describe '#confirm_idv_needed' do
+    controller do
+      before_action :confirm_idv_needed
+
+      def show
+        render text: 'Hello'
+      end
+    end
+
+    before(:each) do
+      sign_in(user)
+      routes.draw do
+        get 'show' => 'idv/step#show'
+      end
+    end
+
+    context 'user has active profile' do
+      before do
+        allow(user).to receive(:active_profile).and_return(Profile.new)
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
+        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      end
+
+      it 'redirects to activated page' do
+        get :show
+
+        expect(response).to redirect_to idv_activated_url
+      end
+    end
+
+    context 'user does not have active profile' do
+      before do
+        allow(subject).to receive(:current_user).and_return(user)
+        allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
+        allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+      end
+
+      it 'does not redirect to activated page' do
+        get :show
+
+        expect(response.body).to eq 'Hello'
+        expect(response).to_not redirect_to idv_activated_url
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Users should not be able to self-initiate IdV
if they already have an active profile.