### PR TITLE
Clean up specs

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 include Features::ActiveJobHelper
 
-#   As a user
-#   I want to sign in
-#   So I can visit protected areas of the site
 feature 'Two Factor Authentication' do
   describe 'When the user has not setup 2FA' do
     scenario 'user is prompted to setup two factor authentication at first sign in' do
@@ -57,16 +54,10 @@ feature 'Two Factor Authentication' do
         expect(user.reload.phone).to_not eq '+1 (555) 555-1212'
       end
     end
-  end # describe 'When the user has not set a preferred method'
+  end
 
   describe 'When the user has set a preferred method' do
     describe 'Using phone' do
-      # Scenario: User with phone 2fa is prompted for otp
-      #   Given I exist as a user
-      #   And I am not signed in and have phone 2fa enabled
-      #   When I sign in
-      #   Then an OTP is sent to my phone
-      #   And I am prompted to enter it
       context 'user is prompted for otp via phone only' do
         before do
           reset_job_queues
@@ -148,7 +139,7 @@ feature 'Two Factor Authentication' do
         expect(current_path).to eq root_path
       end
     end
-  end # describe 'When the user has set a preferred method'
+  end
 
   describe 'when the user is TOTP enabled' do
     it 'allows SMS and Voice fallbacks' do
@@ -197,4 +188,4 @@ feature 'Two Factor Authentication' do
       expect(current_path).to eq profile_path
     end
   end
-end # feature 'Two Factor Authentication'
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -3,25 +3,12 @@ require 'rails_helper'
 include SessionTimeoutWarningHelper
 include ActionView::Helpers::DateHelper
 
-# Feature: Sign in
-#   As a user
-#   I want to sign in
-#   So I can visit protected areas of the site
 feature 'Sign in' do
-  # Scenario: User cannot sign in if not registered
-  #   Given I do not exist as a user
-  #   When I sign in with valid credentials
-  #   Then I see an invalid credentials message
   scenario 'user cannot sign in if not registered' do
     signin('test@example.com', 'Please123!')
     expect(page).to have_content t('devise.failure.not_found_in_database')
   end
 
-  # Scenario: User cannot sign in with wrong email
-  #   Given I exist as a user
-  #   And I am not signed in
-  #   When I sign in with a wrong email
-  #   Then I see an invalid email message
   scenario 'user cannot sign in with wrong email' do
     user = create(:user)
     signin('invalid@email.com', user.password)
@@ -40,11 +27,6 @@ feature 'Sign in' do
     expect(page).to have_content 'Please fill in this field.'
   end
 
-  # Scenario: User cannot sign in with wrong password
-  #   Given I exist as a user
-  #   And I am not signed in
-  #   When I sign in with a wrong password
-  #   Then I see an invalid password message
   scenario 'user cannot sign in with wrong password' do
     user = create(:user)
     signin(user.email, 'invalidpass')

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
-# Feature: Sign out
-#   As a user
-#   I want to sign out
-#   So I can protect my account from unauthorized access
 feature 'Sign out' do
-  # Scenario: User signs out successfully
-  #   Given I am signed in
-  #   When I sign out
-  #   Then I see a signed out message
   scenario 'user signs out successfully' do
     sign_in_and_2fa_user
     click_link(t('links.sign_out'))

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-# Feature: User edit
-#   As a user
-#   I want to edit my user profile
-#   So I can change my email address
 feature 'User edit' do
   scenario 'user sees error message if form is submitted without email', js: true do
     sign_in_and_2fa_user

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 
-# Feature: User profile
-#   As a user
-#   I want to interact with my user info
 feature 'User profile' do
   context 'user clicks the delete account button' do
     xit 'deletes the account and signs the user out with a flash message' do

--- a/spec/features/visitors/confirmation_instructions_spec.rb
+++ b/spec/features/visitors/confirmation_instructions_spec.rb
@@ -1,24 +1,16 @@
 require 'rails_helper'
 require 'email_spec'
 
-# Feature: Confirmation Instructions
-#   As a user
-#   I want to resend my confirmation instructions
-#   So I can confirm my account and gain access to the site
 feature 'Confirmation Instructions', devise: true do
   include(EmailSpec::Helpers)
   include(EmailSpec::Matchers)
 
-  let!(:user) { FactoryGirl.build(:user, confirmed_at: nil) }
+  let!(:user) { build(:user, confirmed_at: nil) }
 
   before(:each) do
     visit new_user_confirmation_path
   end
 
-  # Scenario: User can request confirmation instructions be sent to them
-  #   Given I do not confirm my account in time
-  #   When I complete the form on the resend confirmation instructions page
-  #   Then I receive an email
   scenario 'user can resend their confirmation instructions via email' do
     user.save!
     fill_in 'Email', with: user.email
