### PR TITLE
Removes inaccurate recovery code content

### DIFF
--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -2,7 +2,7 @@ en:
   instructions:
     recovery_code: >
       You can still log in using a special recovery code if you can’t get to
-      your phone. Check your email for a link to your personal code.
+      your phone.
     password:
       info:
         lead: Your password must be at least %{min_length} characters long.

--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -12,4 +12,4 @@ en:
     items:
       recovery_code: Recovery code
     links:
-      regenerate_recovery_code: View
+      regenerate_recovery_code: Get a new code


### PR DESCRIPTION
**Why**: Our content on the recovery code page was out-of-sync with development.