### PR TITLE
I18n override cleanup

### DIFF
--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -5,7 +5,7 @@ I18n.module_eval do
     def translate_with_markup(*args)
       i18n_text = normal_translate(*args)
       return i18n_text unless FeatureManagement.enable_i18n_mode? && i18n_text.is_a?(String)
-      return i18n_text if caller[1] =~ /flows_spec.rb/ # skip markup if called from flows spec
+      return i18n_text if caller[1] =~ /flows_spec.rb|session_helper.rb/
 
       key = args.first.to_s
       rtn = i18n_text + i18n_mode_additional_markup(key)

--- a/spec/features/flows/visitor_flows_spec.rb
+++ b/spec/features/flows/visitor_flows_spec.rb
@@ -7,7 +7,7 @@ feature 'Visitors requesting login.gov directly', devise: true, user_flow: true 
     end
 
     it 'loads the home page' do
-      Capybara::Screenshot.screenshot_and_save_page
+      screenshot_and_save_page
     end
 
     context 'when choosing create account' do
@@ -16,7 +16,7 @@ feature 'Visitors requesting login.gov directly', devise: true, user_flow: true 
       end
 
       it 'informs the user about login.gov' do
-        Capybara::Screenshot.screenshot_and_save_page
+        screenshot_and_save_page
       end
 
       context 'when creating account with valid email' do
@@ -25,7 +25,7 @@ feature 'Visitors requesting login.gov directly', devise: true, user_flow: true 
         end
 
         it 'notifies user to check email' do
-          Capybara::Screenshot.screenshot_and_save_page
+          screenshot_and_save_page
         end
 
         context 'when confirming email' do
@@ -34,7 +34,7 @@ feature 'Visitors requesting login.gov directly', devise: true, user_flow: true 
           end
 
           it 'prompts user to set password' do
-            Capybara::Screenshot.screenshot_and_save_page
+            screenshot_and_save_page
           end
         end
       end
@@ -45,7 +45,7 @@ feature 'Visitors requesting login.gov directly', devise: true, user_flow: true 
         end
 
         it 'informs the user to try again' do
-          Capybara::Screenshot.screenshot_and_save_page
+          screenshot_and_save_page
         end
       end
     end


### PR DESCRIPTION
### Why
To allow I18n mode to be enabled with the user screen index tool

### How
Disables the injection of markup when `I18n.t` is called from user flows specs or the session helper.