### PR TITLE
Remove comments from config files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,35 +1,18 @@
 require File.expand_path('../boot', __FILE__)
-
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# User visible application name. Stored here in a global since it is
-# accessed from a wide variety of different places (views, controllers,
-# jobs, etc). Please file complaints about use of global variables
-# with the appropriate government office.
 APP_NAME = 'login.gov'.freeze
 
 module Upaya
   class Application < Rails::Application
     config.active_job.queue_adapter = :sidekiq
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
     config.autoload_paths << Rails.root.join('app/mailers/concerns')
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = 'UTC'
-
     config.middleware.use Rack::Attack
-
-    # Configure Browserify to use babelify to compile ES6
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'
-
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{yml}')]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,42 +1,15 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-
-  # Do not eager load code on boot.
   config.eager_load = false
-
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-
-  # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
-
-  # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
-
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
   config.assets.debug = true
-
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
-
-  # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
-  # ActionMailer Config
   config.action_mailer.default_url_options = {
     host: Figaro.env.domain_name,
     protocol: 'http'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,74 +1,17 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # Code is not reloaded between requests.
   config.cache_classes = true
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
-
-  # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # `config.assets.precompile` and `config.assets.version` have moved to
-  # config/initializers/assets.rb
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # Note: We are not enabling this here since these three policies are enforces by other means:
-  # Strict-Transport-Security: enforced by secure_headers gem
-  # secure cookes: enforced by secure_headers gem
-  # SSL everywhre: enforced by the webserver (nginx) that terminates user SSL connections
-  # config.force_ssl = true
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
-
-  # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Keys must be symbolized per ActionMailer documentation
   config.action_mailer.smtp_settings = JSON.parse(Figaro.env.smtp_settings).symbolize_keys
 
-  # ActionMailer Config
   config.action_mailer.default_url_options = {
     host: Figaro.env.domain_name,
     protocol: 'https'
@@ -81,20 +24,11 @@ Rails.application.configure do
   # creates false positive results.
   config.action_dispatch.ip_spoofing_check = false
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
   config.log_level = :info
-
-  # Enable Lograge in production for succinct logging
   config.lograge.enabled = true
   config.lograge.custom_options = ->(event) { event.payload.except(:params) }
   config.lograge.ignore_actions = ['Users::SessionsController#active']
   config.lograge.formatter = Lograge::Formatters::Json.new
   config.logstash.type = :multi_delegator
-  config.logstash.outputs = [
-    {
-      type: :file,
-      path: 'log/production.log'
-    }
-  ]
+  config.logstash.outputs = [{ type: :file, path: 'log/production.log' }]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,45 +1,17 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
   config.active_job.queue_adapter = :test
-
   config.cache_classes = true
-
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
-
-  # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
+  config.serve_static_files = true
   config.static_cache_control = 'public, max-age=3600'
-
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-
-  # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
-
-  # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-
-  # Randomize the order test cases are executed.
   config.active_support.test_order = :random
-
-  # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-
-  # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Figaro.env.domain_name }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
@@ -49,28 +21,17 @@ Rails.application.configure do
     config.action_controller.asset_host = ENV['RAILS_ASSET_HOST']
   end
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
   config.assets.debug = true
-
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # For testing session variables in Capybara specs
   config.middleware.use RackSessionAccess::Middleware
-
   config.lograge.enabled = true
   config.lograge.custom_options = ->(event) { event.payload }
 
-  # Bullet gem config
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true
   end
 
-  # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 end


### PR DESCRIPTION
**Why**:
* This makes the config files easier to read
* Next step is to alpha order so we know that we don't config something
  twice in a single file
* Also may find that there is repetitive setup that we can add in
  `config/application.rb` rather than in each environment