### PR TITLE
Improve invalid confirmation token error

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -64,6 +64,8 @@ module Users
       track_invalid_confirmation_token(params[:confirmation_token])
 
       set_view_variables
+
+      flash[:error] = t('errors.messages.confirmation_invalid_token')
       render :new
     end
 

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -6,8 +6,5 @@ h1.heading = t('headings.confirmations.new')
                   as: resource_name,
                   url: confirmation_path(resource_name),
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
-  .mb2
-    = f.error_notification
-    = f.full_error :confirmation_token
   = f.input :email, required: true
   = f.button :submit, t('forms.buttons.resend_confirmation'), class: 'mt2 mb1'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -84,6 +84,9 @@ en:
       confirmation_period_expired: >
         You have taken longer than %{period} to confirm your email.
         Please click "Resend confirmation instructions."
+      confirmation_invalid_token: >
+        The confirmation link you clicked on is no longer valid.  This may have been caused by
+        clicking on an old link in your email, or you may have already confirmed your account.
       expired: "has expired, please request a new one"
       not_found: "not found"
       not_locked: "was not locked"

--- a/spec/features/confirmations/confirmations_spec.rb
+++ b/spec/features/confirmations/confirmations_spec.rb
@@ -5,25 +5,25 @@ feature 'Confirmations', devise: true do
     scenario 'user cannot access users/confirmations' do
       visit user_confirmation_path
 
-      expect(page).to have_content("Confirmation token #{t('errors.messages.blank')}")
+      expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     end
 
     scenario 'user cannot submit a blank confirmation token' do
       visit "#{user_confirmation_path}?confirmation_token="
 
-      expect(page).to have_content("Confirmation token #{t('errors.messages.blank')}")
+      expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     end
 
     scenario 'user cannot submit an empty single-quoted string as a token' do
       visit "#{user_confirmation_path}?confirmation_token=''"
 
-      expect(page).to have_content("Confirmation token #{t('errors.messages.invalid')}")
+      expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     end
 
     scenario 'user cannot submit an empty double-quoted string as a token' do
       visit "#{user_confirmation_path}?confirmation_token=%22%22"
 
-      expect(page).to have_content("Confirmation token #{t('errors.messages.invalid')}")
+      expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     end
   end
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -295,7 +295,7 @@ feature 'Sign Up', devise: true do
     create(:user, :unconfirmed)
     visit '/users/confirmation?confirmation_token=invalid_token'
 
-    expect(page).to have_content 'Confirmation token is invalid'
+    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     expect(current_path).to eq user_confirmation_path
   end
 


### PR DESCRIPTION
**Why**: Help explain to users why the confirmation link they clicked on is no longer working

This:
![image 2016-10-07 at 11 16 35 am](https://cloud.githubusercontent.com/assets/1178494/19195593/443acd96-8c80-11e6-9c5e-ed971a328226.png)

Instead of:
![image 2016-10-07 at 11 23 17 am](https://cloud.githubusercontent.com/assets/1178494/19195654/77e4a702-8c80-11e6-8515-cef61075e203.png)
