### PR TITLE
Fix CSS inlining for emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'hiredis'
 gem 'httparty'
 gem 'lograge'
 gem 'newrelic_rpm'
+gem 'nokogiri' # required for premailer-rails
 gem 'omniauth-saml'
 gem 'phony_rails'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,6 +633,7 @@ DEPENDENCIES
   lograge
   mailcatcher
   newrelic_rpm
+  nokogiri
   omniauth-saml
   overcommit
   pg


### PR DESCRIPTION
* It is a best practice to inline CSS in emails
* We were already using premailer for inlining CSS, but it was not
  working
* Through reading Premailer README, I saw that it requires either
  nokogiri or hpricot, we had not included either. Nokogiri is preferred
  since it is actively maintained. See https://github.com/fphilipe/premailer-rails
* If this doesn't work, I would suggest trying Roadie, which I've used
  in the past to inline CSS with Rails and Mandrill
* Fixes https://github.com/18F/identity-private/issues/751