### PR TITLE
Update dev & qa server hostnames in deploy config

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,1 +1,2 @@
-server 'upaya-idp-dev.18f.gov', roles: %w(web app db)
+server 'dev.login.gov', roles: %w(web db)
+server 'worker.dev.login.gov', roles: %w(app)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,2 @@
-server 'upaya-idp-qa.18f.gov', roles: %w(web app db)
+server 'qa.login.gov', roles: %w(web db)
+server 'worker.qa.login.gov', roles: %w(app)


### PR DESCRIPTION
**Why**: To point to the latest servers