### PR TITLE
Updates bin/setup to sign overcommit

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -55,6 +55,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Adding git hooks via Overcommit =="
   run 'overcommit --install'
+  run 'overcommit --sign'
 
   puts "\n== Restarting application server =="
   run "mkdir -p tmp"


### PR DESCRIPTION
**Why**:
When the repo is first installed, overcommit complains that a signature
is missing. According to the docs here:
https://github.com/brigade/overcommit#installation, this is a necessary
step.