### PR TITLE
Remove `ApplicationPolicy`

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,7 +1,0 @@
-class ApplicationPolicy
-  def initialize(user, record)
-    raise Pundit::NotAuthorizedError, 'must be logged in' unless user
-    @user = user
-    @record = record
-  end
-end


### PR DESCRIPTION
**Why**:

* This file showed up as having zero test coverage in code climate
* Our policies are not inheriting from this, so it is unused