### PR TITLE
Fix tooltip focus state

### DIFF
--- a/app/assets/stylesheets/components/_tooltip.scss
+++ b/app/assets/stylesheets/components/_tooltip.scss
@@ -12,6 +12,37 @@
     white-space: normal;
     width: 100%;
   }
+
+  &:focus::before,
+  &:focus::after {
+    opacity: 1;
+    transition-delay: 100ms;
+    visibility: visible;
+  }
+}
+
+.hint--top {
+  &:focus::before {
+    transform: translateY($space-1);
+  }
+
+  &:focus::after {
+    transform: translateX(-50%) translateY($space-1);
+  }
+}
+
+.hint--no-animate {
+  &::before,
+  &::after {
+    display: none;
+  }
+
+  &:focus::before,
+  &:focus::after,
+  &:hover::before,
+  &:hover::after {
+    display: block;
+  }
 }
 
 .img-tooltip {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,9 @@ module ApplicationHelper
     content_tag(
       :span, \
       image_tag(asset_url('tooltip.svg'), width: 16, class: 'px1 img-tooltip'), \
-      class: 'hint--top', \
-      'aria-label': text
+      class: 'hint--top hint--no-animate', \
+      'aria-label': text, \
+      'tabindex': '0'
     )
   end
 

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -9,7 +9,7 @@
   h2.heading.mr1.inline-block
     = t('headings.profile.profile_info')
   = content_tag(:span, t('headings.profile.profile_info_tt'),
-    class: 'h5 blue sans-serif underline hint--top', tabindex: 0,
+    class: 'h5 blue sans-serif underline hint--top hint--no-animate', tabindex: 0,
     'aria-label': t('tooltips.profile_idv'))
   .mt3.mb4
     .py-12p.border-top


### PR DESCRIPTION
**Why**: Removes blue outline artifact left after clicking tooltip (https://github.com/18F/identity-private/issues/798), also adds focus state allowing keyboard navigators to see the tooltip by tabbing to the link.

![screen recording 2016-10-05 at 12 49 pm](https://cloud.githubusercontent.com/assets/1178494/19123230/d1c691bc-8afb-11e6-8b6a-b5aa3307d092.gif)
