### PR TITLE
Localize and fix typo in SMS message

### DIFF
--- a/app/jobs/sms_sender_number_change_job.rb
+++ b/app/jobs/sms_sender_number_change_job.rb
@@ -15,10 +15,10 @@ class SmsSenderNumberChangeJob < ActiveJob::Base
   end
 
   def number_change_message
-    <<-END.strip_heredoc
-      You have changed the phone number for your #{APP_NAME} Account.
-
-      If you did not request this change, please contact #{APP_NAME} at #{Figaro.env.support_url}
-    END
+    I18n.t(
+      'jobs.sms_sender_number_change_job.message',
+      app: APP_NAME,
+      support_url: Figaro.env.support_url
+    )
   end
 end

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -29,6 +29,6 @@ class VoiceOtpSenderJob < ActiveJob::Base
   end
 
   def otp_message(code)
-    I18n.t('voice.otp_confirmation', code: code)
+    I18n.t('jobs.voice_otp_sender_job.message', code: code)
   end
 end

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -1,0 +1,11 @@
+en:
+  jobs:
+    sms_sender_number_change_job:
+      message: |
+        You have changed the phone number for your %{app} Account.
+
+        If you did not request this change, please contact %{app} at %{support_url}
+    voice_otp_sender_job:
+      message: >
+        Hello! Your login.gov one time passcode is, %{code},
+        again, your passcode is, %{code}, goodbye!

--- a/config/locales/voice/en.yml
+++ b/config/locales/voice/en.yml
@@ -1,5 +1,0 @@
-en:
-  voice:
-    otp_confirmation: >
-      Hello! Your login.gov one time passcode is, %{code},
-      again, your passcode is, %{code}, goodbye!

--- a/spec/jobs/sms_sender_number_change_job_spec.rb
+++ b/spec/jobs/sms_sender_number_change_job_spec.rb
@@ -13,7 +13,13 @@ describe SmsSenderNumberChangeJob do
       msg = messages.first
       expect(msg.from).to match(/(\+19999999999|\+12222222222)/)
       expect(msg.to).to eq('1234')
-      expect(msg.body).to include('You have changed the phone number')
+      expect(msg.body).to eq(
+        I18n.t(
+          'jobs.sms_sender_number_change_job.message',
+          app: APP_NAME,
+          support_url: Figaro.env.support_url
+        )
+      )
     end
   end
 end

--- a/spec/jobs/voice_otp_sender_job_spec.rb
+++ b/spec/jobs/voice_otp_sender_job_spec.rb
@@ -15,7 +15,7 @@ describe VoiceOtpSenderJob do
       calls = FakeVoiceCall.calls
 
       code = '1234'.scan(/\d/).join(', ')
-      message = t('voice.otp_confirmation', code: code)
+      message = t('jobs.voice_otp_sender_job.message', code: code)
       url_message = URI.escape(message)
 
       expect(calls.size).to eq(1)


### PR DESCRIPTION
**Why**:
* This sneaky string escaped me in my last I18n rampage
* Account should not be capitalized