### PR TITLE
[Issue #894] Adds custom I18n override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -214,3 +214,6 @@ Style/TrailingCommaInLiteral:
     - comma
     - consistent_comma
     - no_comma
+
+Style/SingleLineBlockParams:
+  Enabled: false

--- a/app/assets/javascripts/misc/i18n-mode.js
+++ b/app/assets/javascripts/misc/i18n-mode.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const lookupTxt = '<small class="i18n-anchor">';
+  const inputs = document.querySelectorAll('input[type="submit"]');
+
+  if (inputs) {
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i];
+      const val = input.value;
+      const i18nStart = val.indexOf(lookupTxt);
+
+      if (i18nStart > -1) {
+        input.insertAdjacentHTML('afterend', val.slice(i18nStart));
+        input.value = val.slice(0, i18nStart);
+      }
+    }
+  }
+});

--- a/app/assets/stylesheets/components/_space-misc.scss
+++ b/app/assets/stylesheets/components/_space-misc.scss
@@ -1,5 +1,6 @@
 .mxn-tiny { margin-left: -$space-tiny; margin-right: -$space-tiny; }
 .mb-tiny { margin-bottom: $space-tiny; }
+.ml-tiny { margin-left: $space-tiny; }
 .mr-tiny { margin-right: $space-tiny; }
 .mt-tiny { margin-top: $space-tiny; }
 .pb-tiny { padding-bottom: $space-tiny; }

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -4,6 +4,8 @@
 
 .bg-light-blue { background-color: $blue-light; }
 
+.no-hover-decoration:hover { text-decoration: none; }
+
 @media #{$breakpoint-sm} {
   .sm-bg-light-blue { background-color: $blue-light; }
 

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -1,5 +1,3 @@
-require 'feature_management'
-
 module Devise
   class TwoFactorAuthenticationController < DeviseController
     include TwoFactorAuthenticatable

--- a/app/models/app_setting.rb
+++ b/app/models/app_setting.rb
@@ -1,5 +1,3 @@
-require 'feature_management'
-
 class AppSetting < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -10,4 +10,4 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email', app: APP_
   = f.input :email,
             required: true,
             input_html: { 'aria-describedby' => 'email-description' }
-  = f.button :submit, 'Sign up', class: 'btn-wide mt2 mb1'
+  = f.button :submit, t('links.sign_up'), class: 'btn-wide mt2 mb1'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -37,6 +37,7 @@ html lang="#{I18n.locale}"
 
   body class="#{Rails.env}-env site sm-bg-light-blue"
     .site-wrap
+      = render 'shared/i18n_mode' if FeatureManagement.enable_i18n_mode?
       = render 'shared/usa_banner'
       - if signed_in?
         = render 'shared/nav_auth'
@@ -50,6 +51,9 @@ html lang="#{I18n.locale}"
   - if current_user
     #session-timeout-cntnr
     = auto_session_timeout_js
+
+  - if FeatureManagement.enable_i18n_mode?
+    == javascript_include_tag 'misc/i18n-mode'
 
   - if Figaro.env.participate_in_dap == 'true'
     = t('notices.dap_html')

--- a/app/views/shared/_i18n_mode.html.slim
+++ b/app/views/shared/_i18n_mode.html.slim
@@ -1,0 +1,1 @@
+.py1.bg-yellow.black.h5.caps.bold.center I18n Mode

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -58,6 +58,7 @@ development:
   telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   valid_service_providers: '["https://rp1.serviceprovider.com/auth/saml/metadata", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails", "https://dashboard.login.gov"]'
+  enable_i18n_mode: 'false'
 
 production:
   allow_third_party_auth: 'true'
@@ -85,6 +86,7 @@ production:
   smtp_settings: '{"address":"smtp.mandrillapp.com", "port":587, "authentication":"login", "enable_starttls_auto":true, "user_name":"user@gmail.com","password":"xxx"}'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   valid_service_providers: '["https://upaya-dev.18f.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo", "https://dashboard.demo.login.gov", "https://dashboard.qa.login.gov", "https://dashboard.dev.login.gov"]'
