### PR TITLE
Encrypt Rails session at rest

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,0 +1,15 @@
+class SessionEncryptor
+  def self.load(value)
+    decrypted = encryptor.decrypt(value)
+    Marshal.load(::Base64.decode64(decrypted))
+  end
+
+  def self.dump(value)
+    plain = ::Base64.encode64(Marshal.dump(value))
+    encryptor.encrypt(plain)
+  end
+
+  def self.encryptor
+    Pii::Encryptor.new
+  end
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,7 +6,7 @@ options = {
     key_prefix: "#{Figaro.env.domain_name}:session:",
     url: Figaro.env.redis_url
   },
-  serializer: :marshal
+  serializer: SessionEncryptor
 }
 
 Rails.application.config.session_store :redis_session_store, options

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe SessionEncryptor do
+  describe '#load' do
+    it 'decrypts encrypted session' do
+      session = SessionEncryptor.dump(foo: 'bar')
+
+      expect(SessionEncryptor.load(session)).to eq(foo: 'bar')
+    end
+  end
+
+  describe '#dump' do
+    it 'encrypts session' do
+      session = SessionEncryptor.dump(foo: 'bar')
+
+      expect(session).to_not match 'foo'
+      expect(session).to_not match 'bar'
+    end
+  end
+
+  describe '#encryptor' do
+    it 'is a Pii::Encryptor' do
+      expect(SessionEncryptor.encryptor).to be_a Pii::Encryptor
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Protects PII

**How**: Provide custom serializer to session store.

Note this does not provide any actual encryption. That will come in an update to `Pii::Encryptor`.