### PR TITLE
Do not show My Account link within 2FA process

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::InvalidAuthenticityToken,
               with: :invalid_auth_token
 
-  helper_method :decorated_user, :reauthn?
+  helper_method :decorated_user, :reauthn?, :user_fully_authenticated?
 
   prepend_before_action :session_expires_at
   after_action :track_get_requests

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -14,7 +14,8 @@ nav.bg-white
       .sm-col-right.sm-right-align
         div = t('shared.nav_auth.welcome', email: current_user.email)
         .mt-12p.h6
-          = link_to t('shared.nav_auth.my_account'), profile_path,
-            class: current_page?(profile_path) ? 'bold gray' : 'underline'
-          span.px1.silver = '|'
+          - if user_fully_authenticated?
+            = link_to t('shared.nav_auth.my_account'), profile_path,
+              class: current_page?(profile_path) ? 'bold gray' : 'underline'
+            span.px1.silver = '|'
           = link_to t('links.sign_out'), destroy_user_session_path, class: 'underline'

--- a/spec/views/shared/_nav_auth.html.slim_spec.rb
+++ b/spec/views/shared/_nav_auth.html.slim_spec.rb
@@ -5,7 +5,7 @@ describe 'shared/_nav_auth.html.slim' do
     before do
       @user = build_stubbed(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(@user)
-      allow(view).to receive(:signed_in?).and_return(true)
+      allow(view).to receive(:user_fully_authenticated?).and_return(true)
     end
 
     it 'contains welcome message' do
@@ -14,10 +14,30 @@ describe 'shared/_nav_auth.html.slim' do
       expect(rendered).to have_content "Welcome #{@user.email}"
     end
 
+    it 'contains link to my account' do
+      render
+
+      expect(rendered).to have_link(t('shared.nav_auth.my_account'), href: profile_path)
+    end
+
     it 'contains sign out link' do
       render
 
       expect(rendered).to have_link(t('links.sign_out'), href: destroy_user_session_path)
+    end
+  end
+
+  context 'user has entered password but not complete 2fa' do
+    before do
+      @user = build_stubbed(:user, :signed_up)
+      allow(view).to receive(:current_user).and_return(@user)
+      allow(view).to receive(:user_fully_authenticated?).and_return(false)
+    end
+
+    it 'does not contain link to my account' do
+      render
+
+      expect(rendered).to_not have_link(t('shared.nav_auth.my_account'), href: profile_path)
     end
   end
 end


### PR DESCRIPTION
**Why**: The link to My Account should only show
when the user has completed the full 2FA process.