### PR TITLE
Fixes github URL of locales in I18n override

### DIFF
--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -38,7 +38,7 @@ class I18nLocaleTraverser
 
   def locale_uri
     return nil unless @file
-    base_uri = 'https://github.com/18F/identity-idp/tree/master/config/locales/'
+    base_uri = 'https://github.com/18F/identity-idp/blob/master/config/locales/'
     base_uri + filename + '#L' + find_line_number.to_s
   end
 

--- a/spec/lib/i18n_override_spec.rb
+++ b/spec/lib/i18n_override_spec.rb
@@ -9,7 +9,7 @@ describe 'i18n override' do
       localized_str = I18n.translate_with_markup('shared.usa_banner.official_site')
 
       regex = /^An official website of the United States government.+i18n-anchor/
-      file_path = '/18F/identity-idp/tree/master/config/locales/shared/en.yml'
+      file_path = '/18F/identity-idp/blob/master/config/locales/shared/en.yml'
 
       expect(localized_str).to match regex
       expect(localized_str.scan(URI.regexp).flatten).to include(file_path)


### PR DESCRIPTION
### Why
Github forwards requests like
https://github.com/18F/identity-idp/tree/master/config/locales/shared/en.yml#L2
to 
https://github.com/18F/identity-idp/blob/master/config/locales/shared/en.yml#L2

### How
Uses `blob` instead of `tree` in URL

Thanks to @monfresh for finding this 🐛 