### PR TITLE
Link to contact page in emails / texts

### DIFF
--- a/app/jobs/sms_sender_number_change_job.rb
+++ b/app/jobs/sms_sender_number_change_job.rb
@@ -1,4 +1,5 @@
 class SmsSenderNumberChangeJob < ActiveJob::Base
+  include Rails.application.routes.url_helpers
   queue_as :sms
 
   def perform(phone)
@@ -18,7 +19,7 @@ class SmsSenderNumberChangeJob < ActiveJob::Base
     I18n.t(
       'jobs.sms_sender_number_change_job.message',
       app: APP_NAME,
-      support_url: Figaro.env.support_url
+      support_url: contact_url
     )
   end
 end

--- a/app/views/idv/activated.html.slim
+++ b/app/views/idv/activated.html.slim
@@ -2,5 +2,5 @@
 
 h1.h3.my0 = t('idv.titles.activated')
 p.mt-tiny.mb0 = t('idv.messages.activated_html',
-                link: link_to(t('idv.messages.activated_link'), Figaro.env.support_url))
+                  link: link_to(t('idv.messages.activated_link'), contact_path))
 = link_to 'Back', idv_url

--- a/app/views/layouts/user_mailer.html.slim
+++ b/app/views/layouts/user_mailer.html.slim
@@ -77,8 +77,8 @@ html xmlns="http://www.w3.org/1999/xhtml"
                                       tr
                                         th
                                           p == t('mailer.help',
-                                                link: link_to(Figaro.env.support_url,
-                                                              Figaro.env.support_url),
+                                                link: link_to(contact_url,
+                                                              contact_url),
                                                 app: link_to(APP_NAME,
                                                              Figaro.env.mailer_domain_name,
                                                              style: 'text-decoration: none;'))

--- a/app/views/user_mailer/email_changed.html.slim
+++ b/app/views/user_mailer/email_changed.html.slim
@@ -10,4 +10,4 @@ table.hr
     th
       | &nbsp;
 
-p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))
+p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -10,4 +10,4 @@ table.hr
     th
       | &nbsp;
 
-p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))
+p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))

--- a/app/views/user_mailer/signup_with_your_email.html.slim
+++ b/app/views/user_mailer/signup_with_your_email.html.slim
@@ -29,4 +29,4 @@ table.hr
 
 p = t('.reset_password', app: APP_NAME)
 
-p == t('.help', app: APP_NAME, link: link_to(Figaro.env.support_url, Figaro.env.support_url))
+p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,7 @@ module Upaya
     config.middleware.use Rack::Attack
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{yml}')]
+
+    routes.default_url_options[:host] = Figaro.env.mailer_domain_name
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,6 @@ module Upaya
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{yml}')]
 
-    routes.default_url_options[:host] = Figaro.env.mailer_domain_name
+    routes.default_url_options[:host] = Figaro.env.domain_name
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -43,7 +43,6 @@ session_check_frequency: '30'
 stale_session_window: '180'
 
 support_email: 'hello@login.gov'
-support_url: 'https://18f.gov/contact'
 
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
 

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -25,8 +25,7 @@ feature 'Password Recovery' do
     end
 
     it 'includes a link to customer service in the email' do
-      expect(last_email.html_part.body).
-        to include Figaro.env.support_url
+      expect(last_email.html_part.body).to include contact_url
     end
 
     it 'displays a localized notice' do

--- a/spec/jobs/sms_sender_number_change_job_spec.rb
+++ b/spec/jobs/sms_sender_number_change_job_spec.rb
@@ -17,7 +17,7 @@ describe SmsSenderNumberChangeJob do
         I18n.t(
           'jobs.sms_sender_number_change_job.message',
           app: APP_NAME,
-          support_url: 'http://localhost:3000/contact'
+          support_url: 'http://www.example.com/contact'
         )
       )
     end

--- a/spec/jobs/sms_sender_number_change_job_spec.rb
+++ b/spec/jobs/sms_sender_number_change_job_spec.rb
@@ -17,7 +17,7 @@ describe SmsSenderNumberChangeJob do
         I18n.t(
           'jobs.sms_sender_number_change_job.message',
           app: APP_NAME,
-          support_url: Figaro.env.support_url
+          support_url: 'http://localhost:3000/contact'
         )
       )
     end

--- a/spec/views/layouts/user_mailer.html.slim_spec.rb
+++ b/spec/views/layouts/user_mailer.html.slim_spec.rb
@@ -28,9 +28,9 @@ describe 'layouts/user_mailer.html.slim' do
   it 'includes the support text and link' do
     expect(rendered).to have_content(t('mailer.no_reply'))
     expect(rendered).to have_content(
-      t('mailer.help', app: APP_NAME, link: Figaro.env.support_url)
+      t('mailer.help', app: APP_NAME, link: contact_url)
     )
-    expect(rendered).to have_link(Figaro.env.support_url, href: Figaro.env.support_url)
+    expect(rendered).to have_link(contact_url, href: contact_url)
   end
 
   it 'includes placeholder link to About login.gov' do


### PR DESCRIPTION
**Why**:
* Before, we were linking to the figaro support url, which was not
  configured with a full URL
* Right now, `/contact` is where users can contact us

![screen shot 2016-11-17 at 1 26 35 pm](https://cloud.githubusercontent.com/assets/601515/20408303/c1086d24-acc9-11e6-8d71-a71f123e42cd.png)
