### PR TITLE
Consolidate Password Reset analytics

### DIFF
--- a/.reek
+++ b/.reek
@@ -9,12 +9,14 @@ FeatureEnvy:
     - append_info_to_payload
     - generate_slo_request
     - reauthn?
+    - mark_profile_inactive
 IrresponsibleModule:
   enabled: false
 NilCheck:
   exclude:
     - AdminConstraint#user_is_admin?
     - PasswordsController#edit
+    - PasswordResetTokenValidator#result
     - PhoneConfirmationFlow
     - slo_not_implemented_at_sp?
     - in_slo?

--- a/.reek
+++ b/.reek
@@ -16,6 +16,7 @@ NilCheck:
   exclude:
     - AdminConstraint#user_is_admin?
     - PasswordsController#edit
+    - PasswordsController#mark_profile_inactive
     - PasswordResetTokenValidator#result
     - PhoneConfirmationFlow
     - slo_not_implemented_at_sp?

--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -35,7 +35,7 @@ function getFeedback(z) {
 
 function analyzePw() {
   const input = document.querySelector(
-    '#password_form_password, #update_user_password_form_password'
+    '#password_form_password, #reset_password_form_password, #update_user_password_form_password'
   );
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -2,11 +2,8 @@ class PasswordForm
   include ActiveModel::Model
   include FormPasswordValidator
 
-  attr_accessor :reset_password_token
-
   def initialize(user)
     @user = user
-    self.reset_password_token = @user.reset_password_token
   end
 
   def submit(params)
@@ -14,19 +11,10 @@ class PasswordForm
 
     self.password = submitted_password
 
-    if valid? && user_valid?
+    if valid?
       user.password = submitted_password
     else
       false
     end
-  end
-
-  private
-
-  # This is needed because @user.valid? only checks for validation errors,
-  # but in this case the error would be with the reset_password_token,
-  # which is added by Devise via errors.add
-  def user_valid?
-    user.errors.empty?
   end
 end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -35,7 +35,8 @@ class ResetPasswordForm
     {
       success: success,
       errors: errors.messages.values.flatten,
-      user_id: user.uuid
+      user_id: user.uuid,
+      active_profile: user.active_profile.present?
     }
   end
 end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -1,0 +1,41 @@
+class ResetPasswordForm
+  include ActiveModel::Model
+  include FormPasswordValidator
+
+  attr_accessor :reset_password_token
+
+  validate :valid_token
+
+  def initialize(user)
+    @user = user
+    self.reset_password_token = @user.reset_password_token
+  end
+
+  def submit(params)
+    submitted_password = params[:password]
+
+    self.password = submitted_password
+
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_reader :success
+
+  def valid_token
+    return if user.reset_password_period_valid?
+
+    errors.add(:reset_password_token, 'token_expired')
+  end
+
+  def result
+    {
+      success: success,
+      errors: errors.messages.values.flatten,
+      user_id: user.uuid
+    }
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -48,11 +48,9 @@ class Analytics
   PASSWORD_CREATE_INVALID = 'Password Create: invalid password'.freeze
   PASSWORD_CREATE_USER_CONFIRMED = 'Password Create: created and user confirmed'.freeze
   PASSWORD_RESET_DEACTIVATED_ACCOUNT = 'Password Reset: deactivated verified profile via password reset'.freeze
-  PASSWORD_RESET_INVALID_PASSWORD = 'Password Reset: invalid password'.freeze
-  PASSWORD_RESET_INVALID_TOKEN = 'Password Reset: invalid token'.freeze
-  PASSWORD_RESET_REQUEST = 'Password Reset: request'.freeze
-  PASSWORD_RESET_SUCCESSFUL = ''.freeze
-  PASSWORD_RESET_TOKEN_EXPIRED = 'Reset password: token expired'.freeze
+  PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
+  PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
+  PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PHONE_CHANGE_SUCCESSFUL = 'Phone Number Change: successful'.freeze
   SAML_AUTH = 'SAML Auth'.freeze

--- a/app/services/password_reset_token_validator.rb
+++ b/app/services/password_reset_token_validator.rb
@@ -1,0 +1,33 @@
+class PasswordResetTokenValidator
+  include ActiveModel::Model
+
+  validates :user, presence: { message: 'invalid_token' }
+  validate :valid_token, if: :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def submit
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_accessor :user
+  attr_reader :success
+
+  def result
+    {
+      success: success,
+      error: errors.messages.values.flatten.first,
+      user_id: user&.uuid
+    }
+  end
+
+  def valid_token
+    errors.add(:user, 'token_expired') unless user.reset_password_period_valid?
+  end
+end

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -2,7 +2,7 @@
 
 
 h1.h3.my0 = t('headings.passwords.change')
-= simple_form_for(@password_form,
+= simple_form_for(@reset_password_form,
     url: user_password_path,
     html: { autocomplete: 'off',
     method: :put,

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -9,8 +9,14 @@ describe Users::PasswordsController, devise: true do
 
         get :edit, reset_password_token: 'foo'
 
+        analytics_hash = {
+          success: false,
+          error: 'invalid_token',
+          user_id: nil
+        }
+
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_INVALID_TOKEN, token: 'foo')
+          with(Analytics::PASSWORD_RESET_TOKEN, analytics_hash)
 
         expect(response).to redirect_to new_user_password_path
         expect(flash[:error]).to eq t('devise.passwords.invalid_token')
@@ -28,8 +34,14 @@ describe Users::PasswordsController, devise: true do
 
         get :edit, reset_password_token: 'foo'
 
+        analytics_hash = {
+          success: false,
+          error: 'token_expired',
+          user_id: '123'
+        }
+
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_TOKEN_EXPIRED, user_id: user.uuid)
+          with(Analytics::PASSWORD_RESET_TOKEN, analytics_hash)
 
         expect(response).to redirect_to new_user_password_path
         expect(flash[:error]).to eq t('devise.passwords.token_expired')
@@ -40,7 +52,7 @@ describe Users::PasswordsController, devise: true do
       it 'displays the form to enter a new password' do
         stub_analytics
 
-        user = instance_double('User', email: 'test@test1.com')
+        user = instance_double('User', uuid: '123')
         allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
@@ -58,17 +70,28 @@ describe Users::PasswordsController, devise: true do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        params = { password: 'password', reset_password_token: 'foo' }
+        user = create(
+          :user,
+          :signed_up,
+          reset_password_sent_at: Time.current - Devise.reset_password_within - 1.hour
+        )
 
-        user = instance_double('User', uuid: '123', email: 'test1@test.com')
-        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
-        allow(user).to receive(:reset_password_token).and_return('foo')
-        allow(user).to receive(:errors).and_return(reset_password_token: 'token expired')
+        raw_reset_token, db_confirmation_token =
+          Devise.token_generator.generate(User, :reset_password_token)
+        user.update(reset_password_token: db_confirmation_token)
 
-        put :update, password_form: params
+        params = { password: 'short', reset_password_token: raw_reset_token }
+
+        put :update, reset_password_form: params
+
+        analytics_hash = {
+          success: false,
+          errors: ['is too short (minimum is 8 characters)', 'token_expired'],
+          user_id: user.uuid
+        }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_TOKEN_EXPIRED, user_id: user.uuid)
+          with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
         expect(response).to redirect_to new_user_password_path
         expect(flash[:error]).to eq t('devise.passwords.token_expired')
@@ -82,15 +105,20 @@ describe Users::PasswordsController, devise: true do
 
         params = { password: 'pass', reset_password_token: 'foo' }
 
-        user = instance_double('User', uuid: '123')
-        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
-        allow(user).to receive(:reset_password_token).and_return('foo')
-        allow(user).to receive(:errors).and_return({})
+        user = User.new(uuid: '123')
+        allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
-        put :update, password_form: params
+        put :update, reset_password_form: params
+
+        analytics_hash = {
+          success: false,
+          errors: ['is too short (minimum is 8 characters)'],
+          user_id: '123'
+        }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_INVALID_PASSWORD, user_id: user.uuid)
+          with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
         expect(response).to render_template(:edit)
       end
@@ -105,16 +133,23 @@ describe Users::PasswordsController, devise: true do
         token = 'foo'
         params = { password: password, reset_password_token: token }
 
-        user = User.new(reset_password_token: token)
-        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
+        user = User.new(uuid: '123')
+        allow(User).to receive(:with_reset_password_token).with(token).and_return(user)
         allow(user).to receive(:active_profile).and_return(nil)
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
         stub_email_notifier(user)
 
-        put :update, password_form: params
+        put :update, reset_password_form: params
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: user.uuid
+        }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_SUCCESSFUL, user_id: user.uuid)
+          with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
         expect(response).to redirect_to new_user_session_path
         expect(flash[:notice]).to eq t('devise.passwords.updated_not_active')
