### PR TITLE
Refactor IdV controllers to DRY up some methods

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -33,4 +33,18 @@ module IdvSession
   def idv_attempter
     @_idv_attempter ||= Idv::Attempter.new(current_user)
   end
+
+  def idv_agent
+    @_agent ||= Proofer::Agent.new(
+      applicant: idv_session.applicant,
+      vendor: (idv_session.vendor || idv_vendor.pick),
+      kbv: FeatureManagement.proofing_requires_kbv?
+    )
+  end
+
+  def init_questions_and_profile(resolution)
+    idv_session.resolution = resolution
+    idv_session.question_number = 0
+    idv_session.profile_from_applicant(idv_session.applicant)
+  end
 end

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -33,14 +33,10 @@ module Idv
       finish_proofing_success
     end
 
-    def proofer_agent
-      @_agent ||= Proofer::Agent.new(vendor: idv_session.vendor, applicant: idv_session.applicant)
-    end
-
     def submit_answers
       @idv_vendor = idv_session.vendor
       resolution = idv_session.resolution
-      @confirmation = proofer_agent.submit_answers(resolution.questions, resolution.session_id)
+      @confirmation = idv_agent.submit_answers(resolution.questions, resolution.session_id)
       if @confirmation.success?
         finish_proofing_success
       else

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -16,7 +16,6 @@ module Idv
     end
 
     def create
-      idv_session.applicant = applicant_from_params
       resolution = start_idv_session
       process_resolution(resolution)
     end
@@ -59,7 +58,7 @@ module Idv
     end
 
     def start_idv_session
-      idv_session.applicant = applicant_from_params
+      idv_session.applicant = idv_session.applicant_from_params
       idv_session.vendor = idv_agent.vendor
       submit_applicant
     end
@@ -68,24 +67,6 @@ module Idv
       resolution = idv_agent.start(idv_session.applicant)
       idv_attempter.increment
       resolution
-    end
-
-    def idv_agent
-      @_agent ||= Proofer::Agent.new(
-        vendor: idv_vendor.pick,
-        kbv: FeatureManagement.proofing_requires_kbv?
-      )
-    end
-
-    def applicant_from_params
-      app_vars = idv_session.params.select { |key, _value| Proofer::Applicant.method_defined?(key) }
-      Proofer::Applicant.new(app_vars)
-    end
-
-    def init_questions_and_profile(resolution)
-      idv_session.resolution = resolution
-      idv_session.question_number = 0
-      idv_session.profile_from_applicant(idv_session.applicant)
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -35,6 +35,11 @@ module Idv
       self.profile_id = Profile.create_from_proofer_applicant(applicant, current_user).id
     end
 
+    def applicant_from_params
+      app_vars = params.select { |key, _value| Proofer::Applicant.method_defined?(key) }
+      Proofer::Applicant.new(app_vars)
+    end
+
     def profile
       @_profile ||= Profile.find(profile_id)
     end


### PR DESCRIPTION
This is part 1 of #498 

**Why**: Creates some method-count headroom in the IdV
controllers for adding passphrase collection later.