### PR TITLE
Allow identity to have concurrent sessions

### DIFF
--- a/.reek
+++ b/.reek
@@ -67,6 +67,7 @@ UtilityFunction:
     exclude:
       - complete_2fa_confirmation
       - complete_idv_profile
+      - stub_session_store
       - stub_subject
       - stub_idv_session
       - saml_settings

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -52,7 +52,7 @@ module SamlIdpAuthConcern
   def link_identity_from_session_data
     provider = saml_request.service_provider.identifier
 
-    IdentityLinker.new(current_user, provider).link_identity
+    IdentityLinker.new(current_user, provider, session.id).link_identity
   end
 
   def identity_needs_verification?
@@ -64,7 +64,7 @@ module SamlIdpAuthConcern
   end
 
   def active_identity
-    current_user.last_identity
+    decorated_user.active_identity_for(current_service_provider)
   end
 
   def encode_authn_response(principal, opts)
@@ -95,7 +95,7 @@ module SamlIdpAuthConcern
     encode_response(
       current_user,
       authn_context_classref: requested_authn_context,
-      reference_id: active_identity.session_uuid,
+      reference_id: active_identity.decorate.session_for(session.id).uuid,
       encryption: current_service_provider.encryption_opts
     )
   end

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -33,10 +33,10 @@ module SamlIdpLogoutConcern
   end
 
   def handle_saml_logout_request(resource)
-    # multiple identities present. initiate logoff at first
-    return generate_slo_request if resource.multiple_identities?
+    # multiple sessions present. initiate logoff at first
+    return generate_slo_request if resource.multiple_sessions?(session.id)
 
-    # no more active identities available. deactivate the final identity,
+    # no more active sessions available. deactivate the final identity,
     # log the user out, and send response to SP
     resource.first_identity.deactivate
 

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -6,4 +6,8 @@ IdentityDecorator = Struct.new(:identity) do
   def happened_at
     identity.last_authenticated_at
   end
+
+  def session_for(session_id)
+    identity.sessions.find_by(session_id: session_id)
+  end
 end

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -8,6 +8,6 @@ IdentityDecorator = Struct.new(:identity) do
   end
 
   def session_for(session_id)
-    identity.sessions.find_by(session_id: session_id)
+    identity.sessions.find_by(session_id: session_id) || Session.new
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -47,6 +47,14 @@ UserDecorator = Struct.new(:user) do
     omniauthed?(session)
   end
 
+  def too_many_sessions?
+    limit = Figaro.env.max_concurrent_sessions.to_i
+    user.active_identities.each do |identity|
+      return true if identity.sessions.count >= limit
+    end
+    false
+  end
+
   def masked_two_factor_phone_number
     masked_number(user.phone)
   end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -2,10 +2,17 @@ class Identity < ActiveRecord::Base
   include NonNullUuid
 
   belongs_to :user
+  has_many :sessions
   validates :service_provider, presence: true
 
-  def deactivate
-    update!(session_uuid: nil)
+  LOCAL = 'login.gov'.freeze
+
+  def deactivate(session_id = nil)
+    if session_id
+      sessions.where(session_id: session_id).destroy_all
+    else
+      sessions.destroy_all
+    end
   end
 
   def sp_metadata

--- a/app/models/null_identity.rb
+++ b/app/models/null_identity.rb
@@ -1,5 +1,5 @@
 class NullIdentity
-  def deactivate
+  def deactivate(_session_id)
     # no-op
   end
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,6 @@
+class Session < ActiveRecord::Base
+  include NonNullUuid
+
+  belongs_to :identity
+  validates :session_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ActiveRecord::Base
   has_many :identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
+  has_many :sessions, through: :identities
 
   attr_accessor :asserted_attributes
 
@@ -66,12 +67,10 @@ class User < ActiveRecord::Base
   end
 
   def active_identities
-    identities.where(
-      'session_uuid IS NOT ?',
-      nil
-    ).order(
-      last_authenticated_at: :asc
-    ) || []
+    identities.
+      joins(:sessions).
+      where.not(sessions: { identity_id: nil }).
+      order(last_authenticated_at: :asc) || []
   end
 
   def multiple_identities?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,11 +70,16 @@ class User < ActiveRecord::Base
     identities.
       joins(:sessions).
       where.not(sessions: { identity_id: nil }).
