### PR TITLE
Store OTP context in session rather than params

### DIFF
--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -1,19 +1,19 @@
 module PhoneConfirmation
   def prompt_to_confirm_phone(phone:, otp_method: nil, context: 'confirmation')
     user_session[:unconfirmed_phone] = phone
+    user_session[:context] = context
     # If the user selected delivery method, the code is sent and user is
     # prompted to confirm.
-    prompt_to_choose_delivery_method(context) and return unless otp_method
+    prompt_to_choose_delivery_method and return unless otp_method
 
     redirect_to otp_send_path(
-      otp_delivery_selection_form: { otp_method: otp_method, context: context }
+      otp_delivery_selection_form: { otp_method: otp_method }
     )
   end
 
-  def prompt_to_choose_delivery_method(context)
+  def prompt_to_choose_delivery_method
     @phone_number = user_session[:unconfirmed_phone]
     @otp_delivery_selection_form = OtpDeliverySelectionForm.new
-    @context = context
     render 'devise/two_factor_authentication/show'
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -43,6 +43,7 @@ module TwoFactorAuthenticatable
     end
 
     redirect_to after_otp_verification_confirmation_path
+    reset_otp_session_data
   end
 
   def authentication_context?
@@ -82,7 +83,6 @@ module TwoFactorAuthenticatable
 
   def handle_valid_otp_for_confirmation_context
     assign_phone
-    clear_session_data
 
     flash[:success] = t('notices.phone_confirmation_successful')
   end
@@ -132,8 +132,9 @@ module TwoFactorAuthenticatable
     end
   end
 
-  def clear_session_data
+  def reset_otp_session_data
     user_session.delete(:unconfirmed_phone)
+    user_session[:context] = 'authentication'
   end
 
   def after_otp_verification_confirmation_path

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -6,6 +6,7 @@ class ReauthnRequiredController < ApplicationController
     return unless user_signed_in?
     return if recently_authenticated?
     store_location_for(:user, request.url)
+    user_session[:context] = 'authentication'
     redirect_to user_password_confirm_url
   end
 

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -22,7 +22,6 @@ p.mt-tiny.mb0#2fa-description
       = f.radio_button :otp_method, 'voice'
       span.indicator
       = t('devise.two_factor_authentication.otp_method.voice')
-  = f.input :context, as: :hidden, input_html: { value: @context }
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn btn-primary btn-wide'
 
 - link = link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),

--- a/app/views/two_factor_authentication/_phone_confirmation_fallback.html.slim
+++ b/app/views/two_factor_authentication/_phone_confirmation_fallback.html.slim
@@ -1,7 +1,7 @@
 p.mb1
   - if @delivery_method == 'sms'
     = link_to t('links.phone_confirmation.fallback_to_voice'),
-      otp_send_path(otp_delivery_selection_form: { otp_method: :voice, context: @context })
+      otp_send_path(otp_delivery_selection_form: { otp_method: :voice })
   - elsif @delivery_method == 'voice'
     = link_to t('links.phone_confirmation.fallback_to_sms'),
-      otp_send_path(otp_delivery_selection_form: { otp_method: :sms, context: @context })
+      otp_send_path(otp_delivery_selection_form: { otp_method: :sms })

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -7,7 +7,6 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
 
 = form_tag(:login_otp, method: :post, role: 'form', class: 'mt3 sm-mt4') do
   = hidden_field_tag(:reauthn, reauthn?)
-  = hidden_field_tag(:context, @context)
   = label_tag 'code', \
     raw(t('simple_form.required.html')) + t('forms.two_factor.code'), \
     class: 'block bold'
@@ -18,7 +17,7 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,
-                                                            resend: true, context: @context })
+                                                            resend: true })
 - resend_link = link_to(t('links.two_factor_authentication.resend_code'), resend_uri)
 
 .mt3.mb1

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -30,7 +30,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       end
 
       it 'redirects to the profile' do
-        get :index, context: 'authentication'
+        get :index
 
         expect(response).to redirect_to(profile_url)
       end
@@ -41,10 +41,11 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
 
       before do
         sign_in user
