### PR TITLE
Underline links by default

### DIFF
--- a/app/assets/stylesheets/variables/_web.scss
+++ b/app/assets/stylesheets/variables/_web.scss
@@ -58,6 +58,10 @@ $button-padding-x: 1.5rem !default;
 $button-color: $white !default;
 $button-background-color: $blue !default;
 
+$link-color: $blue !default;
+$link-text-decoration: underline !default;
+$link-hover-text-decoration: underline !default;
+
 $darken-1: rgba(0, 0, 0, .0625) !default;
 $darken-2: rgba(0, 0, 0, .125) !default;
 $darken-3: rgba(0, 0, 0, .25) !default;

--- a/app/views/devise/sessions/_return_to_service_provider.html.slim
+++ b/app/views/devise/sessions/_return_to_service_provider.html.slim
@@ -1,4 +1,4 @@
 .sm-col.py1.sm-p0
   = link_to t('links.back_to_sp', sp: @sp_name),
     @sp_return_url,
-    class: 'inline-block truncate align-bottom underline sm-maxw-190p'
+    class: 'inline-block truncate align-bottom sm-maxw-190p'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -16,6 +16,6 @@ p.my3 == t('notices.log_in_consent.text', app: APP_NAME, link: link)
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial
   .sm-col-right
-    = link_to t('headings.passwords.forgot'), new_password_path(resource_name), class: 'underline'
+    = link_to t('headings.passwords.forgot'), new_password_path(resource_name)
     span.px1.silver = '|'
-    = link_to t('links.create_account'), new_user_start_path, class: 'underline'
+    = link_to t('links.create_account'), new_user_start_path

--- a/app/views/idv/activated.html.slim
+++ b/app/views/idv/activated.html.slim
@@ -3,4 +3,4 @@
 h1.h3.my0 = t('idv.titles.activated')
 - activated_link = link_to(t('idv.messages.activated_link'), Figaro.env.support_url)
 p.mt-tiny.mb0 = t('idv.messages.activated', link: activated_link).html_safe
-= link_to 'Back', idv_url, class: 'underline'
+= link_to 'Back', idv_url

--- a/app/views/idv/cancel.html.slim
+++ b/app/views/idv/cancel.html.slim
@@ -2,4 +2,4 @@
 
 h1.h3.my0 = t('idv.titles.cancel')
 p.mt-tiny.mb0 = t('idv.messages.cancel', app: APP_NAME)
-= link_to t('forms.buttons.back'), idv_url, class: 'underline'
+= link_to t('forms.buttons.back'), idv_url

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -16,6 +16,6 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
   = f.input :finance_account, required: true,
     label: @finance_account_label, label_html: { class: 'js-finance-label' }
   = f.button :submit, t('idv.messages.finance.continue'), class: 'btn btn-primary btn-wide'
-  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path, class: 'underline'
+  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/index.html.slim
+++ b/app/views/idv/index.html.slim
@@ -33,4 +33,4 @@ h1.h3.my0 = t('idv.titles.expectations')
 p.mb3 = t('idv.index.paragraph_1')
 p.mb3.bold = t('idv.index.prompt')
 = link_to t('idv.index.continue_link'), idv_session_path, class: 'btn btn-primary btn-wide'
-.mt1 = link_to t('idv.index.cancel_link'), idv_cancel_path, class: 'underline'
+.mt1 = link_to t('idv.index.cancel_link'), idv_cancel_path

--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -18,6 +18,6 @@ p = t('idv.messages.phone.same_as_2fa')
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.input :phone, required: true
   = f.button :submit, t('forms.buttons.submit.continue'), class: 'btn btn-primary btn-wide'
-  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path, class: 'underline'
+  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/review/new.html.slim
+++ b/app/views/idv/review/new.html.slim
@@ -35,6 +35,6 @@ p.mt-tiny.mb0 = t('idv.messages.review.intro')
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.input :password, label: t('idv.form.password'), required: true
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn btn-primary btn-wide'
-  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path, class: 'underline'
+  .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -41,6 +41,6 @@ h1.h3.my0 = t('idv.titles.session.basic')
       tabindex: 0, 'aria-label': t('tooltips.placeholder'))
   .mt5
     button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.submit.continue')
