### PR TITLE
Fix "already initialized constant VALID_PASSWORD" errors

### DIFF
--- a/spec/features/visitors/confirm_email_spec.rb
+++ b/spec/features/visitors/confirm_email_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 feature 'Confirm email' do
-  VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
-
   scenario 'confirms valid email and sets valid password' do
     sign_up_with('test@example.com')
     confirm_last_user
@@ -11,7 +9,7 @@ feature 'Confirm email' do
     expect(page).to have_title t('titles.confirmations.show')
     expect(page).to have_content t('forms.confirmation.show_hdr')
 
-    fill_in 'password_form_password', with: VALID_PASSWORD
+    fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
     click_button t('forms.buttons.submit.default')
 
     expect(current_url).to eq phone_setup_url

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 
-VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
-INVALID_PASSWORD = 'asdf'.freeze
-
 feature 'Sign Up', devise: true do
   scenario 'visitor can sign up with valid email address' do
     email = 'test@example.com'


### PR DESCRIPTION
Why: I got this warning in my console when getting specs up and running

How: Removing additional definitions of the `VALID_PASSWORD` constant and re-using the one defined in `Features::SessionHelper`