### PR TITLE
Ignore Reek NestedIterators offense in spec

### DIFF
--- a/.reek
+++ b/.reek
@@ -81,6 +81,7 @@ UtilityFunction:
     exclude:
       - complete_idv_questions_fail
       - complete_idv_questions_ok
+      - create_sidekiq_queues
   NilCheck:
     exclude:
       - complete_idv_questions_fail


### PR DESCRIPTION
**Why**: We don't care about this offense in this spec.