+  enable_i18n_mode: 'false'
 
 test:
   allow_third_party_auth: 'true'
@@ -110,3 +112,4 @@ test:
   session_timeout_in: '8'
   twilio_accounts: '[{"sid":"sid1", "auth_token":"token1", "number":"9999999999"}, {"sid":"sid2", "auth_token":"token2", "number":"2222222222"}]'
   valid_service_providers: '["http://localhost:3000", "https://rp1.serviceprovider.com/auth/saml/metadata", "https://rp2.serviceprovider.com/auth/saml/metadata", "http://test.host"]'
+  enable_i18n_mode: 'false'

--- a/config/initializers/i18n_mode.rb
+++ b/config/initializers/i18n_mode.rb
@@ -1,0 +1,5 @@
+require 'feature_management'
+if FeatureManagement.enable_i18n_mode?
+  # load libraries or overrides to be enabled with i18n_mode:
+  require File.join(Rails.root, 'lib', 'i18n_override.rb')
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
     resend: Resend
     sign_out: Sign out
     sign_in: Log in
+    sign_up: Sign up
     my_account: My account
     user_confirmation: Confirm account
     edit: Edit

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -16,4 +16,8 @@ class FeatureManagement
   def self.proofing_requires_kbv?
     Figaro.env.proofing_kbv == 'true'
   end
+
+  def self.enable_i18n_mode?
+    Figaro.env.enable_i18n_mode == 'true'
+  end
 end

