### PR TITLE
Deactivate invalid encrypted Profile on login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -55,7 +55,13 @@ module Users
 
     def cache_active_profile
       cacher = Pii::Cacher.new(current_user, user_session)
-      cacher.save(current_user.user_access_key)
+      begin
+        cacher.save(current_user.user_access_key)
+      rescue Pii::EncryptionError => _err
+        current_user.active_profile.deactivate
+        properties = { user_id: current_user.uuid }
+        analytics.track_event(Analytics::PROFILE_ENCRYPTION_INVALID, properties)
+      end
     end
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,6 +14,10 @@ class Profile < ActiveRecord::Base
     end
   end
 
+  def deactivate
+    update!(active: false)
+  end
+
   def decrypt_pii(user_access_key)
     Pii::Attributes.new_from_encrypted(encrypted_pii, user_access_key)
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -53,7 +53,7 @@ class Analytics
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PHONE_CHANGE_SUCCESSFUL = 'Phone Number Change: successful'.freeze
-  PROFILE_ENCRYPTION_INVALID = 'Profile encryption invalid'.freeze
+  PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SETUP_2FA_INVALID_PHONE = '2FA setup: invalid phone number'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -53,6 +53,7 @@ class Analytics
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PHONE_CHANGE_SUCCESSFUL = 'Phone Number Change: successful'.freeze
+  PROFILE_ENCRYPTION_INVALID = 'Profile encryption invalid'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SETUP_2FA_INVALID_PHONE = '2FA setup: invalid phone number'.freeze

--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -58,7 +58,7 @@ class EncryptedKeyMaker
 
   def unlock_local(user_access_key, encryption_key)
     ciphertext = user_access_key.xor(decode(encryption_key))
-    raise Pii::EncryptionError, 'Invalid base64-encoded ciphertext' unless
+    raise Pii::EncryptionError, 'invalid base64-encoded ciphertext' unless
       valid_base64_encoding?(ciphertext)
     user_access_key.unlock(encryptor.decrypt(ciphertext, Figaro.env.password_pepper))
   end

--- a/app/services/pii/encryptor.rb
+++ b/app/services/pii/encryptor.rb
@@ -18,7 +18,7 @@ module Pii
     end
 
     def decrypt(ciphertext, cek)
-      raise EncryptionError unless sane_payload?(ciphertext)
+      raise EncryptionError, 'ciphertext is invalid' unless sane_payload?(ciphertext)
       decrypt_and_test_payload(decode(ciphertext), cek)
     end
 
@@ -37,7 +37,7 @@ module Pii
       rescue OpenSSL::Cipher::CipherError => err
         raise EncryptionError, err
       end
-      raise EncryptionError unless sane_payload?(payload)
+      raise EncryptionError, 'payload is invalid' unless sane_payload?(payload)
       plaintext, fingerprint = split_into_segments(payload)
       return plaintext if Pii::Fingerprinter.verify(plaintext, fingerprint)
     end

--- a/app/services/pii/password_encryptor.rb
+++ b/app/services/pii/password_encryptor.rb
@@ -12,6 +12,7 @@ module Pii
     end
 
     def decrypt(ciphertext, user_access_key)
+      raise EncryptionError unless sane_payload?(ciphertext)
       encrypted_d, encrypted_c = split_into_segments(ciphertext)
       hash_e = if user_access_key.unlocked?
                  user_access_key.hash_e

--- a/app/services/pii/password_encryptor.rb
+++ b/app/services/pii/password_encryptor.rb
@@ -12,7 +12,7 @@ module Pii
     end
 
     def decrypt(ciphertext, user_access_key)
-      raise EncryptionError unless sane_payload?(ciphertext)
+      raise EncryptionError, 'ciphertext is invalid' unless sane_payload?(ciphertext)
       encrypted_d, encrypted_c = split_into_segments(ciphertext)
       hash_e = if user_access_key.unlocked?
                  user_access_key.hash_e

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -103,6 +103,15 @@ describe Profile do
     end
   end
 
+  describe '#deactivate' do
+    it 'sets active flag to false' do
+      profile = create(:profile, :active, user: user)
+      profile.deactivate
+
+      expect(profile).to_not be_active
+    end
+  end
+
   describe 'scopes' do
     describe '#active' do
       it 'returns only active Profiles' do


### PR DESCRIPTION
**Why**: When encryption logic changes, deactivate
legacy profiles automatically because they cannot be recovered.