### PR TITLE
Refactor ConfirmationsController

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -4,22 +4,28 @@ module Users
 
     def confirm
       with_unconfirmed_confirmable do
-        if @password_form.submit(permitted_params)
-          do_confirm
+        result = @password_form.submit(permitted_params)
+
+        analytics.track_event(Analytics::PASSWORD_CREATION, result)
+
+        if result[:success]
+          process_successful_password_creation
         else
-          process_user_with_password_errors
+          process_unsuccessful_password_creation
         end
       end
     end
 
     def show
       with_unconfirmed_confirmable do
-        return process_user_with_confirmation_errors if @confirmable.errors.present?
+        result = EmailConfirmationTokenValidator.new(@confirmable).submit
 
-        if !@confirmable.confirmed?
-          process_unconfirmed_user
+        analytics.track_event(Analytics::EMAIL_CONFIRMATION, result)
+
+        if result[:success]
+          process_successful_confirmation
         else
-          process_confirmed_user
+          process_unsuccessful_confirmation
         end
       end
     end
@@ -42,64 +48,66 @@ module Users
       self.resource = @confirmable
     end
 
-    def do_confirm
+    def process_successful_password_creation
       @confirmable.confirm
-      @confirmable.update(reset_requested_at: nil)
+      @confirmable.update(reset_requested_at: nil, password: permitted_params[:password])
       sign_in_and_redirect_user
-      analytics.track_event(Analytics::PASSWORD_CREATE_USER_CONFIRMED)
     end
 
-    def process_user_with_password_errors
-      analytics.track_event(Analytics::PASSWORD_CREATE_INVALID, user_id: @confirmable.uuid)
-
+    def process_unsuccessful_password_creation
       set_view_variables
       render :show
     end
 
-    def process_user_with_confirmation_errors
-      return process_already_confirmed_user if @confirmable.confirmed?
+    def process_successful_confirmation
+      if !@confirmable.confirmed?
+        process_valid_confirmation_token
+      else
+        process_confirmed_user
+      end
+    end
 
