### PR TITLE
Improve "resend confirmation email" UX

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -2,7 +2,6 @@ module Users
   class ConfirmationsController < Devise::ConfirmationsController
     include ValidEmailParameter
 
-    # PATCH /confirm
     def confirm
       with_unconfirmed_confirmable do
         if @password_form.submit(permitted_params)
@@ -13,7 +12,6 @@ module Users
       end
     end
 
-    # GET /resource/confirmation?confirmation_token=abcdef
     def show
       with_unconfirmed_confirmable do
         return process_user_with_confirmation_errors if @confirmable.errors.present?

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -35,6 +35,10 @@ module Users
     protected
 
     def process_successful_creation
+      if params[:user][:resend] == 'true'
+        flash.now[:success] = t('notices.resend_confirmation_email.success')
+      end
+
       render :verify_email, locals: { email: @register_user_email_form.user.email }
     end
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -12,6 +12,10 @@ class RegisterUserEmailForm
     @user ||= User.new
   end
 
+  def resend
+    'true'
+  end
+
   def submit(params)
     user.email = params[:email].downcase
 

--- a/app/views/devise/registrations/verify_email.html.slim
+++ b/app/views/devise/registrations/verify_email.html.slim
@@ -8,10 +8,13 @@
     | #{t('notices.signed_up_but_unconfirmed.first_paragraph_start')}
       <strong>#{email}</strong>
       #{t('notices.signed_up_but_unconfirmed.first_paragraph_end')}
+
   .mb2
     p.m0
-      | #{t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')}
-        #{link_to t('links.resend'), new_user_confirmation_path}
+      = simple_form_for(@register_user_email_form, url: user_registration_path) do |f|
+        = f.input :email, as: :hidden, value: email
+        = f.input :resend, as: :hidden
+        = f.button :submit, t('forms.buttons.resend_confirmation'), class: 'mt2 mb1'
     - link = link_to t('notices.use_diff_email.link'), new_user_registration_path
     p.m0 == t('notices.use_diff_email.text_html', link: link)
   p.mb2.h5.italic = t('devise.registrations.close_window')

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -3,7 +3,6 @@ en:
     back_to_sp: '‹ Back to %{sp}'
     create_account: Create account
     privacy_policy: Privacy Policy
-    resend: Send again
     sign_out: Sign out
     sign_in: Sign in
     edit: Edit

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -13,12 +13,13 @@ en:
     send_code:
       voice: You will be called with your one-time passcode.
       sms: Your one-time passcode has been sent via text message.
+    resend_confirmation_email:
+      success: Your confirmation email has been sent.
     signed_up_but_unconfirmed:
       first_paragraph_start: We sent an email to
       first_paragraph_end: >
         with a link to confirm your email address. Follow the link to continue
         creating your account.
-      no_email_sent_explanation_start: Didn’t get an email?
     terms_of_service:
       headline: I agree to the terms of this service
       text: >

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -91,14 +91,15 @@ feature 'Email confirmation during sign up' do
   context 'user signs up and requests confirmation email again' do
     it 'sends the confirmation email again' do
       sign_up_with('test@example.com')
-      click_on t('links.resend')
-      fill_in :user_email, with: 'test@example.com'
 
       expect { click_on t('forms.buttons.resend_confirmation') }.
         to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(last_email.html_part.body).to have_content(
         t('devise.mailer.confirmation_instructions.subject')
+      )
+      expect(page).to have_content(
+        t('notices.resend_confirmation_email.success')
       )
     end
   end

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -7,10 +7,7 @@ feature 'Visitor signs up with email address' do
 
     expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_start')
     expect(page).to have_content t('notices.signed_up_but_unconfirmed.first_paragraph_end')
-    expect(page).
-      to have_content t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')
     expect(page).to have_content email
-    expect(page).to have_link(t('links.resend'), href: new_user_confirmation_path)
   end
 
   scenario 'visitor cannot sign up with invalid email address' do

--- a/spec/views/devise/registrations/verify_email.html.slim_spec.rb
+++ b/spec/views/devise/registrations/verify_email.html.slim_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'devise/registrations/verify_email.html.slim' do
   before do
     allow(view).to receive(:email).and_return('foo@bar.com')
+    @register_user_email_form = RegisterUserEmailForm.new
   end
 
   it 'has a localized title' do
@@ -20,6 +21,6 @@ describe 'devise/registrations/verify_email.html.slim' do
   it 'contains link to resend confirmation page' do
     render
 
-    expect(rendered).to have_link(t('links.resend'), href: new_user_confirmation_path)
+    expect(rendered).to have_button(t('forms.buttons.resend_confirmation'))
   end
 end


### PR DESCRIPTION
**Why**:
* When user wants a second email, they should not have to re-enter their
  email address because we already have it
* This also prevents the user from being redirected to the sign in page,
  which is a confusing place to be when you don't yet have a password.
* This is a re-do of https://github.com/18F/identity-idp/pull/679

What it looks like before you request another email:

![screen shot 2016-11-04 at 5 28 56 pm](https://cloud.githubusercontent.com/assets/601515/20026516/faba50e8-a2b8-11e6-9708-1fa09659f2c6.png)

What it looks like after:

![screen shot 2016-11-04 at 5 29 01 pm](https://cloud.githubusercontent.com/assets/601515/20026518/04235ea4-a2b9-11e6-9c85-95e6e6dccf49.png)


