### PR TITLE
Allow multiple invalid password submissions

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -28,7 +28,7 @@ module Users
 
     # PUT /resource/password
     def update
-      self.resource = token_user(user_params)
+      self.resource = user_matching_token(user_params[:reset_password_token])
 
       @reset_password_form = ResetPasswordForm.new(resource)
 
@@ -44,6 +44,14 @@ module Users
     end
 
     protected
+
+    def user_matching_token(token)
+      reset_password_token = Devise.token_generator.digest(User, :reset_password_token, token)
+
+      user = User.find_or_initialize_with_error_by(:reset_password_token, reset_password_token)
+      user.reset_password_token = token if user.reset_password_token.present?
+      user
+    end
 
     def token_user(params)
       @_token_user ||= User.with_reset_password_token(params[:reset_password_token])

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -263,6 +263,18 @@ feature 'Password Recovery' do
       signin(@user.email, '1234')
       expect(current_path).to eq new_user_session_path
     end
+
+    it 'allows multiple attempts with invalid password' do
+      fill_in 'New password', with: '1234'
+      click_button t('forms.passwords.edit.buttons.submit')
+
+      expect(page).to have_content 'is too short'
+
+      fill_in 'New password', with: '5678'
+      click_button t('forms.passwords.edit.buttons.submit')
+
+      expect(page).to have_content 'is too short'
+    end
   end
 
   scenario 'user takes too long to click the reset password link' do


### PR DESCRIPTION
**Why**: To fix a bug I introduced when I refactored analytics.

**How**: Instead of using a completely different Devise method,
use the same one Devise uses by default in this context, but modify
it so that it doesn't update the user's password. This is because
we removed the model validations, so we shouldn't attempt to update
the user's password until the form has been processed, i.e. until
we know whether or not the password is valid.

Devise, on the other hand, saves the password as soon as `#update` is
called, then checks to see if the resource has any errors. Since we only
validate the password via the form object, we can't update the user
until we know the password is valid.

Note that the original Devise method is a class method on User called
`reset_password_by_token`, but I made it a controller method and
renamed it `user_matching_token` since it better describes what it
returns.