### PR TITLE
Add spec for "logged out" nav

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,7 +38,12 @@ html lang="#{I18n.locale}"
   body class="#{Rails.env}-env site sm-bg-light-blue"
     .site-wrap
       = render 'shared/usa_banner'
-      = render signed_in? ? 'shared/nav' : 'shared/nav_lite'
+      - if signed_in?
+        = render 'shared/nav_auth'
+      - elsif @sp_logo.present?
+        = render 'shared/nav_branded'
+      - else
+        = render 'shared/nav_lite'
       = content_for?(:content) ? yield(:content) : yield
     = render 'shared/footer_lite'
 

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -1,4 +1,0 @@
-- if @sp_logo
-  = render 'shared/nav_branded'
-- else
-  = render signed_in? ? 'shared/nav_auth' : 'shared/nav_lite'

--- a/spec/views/shared/_nav_lite.html.slim_spec.rb
+++ b/spec/views/shared/_nav_lite.html.slim_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'shared/_nav_lite.html.slim' do
+  context 'user is signed out' do
+    before do
+      allow(view).to receive(:signed_in?).and_return(false)
+    end
+
+    it 'does not contain sign out link' do
+      render
+
+      expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
**Why**:

* We had this test before and it was removed when we pulled nav
  templates into two different files (logged in, logged out)
* I there had been a case without `@sp_logo` before, we would have shown
  the same nav twice, so cleaned that up