### PR TITLE
Additional CORS fixes for /api/deploy

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   skip_after_action :track_get_requests
+  skip_before_action :verify_authenticity_token, only: [:deploy_json, :options]
 
   def page_not_found
     analytics.track_event(Analytics::PAGE_NOT_FOUND, path: request.path)
@@ -15,5 +16,10 @@ class PagesController < ApplicationController
     deploy_json = File.exist?(deploy_json_path) ? JSON.parse(File.read(deploy_json_path)) : {}
 
     render json: deploy_json
+  end
+
+  # For CORS preflight requests
+  def options
+    render nothing: true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,9 @@ module Upaya
       allow do
         origins '*'
 
-        resource '/api/deploy.json',
+        resource '/api/deploy*',
                  headers: :any,
-                 methods: [:get]
+                 methods: [:get, :options]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
 
   # Non-devise-controller routes. Alphabetically sorted.
   get '/api/deploy' => 'pages#deploy_json'
+  match '/api/deploy' => 'pages#options', via: [:options]
   get '/api/saml/metadata' => 'saml_idp#metadata'
   match '/api/saml/logout' => 'saml_idp#logout',
         via: [:get, :post, :delete],

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -70,4 +70,11 @@ describe PagesController do
       after { FileUtils.rm_rf(Rails.root.join('public', 'api')) }
     end
   end
+
+  describe '#options' do
+    it 'is blank' do
+      process :options, 'OPTIONS'
+      expect(response.body).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
Even for GET requests, the browser still sends an OPTIONS preflight request
and we need to handle that explicitly

(follow-up #663 based on actually developing that dashboard locally)