### PR TITLE
Add live countdown for session timeout

### DIFF
--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,3 +1,8 @@
+var frequency = <%= frequency %> * 1000;
+var warning = <%= warning %> * 1000;
+var start = <%= start %> * 1000;
+var warning_info = "<%= j render('session_timeout/warning') %>";
+
 function ping() {
   var request = new XMLHttpRequest();
   request.open('GET', '/active', true);
@@ -10,21 +15,21 @@ function ping() {
   };
 
   request.send();
-  setTimeout(ping, (<%= frequency %> * 1000));
+  setTimeout(ping, frequency);
 }
-
 
 function success(data) {
   var el = document.getElementById('session-timeout-msg'),
       cntnr = document.getElementById('session-timeout-cntnr');
 
   var time_timeout = new Date(data.timeout).getTime(),
-      time_cutoff = new Date().getTime() + <%= warning %> * 1000,
+      time_cutoff = new Date().getTime() + warning,
       show_warning = time_timeout < time_cutoff;
 
-  var warning_info = "<%= j render('session_timeout/warning') %>";
-
-  if (show_warning & !el) cntnr.insertAdjacentHTML('afterbegin', warning_info);
+  if (show_warning & !el) {
+    cntnr.insertAdjacentHTML('afterbegin', warning_info);
+    initTimer(warning);
+  }
   if (!show_warning & el) el.remove();
   if (data.live == false) {
     window.onbeforeunload = null;
@@ -33,5 +38,31 @@ function success(data) {
   }
 }
 
+function initTimer(duration) {
+  var countdown = document.getElementById('countdown');
+  var timeLeft = duration;
+  var interval = 1000;
 
-setTimeout(ping, (<%= start %> * 1000));
+  var format = function(milliseconds) {
+    var seconds = milliseconds / 1000;
+    var minutes = parseInt(seconds / 60, 10);
+    var remainingSeconds = parseInt(seconds % 60, 10);
+
+    var displayMinutes = minutes == 0 ? '' :
+      minutes + ' minute' + (minutes !== 1 ? 's' : '') + ' and ';
+    var displaySeconds = remainingSeconds + ' second' + (remainingSeconds !== 1 ? 's' : '');
+
+    return (displayMinutes + displaySeconds)
+  }
+
+  function tick() {
+    countdown.innerHTML = format(timeLeft);
+    if (timeLeft <= 0) return;
+    timeLeft -= interval;
+    setTimeout(tick, interval);
+  }
+
+  tick();
+}
+
+setTimeout(ping, start);

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -4,7 +4,6 @@
       .mx-auto.p4.cntnr-skinny.border-box.bg-white.rounded.relative
         = image_tag(asset_url('clock.svg'), class: 'modal-ico')
         h3.mt0.mb2 = t('headings.session_timeout_warning')
-        p.mb3 = t('session_timeout_warning',
-                  time_left_in_session: time_left_in_session)
+        p.mb3 == t('session_timeout_warning', time_left_in_session: time_left_in_session)
         = link_to t('forms.buttons.continue_browsing'),
           request.original_url, class: 'btn btn-primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
   session_timedout: >
     For your security, we've ended your session due to inactivity. Please log in again.
   session_timeout_warning: >-
-    Your session will end in %{time_left_in_session} due to inactivity.
+    Your session will end in <span id="coountdown">%{time_left_in_session}</span> due to inactivity.
     If you’d like to continue using the site, please click the button below.
 
   titles:
@@ -452,4 +452,3 @@ en:
     otp_confirmation: >
       Hello! Your login.gov one time passcode is, %{code},
       again, your passcode is, %{code}, goodbye!
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
   session_timedout: >
     For your security, we've ended your session due to inactivity. Please log in again.
   session_timeout_warning: >-
-    Your session will end in <span id="coountdown">%{time_left_in_session}</span> due to inactivity.
+    Your session will end in <span id="countdown">%{time_left_in_session}</span> due to inactivity.
     If you’d like to continue using the site, please click the button below.
 
   titles:

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -91,8 +91,8 @@ feature 'Sign in' do
       ajax_headers = { 'name' => 'X-Requested-With', 'value' => 'XMLHttpRequest' }
 
       expect(request_headers).to include ajax_headers
-      expect(page).to have_content("7 minutes and 59 seconds")
-      expect(page).to have_content("7 minutes and 58 seconds")
+      expect(page).to have_content('7 minutes and 59 seconds')
+      expect(page).to have_content('7 minutes and 58 seconds')
 
       find_link(t('forms.buttons.continue_browsing')).trigger('click')
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -76,26 +76,23 @@ feature 'Sign in' do
   context 'session approaches timeout', js: true do
     before :each do
       allow(Figaro.env).to receive(:session_check_frequency).and_return(1)
-      allow(Figaro.env).to receive(:session_check_delay).and_return(1)
+      allow(Figaro.env).to receive(:session_check_delay).and_return(2)
       allow(Figaro.env).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in)
     end
 
     scenario 'user sees warning before session times out' do
-      def warning_content
-        t('session_timeout_warning', time_left_in_session: time_left_in_session)
-      end
-
       sign_in_and_2fa_user
       visit root_path
 
-      expect(page).to have_css('#session-timeout-msg', text: warning_content)
+      expect(page).to have_css('#session-timeout-msg')
 
       request_headers = page.driver.network_traffic.flat_map(&:headers).uniq
-
       ajax_headers = { 'name' => 'X-Requested-With', 'value' => 'XMLHttpRequest' }
 
       expect(request_headers).to include ajax_headers
+      expect(page).to have_content("7 minutes and 59 seconds")
+      expect(page).to have_content("7 minutes and 58 seconds")
 
       find_link(t('forms.buttons.continue_browsing')).trigger('click')
 


### PR DESCRIPTION
**Why**: Countdown previously came up with 2 minutes 30 seconds left but
did not update, which is confusing

**What**: This adds js that does a live countdown. Here is what it looks
like:

![coutndown](https://cloud.githubusercontent.com/assets/601515/19167146/3f239160-8bbf-11e6-9fef-e5e0c5d1978e.gif)


**Notes**: I am not very satisfied with the testing for this. I thought
I'd use Timecop (Ruby gem) to test this more granularly, but that does
not freeze the js from firing. I think having a unit test for this in
the future would be better.