-      order(last_authenticated_at: :asc) || []
+      order(last_authenticated_at: :asc).
+      distinct || []
   end
 
   def multiple_identities?
     active_identities.size > 1
+  end
+
+  def multiple_sessions?(session_id)
+    sessions.where(session_id: session_id).size > 1
   end
 
   def active_profile

--- a/app/services/logout_response_handler.rb
+++ b/app/services/logout_response_handler.rb
@@ -1,4 +1,4 @@
-LogoutResponseHandler = Struct.new(:identity, :response) do
+LogoutResponseHandler = Struct.new(:identity, :response, :session_id) do
   def continue_logout_with_next_identity?
     in_slo?
   end
@@ -8,11 +8,11 @@ LogoutResponseHandler = Struct.new(:identity, :response) do
   end
 
   def deactivate_identity
-    identity.deactivate
+    identity.deactivate(session_id)
   end
 
   def deactivate_last_identity
-    identity.user.last_identity.deactivate
+    identity.user.last_identity.deactivate(session_id)
   end
 
   private

--- a/app/services/logout_response_handler.rb
+++ b/app/services/logout_response_handler.rb
@@ -20,6 +20,6 @@ LogoutResponseHandler = Struct.new(:identity, :response, :session_id) do
   def in_slo?
     user = identity.user
 
-    user.multiple_identities? || (user.active_identities.present? && response.nil?)
+    user.multiple_sessions?(session_id) || (user.active_identities.present? && response.nil?)
   end
 end

--- a/app/services/session_syncer.rb
+++ b/app/services/session_syncer.rb
@@ -1,0 +1,32 @@
+class SessionSyncer
+  def initialize(session_store)
+    self.session_store = session_store
+  end
+
+  def clean(user)
+    user.sessions.pluck(:session_id).each do |session_id|
+      destroy_if_not_in_redis(session_id)
+    end
+  end
+
+  private
+
+  attr_accessor :session_store
+
+  def destroy_if_not_in_redis(session_id)
+    return if session_key_exists?(session_id)
+    Session.where(session_id: session_id).destroy_all
+  end
+
+  def session_key_exists?(session_id)
+    redis.exists(session_key_name(session_id))
+  end
+
+  def session_key_name(session_id)
+    session_store.send(:prefixed, session_id)
+  end
+
+  def redis
+    session_store.send(:redis)
+  end
+end

--- a/app/services/single_logout_handler.rb
+++ b/app/services/single_logout_handler.rb
@@ -1,6 +1,6 @@
 require 'saml_idp/logout_request_builder'
 
-SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user) do
+SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user, :session_id) do
   def successful_saml_response?
     saml_response.present? && saml_response.success?
   end
@@ -17,7 +17,7 @@ SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user) do
     Base64.strict_encode64(slo_request_builder(
       sp_metadata,
       identity.uuid,
-      identity.session_uuid
+      identity.decorate.session_for(session_id).uuid
     ).signed)
   end
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -12,6 +12,7 @@ email_from: 'no-reply@login.gov'
 idv_max_attempts: '3'
 idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
+max_concurrent_sessions: '2'
 
 # The scores 0, 1, 2, 3 or 4 are given when the number of guesses to crack the
 # password are less than 10^3, 10^6, 10^8, 10^10, and >= 10^10 respectively.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -8,6 +8,7 @@ Figaro.require_keys(
   'idp_sso_target_url',
   'logins_per_ip_limit',
   'logins_per_ip_period',
+  'max_concurrent_sessions',
   'min_password_score',
   'otp_delivery_blocklist_bantime',
   'otp_delivery_blocklist_findtime',

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -1,6 +1,7 @@
 en:
   errors:
     messages:
+      concurrent_sessions: This account is already in use. Sign out elsewhere then try signing in here again.
       improbable_phone: Phone number is invalid. Please make sure you enter a 10-digit phone number.
       weak_password: Your password is not strong enough. %{feedback}
       already_confirmed: was already confirmed, please try signing in

