### PR TITLE
Include diff't registration copy for SP vs No SP

### DIFF
--- a/.reek
+++ b/.reek
@@ -30,6 +30,8 @@ UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow
     - render_401
+    - SessionDecorator#registration_bullet_1
+    - ServiceProviderSessionDecorator#registration_bullet_1
 UnusedPrivateMethod:
   exclude:
     - ApplicationController
@@ -44,6 +46,8 @@ UtilityFunction:
     - SessionTimeoutWarningHelper#frequency
     - SessionTimeoutWarningHelper#start
     - SessionTimeoutWarningHelper#warning
+    - SessionDecorator#registration_heading
+    - SessionDecorator#registration_bullet_1
 'spec':
   ControlParameter:
     exclude:

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,0 +1,17 @@
+class ServiceProviderSessionDecorator
+  def initialize(sp_name:)
+    @sp_name = sp_name
+  end
+
+  def registration_heading
+    I18n.t('headings.create_account_with_sp', sp: sp_name)
+  end
+
+  def registration_bullet_1
+    I18n.t('devise.registrations.start.bullet_1_with_sp', sp: sp_name)
+  end
+
+  private
+
+  attr_reader :sp_name
+end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -1,0 +1,9 @@
+class SessionDecorator
+  def registration_heading
+    I18n.t('headings.create_account_without_sp')
+  end
+
+  def registration_bullet_1
+    I18n.t('devise.registrations.start.bullet_1_without_sp')
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
       'tabindex': '0'
     )
   end
+
+  def decorated_session
+    if @sp_name.present?
+      @_decorated_session ||= ServiceProviderSessionDecorator.new(sp_name: @sp_name)
+    else
+      @_decorated_session ||= SessionDecorator.new
+    end
+  end
 end

--- a/app/views/devise/registrations/start.html.slim
+++ b/app/views/devise/registrations/start.html.slim
@@ -1,11 +1,11 @@
 - title t('titles.registrations.start')
 
-h1.h3.my0 = t('headings.create_account')
+h1.h3.my0 = decorated_session.registration_heading
 .clearfix.pt3
   .col.col-1.center
     = image_tag(asset_url('check-outline.svg'), size: '26x26', alt: '', class: 'mt1')
   .col.col-11.pl2
-    p.pb2.sm-pb3.mb2.sm-mb3.border-bottom = t('devise.registrations.start.bullet_1')
+    p.pb2.sm-pb3.mb2.sm-mb3.border-bottom = decorated_session.registration_bullet_1
   .clearfix
   .col.col-1.center
     = image_tag(asset_url('shield.svg'), size: '25x32', alt: '', class: 'mt1')

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -12,6 +12,7 @@ en:
       send_paranoid_instructions: >
         If your email address exists in our database, you will receive an email
         with instructions for how to confirm your email address in a few minutes.
+
     failure:
       already_authenticated: ''
       inactive: Your account is not activated yet.
@@ -22,6 +23,7 @@ en:
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: ''
       unconfirmed: You have to confirm your email address before continuing.
+
     mailer:
       confirmation_instructions:
         subject: Email confirmation instructions
@@ -31,9 +33,11 @@ en:
         subject: Password change notification
       account_locked:
         subject: Your login.gov account has been locked
+
     omniauth_callbacks:
       failure: 'Could not authenticate you due to: %{reason}.'
       success: Third party authentication successful!
+
     passwords:
       no_token: >
         You can’t access this page without coming from a password reset email.
@@ -52,11 +56,13 @@ en:
       choose_new_password: Choose a new password.
       token_expired: You have taken too long to reset your password. Please try again.
       invalid_token: The reset password token is invalid. Please try again.
+
     registrations:
       start:
-        bullet_1: >
-          Please use this site to securely log in to your participating
-          government agency.
+        bullet_1_with_sp: >
+          login.gov is providing account services to %{sp}
+        bullet_1_without_sp: >
+          login.gov provides account services for government agencies
         bullet_2: >
           U.S. government agencies are using login.gov to make interacting with
           the government easier.
@@ -91,6 +97,7 @@ en:
       updated: Account update successful!
       enabled_twofactor: Successfully enabled two-factor authentication.
       close_window: You can close this browser window once you have verified your email address.
+
     sessions:
       signed_in: ''
       signed_out: You are now signed out.

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -5,7 +5,8 @@ en:
     confirmations:
       new: Resend confirmation instructions
     contact: Contact us
-    create_account: Create an account
+    create_account_with_sp: Make a login.gov account to continue to %{sp}
+    create_account_without_sp: Make a login.gov account
     edit_info:
       email: Edit your email
       password: Edit your password

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,4 +12,24 @@ describe ApplicationHelper do
       expect(html).to have_xpath("//span[@aria-label='#{tooltip_text}']")
     end
   end
+
+  describe '#decorated_session' do
+    context 'with service provider' do
+      it 'returns the service provider decorator' do
+        @sp_name = 'any sp'
+
+        expect(helper.decorated_session).to be_an_instance_of(
+          ServiceProviderSessionDecorator
+        )
+      end
+    end
+
+    context 'without service provider' do
+      it 'returns the regular sessiin decorator' do
+        @sp_name = nil
+
+        expect(helper.decorated_session).to be_an_instance_of(SessionDecorator)
+      end
+    end
+  end
 end

--- a/spec/views/devise/registrations/start.html.slim_spec.rb
+++ b/spec/views/devise/registrations/start.html.slim_spec.rb
@@ -19,4 +19,38 @@ describe 'devise/registrations/start.html.slim' do
     expect(rendered).
       to have_link(t('experiments.demo.get_started'), href: new_user_registration_path)
   end
+
+  context 'when @sp_name is not set' do
+    before do
+      @sp_name = nil
+    end
+
+    it 'includes sp-specific copy' do
+      render
+
+      expect(rendered).to have_content(
+        t('headings.create_account_without_sp', sp: nil)
+      )
+      expect(rendered).to have_content(
+        t('devise.registrations.start.bullet_1_without_sp', sp: nil)
+      )
+    end
+  end
+
+  context 'when @sp_name is set' do
+    before do
+      @sp_name = 'Awesome Application!'
+    end
+
+    it 'includes sp-specific copy' do
+      render
+
+      expect(rendered).to have_content(
+        t('headings.create_account_with_sp', sp: @sp_name)
+      )
+      expect(rendered).to have_content(
+        t('devise.registrations.start.bullet_1_with_sp', sp: @sp_name)
+      )
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
* We already have some copy that is specific to when a user is coming
  to the idp app via a service provider
* That copy was added here: https://github.com/18F/identity-idp/pull/564
* This PR establishes a pattern for the future
* Also adds copy per request of @esgoodman