@@ -27,20 +19,12 @@ feature 'Confirmation Instructions', devise: true do
     expect(unread_emails_for(user.email)).to be_present
   end
 
-  # Scenario: User is unable to determine if someone else's account exists
-  #   Given I want to find out if an account exists for no_account_exists@example.com
-  #   When I complete the form on the resend confirmation instructions page
-  #   Then I still don't know if an account exists
   scenario 'user is unable to determine if account exists' do
     fill_in 'Email', with: 'no_account_exists@example.com'
     click_button t('forms.buttons.resend_confirmation')
     expect(page).to have_content t('devise.confirmations.send_paranoid_instructions')
   end
 
-  # Scenario: User must enter a valid email address
-  #   Given I am phising for accounts
-  #   When I enter invalid email addresses
-  #   Then I receive an error
   scenario 'user enters email with invalid format' do
     invalid_addresses = [
       'user@domain-without-suffix',

--- a/spec/features/visitors/contact_spec.rb
+++ b/spec/features/visitors/contact_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
-# Feature: Contact us
-#   As a visitor
-#   I want to fill out and submit contact form
 feature 'Contact us' do
-  # Scenario: User submits filled-in contact form
-  #   When I fill in form and click submit
-  #   Then I get success message
   scenario 'user submits contact form with non-empty email / phone' do
     visit contact_path
 
@@ -16,9 +10,6 @@ feature 'Contact us' do
     expect(page).to have_content t('contact.messages.thanks')
   end
 
-  # Scenario: User cannot submit contact without adding email or phone
-  #   When I leave the email / phone field empty and click submit
-  #   Then I receive a useful error
   scenario 'user submits contact form with no email / phone' do
     visit contact_path
 

--- a/spec/features/visitors/navigation_spec.rb
+++ b/spec/features/visitors/navigation_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
-# Feature: Navigation links
-#   As a visitor
-#   I want to see navigation links
-#   So I can find home, sign in, or sign up
 feature 'Navigation links', devise: true do
-  # Scenario: View navigation links
-  #   Given I am a visitor
-  #   When I visit the home page
-  #   Then I see "home," "sign in," and "sign up"
   scenario 'view navigation links' do
     visit root_path
     expect(page).to have_content 'Log in'

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-# Feature: Password Recovery
-#   As a user
-#   I want to recover my password
-#   So I can regain access to protected areas of the site
 feature 'Password Recovery' do
   def reset_password_and_sign_back_in(user)
     password = 'a really long password'
@@ -14,10 +10,6 @@ feature 'Password Recovery' do
     click_button t('links.sign_in')
   end
 
-  # Scenario: User can request a password reset link be sent to them
-  #   Given I do not remember my password as a user
-  #   When I complete the form on the password recovery page
-  #   Then I receive an email
   context 'user can reset their password via email', email: true do
     before do
       user = create(:user, :signed_up)
@@ -55,12 +47,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User that has only confirmed their email can reset their password
-  #   Given I have not created my password yet
-  #   And I click the Forgot password? link and enter my email
-  #   Then I receive the confirmation email again
-  #   And when I click the link in the confirmation email
-  #   Then I can set my password
   context 'user with only email confirmation resets password', email: true do
     before do
       user = create(:user, :unconfirmed)
@@ -78,11 +64,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User that has only confirmed their email can reset their password
-  #   Given I have not created my password yet
-  #   And I go to new user confirmation page and enter my email
-  #   When I click the link in the confirmation email
-  #   Then I can set a new password
   context 'user with email confirmation resends confirmation', email: true do
     before do
       user = create(:user, :unconfirmed)
@@ -100,11 +81,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User that has only confirmed password can reset their password
-  #   Given I have not set up 2FA yet
-  #   And I click the Forgot password? link and enter my email
-  #   When I click the link in the email
-  #   Then I can set a new password
   context 'user with password confirmation resets password', email: true do
     before do
       @user = create(:user)
@@ -147,10 +123,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User that has only confirmed 2FA can reset their password
-  #   When I click the Forgot password? link and enter my email
-  #   And I click the link in the email
-  #   Then I can set a new password
   context 'user with 2FA confirmation resets password', email: true do
     before do
       @user = create(:user, :signed_up)
@@ -171,10 +143,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User can only submit valid email addresses
-  #   Given I do not remember my password as a user
-  #   When I complete the form with invalid email addresses
-  #   Then I receive a useful error
   scenario 'user submits email address with invalid format' do
     invalid_addresses = [
       'user@domain-without-suffix',
@@ -223,10 +191,6 @@ feature 'Password Recovery' do
     expect(page).to have_content 'Please fill in this field.'
   end
 
-  # Scenario: User is unable to determine if someone else's account exists
-  #   Given I want to find out if an account exists
-  #   When I complete the form on the password recovery page
-  #   Then I still don't know if an account exists
   scenario 'user is unable to determine if account exists' do
     visit new_user_password_path
     fill_in 'Email', with: 'no_account_exists@gmail.com'
@@ -235,10 +199,6 @@ feature 'Password Recovery' do
     expect(page).to have_content(t('devise.passwords.send_instructions'))
   end
 
-  # Scenario: User can reset their password
-  #   Given I do not remember my password as a user
-  #   When I complete the form on the password recovery page
-  #   Then I receive an email
   context 'user can reset their password' do
     before do
       @user = create(:user, :signed_up)
@@ -293,11 +253,6 @@ feature 'Password Recovery' do
     end
   end
 
-  # Scenario: User takes too long to click the reset password link
-  #   Given I have waited too long to click the link in my email
-  #   When I click the link
-  #   Then I see a error message that tells me the token has expired
-  #   And I am prompted to send instructions again
   scenario 'user takes too long to click the reset password link' do
     user = create(:user, :signed_up)
 
@@ -319,11 +274,6 @@ feature 'Password Recovery' do
     expect(current_path).to eq new_user_password_path
   end
 
-  # Scenario: User takes too long to reset password
-  #   Given I do not remember my password as a user
-  #   When I complete the forms to reset password after time limit
-  #   Then I see a helpful error message
-  #   And I am redirected to the new_user_password_path
   scenario 'user takes too long to reset password' do
     user = create(:user, :signed_up)
 
@@ -348,10 +298,6 @@ feature 'Password Recovery' do
     Timecop.return
   end
 
-  # Scenario: Unconfirmed user account receives confirmation instructions
-  #   Given my user account is unconfirmed
-  #   When I complete the form on the password recovery page
-  #   Then I receive confirmation instructions
   scenario 'unconfirmed user requests reset instructions', email: true do
     user = create(:user, :unconfirmed)
 
@@ -363,10 +309,6 @@ feature 'Password Recovery' do
       to eq t('devise.mailer.confirmation_instructions.subject')
   end
 
-  # Scenario: User enters non-existent email address into password reset form
-  #   Given I am not signed in
-  #   When I enter a non-existent email address
-  #   Then I see 'email sent'
   scenario 'user enters non-existent email address into password reset form' do
     visit new_user_password_path
     fill_in 'user_email', with: 'ThisEmailAddressShall@NeverExist.com'
@@ -377,10 +319,6 @@ feature 'Password Recovery' do
     expect(page).not_to(have_content(t('simple_form.error_notification.default_message')))
   end
 
-  # Scenario: Tech support user requests password reset
-  #   Given I am not signed in
-  #   When I enter my email address
-  #   Then I see 'email sent' but do not receive recovery email.
   scenario 'tech user enters email address into password reset form' do
     reset_email
     user = create(:user, :signed_up, :tech_support)
@@ -393,10 +331,6 @@ feature 'Password Recovery' do
     expect(ActionMailer::Base.deliveries).to be_empty
   end
 
-  # Scenario: Admin user requests password reset
-  #   Given I am not signed in
-  #   When I enter my email address
-  #   Then I see 'email sent' but do not receive recovery email.
   scenario 'admin user enters email address into password reset form' do
     reset_email
     user = create(:user, :signed_up, :admin)

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -1,18 +1,9 @@
 require 'rails_helper'
 
-# Feature: Sign up
-#   As a visitor
-#   I want to sign up
-#   So I can visit protected areas of the site
-
 VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
 INVALID_PASSWORD = 'asdf'.freeze
 
 feature 'Sign Up', devise: true do
-  # Scenario: Visitor can sign up with valid email address
-  #   Given I am not signed in
-  #   When I sign up with a valid email address
-  #   Then I see a message that I need to confirm my email address
   scenario 'visitor can sign up with valid email address' do
     email = 'test@example.com'
     sign_up_with(email)
@@ -25,12 +16,6 @@ feature 'Sign Up', devise: true do
     expect(page).to have_link(t('links.resend'), href: new_user_confirmation_path)
   end
 
-  # Scenario: Visitor can sign up and confirm with valid email address and password
-  #   Given I am not signed in
-  #   When I sign up with a valid email address and click my confirmation link
-  #   Then I see a message letting me know I need to set a password to finish creating my account
-  #   And when I set a valid password
-  #   Then I am prompted to set up 2FA without any flash messages
   scenario 'visitor can sign up and confirm a valid email' do
     sign_up_with('test@example.com')
 
@@ -228,10 +213,6 @@ feature 'Sign Up', devise: true do
     end
   end
 
-  # Scenario: Visitor cannot sign up with invalid email address
-  #   Given I am not signed in
-  #   When I sign up with an invalid email address
-  #   Then I see an invalid email message
   scenario 'visitor cannot sign up with invalid email address' do
     sign_up_with('bogus')
     expect(page).to have_content t('valid_email.validations.email.invalid')
@@ -262,11 +243,6 @@ feature 'Sign Up', devise: true do
     expect(page).to have_content(invalid_email_message)
   end
 
-  # Scenario: Visitor tries to determine if email exists in the system
-  #   Given I am not signed in
-  #   When I sign up with an existing email address
-  #   Then I can't tell whether or not the email exists
-  #   And no email is sent to the existing user
   scenario 'visitor signs up with an email already in the system', email: true do
     user = create(:user, email: 'existing_user@example.com')
     sign_up_with('existing_user@example.com')
@@ -280,11 +256,6 @@ feature 'Sign Up', devise: true do
     expect(last_email.html_part.body).to have_content 'This email address is already in use.'
   end
 
-  # Scenario: Visitor signs up but confirms with an expired token
-  #   Given I am not signed in
-  #   When I sign up with a email address and attempt to confirm with expired token
-  #   Then I see a message that my confirmation token has expired
-  #   And that I should request a new one
   scenario 'visitor signs up but confirms with an expired token' do
     allow(Devise).to receive(:confirm_within).and_return(24.hours)
     user = create(:user, :unconfirmed)
@@ -299,10 +270,6 @@ feature 'Sign Up', devise: true do
     )
   end
 
-  # Scenario: Visitor signs up but confirms with an invalid token
-  #   Given I am not signed in
-  #   When I sign up with a email address and attempt to confirm with invalid token
-  #   Then I see a message that the token is invalid
   scenario 'visitor signs up but confirms with an invalid token' do
     create(:user, :unconfirmed)
     visit '/users/confirmation?confirmation_token=invalid_token'
@@ -311,9 +278,6 @@ feature 'Sign Up', devise: true do
     expect(current_path).to eq user_confirmation_path
   end
 
-  # Scenario: Visitor tries to spam an existing user
-  #   When I resend confirmation instructions to an existing user
-  #   Then the user does not receive an email
   context 'confirmation instructions sent to existing user', email: true do
     xit 'does not send an email to the existing user' do
       user = create(:user)
@@ -327,11 +291,6 @@ feature 'Sign Up', devise: true do
     end
   end
 
-  # Scenario: Confirmed visitor confirms again while signed out
-  #   Given I've confirmed my email, created a password, and signed out
-  #   When I click the confirmation link in the email again
-  #   Then I see a message that I've already confirmed
-  #   And I am redirected to the sign in page
   context 'confirmed user clicks confirmation link while again signed out' do
     it 'redirects to sign in page with message that user is already confirmed' do
       sign_up_and_set_password

--- a/spec/policies/app_setting_policy_spec.rb
+++ b/spec/policies/app_setting_policy_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe AppSettingPolicy do
   subject { AppSettingPolicy }
 
-  let(:current_user) { FactoryGirl.build_stubbed :user }
-  let(:other_user) { FactoryGirl.build_stubbed :user }
-  let(:tech_support_user) { FactoryGirl.build_stubbed :user, :tech_support }
-  let(:admin) { FactoryGirl.build_stubbed :user, :admin }
+  let(:current_user) { build_stubbed :user }
+  let(:other_user) { build_stubbed :user }
+  let(:tech_support_user) { build_stubbed :user, :tech_support }
+  let(:admin) { build_stubbed :user, :admin }
 
   permissions :index? do
     it 'denies access if not an admin' do

--- a/spec/policies/tech_support_policy_spec.rb
+++ b/spec/policies/tech_support_policy_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe TechSupportPolicy do
   subject { TechSupportPolicy }
 
-  let(:regular_user) { FactoryGirl.build_stubbed :user }
-  let(:privileged_user) { FactoryGirl.build_stubbed :user, :privileged }
-  let(:admin) { FactoryGirl.build_stubbed :user, :admin }
-  let(:tech) { FactoryGirl.build_stubbed :user, :tech_support }
+  let(:regular_user) { build_stubbed :user }
+  let(:privileged_user) { build_stubbed :user, :privileged }
+  let(:admin) { build_stubbed :user, :admin }
+  let(:tech) { build_stubbed :user, :tech_support }
 
   shared_examples 'allows_admin_and_tech' do
     it 'allows tech' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,7 +1,7 @@
 module ControllerHelper
   def sign_in_as_admin
     @request.env['devise.mapping'] = Devise.mappings[:user]
-    sign_in FactoryGirl.create(:user, :admin, :signed_up)
+    sign_in create(:user, :admin, :signed_up)
   end
 
   def sign_in_as_user(user = create(:user, :signed_up))


### PR DESCRIPTION
**Why**:
* We no longer use Gherkin-like comments for feature specs
* We are using FG syntax methods so no need to explicityl call
  `FactoryGirl` when using factories.