### PR TITLE
Passcode input format / validate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,9 +11,9 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-        # mass_threshold: 30
-      - javascript
+        ruby:
+        javascript:
+          mass_threshold: 50
     exclude_paths:
     - 'spec/**/*'
     - 'node_modules/**/*'

--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -2,6 +2,7 @@ import { PhoneFormatter, SocialSecurityNumberFormatter, TextField } from 'field-
 
 import validateField from './validate-field';
 import DateFormatter from './modules/date-formatter';
+import OtpCodeFormatter from './modules/otp-code-formatter';
 import ZipCodeFormatter from './modules/zip-code-formatter';
 
 
@@ -11,6 +12,7 @@ function formatForm() {
     ['[type=tel]', new PhoneFormatter()],
     ['.ssn', new SocialSecurityNumberFormatter()],
     ['.zipcode', new ZipCodeFormatter()],
+    ['.mfa', new OtpCodeFormatter()],
   ];
 
   formats.forEach(function(f) {

--- a/app/assets/javascripts/app/modules/otp-code-formatter.js
+++ b/app/assets/javascripts/app/modules/otp-code-formatter.js
@@ -1,0 +1,23 @@
+import { Formatter } from 'field-kit';
+
+
+const DIGITS_PATTERN = /^\d*$/;
+const maxLength = 6;
+
+
+class OtpCodeFormatter extends Formatter {
+  constructor() {
+    super();
+    this.maximumLength = maxLength;
+  }
+
+  isChangeValid(change, error) {
+    if (DIGITS_PATTERN.test(change.inserted.text)) {
+      return super.isChangeValid(change, error);
+    }
+    return false;
+  }
+}
+
+
+export default OtpCodeFormatter;

--- a/app/views/idv/phone_confirmation/show.html.slim
+++ b/app/views/idv/phone_confirmation/show.html.slim
@@ -6,10 +6,11 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
   number: "<strong>#{@unconfirmed_phone}</strong>")
 
 = form_tag([:idv_phone_confirmation], method: :put, role: 'form', class: 'mt3 sm-mt4') do
-  = label_tag 'code', t('forms.two_factor.code'), class: 'block caps ls-05 bold'
+  = label_tag 'code', t('forms.two_factor.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = number_field_tag(:code, '', required: true, value: @code_value, \
-      class: 'col-12 field mfa', autofocus: true, 'aria-describedby': 'code-instructs')
+    = text_field_tag(:code, '', value: @code_value, required: true,
+      autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
+      'aria-describedby': 'code-instructs')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_link = link_to(t('forms.buttons.resend'), \

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -11,8 +11,9 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
     raw(t('simple_form.required.html')) + t('forms.two_factor.code'), \
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = number_field_tag(:code, '', required: true, value: @code_value, class: 'col-12 field mfa',
-      autofocus: true, 'aria-describedby': 'code-instructs')
+    = text_field_tag(:code, '', value: @code_value, required: true,
+      autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
+      'aria-describedby': 'code-instructs')
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 - resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -1,10 +1,12 @@
 - title t('titles.enter_2fa_code')
 
 h1.h3.my0 = t('devise.two_factor_authentication.recovery_code_header_text')
-p = t('devise.two_factor_authentication.recovery_code_prompt')
+p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
 
-= form_tag(:login_two_factor_recovery_code, method: :post, role: 'form') do
+= form_tag(:login_two_factor_recovery_code, method: :post, role: 'form', class: 'mt3 sm-mt4') do
   .mb2
-    = label_tag 'code', raw(t('simple_form.required.html')) + t('forms.two_factor.recovery_code')
-    = block_text_field_tag :code, '', class: 'block col-12 field mfa', required: true
-  = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary'
+    = label_tag 'code',
+      raw(t('simple_form.required.html')) + t('forms.two_factor.recovery_code'),
+      class: 'block bold'
+    = block_text_field_tag :code, '', required: true
+  = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -9,8 +9,9 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.totp_intro', \
 = form_tag(:login_two_factor_authenticator, method: :post, role: 'form') do
   .mb2
     = label_tag 'code', raw(t('simple_form.required.html')) + t('forms.two_factor.code')
-    = number_field_tag :code, '', class: 'block col-12 field mfa', required: true,
-      autofocus: true,  'aria-describedby': 'code-instructs'
+    = text_field_tag :code, '', required: true, autofocus: true,
+      pattern: '[0-9]*', class: 'block col-12 field monospace mfa',
+      'aria-describedby': 'code-instructs'
   = submit_tag 'Submit', class: 'btn btn-primary'
 
 hr

--- a/app/views/users/phone_confirmation/show.html.slim
+++ b/app/views/users/phone_confirmation/show.html.slim
@@ -8,10 +8,8 @@ p.mt-tiny.mb0 == t('instructions.2fa.confirm_code', \
 = form_tag([:phone_confirmation], method: :put, role: 'form', class: 'mt3 sm-mt4') do
   = label_tag 'code', t('forms.two_factor.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = number_field_tag(:code, \
-                       '', required: true, \
-                       value: @code_value, \
-                       class: 'col-12 field mfa')
+    = text_field_tag(:code, '', value: @code_value, required: true,
+      autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_link = link_to(t('forms.buttons.resend'), \

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -8,5 +8,6 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
 = form_tag(authenticator_setup_path, method: :patch, role: 'form', class: 'mb1') do
   = label_tag 'code', t('forms.totp_setup.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = number_field_tag :code, '', required: true, class: 'col-12 field mfa'
+    = text_field_tag :code, '', required: true, pattern: '[0-9]*',
+      class: 'block col-12 field monospace mfa'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'


### PR DESCRIPTION
**Why**: better usability to have input length (& format)
correspond with code length