### PR TITLE
Removes error banner from forms w/ inline messages

### DIFF
--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -7,7 +7,6 @@ h1.h3.my0 = t('headings.passwords.change')
     html: { autocomplete: 'off',
     method: :put,
     role: 'form' }) do |f|
-  = f.error_notification
   = f.input :reset_password_token, as: :hidden
   = f.full_error :reset_password_token
   = f.input :password, label: t('forms.passwords.edit.labels.password'), required: true

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -5,6 +5,6 @@ h1.h3.my0 = t('headings.passwords.forgot')
 = simple_form_for(resource,
                   url: user_password_path,
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
-  = f.error_notification
+
   = f.input :email, required: true
   = f.button :submit, t('forms.buttons.reset_password'), class: 'mt2 mb1'

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -8,7 +8,6 @@ p.mt-tiny.mb0#2fa-description
     html: { autocomplete: 'off', role: 'form' },
     method: :patch,
     url: phone_setup_path) do |f|
-  = f.error_notification
   = f.label :phone, class: 'block'
     strong.left = t('devise.two_factor_authentication.otp_phone_label')
     span.ml1.italic = t('devise.two_factor_authentication.otp_phone_label_info')

--- a/app/views/users/confirmations/show.html.slim
+++ b/app/views/users/confirmations/show.html.slim
@@ -12,7 +12,6 @@ p.mb0
     url: confirm_path,
     method: :patch,
     html: { role: 'form', autocomplete: 'off' }) do |f|
-  = f.error_notification
   = f.input :password, required: true,
       input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'

--- a/app/views/users/edit_password/edit.html.slim
+++ b/app/views/users/edit_password/edit.html.slim
@@ -6,7 +6,6 @@ p.mt-tiny.mb0#password-description
   = t('instructions.password.info.lead', min_length: Devise.password_length.first)
 = simple_form_for(@update_user_password_form, url: settings_password_path,
     html: { autocomplete: 'off', method: :patch, role: 'form' }) do |f|
-  = f.error_notification
   = f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
             input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'

--- a/app/views/users/edit_phone/edit.html.slim
+++ b/app/views/users/edit_phone/edit.html.slim
@@ -4,7 +4,6 @@
 h1.h3.my0 = t('headings.edit_info.phone')
 = simple_form_for(@update_user_phone_form, url: edit_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
-  = f.error_notification
   = f.input :phone, as: :tel, required: true
   = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
 .mt1 = link_to t('forms.buttons.cancel'), profile_path


### PR DESCRIPTION
**Why**:
Multiple error alerts add noise to the form. We already display inline
errors after the user submits an invalid form, an additional
banner directing users to those errors is unecessary.

Only forms that currently display a banner _and_ and inline error
message were changed.