### PR TITLE
Revise headers and instructions

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -12,7 +12,7 @@ class ServiceProviderSessionDecorator
   end
 
   def new_session_heading
-    I18n.t('headings.log_in_branded', sp: sp_name)
+    I18n.t('headings.sign_in_branded', sp: sp_name)
   end
 
   def registration_heading

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -10,8 +10,8 @@ h1.h3.my0 = decorated_session.new_session_heading
   = f.input :password, required: true
   = f.button :submit, t('headings.log_in'), class: 'btn-wide'
 
-- link = link_to t('notices.log_in_consent.link'), privacy_path
-p.my3 == t('notices.log_in_consent.text', app: APP_NAME, link: link)
+- link = link_to t('notices.sign_in_consent.link'), privacy_path
+p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
 
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -10,52 +10,52 @@ en:
         You will receive an email with instructions for how to confirm your
         email address in a few minutes.
       send_paranoid_instructions: >
-        If your email address exists in our database, you will receive an email
-        with instructions for how to confirm your email address in a few minutes.
+        You will receive an email with instructions for how to confirm your
+        email address in a few minutes.
 
     failure:
       already_authenticated: ''
       inactive: Your account is not activated yet.
       invalid: Invalid email or password.
-      locked: Your account is locked.
+      locked: Your account is now locked.
       last_attempt: You have one more attempt before your account is locked.
       not_found_in_database: Invalid email or password.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: ''
-      unconfirmed: You have to confirm your email address before continuing.
+      unconfirmed: You need to confirm your email address before continuing.
 
     mailer:
       confirmation_instructions:
-        subject: Email confirmation instructions
+        subject: Confirm your email
       reset_password_instructions:
-        subject: Password reset instructions
+        subject: Reset your password
       password_updated:
-        subject: Password change notification
+        subject: Your password has been changed
       account_locked:
         subject: Your login.gov account has been locked
 
     omniauth_callbacks:
-      failure: 'Could not authenticate you due to: %{reason}.'
+      failure: 'Could not sign you in due to: %{reason}.'
       success: Third party authentication successful!
 
     passwords:
       no_token: >
         You can’t access this page without coming from a password reset email.
         If you do come from a password reset email, please make sure you used the full
-        URL provided.
+        link provided.
       send_instructions: >
         You will receive an email with instructions on how to reset your
         password in a few minutes.
       send_paranoid_instructions: >
-        If your email address exists in our database, you will receive a
-        password recovery link at your email address in a few minutes.
-      updated: Your password has been changed successfully. You are now signed in.
+        You will receive an email with instructions on how to reset your
+        password in a few minutes.
+      updated: Your password has been changed. You are now signed in.
       updated_not_active: >
-        Your password has been changed successfully.
+        Your password has been changed.
         Please sign in with your new password.
       choose_new_password: Choose a new password.
-      token_expired: You have taken too long to reset your password. Please try again.
-      invalid_token: The reset password token is invalid. Please try again.
+      token_expired: You took too long to reset your password. Try again.
+      invalid_token: The reset password token is invalid. Try again.
 
     registrations:
       start:
@@ -73,29 +73,29 @@ en:
         Deleting your account cannot be undone. All data associated with your
         account will be removed. Are you sure you’d like to delete your account?
       destroyed: Your account has been successfully deleted.
-      signed_up: Welcome! You have signed up successfully.
+      signed_up: Welcome! You have created an account.
       signed_up_but_inactive: >
-        You have signed up successfully. However, we could not sign you in
+        You have created an account. However, we could not sign you in
         because your account is not yet activated.
       signed_up_but_locked: >
-        You have signed up successfully. However, we could not sign you in
+        You have created an account. However, we could not sign you in
         because your account is locked.
       email_update_needs_confirmation: >
-        You updated your account successfully, but we need to verify your new
-        email address. Please check your email and follow the confirm link to
-        confirm your new email address.
+        You updated your account, but we need to confirm your new
+        email address. Check for an email from us, then follow the link in the email to
+        confirm your new address.
       phone_update_needs_confirmation: >
         Your request to update your phone number was processed,
-        but we need to verify your new number first. Please follow the
+        but we need to confirm your new number first. Please follow the
         instructions below. If you do not confirm your new number, we will
         keep using your old phone number.
       email_and_phone_need_confirmation: >
-        Your request to update your account was processed,
-        but we need to verify both your new number and new email. Please follow
-        the instructions below to verify your new number, then check your
-        email and click the confirmation link to confirm your new email address.
-      updated: Account update successful!
-      enabled_twofactor: Successfully enabled two-factor authentication.
+        Before we finish updating your account, we need to confirm both your new number
+        and new email. Please follow the instructions below to confirm your new number, then
+        check for an email from us. Follow the link in the email to confirm your new email
+        address.
+      updated: Your account has been updated!
+      enabled_twofactor: You have enabled two-factor authentication.
       close_window: You can close this browser window once you have confirmed your email address.
 
     sessions:
