### PR TITLE
Fix zip code input field

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,6 @@ module Upaya
     config.middleware.use Rack::Attack
 
     # Configure Browserify to use babelify to compile ES6
-    config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'
+    config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015-loose ] ]'
   end
 end

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "zxcvbn": "^4.3.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2015-loose": "^8.0.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",
     "browserify-incremental": "^3.1.1",


### PR DESCRIPTION
**Why**: Due to the way Babelify was transforming the field-kit js, our custom form inputs were not inserting separators into formatted fields like zip-code in IE<=10. https://github.com/18F/identity-idp/pull/496