+        subject.user_session[:context] = 'confirmation'
       end
 
       it 'does not redirect to the profile' do
-        get :index, context: 'confirmation'
+        get :index
 
         expect(response).to_not be_redirect
       end
@@ -117,7 +118,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       it 'tracks the events' do
         stub_analytics
 
-        analytics_hash = { success?: true, delivery_method: 'sms', resend?: nil, errors: [] }
+        analytics_hash = {
+          success?: true,
+          delivery_method: 'sms',
+          resend?: nil,
+          errors: [],
+          context: 'authentication'
+        }
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
@@ -170,7 +177,13 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       it 'tracks the event' do
         stub_analytics
 
-        analytics_hash = { success?: true, delivery_method: 'voice', resend?: nil, errors: [] }
+        analytics_hash = {
+          success?: true,
+          delivery_method: 'voice',
+          resend?: nil,
+          errors: [],
+          context: 'authentication'
+        }
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)

--- a/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
@@ -41,9 +41,11 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_method: 'voice', context: 'confirmation' }
+            otp_delivery_selection_form: { otp_method: 'voice' }
           )
         )
+
+        expect(subject.user_session[:context]).to eq 'confirmation'
       end
     end
 
@@ -62,9 +64,11 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_method: 'sms', context: 'confirmation' }
+            otp_delivery_selection_form: { otp_method: 'sms' }
           )
         )
+
+        expect(subject.user_session[:context]).to eq 'confirmation'
       end
     end
 
@@ -82,9 +86,11 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_method: 'sms', context: 'confirmation' }
+            otp_delivery_selection_form: { otp_method: 'sms' }
           )
         )
+
+        expect(subject.user_session[:context]).to eq 'confirmation'
       end
     end
   end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -211,6 +211,7 @@ describe Idv::ReviewController do
         put :create, user: { password: ControllerHelper::VALID_PASSWORD }
 
         expect(response).to render_template('devise/two_factor_authentication/show')
+        expect(subject.user_session[:context]).to eq 'idv'
       end
     end
   end

--- a/spec/controllers/reauthn_required_controller_spec.rb
+++ b/spec/controllers/reauthn_required_controller_spec.rb
@@ -35,6 +35,12 @@ describe ReauthnRequiredController do
 
         expect(response).to redirect_to user_password_confirm_url
       end
+
+      it 'sets context to authentication' do
+        get :show
+
+        expect(controller.user_session[:context]).to eq 'authentication'
+      end
     end
   end
 end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -158,8 +158,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
             )
           end
 
-          it 'clears session data' do
+          it 'resets otp session data' do
             expect(subject.user_session[:unconfirmed_phone]).to be_nil
+            expect(subject.user_session[:context]).to eq 'authentication'
           end
 
           it 'tracks the update event' do
@@ -231,6 +232,10 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
             expect(subject).to have_received(:create_user_event).with(:phone_confirmed)
             expect(subject).to have_received(:create_user_event).exactly(:once)
           end
+
+          it 'resets context to authentication' do
+            expect(subject.user_session[:context]).to eq 'authentication'
+          end
         end
       end
     end
@@ -266,8 +271,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
           )
         end
 
-        it 'clears session data' do
+        it 'resets otp session data' do
           expect(subject.user_session[:unconfirmed_phone]).to be_nil
+          expect(subject.user_session[:context]).to eq 'authentication'
         end
 
         it 'tracks the update event' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -140,6 +140,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
       before do
         sign_in_as_user
         subject.user_session[:unconfirmed_phone] = '+1 (555) 555-5555'
+        subject.user_session[:context] = 'confirmation'
         @previous_phone_confirmed_at = subject.current_user.phone_confirmed_at
         subject.current_user.create_direct_otp
         stub_analytics
@@ -153,8 +154,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
             post(
               :create,
               code: subject.current_user.direct_otp,
-              delivery_method: 'sms',
-              context: 'confirmation'
+              delivery_method: 'sms'
             )
           end
 
@@ -172,7 +172,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         end
 
         context 'user enters an invalid code' do
