### PR TITLE
Add health checks for background queue

### DIFF
--- a/.reek
+++ b/.reek
@@ -54,6 +54,7 @@ UtilityFunction:
     - SessionDecorator#registration_heading
     - SessionDecorator#registration_bullet_1
     - SessionDecorator#new_session_heading
+    - WorkerHealthChecker::Middleware#call
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/app/services/worker_health_checker.rb
+++ b/app/services/worker_health_checker.rb
@@ -1,0 +1,70 @@
+# Helps with reading and writing queue health from Sidekiq
+module WorkerHealthChecker
+  module_function
+
+  # Reported directly to NewRelic when a queue appears unhealthy
+  class QueueHealthError < StandardError; end
+
+  # Sidekiq server-side middleware that wraps jobs and marks the queues as healthy
+  # when a job completes successfully
+  class Middleware
+    def call(_worker, _job, queue)
+      yield
+
+      WorkerHealthChecker.mark_healthy!(queue)
+    end
+  end
+
+  # Empty job that we put in each background queue to make sure the queue is running
+  # Relies on the Middleware to mark the queue as healthy
+  class DummyJob < ActiveJob::Base
+    def perform
+    end
+  end
+
+  # called on an interval to enqueues a dummy job in each queue
+  # @see deploy/schedule.rb
+  def enqueue_dummy_jobs
+    Sidekiq::Queue.all.each do |queue|
+      DummyJob.set(queue: queue.name).perform_later
+    end
+  end
+
+  # Called on an interval to check background queue health and report errors to NewRelic
+  # @see deploy/schedule.rb
+  def check
+    Sidekiq::Queue.all.map(&:name).each do |name|
+      next if healthy?(name)
+
+      NewRelic::Agent.notice_error(
+        QueueHealthError.new("Background queue #{name} is unhealthy")
+      )
+    end
+  end
+
+  def mark_healthy!(queue_name, now: Time.zone.now)
+    with_redis do |redis|
+      redis.set(health_check_key(queue_name), now.to_i)
+    end
+  end
+
+  # Checks that a queue has had a job run successfully recently
+  # @return [true, false]
+  def healthy?(queue_name, now: Time.zone.now)
+    queue_last_run = with_redis { |redis| redis.get(health_check_key(queue_name)) }
+
+    queue_last_run.present? &&
+      (now.to_i - queue_last_run.to_i < Figaro.env.queue_health_check_dead_interval_seconds.to_i)
+  end
+
+  # @api private
+  def health_check_key(queue_name)
+    "health:#{queue_name}"
+  end
+
+  # @api private
+  # This makes reek complain less about referencing things less than self
+  def with_redis(&block)
+    Sidekiq.redis(&block)
+  end
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -19,6 +19,12 @@ mailer_domain_name: 'http://localhost:3000'
 # https://github.com/dropbox/zxcvbn#usage
 min_password_score: '3'
 
+# If a queue does not have a healthy job after this many seconds, report it as unhealthy
+queue_health_check_dead_interval_seconds: '240'
+
+# How often to enqueue simple jobs to make sure the background queues are running
+queue_health_check_frequency_seconds: '120'
+
 # Must be an even number. 16 seems to be what most sites use.
 recovery_code_length: '16'
 

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -15,6 +15,8 @@ Figaro.require_keys(
   'otp_valid_for',
   'password_pepper',
   'password_strength_enabled',
+  'queue_health_check_dead_interval_seconds',
+  'queue_health_check_frequency_seconds',
   'reauthn_window',
   'recovery_code_length',
   'redis_url',

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,12 @@ Sidekiq::Logging.logger.level = Logger::WARN
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Figaro.env.redis_url }
+
+  # NOTE: Sidekiq does not run middleware in tests by default. Make sure to also add
+  # middleware to spec/rails_helper.rb to run in tests as well
+  config.server_middleware do |chain|
+    chain.add WorkerHealthChecker::Middleware
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,3 +7,12 @@
 every :day, at: '3:00 am', roles: [:job_creator] do
   rake 'clear_expired_sessions'
 end
+
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+health_check = Whenever.seconds(Figaro.env.queue_health_check_frequency_seconds.to_i, :seconds)
+
+every health_check, roles: [:job_creator] do
+  runner 'WorkerHealthChecker.check'
+  runner 'WorkerHealthChecker.enqueue_dummy_jobs'
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require 'rspec/rails'
 require 'email_spec'
 require 'factory_girl'
 require 'shoulda/matchers'
