### PR TITLE
Update email validation error message

### DIFF
--- a/app/assets/javascripts/app/validate-field.js
+++ b/app/assets/javascripts/app/validate-field.js
@@ -1,21 +1,16 @@
 import 'classlist.js';
 
-
-const msgs = {
-  email: 'Please enter a valid email address.',
-  missing: 'Please fill in this field.',
-  mismatch: 'Please match the requested format.',
-};
+const I18n = window.LoginGov.I18n;
 
 function addInvalidMarkup(f) {
   f.setAttribute('aria-invalid', 'true');
   f.setAttribute('aria-describedby', `alert_${f.id}`);
 
-  if (f.validity.valueMissing) f.setCustomValidity(msgs.missing);
+  if (f.validity.valueMissing) f.setCustomValidity(I18n.t('errors.messages.missing_field'));
   else if (f.validity.typeMismatch &&
-    f.type === 'email') f.setCustomValidity(msgs.email);
+    f.type === 'email') f.setCustomValidity(I18n.t('valid_email.validations.email.invalid'));
   else if (f.validity.patternMismatch
-    || f.validity.typeMismatch) f.setCustomValidity(msgs.mismatch);
+    || f.validity.typeMismatch) f.setCustomValidity(I18n.t('errors.messages.format_mismatch'));
 
   f.insertAdjacentHTML(
     'afterend',

--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -1,11 +1,14 @@
 window.LoginGov = window.LoginGov || {};
 
 <% keys = [
+  'errors.messages.format_mismatch',
+  'errors.messages.missing_field',
   'instructions.password.strength.i',
   'instructions.password.strength.ii',
   'instructions.password.strength.iii',
   'instructions.password.strength.iv',
   'instructions.password.strength.v',
+  'valid_email.validations.email.invalid',
 ] %>
 
 window.LoginGov.I18n = {

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -5,7 +5,6 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 = simple_form_for(@register_user_email_form,
     html: { autocomplete: 'off', role: 'form' },
     url: user_registration_path) do |f|
-  = f.error_notification
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -17,6 +17,8 @@ en:
         one: '1 error prohibited this %{resource} from being saved:'
         other: '%{count} errors prohibited this %{resource} from being saved:'
       requires_phone: requires you to enter your phone number.
+      missing_field: 'Please fill in this field.'
+      format_mismatch: 'Please match the requested format.'
     confirm_password_incorrect: The password you provided is incorrect.
     invalid_totp: Invalid code entered.  Please try again.
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/valid_email/en.yml
+++ b/config/locales/valid_email/en.yml
@@ -2,4 +2,4 @@ en:
   valid_email:
     validations:
       email:
-        invalid: Please enter a valid email in the format of user@domain.com
+        invalid: Invalid email format or domain entered. Correct the address and re-enter it.

--- a/spec/controllers/users/edit_email_controller_spec.rb
+++ b/spec/controllers/users/edit_email_controller_spec.rb
@@ -65,7 +65,7 @@ describe Users::EditEmailController do
         stub_sign_in(user)
         put :update, update_user_email_form: { email: 'foo' }
 
-        expect(response.body).to have_content('Please enter a valid email')
+        expect(response.body).to have_content(t('valid_email.validations.email.invalid'))
       end
     end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -24,7 +24,7 @@ feature 'Sign in' do
   scenario 'user cannot sign in with invalid email', js: true do
     signin('invalid', 'foo')
 
-    expect(page).to have_content 'Please enter a valid email address.'
+    expect(page).to have_content t('valid_email.validations.email.invalid')
   end
 
   scenario 'user cannot sign in with empty password', js: true do


### PR DESCRIPTION
<del>**Why**:</del>
<del>The server uses .has-error to mark error fields and the client uses
.invalid, so we need to clear both client-side when errors are cleared.</del>

---

<del>What is our policy for tests on this?</del>

---

Updates error messages for the email signup page