### PR TITLE
Fix email confirmation from name display bug

### DIFF
--- a/app/mailers/concerns/mailable.rb
+++ b/app/mailers/concerns/mailable.rb
@@ -1,0 +1,16 @@
+module Mailable
+  extend ActiveSupport::Concern
+
+  private
+
+  def email_with_name(email, name)
+    # http://stackoverflow.com/a/8106387/358804
+    address = Mail::Address.new(email)
+    address.display_name = name
+    address.format
+  end
+
+  def attach_images
+    attachments.inline['logo.png'] = File.read('app/assets/images/logo.png')
+  end
+end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,15 +1,13 @@
 class CustomDeviseMailer < Devise::Mailer
+  include Mailable
   before_action :attach_images
   layout 'layouts/user_mailer'
+  default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
 
   def confirmation_instructions(record, token, options = {})
     user_decorator = record.decorate
     @first_sentence = user_decorator.first_sentence_for_confirmation_email
     @confirmation_period = user_decorator.confirmation_period
     super
-  end
-
-  def attach_images
-    attachments.inline['logo.png'] = File.read('app/assets/images/logo.png')
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,7 @@
 class UserMailer < ActionMailer::Base
+  include Mailable
   before_action :attach_images
-  default from: Figaro.env.email_from
+  default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
 
   def email_changed(old_email)
     mail(to: old_email, subject: t('mailer.email_change_notice.subject'))
@@ -19,9 +20,5 @@ class UserMailer < ActionMailer::Base
   def contact_request(details)
     @details = details
     mail(to: Figaro.env.support_email, subject: t('mailer.contact_request.subject'))
-  end
-
-  def attach_images
-    attachments.inline['logo.png'] = File.read('app/assets/images/logo.png')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module Upaya
 
     config.middleware.use Rack::Attack
 
+    config.autoload_paths << Rails.root.join('app/mailers/concerns')
+
     # Configure Browserify to use babelify to compile ES6
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,13 +1,14 @@
 require 'saml_idp_constants'
 
 Devise.setup do |config|
+  include Mailable
   require 'devise/orm/active_record'
   config.allow_unconfirmed_access_for = 0.days
   config.case_insensitive_keys = [:email]
   config.confirm_within = 24.hours
   config.expire_all_remember_me_on_sign_out = true
   config.mailer = 'CustomDeviseMailer'
-  config.mailer_sender = Figaro.env.email_from
+  config.mailer_sender = email_with_name(Figaro.env.email_from, Figaro.env.email_from)
   config.paranoid = true
   config.password_length = 8..128
   config.pepper = Figaro.env.password_pepper

--- a/config/initializers/devise_mailer_helpers.rb
+++ b/config/initializers/devise_mailer_helpers.rb
@@ -9,8 +9,6 @@ module Devise
         headers = {
           subject: subject_for(action),
           to: recipient,
-          from: mailer_sender(devise_mapping),
-          reply_to: mailer_reply_to(devise_mapping),
           template_path: template_paths,
           template_name: action
         }.merge(opts)

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe CustomDeviseMailer do
+  let(:user) { build_stubbed(:user) }
+
+  describe '#confirmation_instructions' do
+    let(:mail) { CustomDeviseMailer.confirmation_instructions(user, '123ABC') }
+
+    it_behaves_like 'a system email'
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -6,6 +6,8 @@ describe UserMailer, type: :mailer do
   describe 'email_changed' do
     let(:mail) { UserMailer.email_changed('old@email.com') }
 
+    it_behaves_like 'a system email'
+
     it 'sends to the old email' do
       expect(mail.to).to eq ['old@email.com']
     end
@@ -26,6 +28,8 @@ describe UserMailer, type: :mailer do
   describe 'password_changed' do
     let(:mail) { UserMailer.password_changed(user) }
 
+    it_behaves_like 'a system email'
+
     it 'sends to the current email' do
       expect(mail.to).to eq [user.email]
     end
@@ -45,6 +49,8 @@ describe UserMailer, type: :mailer do
 
   describe 'signup_with_your_email' do
     let(:mail) { UserMailer.signup_with_your_email(user.email) }
+
+    it_behaves_like 'a system email'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [user.email]
@@ -68,6 +74,8 @@ describe UserMailer, type: :mailer do
     }
 
     let(:mail) { UserMailer.contact_request(details) }
+
+    it_behaves_like 'a system email'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [Figaro.env.support_email]

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -1,0 +1,6 @@
+shared_examples 'a system email' do
+  it 'is from the default email' do
+    expect(mail.from).to eq [Figaro.env.email_from]
+    expect(mail[:from].display_names).to eq [Figaro.env.email_from]
+  end
+end


### PR DESCRIPTION
**Why**:
* Some email clients, eg: gmail, will truncate a regular "From" email
* In our case, this was showing from as just "no-reply"
* Now, all email will show as being "from" full no-reply address