### PR TITLE
Use Time.zone.now when direct_otp_sent_at is null

### DIFF
--- a/app/controllers/concerns/phone_confirmation_flow.rb
+++ b/app/controllers/concerns/phone_confirmation_flow.rb
@@ -76,7 +76,7 @@ module PhoneConfirmationFlow
     job.perform_later(
       code: confirmation_code,
       phone: unconfirmed_phone,
-      otp_created_at: current_user.direct_otp_sent_at.to_s
+      otp_created_at: (current_user.direct_otp_sent_at || Time.zone.now).to_s
     )
   end
 

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -47,7 +47,7 @@ module Devise
       job.perform_later(
         code: current_user.direct_otp,
         phone: current_user.phone,
-        otp_created_at: current_user.direct_otp_sent_at.to_s
+        otp_created_at: (current_user.direct_otp_sent_at || Time.zone.now).to_s
       )
     end
 

--- a/spec/controllers/users/phone_confirmation_controller_spec.rb
+++ b/spec/controllers/users/phone_confirmation_controller_spec.rb
@@ -42,14 +42,17 @@ describe Users::PhoneConfirmationController, devise: true do
         end
 
         it 're-sends existing code' do
-          expect(SmsOtpSenderJob).to receive(:perform_later).
-            with(
-              code: '1234',
-              phone: '+1 (555) 555-5555',
-              otp_created_at: controller.current_user.direct_otp_sent_at.to_s
-            )
+          now = Time.zone.now
+          Timecop.freeze(now) do
+            expect(SmsOtpSenderJob).to receive(:perform_later).
+              with(
+                code: '1234',
+                phone: '+1 (555) 555-5555',
+                otp_created_at: now.to_s
+              )
 
-          get :send_code
+            get :send_code
+          end
         end
       end
 


### PR DESCRIPTION
**Why**: Under some conditions the direct_otp_sent_at value
is not yet set when the Sidekiq job is created.