### PR TITLE
Require session_encryptor in session_store init

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+require 'session_encryptor'
+
 options = {
   key: '_upaya_session',
   redis: {


### PR DESCRIPTION
**Why**: SessionEncryptor is a reloadable module, but it's called in an
initializer, which is not reloadable. This causes the following error
when making a change to a reloadable file and then refreshing the
browser in development:
```
A copy of SessionEncryptor has been removed from the module tree but is
still active!
```

**How**: Add a require statement in the initializer.