### PR TITLE
Add User.password_cost and User.recovery_cost

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -8,9 +8,14 @@ module UserAccessKeyOverrides
   attr_accessor :user_access_key
 
   def password_digest(password)
-    user_access_key = UserAccessKey.new(password, authenticatable_salt)
+    user_access_key = UserAccessKey.new(
+      password: password,
+      salt: authenticatable_salt,
+      cost: password_cost
+    )
     encrypted_key_maker.make(user_access_key)
     self.encryption_key ||= user_access_key.encryption_key
+    self.password_cost ||= user_access_key.cost
     user_access_key.encrypted_password
   end
 
@@ -25,7 +30,11 @@ module UserAccessKeyOverrides
   end
 
   def unlock_user_access_key(password)
-    self.user_access_key = UserAccessKey.new(password, authenticatable_salt)
+    self.user_access_key = UserAccessKey.new(
+      password: password,
+      salt: authenticatable_salt,
+      cost: password_cost
+    )
     encrypted_key_maker.unlock(user_access_key, encryption_key)
     user_access_key
   end
@@ -34,6 +43,7 @@ module UserAccessKeyOverrides
     if new_password.present?
       self.password_salt = Devise.friendly_token[0, 20]
       self.encryption_key = nil
+      self.password_cost = nil
     end
     super
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,7 +25,11 @@ class Profile < ActiveRecord::Base
   end
 
   def recover_pii(recovery_code)
-    rc_user_access_key = UserAccessKey.new(recovery_code, user.recovery_salt)
+    rc_user_access_key = UserAccessKey.new(
+      password: recovery_code,
+      salt: user.recovery_salt,
+      cost: user.recovery_cost
+    )
     EncryptedKeyMaker.new.make(rc_user_access_key)
     Pii::Attributes.new_from_encrypted(encrypted_pii_recovery, rc_user_access_key)
   end

--- a/app/services/recovery_code_generator.rb
+++ b/app/services/recovery_code_generator.rb
@@ -8,16 +8,16 @@ class RecoveryCodeGenerator
   end
 
   def create
-    salt = Devise.friendly_token[0, 20]
-    @user_access_key = make_user_access_key(raw_recovery_code, salt)
-
-    user.update!(recovery_code: hashed_code, recovery_salt: salt)
-
+    user.recovery_salt = Devise.friendly_token[0, 20]
+    user.recovery_cost = Figaro.env.scrypt_cost
+    @user_access_key = make_user_access_key(raw_recovery_code)
+    user.recovery_code = hashed_code
+    user.save!
     raw_recovery_code
   end
 
   def verify(plaintext_code)
-    @user_access_key = make_user_access_key(plaintext_code, user.recovery_salt)
+    @user_access_key = make_user_access_key(plaintext_code)
     encryption_key, encrypted_code = user.recovery_code.split(Pii::Encryptor::DELIMITER)
     begin
       key_maker.unlock(user_access_key, encryption_key)
@@ -31,8 +31,8 @@ class RecoveryCodeGenerator
 
   attr_reader :length, :user, :key_maker
 
-  def make_user_access_key(code, salt)
-    UserAccessKey.new(code, salt)
+  def make_user_access_key(code)
+    UserAccessKey.new(password: code, salt: user.recovery_salt, cost: user.recovery_cost)
   end
 
   def hashed_code

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,7 +1,7 @@
 class SessionEncryptor
   def self.build_user_access_key
     env = Figaro.env
-    UserAccessKey.new(env.session_encryption_key, env.password_pepper)
+    UserAccessKey.new(password: env.session_encryption_key, salt: env.password_pepper)
   end
 
   cattr_reader :user_access_key do

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -75,6 +75,7 @@ development:
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'
   saml_passphrase: 'trust-but-verify'
+  scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   secret_key_base: 'development_secret_key_base'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
   session_timeout_in_minutes: '15'
@@ -112,6 +113,7 @@ production:
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'
   saml_passphrase: 'trust-but-verify'
+  scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   secret_key_base: 'rake secret'
   session_encryption_key: 'rake secret'
   session_timeout_in_minutes: '8'
@@ -146,6 +148,7 @@ test:
   requests_per_ip_limit: '3'
   requests_per_ip_period: '60'
   saml_passphrase: 'trust-but-verify'
