### PR TITLE
Encrypt recovery_code with HSM

### DIFF
--- a/app/forms/recovery_code_form.rb
+++ b/app/forms/recovery_code_form.rb
@@ -17,7 +17,8 @@ class RecoveryCodeForm
   attr_reader :user, :code, :success
 
   def valid_recovery_code?
-    Devise::Encryptor.compare(User, user.recovery_code, code)
+    recovery_code_generator = RecoveryCodeGenerator.new(user)
+    recovery_code_generator.verify(code)
   end
 
   def result

--- a/app/services/recovery_code_generator.rb
+++ b/app/services/recovery_code_generator.rb
@@ -2,6 +2,7 @@ class RecoveryCodeGenerator
   def initialize(user, length: 16)
     @user = user
     @length = length
+    @key_maker = EncryptedKeyMaker.new
   end
 
   def create
@@ -10,12 +11,29 @@ class RecoveryCodeGenerator
     raw_recovery_code
   end
 
+  def verify(plaintext_code)
+    uak = user_access_key(plaintext_code)
+    encryption_key, encrypted_code = user.recovery_code.split(Pii::Encryptor::DELIMITER)
+    begin
+      key_maker.unlock(uak, encryption_key)
+    rescue Pii::EncryptionError => _err
+      return false
+    end
+    Devise.secure_compare(encrypted_code, uak.encrypted_password)
+  end
+
   private
 
-  attr_reader :length, :user
+  attr_reader :length, :user, :key_maker
+
+  def user_access_key(code)
+    UserAccessKey.new(code, user.password_salt)
+  end
 
   def hashed_code
-    Devise::Encryptor.digest(User, raw_recovery_code)
+    uak = user_access_key(raw_recovery_code)
+    key_maker.make(uak)
+    [uak.encryption_key, uak.encrypted_password].join(Pii::Encryptor::DELIMITER)
   end
 
   def raw_recovery_code

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,7 +21,9 @@ FactoryGirl.define do
 
     trait :signed_up do
       with_phone
-      recovery_code '$2a$10$vOkU3l3j0aYgWbXVdwJA5.FICxwydpvPrzBuzjFZUXDnPeXkMHeLe'
+      after :build do |user|
+        user.recovery_code = RecoveryCodeGenerator.new(user).create
+      end
     end
 
     trait :unconfirmed do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -177,7 +177,8 @@ feature 'Two Factor Authentication' do
   describe 'signing in when user does not already have recovery code' do
     # For example, when migrating users from another DB
     it 'displays recovery code and redirects to profile after acknowledging' do
-      user = create(:user, :signed_up, recovery_code: nil)
+      user = create(:user, :signed_up)
+      user.update!(recovery_code: nil)
 
       sign_in_user(user)
       click_button t('forms.buttons.submit.default')

--- a/spec/forms/recovery_code_form_spec.rb
+++ b/spec/forms/recovery_code_form_spec.rb
@@ -21,6 +21,7 @@ describe RecoveryCodeForm do
     context 'when the form is invalid' do
       it 'returns false for success?' do
         user = build_stubbed(:user, :signed_up)
+        RecoveryCodeGenerator.new(user).create
 
         result = RecoveryCodeForm.new(user, 'foo').submit
 

--- a/spec/services/recovery_code_generator_spec.rb
+++ b/spec/services/recovery_code_generator_spec.rb
@@ -1,38 +1,64 @@
 require 'rails_helper'
 
 describe RecoveryCodeGenerator do
+  let(:recovery_code) { 'a1b2c3d4e5f6g7h8' }
+
   describe '#create' do
     it 'returns the raw recovery code' do
-      generator = RecoveryCodeGenerator.new(User.new)
+      user = create(:user)
+      generator = RecoveryCodeGenerator.new(user)
 
-      allow(SecureRandom).to receive(:hex).with(8).and_return('a1b2c3d4e5f6g7h8')
+      allow(SecureRandom).to receive(:hex).with(8).and_return(recovery_code)
 
-      expect(generator.create).to eq 'a1b2c3d4e5f6g7h8'
+      expect(generator.create).to eq recovery_code
     end
 
     it 'hashes the raw recovery code' do
       user = create(:user)
-
       generator = RecoveryCodeGenerator.new(user)
 
-      allow(SecureRandom).to receive(:hex).with(8).and_return('a1b2c3d4e5f6g7h8')
+      allow(SecureRandom).to receive(:hex).with(8).and_return(recovery_code)
 
       generator.create
 
-      expect(user.recovery_code).to_not eq 'a1b2c3d4e5f6g7h8'
+      expect(user.recovery_code).to_not eq recovery_code
     end
 
     it 'generates an alphanumeric string of length 16 by default' do
-      generator = RecoveryCodeGenerator.new(User.new)
+      user = create(:user)
+      generator = RecoveryCodeGenerator.new(user)
 
       expect(generator.create).to match(/\A[a-zA-Z0-9]{16}\z/)
     end
 
     it 'allows length to be configured via ENV var' do
+      user = create(:user)
       allow(Figaro.env).to receive(:recovery_code_length).and_return('14')
-      generator = RecoveryCodeGenerator.new(User.new)
+      generator = RecoveryCodeGenerator.new(user)
 
       expect(generator.create).to match(/\A[a-zA-Z0-9]{14}\z/)
+    end
+  end
+
+  describe '#verify' do
+    before do
+      allow(SecureRandom).to receive(:hex).with(8).and_return(recovery_code)
+    end
+
+    it 'returns false for the wrong code' do
+      user = create(:user)
+      generator = RecoveryCodeGenerator.new(user)
+      generator.create
+
+      expect(generator.verify('not the real recovery code')).to eq false
+    end
+
+    it 'returns true for the correct code' do
+      user = create(:user)
+      generator = RecoveryCodeGenerator.new(user)
+      generator.create
+
+      expect(generator.verify(recovery_code)).to eq true
     end
   end
 end


### PR DESCRIPTION
**Why**: Applies same encryption model to recovery_code as to password.