### PR TITLE
Fix double submit button bug for password creation

### DIFF
--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -1,5 +1,4 @@
 import { PhoneFormatter, SocialSecurityNumberFormatter, TextField } from 'field-kit';
-
 import validateField from './validate-field';
 import DateFormatter from './modules/date-formatter';
 import OtpCodeFormatter from './modules/otp-code-formatter';

--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -21,7 +21,6 @@ const validate = {
   },
 
   addEvents() {
-    this.form.addEventListener('change', e => validateField(e.target));
     this.form.addEventListener('submit', e => this.validateForm(e));
   },
 
@@ -46,6 +45,5 @@ const validate = {
     if (invalidField) invalidField.focus();
   },
 };
-
 
 document.addEventListener('DOMContentLoaded', () => validate.init());

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,3 @@
-
 import 'app/pw-toggle';
 import 'app/form-validation';
 import 'app/form-field-format';

--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -56,5 +56,4 @@ function analyzePw() {
   });
 }
 
-
 document.addEventListener('DOMContentLoaded', analyzePw);

--- a/spec/features/visitors/confirm_email_spec.rb
+++ b/spec/features/visitors/confirm_email_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature 'Confirm email' do
+  VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
+
+  scenario 'confirms valid email and sets valid password' do
+    sign_up_with('test@example.com')
+    confirm_last_user
+
+    expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
+    expect(page).to have_title t('titles.confirmations.show')
+    expect(page).to have_content t('forms.confirmation.show_hdr')
+
+    fill_in 'password_form_password', with: VALID_PASSWORD
+    click_button t('forms.buttons.submit.default')
+
+    expect(current_url).to eq phone_setup_url
+    expect(page).to_not have_content t('devise.confirmations.confirmed_but_must_set_password')
+  end
+
+  scenario 'it sets reset_requested_at to nil after password confirmation' do
+    user = sign_up_and_set_password
+
+    expect(user.reset_requested_at).to be_nil
+  end
+end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -16,29 +16,6 @@ feature 'Sign Up', devise: true do
     expect(page).to have_link(t('links.resend'), href: new_user_confirmation_path)
   end
 
-  scenario 'visitor can sign up and confirm a valid email' do
-    sign_up_with('test@example.com')
-
-    confirm_last_user
-
-    expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
-    expect(page).to have_title t('titles.confirmations.show')
-    expect(page).to have_content t('forms.confirmation.show_hdr')
-
-    fill_in 'password_form_password', with: VALID_PASSWORD
-    click_button t('forms.buttons.submit.default')
-
-    expect(current_url).to eq phone_setup_url
-    expect(page).to_not have_content t('devise.confirmations.confirmed')
-    expect(page).to_not have_content t('devise.confirmations.confirmed_but_must_set_password')
-  end
-
-  scenario 'it sets reset_requested_at to nil after password confirmation' do
-    user = sign_up_and_set_password
-
-    expect(user.reset_requested_at).to be_nil
-  end
-
   context 'visitor can sign up and confirm a valid phone for OTP' do
     before do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)


### PR DESCRIPTION
**Why**:
* Yhis problem occurs when the password was determined invalid by
  zxcvbn, eg "password" and "passwordpassword". When I submit those, I
  get the localized error message for a weak password:
  https://github.com/bitzesty/devise_zxcvbn#error-message
* When I then add a new valid password and click submit, the "weak
  password" error message goes away, but the new password is not
  submitted and the submit button must be clicked again.