### PR TITLE
Remove unused helper / method

### DIFF
--- a/app/helpers/devise/two_factor_authentication_helper.rb
+++ b/app/helpers/devise/two_factor_authentication_helper.rb
@@ -1,7 +1,0 @@
-module Devise
-  module TwoFactorAuthenticationHelper
-    def otp_valid_for_in_words
-      distance_of_time_in_words(Devise.direct_otp_valid_for)
-    end
-  end
-end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -3,18 +3,6 @@ module FormHelper
     text_field_tag(name, value, options.merge(class: 'block col-12 field'))
   end
 
-  def block_date_field_tag(name, value, options = {})
-    date_field_tag(name, value, options.merge(class: 'block col-12 field'))
-  end
-
-  def us_states_territories_select_tag(options = {})
-    select_tag(
-      'state',
-      options_for_select(us_states_territories),
-      options.merge(class: 'block col-12 field')
-    )
-  end
-
   # rubocop:disable MethodLength, WordArray
   # This method is single statement spread across many lines for readability
   def us_states_territories


### PR DESCRIPTION
**Why**:
  Noticed these methods had low (no) test coverage
  Appears to not be used
  Looked at commit where it was added to confirm that original use case
  for these methods is no long present in codebase
  eg: 42f6eef