@@ -104,20 +104,20 @@ en:
       already_signed_out: You are now signed out.
     two_factor_authentication:
       contact_administrator: Please contact your system administrator.
-      header_text: Enter the passcode we sent you
+      header_text: Enter your passcode
       invalid_otp: >
-        That one-time passcode is invalid. Please try again or request a new
+        That passcode is invalid. You can try entering it again or request a new
         one-time passcode.
-      invalid_recovery_code: Invalid recovery code. Please try again.
+      invalid_recovery_code: That recovery code is invalid.
       totp_header_text: Enter your authenticator code
       max_login_attempts_reached: >
         Your account is temporarily locked because you have entered the
         one-time passcode incorrectly too many times.
       please_try_again: Please try again in %{time_remaining}.
-      recovery_code_header_text: Enter a recovery code
+      recovery_code_header_text: Enter your recovery code
       recovery_code_prompt: >
-        Please enter your recovery code. Once used, a new one will be generated
-        for you.
+        You can use this recovery code once. If you still need a code after signing in, go to your
+        account settings page to get a new one.
       recovery_code_fallback:
         text: Don’t have access to your phone? Use a %{link} instead.
         link: recovery code
@@ -127,25 +127,24 @@ en:
         <strong>Every time you log in,</strong> we will send you a one-time passcode via text
         message or phone call. This helps safeguard your account.
       choose_delivery_confirmation: >
-        Please select how you would like to receive your confirmation code for %{phone}
+        How would you like to receive your confirmation passcode for %{phone}?
       choose_otp_delivery: >
         Please select how you would like to receive your one-time passcode for %{phone}
       otp_sms_disclaimer: Message and data rates may apply.
       please_confirm: >
-        Your phone number has been set. Please confirm it by entering the
+        Your phone number has been set. Confirm it by entering the
         passcode below.
-      two_factor_setup: Add extra protection
+      two_factor_setup: Add a phone number
       totp_info: >
-        Use any authenticator app (such as Google Authenticator) to scan the QR
-        code below.
+        Use any authenticator app to scan the QR code below.
       totp_fallback:
         text: >
-          If you don’t have access to your authenticator app you can choose to %{sms_link}
+          If you can't use your authenticator app right now you can %{sms_link}
           or %{voice_link}.
         sms_link_text: receive a code via text message
         voice_link_text: with a phone call
       user:
-        new_otp_sent: A new one-time passcode has been sent.
+        new_otp_sent: We sent you a new one-time passcode.
       buttons:
         confirm_with_sms: Confirm with text message
         confirm_with_voice: Confirm with voice call

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -6,4 +6,4 @@ en:
     email_changed: Email changed
     authenticator_enabled: Authenticator app enabled
     authenticator_disabled: Authenticator app disabled
-    authenticated_at: Authenticated at %{service_provider}
+    authenticated_at: Signed in at %{service_provider}

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -30,10 +30,10 @@ en:
     totp_setup:
       code: One-time passcode
       totp_info: >
-        To enable two-factor authentication, use the QR code provided here to
-        link your account to your authentication app.
+        To enable two-factor authentication, use the QR code provided to
+        link this account to your authentication app.
       totp_intro: >
-        To receive a one-time passode,  you may choose to use a two-factor
+        To receive a one-time passode, you may choose to use a two-factor
         authentication application to log into to your account. If so, you’ll
         need to link your login.gov account to the application you choose. Each
         time you sign in you’ll need to open the application and retrieve a code.

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -17,13 +17,13 @@ en:
       forgot: Forget your password? #why is this here and not in links/en.yml?
       confirm: Confirm your password to continue
     privacy_policy:
-      privacy_act: Privacy Act Statement
-      security_practices: Our Security Practices #should this be in sentence case?
-      privacy_practices: Our Privacy Practices #should this be in sentence case?
+      privacy_act: Privacy Act statement
+      security_practices: Our security practices 
+      privacy_practices: Our privacy practices 
       authorities: Authorities
       purpose: Purpose
       disclosure: Disclosure
-      routine_uses: Routine Uses #should this be in sentence case?
+      routine_uses: Routine uses
       more_information: For more information
     profile:
       profile_info: Profile information

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -10,7 +10,7 @@ en:
       password: Change your password
       phone: Change your phone number
     log_in: Sign in
-    log_in_branded: Sign in to continue to %{sp} #question about variable names -- "_branded" vs _"w_with_SP"?
+    sign_in_branded: Sign in to continue to %{sp} #question about variable names -- "_branded" vs _"w_with_SP"?
     choose_otp_delivery: Choose how you'd like to receive a one-time passcode
     passwords:
       change: Change your password

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -1,39 +1,39 @@
 en:
   headings:
     confirmations:
-      new: Resend confirmation instructions
+      new: Send another confirmation email
     contact: Contact us
-    create_account_with_sp: Make a login.gov account to continue to %{sp}
-    create_account_without_sp: Make a login.gov account
+    create_account_with_sp: Create a login.gov account to continue to %{sp}
+    create_account_without_sp: Create a login.gov account
     edit_info:
