### PR TITLE
Changing casing on the create password screen

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
         need to link your login.gov account to the application you choose. Each
         time you log in you’ll need to open the application and retrieve a code.
     confirmation:
-      show_hdr: Create a Password
+      show_hdr: Create a password
     passwords:
       edit:
         labels:


### PR DESCRIPTION
We were using title casing on the create a password screen. This PR changes it to sentence casing, to match the rest of the site.

