### PR TITLE
Consolidate Saml Auth analytics

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -16,8 +16,7 @@ class SamlIdpController < ApplicationController
     link_identity_from_session_data
 
     needs_idv = identity_needs_verification?
-
-    analytics.track_event(Analytics::SAML_AUTH, idv: needs_idv)
+    analytics.track_event(Analytics::SAML_AUTH, @result.merge(idv: needs_idv))
 
     return redirect_to idv_url if needs_idv
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -55,8 +55,7 @@ class Analytics
   PASSWORD_RESET_TOKEN_EXPIRED = 'Reset password: token expired'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PHONE_CHANGE_SUCCESSFUL = 'Phone Number Change: successful'.freeze
-  SAML_AUTH = 'SAML: auth'.freeze
-  SAML_INVALID_SERVICE_PROVIDER = 'SAML: invalid service provider'.freeze
+  SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SETUP_2FA_INVALID_PHONE = '2FA setup: invalid phone number'.freeze
   SETUP_2FA_VALID_PHONE = '2FA setup: valid phone number'.freeze

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -1,0 +1,41 @@
+class SamlRequestValidator
+  include ActiveModel::Model
+
+  validate :authorized_service_provider
+  validate :authorized_authn_context
+
+  def call(service_provider:, authn_context:)
+    self.service_provider = service_provider
+    self.authn_context = authn_context
+
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_accessor :service_provider, :authn_context
+  attr_reader :success
+
+  def result
+    {
+      authn_context: authn_context,
+      errors: errors.messages.values.flatten,
+      service_provider: service_provider.issuer,
+      valid: success
+    }
+  end
+
+  def authorized_service_provider
+    return if service_provider.valid?
+
+    errors.add(:service_provider, 'Unauthorized Service Provider')
+  end
+
+  def authorized_authn_context
+    return if Saml::Idp::Constants::VALID_AUTHN_CONTEXTS.include?(authn_context)
+
+    errors.add(:authn_context, 'Unauthorized authentication context')
+  end
+end

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -6,4 +6,12 @@ class FakeSamlRequest
   def identifier
     'http://localhost:3000'
   end
+
+  def requested_authn_context
+    Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+  end
+
+  def valid?
+    true
+  end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -82,6 +82,13 @@ module SamlAuthHelper
     settings
   end
 
+  def invalid_service_provider_and_authn_context_settings
+    settings = saml_settings.dup
+    settings.authn_context = 'http://idmanagement.gov/ns/assurance/loa/5'
+    settings.issuer = 'invalid_provider'
+    settings
+  end
+
   def sp1_saml_settings
     settings = saml_settings.dup
     settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'


### PR DESCRIPTION
**Why**: To capture all attributes of a Saml Auth event in one place.

**How**:
- Use a separate class to validate the Service Provider and AuthnContext
- Store the attributes in a result hash, just like we do with other form
objects