### PR TITLE
Add User.recovery_salt

### DIFF
--- a/app/controllers/two_factor_authentication/recovery_code_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_controller.rb
@@ -13,19 +13,21 @@ module TwoFactorAuthentication
     private
 
     def create_new_code
-      generator = RecoveryCodeGenerator.new(current_user)
-      code = generator.create
       if current_user.active_profile.present?
-        reencrypt_pii_recovery(generator.user_access_key)
+        reencrypt_pii_recovery
+      else
+        generator = RecoveryCodeGenerator.new(current_user)
+        generator.create
       end
-      code
     end
 
-    def reencrypt_pii_recovery(uak)
+    def reencrypt_pii_recovery
       profile = current_user.active_profile
       cacher = Pii::Cacher.new(current_user, user_session)
       pii_attributes = cacher.fetch
-      profile.update!(encrypted_pii_recovery: pii_attributes.encrypted(uak))
+      profile.encrypt_recovery_pii(pii_attributes)
+      profile.save!
+      profile.recovery_code
     end
   end
 end

--- a/db/migrate/20161118150203_add_recovery_salt.rb
+++ b/db/migrate/20161118150203_add_recovery_salt.rb
@@ -1,0 +1,5 @@
+class AddRecoverySalt < ActiveRecord::Migration
+  def change
+    add_column :users, :recovery_salt, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116193316) do
+ActiveRecord::Schema.define(version: 20161118150203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 20161116193316) do
     t.string   "unique_session_id"
     t.string   "password_salt"
     t.string   "encryption_key"
+    t.string   "recovery_salt"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -36,7 +36,7 @@ describe TwoFactorAuthentication::RecoveryCodeController do
         cacher.save(user.user_access_key, profile)
         allow(Pii::Cacher).to receive(:new).and_return(cacher)
 
-        expect(user.active_profile).to receive(:update!).and_call_original
+        expect(user.active_profile).to receive(:save!).and_call_original
 
         get :show
       end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -39,6 +39,20 @@ describe Profile do
     end
   end
 
+  describe '#encrypt_recovery_pii' do
+    it 'generates new recovery code' do
+      expect(profile.encrypted_pii_recovery).to be_nil
+
+      initial_recovery_code = user.recovery_code
+
+      profile.encrypt_recovery_pii(pii)
+
+      expect(profile.encrypted_pii_recovery).to_not be_nil
+      expect(user.recovery_code).to_not eq initial_recovery_code
+      expect(profile.recovery_code).to_not eq user.recovery_code
+    end
+  end
+
   describe '#decrypt_pii' do
     it 'decrypts PII' do
       expect(profile.encrypted_pii).to be_nil


### PR DESCRIPTION
**Why**: User.password_salt changes every time password is reset.
In order to recover PII with a recovery code, we need to use a separate salt.