--- a/db/migrate/20161103172947_update_sessions_for_concurrency.rb
+++ b/db/migrate/20161103172947_update_sessions_for_concurrency.rb
@@ -1,0 +1,6 @@
+class UpdateSessionsForConcurrency < ActiveRecord::Migration
+  def change
+    remove_column :sessions, :data
+    add_reference :sessions, :identity, index: true, foreign_key: true, null: false
+  end
+end

--- a/db/migrate/20161103183919_drop_identity_session_uuid.rb
+++ b/db/migrate/20161103183919_drop_identity_session_uuid.rb
@@ -1,0 +1,6 @@
+class DropIdentitySessionUuid < ActiveRecord::Migration
+  def change
+    remove_column :identities, :session_uuid
+    add_column :sessions, :uuid, :string
+  end
+end

--- a/db/migrate/20161104215255_change_session_unique_id.rb
+++ b/db/migrate/20161104215255_change_session_unique_id.rb
@@ -1,0 +1,7 @@
+class ChangeSessionUniqueId < ActiveRecord::Migration
+  def change
+    remove_index :sessions, [:session_id] # unique
+    add_index :sessions, [:session_id, :identity_id], unique: true
+    add_index :sessions, [:session_id] # not unique
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923195429) do
+ActiveRecord::Schema.define(version: 20161104215255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,22 +52,20 @@ ActiveRecord::Schema.define(version: 20160923195429) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "session_uuid",          limit: 255
     t.string   "uuid",                              null: false
   end
 
-  add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree
   add_index "identities", ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", using: :btree
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
   add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "profiles", force: :cascade do |t|
-    t.integer  "user_id",                       null: false
-    t.boolean  "active",        default: false, null: false
+    t.integer  "user_id",                                  null: false
+    t.boolean  "active",                   default: false, null: false
     t.datetime "verified_at"
     t.datetime "activated_at"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "vendor"
     t.text     "encrypted_pii"
     t.string   "ssn_signature", limit: 64
@@ -80,13 +78,16 @@ ActiveRecord::Schema.define(version: 20160923195429) do
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255, null: false
-    t.text     "data"
+    t.string   "session_id",  limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "identity_id",             null: false
+    t.string   "uuid"
   end
 
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["identity_id"], name: "index_sessions_on_identity_id", using: :btree
+  add_index "sessions", ["session_id", "identity_id"], name: "index_sessions_on_session_id_and_identity_id", unique: true, using: :btree
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "users", force: :cascade do |t|
@@ -137,4 +138,5 @@ ActiveRecord::Schema.define(version: 20160923195429) do
   add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
 
   add_foreign_key "events", "users"
+  add_foreign_key "sessions", "identities"
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -84,6 +84,19 @@ describe Users::SessionsController, devise: true do
 
         expect(session[:pinged_at]).to_not eq(now)
       end
+
+      it 'updates Session.updated_at' do
+        user = stub_sign_in
+        IdentityLinker.new(user, Identity::LOCAL, session.id).link_identity
+
+        Timecop.travel(Time.current + 10)
+        get :active
+        Timecop.return
+
+        identity_session = Session.find_by(session_id: session.id)
+
+        expect(identity_session.updated_at).to_not eq(identity_session.created_at)
+      end
     end
 
     it 'does not track analytics event' do
@@ -130,6 +143,7 @@ describe Users::SessionsController, devise: true do
 
   describe 'POST /' do
     it 'tracks the successful authentication for existing user' do
+      stub_session_store
       user = create(:user, :signed_up)
 
       stub_analytics

--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -1,9 +1,19 @@
 FactoryGirl.define do
   factory :identity do
     service_provider 'https://serviceprovider.com'
-  end
 
-  trait :active do
-    last_authenticated_at Time.zone.now
+    trait :active do
+      last_authenticated_at Time.zone.now
+    end
+
+    transient do
+      session false
+    end
+
+    after(:build) do |identity, evaluator|
+      if evaluator.session
+        identity.sessions << build(:session, session_id: evaluator.session)
+      end
+    end
   end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :session do
+  end
+end

--- a/spec/features/saml/idp_initiated_slo_spec.rb
+++ b/spec/features/saml/idp_initiated_slo_spec.rb
@@ -73,7 +73,7 @@ feature 'IDP-initiated logout', devise: true do
       click_button t('forms.buttons.submit.default') # logout request for second SP
 
       logout_user.identities.each do |ident|
-        expect(ident.sessions.any?).to eq false
+        expect(ident.sessions).to be_blank
       end
 
       expect(logout_user.active_identities).to be_empty

--- a/spec/features/saml/idp_initiated_slo_spec.rb
+++ b/spec/features/saml/idp_initiated_slo_spec.rb
@@ -59,6 +59,11 @@ feature 'IDP-initiated logout', devise: true do
       visit sp2_authnrequest
       @sp2_asserted_session_index = response_xmldoc.assertion_statement_node['SessionIndex']
       click_button t('forms.buttons.submit.default')
+
+      expect(logout_user.active_identities.count).to eq 2
+      logout_user.identities.each do |ident|
+        expect(ident.sessions.count).to eq 1
+      end
     end
 
     it 'deactivates each authenticated Identity and logs the user out' do
@@ -68,7 +73,7 @@ feature 'IDP-initiated logout', devise: true do
       click_button t('forms.buttons.submit.default') # logout request for second SP
 
       logout_user.identities.each do |ident|
-        expect(ident.session_uuid).to be_nil
+        expect(ident.sessions.any?).to eq false
       end
 
       expect(logout_user.active_identities).to be_empty

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -148,14 +148,14 @@ feature 'Sign in' do
 
       Figaro.env.max_concurrent_sessions.to_i.times do |i|
         browser_name = "browser_#{i}".to_sym
-        in_browser(browser_name) do
+        perform_in_browser(browser_name) do
           visit new_user_session_path
           signin(user.email, user.password)
           expect(current_path).to eq user_two_factor_authentication_path
         end
       end
 
-      in_browser(:over_limit) do
+      perform_in_browser(:over_limit) do
         visit new_user_session_path
         signin(user.email, user.password)
 
@@ -163,12 +163,5 @@ feature 'Sign in' do
         expect(page).to have_content(t('errors.messages.concurrent_sessions'))
       end
     end
-  end
-
-  def in_browser(name)
-    old_session = Capybara.session_name
-    Capybara.session_name = name
-    yield
-    Capybara.session_name = old_session
   end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -2,24 +2,24 @@ require 'rails_helper'
 
 describe Identity do
   let(:user) { create(:user, :signed_up) }
-  let(:identity) do
-    Identity.create(
-      user_id: user.id,
-      service_provider: 'externalapp'
-    )
-  end
+  let(:identity) { create(:identity, user: user, service_provider: 'externalapp') }
   subject { identity }
 
   it { is_expected.to belong_to(:user) }
-
+  it { is_expected.to have_many(:sessions) }
   it { is_expected.to validate_presence_of(:service_provider) }
 
-  describe '.deactivate' do
-    let(:active_identity) { create(:identity, :active) }
+  describe '#deactivate' do
+    let(:session_id) { SecureRandom.uuid }
+    let(:active_identity) { create(:identity, :active, session: session_id) }
 
-    it 'sets last_authenticated_at to nil' do
-      active_identity.deactivate
-      expect(identity.last_authenticated_at).to be_nil
+    it 'destroys corresponding Session' do
+      expect(active_identity.sessions.any?).to eq true
+
+      active_identity.deactivate(session_id)
+      active_identity.reload
+
+      expect(active_identity.sessions.any?).to eq false
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Session do
+  let(:session_id) { SecureRandom.uuid }
+  let(:identity) { build(:identity) }
+  subject { Session.new(identity: identity) }
+
+  describe 'Associations' do
+    it { is_expected.to belong_to(:identity) }
+
+    it { is_expected.to validate_presence_of(:session_id) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ describe User do
     it { is_expected.to have_many(:identities) }
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_many(:sessions) }
   end
 
   it 'should only send one email during creation' do
@@ -136,10 +137,10 @@ describe User do
   context 'when identities are present' do
     let(:user) { create(:user, :signed_up) }
     let(:active_identity) do
-      Identity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
+      build(:identity, :active, session: 'some-session-id', service_provider: 'entity_id')
     end
     let(:inactive_identity) do
-      Identity.create(service_provider: 'entity_id', session_uuid: nil)
+      build(:identity, service_provider: 'entity_id')
     end
 
     describe '#active_identities' do
@@ -153,17 +154,24 @@ describe User do
 
   context 'when user has multiple identities' do
     let(:user) { create(:user, :signed_up) }
+    let(:session_id) { SecureRandom.uuid }
 
     before do
-      user.identities << Identity.create(
+      create(
+        :identity,
+        :active,
+        user: user,
         service_provider: 'first',
         last_authenticated_at: Time.current - 1.hour,
-        session_uuid: SecureRandom.uuid
+        session: session_id
       )
-      user.identities << Identity.create(
+      create(
+        :identity,
+        :active,
+        user: user,
         service_provider: 'last',
         last_authenticated_at: Time.current,
-        session_uuid: SecureRandom.uuid
+        session: session_id
       )
     end
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -9,7 +9,7 @@ describe AttributeAsserter do
     build(
       :identity,
       service_provider: service_provider.issuer,
-      session_uuid: SecureRandom.uuid
+      session: SecureRandom.uuid
     )
   end
   let(:service_provider) do

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -5,10 +5,12 @@ describe IdentityLinker do
     let(:user) { create(:user) }
 
     it "updates user's last authenticated identity" do
-      IdentityLinker.new(user, 'test.host').link_identity
+      IdentityLinker.new(user, 'test.host', 'foo').link_identity
       user.reload
 
       last_identity = user.last_identity
+
+      expect(last_identity).to be_a Identity
 
       new_attributes = {
         service_provider: 'test.host',
@@ -17,16 +19,23 @@ describe IdentityLinker do
       }
 
       identity_attributes = last_identity.attributes.symbolize_keys.
-                            except(:created_at, :updated_at, :id, :session_uuid,
-                                   :last_authenticated_at)
+                            except(:created_at, :updated_at, :id, :last_authenticated_at)
 
-      expect(last_identity.session_uuid).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)
       expect(last_identity.last_authenticated_at).to be_present
       expect(identity_attributes).to eq new_attributes
     end
 
+    it 'sets session_id on child Session' do
+      IdentityLinker.new(user, 'test.host', 'foo').link_identity
+      user.reload
+
+      last_identity = user.last_identity
+
+      expect(last_identity.sessions.first.session_id).to eq 'foo'
+    end
+
     it 'fails when given a nil provider' do
-      linker = IdentityLinker.new(user, nil)
+      linker = IdentityLinker.new(user, nil, 'foo')
       expect { linker.link_identity }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -42,6 +42,14 @@ module ControllerHelper
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end
+
+  def stub_session_store
+    session_store = instance_double(RedisSessionStore)
+    allow(session_store).to receive(:generate_sid).and_return('random-session-id')
+    allow(controller.session).to receive(:options).and_return({})
+    allow(controller.session).to receive(:instance_variable_get).with('@by').
+      and_return(session_store)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -7,7 +7,7 @@ module Features
     def sign_up_with(email)
       visit new_user_registration_path
       fill_in 'Email', with: email
-      click_button t('forms.buttons.submit.default')
+      click_submit_default
     end
 
     def signin(email, password)
@@ -25,7 +25,7 @@ module Features
       user = create(:user, :unconfirmed)
       confirm_last_user
       fill_in 'password_form_password', with: VALID_PASSWORD
-      click_button t('forms.buttons.submit.default')
+      click_submit_default
       user
     end
 
@@ -84,7 +84,7 @@ module Features
       # Select SMS delivery
       click_button t('forms.buttons.send_passcode')
       # Enter 2FA code
-      click_button t('forms.buttons.submit.default')
+      click_submit_default
       # Acknowledge recovery code
       click_button t('forms.buttons.submit.continue')
       user
@@ -97,6 +97,13 @@ module Features
     def enter_correct_otp_code_for_user(user)
       fill_in 'code', with: user.reload.direct_otp
       click_submit_default
+    end
+
+    def perform_in_browser(name)
+      old_session = Capybara.session_name
+      Capybara.session_name = name
+      yield
+      Capybara.session_name = old_session
     end
   end
 end


### PR DESCRIPTION
**Why**: In order to limit concurrent sessions we first must
start tracking concurrent sessions.

**How**: Repurposing the recently-defunct sessions table to create
a one-to-many relationship between Identity and Session.
This eliminates the `session_uuid` column on the Identity model
and instead uses the sessions table with a `uuid`
column. 