### PR TITLE
Remove success message after 2FA login

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -90,7 +90,6 @@ module TwoFactorAuthenticatable
   def handle_valid_otp_for_authentication_context
     mark_user_session_authenticated
     bypass_sign_in current_user
-    flash[:notice] = t('devise.two_factor_authentication.success') unless reauthn?
 
     current_user.update(second_factor_attempts_count: 0)
   end

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -132,7 +132,6 @@ en:
       please_confirm: >
         Your phone number has been set. Please confirm it by entering the
         passcode below.
-      success: Two-factor authentication successful.
       two_factor_setup: Add extra protection
       totp_info: >
         Use any standards compliant authenticator app (such as Google Authenticator) to scan the QR


### PR DESCRIPTION
**Why**:
* The banner is not necessary, since it's obvious the user signed in.