--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -1,0 +1,117 @@
+require 'i18n'
+
+I18n.module_eval do
+  class << self
+    def translate_with_markup(*args)
+      i18n_text = normal_translate(*args)
+      return i18n_text unless FeatureManagement.enable_i18n_mode? && i18n_text.is_a?(String)
+
+      key = args.first.to_s
+      rtn = i18n_text + i18n_mode_additional_markup(key)
+
+      rtn.html_safe
+    end
+
+    private
+
+    def i18n_mode_additional_markup(key)
+      traverser = I18nLocaleTraverser.new(key, normal_translate(key))
+      uri = traverser.locale_uri
+
+      return '' unless uri
+
+      "<small class=\"i18n-anchor\"><a href=\"#{uri}\" " \
+      "target=\"_blank\" class=\"ml-tiny no-hover-decoration\">🔗</a></small>"
+    end
+
+    alias_method :normal_translate, :translate
+    alias_method :translate, :translate_with_markup
+  end
+end
+
+class I18nLocaleTraverser
+  def initialize(key, localized_str)
+    @key = key
+    @localized_str = localized_str
+    @file = find_file_by_key
+  end
+
+  def locale_uri
+    return nil unless @file
+    base_uri = 'https://github.com/18F/identity-idp/tree/master/config/locales/'
+    base_uri + filename + '#L' + find_line_number.to_s
+  end
+
+  private
+
+  def find_file_by_key
+    i18n_files.each do |file|
+      location = traverse_file_for_key(file)
+      return location if location
+    end
+    nil
+  end
+
+  def filename
+    @file.split('/').last
+  end
+
+  def find_line_number
+    match_line_in_file(@file, line_regex)
+  end
+
+  def match_line_in_file(file, match_arr)
+    File.foreach(file).with_index do |line, index|
+      break index + 1 if line =~ /#{match_arr.join('|')}/
+    end
+  end
+
+  def i18n_files
+    Dir[Rails.root.join('config', 'locales', '*.{yml}').to_s]
+  end
+
+  def traverse_file_for_key(file)
+    yml = YAML.load(File.open(file))[I18n.config.locale.to_s]
+
+    elements = @key.split('.')
+
+    return file if find_multilevel_hash_value(yml, elements)
+  end
+
+  def find_multilevel_hash_value(hsh, keys)
+    keys.inject(hsh) { |sub, elm| sub[elm] if sub.is_a?(Hash) }
+  end
+
+  def line_regex
+    key_arr = @key.split('.')
+    spaces = 2 * key_arr.length
+    last_key = key_arr.last
+
+    @match_str = ' ' * spaces + last_key + ':'
+
+    line_match_regex_arr
+  end
+
+  def line_match_regex_arr
+    [match_with_value,
+     match_with_single_quotes,
+     match_with_double_quotes,
+     match_with_multiline]
+  end
+
+  def match_with_value
+    @match_str + ' ' + @localized_str
+  end
+
+  def match_with_single_quotes
+    @match_str + ' \'' + @localized_str
+  end
+
+  def match_with_double_quotes
+    @match_str + ' "' + @localized_str
+  end
+
+  def match_with_multiline
+    @match_str + ' >' # assuming localized_str is on next line
+  end
+end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -34,4 +34,26 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#enable_i18n_mode?' do
+    context 'when enabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_i18n_mode).and_return('true')
+      end
+
+      it 'enables the feature' do
+        expect(FeatureManagement.enable_i18n_mode?).to eq(true)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_i18n_mode).and_return('false')
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.enable_i18n_mode?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/lib/i18n_override_spec.rb
+++ b/spec/lib/i18n_override_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'i18n override' do
+  describe '.translate_with_markup' do
+    it 'provides anchor tag to translated source' do
+      allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(true)
+      require File.join(Rails.root, 'lib', 'i18n_override.rb')
+
+      localized_str = I18n.translate_with_markup('shared.usa_banner.official_site')
+
+      expect(localized_str).to eq('An official website of the United States government' \
+        '<small class="i18n-anchor"><a href="https://github.com/18F/identity-idp/' \
+        'tree/master/config/locales/en.yml#L404" target="_blank" class="ml-tiny ' \
+        'no-hover-decoration">🔗</a></small>')
+    end
+  end
+end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'layouts/application.html.slim' do
+  include Devise::Test::ControllerHelpers
+
+  context 'when i18n mode enabled' do
+    before do
+      allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(true)
+    end
+
+    after do
+      allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(false)
+    end
+
+    it 'renders _i18n_mode.html' do
+      render
+
+      expect(view).to render_template(partial: '_i18n_mode')
+    end
+  end
+
+  context 'when i18n mode disabled' do
+    before do
+      allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(false)
+    end
+
+    it 'does not render _i18n_mode.html' do
+      render
+
+      expect(view).to_not render_template(partial: '_i18n_mode')
+    end
+  end
+end


### PR DESCRIPTION
### Why
Completes https://github.com/18F/identity-private/issues/894
Content reviewers do not have an easy method for locating the source of localized strings

### How
Adds an override for I18n's translate method to inject an anchor tag on all localized strings located in locale files.
Adds `enable_i18n_mode` to feature management for handling feature.
Big props to @brendansudol for improving the UI and fixing the wonky button markup with JavaScript-fu 💃 

#### Adds friendly banner to notify of the current mode
<img width="744" alt="screen shot 2016-10-12 at 2 07 53 pm" src="https://cloud.githubusercontent.com/assets/1328699/19327746/524accde-9085-11e6-9829-0a67f5c3b8c6.png">



#### Adds anchor tags to link to source of localized strings
<img width="833" alt="screen shot 2016-10-06 at 4 31 26 pm" src="https://cloud.githubusercontent.com/assets/1328699/19174275/6d07538c-8be2-11e6-8286-6cc15aceeb99.png">


#### Anchor tags link directly to source of translation
<img width="1100" alt="screen shot 2016-10-04 at 4 09 34 pm" src="https://cloud.githubusercontent.com/assets/1328699/19095818/0cf89398-8a4d-11e6-8265-35f8e32bdce1.png">

### To test the feature:
1. Update application.yml to include `enable_i18n_mode: 'true'` in your development environment.
2. Start application as normal with `foreman start`
3. View the site in your favorite browser and enjoy the rush of elation as you seamlessly fly through the application and update copy as you see fit.