### PR TITLE
Rename OTP jobs

### DIFF
--- a/app/controllers/concerns/phone_confirmation_flow.rb
+++ b/app/controllers/concerns/phone_confirmation_flow.rb
@@ -72,7 +72,7 @@ module PhoneConfirmationFlow
     # Generate a new confirmation code only if there isn't already one set in the
     # user's session. Re-sending the confirmation code doesn't generate a new one.
     self.confirmation_code = generate_confirmation_code unless confirmation_code
-    job = "#{current_otp_method.to_s.capitalize}SenderOtpJob".constantize
+    job = "#{current_otp_method.to_s.capitalize}OtpSenderJob".constantize
     job.perform_later(
       code: confirmation_code,
       phone: unconfirmed_phone,

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -42,7 +42,7 @@ module Devise
     def send_user_otp(method)
       current_user.create_direct_otp
 
-      job = "#{method.capitalize}SenderOtpJob".constantize
+      job = "#{method.capitalize}OtpSenderJob".constantize
 
       job.perform_later(
         code: current_user.direct_otp,

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -1,4 +1,4 @@
-class SmsSenderOtpJob < ActiveJob::Base
+class SmsOtpSenderJob < ActiveJob::Base
   queue_as :sms
 
   def perform(code:, phone:, otp_created_at:)

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -1,4 +1,4 @@
-class VoiceSenderOtpJob < ActiveJob::Base
+class VoiceOtpSenderJob < ActiveJob::Base
   queue_as :voice
 
   def perform(code:, phone:, otp_created_at:)

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -82,13 +82,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       before do
         sign_in_before_2fa
         @old_otp = subject.current_user.direct_otp
-        allow(SmsSenderOtpJob).to receive(:perform_later)
+        allow(SmsOtpSenderJob).to receive(:perform_later)
       end
 
       it 'sends OTP via SMS' do
         get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
 
-        expect(SmsSenderOtpJob).to have_received(:perform_later).
+        expect(SmsOtpSenderJob).to have_received(:perform_later).
           with(
             code: subject.current_user.direct_otp,
             phone: subject.current_user.phone,
@@ -125,13 +125,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       before do
         sign_in_before_2fa
         @old_otp = subject.current_user.direct_otp
-        allow(VoiceSenderOtpJob).to receive(:perform_later)
+        allow(VoiceOtpSenderJob).to receive(:perform_later)
       end
 
       it 'sends OTP via voice' do
         get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
 
-        expect(VoiceSenderOtpJob).to have_received(:perform_later).
+        expect(VoiceOtpSenderJob).to have_received(:perform_later).
           with(
             code: subject.current_user.direct_otp,
             phone: subject.current_user.phone,

--- a/spec/controllers/idv/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/idv/phone_confirmation_controller_spec.rb
@@ -37,11 +37,11 @@ describe Idv::PhoneConfirmationController, devise: true do
       end
 
       it 'sends confirmation code via SMS' do
-        allow(SmsSenderOtpJob).to receive(:perform_later)
+        allow(SmsOtpSenderJob).to receive(:perform_later)
 
         get :send_code
 
-        expect(SmsSenderOtpJob).to have_received(:perform_later).
+        expect(SmsOtpSenderJob).to have_received(:perform_later).
           with(
             code: subject.user_session[:idv_phone_confirmation_code],
             phone: '+1 (555) 555-5555',
@@ -53,11 +53,11 @@ describe Idv::PhoneConfirmationController, devise: true do
         before { subject.user_session[:idv_phone_confirmation_code] = '1234' }
 
         it 're-sends existing code' do
-          allow(SmsSenderOtpJob).to receive(:perform_later)
+          allow(SmsOtpSenderJob).to receive(:perform_later)
 
           get :send_code
 
-          expect(SmsSenderOtpJob).to have_received(:perform_later).
+          expect(SmsOtpSenderJob).to have_received(:perform_later).
             with(
               code: '1234',
               phone: '+1 (555) 555-5555',

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -42,7 +42,7 @@ describe Users::PhoneConfirmationController, devise: true do
         end
 
         it 're-sends existing code' do
-          expect(SmsSenderOtpJob).to receive(:perform_later).
+          expect(SmsOtpSenderJob).to receive(:perform_later).
             with(
               code: '1234',
               phone: '+1 (555) 555-5555',

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 include Features::ActiveJobHelper
 
-describe SmsSenderOtpJob do
+describe SmsOtpSenderJob do
   describe '.perform' do
     it 'sends a message containing the OTP code to the mobile number', twilio: true do
       TwilioService.telephony_service = FakeSms
 
-      SmsSenderOtpJob.perform_now(
+      SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
         otp_created_at: Time.current
@@ -30,7 +30,7 @@ describe SmsSenderOtpJob do
       FakeSms.messages = []
       otp_expiration_period = Devise.direct_otp_valid_for
 
-      SmsSenderOtpJob.perform_now(
+      SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
         otp_created_at: otp_expiration_period.ago

--- a/spec/jobs/voice_otp_sender_job_spec.rb
+++ b/spec/jobs/voice_otp_sender_job_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 include Features::ActiveJobHelper
 
-describe VoiceSenderOtpJob do
+describe VoiceOtpSenderJob do
   describe '.perform' do
     it 'initiates the phone call to deliver the OTP', twilio: true do
       TwilioService.telephony_service = FakeVoiceCall
 
-      VoiceSenderOtpJob.perform_now(
+      VoiceOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
         otp_created_at: Time.current
@@ -31,7 +31,7 @@ describe VoiceSenderOtpJob do
       FakeVoiceCall.calls = []
       otp_expiration_period = Devise.direct_otp_valid_for
 
-      VoiceSenderOtpJob.perform_now(
+      VoiceOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
         otp_created_at: otp_expiration_period.ago

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -56,7 +56,7 @@ describe TwilioService do
     it 'does not send OTP messages', twilio: true do
       TwilioService.telephony_service = FakeSms
 
-      SmsSenderOtpJob.perform_now(
+      SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
         otp_created_at: Time.current


### PR DESCRIPTION
**Why**:
* `OtpSender` makes more sense than `SenderOtp`