### PR TITLE
Call reset_email before specs that open emails

### DIFF
--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Email confirmation during sign up' do
   scenario 'confirms valid email and sets valid password' do
+    reset_email
     email = 'test@example.com'
     sign_up_with(email)
     open_email(email)


### PR DESCRIPTION
**Why**: To make sure any previous emails from other specs are not
opened instead.

This fixes the flickering spec on Travis.