### PR TITLE
Address demo deploy restart of all apps

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,9 @@ require 'capistrano/setup'
 # Includes default deployment tasks
 require 'capistrano/deploy'
 
+# support for passenger
+require 'capistrano/passenger'
+
 # support for bundler, rails/assets and rails/migrations
 require 'capistrano/rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'xml-simple'
 
 group :deploy do
   gem 'capistrano'
+  gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-rbenv'
   gem 'capistrano-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-harrow (0.5.3)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
     capistrano-rails (1.1.7)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -609,6 +611,7 @@ DEPENDENCIES
   bullet
   bummr
   capistrano
+  capistrano-passenger
   capistrano-rails
   capistrano-rbenv
   capistrano-sidekiq
@@ -682,4 +685,4 @@ DEPENDENCIES
   xmlenc (~> 0.6.4)
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,6 +15,9 @@ set :linked_files, %w(certs/saml.crt
                       config/newrelic.yml
                       keys/saml.key.enc)
 set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
+set :passenger_roles, [:app, :web]
+set :passenger_restart_wait, 5
+set :passenger_restart_runner, :sequence
 set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-idp.git'
 set :sidekiq_options, ''
@@ -28,13 +31,6 @@ set :whenever_roles, [:app]
 # TASKS
 #########
 namespace :deploy do
-  desc 'Restart application'
-  task :restart do
-    on roles(:app, :web), in: :sequence, wait: 5 do
-      execute :touch, release_path.join('tmp/restart.txt')
-    end
-  end
-
   desc 'Install npm packages required for asset compilation with browserify'
   task :browserify do
     on roles(:app, :web), in: :sequence do
@@ -46,5 +42,4 @@ namespace :deploy do
 
   before 'assets:precompile', :browserify
   after 'deploy:updated', 'newrelic:notice_deployment'
-  after :publishing, :restart
 end


### PR DESCRIPTION
__Why__
Capistrano versions 3.1 and higher no longer run the restart
task after deploy.  A restart is expected after a deployment.

__How__
Modify capistrano configuration to use capistrano-passenger
gem for deployments.

Fix #668