### PR TITLE
Move dev seeds to their own task and add a test

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -46,6 +46,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   run "bin/rake db:reset RAILS_ENV=development"
+  run 'bin/rake dev:prime RAILS_ENV=development'
   run 'bin/rake db:reset RAILS_ENV=test'
 
   puts "\n== Removing old logs and tempfiles =="

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,17 +2,3 @@
 AppSetting.find_or_create_by!(name: 'RegistrationsEnabled') do |setting|
   setting.value = '1'
 end
-
-if Rails.env.development?
-  # Create a few dummy accounts for use during development.  These accounts all
-  # have 'password' as password and are setup for phone OTP delivery.
-  %w(test1@test.com test2@test.com).each_with_index do |email, index|
-    User.find_or_create_by!(email: email) do |user|
-      user.skip_confirmation!
-      user.reset_password('password', 'password')
-      user.phone = format('+1 (415) 555-01%02d', index)
-      user.phone_confirmed_at = Time.current
-      Event.create(user_id: user.id, event_type: :account_created)
-    end
-  end
-end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,14 @@
+namespace :dev do
+  desc 'Sample data for local development environment'
+  task prime: 'db:setup' do
+    %w(test1@test.com test2@test.com).each_with_index do |email, index|
+      User.find_or_create_by!(email: email) do |user|
+        user.skip_confirmation!
+        user.reset_password('password', 'password')
+        user.phone = format('+1 (415) 555-01%02d', index)
+        user.phone_confirmed_at = Time.current
+        Event.create(user_id: user.id, event_type: :account_created)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'dev:prime' do
+  it 'runs successfully' do
+    Rake.application.rake_require('lib/tasks/dev', [Rails.root.to_s])
+    Rake::Task.define_task(:environment)
+    Rake::Task.define_task('db:setup')
+
+    Rake::Task['dev:prime'].invoke
+
+    expect(User.count).to eq 2
+  end
+end


### PR DESCRIPTION
**Why**:
  `db:seeds` is for data that is required in all environments
  `dev:prime` is a convention for adding seed data for a dev env
  With dev data separated, it's easier to test that in isolation
  Related to adding test coverage
  See: https://github.com/18F/identity-private/issues/850