### PR TITLE
Disable SafeNavigation rubocop style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -184,7 +184,7 @@ Style/MultilineOperationIndentation:
   IndentationWidth: ~
 
 Style/SafeNavigation:
-  ConvertCodeThatCanStartToReturnNil: true
+  ConvertCodeThatCanStartToReturnNil: false
 
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -183,6 +183,9 @@ Style/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/SafeNavigation:
+  ConvertCodeThatCanStartToReturnNil: true
+
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -184,7 +184,7 @@ Style/MultilineOperationIndentation:
   IndentationWidth: ~
 
 Style/SafeNavigation:
-  ConvertCodeThatCanStartToReturnNil: false
+  Enabled: false
 
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.


### PR DESCRIPTION
**Why**: Reek disagrees, and the longer older
syntax is more clear to non-Rubyists.

Introduced in https://github.com/bbatsov/rubocop/pull/3517

Here's what Rubocop now reports:
![screen shot 2016-10-24 at 3 01 10 pm](https://cloud.githubusercontent.com/assets/1205061/19662030/a471a972-99fb-11e6-9ff3-927b64f3b662.png)

And here's what Reek says:
![screen shot 2016-10-24 at 2 55 46 pm](https://cloud.githubusercontent.com/assets/1205061/19662049/b3de4da2-99fb-11e6-8f86-3e5fb800888f.png)
