### PR TITLE
Add progress bar (LOA3 user flow)

### DIFF
--- a/.reek
+++ b/.reek
@@ -64,7 +64,7 @@ UtilityFunction:
   public_methods_only: true
   exclude:
     - AnalyticsEventJob#perform
-    - ApplicationHelper#step_cls
+    - ApplicationHelper#step_class
     - SessionTimeoutWarningHelper#frequency
     - SessionTimeoutWarningHelper#start
     - SessionTimeoutWarningHelper#warning

--- a/.reek
+++ b/.reek
@@ -64,6 +64,7 @@ UtilityFunction:
   public_methods_only: true
   exclude:
     - AnalyticsEventJob#perform
+    - ApplicationHelper#step_cls
     - SessionTimeoutWarningHelper#frequency
     - SessionTimeoutWarningHelper#start
     - SessionTimeoutWarningHelper#warning

--- a/app/assets/stylesheets/components/_progress.scss
+++ b/app/assets/stylesheets/components/_progress.scss
@@ -1,0 +1,67 @@
+$step-size: 24px;
+$step-border-width: 2px;
+
+.col-5th { width: (1 / 5 * 100%); }
+
+.steps-2-thru-n { margin: -$step-size 0 0 $step-size; }
+
+.step {
+  position: relative;
+  z-index: 0;
+
+  span {
+    background-color: $white;
+    border: $step-border-width solid $border-color;
+    border-radius: 50%;
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: $h6;
+    font-weight: bold;
+    height: $step-size;
+    line-height: $step-size - ($step-border-width * 2);
+    text-align: center;
+    vertical-align: bottom;
+    width: $step-size;
+  }
+
+  &::after {
+    border-top: $step-border-width solid $border-color;
+    content: '';
+    left: 0;
+    position: absolute;
+    top: ($step-size - $step-border-width) / 2;
+    width: 100%;
+    z-index: -1;
+  }
+}
+
+// scss-lint:disable MergeableSelector
+.step.active {
+  span {
+    background-color: $blue;
+    border-color: $blue;
+    color: #fff;
+  }
+
+  &::after { border-color: $blue; }
+}
+
+// scss-lint:disable MergeableSelector
+.step.complete {
+  span {
+    position: relative;
+
+    &::before {
+      background-image: url(image-path('alert/ico-check.svg'));
+      background-repeat: no-repeat;
+      content: '';
+      height: $step-size;
+      left: -$step-border-width;
+      position: absolute;
+      top: -$step-border-width;
+      width: $step-size;
+    }
+  }
+
+  &::after { border-color: $green; }
+}

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -12,6 +12,7 @@
 @import 'nav';
 @import 'password';
 @import 'position';
+@import 'progress';
 @import 'tooltip';
 @import 'util';
 

--- a/app/assets/stylesheets/variables/_colors.scss
+++ b/app/assets/stylesheets/variables/_colors.scss
@@ -3,7 +3,7 @@ $blue: #0071bc !default;
 $blue-light: #ebf3fa !default;
 $navy: #112e51 !default;
 $teal: #00bfe7 !default;
-$green: #2ecc40 !default;
+$green: #088a22 !default;
 $olive: #3d9970 !default;
 $lime: #01ff70 !default;
 $yellow: #ffdc00 !default;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
     content_for(:card_cls) { cls }
   end
 
-  def step_cls(step, active)
+  def step_class(step, active)
     if active > step
       'complete'
     elsif active == step

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,14 @@ module ApplicationHelper
     content_for(:card_cls) { cls }
   end
 
