### PR TITLE
Only handle phone change during confirmation context

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -98,7 +98,7 @@ module TwoFactorAuthenticatable
   def assign_phone
     @updating_existing_number = old_phone
 
-    if @updating_existing_number
+    if @updating_existing_number && context == 'confirmation'
       phone_changed
     else
       phone_confirmed


### PR DESCRIPTION
**Why**: If a user has an existing phone number, then sets up and
confirms a different phone number during IdV, handling this as a phone
change event will send an SMS to the existing phone number alerting the
user that their phone number was changed, which isn't true. It will also
log analytics related to changing the user's phone, which is also
inaccurate.

**How**: Add another condition to the if statement that checks that the
context is confirmation in order to handle a phone change event.