### PR TITLE
Add cancel links to the authenticator setup pages

### DIFF
--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -11,3 +11,4 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
     = text_field_tag :code, '', required: true, pattern: '[0-9]*',
       class: 'block col-12 field monospace mfa'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'

--- a/app/views/users/totp_setup/start.html.slim
+++ b/app/views/users/totp_setup/start.html.slim
@@ -7,3 +7,4 @@ p.mt-tiny.mb3 = t('forms.totp_setup.totp_intro')
 .mt3.sm-mt4.mb1
   = link_to t('forms.buttons.setup_totp'), authenticator_setup_url, \
     class: 'btn btn-primary'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'


### PR DESCRIPTION
**Why**:
- We need to give users the opportunity to get back to their profile
  from the authenticator setup pages
![screen shot 2016-10-24 at 9 36 31 am](https://cloud.githubusercontent.com/assets/126935/19654497/69334376-99cd-11e6-9c0f-a5457272d596.png)
![screen shot 2016-10-24 at 9 36 40 am](https://cloud.githubusercontent.com/assets/126935/19654498/6a982e3e-99cd-11e6-892d-45b1d838134d.png)