-      email: Edit your email
-      password: Edit your password
-      phone: Edit your phone number
+      email: Change your email
+      password: Change your password
+      phone: Change your phone number
     log_in: Sign in
-    log_in_branded: Sign in to continue to %{sp}
-    choose_otp_delivery: Choose delivery method
+    log_in_branded: Sign in to continue to %{sp} #question about variable names -- "_branded" vs _"w_with_SP"?
+    choose_otp_delivery: Choose how you'd like to receive a one-time passcode
     passwords:
       change: Change your password
-      forgot: Forgot password
-      confirm: Confirm your password
+      forgot: Forget your password? #why is this here and not in links/en.yml?
+      confirm: Confirm your password to continue
     privacy_policy:
       privacy_act: Privacy Act Statement
-      security_practices: Our Security Practices
-      privacy_practices: Our Privacy Practices
+      security_practices: Our Security Practices #should this be in sentence case?
+      privacy_practices: Our Privacy Practices #should this be in sentence case?
       authorities: Authorities
       purpose: Purpose
       disclosure: Disclosure
-      routine_uses: Routine Uses
+      routine_uses: Routine Uses #should this be in sentence case?
       more_information: For more information
     profile:
       profile_info: Profile information
       profile_info_tt: Why can’t I edit my profile information?
       account_history: Account history
-      login_info: Login information
+      login_info: Account information
       two_factor: Two-factor authentication
-    recovery_code: Make sure you can always log in, even without your phone
+    recovery_code: Make sure you can always sign in
     registrations:
-      enter_email: Start making your account
+      enter_email: Start creating an account
       verify_email: Check your email
     search: Search for a user
     session_timeout_warning: Session timeout

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -1,8 +1,8 @@
 en:
   instructions:
     recovery_code: >
-      You can still log in using a special recovery code if you can’t get to
-      your phone.
+      Write this recovery code down and store it someplace safe. If you can't get to your phone,
+      you can use it instead of a one-time passcode to sign in.
     password:
       info:
         lead: Your password must be at least %{min_length} characters long.
@@ -21,13 +21,13 @@ en:
         iv: Good
         v: Great!
     registration:
-      already_have_account: Already have account? %{link}
+      already_have_account: Already have an account? %{link}
       email: Pick an address to use for government communications.
     2fa:
       resend: Didn’t receive a code? %{link}
-      confirm_code: We sent the code to %{number}.
+      confirm_code: We sent it to %{number}.
       wrong_number: Entered the wrong phone number? %{link}
       totp_intro_html: >
-        Please enter the code from your authenticator app.
+        Enter the code from your authenticator app.
         If you have several accounts set up in your app, enter the code
         corresponding to <strong>%{email}</strong> at <strong>%{app}</strong>.

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -3,7 +3,7 @@ en:
     password_changed: You changed your password.
     totp_configured: You enabled an authentication app.
     totp_disabled: You disabled your authentication app.
-    log_in_consent:
+    sign_in_consent:
       text: By signing in, you agree to %{app}’s %{link}
       link: Security Consent & Privacy Act Statement.
     phone_confirmation_successful: You confirmed your phone number. Now your account is more secure!

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -74,6 +74,6 @@ feature 'Visit requests confirmation instructions again during sign up' do
   end
 
   scenario 'confirmations new page has localized heading' do
-    expect(page).to have_title t('headings.confirmations.new')
+    expect(page).to have_content t('headings.confirmations.new')
   end
 end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -33,7 +33,7 @@ describe 'devise/sessions/new.html.slim' do
     render
 
     expect(rendered).
-      to have_link(t('notices.log_in_consent.link'), href: privacy_path)
+      to have_link(t('notices.sign_in_consent.link'), href: privacy_path)
   end
 
   context 'when @sp_name is set' do
@@ -46,7 +46,7 @@ describe 'devise/sessions/new.html.slim' do
       render
 
       expect(rendered).to have_content(
-        t('headings.log_in_branded', sp: 'Awesome Application!')
+        t('headings.sign_in_branded', sp: 'Awesome Application!')
       )
     end
 
@@ -68,7 +68,7 @@ describe 'devise/sessions/new.html.slim' do
       render
 
       expect(rendered).not_to have_content(
-        t('headings.log_in_branded', sp: 'Awesome Application!')
+        t('headings.sign_in_branded', sp: 'Awesome Application!')
       )
       expect(rendered).not_to have_link(
         t('links.back_to_sp', sp: 'Awesome Application!')

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -8,7 +8,7 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
 
     render
 
-    expect(rendered).to have_content 'Please enter the code from your authenticator app'
+    expect(rendered).to have_content 'Enter the code from your authenticator app.'
     expect(rendered).to have_content "enter the code corresponding to #{user.email}"
   end
 


### PR DESCRIPTION
**Why**: To match our styleguide, to improve the clarity of instructions, and to make a better experience for people using screenreaders