### PR TITLE
Do not show "OTP sent" flash on first send

### DIFF
--- a/app/controllers/concerns/phone_confirmation_flow.rb
+++ b/app/controllers/concerns/phone_confirmation_flow.rb
@@ -27,7 +27,10 @@ module PhoneConfirmationFlow
 
   def send_code
     send_confirmation_code
-    flash[:success] = t("notices.send_code.#{current_otp_method}")
+    resent_message = t("notices.send_code.#{current_otp_method}")
+    flash[:success] = resent_message if session[:code_sent].present?
+
+    session[:code_sent] = 'true'
     redirect_to this_phone_confirmation_path
   end
 
@@ -59,7 +62,6 @@ module PhoneConfirmationFlow
   def process_valid_code
     assign_phone
     clear_session_data
-
     flash[:success] = t('notices.phone_confirmation_successful')
     redirect_to after_confirmation_path
   end

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -34,8 +34,9 @@ module Devise
 
     def handle_valid_delivery_method(method)
       send_user_otp(method)
-
-      flash[:success] = t("notices.send_code.#{method}")
+      resent_message = t("notices.send_code.#{method}")
+      flash[:success] = resent_message if session[:code_sent].present?
+      session[:code_sent] = 'true'
       redirect_to login_two_factor_path(delivery_method: method, reauthn: reauthn?)
     end
 

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -88,12 +88,11 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       it 'sends OTP via SMS' do
         get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
 
-        expect(SmsOtpSenderJob).to have_received(:perform_later).
-          with(
-            code: subject.current_user.direct_otp,
-            phone: subject.current_user.phone,
-            otp_created_at: subject.current_user.direct_otp_sent_at.to_s
-          )
+        expect(SmsOtpSenderJob).to have_received(:perform_later).with(
+          code: subject.current_user.direct_otp,
+          phone: subject.current_user.phone,
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s
+        )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
         expect(response).to redirect_to(
@@ -108,16 +107,28 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
         expect(@analytics).to receive(:track_event).
           with(:otp_delivery_selection, analytics_hash)
-        expect(@analytics).to receive(:track_event).with('GET request for ' \
-          'two_factor_authentication#send_code')
+        expect(@analytics).to receive(:track_event).with(
+          'GET request for two_factor_authentication#send_code'
+        )
 
         get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
       end
 
-      it 'notifies the user of OTP transmission' do
-        get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
+      context 'first request' do
+        it 'does not notify the user of OTP transmission via flash message' do
+          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
 
-        expect(flash[:success]).to eq t('notices.send_code.sms')
+          expect(flash[:success]).to eq nil
+        end
+      end
+
+      context 'multiple requests' do
+        it 'notifies the user of OTP transmission via flash message' do
+          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
+          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
+
+          expect(flash[:success]).to eq t('notices.send_code.sms')
+        end
       end
     end
 
@@ -131,12 +142,11 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       it 'sends OTP via voice' do
         get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
 
-        expect(VoiceOtpSenderJob).to have_received(:perform_later).
-          with(
-            code: subject.current_user.direct_otp,
-            phone: subject.current_user.phone,
-            otp_created_at: subject.current_user.direct_otp_sent_at.to_s
-          )
+        expect(VoiceOtpSenderJob).to have_received(:perform_later).with(
+          code: subject.current_user.direct_otp,
+          phone: subject.current_user.phone,
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s
+        )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
         expect(response).to redirect_to(
@@ -152,15 +162,26 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(:otp_delivery_selection, analytics_hash)
         expect(@analytics).to receive(:track_event).with('GET request for ' \
-          'two_factor_authentication#send_code')
+                                                         'two_factor_authentication#send_code')
 
         get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
       end
 
-      it 'notifies the user of OTP transmission' do
-        get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
+      context 'first request' do
+        it 'does not notify the user of OTP transmission via flash message' do
+          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
 
-        expect(flash[:success]).to eq t('notices.send_code.voice')
+          expect(flash[:success]).to eq nil
+        end
+      end
+
+      context 'multiple requests' do
+        it 'notifies the user of OTP transmission via flash message' do
+          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
+          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
+
+          expect(flash[:success]).to eq t('notices.send_code.voice')
+        end
       end
     end
 

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -54,18 +54,40 @@ describe Users::PhoneConfirmationController, devise: true do
       end
 
       context 'when choosing SMS OTP delivery' do
-        it 'notifies the user of OTP transmission' do
-          get :send_code, otp_method: :sms
+        context 'first request' do
+          it 'does not notify the user of OTP transmission via flash message' do
+            get :send_code, otp_method: :sms
 
-          expect(flash[:success]).to eq t('notices.send_code.sms')
+            expect(flash[:success]).to eq nil
+          end
+        end
+
+        context 'multiple requests' do
+          it 'notifies the user of OTP transmission via flash message' do
+            get :send_code, otp_method: :sms
+            get :send_code, otp_method: :sms
+
+            expect(flash[:success]).to eq t('notices.send_code.sms')
+          end
         end
       end
 
       context 'when choosing voice OTP delivery' do
-        it 'notifies the user of OTP transmission' do
-          get :send_code, otp_method: :voice
+        context 'first request' do
+          it 'does not notify the user of OTP transmission via flash message' do
+            get :send_code, otp_method: :voice
 
-          expect(flash[:success]).to eq t('notices.send_code.voice')
+            expect(flash[:success]).to eq nil
+          end
+        end
+
+        context 'multiple requests' do
+          it 'notifies the user of OTP transmission via flash message' do
+            get :send_code, otp_method: :voice
+            get :send_code, otp_method: :voice
+
+            expect(flash[:success]).to eq t('notices.send_code.voice')
+          end
         end
       end
     end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -110,7 +110,7 @@ feature 'Two Factor Authentication' do
       click_button t('forms.buttons.submit.default')
       click_link t('links.two_factor_authentication.resend_code')
 
-      expect(page).to have_content t('notices.send_code.sms')
+      expect(page).to have_content(t('notices.send_code.sms'))
     end
 
     scenario 'user who enters OTP incorrectly 3 times is locked out for OTP validity period' do


### PR DESCRIPTION
**Why**:
* Before, there was no user feedback when a user clicked on the "resend"
  link because the page stated looked the same and the reload happened
  lightning fast
* Now, at least it will be easier to distinguish between first send and
  second send

**How**:
* Do not show flash message on first send (per Ryan T mocks)
* Use session var to store whether user has requested OTP before
* If not first request, show flash message