### PR TITLE
Remove automatic telephone links on mobile

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,6 +7,7 @@ html lang="#{I18n.locale}"
     meta http-equiv='X-UA-Compatible' content='IE=edge'
     meta name='msapplication-config' content='none'
     meta[name='viewport' content='width=device-width, initial-scale=1.0']
+    meta name="format-detection" content="telephone=no"
 
     title
       = content_for?(:title) ? APP_NAME + ' - ' + yield(:title) : APP_NAME


### PR DESCRIPTION
**Why**: Since we are displaying the users own phone number in most cases, having it appear as a link may lead to confusion or accidental clicks.  This makes the functionality opt-in instead.  https://github.com/18F/identity-private/issues/835