@@ -136,14 +171,19 @@ describe Users::PasswordsController, devise: true do
 
         stub_email_notifier(user)
 
-        allow(User).to receive(:reset_password_by_token).with(params).and_return(user)
+        allow(User).to receive(:with_reset_password_token).with(token).and_return(user)
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
-        put :update, password_form: params
+        put :update, reset_password_form: params
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: user.uuid
+        }
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_SUCCESSFUL, user_id: user.uuid)
-        expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_RESET_DEACTIVATED_ACCOUNT, user_id: user.uuid)
+          with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
         expect(user.active_profile.present?).to eq false
 
@@ -161,7 +201,7 @@ describe Users::PasswordsController, devise: true do
         allow(NonexistentUser).to receive(:new).and_return(nonexistent_user)
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_REQUEST,
+          with(Analytics::PASSWORD_RESET_EMAIL,
                user_id: nonexistent_user.uuid, role: nonexistent_user.role)
 
         put :create, user: { email: 'nonexistent@example.com' }
@@ -176,7 +216,7 @@ describe Users::PasswordsController, devise: true do
         allow(User).to receive(:find_by).with(email: 'tech@example.com').and_return(tech_user)
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_REQUEST, user_id: tech_user.uuid, role: 'tech')
+          with(Analytics::PASSWORD_RESET_EMAIL, user_id: tech_user.uuid, role: 'tech')
 
         put :create, user: { email: 'TECH@example.com' }
       end
