### PR TITLE
Fix OTP sending during initial phone setup

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -50,7 +50,7 @@ module Devise
 
       job.perform_later(
         code: current_user.direct_otp,
-        phone: current_user.phone,
+        phone: user_session[:unconfirmed_phone] || current_user.phone,
         otp_created_at: current_user.direct_otp_sent_at.to_s
       )
     end


### PR DESCRIPTION
**Why**: The `send_code` method was assuming the user already had a
phone, but was supposed to check for the unconfirmed phone first since
this is the initial phone setup.