### PR TITLE
Skip OutputSafety rubocop rule for i18n

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,10 @@ Metrics/ModuleLength:
   - spec/**/*
   - 'app/controllers/concerns/two_factor_authenticatable.rb'
 
+Rails/OutputSafety:
+  Exclude:
+  - lib/i18n_override.rb
+
 Rails/TimeZone:
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.


### PR DESCRIPTION
**Why**: quiets this warning:
```
lib/i18n_override.rb:12:11: C: Tagging a string as html safe may be a security risk, prefer safe_join or other Rails tag helpers instead
      rtn.html_safe
          ^^^^^^^^^
```