### PR TITLE
Add autofocus to OTP pages

### DIFF
--- a/app/views/idv/phone_confirmation/show.html.slim
+++ b/app/views/idv/phone_confirmation/show.html.slim
@@ -3,13 +3,14 @@
 
 h1.heading = t('forms.phone_confirmation.header_text')
 
-p == t('instructions.2fa.confirm_code', number: "<strong>#{@unconfirmed_phone}</strong>")
+p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
+  number: "<strong>#{@unconfirmed_phone}</strong>")
 
 = form_tag([:idv_phone_confirmation], method: :put, role: 'form', class: 'mt4') do
   = label_tag 'code', t('forms.two_factor.code'), class: 'block caps ls-05 bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = number_field_tag(:code, '', required: true, value: @code_value, \
-                       class: 'col-12 field mfa')
+      class: 'col-12 field mfa', autofocus: true, 'aria-describedby': 'code-instructs')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_link = link_to(t('forms.buttons.resend'), \

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -2,14 +2,16 @@
 
 
 h1.heading = t('devise.two_factor_authentication.header_text')
-p.mt-tiny.mb0 == t('instructions.2fa.confirm_code', number: "<strong>#{@phone_number}</strong>")
+p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
+  number: "<strong>#{@phone_number}</strong>")
 
 = form_tag(:login_otp, method: :post, role: 'form', class: 'mt4') do
   = label_tag 'code', \
     raw(t('simple_form.required.html')) + t('forms.two_factor.code'), \
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = number_field_tag(:code, '', required: true, value: @code_value, class: 'col-12 field mfa')
+    = number_field_tag(:code, '', required: true, value: @code_value, class: 'col-12 field mfa',
+      autofocus: true, 'aria-describedby': 'code-instructs')
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 - resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -2,14 +2,15 @@
 
 
 h1.heading = t('devise.two_factor_authentication.totp_header_text')
-p== t('instructions.2fa.totp_intro', \
+p.mt-tiny.mb0#code-instructs == t('instructions.2fa.totp_intro', \
       email: "<strong>#{current_user.email}</strong>",
       app: "<strong>#{APP_NAME}</strong>")
 
 = form_tag(:login_two_factor_authenticator, method: :post, role: 'form') do
   .mb2
     = label_tag 'code', raw(t('simple_form.required.html')) + t('forms.two_factor.code')
-    = number_field_tag :code, '', class: 'block col-12 field mfa', required: true
+    = number_field_tag :code, '', class: 'block col-12 field mfa', required: true,
+      autofocus: true,  'aria-describedby': 'code-instructs'
   = submit_tag 'Submit', class: 'btn btn-primary'
 
 hr


### PR DESCRIPTION
**Why**: Since the OTP pages only contain one form field and is the main focus of the page, readded autofocus w/ aria-describedby.