+require 'sidekiq/testing'
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -45,4 +46,10 @@ RSpec.configure do |config|
     FakeSms.messages = []
     FakeVoiceCall.calls = []
   end
+end
+
+Sidekiq::Testing.inline!
+
+Sidekiq::Testing.server_middleware do |chain|
+  chain.add WorkerHealthChecker::Middleware
 end

--- a/spec/services/worker_health_checker_spec.rb
+++ b/spec/services/worker_health_checker_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe WorkerHealthChecker do
+  before do
+    ActiveJob::Base.queue_adapter = :sidekiq
+    Sidekiq.redis(&:flushdb)
+  end
+
+  after do
+    Sidekiq.redis(&:flushdb)
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  def create_sidekiq_queues(*queues)
+    # TODO: find an API to use rather than manually mess with redis?
+    Sidekiq.redis do |redis|
+      queues.each do |queue|
+        redis.sadd('queues', queue)
+      end
+    end
+  end
+
+  describe '#enqueue_dummy_jobs' do
+    let(:queue1) { 'queue1' }
+    let(:queue2) { 'queue2' }
+
+    before do
+      create_sidekiq_queues(queue1, queue2)
+    end
+
+    subject(:enqueue_dummy_jobs) { WorkerHealthChecker.enqueue_dummy_jobs }
+
+    it 'queues a dummy job per queue that update health per job' do
+      expect(WorkerHealthChecker.healthy?(queue1)).to eq(false)
+      expect(WorkerHealthChecker.healthy?(queue2)).to eq(false)
+
+      enqueue_dummy_jobs
+
+      expect(WorkerHealthChecker.healthy?(queue1)).to eq(true)
+      expect(WorkerHealthChecker.healthy?(queue2)).to eq(true)
+    end
+  end
+
+  describe '#check' do
+    let(:queue1) { 'queue1' }
+    let(:queue2) { 'queue2' }
+    subject(:check) { WorkerHealthChecker.check }
+
+    before do
+      create_sidekiq_queues(queue1, queue2)
+    end
+
+    context 'successful jobs have run in all queues' do
+      before do
+        WorkerHealthChecker::DummyJob.set(queue: queue1).perform_later
+        WorkerHealthChecker::DummyJob.set(queue: queue2).perform_later
+      end
+
+      it 'does not report anything to NewRelic' do
+        expect(NewRelic::Agent).to_not receive(:notice_error)
+        check
+      end
+    end
+
+    context 'successful jobs have run in some queues' do
+      before do
+        WorkerHealthChecker::DummyJob.set(queue: queue1).perform_later
+      end
+
+      it 'reports errors to NewRelic for the failing queues' do
+        expect(NewRelic::Agent).to receive(:notice_error).
+          with(WorkerHealthChecker::QueueHealthError.new('Background queue queue2 is unhealthy'))
+        check
+      end
+    end
+  end
+
+  describe '#mark_healthy!' do
+    let(:queue) { 'myqueue' }
+    let(:now) { Time.zone.now }
+
+    it 'sets a key in redis' do
+      expect { WorkerHealthChecker.mark_healthy!(queue, now: now) }.
+        to change { WorkerHealthChecker.healthy?(queue, now: now) }.
+        from(false).to(true)
+    end
+  end
+
+  describe '#healthy?' do
+    let(:queue) { 'myqueue' }
+    let(:now) { Time.zone.now }
+    subject(:healthy?) { WorkerHealthChecker.healthy?(queue, now: now) }
+
+    context 'no value in redis' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'a recent healthy timestamp in redis' do
+      before { WorkerHealthChecker.mark_healthy!(queue, now: now) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'an old healthy timestamp in redis' do
+      before { WorkerHealthChecker.mark_healthy!(queue, now: now - 500) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
We want to be notified when background queues are not moving

**How**:
- Add a Sidekiq Middleware that records a timestamp in Redis per queue
- Schedule dummy jobs to run in each queue to make sure we always have
  something moving through the queues
- Schedule a checker to check the queues for successful runs and report
  unhealthy queues to NewRelic

Follow-up to #576

cc @amoose @monfresh @jessieay 