### PR TITLE
Add rate limiting to all phone confirmation routes

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -87,6 +87,7 @@ module Rack
       # `filter` returns truthy value if request fails, or if it's to a
       # previously banned phone_number so the request is blocked
       phone_number = req.env['warden'].user&.phone
+      paths = %w(/otp/send /phone_confirmation/send /idv/phone_confirmation/send)
 
       Allow2Ban.filter(
         "otp-#{phone_number}",
@@ -95,7 +96,7 @@ module Rack
         bantime: Figaro.env.otp_delivery_blocklist_bantime.to_i.minutes
       ) do
         # The count for the phone_number is incremented if the return value is truthy
-        req.get? && req.path == '/otp/send'
+        req.get? && paths.include?(req.path)
       end
     end
 


### PR DESCRIPTION
**Why**:
  * Someone shouldn't be able to send a bunch of confirmation texts in a
    row. Expensive for them and for us!

**How**:
  * Use same rate limit as `otp/send` (5 times in 5 mins currently)
  * Were rate limiting `otp/send` but this adds
    `phone_confirmation/send` and `idv/phone_confirmations/send`
  * Rate limiting with Rack Attack gem
  * Remove magic numbers from specs by referencing the ENV vars from
    figaro rather than "3"