### PR TITLE
I18n zxcvbn javascript library

### DIFF
--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -9,6 +9,33 @@ window.LoginGov = window.LoginGov || {};
   'instructions.password.strength.iv',
   'instructions.password.strength.v',
   'valid_email.validations.email.invalid',
+  'zxcvbn.feedback.Use a few words, avoid common phrases',
+  'zxcvbn.feedback.No need for symbols, digits, or uppercase letters',
+  'zxcvbn.feedback.Add another word or two_ Uncommon words are better_',
+  'zxcvbn.feedback.Straight rows of keys are easy to guess',
+  'zxcvbn.feedback.Short keyboard patterns are easy to guess',
+  'zxcvbn.feedback.Use a longer keyboard pattern with more turns',
+  'zxcvbn.feedback.Repeats like "aaa" are easy to guess',
+  'zxcvbn.feedback.Repeats like "abcabcabc" are only slightly harder to guess than "abc"',
+  'zxcvbn.feedback.Avoid repeated words and characters',
+  'zxcvbn.feedback.Sequences like abc or 6543 are easy to guess',
+  'zxcvbn.feedback.Avoid sequences',
+  'zxcvbn.feedback.Recent years are easy to guess',
+  'zxcvbn.feedback.Avoid recent years',
+  'zxcvbn.feedback.Avoid years that are associated with you',
+  'zxcvbn.feedback.Dates are often easy to guess',
+  'zxcvbn.feedback.Avoid dates and years that are associated with you',
+  'zxcvbn.feedback.This is a top-10 common password',
+  'zxcvbn.feedback.This is a top-100 common password',
+  'zxcvbn.feedback.This is a very common password',
+  'zxcvbn.feedback.This is similar to a commonly used password',
+  'zxcvbn.feedback.A word by itself is easy to guess',
+  'zxcvbn.feedback.Names and surnames by themselves are easy to guess',
+  'zxcvbn.feedback.Common names and surnames are easy to guess',
+  'zxcvbn.feedback.Capitalization doesn\'t help very much',
+  'zxcvbn.feedback.All-uppercase is almost as easy to guess as all-lowercase',
+  'zxcvbn.feedback.Reversed words aren\'t much harder to guess',
+  'zxcvbn.feedback.Predictable substitutions like \'@\' instead of \'a\' don\'t help very much'
 ] %>
 
 window.LoginGov.I18n = {
@@ -17,5 +44,5 @@ window.LoginGov.I18n = {
 };
 
 <% keys.each do |key| %>
-  window.LoginGov.I18n.strings['<%= key %>'] = '<%= I18n.t(key) %>';
+window.LoginGov.I18n.strings['<%= ActionController::Base.helpers.j key %>'] = '<%= ActionController::Base.helpers.j I18n.t(key) %>';
 <% end %>

--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -27,9 +27,15 @@ function getFeedback(z) {
   if (!z || z.score > 2) return '';
 
   const { warning, suggestions } = z.feedback;
-  if (!warning && !suggestions.length) return '';
+  function lookup(str) {
+    const strFormatted = str.replace(/\./g, '_');
+    return I18n.t(`zxcvbn.feedback.${strFormatted}`);
+  }
 
-  return warning || `${suggestions.map(function(s) { return s; }).join('; ')}`;
+  if (!warning && !suggestions.length) return '';
+  if (warning) return lookup(warning);
+
+  return `${suggestions.map(function(s) { return lookup(s); }).join('; ')}`;
 }
 
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -82,18 +82,20 @@ search:
 #   api_key: "AbC-dEf5"
 
 ## Do not consider these keys missing:
-# ignore_missing:
+ignore_missing:
+  - 'zxcvbn.*'
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 
 ## Consider these keys used:
 ignore_unused:
-- 'activerecord.errors.*'
-- 'errors.messages.*'
-- '{devise,simple_form}.*'
-- 'errors.not_authorized'
-- 'experiments.*'
-- 'event_types.*'
+  - 'activerecord.errors.*'
+  - 'errors.messages.*'
+  - '{devise,simple_form}.*'
+  - 'errors.not_authorized'
+  - 'experiments.*'
+  - 'event_types.*'
+  - 'zxcvbn.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/locales/zxcvbn/en.yml
+++ b/config/locales/zxcvbn/en.yml
@@ -1,0 +1,38 @@
+en:
+  zxcvbn:
+    feedback:
+      "Use a few words, avoid common phrases": Use a few words, avoid common phrases
+      "No need for symbols, digits, or uppercase letters": >-
+        No need for symbols, digits, or uppercase letters
+      "Add another word or two_ Uncommon words are better_": >-
+        Add another word or two. Uncommon words are better.
+      "Straight rows of keys are easy to guess": Straight rows of keys are easy to guess
+      "Short keyboard patterns are easy to guess": Short keyboard patterns are easy to guess
+      "Use a longer keyboard pattern with more turns": >-
+        Use a longer keyboard pattern with more turns
+      "Repeats like \"aaa\" are easy to guess": Repeats like "aaa" are easy to guess
+      "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\"": >-
+        Repeats like "abcabcabc" are only slightly harder to guess than "abc"
+      "Avoid repeated words and characters": Avoid repeated words and characters
+      "Sequences like abc or 6543 are easy to guess": Sequences like abc or 6543 are easy to guess
+      "Avoid sequences": Avoid sequences
+      "Recent years are easy to guess": Recent years are easy to guess
+      "Avoid recent years": Avoid recent years
+      "Avoid years that are associated with you": Avoid years that are associated with you
+      "Dates are often easy to guess": Dates are often easy to guess
+      "Avoid dates and years that are associated with you": >-
+        Avoid dates and years that are associated with you
+      "This is a top-10 common password": This is a top-10 common password
+      "This is a top-100 common password": This is a top-100 common password
+      "This is a very common password": This is a very common password
+      "This is similar to a commonly used password": This is similar to a commonly used password
+      "A word by itself is easy to guess": A word by itself is easy to guess
+      "Names and surnames by themselves are easy to guess": >-
+        Names and surnames by themselves are easy to guess
+      "Common names and surnames are easy to guess": Common names and surnames are easy to guess
+      "Capitalization doesn't help very much": Capitalization doesn't help very much
+      "All-uppercase is almost as easy to guess as all-lowercase": >-
+        All-uppercase is almost as easy to guess as all-lowercase
+      "Reversed words aren't much harder to guess": Reversed words aren't much harder to guess
+      "Predictable substitutions like '@' instead of 'a' don't help very much":
+        Predictable substitutions like '@' instead of 'a' don't help very much


### PR DESCRIPTION
**Why**: To allow for custom translation of the zxcvbn library

~~This removes the zxcvbn library from npm and replaces it with our own local copy.  Local copy has been adapted to use translation strings (feedback.coffee is the specific file that has changed).~~

~~Still to do in a follow up PR... we are currently including the zxcvbn-js gem, which is basically another copy of this same javascript file that is used for server side validation.  I'd like to look into pointing that gem at our customized version of the javascript file so we can get rid of the duplication and have consistency between the client side and server side validation.~~

This intercepts the feedback from the client size zxcvbn and associates it with a corresponding i18n string.  If a corresponding string is not found, it will fall back to using the string hardcoded into the script.

**Next steps**:  I was running into some issues recreating this same logic on the server side of things, so will try and accomplish that in followup PR, may need some assistance though.  I think the best way forward would be to override the path to the javascript file used by the zxcvbn-js gem to point the the npm version to ensure that the front and backend are always in sync.  Then use a similar method of intercepting the feedback server side.