### PR TITLE
Add custom validation message for email inputs

### DIFF
--- a/app/assets/javascripts/app/validate-field.js
+++ b/app/assets/javascripts/app/validate-field.js
@@ -2,6 +2,7 @@ import 'classlist.js';
 
 
 const msgs = {
+  email: 'Please enter a valid email address.',
   missing: 'Please fill in this field.',
   mismatch: 'Please match the requested format.',
 };
@@ -11,9 +12,10 @@ function addInvalidMarkup(f) {
   f.setAttribute('aria-describedby', `alert_${f.id}`);
 
   if (f.validity.valueMissing) f.setCustomValidity(msgs.missing);
+  else if (f.validity.typeMismatch &&
+    f.type === 'email') f.setCustomValidity(msgs.email);
   else if (f.validity.patternMismatch
     || f.validity.typeMismatch) f.setCustomValidity(msgs.mismatch);
-  else f.setCustomValidity('');
 
   f.insertAdjacentHTML(
     'afterend',
@@ -30,6 +32,7 @@ function removeInvalidMarkup(f) {
 }
 
 function validateField(f) {
+  f.setCustomValidity('');
   f.classList.add('interacted');
 
   const parent = f.parentNode;

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -21,6 +21,12 @@ feature 'Sign in' do
     expect(page).to have_content 'Please fill in this field.'
   end
 
+  scenario 'user cannot sign in with invalid email', js: true do
+    signin('invalid', 'foo')
+
+    expect(page).to have_content 'Please enter a valid email address.'
+  end
+
   scenario 'user cannot sign in with empty password', js: true do
     signin('test@example.com', '')
 


### PR DESCRIPTION
**Why**: Input specific error message rather than the default of 'Please match the requested format'.