### PR TITLE
Fix `I18nOverride` to look for strings in subdirs

### DIFF
--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -53,7 +53,7 @@ class I18nLocaleTraverser
   end
 
   def filename
-    @file.split('/').last
+    @file.split('/').last(2).join('/')
   end
 
   def find_line_number

--- a/spec/lib/i18n_override_spec.rb
+++ b/spec/lib/i18n_override_spec.rb
@@ -9,8 +9,10 @@ describe 'i18n override' do
       localized_str = I18n.translate_with_markup('shared.usa_banner.official_site')
 
       regex = /^An official website of the United States government.+i18n-anchor/
+      file_path = '/18F/identity-idp/tree/master/config/locales/shared/en.yml'
 
       expect(localized_str).to match regex
+      expect(localized_str.scan(URI.regexp).flatten).to include(file_path)
     end
   end
 end


### PR DESCRIPTION
**Why**:
* Previously, assumed all files were within `config/locales`
* Now, all files are within subdirs in `config/locales`
* It was finding the translations correctly, but not linking to them
  in the correct location
* Added specs to confirm fixed behavior