### PR TITLE
Re-encrypt PII on password change

### DIFF
--- a/app/controllers/users/edit_password_controller.rb
+++ b/app/controllers/users/edit_password_controller.rb
@@ -27,11 +27,25 @@ module Users
     end
 
     def handle_success
+      re_encrypt_active_profile
+
       bypass_sign_in current_user
 
       redirect_to profile_url, notice: t('notices.password_changed')
 
       EmailNotifier.new(current_user).send_password_changed_email
+    end
+
+    def re_encrypt_active_profile
+      active_profile = current_user.active_profile
+      return unless active_profile.present?
+      active_profile.encrypt_pii(user_params[:password], current_pii)
+      active_profile.save!
+    end
+
+    def current_pii
+      cacher = Pii::Cacher.new(current_user, user_session)
+      cacher.fetch
     end
   end
 end


### PR DESCRIPTION
**Why**: PII is encrypted with the user password.
When the password changes, so must the encryption.

Supercedes #518 