### PR TITLE
Set HSTS max-age to one year and preload

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,5 @@
 SecureHeaders::Configuration.default do |config|
-  config.hsts = "max-age=#{1.day.to_i}; includeSubDomains"
+  config.hsts = "max-age=#{365.days.to_i}; includeSubDomains"
   config.x_frame_options = 'SAMEORIGIN'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,5 @@
 SecureHeaders::Configuration.default do |config|
-  config.hsts = "max-age=#{365.days.to_i}; includeSubDomains"
+  config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
   config.x_frame_options = 'SAMEORIGIN'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'


### PR DESCRIPTION
This PR sets the HSTS max-age to one year, rather than the current one day. This is best practice and brings this up to par with the [HSTS preload list requirements](https://hstspreload.appspot.com/#submission-requirements).

login.gov [is already in the preload list](https://chromium.googlesource.com/chromium/src/net/+/f70ad033bfb16a7a23eafbae453a233c172935ba), but I'd suggest it's still a good practice to explicitly declare it as willingly preloaded.