### PR TITLE
Reformat Analytics JSON output

### DIFF
--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -4,7 +4,11 @@ class IdvController < ApplicationController
   before_action :confirm_two_factor_authenticated
 
   def index
-    redirect_to idv_activated_url if current_user.active_profile.present?
+    if current_user.active_profile.present?
+      redirect_to idv_activated_url
+    else
+      analytics.track_event(Analytics::IDV_INTRO_VISIT)
+    end
   end
 
   def cancel

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,6 +6,7 @@ module Users
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def start
+      analytics.track_event(Analytics::ACCOUNT_CREATION_INTRO_VISIT)
     end
 
     def new

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -4,12 +4,14 @@ class Analytics
     @request = request
   end
 
-  def track_event(event, attributes = { user_id: uuid })
-    attributes[:user_id] = uuid unless attributes.key?(:user_id)
+  def track_event(event, attributes = {})
+    analytics_hash = {
+      event: event,
+      properties: attributes.except(:user_id),
+      user_id: attributes[:user_id] || uuid
+    }
 
-    consolidated_attributes = attributes.merge!(request_attributes)
-
-    Rails.logger.info(consolidated_attributes.merge(event: event))
+    Rails.logger.info(analytics_hash.merge!(request_attributes))
   end
 
   private
@@ -28,12 +30,14 @@ class Analytics
   end
 
   # rubocop:disable Metrics/LineLength
+  ACCOUNT_CREATION_INTRO_VISIT = 'Account creation intro visited'.freeze
   AUTHENTICATION_MAX_2FA_ATTEMPTS = 'Authentication: user reached max 2FA attempts'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUESTED = 'Email Change: requested'.freeze
   EMAIL_CHANGED_TO_EXISTING = 'Email Change: user attempted to change their email to an existing email'.freeze
   EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
   IDV_FAILED = 'IdV: Failed'.freeze
+  IDV_INTRO_VISIT = 'IdV Intro Visited'.freeze
   IDV_SUCCESSFUL = 'IdV: Successful'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   INVALID_SERVICE_PROVIDER = 'Invalid Service Provider'.freeze
@@ -53,6 +57,7 @@ class Analytics
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SETUP_2FA_INVALID_PHONE = '2FA setup: invalid phone number'.freeze
   SETUP_2FA_VALID_PHONE = '2FA setup: valid phone number'.freeze
+  SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   TOTP_SETUP_INVALID_CODE = 'TOTP Setup: invalid code'.freeze
   TOTP_SETUP_VALID_CODE = 'TOTP Setup: valid code'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe IdvController do
+  describe '#index' do
+    it 'tracks page visit' do
+      stub_sign_in
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).with(Analytics::IDV_INTRO_VISIT)
+
+      get :index
+    end
+
+    it 'does not track page visit if profile is active' do
+      profile = create(:profile, :active)
+
+      stub_sign_in(profile.user)
+      stub_analytics
+
+      expect(@analytics).to_not receive(:track_event).with(Analytics::IDV_INTRO_VISIT)
+
+      get :index
+    end
+  end
+end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -91,4 +91,15 @@ describe Users::RegistrationsController, devise: true do
       post :create, user: { email: 'invalid@' }
     end
   end
+
+  describe '#start' do
+    it 'tracks page visit' do
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_CREATION_INTRO_VISIT)
+
+      get :start
+    end
+  end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -203,14 +203,29 @@ describe Users::SessionsController, devise: true do
         stub_analytics
         expect(@analytics).to receive(:track_event).
           with(Analytics::EMAIL_AND_PASSWORD_AUTH, success?: true, user_id: user.uuid)
+
+        profile_encryption_error = {
+          error: 'Unable to parse encrypted payload. ' \
+                 '#<TypeError: no implicit conversion of nil into String>'
+        }
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PROFILE_ENCRYPTION_INVALID, user_id: user.uuid)
+          with(Analytics::PROFILE_ENCRYPTION_INVALID, profile_encryption_error)
 
         post :create, user: { email: user.email, password: user.password }
 
         expect(controller.user_session[:decrypted_pii]).to be_nil
         expect(profile.reload).to_not be_active
       end
+    end
+  end
+
+  describe '#new' do
+    it 'tracks page visit' do
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).with(Analytics::SIGN_IN_PAGE_VISIT)
+
+      get :new
     end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -13,10 +13,15 @@ describe Analytics do
       user = build_stubbed(:user, uuid: '123')
 
       analytics = Analytics.new(user, FakeRequest.new)
-      consolidated_attributes = request_attributes.reverse_merge(user_id: user.uuid)
+
+      analytics_hash = {
+        event: 'Trackable Event',
+        properties: {},
+        user_id: user.uuid
+      }
 
       expect(Rails.logger).to receive(:info).
-        with(consolidated_attributes.merge(event: 'Trackable Event'))
+        with(analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event')
     end
@@ -26,10 +31,15 @@ describe Analytics do
       tracked_user = build_stubbed(:user, uuid: '456')
 
       analytics = Analytics.new(current_user, FakeRequest.new)
-      consolidated_attributes = request_attributes.reverse_merge(user_id: tracked_user.uuid)
+
+      analytics_hash = {
+        event: 'Trackable Event',
+        properties: {},
+        user_id: tracked_user.uuid
+      }
 
       expect(Rails.logger).to receive(:info).
-        with(consolidated_attributes.merge(event: 'Trackable Event'))
+        with(analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
     end


### PR DESCRIPTION
**Why**: To make it easier to run queries

**How**:
- Add a `properties` hash for event-specific attributes
- Move `user_id` to the top level
- Add events to track certain page visits