### PR TITLE
Store analytics events in the DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   apt:
     packages:
       - jq
+  postgresql: "9.4"
 cache:
   directories:
     - "travis_phantomjs"

--- a/app/models/ahoy_event.rb
+++ b/app/models/ahoy_event.rb
@@ -1,0 +1,5 @@
+class AhoyEvent < ActiveRecord::Base
+  belongs_to :user
+
+  validates :name, presence: true
+end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -2,4 +2,8 @@ class AnonymousUser
   def uuid
     'anonymous-uuid'
   end
+
+  def id
+    nil
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ActiveRecord::Base
   has_many :identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
+  has_many :ahoy_events, dependent: :destroy
 
   attr_accessor :asserted_attributes
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -12,6 +12,8 @@ class Analytics
     ahoy.track(event, attributes.merge!(request_attributes))
   end
 
+  attr_writer :ahoy
+
   private
 
   attr_reader :user, :request

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -3,6 +3,25 @@ Ahoy.throttle = false
 Ahoy.api_only = true
 
 module Ahoy
-  class Store < Ahoy::Stores::LogStore
+  class Store < Ahoy::Stores::ActiveRecordTokenStore
+  end
+
+  module Stores
+    class ActiveRecordTokenStore < BaseStore
+      def track_event(name, properties, _options)
+        AhoyEvent.create!(
+          user_id: user_id_from_uuid(properties),
+          name: name,
+          properties: properties
+        )
+      end
+
+      private
+
+      def user_id_from_uuid(properties)
+        user = User.find_by_uuid(properties[:user_id]) || AnonymousUser.new
+        user.id
+      end
+    end
   end
 end

--- a/db/migrate/20161027175214_create_ahoy_events.rb
+++ b/db/migrate/20161027175214_create_ahoy_events.rb
@@ -1,0 +1,12 @@
+class CreateAhoyEvents < ActiveRecord::Migration
+  def change
+    create_table :ahoy_events do |t|
+      t.string :name, null: false
+      t.jsonb :properties
+      t.integer :user_id
+      t.timestamps
+      t.index [:user_id, :name]
+      t.index [:name, :created_at]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923195429) do
+ActiveRecord::Schema.define(version: 20161027175214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ahoy_events", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.jsonb    "properties"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "ahoy_events", ["name", "created_at"], name: "index_ahoy_events_on_name_and_created_at", using: :btree
+  add_index "ahoy_events", ["user_id", "name"], name: "index_ahoy_events_on_user_id_and_name", using: :btree
 
   create_table "app_settings", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -62,12 +73,12 @@ ActiveRecord::Schema.define(version: 20160923195429) do
   add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "profiles", force: :cascade do |t|
-    t.integer  "user_id",                       null: false
-    t.boolean  "active",        default: false, null: false
+    t.integer  "user_id",                                  null: false
+    t.boolean  "active",                   default: false, null: false
     t.datetime "verified_at"
     t.datetime "activated_at"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "vendor"
     t.text     "encrypted_pii"
     t.string   "ssn_signature", limit: 64

--- a/spec/models/ahoy_event_spec.rb
+++ b/spec/models/ahoy_event_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe AhoyEvent do
+  subject { AhoyEvent.new }
+
+  it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ describe User do
     it { is_expected.to have_many(:identities) }
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:ahoy_events).dependent(:destroy) }
   end
 
   it 'should only send one email during creation' do

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -10,8 +10,6 @@ describe Analytics do
 
   let(:ahoy) { instance_double(FakeAhoyTracker) }
 
-  let(:google_analytics_options) { request_attributes.merge(anonymize_ip: true) }
-
   before { allow(FakeAhoyTracker).to receive(:new).and_return(ahoy) }
 
   describe '#track_event' do
@@ -41,6 +39,33 @@ describe Analytics do
         with("Trackable Event: #{{ user_id: tracked_user.uuid }}")
 
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
+    end
+  end
+
+  describe '#track_event with DB storage' do
+    it 'uses Ahoy::Stores::ActiveRecordTokenStore as the Ahoy::Store' do
+      expect(Ahoy::Store.superclass).to eq Ahoy::Stores::ActiveRecordTokenStore
+    end
+
+    it 'stores events in the DB' do
+      user = create(:user, uuid: '123')
+      analytics = Analytics.new(user, FakeRequest.new)
+      analytics.ahoy = Ahoy::Tracker.new(request: FakeRequest.new)
+
+      analytics.track_event(:test_event)
+
+      last_event_attributes = user.reload.ahoy_events.last.attributes
+      properties = {
+        'user_id' => user.uuid,
+        'user_ip' => '127.0.0.1',
+        'user_agent' => FakeRequest.new.user_agent
+      }
+
+      expect(last_event_attributes.keys).
+        to eq %w(id name properties user_id created_at updated_at)
+      expect(last_event_attributes['name']).to eq 'test_event'
+      expect(last_event_attributes['properties']).to eq properties
+      expect(last_event_attributes['user_id']).to eq user.id
     end
   end
 end


### PR DESCRIPTION
**Why**: To make it easier to query the data and generate reports with
tools such as Metabase.

**How**:
- Change the Ahoy::Store to Ahoy::Stores::ActiveRecordTokenStore
- Create an AhoyEvents table to hold the data