-          before { post :create, code: '999', delivery_method: 'sms', context: 'confirmation' }
+          before { post :create, code: '999', delivery_method: 'sms' }
 
           it 'does not increment second_factor_attempts_count' do
             expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
@@ -214,8 +214,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
             post(
               :create,
               code: subject.current_user.direct_otp,
-              delivery_method: 'sms',
-              context: 'confirmation'
+              delivery_method: 'sms'
             )
           end
 
@@ -242,6 +241,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         idv_session = Idv::Session.new(subject.user_session, subject.current_user)
         idv_session.params = { 'phone' => '+1 (555) 555-5555' }
         subject.user_session[:unconfirmed_phone] = '+1 (555) 555-5555'
+        subject.user_session[:context] = 'idv'
         @previous_phone_confirmed_at = subject.current_user.phone_confirmed_at
         allow(subject).to receive(:idv_session).and_return(idv_session)
         stub_analytics
@@ -262,8 +262,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
           post(
             :create,
             code: subject.current_user.direct_otp,
-            delivery_method: 'sms',
-            context: 'idv'
+            delivery_method: 'sms'
           )
         end
 
@@ -295,7 +294,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
       end
 
       context 'user enters an invalid code' do
-        before { post :create, code: '999', delivery_method: 'sms', context: 'idv' }
+        before { post :create, code: '999', delivery_method: 'sms' }
 
         it 'does not increment second_factor_attempts_count' do
           expect(subject.current_user.reload.second_factor_attempts_count).to eq 0

--- a/spec/controllers/users/edit_phone_controller_spec.rb
+++ b/spec/controllers/users/edit_phone_controller_spec.rb
@@ -25,6 +25,7 @@ describe Users::EditPhoneController do
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to render_template('devise/two_factor_authentication/show')
+        expect(subject.user_session[:context]).to eq 'confirmation'
       end
     end
 
@@ -56,6 +57,7 @@ describe Users::EditPhoneController do
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to render_template('devise/two_factor_authentication/show')
+        expect(subject.user_session[:context]).to eq 'confirmation'
       end
     end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -36,6 +36,9 @@ feature 'Changing authentication factor' do
       expect(current_path).to eq profile_path
       expect(SmsSenderNumberChangeJob).to have_received(:perform_later).with('+1 (202) 555-1212')
       expect(user.reload.phone).to eq '+1 (703) 555-0100'
+
+      visit login_two_factor_path(delivery_method: 'sms')
+      expect(current_path).to eq profile_path
     end
 
     scenario 'waiting too long to change phone number' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -188,4 +188,17 @@ feature 'Two Factor Authentication' do
       expect(current_path).to eq profile_path
     end
   end
+
+  describe 'visiting OTP delivery and verification pages after fully authenticating' do
+    it 'redirects to profile page' do
+      sign_in_and_2fa_user
+      visit login_two_factor_path(delivery_method: 'sms')
+
+      expect(current_path).to eq profile_path
+
+      visit user_two_factor_authentication_path
+
+      expect(current_path).to eq profile_path
+    end
+  end
 end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -37,7 +37,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         to have_link(
           t('links.two_factor_authentication.resend_code'),
           href: otp_send_path(otp_delivery_selection_form: { otp_method: 'sms',
-                                                             resend: true, context: nil })
+                                                             resend: true })
         )
     end
 
@@ -59,7 +59,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         expect(rendered).to have_link(
           t('links.phone_confirmation.fallback_to_voice'),
-          href: otp_send_path(otp_delivery_selection_form: { otp_method: 'voice', context: '' })
+          href: otp_send_path(otp_delivery_selection_form: { otp_method: 'voice' })
         )
       end
     end
@@ -73,7 +73,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         expect(rendered).to have_link(
           t('links.phone_confirmation.fallback_to_sms'),
-          href: otp_send_path(otp_delivery_selection_form: { otp_method: 'sms', context: '' })
+          href: otp_send_path(otp_delivery_selection_form: { otp_method: 'sms' })
         )
       end
     end


### PR DESCRIPTION
**Why**:
- The context is not meant to be submitted or manipulated by the user
- It allows for better control over setting the proper context at the
right time
- It fixes bugs we discovered due to setting the context via params