### PR TITLE
Increase stretches in Devise password bcrypt

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -96,7 +96,7 @@ Devise.setup do |config|
   # a value less than 10 in other environments. Note that, for bcrypt (the default
   # encryptor), the cost increases exponentially with the number of stretches (e.g.
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  config.stretches = Rails.env.test? ? 1 : 10
+  config.stretches = Rails.env.test? ? 1 : 12
 
   # Setup a pepper to generate the encrypted password.
   # config.pepper = 'b1108db70077daa6b0be8863b3b611ade79090f24be0e2f53aea51a59bca8462265fb4407110b182a69fdf2fef56589da7c2dbeaf3081b21794387f052e1ea47'


### PR DESCRIPTION
**Why**: Change from 10 to 12. Devise default is now 11.
NIST recommendation is 14 (too slow for UX). Compromise is 12.

```
Calculating -------------------------------------
  12 stretches      4.056  (± 0.0%) i/s -     21.000  in   5.181828s
  10 stretches     16.524  (± 6.1%) i/s -     83.000  in   5.030160s

Comparison:
  10 stretches:       16.5 i/s
  12 stretches:        4.1 i/s - 4.07x slower
```