### PR TITLE
Re-send registration email if user signs up twice without confirming email

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -35,11 +35,22 @@ class RegisterUserEmailForm
   def process_errors
     # To prevent discovery of existing emails, we check to see if the email is
     # already taken and if so, we act as if the user registration was successful.
-    if email_taken?
+    if email_taken? && user_unconfirmed?
+      existing_user.send_confirmation_instructions
+      return true
+    elsif email_taken?
       UserMailer.signup_with_your_email(email).deliver_later
       return true
     end
 
     false
+  end
+
+  def user_unconfirmed?
+    !existing_user.confirmed?
+  end
+
+  def existing_user
+    @_user ||= User.find_by(email: email)
   end
 end

--- a/spec/features/visitors/confirm_email_spec.rb
+++ b/spec/features/visitors/confirm_email_spec.rb
@@ -21,4 +21,18 @@ feature 'Confirm email' do
 
     expect(user.reset_requested_at).to be_nil
   end
+
+  scenario 'user goes through create account flow twice without confirming email' do
+    sign_up_with('test@example.com')
+
+    expect(last_email.html_part.body).to have_content(
+      t('devise.mailer.confirmation_instructions.subject')
+    )
+
+    sign_up_with('test@example.com')
+
+    expect(last_email.html_part.body).to have_content(
+      t('devise.mailer.confirmation_instructions.subject')
+    )
+  end
 end


### PR DESCRIPTION
**Why**:
* Previously, we assumed anyone registering with an email for an
  existing user account was doing so after the existing user had
  confirmed their email address
* So, the email we sent on subsequent registrations said:
  > We received a request to use this email address for a login.gov
  > account. This email address is already in use. Click the button to
  > continue signing in to login.gov using this email address. You can
  > also paste the link into your browser.

* This email does not make sense if someone has not yet confirmed their
  email address, because the link leads them to sign in but they do not
  yet have a password
* This PR looks at whether a user is confirmed when they are
  registering. If they are not, they get the regular "set up your email"
  email notification.