### PR TITLE
Consolidate authentication events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,8 +46,6 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    analytics.track_event(Analytics::AUTHENTICATION_SUCCESSFUL)
-
     stored_location_for(resource) || session[:saml_request_url] || profile_path
   end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -9,7 +9,7 @@ module TwoFactorAuthentication
     def create
       result = OtpVerificationForm.new(current_user, form_params[:code].strip).submit
 
-      analytics.track_event(Analytics::OTP_RESULT, result.merge(context: context))
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(analytics_properties))
 
       if result[:success?]
         handle_valid_otp
@@ -22,6 +22,13 @@ module TwoFactorAuthentication
 
     def form_params
       params.permit(:code)
+    end
+
+    def analytics_properties
+      {
+        context: context,
+        method: params[:delivery_method]
+      }
     end
   end
 end

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -11,7 +11,7 @@ module TwoFactorAuthentication
     def create
       result = RecoveryCodeForm.new(current_user, params[:code]).submit
 
-      analytics.track_event(Analytics::AUTHENTICATION_RECOVERY_CODE, result)
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'recovery code'))
 
       if result[:success?]
         handle_valid_otp

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -8,7 +8,7 @@ module TwoFactorAuthentication
     def create
       result = TotpVerificationForm.new(current_user, params[:code].strip).submit
 
-      analytics.track_event(Analytics::AUTHENTICATION_TOTP, result)
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'totp'))
 
       if result[:success?]
         handle_valid_otp

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -45,13 +45,13 @@ module Users
     end
 
     def track_authentication_attempt(email)
-      existing_user = User.find_by(email: email.downcase)
+      user = User.find_by(email: email.downcase) || AnonymousUser.new
 
-      if existing_user
-        return analytics.track_event(Analytics::AUTHENTICATION_ATTEMPT, user_id: existing_user.uuid)
-      end
+      properties = {
+        success?: current_user.present?, user_id: user.uuid
+      }
 
-      analytics.track_event(Analytics::AUTHENTICATION_ATTEMPT_NONEXISTENT)
+      analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)
     end
 
     def cache_active_profile

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -7,9 +7,11 @@ class Analytics
   def track_event(event, attributes = { user_id: uuid })
     attributes[:user_id] = uuid unless attributes.key?(:user_id)
 
-    Rails.logger.info("#{event}: #{attributes}")
+    consolidated_attributes = attributes.merge!(request_attributes)
 
-    ahoy.track(event, attributes.merge!(request_attributes))
+    Rails.logger.info("#{event}: #{consolidated_attributes}")
+
+    ahoy.track(event, consolidated_attributes)
   end
 
   private
@@ -32,12 +34,8 @@ class Analytics
   end
 
   # rubocop:disable Metrics/LineLength
-  AUTHENTICATION_ATTEMPT = 'Authentication Attempt'.freeze
-  AUTHENTICATION_ATTEMPT_NONEXISTENT = 'Authentication: attempt with nonexistent user'.freeze
   AUTHENTICATION_MAX_2FA_ATTEMPTS = 'Authentication: user reached max 2FA attempts'.freeze
-  AUTHENTICATION_RECOVERY_CODE = 'Authentication: recovery code'.freeze
-  AUTHENTICATION_SUCCESSFUL = 'Authentication: successful'.freeze
-  AUTHENTICATION_TOTP = 'Authentication: TOTP'.freeze
+  EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUESTED = 'Email Change: requested'.freeze
   EMAIL_CHANGED_AND_CONFIRMED = 'Email Change: changed and confirmed'.freeze
   EMAIL_CHANGED_TO_EXISTING = 'Email Change: user attempted to change their email to an existing email'.freeze
@@ -51,7 +49,7 @@ class Analytics
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   INVALID_SERVICE_PROVIDER = 'Invalid Service Provider'.freeze
   OTP_DELIVERY_SELECTION = 'OTP: Delivery Selection'.freeze
