### PR TITLE
Make accepted LOA values configurable in ENV

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -12,7 +12,7 @@ module SamlIdpAuthConcern
   private
 
   def verify_authn_context
-    return if Saml::Idp::Constants::VALID_AUTHNCONTEXTS.include?(requested_authn_context)
+    return if Saml::Idp::Constants::VALID_AUTHN_CONTEXTS.include?(requested_authn_context)
 
     process_invalid_authn_context
   end
@@ -59,7 +59,7 @@ module SamlIdpAuthConcern
   end
 
   def loa3_requested?
-    requested_authn_context == Saml::Idp::Constants::LOA3_AUTHNCONTEXT_CLASSREF
+    requested_authn_context == Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
   end
 
   def active_identity

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -33,6 +33,8 @@ stale_session_window: '180'
 support_email: 'hello@login.gov'
 support_url: 'https://18f.gov/contact'
 
+valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
+
 development:
   allow_third_party_auth: 'true'
   domain_name: 'localhost:3000'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -20,6 +20,7 @@ Figaro.require_keys(
   'session_timeout_in',
   'support_email',
   'twilio_accounts',
+  'valid_authn_contexts',
   'valid_service_providers'
 )
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -2,14 +2,11 @@
 module Saml
   module Idp
     module Constants
-      LOA1_AUTHNCONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'.freeze
-      LOA3_AUTHNCONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'.freeze
+      LOA1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'.freeze
+      LOA3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'.freeze
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
-      VALID_AUTHNCONTEXTS = [
-        LOA1_AUTHNCONTEXT_CLASSREF,
-        LOA3_AUTHNCONTEXT_CLASSREF
-      ].freeze
+      VALID_AUTHN_CONTEXTS = JSON.parse(Figaro.env.valid_authn_contexts).freeze
     end
   end
 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -618,7 +618,7 @@ describe SamlIdpController do
           end
 
           it 'has contents set to LOA1' do
-            expect(subject.content).to eq Saml::Idp::Constants::LOA1_AUTHNCONTEXT_CLASSREF
+            expect(subject.content).to eq Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
           end
         end
       end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -10,7 +10,7 @@ module SamlAuthHelper
     settings.assertion_consumer_logout_service_url = 'http://localhost:3000/test/saml/decode_slo_request'
     settings.certificate = saml_test_sp_cert
     settings.private_key = saml_test_sp_key
-    settings.authn_context = Saml::Idp::Constants::LOA1_AUTHNCONTEXT_CLASSREF
+    settings.authn_context = Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
 
     # SP + IdP Settings
     settings.issuer = 'http://localhost:3000'
@@ -96,7 +96,7 @@ module SamlAuthHelper
 
   def loa3_saml_settings
     settings = sp1_saml_settings.dup
-    settings.authn_context = Saml::Idp::Constants::LOA3_AUTHNCONTEXT_CLASSREF
+    settings.authn_context = Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
     settings
   end
 


### PR DESCRIPTION
**Why**: To make it easier to disable and enable LOA3. For example,
if we're not yet ready to support LOA3, or if we need to temporarily
disable it due to an issue with proofing vendors.

Fixes https://github.com/18F/identity-private/issues/841