### PR TITLE
Reorganize some of the sign up specs

### DIFF
--- a/spec/features/visitors/confirm_email_spec.rb
+++ b/spec/features/visitors/confirm_email_spec.rb
@@ -21,18 +21,4 @@ feature 'Confirm email' do
 
     expect(user.reset_requested_at).to be_nil
   end
-
-  scenario 'user goes through create account flow twice without confirming email' do
-    sign_up_with('test@example.com')
-
-    expect(last_email.html_part.body).to have_content(
-      t('devise.mailer.confirmation_instructions.subject')
-    )
-
-    sign_up_with('test@example.com')
-
-    expect(last_email.html_part.body).to have_content(
-      t('devise.mailer.confirmation_instructions.subject')
-    )
-  end
 end


### PR DESCRIPTION
**Why**:
* `visitors/sign_up` is a better location for the specs about which
  emails should go out during sign up
* Noticed there was a commented out test.
* Reg: https://github.com/18F/identity-idp/pull/564/files#r83312773
* Also add localized string for one test. Yay I18n!