### PR TITLE
Add specs to make sure *SessionDecorator classes don't diverge

### DIFF
--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ServiceProviderSessionDecorator do
+  it 'has the same public API as SessionDecorator' do
+    SessionDecorator.public_instance_methods.each do |method|
+      expect(described_class.public_method_defined?(method)).to be(true),
+        "expected #{described_class} to have ##{method}"
+    end
+  end
+end

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe SessionDecorator do
+  it 'has the same public API as ServiceProviderSessionDecorator' do
+    ServiceProviderSessionDecorator.public_instance_methods.each do |method|
+      expect(described_class.public_method_defined?(method)).to be(true),
+        "expected #{described_class} to have ##{method}"
+    end
+  end
+end


### PR DESCRIPTION
@jessieay This is an idea I had after seeing how you extracted session decorators. It didn't work before because of the `return_to_service_provider_partial` was implemented on one but not other, but after your PR (#651), now it does work, so yay!
 
**Why**:
Because Ruby does not have static interfaces, we may need some help
making sure that classes are interchangeable