### PR TITLE
Enable SP-initiated SLO when user logged out of IDP

### DIFF
--- a/.reek
+++ b/.reek
@@ -21,6 +21,7 @@ NilCheck:
     - TotpSetupController#new
     - TotpSetupController#valid_code?
     - user_not_found?
+    - SamlIdpLogoutConcern#name_id
 TooManyConstants:
   exclude:
     - Analytics

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -163,7 +163,7 @@ feature 'saml api', devise: true do
   end
 
   context 'visiting /api/saml/logout' do
-    context 'with authentication at a SP and session times out' do
+    context 'session timed out' do
       let(:logout_user) { create(:user, :signed_up) }
 
       before do


### PR DESCRIPTION
**Why**:
* Previously, SLO logic depended on a "current user" to work
* Now, if no current user, we look at the UUID and find the identity
  and associated user based on the identity