### PR TITLE
Remove unnecessary Reek exclusions

### DIFF
--- a/.reek
+++ b/.reek
@@ -24,9 +24,7 @@ TooManyStatements:
     - Users::PhoneConfirmationController
 TooManyMethods:
   exclude:
-    - Devise::TwoFactorAuthenticationController
     - Users::ConfirmationsController
-    - ServiceProvider
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow


### PR DESCRIPTION
**Why**: Classes were being excluded even though they don't violate the
TooManyMethods offense.