### PR TITLE
Fix `TypeError` for OTP jobs

### DIFF
--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -8,7 +8,7 @@ class SmsOtpSenderJob < ActiveJob::Base
   private
 
   def otp_valid?(otp_created_at)
-    Time.now.utc < otp_created_at + Devise.direct_otp_valid_for
+    Time.now.utc < DateTime.parse(otp_created_at) + Devise.direct_otp_valid_for
   end
 
   def send_otp(twilio_service, code, phone)

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -8,7 +8,7 @@ class VoiceOtpSenderJob < ActiveJob::Base
   private
 
   def otp_valid?(otp_created_at)
-    Time.now.utc < otp_created_at + Devise.direct_otp_valid_for
+    Time.now.utc < DateTime.parse(otp_created_at) + Devise.direct_otp_valid_for
   end
 
   def send_otp(twilio_service, code, phone)

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -9,7 +9,7 @@ describe SmsOtpSenderJob do
       SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: Time.current
+        otp_created_at: Time.current.to_s
       )
 
       messages = FakeSms.messages
@@ -33,7 +33,7 @@ describe SmsOtpSenderJob do
       SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: otp_expiration_period.ago
+        otp_created_at: otp_expiration_period.ago.to_s
       )
 
       messages = FakeSms.messages

--- a/spec/jobs/voice_otp_sender_job_spec.rb
+++ b/spec/jobs/voice_otp_sender_job_spec.rb
@@ -9,7 +9,7 @@ describe VoiceOtpSenderJob do
       VoiceOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: Time.current
+        otp_created_at: Time.current.to_s
       )
 
       calls = FakeVoiceCall.calls
@@ -34,7 +34,7 @@ describe VoiceOtpSenderJob do
       VoiceOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: otp_expiration_period.ago
+        otp_created_at: otp_expiration_period.ago.to_s
       )
 
       calls = FakeVoiceCall.calls

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -59,7 +59,7 @@ describe TwilioService do
       SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: Time.current
+        otp_created_at: Time.current.to_s
       )
 
       expect(FakeSms.messages.size).to eq 0


### PR DESCRIPTION
**Why**:
* Full error:
```
TypeError: no implicit conversion of ActiveSupport::Duration into String
```
* We were not getting this in our tests because they passed time
* In real world, we pass a string bc jobs can only handle string args