@@ -190,7 +230,7 @@ describe Users::PasswordsController, devise: true do
         allow(User).to receive(:find_by).with(email: 'admin@example.com').and_return(admin)
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_REQUEST, user_id: admin.uuid, role: 'admin')
+          with(Analytics::PASSWORD_RESET_EMAIL, user_id: admin.uuid, role: 'admin')
 
         put :create, user: { email: 'ADMIN@example.com' }
       end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -87,7 +87,8 @@ describe Users::PasswordsController, devise: true do
         analytics_hash = {
           success: false,
           errors: ['is too short (minimum is 8 characters)', 'token_expired'],
-          user_id: user.uuid
+          user_id: user.uuid,
+          active_profile: false
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -114,7 +115,8 @@ describe Users::PasswordsController, devise: true do
         analytics_hash = {
           success: false,
           errors: ['is too short (minimum is 8 characters)'],
-          user_id: '123'
+          user_id: '123',
+          active_profile: false
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -145,7 +147,8 @@ describe Users::PasswordsController, devise: true do
         analytics_hash = {
           success: true,
           errors: [],
-          user_id: user.uuid
+          user_id: user.uuid,
+          active_profile: false
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -179,7 +182,8 @@ describe Users::PasswordsController, devise: true do
         analytics_hash = {
           success: true,
           errors: [],
-          user_id: user.uuid
+          user_id: user.uuid,
+          active_profile: true
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -255,6 +255,14 @@ feature 'Password Recovery' do
 
       expect(page).to have_content 'is too short (minimum is 8 characters)'
     end
+
+    it "does not update the user's password when password is invalid" do
+      fill_in 'New password', with: '1234'
+      click_button t('forms.passwords.edit.buttons.submit')
+
+      signin(@user.email, '1234')
+      expect(current_path).to eq new_user_session_path
+    end
   end
 
   scenario 'user takes too long to click the reset password link' do
@@ -276,30 +284,6 @@ feature 'Password Recovery' do
     expect(page).to have_content t('devise.passwords.token_expired')
 
     expect(current_path).to eq new_user_password_path
-  end
-
-  scenario 'user takes too long to reset password' do
-    user = create(:user, :signed_up)
-
-    visit new_user_password_path
-    fill_in 'Email', with: user.email
-    click_button t('forms.buttons.reset_password')
-
-    raw_reset_token, db_confirmation_token =
-      Devise.token_generator.generate(User, :reset_password_token)
-    user.update(reset_password_token: db_confirmation_token)
-
-    visit edit_user_password_path(reset_password_token: raw_reset_token)
-
-    Timecop.travel(Devise.reset_password_within + 1.minute)
-
-    fill_in 'New password', with: 'NewVal!dPassw0rd'
-    click_button t('forms.passwords.edit.buttons.submit')
-
-    expect(page).to have_content t('devise.passwords.token_expired')
-    expect(current_path).to eq new_user_password_path
-
-    Timecop.return
   end
 
   scenario 'unconfirmed user requests reset instructions', email: true do

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -5,29 +5,7 @@ describe PasswordForm, type: :model do
 
   it_behaves_like 'password validation'
 
-  it "is initialized with the user's reset_password_token" do
-    user = build_stubbed(:user, reset_password_token: 'foo')
-
-    form = PasswordForm.new(user)
-
-    expect(form.reset_password_token).to eq 'foo'
-  end
-
   describe '#submit' do
-    context 'when the form is valid but the user is not valid' do
-      it 'returns false' do
-        user = build_stubbed(:user)
-        user.errors.add(:reset_password_token, 'expired')
-
-        form = PasswordForm.new(user)
-
-        password = 'valid password'
-
-        expect(form.submit(password: password)).
-          to eq false
-      end
-    end
-
     context 'when the form is invalid' do
       it 'returns false' do
         user = build_stubbed(:user)
@@ -38,10 +16,12 @@ describe PasswordForm, type: :model do
 
         expect(form.submit(password: password)).
           to eq false
+
+        expect(user.password).to_not eq password
       end
     end
 
-    context 'when both the form and user are valid' do
+    context 'when the form is valid' do
       it 'sets the user password to the submitted password' do
         user = build_stubbed(:user)
 
@@ -66,9 +46,7 @@ describe PasswordForm, type: :model do
         passwords = [user.email, 'custom!@', 'benevolent', 'custom benevolent comcast', APP_NAME]
 
         passwords.each do |password|
-          expect(form.submit(password: password)).
-            to eq false
-
+          expect(form.submit(password: password)).to eq false
           expect(form.errors.full_messages.first).to match 'not strong enough'
         end
       end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -18,7 +18,8 @@ describe ResetPasswordForm, type: :model do
         result = {
           success: false,
           errors: ['token_expired'],
-          user_id: '123'
+          user_id: '123',
+          active_profile: false
         }
 
         expect(form.submit(password: password)).to eq result
@@ -37,7 +38,8 @@ describe ResetPasswordForm, type: :model do
         result = {
           success: false,
           errors: ['is too short (minimum is 8 characters)'],
-          user_id: '123'
+          user_id: '123',
+          active_profile: false
         }
 
         expect(form.submit(password: password)).to eq result
@@ -56,7 +58,8 @@ describe ResetPasswordForm, type: :model do
         result = {
           success: true,
           errors: [],
-          user_id: '123'
+          user_id: '123',
+          active_profile: false
         }
 
         expect(form.submit(password: password)).to eq result
@@ -75,7 +78,8 @@ describe ResetPasswordForm, type: :model do
         result = {
           success: false,
           errors: ['is too short (minimum is 8 characters)', 'token_expired'],
-          user_id: '123'
+          user_id: '123',
+          active_profile: false
         }
 
         expect(form.submit(password: password)).to eq result
@@ -100,7 +104,8 @@ describe ResetPasswordForm, type: :model do
               'Your password is not strong enough. Add another word or two. ' \
               'Uncommon words are better.'
             ],
-            user_id: nil
+            user_id: nil,
+            active_profile: false
           }
 
           expect(form.submit(password: password)).

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+describe ResetPasswordForm, type: :model do
+  subject { ResetPasswordForm.new(build_stubbed(:user, uuid: '123')) }
+
+  it_behaves_like 'password validation'
+
+  describe '#submit' do
+    context 'when the password is valid but the token has expired' do
+      it 'returns a hash with errors' do
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(false)
+
+        form = ResetPasswordForm.new(user)
+
+        password = 'valid password'
+
+        result = {
+          success: false,
+          errors: ['token_expired'],
+          user_id: '123'
+        }
+
+        expect(form.submit(password: password)).to eq result
+      end
+    end
+
+    context 'when the password is invalid and token is valid' do
+      it 'returns a hash with errors' do
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
+
+        form = ResetPasswordForm.new(user)
+
+        password = 'invalid'
+
+        result = {
+          success: false,
+          errors: ['is too short (minimum is 8 characters)'],
+          user_id: '123'
+        }
+
+        expect(form.submit(password: password)).to eq result
+      end
+    end
+
+    context 'when both the password and token are valid' do
+      it 'sets the user password to the submitted password' do
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
+
+        form = ResetPasswordForm.new(user)
+
+        password = 'valid password'
+
+        result = {
+          success: true,
+          errors: [],
+          user_id: '123'
+        }
+
+        expect(form.submit(password: password)).to eq result
+      end
+    end
+
+    context 'when both the password and token are invalid' do
+      it 'returns a hash with errors' do
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid).and_return(false)
+
+        form = ResetPasswordForm.new(user)
+
+        password = 'short'
+
+        result = {
+          success: false,
+          errors: ['is too short (minimum is 8 characters)', 'token_expired'],
+          user_id: '123'
+        }
+
+        expect(form.submit(password: password)).to eq result
+      end
+    end
+
+    context 'when the password is not strong enough' do
+      it 'returns false and adds user errors to the form errors' do
+        allow(Figaro.env).to receive(:password_strength_enabled).and_return('true')
+
+        user = build_stubbed(:user, email: 'custom@benevolent.com')
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
+
+        form = ResetPasswordForm.new(user)
+
+        passwords = [user.email, 'custom!@', 'benevolent', 'custom benevolent comcast', APP_NAME]
+
+        passwords.each do |password|
+          result = {
+            success: false,
+            errors: [
+              'Your password is not strong enough. Add another word or two. ' \
+              'Uncommon words are better.'
+            ],
+            user_id: nil
+          }
+
+          expect(form.submit(password: password)).
+            to eq result
+        end
+      end
+    end
+  end
+end

--- a/spec/views/devise/passwords/edit.html.slim_spec.rb
+++ b/spec/views/devise/passwords/edit.html.slim_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'devise/passwords/edit.html.slim' do
   before do
     user = build_stubbed(:user, :signed_up)
-    @password_form = PasswordForm.new(user)
+    @reset_password_form = ResetPasswordForm.new(user)
   end
 
   it 'has a localized title' do


### PR DESCRIPTION
**Why**: For better organization and to make it easier to run
queries related to password reset events.