### PR TITLE
Add Profile.encrypted_pii_recovery

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -19,6 +19,7 @@ module IdvSession
   end
 
   def confirm_idv_vendor_session_started
+    return if flash[:allow_confirmations_continue]
     redirect_to idv_session_path unless idv_session.proofing_started?
   end
 

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -13,6 +13,10 @@ module Idv
       end
     end
 
+    def continue
+      redirect_to after_sign_in_path_for(current_user)
+    end
+
     private
 
     def idv_questions
@@ -57,12 +61,12 @@ module Idv
     end
 
     def finish_proofing_success
+      @recovery_code = idv_session.recovery_code
       idv_attempter.reset
       idv_session.complete_profile
       idv_session.clear
-      flash[:success] = I18n.t('idv.titles.complete')
+      flash[:allow_confirmations_continue] = true
       analytics.track_event(Analytics::IDV_SUCCESSFUL)
-      redirect_to after_sign_in_path_for(current_user)
     end
   end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -5,5 +5,7 @@ class ProfileController < ApplicationController
   def index
     cacher = Pii::Cacher.new(current_user, user_session)
     @decrypted_pii = cacher.fetch
+    @recovery_code = flash[:recovery_code]
+    flash.delete(:recovery_code)
   end
 end

--- a/app/controllers/two_factor_authentication/recovery_code_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_controller.rb
@@ -3,11 +3,29 @@ module TwoFactorAuthentication
     before_action :confirm_two_factor_authenticated
 
     def show
-      @code = RecoveryCodeGenerator.new(current_user).create
+      @code = create_new_code
     end
 
     def acknowledge
       redirect_to after_sign_in_path_for(current_user)
+    end
+
+    private
+
+    def create_new_code
+      generator = RecoveryCodeGenerator.new(current_user)
+      code = generator.create
+      if current_user.active_profile.present?
+        reencrypt_pii_recovery(generator.user_access_key)
+      end
+      code
+    end
+
+    def reencrypt_pii_recovery(uak)
+      profile = current_user.active_profile
+      cacher = Pii::Cacher.new(current_user, user_session)
+      pii_attributes = cacher.fetch
+      profile.update!(encrypted_pii_recovery: pii_attributes.encrypted(uak))
     end
   end
 end

--- a/app/controllers/users/edit_password_controller.rb
+++ b/app/controllers/users/edit_password_controller.rb
@@ -40,7 +40,7 @@ module Users
       active_profile = current_user.active_profile
       return unless active_profile.present?
       user_access_key = current_user.unlock_user_access_key(user_params[:password])
-      active_profile.encrypt_pii(user_access_key, current_pii)
+      flash[:recovery_code] = active_profile.encrypt_pii(user_access_key, current_pii)
       active_profile.save!
     end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,6 +7,8 @@ class Profile < ActiveRecord::Base
   scope :active, -> { where(active: true) }
   scope :verified, -> { where.not(verified_at: nil) }
 
+  attr_reader :recovery_code
+
   def activate
     transaction do
       Profile.where('user_id=?', user_id).update_all(active: false)
@@ -22,9 +24,29 @@ class Profile < ActiveRecord::Base
     Pii::Attributes.new_from_encrypted(encrypted_pii, user_access_key)
   end
 
+  def recover_pii(recovery_code)
+    raise 'invalid recovery code' unless recovery_code_generator.verify(recovery_code)
+    uak = recovery_code_generator.user_access_key
+    Pii::Attributes.new_from_encrypted(encrypted_pii_recovery, uak)
+  end
+
   def encrypt_pii(user_access_key, pii)
     ssn = pii.ssn
     self.ssn_signature = Pii::Fingerprinter.fingerprint(ssn) if ssn
     self.encrypted_pii = pii.encrypted(user_access_key)
+    recovery_code, rc_user_access_key = generate_recovery_code
+    self.encrypted_pii_recovery = pii.encrypted(rc_user_access_key)
+    @recovery_code = recovery_code
+  end
+
+  private
+
+  def recovery_code_generator
+    @_recovery_code_generator ||= RecoveryCodeGenerator.new(user)
+  end
+
+  def generate_recovery_code
+    recovery_code = recovery_code_generator.create
+    [recovery_code, recovery_code_generator.user_access_key]
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -3,7 +3,7 @@ module Idv
     delegate :questions, to: :resolution
 
     VALID_SESSION_ATTRIBUTES = [
-      :question_number, :resolution, :vendor, :applicant, :params, :profile_id
+      :question_number, :resolution, :vendor, :applicant, :params, :profile_id, :recovery_code
     ].freeze
 
     def initialize(user_session, current_user)
