### PR TITLE
Mix Agency activity with Account history

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -2,4 +2,8 @@ EventDecorator = Struct.new(:event) do
   def pretty_event_type
     I18n.t("event_types.#{event.event_type}")
   end
+
+  def happened_at
+    event.created_at
+  end
 end

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -1,0 +1,9 @@
+IdentityDecorator = Struct.new(:identity) do
+  def pretty_event_type
+    I18n.t('event_types.authenticated_at', service_provider: identity.display_name)
+  end
+
+  def happened_at
+    identity.last_authenticated_at
+  end
+end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -15,4 +15,8 @@ class Identity < ActiveRecord::Base
   def display_name
     sp_metadata[:friendly_name] || sp_metadata[:agency] || service_provider
   end
+
+  def decorate
+    IdentityDecorator.new(self)
+  end
 end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -77,28 +77,14 @@ h2.heading = t('headings.profile.login_info')
         = link_to t('profile.links.regenerate_recovery_code'), \
           settings_recovery_code_url, class: btn_cls
 
-h2.heading = t('headings.profile.agencies')
-.mt3.mb4
-  - if current_user.active_identities.empty?
-    .py-12p.border-bottom.border-top.italic
-      | #{t('.no_identities')}#{tooltip(t('tooltips.placeholder'))}
-  - else
-    - current_user.active_identities.each do |i|
-      .py-12p.border-top
-        .clearfix.mxn1
-          .sm-col.sm-col-8.px1
-            .h3.truncate = i.display_name
-          .sm-col.sm-col-4.px1
-            .h6.bold = t('.last_login')
-            .h5 = i.last_authenticated_at.to_s(:date_pretty)
-
 h2.heading = t('headings.profile.account_history')
 .mt3.mb2
-  - events_len = current_user.events.length
-  - current_user.events.each_with_index do |event, i|
+  - decorated_user = current_user.decorate
+  - events_len = decorated_user.recent_events.length
+  - decorated_user.recent_events.each_with_index do |event, i|
     div class="py-12p border-top #{'border-bottom' if i + 1 == events_len}"
       .clearfix.mxn1
         .sm-col.sm-col-6.px1
-          .truncate = event.decorate.pretty_event_type
+          .truncate = event.pretty_event_type
         .sm-col.sm-col-6.px1.sm-right-align
-          = event.created_at.to_s(:date_pretty)
+          = event.happened_at.to_s(:date_pretty)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
     email_changed: Email changed
     authenticator_enabled: Authenticator app enabled
     authenticator_disabled: Authenticator app disabled
+    authenticated_at: Authenticated at %{service_provider}
 
   forms:
     buttons:
@@ -184,7 +185,6 @@ en:
       change: Change your password
       forgot: Forgot password
     profile:
-      agencies: Agencies I've logged into
       profile_info: Profile information
       profile_info_tt: Why can't I edit my profile information?
       account_history: Account history
@@ -391,8 +391,6 @@ en:
       email: Email address
       password: Password
       authentication_app: Authentication app
-      last_login: Last login
-      no_identities: You haven't logged into any agencies yet.
     items:
       recovery_code: Recovery code
     links:

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -9,4 +9,13 @@ describe EventDecorator do
       expect(decorator.pretty_event_type).to eq t('event_types.email_changed')
     end
   end
+
+  describe '#happened_at' do
+    it 'returns created_at' do
+      event = build_stubbed(:event, event_type: :email_changed)
+      decorator = EventDecorator.new(event)
+
+      expect(decorator.happened_at).to eq event.created_at
+    end
+  end
 end

--- a/spec/decorators/identity_decorator_spec.rb
+++ b/spec/decorators/identity_decorator_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe IdentityDecorator do
+  let(:user) { create(:user) }
+  let(:identity) { create(:identity, :active, user: user) }
+
+  subject { IdentityDecorator.new(identity) }
+
+  describe '#pretty_event_type' do
+    it 'returns the localized text corresponding to the identity event' do
+      expect(subject.pretty_event_type).to eq(
+        t('event_types.authenticated_at', service_provider: identity.display_name)
+      )
+    end
+  end
+
+  describe '#happened_at' do
+    it 'returns last_authenticated_at' do
+      expect(subject.happened_at).to eq identity.last_authenticated_at
+    end
+  end
+end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -138,4 +138,18 @@ describe UserDecorator do
       expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
     end
   end
+
+  describe '#recent_events' do
+    it 'interleaves identities and events' do
+      user_decorator = UserDecorator.new(User.new)
+      identity = create(
+        :identity,
+        last_authenticated_at: Time.zone.now - 1,
+        user: user_decorator.user
+      )
+      event = create(:event, event_type: :email_changed, user: user_decorator.user)
+
+      expect(user_decorator.recent_events).to eq [event.decorate, identity.decorate]
+    end
+  end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -72,4 +72,12 @@ describe Identity do
       end
     end
   end
+
+  describe '#decorate' do
+    it 'returns a IdentityDecorator' do
+      identity = build(:identity)
+
+      expect(identity.decorate).to be_a(IdentityDecorator)
+    end
+  end
 end

--- a/spec/views/profile/index.html.slim_spec.rb
+++ b/spec/views/profile/index.html.slim_spec.rb
@@ -52,4 +52,13 @@ describe 'profile/index.html.slim' do
     expect(rendered).
       to have_link(t('profile.links.regenerate_recovery_code'), href: settings_recovery_code_url)
   end
+
+  it 'contains account history' do
+    user = User.new
+    allow(view).to receive(:current_user).and_return(user)
+
+    render
+
+    expect(rendered).to have_content t('headings.profile.account_history')
+  end
 end


### PR DESCRIPTION
**Why**: Consolidated Agency and Account history means simpler layout and UX.

**How**: Remove "Agencies I've logged into" and instead interleave agency last log in as events in the "Account history" section.