### PR TITLE
Remove non-implemented route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,10 +54,6 @@ Rails.application.routes.draw do
       get '/saml' => 'saml_test#start'
       get '/saml/decode_assertion' => 'saml_test#start'
       post '/saml/decode_assertion' => 'saml_test#decode_response'
-
-      # Logout test start + return.
-      get '/saml/logout' => 'saml_test#logout'
-      post '/saml/decode_logoutresponse' => 'saml_test#decode_response'
       post '/saml/decode_slo_request' => 'saml_test#decode_slo_request'
     end
   end


### PR DESCRIPTION
**Why**:
* I was trying to use this to test SLO but it was not working
* Was removed at https://github.com/18F/identity-idp/commit/9a0b2925975a4c2e651221f2529ecd9dc75e685f#diff-520a78473f803efc237894d287c50324
* Should we re-implement?