### PR TITLE
Only test modal appearance in JS timeout spec

### DIFF
--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -12,6 +12,10 @@ module Features
 
     def signin(email, password)
       visit new_user_session_path
+      fill_in_credentials_and_click_sign_in(email, password)
+    end
+
+    def fill_in_credentials_and_click_sign_in(email, password)
       fill_in 'Email', with: email
       fill_in 'Password', with: password
       click_button t('links.sign_in')


### PR DESCRIPTION
**Why**: To keep tests fast. Since all the JS does is pop up the modal,
we only need to test that the modal appears after the session times out,
and we can make the session timeout short.

Testing that the user can sign back in can be done in a non-JS test
using Timecop without slowing down the test.