### PR TITLE
Update email visual design

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -23,10 +23,8 @@
 }
 
 h4 {
-  border-bottom: 6px solid $red;
   font-weight: bold;
-  margin-bottom: 30px;
-  padding-bottom: 10px;
+  margin-bottom: 16px;
 }
 
 .button.large.expanded table a { padding: 20px 0; }

--- a/app/assets/stylesheets/variables/_email.scss
+++ b/app/assets/stylesheets/variables/_email.scss
@@ -53,7 +53,7 @@ $block-grid-gutter: $global-gutter;
 // 4. Typography
 // -------------
 
-$global-font-color: $black;
+$global-font-color: $gray;
 $body-font-family: Arial, Helvetica, sans-serif;
 $global-font-weight: normal;
 $header-color: inherit;
@@ -81,7 +81,7 @@ $subheader-font-weight: $global-font-weight;
 $subheader-margin-top: 4px;
 $subheader-margin-bottom: 8px;
 $hr-width: $global-width;
-$hr-border: 6px solid $red;
+$hr-border: 2px solid $blue-light;
 $hr-margin: 10px auto;
 $anchor-text-decoration: none;
 $anchor-color: $primary-color;

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -21,7 +21,11 @@ p = link_to confirmation_url(@resource, confirmation_token: @token), \
 table.spacer
   tbody
     tr
-      td.s30 height="30px"
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
       | &nbsp;
 
 p= t('mailer.confirmation_instructions.footer', confirmation_period: @confirmation_period)

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -23,7 +23,11 @@ p
 table.spacer
   tbody
     tr
-      td.s30 height="30px"
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
       | &nbsp;
 
 p= t('mailer.reset_password.footer', expires: Devise.reset_password_within / 3600)

--- a/app/views/layouts/user_mailer.html.slim
+++ b/app/views/layouts/user_mailer.html.slim
@@ -53,10 +53,11 @@ html xmlns="http://www.w3.org/1999/xhtml"
                                     h4
                                       = message.subject
                                     == yield
-                                    table.hr
-                                      tr
-                                        th
-                                          | &nbsp;
+                                    table.spacer
+                                      tbody
+                                        tr
+                                          td.s30 height="30px"
+                                            | &nbsp;
                                     p
                                       i = t('mailer.no_reply')
                                     table.spacer

--- a/app/views/user_mailer/email_changed.html.slim
+++ b/app/views/user_mailer/email_changed.html.slim
@@ -1,4 +1,13 @@
 p.lead = t('.intro', app: APP_NAME)
 
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;
 
 p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -1,4 +1,13 @@
 p.lead = t('.intro', app: APP_NAME)
 
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;
 
 p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))

--- a/app/views/user_mailer/signup_with_your_email.html.slim
+++ b/app/views/user_mailer/signup_with_your_email.html.slim
@@ -20,9 +20,13 @@ p= link_to @root_url, @root_url, target: '_blank'
 table.spacer
   tbody
     tr
-      td.s30 height="30px"
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
       | &nbsp;
 
-p = t('.reset_password')
+p = t('.reset_password', app: APP_NAME)
 
 p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))


### PR DESCRIPTION
**Why**: As per latest designs - removed/replaced red horizontal rules with light blue version, changed font color, added missing translation string var.

![image 2016-11-10 at 9 57 37 am](https://cloud.githubusercontent.com/assets/1178494/20181483/5ed65866-a72c-11e6-97e6-1f8f186a5d60.png)