+  def step_cls(step, active)
+    if active > step
+      'complete'
+    elsif active == step
+      'active'
+    end
+  end
+
   def tooltip(text)
     content_tag(
       :span, \

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -1,6 +1,6 @@
 - title t('titles.two_factor_setup')
 
-
+= render 'shared/progress_steps', active: 3
 h1.h3.my0 = t('devise.two_factor_authentication.two_factor_setup')
 p.mt-tiny.mb0#2fa-description
   = t('devise.two_factor_authentication.otp_setup_html')

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -1,8 +1,8 @@
 - title t('idv.titles.session.finance')
 
+= render 'shared/progress_steps', active: 5
 h1.h3.my0 = t('idv.titles.session.finance')
 p.mt-tiny.mb0 = t('idv.messages.finance.intro')
-
 = simple_form_for(idv_finance_form, url: idv_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   = f.error_notification

--- a/app/views/idv/index.html.slim
+++ b/app/views/idv/index.html.slim
@@ -1,5 +1,6 @@
 - title t('idv.titles.intro')
 
+= render 'shared/progress_steps', active: 4
 h1.h3.my0 = t('idv.titles.expectations')
 
 .mb-40p

--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -1,5 +1,6 @@
 - title t('idv.titles.phone')
 
+= render 'shared/progress_steps', active: 6
 h1.h3.my0 = t('idv.titles.session.phone')
 p.mt-tiny.mb0 = t('idv.messages.phone.intro')
 ul.py1.m0

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -1,8 +1,8 @@
 - title t('idv.titles.session.basic')
 
+= render 'shared/progress_steps', active: 4
 - if @using_mock_vendor
   .mt1.mb2.h6.caps.bold.red = t('idv.messages.sessions.no_pii')
-
 h1.h3.my0 = t('idv.titles.session.basic')
 = simple_form_for(idv_profile_form, url: idv_session_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/app/views/shared/_progress_steps.html.slim
+++ b/app/views/shared/_progress_steps.html.slim
@@ -1,8 +1,10 @@
 - active ||= 0
+- num_steps ||= 6
+
 .mb4.progress-steps
-  div class="step #{step_cls(1, active)}"
+  div class="step step-1 #{step_class(1, active)}"
     span 1
   .clearfix.steps-2-thru-n
-    - (2..6).each do |num|
-      div class="col col-5th right-align step #{step_cls(num, active)}"
+    - (2..num_steps).each do |num|
+      div class="col col-5th right-align step step-#{num} #{step_class(num, active)}"
         span = num

--- a/app/views/shared/_progress_steps.html.slim
+++ b/app/views/shared/_progress_steps.html.slim
@@ -1,0 +1,8 @@
+- active ||= 0
+.mb4.progress-steps
+  div class="step #{step_cls(1, active)}"
+    span 1
+  .clearfix.steps-2-thru-n
+    - (2..6).each do |num|
+      div class="col col-5th right-align step #{step_cls(num, active)}"
+        span = num

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -1,6 +1,6 @@
 - title t('titles.enter_2fa_code')
 
-- unless reauthn?
+- unless current_user && current_user.phone
   = render 'shared/progress_steps', active: 3
 
 h1.h3.my0 = t('devise.two_factor_authentication.header_text')

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -1,5 +1,7 @@
 - title t('titles.enter_2fa_code')
 
+- if !reauthn?
+  = render 'shared/progress_steps', active: 3
 
 h1.h3.my0 = t('devise.two_factor_authentication.header_text')
 p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -1,6 +1,6 @@
 - title t('titles.enter_2fa_code')
 
-- if !reauthn?
+- unless reauthn?
   = render 'shared/progress_steps', active: 3
 
 h1.h3.my0 = t('devise.two_factor_authentication.header_text')

--- a/app/views/two_factor_authentication/recovery_code/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code/show.html.slim
@@ -1,5 +1,6 @@
 - title t('titles.recovery_code')
 
+= render 'shared/progress_steps', active: 3
 h1.h3.my0 = t('headings.recovery_code')
 p.mt-tiny.mb0 = t('instructions.recovery_code')
 .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @code

--- a/app/views/users/confirmations/show.html.slim
+++ b/app/views/users/confirmations/show.html.slim
@@ -1,6 +1,6 @@
 - title t('titles.confirmations.show')
 
-
+= render 'shared/progress_steps', active: 2
 h1.h3.my0 = t('forms.confirmation.show_hdr')
 p.my2#password-description
   strong = t('instructions.password.info.lead', min_length: Devise.password_length.first)

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,5 +1,6 @@
 - title t('titles.registrations.new')
 
+= render 'shared/progress_steps', active: 1
 h1.h3.my0 = t('headings.registrations.enter_email')
 p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 = simple_form_for(@register_user_email_form,

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -183,6 +183,7 @@ feature 'IdV session' do
         complete_idv_profile_with_phone('416-555-0190')
 
         expect(page).to have_link t('forms.two_factor.try_again'), href: idv_phone_path
+        expect(page).not_to have_css('.progress-steps')
 
         enter_correct_otp_code_for_user(user)
         click_acknowledge_recovery_code

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -97,6 +97,14 @@ feature 'Two Factor Authentication' do
       expect(page).to have_content(t('notices.send_code.sms'))
     end
 
+    scenario 'user does not see progress steps' do
+      user = create(:user, :signed_up)
+      sign_in_before_2fa(user)
+      click_button t('forms.buttons.submit.default')
+
+      expect(page).not_to have_css('.progress-steps')
+    end
+
     scenario 'user who enters OTP incorrectly 3 times is locked out for OTP validity period' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
+  describe '#step_cls' do
+    it 'creates CSS class based on current and active step' do
+      expect(helper.step_cls(1, 2)).to eq 'complete'
+      expect(helper.step_cls(2, 2)).to eq 'active'
+      expect(helper.step_cls(2, 1)).to be_nil
+    end
+  end
+
   describe '#tooltip' do
     it 'creates a span containing aria label with text and image' do
       tooltip_text = 'foobar'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe '#step_cls' do
+  describe '#step_class' do
     it 'creates CSS class based on current and active step' do
-      expect(helper.step_cls(1, 2)).to eq 'complete'
-      expect(helper.step_cls(2, 2)).to eq 'active'
-      expect(helper.step_cls(2, 1)).to be_nil
+      expect(helper.step_class(1, 2)).to eq 'complete'
+      expect(helper.step_class(2, 2)).to eq 'active'
+      expect(helper.step_class(2, 1)).to be_nil
     end
   end
 

--- a/spec/views/devise/two_factor_authentication_setup/index.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication_setup/index.html.slim_spec.rb
@@ -1,10 +1,20 @@
 require 'rails_helper'
 
 describe 'devise/two_factor_authentication_setup/index.html.slim' do
+  before do
+    user = build_stubbed(:user, :signed_up)
+    @two_factor_setup_form = TwoFactorSetupForm.new(user)
+  end
+
   it 'sets form autocomplete to off' do
-    @two_factor_setup_form = TwoFactorSetupForm.new(build_stubbed(:user))
     render
 
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
+  end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-3.active')
   end
 end

--- a/spec/views/idv/finance/new.html.slim_spec.rb
+++ b/spec/views/idv/finance/new.html.slim_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'idv/finance/new.html.slim' do
+  before do
+    allow(view).to receive(:idv_finance_form).and_return(Idv::FinanceForm.new({}))
+  end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-5.active')
+  end
+end

--- a/spec/views/idv/index.html.slim_spec.rb
+++ b/spec/views/idv/index.html.slim_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'idv/index.html.slim' do
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-4.active')
+  end
+end

--- a/spec/views/idv/phone/new.html.slim_spec.rb
+++ b/spec/views/idv/phone/new.html.slim_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'idv/phone/new.html.slim' do
+  before do
+    user = build_stubbed(:user, :signed_up)
+    form = Idv::PhoneForm.new({}, user)
+    allow(view).to receive(:idv_phone_form).and_return(form)
+  end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-6.active')
+  end
+end

--- a/spec/views/idv/sessions/new.html.slim_spec.rb
+++ b/spec/views/idv/sessions/new.html.slim_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'idv/sessions/new.html.slim' do
+  before do
+    user = build_stubbed(:user, :signed_up)
+    form = Idv::ProfileForm.new({}, user)
+    allow(view).to receive(:idv_profile_form).and_return(form)
+  end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-4.active')
+  end
+end

--- a/spec/views/shared/_progress_steps.html.slim_spec.rb
+++ b/spec/views/shared/_progress_steps.html.slim_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'shared/_progress_steps.html.slim' do
+  it 'displays the correct number of step units' do
+    render
+
+    expect(rendered).to have_css('.step', count: 6)
+  end
+end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
     before do
       allow(view).to receive(:reauthn?).and_return(false)
       allow(view).to receive(:user_session).and_return({})
+      allow(view).to receive(:current_user).and_return(User.new)
       controller.request.path_parameters[:delivery_method] = 'sms'
       @delivery_method = 'sms'
     end

--- a/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
@@ -35,4 +35,10 @@ describe 'two_factor_authentication/recovery_code/show.html.slim' do
 
     expect(rendered).to have_content 'foo'
   end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-3.active')
+  end
 end

--- a/spec/views/users/confirmations/show.html.slim_spec.rb
+++ b/spec/views/users/confirmations/show.html.slim_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'users/confirmations/show.html.slim' do
+  before do
+    user = build_stubbed(:user, :signed_up)
+    @password_form = PasswordForm.new(user)
+  end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-2.active')
+  end
+end

--- a/spec/views/users/registrations/new.html.slim_spec.rb
+++ b/spec/views/users/registrations/new.html.slim_spec.rb
@@ -24,4 +24,10 @@ describe 'users/registrations/new.html.slim' do
 
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
+
+  it 'displays the correct progress step' do
+    render
+
+    expect(rendered).to have_css('.step-1.active')
+  end
 end


### PR DESCRIPTION
Progress indicator appears when initially creating a new login.gov account - beginning with the initial email address entry form and ending on the IDV review page.

![screen shot 2016-11-23 at 2 06 02 pm](https://cloud.githubusercontent.com/assets/1178494/20575223/5840a1d2-b186-11e6-9d13-7f3fd675a5a4.png)
