### PR TITLE
Add Users.password_cost

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -8,9 +8,10 @@ module UserAccessKeyOverrides
   attr_accessor :user_access_key
 
   def password_digest(password)
-    user_access_key = UserAccessKey.new(password, authenticatable_salt)
+    user_access_key = UserAccessKey.new(password, authenticatable_salt, password_cost)
     encrypted_key_maker.make(user_access_key)
     self.encryption_key ||= user_access_key.encryption_key
+    self.password_cost ||= user_access_key.cost
     user_access_key.encrypted_password
   end
 
@@ -25,7 +26,7 @@ module UserAccessKeyOverrides
   end
 
   def unlock_user_access_key(password)
-    self.user_access_key = UserAccessKey.new(password, authenticatable_salt)
+    self.user_access_key = UserAccessKey.new(password, authenticatable_salt, password_cost)
     encrypted_key_maker.unlock(user_access_key, encryption_key)
     user_access_key
   end
@@ -34,6 +35,7 @@ module UserAccessKeyOverrides
     if new_password.present?
       self.password_salt = Devise.friendly_token[0, 20]
       self.encryption_key = nil
+      self.password_cost = nil
     end
     super
   end

--- a/db/migrate/20161117153726_add_user_password_cost.rb
+++ b/db/migrate/20161117153726_add_user_password_cost.rb
@@ -1,0 +1,5 @@
+class AddUserPasswordCost < ActiveRecord::Migration
+  def change
+    add_column :users, :password_cost, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116193316) do
+ActiveRecord::Schema.define(version: 20161117153726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 20161116193316) do
     t.string   "unique_session_id"
     t.string   "password_salt"
     t.string   "encryption_key"
+    t.string   "password_cost"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/services/user_access_key_spec.rb
+++ b/spec/services/user_access_key_spec.rb
@@ -7,6 +7,17 @@ describe UserAccessKey do
 
   subject { UserAccessKey.new(password, salt) }
 
+  describe '#cost' do
+    it 'uses explicit scrypt cost if passed to new' do
+      cost = SCrypt::Engine.calibrate(max_time: 0.2)
+      uak = UserAccessKey.new(password, salt, cost)
+
+      expect(cost).to_not eq UserAccessKey::COST
+      expect(uak.z1).to_not eq subject.z1
+      expect(uak.cost).to eq cost
+    end
+  end
+
   describe '#encrypted_password' do
     it 'is an alias for hash_f' do
       expect(subject.method(:encrypted_password)).to eq subject.method(:hash_f)


### PR DESCRIPTION
**Why**: We will eventually change default SCrypt calibration string
as computers get faster.

**How**: Rather than relying on SCrypt calibration string
hardcoded in UserAccessKey, store it in `password_cost` column
and prefer it when verifying user password.