### PR TITLE
Updates session timeout warning modal

### DIFF
--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -52,8 +52,8 @@ function initTimer(duration) {
       minutes + ' minute' + (minutes !== 1 ? 's' : '') + ' and ';
     var displaySeconds = remainingSeconds + ' second' + (remainingSeconds !== 1 ? 's' : '');
 
-    return (displayMinutes + displaySeconds)
-  }
+    return (displayMinutes + displaySeconds);
+  };
 
   function tick() {
     countdown.innerHTML = format(timeLeft);

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -7,3 +7,5 @@
         p.mb3 == t('session_timeout_warning', time_left_in_session: time_left_in_session)
         = link_to t('forms.buttons.continue_browsing'),
           request.original_url, class: 'btn btn-primary'
+        = link_to t('forms.buttons.sign_out'),
+          destroy_user_session_path, class: 'ml2 btn btn-outline'

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -3,7 +3,8 @@ en:
     buttons:
       acknowledge_recovery_code: Continue
       continue: Continue
-      continue_browsing: Continue browsing
+      continue_browsing: Keep me signed in
+      sign_out: Sign me out
       resend_confirmation: Resend confirmation instructions
       reset_password: Send reset password instructions
       send: Send

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -36,7 +36,7 @@ en:
       enter_email: Start making your account
       verify_email: Check your email
     search: Search for a user
-    session_timeout_warning: Session timeout
+    session_timeout_warning: Need more time?
     totp_setup:
       start: Set up two-factor authentication
       new: Scan the QR code with your device

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -37,5 +37,4 @@ en:
   session_timedout: >
     We signed you out due to inactivity. This helps keep your account safe. Please sign in again.
   session_timeout_warning: >-
-    We will sign you out in <span id="countdown">%{time_left_in_session}</span> for your security.
-    If you’d like to stay signed in, please click the button below.
+    Your session will end in <span id="countdown">%{time_left_in_session}</span> due to inactivity.

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -67,12 +67,12 @@ feature 'Sign in' do
       allow(Figaro.env).to receive(:session_check_delay).and_return('2')
       allow(Figaro.env).to receive(:session_timeout_warning_seconds).
         and_return(Devise.timeout_in.to_s)
+
+      sign_in_and_2fa_user
+      visit root_path
     end
 
     scenario 'user sees warning before session times out' do
-      sign_in_and_2fa_user
-      visit root_path
-
       expect(page).to have_css('#session-timeout-msg')
 
       request_headers = page.driver.network_traffic.flat_map(&:headers).uniq
@@ -81,10 +81,19 @@ feature 'Sign in' do
       expect(request_headers).to include ajax_headers
       expect(page).to have_content('7 minutes and 59 seconds')
       expect(page).to have_content('7 minutes and 58 seconds')
+    end
 
+    scenario 'user can continue browsing' do
       find_link(t('forms.buttons.continue_browsing')).trigger('click')
 
       expect(current_path).to eq profile_path
+    end
+
+    scenario 'user has option to sign out' do
+      click_link(t('forms.buttons.sign_out'))
+
+      expect(page).to have_content t('devise.sessions.signed_out')
+      expect(current_path).to eq new_user_session_path
     end
   end
 


### PR DESCRIPTION
**Why**:
We are legally required to present users with the option to manually
logout when they are finished with our service.

**How**:
In addition to automatically signing a user out fo their session due to
inactivity, we supply a button allowing the user to log out immediately