### PR TITLE
Add specs for `NullTwilioClient`

### DIFF
--- a/spec/services/null_twilio_client_spec.rb
+++ b/spec/services/null_twilio_client_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe NullTwilioClient do
+  describe '#messages' do
+    it 'returns self' do
+      client = NullTwilioClient.new
+
+      expect(client.messages).to eq client
+    end
+  end
+
+  describe '#calls' do
+    it 'returns self' do
+      client = NullTwilioClient.new
+
+      expect(client.calls).to eq client
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 if ENV['TRAVIS']
   require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
-elsif ENV['COVERAGE']
-  require 'simplecov'
-  SimpleCov.start 'rails'
+end
+
+require 'simplecov'
+SimpleCov.start 'rails' do
+  add_filter '/config/'
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
**Why**:
* Even though it's super simple, nice to have test coverage for
  everything
* Also, remove `config` dir from SimpleCov so code climate doesn't
  analyze that code when looking at test coverage
* Run Simplecov by default