-    .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path, class: 'underline'
+    .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -3,4 +3,5 @@ footer.footer.bg-navy.white
     .clearfix
       .sm-col = t('shared.footer_lite.gsa')
       .sm-col-right
-        = link_to t('links.privacy_policy'), privacy_path, class: 'caps white'
+        = link_to t('links.privacy_policy'), privacy_path,
+          class: 'caps white text-decoration-none'

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -18,6 +18,6 @@ nav.bg-white
         .mt-12p.h6
           - if user_fully_authenticated?
             = link_to t('shared.nav_auth.my_account'), profile_path,
-              class: current_page?(profile_path) ? 'bold gray' : 'underline'
+              class: current_page?(profile_path) ? 'bold gray text-decoration-none' : ''
             span.px1.silver = '|'
-          = link_to t('links.sign_out'), destroy_user_session_path, class: 'underline'
+          = link_to t('links.sign_out'), destroy_user_session_path

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -10,4 +10,4 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
       class: 'block bold'
     = block_text_field_tag :code, '', required: true
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
-.mt1 = link_to t('forms.buttons.cancel'), user_two_factor_authentication_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), user_two_factor_authentication_path

--- a/app/views/users/edit_email/edit.html.slim
+++ b/app/views/users/edit_email/edit.html.slim
@@ -7,4 +7,4 @@ h1.h3.my0 = t('headings.edit_info.email')
   = f.error_notification
   = f.input :email, required: true
   = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
-.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/users/edit_password/edit.html.slim
+++ b/app/views/users/edit_password/edit.html.slim
@@ -11,6 +11,6 @@ p.mt-tiny.mb0#password-description
             input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'
   = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
-.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path
 
 == javascript_include_tag 'misc/pw-strength'

--- a/app/views/users/edit_phone/edit.html.slim
+++ b/app/views/users/edit_phone/edit.html.slim
@@ -7,4 +7,4 @@ h1.h3.my0 = t('headings.edit_info.phone')
   = f.error_notification
   = f.input :phone, as: :tel, required: true
   = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
-.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -8,6 +8,6 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')
-  - link = link_to t('notices.terms_of_service.link'), privacy_path, class: 'underline'
+  - link = link_to t('notices.terms_of_service.link'), privacy_path
   p.mb-40p == t('notices.terms_of_service.text', link: link)
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'

--- a/app/views/users/registrations/start.html.slim
+++ b/app/views/users/registrations/start.html.slim
@@ -20,5 +20,5 @@ h1.h3.my0 = decorated_session.registration_heading
   - ab_test(:demo) do |variant, _|
     = link_to t(variant), new_user_registration_path, class: 'btn btn-primary btn-wide mb4'
 .clearfix.pt1.border-top
-  - auth_link = link_to(t('links.sign_in'), new_user_session_path, class: 'underline')
+  - auth_link = link_to t('links.sign_in'), new_user_session_path
   .sm-col-right == t('instructions.registration.already_have_account', link: auth_link)

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -11,4 +11,4 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
     = text_field_tag :code, '', required: true, pattern: '[0-9]*',
       class: 'block col-12 field monospace mfa'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
-.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/users/totp_setup/start.html.slim
+++ b/app/views/users/totp_setup/start.html.slim
@@ -7,4 +7,4 @@ p.mt-tiny.mb3 = t('forms.totp_setup.totp_intro')
 .mt3.sm-mt4.mb1
   = link_to t('forms.buttons.setup_totp'), authenticator_setup_url, \
     class: 'btn btn-primary'
-.mt1 = link_to t('forms.buttons.cancel'), profile_path, class: 'underline'
+.mt1 = link_to t('forms.buttons.cancel'), profile_path


### PR DESCRIPTION
**Why**: better for accessibility

**How**: by default, links are now underlined and
can be overridden with `text-decoration-none` class