### PR TITLE
Hook whenever gem into capistrano deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -17,5 +17,8 @@ require 'capistrano/sidekiq/monit'
 # support for new relic deploy updates
 require 'new_relic/recipes'
 
+# support for whenever
+require 'whenever/capistrano'
+
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,8 @@ set :sidekiq_queue, [:analytics, :mailers, :sms, :voice]
 set :sidekiq_monit_use_sudo, true
 set :sidekiq_user, 'ubuntu'
 set :ssh_options, forward_agent: false, user: 'ubuntu'
-set :whenever_roles, [:app]
+set :whenever_roles, [:job_creator]
+set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
 #########
 # TASKS

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,2 +1,2 @@
 server 'demo.login.gov', roles: %w(web db)
-server 'demo-worker.login.gov', roles: %w(app)
+server 'demo-worker.login.gov', roles: %w(app job_creator)

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,2 +1,2 @@
 server 'dev.login.gov', roles: %w(web db)
-server 'worker.dev.login.gov', roles: %w(app)
+server 'worker.dev.login.gov', roles: %w(app job_creator)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,2 +1,2 @@
 server 'qa.login.gov', roles: %w(web db)
-server 'worker.qa.login.gov', roles: %w(app)
+server 'worker.qa.login.gov', roles: %w(app job_creator)


### PR DESCRIPTION
**Why**:
Because we want our crontab schedules to update when we deploy

cc @jgrevich @amoose 