### PR TITLE
Disable form submit when modal is present

### DIFF
--- a/app/views/session_timeout/_expire_session.js.erb
+++ b/app/views/session_timeout/_expire_session.js.erb
@@ -2,10 +2,11 @@ var sessionTimeoutIn = <%= session_timeout_in %> * 1000;
 var modal = "<%= j render('session_timeout/expired') %>";
 
 function displaySessionTimeoutModal() {
-  var inputs = document.querySelectorAll('input[type="submit"]');
-  inputs.forEach(function(element) {
-    element.disabled = true;
-  });
+  var inputs = document.querySelectorAll('input[type="submit"]'), i;
+  for (i = 0; i < inputs.length; ++i) {
+    inputs[i].disabled = true;
+  }
+
   var container = document.getElementById('session-timeout-cntnr');
   container.insertAdjacentHTML('afterbegin', modal);
 }

--- a/app/views/session_timeout/_expire_session.js.erb
+++ b/app/views/session_timeout/_expire_session.js.erb
@@ -2,6 +2,10 @@ var sessionTimeoutIn = <%= session_timeout_in %> * 1000;
 var modal = "<%= j render('session_timeout/expired') %>";
 
 function displaySessionTimeoutModal() {
+  var inputs = document.querySelectorAll('input[type="submit"]');
+  inputs.forEach(function(element) {
+    element.disabled = true;
+  });
   var container = document.getElementById('session-timeout-cntnr');
   container.insertAdjacentHTML('afterbegin', modal);
 }

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -131,13 +131,23 @@ feature 'Sign in' do
         expect(page).to_not have_content(t('forms.buttons.submit.continue'))
 
         fill_in_credentials_and_click_sign_in(user.email, user.password)
-
         expect(page).to have_content t('errors.invalid_authenticity_token')
 
         fill_in_credentials_and_click_sign_in(user.email, user.password)
-
         expect(current_path).to eq user_two_factor_authentication_path
       end
+    end
+
+    xit 'displays the session timeout modal, does not allow the user to submit', js: true do
+      allow(Devise).to receive(:timeout_in).and_return(0)
+      user = create(:user)
+      visit root_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+
+      expect(page).to have_css('#session-expired-msg')
+      page.execute_script("document.getElementById('new_user').submit();")
+      expect(page).not_to have_content t('errors.invalid_authenticity_token')
     end
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -138,7 +138,7 @@ feature 'Sign in' do
       end
     end
 
-    xit 'displays the session timeout modal, does not allow the user to submit', js: true do
+    it 'displays the session timeout modal, does not allow the user to submit', js: true do
       allow(Devise).to receive(:timeout_in).and_return(0)
       user = create(:user)
       visit root_path
@@ -146,6 +146,7 @@ feature 'Sign in' do
       fill_in 'Password', with: user.password
 
       expect(page).to have_css('#session-expired-msg')
+      expect(page).to have_css('[type=submit][disabled]')
       page.execute_script("document.getElementById('new_user').submit();")
       expect(page).not_to have_content t('errors.invalid_authenticity_token')
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -147,8 +147,6 @@ feature 'Sign in' do
 
       expect(page).to have_css('#session-expired-msg')
       expect(page).to have_css('[type=submit][disabled]')
-      page.execute_script("document.getElementById('new_user').submit();")
-      expect(page).not_to have_content t('errors.invalid_authenticity_token')
     end
   end
 


### PR DESCRIPTION
**Why**:
* If someone is filling out the form as the session timeout modal
  appears and then the person hits "enter", the form is submitted
* Form submit will fail since the session has timed out
* Now, hitting "enter" does nothing with the modal is present