### PR TITLE
Fix alert styling

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,36 +1,39 @@
-$alert-ico-size: 1.5rem;
+$ico-size: 1.5rem;
+$ico-offset: -10px;
 
 .alert {
+  background-color: #fff4db;
+  border-radius: $space-1;
+  color: #5b616a;
+  font-size: $sm-h6;
+  font-weight: $bold-font-weight;
+  line-height: $line-height-2;
+  margin-bottom: $space-4;
+  padding: $space-2 1.5rem;
   position: relative;
 
   &::before {
     background-image: url(image-path('alert/ico-warning.svg'));
     background-repeat: no-repeat;
     content: '';
-    height: $alert-ico-size;
-    left: -10px;
+    height: $ico-size;
+    left: $ico-offset;
     position: absolute;
-    top: -10px;
-    width: $alert-ico-size;
+    top: $ico-offset;
+    width: $ico-size;
   }
-}
-
-.alert-inner {
-  background-color: #fff4db;
-  border-radius: .5rem;
-  color: #5b616a;
 }
 
 .alert-notice,
 .alert-success {
-  &::before { background-image: url(image-path('alert/ico-check.svg')); }
+  background-color: #f0faed;
 
-  .alert-inner { background-color: #f0faed; }
+  &::before { background-image: url(image-path('alert/ico-check.svg')); }
 }
 
 .alert-error,
 .alert-alert {
-  &::before { background-image: url(image-path('alert/ico-exclamation.svg')); }
+  background-color: #fff0f2;
 
-  .alert-inner { background-color: #fff0f2; }
+  &::before { background-image: url(image-path('alert/ico-exclamation.svg')); }
 }

--- a/app/views/shared/_messages.html.slim
+++ b/app/views/shared/_messages.html.slim
@@ -2,5 +2,4 @@
   - flash.each do |name, msg|
     - if msg.present? && msg.is_a?(String)
       div class="alert alert-#{name}" role='alert'
-        .p2.mb4.h6.bold.line-height-2.rounded.alert-inner
-          .px1.alert-msg = msg
+        = msg

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -3,7 +3,7 @@ SimpleForm.setup do |config|
   config.boolean_label_class = nil
   config.default_form_class = 'mt3 sm-mt4'
   config.error_notification_tag = :div
-  config.error_notification_class = 'mb3 p2 h5 rounded alert alert-error'
+  config.error_notification_class = 'alert alert-error'
 
   config.wrappers :base do |b|
     b.use :html5


### PR DESCRIPTION
**Why**:
* the stylez & markup for alerts added via simple_form vs. our controllers
had gotten out of sync
* i think this is one case where componentizing the css for this module
makes sense (vs. updating our atomic classes in 2 places)

before:
![image](https://cloud.githubusercontent.com/assets/1060893/19893907/4f1f58bc-a021-11e6-9c4e-3c489b0e1d6f.png)

after:
<img width="541" alt="screen shot 2016-11-01 at 10 53 06 am" src="https://cloud.githubusercontent.com/assets/1060893/19893933/69504cb4-a021-11e6-82dc-6b3a036f7ccc.png">
