### PR TITLE
Adds information about overcommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Testing dependencies:
   $ make run
   ```
 
+Before making any commits, you'll also need to run `overcommit --sign.`
+This verifies that the commit hooks defined in our `.overcommit.yml` file are
+the ones we expect. Each change to the `.overcommit.yml` file, including the initial install
+performed in the setup script, will necessitate a new signature.
+
+For more information, see [overcommit](https://github.com/brigade/overcommit)
+
+
 If you want to develop without and internet connection, you can set
 `RAILS_OFFLINE=1` in your environment. This disables the `mx` record
 check on email addresses.


### PR DESCRIPTION
**Why**:
The overcommit tool requires that a signature of the current file be
generated before git commands can be used when developing this
application. Although simple to set up, it isn't clear what overcommit
is or why the signature is necessary if one hasn't used it before.

A small section on overcommit is added to the README so new devs
can be made aware of it.