-      track_invalid_confirmation_token(params[:confirmation_token])
+    def process_valid_confirmation_token
+      set_view_variables
+      flash.now[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
+      render :show
+    end
+
+    def process_confirmed_user
+      create_user_event(:email_changed, @confirmable)
+
+      flash[:notice] = t('devise.confirmations.confirmed')
+      redirect_to after_confirmation_path_for(@confirmable)
+      EmailNotifier.new(@confirmable).send_email_changed_email
+    end
+
+    def process_unsuccessful_confirmation
+      return process_already_confirmed_user if @confirmable.confirmed?
 
       set_view_variables
 
-      flash[:error] = t('errors.messages.confirmation_invalid_token')
-      render :new
+      if resource.confirmation_period_expired?
+        process_expired_confirmation_token
+      else
+        process_invalid_confirmation_token
+      end
     end
 
     def process_already_confirmed_user
-      analytics.track_event(
-        Analytics::EMAIL_CONFIRMATION_USER_ALREADY_CONFIRMED, user_id: @confirmable.uuid
-      )
-
       action_text = 'Please sign in.' unless user_signed_in?
       flash[:error] = t('devise.confirmations.already_confirmed', action: action_text)
 
       redirect_to user_signed_in? ? profile_path : new_user_session_url
     end
 
-    def process_unconfirmed_user
-      set_view_variables
-
-      if resource.confirmation_period_expired?
-        process_expired_confirmation_token
-      else
-        process_valid_confirmation_token
-      end
-    end
-
     def process_expired_confirmation_token
-      analytics.track_event(Analytics::EMAIL_CONFIRMATION_TOKEN_EXPIRED, user_id: @confirmable.uuid)
-
       flash[:error] = resource.decorate.confirmation_period_expired_error
       render :new
     end
 
-    def process_valid_confirmation_token
-      analytics.track_event(Analytics::EMAIL_CONFIRMATION_VALID_TOKEN, user_id: @confirmable.uuid)
-
-      flash.now[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
-      render :show
+    def process_invalid_confirmation_token
+      flash[:error] = t('errors.messages.confirmation_invalid_token')
+      render :new
     end
 
     def after_confirmation_path_for(resource)
@@ -112,15 +120,6 @@ module Users
       end
     end
 
-    def process_confirmed_user
-      analytics.track_event(Analytics::EMAIL_CHANGED_AND_CONFIRMED, user_id: @confirmable.uuid)
-      create_user_event(:email_changed, @confirmable)
-
-      flash[:notice] = t('devise.confirmations.confirmed')
-      redirect_to after_confirmation_path_for(@confirmable)
-      EmailNotifier.new(@confirmable).send_email_changed_email
-    end
-
     private
 
     def permitted_params
@@ -131,12 +130,6 @@ module Users
     def sign_in_and_redirect_user
       sign_in @confirmable
       redirect_to after_confirmation_path_for(@confirmable)
-    end
-
-    def track_invalid_confirmation_token(token)
-      token ||= 'nil'
-
-      analytics.track_event(Analytics::EMAIL_CONFIRMATION_INVALID_TOKEN, token: token)
     end
   end
 end

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -11,10 +11,20 @@ class PasswordForm
 
     self.password = submitted_password
 
-    if valid?
-      user.password = submitted_password
-    else
-      false
-    end
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_reader :success
+
+  def result
+    {
+      success: success,
+      errors: errors.messages.values.flatten,
+      user_id: user.uuid
+    }
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -31,12 +31,8 @@ class Analytics
   AUTHENTICATION_MAX_2FA_ATTEMPTS = 'Authentication: user reached max 2FA attempts'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUESTED = 'Email Change: requested'.freeze
-  EMAIL_CHANGED_AND_CONFIRMED = 'Email Change: changed and confirmed'.freeze
   EMAIL_CHANGED_TO_EXISTING = 'Email Change: user attempted to change their email to an existing email'.freeze
-  EMAIL_CONFIRMATION_INVALID_TOKEN = 'Email Confirmation: invalid email confirmation token'.freeze
-  EMAIL_CONFIRMATION_TOKEN_EXPIRED = 'Email Confirmation: token expired'.freeze
-  EMAIL_CONFIRMATION_USER_ALREADY_CONFIRMED = 'Email Confirmation: user already confirmed'.freeze
-  EMAIL_CONFIRMATION_VALID_TOKEN = 'Email Confirmation: valid token'.freeze
+  EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
   IDV_FAILED = 'IdV: Failed'.freeze
   IDV_SUCCESSFUL = 'IdV: Successful'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
@@ -45,8 +41,7 @@ class Analytics
   MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   PAGE_NOT_FOUND = 'Page Not Found'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze
-  PASSWORD_CREATE_INVALID = 'Password Create: invalid password'.freeze
-  PASSWORD_CREATE_USER_CONFIRMED = 'Password Create: created and user confirmed'.freeze
+  PASSWORD_CREATION = 'Password Creation'.freeze
   PASSWORD_RESET_DEACTIVATED_ACCOUNT = 'Password Reset: deactivated verified profile via password reset'.freeze
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -1,0 +1,37 @@
+class EmailConfirmationTokenValidator
+  include ActiveModel::Model
+
+  validate :token_not_expired
+
+  def initialize(user)
+    @user = user
+  end
+
+  def submit
+    @success = valid? && user_valid?
+
+    result
+  end
+
+  private
+
+  attr_accessor :user
+  attr_reader :success
+
+  def result
+    {
+      success: success,
+      error: [errors.full_messages, user.errors.full_messages].join,
+      user_id: user.uuid,
+      existing_user: user.confirmed?
+    }
+  end
+
+  def user_valid?
+    user.errors.empty?
+  end
+
+  def token_not_expired
+    errors.add(:confirmation_token, 'has expired') if user.confirmation_period_expired?
+  end
+end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -14,7 +14,7 @@ feature 'Changing authentication factor' do
     scenario 'editing phone number' do
       allow(SmsSenderNumberChangeJob).to receive(:perform_later)
 
-      @previous_phone_confirmed_at = user.phone_confirmed_at
+      @previous_phone_confirmed_at = user.reload.phone_confirmed_at
 
       visit edit_phone_path
       complete_2fa_confirmation
@@ -27,7 +27,6 @@ feature 'Changing authentication factor' do
 
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')
       expect(user.reload.phone).to_not eq '+1 (703) 555-0100'
-      expect(user.reload.phone_confirmed_at).to_not eq(@previous_phone_confirmed_at)
       expect(page).to have_link t('forms.two_factor.try_again'), href: edit_phone_path
 
       enter_correct_otp_code_for_user(user)
@@ -36,6 +35,7 @@ feature 'Changing authentication factor' do
       expect(current_path).to eq profile_path
       expect(SmsSenderNumberChangeJob).to have_received(:perform_later).with('+1 (202) 555-1212')
       expect(user.reload.phone).to eq '+1 (703) 555-0100'
+      expect(user.reload.phone_confirmed_at).to_not eq(@previous_phone_confirmed_at)
 
       visit login_two_factor_path(delivery_method: 'sms')
       expect(current_path).to eq profile_path

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -58,12 +58,15 @@ feature 'Email confirmation during sign up' do
   end
 
   scenario 'visitor signs up but confirms with an expired token' do
-    allow(Devise).to receive(:confirm_within).and_return(24.hours)
     user = create(:user, :unconfirmed)
-    confirm_last_user
-    user.update(confirmation_sent_at: Time.current - 2.days)
+    raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
 
-    visit user_confirmation_url(confirmation_token: @raw_confirmation_token)
+    user.update(
+      confirmation_token: raw_confirmation_token,
+      confirmation_sent_at: Time.current - Devise.confirm_within - 2.days
+    )
+
+    visit user_confirmation_url(confirmation_token: raw_confirmation_token)
 
     expect(current_path).to eq user_confirmation_path
     expect(page).to have_content t(

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -8,30 +8,19 @@ describe PasswordForm, type: :model do
   describe '#submit' do
     context 'when the form is invalid' do
       it 'returns false' do
-        user = build_stubbed(:user)
+        user = build_stubbed(:user, uuid: '123')
 
         form = PasswordForm.new(user)
 
         password = 'invalid'
 
-        expect(form.submit(password: password)).
-          to eq false
+        result_hash = {
+          success: false,
+          errors: ['is too short (minimum is 8 characters)'],
+          user_id: '123'
+        }
 
-        expect(user.password).to_not eq password
-      end
-    end
-
-    context 'when the form is valid' do
-      it 'sets the user password to the submitted password' do
-        user = build_stubbed(:user)
-
-        form = PasswordForm.new(user)
-
-        password = 'valid password'
-
-        form.submit(password: password)
-
-        expect(user.password).to eq password
+        expect(form.submit(password: password)).to eq result_hash
       end
     end
 
@@ -39,14 +28,21 @@ describe PasswordForm, type: :model do
       it 'returns false and adds user errors to the form errors' do
         allow(Figaro.env).to receive(:password_strength_enabled).and_return('true')
 
-        user = build_stubbed(:user, email: 'custom@benevolent.com')
+        user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
 
         form = PasswordForm.new(user)
 
         passwords = [user.email, 'custom!@', 'benevolent', 'custom benevolent comcast', APP_NAME]
 
+        result_hash = {
+          success: false,
+          errors: ['Your password is not strong enough. Add another word or two. ' \
+            'Uncommon words are better.'],
+          user_id: '123'
+        }
+
         passwords.each do |password|
-          expect(form.submit(password: password)).to eq false
+          expect(form.submit(password: password)).to eq result_hash
           expect(form.errors.full_messages.first).to match 'not strong enough'
         end
       end


### PR DESCRIPTION
**Why**:
- To consolidate analytics events around email confirmation and
password creation
- To make method names more descriptive
- To make the flow easier to understand

**How**:
- Apply the same pattern we've been using for analytics, i.e form
objects and service classes that return a hash of attributes pertinent
to the event
- Use a consistent pattern in the controller action for naming the success
and failure path, i.e. `process_successful_[event]` and
`process_unsuccessful[event]`.