### PR TITLE
Avoid multiple trips to HSM for UserAccessKey

### DIFF
--- a/app/services/pii/password_encryptor.rb
+++ b/app/services/pii/password_encryptor.rb
@@ -6,7 +6,7 @@ module Pii
     end
 
     def encrypt(plaintext, user_access_key)
-      encrypted_key_maker.make(user_access_key)
+      encrypted_key_maker.make(user_access_key) unless user_access_key.made?
       encrypted_c = cipher.encrypt(fingerprint_and_concat(plaintext), user_access_key.hash_e)
       join_segments(user_access_key.encryption_key, encrypted_c)
     end

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,5 +1,12 @@
 class SessionEncryptor
-  @user_access_key = nil
+  def self.build_user_access_key
+    env = Figaro.env
+    UserAccessKey.new(env.session_encryption_key, env.password_pepper)
+  end
+
+  cattr_reader :user_access_key do
+    build_user_access_key
+  end
 
   def self.load(value)
     decrypted = encryptor.decrypt(value, user_access_key)
@@ -14,13 +21,4 @@ class SessionEncryptor
   def self.encryptor
     Pii::PasswordEncryptor.new
   end
-
-  def self.user_access_key
-    @user_access_key ||= UserAccessKey.new(env.session_encryption_key, env.password_pepper)
-  end
-
-  def self.env
-    Figaro.env
-  end
-  private_class_method :env
 end

--- a/spec/services/pii/password_encryptor_spec.rb
+++ b/spec/services/pii/password_encryptor_spec.rb
@@ -12,6 +12,22 @@ describe Pii::PasswordEncryptor do
 
       expect(ciphertext).to_not match plaintext
     end
+
+    it 'only builds encrypted key once per user_access_key' do
+      uak = UserAccessKey.new(password, salt)
+
+      expect(uak.made?).to eq false
+
+      ciphertext_one = subject.encrypt(plaintext, uak)
+
+      expect(uak.made?).to eq true
+      expect(uak).to_not receive(:store_encryption_key)
+
+      ciphertext_two = subject.encrypt(plaintext, uak)
+
+      expect(ciphertext_one).to_not eq ciphertext_two
+      expect(subject.decrypt(ciphertext_one, uak)).to eq subject.decrypt(ciphertext_two, uak)
+    end
   end
 
   describe '#decrypt' do

--- a/spec/services/user_access_key_spec.rb
+++ b/spec/services/user_access_key_spec.rb
@@ -92,4 +92,14 @@ describe UserAccessKey do
       expect(subject.unlocked?).to eq true
     end
   end
+
+  describe '#made?' do
+    it 'returns true when #store_encrypted_key has been called' do
+      expect(subject.made?).to eq false
+
+      subject.store_encrypted_key(ciphertext)
+
+      expect(subject.made?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Multiple uses of a single UserAccessKey to encrypt multiple
things resulted in multiple trips to the hardware security module.
Each UAK should need to be made into an encrypted key only once in
its lifetime.