### PR TITLE
Do not return Profile attributes for LOA1 request

### DIFF
--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -655,13 +655,10 @@ describe SamlIdpController do
           expect(uuid['FriendlyName']).to eq('uuid')
         end
 
-        it 'includes the phone Attribute element' do
+        it 'does not include the phone Attribute element when authn_context is LOA1' do
           phone = xmldoc.phone_number
 
-          expect(phone.name).to eq('Attribute')
-          expect(phone['Name']).to eq('phone')
-          expect(phone['NameFormat']).to eq(Saml::XML::Namespaces::Formats::Attr::URI)
-          expect(phone['FriendlyName']).to eq('phone')
+          expect(phone).to be_nil
         end
       end
     end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -243,16 +243,6 @@ feature 'IdV session' do
     end
   end
 
-  def complete_idv_profile_ok(user)
-    fill_out_idv_form_ok
-    click_button t('forms.buttons.submit.continue')
-    fill_out_financial_form_ok
-    click_button t('idv.messages.finance.continue')
-    fill_out_phone_form_ok(user.phone)
-    click_button t('forms.buttons.submit.continue')
-    click_button t('forms.buttons.submit.default')
-  end
-
   def complete_idv_profile_fail(user)
     fill_out_idv_form_fail
     click_button 'Continue'

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -67,4 +67,14 @@ module IdvHelper
   def fill_out_phone_form_ok(phone = '415-555-0199')
     fill_in :idv_phone_form_phone, with: phone
   end
+
+  def complete_idv_profile_ok(user)
+    fill_out_idv_form_ok
+    click_button t('forms.buttons.submit.continue')
+    fill_out_financial_form_ok
+    click_button t('idv.messages.finance.continue')
+    fill_out_phone_form_ok(user.phone)
+    click_button t('forms.buttons.submit.continue')
+    click_button t('forms.buttons.submit.default')
+  end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -110,6 +110,16 @@ module SamlAuthHelper
     settings
   end
 
+  def loa1_with_bundle_saml_settings
+    settings = sp1_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone"
+    ]
+    settings
+  end
+
   def sp1_authnrequest
     auth_request.create(sp1_saml_settings)
   end


### PR DESCRIPTION
**Why**: To protect the user's PII. A Service Provider could
potentially request verified Profile attributes when making an LOA1
request, so we want to make sure we only send back attributes that
correspond to the LOA level.

As Amos said:
LOA1 means lower-risk business transaction. It means the SP does not
need to uniquely identify an individual, which means sensitive PII
attributes are not required. Therefore, we do not allow them to be
transmitted.

We will enforce proper authentication context directives and only
assert data matching the requested assurance levels based on the risk
of the transaction. We will not release sensitive data during low-risk
business transactions.

This is core to how we keep our partner agencies accountable as well.
We will only allow agencies that can properly demonstrate adequate
security posture to access LOA3 attributes.

Fixes https://github.com/18F/identity-private/issues/828