### PR TITLE
Fix color of link in email footer

### DIFF
--- a/app/views/layouts/user_mailer.html.slim
+++ b/app/views/layouts/user_mailer.html.slim
@@ -78,7 +78,9 @@ html xmlns="http://www.w3.org/1999/xhtml"
                                           p == t('mailer.help',
                                                 link: link_to(Figaro.env.support_url,
                                                               Figaro.env.support_url),
-                                                app: APP_NAME)
+                                                app: link_to(APP_NAME,
+                                                             Figaro.env.mailer_domain_name,
+                                                             style: 'text-decoration: none;'))
                                         th.expander
                       table.wrapper.legal align="center"
                         tr


### PR DESCRIPTION
**Why**: Gmail is automatically creating a link out of the string login.gov, this makes it the proper color.