### PR TITLE
Add instructional text to the 2FA setup screen

### DIFF
--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -2,18 +2,25 @@
 
 
 h1.h3.my0 = t('devise.two_factor_authentication.two_factor_setup')
-p.mt-tiny.mb0#2fa-description = t('devise.two_factor_authentication.otp_setup')
+p.mt-tiny.mb0#2fa-description
+  = t('devise.two_factor_authentication.otp_setup_html')
 = simple_form_for(@two_factor_setup_form,
     html: { autocomplete: 'off', role: 'form' },
     method: :patch,
     url: phone_setup_path) do |f|
   = f.error_notification
-  = f.input :phone, as: :tel, label: 'Phone Number', required: true,
-      input_html: { 'aria-describedby' => '2fa-description' }
+  = f.label :phone, class: 'block'
+    strong.left = t('devise.two_factor_authentication.otp_phone_label')
+    span.ml1.italic = t('devise.two_factor_authentication.otp_phone_label_info')
+    = f.input :phone, as: :tel, label: false, required: true,
+        input_html: { 'aria-describedby' => '2fa-description' }
   .mb3
     = label_tag 'two_factor_setup_form[otp_method]',
       t('devise.two_factor_authentication.otp_method.title'),
       class: 'block bold'
+    = label_tag 'two_factor_setup_form[otp_method]',
+      t('devise.two_factor_authentication.otp_method.instruction'),
+      class: 'block'
     label.radio.mb0.mr3
       = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,
         checked: true

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -121,8 +121,10 @@ en:
       recovery_code_fallback:
         text: Don’t have access to your phone? Use a %{link} instead.
         link: recovery code
-      otp_setup: >
-        Every time you log in, we will send you a one-time passcode via text
+      otp_phone_label: Phone number
+      otp_phone_label_info: Mobile or landline okay
+      otp_setup_html: >
+        <strong>Every time you log in,</strong> we will send you a one-time passcode via text
         message or phone call. This helps safeguard your account.
       choose_delivery_confirmation: >
         Please select how you would like to receive your confirmation code for %{phone}
@@ -150,5 +152,6 @@ en:
         confirm_with_voice: Confirm with voice call
       otp_method:
         title: How would you like to receive your passcode?
+        instruction: You can change your choice the next time you sign in
         sms: Text message (SMS)
         voice: Phone call


### PR DESCRIPTION
**Why**:
- Presumably, users found it confusing before

**What**:
- Adds emphasis to first part of info paragraph
- Adds instructional text to each form field
- Moves the label string for the phone field out of the view and into a translation string

**Visual**:
![screen shot 2016-11-04 at 1 14 50 pm](https://cloud.githubusercontent.com/assets/126935/20021008/5b88ee3e-a291-11e6-9d65-9d69fd26cdee.png)
