### PR TITLE
Add health check service class

### DIFF
--- a/app/jobs/health_check/checker_job.rb
+++ b/app/jobs/health_check/checker_job.rb
@@ -1,0 +1,7 @@
+module HealthCheck
+  class CheckerJob < ActiveJob::Base
+    def perform(queue_name)
+      IdentityIdp.redis.set(queue_name, 'alive')
+    end
+  end
+end

--- a/app/models/identity_idp.rb
+++ b/app/models/identity_idp.rb
@@ -1,0 +1,5 @@
+class IdentityIdp
+  def self.redis
+    @_redis ||= Redis.new(url: Figaro.env.redis_url)
+  end
+end

--- a/app/services/queue_health_check.rb
+++ b/app/services/queue_health_check.rb
@@ -1,0 +1,16 @@
+class QueueHealthCheck
+  QUEUES = %w(sms voice analytics mailers).freeze
+
+  def perform
+    QUEUES.each do |job|
+      redis.set(job, 'dead')
+      HealthCheck::CheckerJob.set(queue: job).perform_later(job)
+    end
+  end
+
+  private
+
+  def redis
+    IdentityIdp.redis
+  end
+end

--- a/spec/jobs/health_check/checker_job_spec.rb
+++ b/spec/jobs/health_check/checker_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe HealthCheck::CheckerJob do
+  describe '#perform' do
+    context 'queue is alive' do
+      it 'sets the queue name to alive' do
+        redis = IdentityIdp.redis
+        queue = 'queue_name'
+        redis.set(queue, nil)
+
+        HealthCheck::CheckerJob.set(queue: queue).perform_now(queue)
+
+        expect(redis.get(queue)).to eq 'alive'
+      end
+    end
+  end
+end

--- a/spec/services/queue_health_check_spec.rb
+++ b/spec/services/queue_health_check_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe QueueHealthCheck do
+  describe '#perform' do
+    it 'enqueues jobs for each queue' do
+      queues = QueueHealthCheck::QUEUES
+      queues.each do |queue|
+        allow(HealthCheck::CheckerJob).to receive(:perform_later).with(queue)
+      end
+      allow(HealthCheck::CheckerJob).to receive(:set).and_return(HealthCheck::CheckerJob)
+
+      QueueHealthCheck.new.perform
+
+      queues.each do |queue|
+        expect(HealthCheck::CheckerJob).to have_received(:perform_later).with(queue)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
- We want to know that our queues are firing so jobs are running
- This runs a job for each queue which updates the redis table
- If the queue is broken, the redis key will stay set to `dead`
- If queue runs, the redis key will be set to `alive`

**Next steps**:
- Add this to scheduler
- Also check Twilio / Mandrill integrations in health check