@@ -32,7 +32,9 @@ module Idv
     end
 
     def cache_applicant_profile_id(applicant)
-      self.profile_id = Idv::ProfileFromApplicant.create(applicant, current_user).id
+      profile = Idv::ProfileFromApplicant.create(applicant, current_user)
+      self.profile_id = profile.id
+      self.recovery_code = profile.recovery_code
     end
 
     def cache_encrypted_pii(password)

--- a/app/views/idv/confirmations/index.html.slim
+++ b/app/views/idv/confirmations/index.html.slim
@@ -1,0 +1,7 @@
+- title t('idv.titles.complete')
+
+h1.h3.my0 = t('idv.titles.complete')
+p.mt-tiny.mb0 = t('idv.messages.recovery_code')
+.mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @recovery_code
+= button_to(t('forms.buttons.acknowledge_recovery_code'), \
+  idv_confirmations_continue_path, class: 'btn btn-primary btn-wide mb1')

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -1,6 +1,11 @@
 - title t('titles.profile')
 - btn_cls = 'btn btn-primary p0 w-60p bg-light-blue blue h6 regular border-box center'
 
+- if @recovery_code
+  p.mt-tiny.mb0 = t('idv.messages.recovery_code')
+  .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @recovery_code
+  br
+
 - if @decrypted_pii
   h2.h3.my0.mr1.inline-block = t('headings.profile.profile_info')
   = content_tag(:span, t('headings.profile.profile_info_tt'),

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -85,6 +85,9 @@ en:
           password as long as it meets the criteria above.
       questions:
         intro: Question %{number}
+      recovery_code:
+        This is your new recovery code. Write it down and keep it in a safe place.
+        You will need it if you ever lose your password.
       review:
         intro: Please review your information and ensure it is correct.
       sessions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
   get '/idv/questions' => 'idv/questions#index'
   post '/idv/questions' => 'idv/questions#create'
   get '/idv/confirmations' => 'idv/confirmations#index'
+  post '/idv/confirmations/continue' => 'idv/confirmations#continue'
   get '/idv/session' => 'idv/sessions#new'
   put '/idv/session' => 'idv/sessions#create'
   get '/idv/session/dupe' => 'idv/sessions#dupe'

--- a/db/migrate/20161115171029_add_encrypted_pii_recovery.rb
+++ b/db/migrate/20161115171029_add_encrypted_pii_recovery.rb
@@ -1,0 +1,5 @@
+class AddEncryptedPiiRecovery < ActiveRecord::Migration
+  def change
+    add_column :profiles, :encrypted_pii_recovery, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,15 +62,16 @@ ActiveRecord::Schema.define(version: 20161116193316) do
   add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "profiles", force: :cascade do |t|
-    t.integer  "user_id",                                  null: false
-    t.boolean  "active",                   default: false, null: false
+    t.integer  "user_id",                                           null: false
+    t.boolean  "active",                            default: false, null: false
     t.datetime "verified_at"
     t.datetime "activated_at"
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
     t.string   "vendor"
     t.text     "encrypted_pii"
-    t.string   "ssn_signature", limit: 64
+    t.string   "ssn_signature",          limit: 64
+    t.text     "encrypted_pii_recovery"
   end
 
   add_index "profiles", ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,15 +1,27 @@
 namespace :dev do
   desc 'Sample data for local development environment'
   task prime: 'db:setup' do
+    pw = 'salty pickles'
     %w(test1@test.com test2@test.com).each_with_index do |email, index|
       User.find_or_create_by!(email: email) do |user|
         user.skip_confirmation!
-        pw = 'salty pickles'
         user.reset_password(pw, pw)
         user.phone = format('+1 (415) 555-01%02d', index)
         user.phone_confirmed_at = Time.current
         Event.create(user_id: user.id, event_type: :account_created)
       end
     end
+
+    loa3_user = User.find_by(email: 'test2@test.com')
+    loa3_user.unlock_user_access_key(pw)
+    profile = Profile.new(user: loa3_user)
+    pii = Pii::Attributes.new_from_hash(
+      ssn: '660-00-1234',
+      dob: '1920-01-01',
+      first_name: 'Some',
+      last_name: 'One'
+    )
+    profile.encrypt_pii(loa3_user.user_access_key, pii)
+    profile.activate
   end
 end

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -67,6 +67,8 @@ describe Idv::ConfirmationsController do
           end
 
           it 'redirects to original SAML Authn request' do
+            post :continue
+
             expect(response).to redirect_to saml_authn_request
           end
 
@@ -80,6 +82,7 @@ describe Idv::ConfirmationsController do
             subject.session[:saml_request_url] = nil
             complete_idv_session(true)
             get :index
+            post :continue
           end
 
           it 'redirects to IdP profile' do

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -21,5 +21,25 @@ describe TwoFactorAuthentication::RecoveryCodeController do
 
       expect(response).to redirect_to profile_path
     end
+
+    context 'LOA3 user' do
+      it 're-encrypts PII using new code' do
+        profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
+        user = profile.user
+        stub_sign_in(user)
+
+        generator = RecoveryCodeGenerator.new(user)
+        allow(RecoveryCodeGenerator).to receive(:new).and_return(generator)
+
+        user.unlock_user_access_key(user.password)
+        cacher = Pii::Cacher.new(user, subject.user_session)
+        cacher.save(user.user_access_key, profile)
+        allow(Pii::Cacher).to receive(:new).and_return(cacher)
+
+        expect(user.active_profile).to receive(:update!).and_call_original
+
+        get :show
+      end
+    end
   end
 end

--- a/spec/controllers/users/edit_password_controller_spec.rb
+++ b/spec/controllers/users/edit_password_controller_spec.rb
@@ -51,6 +51,7 @@ describe Users::EditPasswordController do
 
         new_user_access_key = user.unlock_user_access_key(new_password)
 
+        expect(flash[:recovery_code]).to be_present
         expect(profile.decrypt_pii(new_user_access_key)).to be_a Pii::Attributes
         expect(profile.decrypt_pii(new_user_access_key).ssn).to eq '1234'
         expect do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -199,6 +199,7 @@ feature 'saml api', devise: true do
         click_on 'Yes'
 
         complete_idv_profile_ok(user.reload)
+        click_acknowledge_recovery_code
 
         expect(current_url).to eq saml_authn_request
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -35,6 +35,20 @@ feature 'User profile' do
 
       expect(current_path).to eq profile_path
     end
+
+    context 'LOA3 user' do
+      it 'generates a new recovery code' do
+        profile = create(:profile, :active, :verified, pii: { ssn: '1234', dob: '1920-01-01' })
+        sign_in_live_with_2fa(profile.user)
+
+        visit settings_password_path
+        fill_in 'update_user_password_form_password', with: 'this is a great sentence'
+        click_button 'Update'
+
+        expect(current_path).to eq profile_path
+        expect(page).to have_content(t('idv.messages.recovery_code'))
+      end
+    end
   end
 
   describe 'Regenerating recovery code' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -26,6 +26,17 @@ describe Profile do
       expect(profile.encrypted_pii).to_not match 'Jane'
       expect(profile.encrypted_pii).to_not match '666'
     end
+
+    it 'generates new recovery code' do
+      expect(profile.encrypted_pii_recovery).to be_nil
+
+      initial_recovery_code = user.recovery_code
+
+      profile.encrypt_pii(user_access_key, pii)
+
+      expect(profile.encrypted_pii_recovery).to_not be_nil
+      expect(user.recovery_code).to_not eq initial_recovery_code
+    end
   end
 
   describe '#decrypt_pii' do
@@ -37,6 +48,16 @@ describe Profile do
       decrypted_pii = profile.decrypt_pii(user_access_key)
 
       expect(decrypted_pii).to eq pii
+    end
+  end
+
+  describe '#recover_pii' do
+    it 'decrypts the encrypted_pii_recovery using a recovery code' do
+      expect(profile.encrypted_pii_recovery).to be_nil
+
+      recovery_code = profile.encrypt_pii(user_access_key, pii)
+
+      expect(profile.recover_pii(recovery_code)).to eq pii
     end
   end
 

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -80,4 +80,8 @@ module IdvHelper
     fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
     click_submit_default
   end
+
+  def click_acknowledge_recovery_code
+    click_button t('forms.buttons.acknowledge_recovery_code')
+  end
 end


### PR DESCRIPTION
**Why**: Enable recovery of encrypted PII using a recovery code.

**How**:

* Add Profile.encrypted_pii_recovery with copy of PII encrypted with
recovery-code-derived UserAccessKey
* Generate a new recovery code during IdV and present it to the user
on the IdV confirmation page
* Generate a new recovery code when password is changed, and re-encrypt
the PII with it. Display the code to the user on the profile page.
* When user generates a new recovery code, use it to re-encrypt
encrypted_pii_recovery.


NOTE this PR does *not* cover the use case of re-claiming deactivated profile after password reset. That will be a subsequent PR.