### PR TITLE
Fix SP-initiated SLO bug

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -11,7 +11,7 @@ module SamlIdpLogoutConcern
   end
 
   def handle_saml_logout_response
-    handler = LogoutResponseHandler.new(asserted_identity, user_session[:logout_response])
+    handler = LogoutResponseHandler.new(asserted_identity, slo_session[:logout_response])
 
     handler.deactivate_identity
 
@@ -67,14 +67,18 @@ module SamlIdpLogoutConcern
     @saml_response = OneLogin::RubySaml::Logoutresponse.new(params[:SAMLResponse])
   end
 
+  def slo_session
+    return user_session if user_session
+    session
+  end
+
   def prepare_saml_logout_request
     validate_saml_request
-    return unless user_session
-    return if user_session[:logout_response]
+    return if slo_session[:logout_response]
     # store originating SP's logout response in the user session
     # for final step in SLO
-    user_session[:logout_response] = logout_response_builder.signed
-    user_session[:logout_response_url] = saml_request.response_url
+    slo_session[:logout_response] = logout_response_builder.signed
+    slo_session[:logout_response_url] = saml_request.response_url
   end
 
   def finish_slo_at_idp
@@ -89,8 +93,8 @@ module SamlIdpLogoutConcern
 
   def generate_slo_response_and_sign_out
     render_template_for(
-      Base64.strict_encode64(user_session[:logout_response]),
-      user_session[:logout_response_url],
+      Base64.strict_encode64(slo_session[:logout_response]),
+      slo_session[:logout_response_url],
       'SAMLResponse'
     )
 

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -68,8 +68,7 @@ module SamlIdpLogoutConcern
   end
 
   def slo_session
-    return user_session if user_session
-    session
+    user_session || session
   end
 
   def prepare_saml_logout_request

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -69,6 +69,7 @@ module SamlIdpLogoutConcern
 
   def prepare_saml_logout_request
     validate_saml_request
+    return unless user_session
     return if user_session[:logout_response]
     # store originating SP's logout response in the user session
     # for final step in SLO

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -168,8 +168,6 @@ feature 'saml api', devise: true do
 
   context 'visiting /api/saml/logout' do
     context 'via SP-initiated logout when not logged in to IdP' do
-      let(:user) { create(:user, :signed_up) }
-
       it 'does not raise an exception' do
         request = OneLogin::RubySaml::Logoutrequest.new
         settings = sp1_saml_settings

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -175,9 +175,9 @@ feature 'saml api', devise: true do
         settings = sp1_saml_settings
         settings.name_identifier_value = SecureRandom.uuid
 
-        expect {
+        expect  do
           visit request.create(settings)
-        }.to_not raise_error NoMethodError
+        end.to_not raise_error NoMethodError
       end
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -175,9 +175,9 @@ feature 'saml api', devise: true do
         settings = sp1_saml_settings
         settings.name_identifier_value = SecureRandom.uuid
 
-        expect  do
+        expect do
           visit request.create(settings)
-        end.to_not raise_error NoMethodError
+        end.to_not raise_error
       end
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -170,17 +170,14 @@ feature 'saml api', devise: true do
     context 'via SP-initiated logout when not logged in to IdP' do
       let(:user) { create(:user, :signed_up) }
 
-      it 'redirects to home page' do
+      it 'does not raise an exception' do
         request = OneLogin::RubySaml::Logoutrequest.new
         settings = sp1_saml_settings
-        sp1 = ServiceProvider.new(sp1_saml_settings.issuer)
-        linker = IdentityLinker.new(user, sp1.issuer)
-        linker.link_identity
-        settings.name_identifier_value = user.decorate.active_identity_for(sp1).uuid
+        settings.name_identifier_value = SecureRandom.uuid
 
-        visit request.create(settings)
-
-        expect(current_path).to eq root_path
+        expect {
+          visit request.create(settings)
+        }.to_not raise_error NoMethodError
       end
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -167,6 +167,23 @@ feature 'saml api', devise: true do
   end
 
   context 'visiting /api/saml/logout' do
+    context 'via SP-initiated logout when not logged in to IdP' do
+      let(:user) { create(:user, :signed_up) }
+
+      it 'redirects to home page' do
+        request = OneLogin::RubySaml::Logoutrequest.new
+        settings = sp1_saml_settings
+        sp1 = ServiceProvider.new(sp1_saml_settings.issuer)
+        linker = IdentityLinker.new(user, sp1.issuer)
+        linker.link_identity
+        settings.name_identifier_value = user.decorate.active_identity_for(sp1).uuid
+
+        visit request.create(settings)
+
+        expect(current_path).to eq root_path
+      end
+    end
+
     context 'when logged in to single SP with IdP-initiated logout' do
       let(:user) { create(:user, :signed_up) }
       let(:xmldoc) { SamlResponseDoc.new('feature', 'request_assertion') }


### PR DESCRIPTION
**Why**: If a SP initiates SLO at the IdP, but the user is not
actively logged in to the IdP, would throw an exception.

**How**: Verify `user_session` exists before we access it.