### PR TITLE
Update ahoy_matey from 1.4.2 to 1.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,11 +57,11 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    ahoy_matey (1.4.2)
+    ahoy_matey (1.5.2)
       addressable
       browser (~> 2.0)
       geocoder
-      rack-attack
+      rack-attack (< 6)
       railties
       referer-parser (>= 0.3.0)
       request_store
@@ -211,7 +211,7 @@ GEM
       thor (~> 0.14)
     formatador (0.2.5)
     foundation_emails (2.2.0.0)
-    geocoder (1.3.7)
+    geocoder (1.4.0)
     get_process_mem (0.2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -288,7 +288,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     nenv (0.3.0)
@@ -379,7 +379,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     randexp (0.1.7)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,5 +1,6 @@
 Ahoy.mount = false
 Ahoy.throttle = false
+Ahoy.api_only = true
 
 module Ahoy
   class Store < Ahoy::Stores::LogStore

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -33,8 +33,8 @@ RSpec::Matchers.define :have_actions do |kind, *names|
 
     actions = callbacks.each_with_object([]) do |f, result|
       result << f.filter unless action_has_only_option?(f) || action_has_except_option?(f)
-      result << [f.filter, only: symbolized_only_action(f)] if action_has_only_option?(f)
-      result << [f.filter, except: symbolized_except_action(f)] if action_has_except_option?(f)
+      result << [f.filter, only: parsed_only_action(f)] if action_has_only_option?(f)
+      result << [f.filter, except: parsed_except_action(f)] if action_has_except_option?(f)
     end
 
     names.all? { |name| actions.include?(name) }
@@ -57,18 +57,38 @@ def unless_option_for(action)
   action.instance_variable_get(:@unless)
 end
 
-def symbol_from_string(string)
-  if string.include?('||')
-    string.split('||').map { |str| str.split('==')[1].strip.tr("'", '').to_sym }
-  else
-    string.split('==')[1].strip.tr("'", '').to_sym
+def parsed_only_action(action)
+  only_option = if_option_for(action)[0]
+
+  "#{only_option.class}OptionParser".constantize.new(only_option).parse
+end
+
+def parsed_except_action(action)
+  except_option = unless_option_for(action)[0]
+
+  "#{except_option.class}OptionParser".constantize.new(except_option).parse
+end
+
+class ProcOptionParser
+  def initialize(option)
+    @option = option
+  end
+
+  def parse
+    @option
   end
 end
 
-def symbolized_only_action(action)
-  symbol_from_string(if_option_for(action)[0])
-end
+class StringOptionParser
+  def initialize(option)
+    @option = option
+  end
 
-def symbolized_except_action(action)
-  symbol_from_string(unless_option_for(action)[0])
+  def parse
+    if @option.include?('||')
+      @option.split('||').map { |str| str.split('==')[1].strip.tr("'", '').to_sym }
+    else
+      @option.split('==')[1].strip.tr("'", '').to_sym
+    end
+  end
 end

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -86,9 +86,19 @@ class StringOptionParser
 
   def parse
     if @option.include?('||')
-      @option.split('||').map { |str| str.split('==')[1].strip.tr("'", '').to_sym }
+      array_of_actions_passed_to_only_or_except_option_in_controller_callback
     else
-      @option.split('==')[1].strip.tr("'", '').to_sym
+      single_action_passed_to_only_or_except_option_in_controller_callback
     end
+  end
+
+  private
+
+  def array_of_actions_passed_to_only_or_except_option_in_controller_callback
+    @option.split('||').map { |str| str.split('==')[1].strip.tr("'", '').to_sym }
+  end
+
+  def single_action_passed_to_only_or_except_option_in_controller_callback
+    @option.split('==')[1].strip.tr("'", '').to_sym
   end
 end


### PR DESCRIPTION
**Why**: To get the latest and greatest

**How**:
- Ahoy uses a conditional callback with a Proc in the controller that
is automatically injected into our app, but our `have_actions` custom
RSpec matcher only expected symbols, which are most commonly used with
conditional callbacks. So, I fixed the matcher to take into account
Procs.
- Set Ahoy's new `api_only` option to true so that the before_actions
in Ahoy's controller don't get called, because we don't use the
controllers. They're only used for JS tracking, but we're only doing
server-side tracking.