### PR TITLE
Add "Sign in" link to create account page

### DIFF
--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -10,4 +10,8 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')
   - link = link_to t('notices.terms_of_service.link'), privacy_path
   p.mb-40p == t('notices.terms_of_service.text', link: link)
-  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'
+  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1 mb4'
+
+.clearfix.pt1.border-top
+  - auth_link = link_to t('links.sign_in'), new_user_session_path
+  .sm-col-right == t('instructions.registration.already_have_account', link: auth_link)

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -10,7 +10,7 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')
   - link = link_to t('notices.terms_of_service.link'), privacy_path
   p.mb-40p == t('notices.terms_of_service.text', link: link)
-  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1 mb4'
+  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
 .clearfix.pt1.border-top
   - auth_link = link_to t('links.sign_in'), new_user_session_path


### PR DESCRIPTION
**Why**:
* User should have a way to cancel out of any page
* This is consistent with the `/start` page

Before:

![screen shot 2016-11-16 at 4 12 57 pm](https://cloud.githubusercontent.com/assets/601515/20371200/ee777820-ac17-11e6-8fb1-b2708c6e0bda.png)


After:

![screen shot 2016-11-16 at 4 14 12 pm](https://cloud.githubusercontent.com/assets/601515/20371204/f2c9c4e6-ac17-11e6-82cc-7f5667f62fa3.png)
