### PR TITLE
Use consistent timezone for parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,4 +96,5 @@ group :test do
   gem 'test_after_commit'
   gem 'timecop'
   gem 'webmock'
+  gem 'zonebie'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,6 +591,7 @@ GEM
       nokogiri (~> 1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zonebie (0.6.1)
     zxcvbn-js (4.2.0.1)
       execjs
 
@@ -681,6 +682,7 @@ DEPENDENCIES
   whenever
   xml-simple
   xmlenc (~> 0.6.4)
+  zonebie
 
 BUNDLED WITH
    1.13.3

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -8,7 +8,8 @@ class SmsOtpSenderJob < ActiveJob::Base
   private
 
   def otp_valid?(otp_created_at)
-    Time.now.utc < DateTime.parse(otp_created_at) + Devise.direct_otp_valid_for
+    time_zone = Time.zone
+    time_zone.now < time_zone.parse(otp_created_at) + Devise.direct_otp_valid_for
   end
 
   def send_otp(twilio_service, code, phone)

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -8,7 +8,8 @@ class VoiceOtpSenderJob < ActiveJob::Base
   private
 
   def otp_valid?(otp_created_at)
-    Time.now.utc < DateTime.parse(otp_created_at) + Devise.direct_otp_valid_for
+    time_zone = Time.zone
+    time_zone.now < time_zone.parse(otp_created_at) + Devise.direct_otp_valid_for
   end
 
   def send_otp(twilio_service, code, phone)

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -40,5 +40,22 @@ describe SmsOtpSenderJob do
       expect(messages.size).to eq(0)
       expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to eq []
     end
+
+    it 'respects time zone' do
+      reset_job_queues
+      TwilioService.telephony_service = FakeSms
+      FakeSms.messages = []
+      otp_expiration_period = Devise.direct_otp_valid_for
+
+      SmsOtpSenderJob.perform_now(
+        code: '1234',
+        phone: '555-5555',
+        otp_created_at: otp_expiration_period.ago.strftime('%F %r')
+      )
+
+      messages = FakeSms.messages
+      expect(messages.size).to eq(0)
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to eq []
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,5 @@ end
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow: [/localhost/, /127\.0\.0\.1/, /codeclimate.com/])
+
+require 'zonebie/rspec'


### PR DESCRIPTION
**Why**: Without explicit call to `.zone` the parse() method
can do unexpected things.