### PR TITLE
Remove unused code in SamlTestController

### DIFF
--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -15,9 +15,8 @@ module Test
 
     def decode_response
       res = SloResponseDecoder.new(params, test_saml_settings)
-      validity = res.valid_response? || res.valid_logout_response?
 
-      render_template_for(validity, res.response)
+      render_template_for(true, res.response)
     end
 
     # Method to handle IdP initiated logouts
@@ -26,13 +25,10 @@ module Test
 
       return decode_response if slo.response?
 
-      if slo.valid_request?
-        slo.log_event
-        redirect_to slo.slo_response
-        return
-      end
+      return unless slo.valid_request?
 
-      render_template_for(false, slo.invalid_response)
+      slo.log_event
+      redirect_to slo.slo_response
     end
 
     private

--- a/app/services/test/single_logout_service.rb
+++ b/app/services/test/single_logout_service.rb
@@ -32,10 +32,6 @@ module Test
       )
     end
 
-    def invalid_response
-      logout_request.errors.to_s
-    end
-
     private
 
     attr_reader :params, :settings

--- a/app/services/test/slo_response_decoder.rb
+++ b/app/services/test/slo_response_decoder.rb
@@ -5,18 +5,6 @@ module Test
       @settings = settings
     end
 
-    def valid_response?
-      response.is_valid? if doc.at_xpath('/samlp:Response', samlp: Saml::XML::Namespaces::PROTOCOL)
-    end
-
-    def valid_logout_response?
-      return unless doc.at_xpath('/samlp:LogoutResponse', samlp: Saml::XML::Namespaces::PROTOCOL)
-
-      doc.valid_signature?(saml_cert)
-    rescue
-      false
-    end
-
     def response
       @response ||= OneLogin::RubySaml::Response.new(
         params[:SAMLResponse],


### PR DESCRIPTION
**Why**: To keep our code lean.

Removing this code doesn't result in any failing tests, which means we
probably don't care about those scenarios since we've never run into
them.