-  OTP_RESULT = 'OTP: Result'.freeze
+  MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   PAGE_NOT_FOUND = 'Page Not Found'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze
   PASSWORD_CREATE_INVALID = 'Password Create: invalid password'.freeze

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -25,12 +25,10 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
 
       it 'tracks the valid authentication event' do
         stub_analytics
-        analytics_hash = { success?: true }
+        analytics_hash = { success?: true, method: 'recovery code' }
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::AUTHENTICATION_RECOVERY_CODE, analytics_hash).ordered
-        expect(@analytics).to receive(:track_event).
-          with(Analytics::AUTHENTICATION_SUCCESSFUL).ordered
+          with(Analytics::MULTI_FACTOR_AUTH, analytics_hash)
 
         post :create, code: 'foo'
       end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -28,8 +28,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
       it 'tracks the valid authentication event' do
         stub_analytics
         expect(@analytics).to receive(:track_event).
-          with(Analytics::AUTHENTICATION_TOTP, success?: true)
-        expect(@analytics).to receive(:track_event).with(Analytics::AUTHENTICATION_SUCCESSFUL)
+          with(Analytics::MULTI_FACTOR_AUTH, success?: true, method: 'totp')
 
         post :create, code: generate_totp_code(@secret)
       end
@@ -65,7 +64,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
         stub_analytics
 
         expect(@analytics).to receive(:track_event).exactly(3).times.
-          with(Analytics::AUTHENTICATION_TOTP, success?: false)
+          with(Analytics::MULTI_FACTOR_AUTH, success?: false, method: 'totp')
         expect(@analytics).to receive(:track_event).with(Analytics::AUTHENTICATION_MAX_2FA_ATTEMPTS)
 
         3.times { post :create, code: '12345' }

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe Analytics do
   let(:request_attributes) do
     {
-      user_agent: FakeRequest.new.user_agent,
-      user_ip: FakeRequest.new.remote_ip
+      user_ip: FakeRequest.new.remote_ip,
+      user_agent: FakeRequest.new.user_agent
     }
   end
 
@@ -19,11 +19,13 @@ describe Analytics do
       user = build_stubbed(:user, uuid: '123')
 
       analytics = Analytics.new(user, FakeRequest.new)
+      consolidated_attributes = request_attributes.reverse_merge(user_id: user.uuid)
 
       expect(ahoy).to receive(:track).
-        with('Trackable Event', request_attributes.merge(user_id: user.uuid))
+        with('Trackable Event', consolidated_attributes)
 
-      expect(Rails.logger).to receive(:info).with("Trackable Event: #{{ user_id: user.uuid }}")
+      expect(Rails.logger).to receive(:info).
+        with("Trackable Event: #{consolidated_attributes}")
 
       analytics.track_event('Trackable Event')
     end
@@ -33,12 +35,13 @@ describe Analytics do
       tracked_user = build_stubbed(:user, uuid: '456')
 
       analytics = Analytics.new(current_user, FakeRequest.new)
+      consolidated_attributes = request_attributes.reverse_merge(user_id: tracked_user.uuid)
 
       expect(ahoy).to receive(:track).
-        with('Trackable Event', request_attributes.merge(user_id: tracked_user.uuid))
+        with('Trackable Event', consolidated_attributes)
 
       expect(Rails.logger).to receive(:info).
-        with("Trackable Event: #{{ user_id: tracked_user.uuid }}")
+        with("Trackable Event: #{consolidated_attributes}")
 
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
     end


### PR DESCRIPTION
**Why**: To make it easier to generate metrics.
- We want to be able to generate various queries about email and
password authentications from a single event collection, as opposed to
three different ones
- Similarly, we want a single event collection for MFA

**How**:
- Use a single event for each type of collection, and use the
properties hash to add more info about the event. For example,
instead of having a separate event for authenticating with a nonexistent
email, we add `{ success?: false, user_id: 'anonymous-uuid' }` to the
event properties.
- Similarly, instead of treating recovery code and TOTP authentication
as separate events, add `{ method: 'recovery code' }` or
`{ method: 'totp' }` to the MFA event.