### PR TITLE
[Issue #799] Adds branded header to sign in page

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,6 +1,10 @@
 - title t('titles.visitors.index')
 
-h1.h3.my0 = t('headings.log_in')
+- if @sp_name
+  h1.h3.my0 = t('headings.log_in_branded', app: @sp_name)
+- else
+  h1.h3.my0 = t('headings.log_in')
+
 = simple_form_for(resource,
                   as: resource_name,
                   url: session_path(resource_name),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
       password: Edit your password
       phone: Edit your phone number
     log_in: Log in
+    log_in_branded: Sign in to continue to %{app}
     choose_otp_delivery: Choose delivery method
     passwords:
       change: Change your password

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -22,4 +22,25 @@ describe 'devise/sessions/new.html.slim' do
         t('links.create_account'), href: new_user_start_path
       )
   end
+
+  context 'when @sp_name is set' do
+    before do
+      @sp_name = 'Awesome Application!'
+    end
+
+    it 'displays a custom header' do
+      render
+
+      expect(rendered).to have_content(t('headings.log_in_branded',
+                                         app: 'Awesome Application!'))
+    end
+  end
+
+  context 'when @sp_name is not set' do
+    it 'displays the normal header' do
+      render
+
+      expect(rendered).to have_content(t('headings.log_in'))
+    end
+  end
 end


### PR DESCRIPTION
Why
I noticed the mockups for the co-branded experience included
a custom heading as well as logo. 
Users want a custom experience when authenticating with
a partner application.

How
Display a custom heading when we validate the originating SP
application.
