### PR TITLE
Add cancel link to recovery code

### DIFF
--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -10,3 +10,4 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
       class: 'block bold'
     = block_text_field_tag :code, '', required: true
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
+.mt1 = link_to t('forms.buttons.cancel'), user_two_factor_authentication_path, class: 'underline'


### PR DESCRIPTION
**Why**: Allow the user to back out of using recovery code when signing in