### PR TITLE
Update ruby-saml gem to official 1.4.0 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,7 @@ gem 'valid_email'
 gem 'rack-attack'
 gem 'readthis'
 gem 'rqrcode'
-
-# unreleased feature via: https://github.com/onelogin/ruby-saml/pull/345
-gem 'ruby-saml', github: 'onelogin/ruby-saml', branch: 'master'
-
+gem 'ruby-saml'
 gem 'saml_idp', '~> 0.4.0'
 gem 'sass-rails', '~> 5.0'
 gem 'savon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,14 +18,6 @@ GIT
       randexp
       rotp
 
-GIT
-  remote: https://github.com/onelogin/ruby-saml.git
-  revision: 709b4c09a06ab7a299a512eaa166a56ddc50290a
-  branch: master
-  specs:
-    ruby-saml (1.3.1)
-      nokogiri (>= 1.5.10)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -309,9 +301,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     newrelic_rpm (3.16.0.318)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     nori (2.6.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -333,7 +324,6 @@ GEM
     phony_rails (0.14.2)
       activesupport (>= 3.0)
       phony (~> 2.12)
-    pkg-config (1.1.7)
     poltergeist (1.10.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -444,6 +434,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    ruby-saml (1.4.0)
+      nokogiri (>= 1.5.10)
     ruby_dep (1.4.0)
     safe_yaml (1.0.4)
     safely_block (0.1.1)
@@ -657,7 +649,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 3.3)
   rubocop
-  ruby-saml!
+  ruby-saml
   saml_idp (~> 0.4.0)
   sass-rails (~> 5.0)
   savon
@@ -685,4 +677,4 @@ DEPENDENCIES
   xmlenc (~> 0.6.4)
 
 BUNDLED WITH
-   1.13.2
+   1.13.3

--- a/app/views/test/saml_test/decode_response.html.slim
+++ b/app/views/test/saml_test/decode_response.html.slim
@@ -11,7 +11,7 @@ div class='container'
         td = is_valid
       tr
         td Issuer
-        td = response.issuers.first
+        td = response.settings.idp_entity_id
       tr
         td XML Document
         td


### PR DESCRIPTION
**Why**: Version 1.4.0 contains our changes. See
https://github.com/onelogin/ruby-saml/releases/tag/1.4.0
esp https://github.com/onelogin/ruby-saml/pull/345