+  scrypt_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
   secret_key_base: 'test_secret_key_base'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
   session_timeout_in_minutes: '8'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -23,6 +23,7 @@ Figaro.require_keys(
   'requests_per_ip_limit',
   'requests_per_ip_period',
   'saml_passphrase',
+  'scrypt_cost',
   'secret_key_base',
   'session_encryption_key',
   'session_timeout_in_minutes',

--- a/db/migrate/20161118150204_add_scrypt_cost.rb
+++ b/db/migrate/20161118150204_add_scrypt_cost.rb
@@ -1,0 +1,19 @@
+class AddScryptCost < ActiveRecord::Migration
+  def up
+    add_column :users, :password_cost, :string
+    add_column :users, :recovery_cost, :string
+    backfill
+  end
+
+  def down
+    remove_column :users, :password_cost
+    remove_column :users, :recovery_cost
+  end
+
+  def backfill
+    cost = Figaro.env.scrypt_cost
+    User.where(password_cost: nil).each do |user|
+      user.update!(password_cost: cost, recovery_cost: cost)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118150203) do
+ActiveRecord::Schema.define(version: 20161118150204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,8 @@ ActiveRecord::Schema.define(version: 20161118150203) do
     t.string   "password_salt"
     t.string   "encryption_key"
     t.string   "recovery_salt"
+    t.string   "password_cost"
+    t.string   "recovery_cost"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/services/encrypted_key_maker_spec.rb
+++ b/spec/services/encrypted_key_maker_spec.rb
@@ -5,7 +5,7 @@ describe EncryptedKeyMaker do
   let(:salt) { 'mmmm salty' }
   let(:ciphered_key) { SecureRandom.random_bytes(32) }
   let(:random_R) { SecureRandom.random_bytes(32) }
-  let(:user_access_key) { UserAccessKey.new(password, salt) }
+  let(:user_access_key) { UserAccessKey.new(password: password, salt: salt) }
   let(:hash_E) { OpenSSL::Digest::SHA256.hexdigest(user_access_key.z2 + random_R) }
   let(:hash_F) { OpenSSL::Digest::SHA256.hexdigest(hash_E) }
 

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Pii::Attributes do
-  let(:user_access_key) { UserAccessKey.new('sekrit', SecureRandom.uuid) }
+  let(:user_access_key) { UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
 
   describe '#new_from_hash' do
     it 'initializes from plain Hash' do

--- a/spec/services/pii/nist_encryption_spec.rb
+++ b/spec/services/pii/nist_encryption_spec.rb
@@ -34,7 +34,7 @@ describe 'NIST Encryption Model' do
       expect(salt.bytes.length).to eq 32
 
       # Z1, Z2 = scrypt(S, password)   # split 256-bit output into two halves
-      user_access_key = UserAccessKey.new(password, salt)
+      user_access_key = UserAccessKey.new(password: password, salt: salt)
 
       expect(hex_to_bin(user_access_key.z1).length).to eq 16
       expect(hex_to_bin(user_access_key.z2).length).to eq 16
@@ -52,7 +52,7 @@ describe 'NIST Encryption Model' do
 
       password = 'a long sekrit'
       salt = SecureRandom.random_bytes(32)
-      user_access_key = UserAccessKey.new(password, salt)
+      user_access_key = UserAccessKey.new(password: password, salt: salt)
 
       # D = KMS_GCM_Encrypt(key=server_secret, plaintext=R) ^ Z1
       # E = hash( Z2 + R )
@@ -104,7 +104,7 @@ describe 'NIST Encryption Model' do
 
       password = 'a long sekrit'
       salt = SecureRandom.random_bytes(32)
-      user_access_key = UserAccessKey.new(password, salt)
+      user_access_key = UserAccessKey.new(password: password, salt: salt)
       pii = 'some sensitive stuff'
 
       # D = KMS_GCM_Encrypt(key=server_secret, plaintext=R) ^ Z1

--- a/spec/services/pii/password_encryptor_spec.rb
+++ b/spec/services/pii/password_encryptor_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Pii::PasswordEncryptor do
   let(:password) { 'sekrit' }
   let(:salt) { SecureRandom.uuid }
-  let(:user_access_key) { UserAccessKey.new(password, salt) }
+  let(:user_access_key) { UserAccessKey.new(password: password, salt: salt) }
   let(:plaintext) { 'four score and seven years ago' }
 
   describe '#encrypt' do
@@ -14,7 +14,7 @@ describe Pii::PasswordEncryptor do
     end
 
     it 'only builds encrypted key once per user_access_key' do
-      uak = UserAccessKey.new(password, salt)
+      uak = UserAccessKey.new(password: password, salt: salt)
 
       expect(uak.made?).to eq false
 
@@ -39,7 +39,7 @@ describe Pii::PasswordEncryptor do
 
     it 'requires same password used for encrypt' do
       ciphertext = subject.encrypt(plaintext, user_access_key)
-      different_user_access_key = UserAccessKey.new('different password', salt)
+      different_user_access_key = UserAccessKey.new(password: 'different password', salt: salt)
 
       expect do
         subject.decrypt(ciphertext, different_user_access_key)

--- a/spec/services/user_access_key_spec.rb
+++ b/spec/services/user_access_key_spec.rb
@@ -5,7 +5,18 @@ describe UserAccessKey do
   let(:salt) { 'NaCL' }
   let(:ciphertext) { OpenSSL::Digest::SHA256.hexdigest('foobar') }
 
-  subject { UserAccessKey.new(password, salt) }
+  subject { UserAccessKey.new(password: password, salt: salt) }
+
+  describe '#cost' do
+    it 'uses explicit scrypt cost if passed to new' do
+      cost = SCrypt::Engine.calibrate(max_time: 0.2)
+      uak = UserAccessKey.new(password: password, salt: salt, cost: cost)
+
+      expect(cost).to_not eq Figaro.env.scrypt_cost
+      expect(uak.z1).to_not eq subject.z1
+      expect(uak.cost).to eq cost
+    end
+  end
 
   describe '#encrypted_password' do
     it 'is an alias for hash_f' do


### PR DESCRIPTION
**Why**: We will eventually change default SCrypt calibration string
as computers get faster.

**How**: Rather than relying on hardcoded SCrypt calibration string,
store it in `*_cost` column and prefer it when building UserAccessKey.