### PR TITLE
Add i18n strings JS object

### DIFF
--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -1,0 +1,18 @@
+window.LoginGov = window.LoginGov || {};
+
+<% keys = [
+  'instructions.password.strength.i',
+  'instructions.password.strength.ii',
+  'instructions.password.strength.iii',
+  'instructions.password.strength.iv',
+  'instructions.password.strength.v',
+] %>
+
+window.LoginGov.I18n = {
+  strings: {},
+  t: function(key) { return this.strings[key]; }
+};
+
+<% keys.each do |key| %>
+  window.LoginGov.I18n.strings['<%= key %>'] = '<%= I18n.t(key) %>';
+<% end %>

--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -1,5 +1,7 @@
 import zxcvbn from 'zxcvbn';
 
+const I18n = window.LoginGov.I18n;
+
 
 // zxcvbn returns a strength score from 0 to 4
 // we map those scores to:
@@ -7,11 +9,11 @@ import zxcvbn from 'zxcvbn';
 // 2. text describing the score
 function getStrength(z) {
   const scale = {
-    0: ['pw-very-weak', 'Very weak'],
-    1: ['pw-weak', 'Weak'],
-    2: ['pw-so-so', 'So-so'],
-    3: ['pw-good', 'Good'],
-    4: ['pw-great', 'Great!'],
+    0: ['pw-very-weak', I18n.t('instructions.password.strength.i')],
+    1: ['pw-weak', I18n.t('instructions.password.strength.ii')],
+    2: ['pw-so-so', I18n.t('instructions.password.strength.iii')],
+    3: ['pw-good', I18n.t('instructions.password.strength.iv')],
+    4: ['pw-great', I18n.t('instructions.password.strength.v')],
   };
 
   // fallback if zxcvbn lookup fails / field is empty

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,7 @@ html lang="#{I18n.locale}"
       = content_for?(:title) ? APP_NAME + ' - ' + yield(:title) : APP_NAME
 
     == stylesheet_link_tag 'application', media: 'all'
+    == javascript_include_tag 'misc/i18n-strings'
     - unless controller_name == 'home'
       == javascript_include_tag 'application'
     == csrf_meta_tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,11 @@ en:
           as bank, email, and social media.
       strength:
         intro: 'Password strength: '
+        i: Very weak
+        ii: Weak
+        iii: So-so
+        iv: Good
+        v: Great!
     registration:
       already_have_account: Already have account? %{link}
       email: Pick an address you want to use for government communications.


### PR DESCRIPTION
i don't think i like this solution anymore because a) adding keys to `i18n-strings.js` is manual, b) `i18n-tasks unused` is now failing because it's not picking these up as being used due to the interpolation, and c) lookups can fail silently in JS (`LoginGov.i18n.foo` will evaluate to undefined (and appear as `''` on screen) but not throw an error, though this could be changed...)

what do you think @amoose @jessieay?