### PR TITLE
Reactivate Profile

### DIFF
--- a/.reek
+++ b/.reek
@@ -25,6 +25,7 @@ NilCheck:
     - TotpSetupController#valid_code?
     - user_not_found?
     - SamlIdpLogoutConcern#name_id
+    - User#password_reset_profile
 TooManyConstants:
   exclude:
     - Analytics

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -7,5 +7,7 @@ class ProfileController < ApplicationController
     @decrypted_pii = cacher.fetch
     @recovery_code = flash[:recovery_code]
     flash.delete(:recovery_code)
+
+    @has_password_reset_profile = current_user.password_reset_profile.present?
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -84,7 +84,7 @@ module Users
     end
 
     def mark_profile_inactive
-      resource.active_profile&.update!(active: false)
+      resource.active_profile&.deactivate(:password_reset)
     end
 
     def user_params

--- a/app/controllers/users/reactivate_profile_controller.rb
+++ b/app/controllers/users/reactivate_profile_controller.rb
@@ -1,0 +1,26 @@
+module Users
+  class ReactivateProfileController < ApplicationController
+    def index
+      @reactivate_profile_form = ReactivateProfileForm.new(current_user)
+    end
+
+    def create
+      @reactivate_profile_form = build_reactivate_profile_form
+
+      if @reactivate_profile_form.submit(flash)
+        redirect_to profile_path
+      else
+        render :index
+      end
+    end
+
+    protected
+
+    def build_reactivate_profile_form
+      ReactivateProfileForm.new(
+        current_user,
+        params[:reactivate_profile_form].permit(:recovery_code, :password)
+      )
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -63,7 +63,7 @@ module Users
       begin
         cacher.save(current_user.user_access_key)
       rescue Pii::EncryptionError => err
-        current_user.active_profile.deactivate
+        current_user.active_profile.deactivate(:encryption_error)
         analytics.track_event(Analytics::PROFILE_ENCRYPTION_INVALID, error: err.message)
       end
     end

--- a/app/forms/reactivate_profile_form.rb
+++ b/app/forms/reactivate_profile_form.rb
@@ -1,0 +1,74 @@
+class ReactivateProfileForm
+  include ActiveModel::Model
+
+  validates :recovery_code, :password, presence: true
+  validate :validate_password_reset_profile
+  validate :validate_password
+  validate :validate_recovery_code
+
+  attr_accessor :recovery_code, :password
+  attr_reader :user
+
+  def initialize(user, attrs = {})
+    @user = user
+    super attrs
+  end
+
+  def submit(flash)
+    if valid?
+      flash[:recovery_code] = reencrypt_pii
+      true
+    else
+      clear_fields
+      false
+    end
+  end
+
+  protected
+
+  def password_reset_profile
+    @_password_reset_profile ||= user.password_reset_profile
+  end
+
+  def user_access_key
+    @_uak ||= user.unlock_user_access_key(password)
+  end
+
+  def decrypted_pii
+    @_pii ||= password_reset_profile.recover_pii(recovery_code)
+  end
+
+  def reencrypt_pii
+    recovery_code = password_reset_profile.encrypt_pii(user_access_key, decrypted_pii)
+    password_reset_profile.deactivation_reason = nil
+    password_reset_profile.save!
+    recovery_code
+  end
+
+  def validate_password_reset_profile
+    errors.add :base, :no_password_reset_profile unless password_reset_profile
+  end
+
+  def validate_password
+    return if password.blank? || valid_password?
+    errors.add :password, :password_incorrect
+  end
+
+  def validate_recovery_code
+    return if recovery_code.blank? || valid_recovery_code?
+    errors.add :recovery_code, :recovery_code_incorrect
+  end
+
+  # Reset sensitive fields so they don't get sent back to the browser
+  def clear_fields
+    self.password = nil
+  end
+
+  def valid_password?
+    user.valid_password?(password)
+  end
+
+  def valid_recovery_code?
+    RecoveryCodeGenerator.new(user).verify(recovery_code)
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -8,7 +8,6 @@ class Profile < ActiveRecord::Base
   scope :verified, -> { where.not(verified_at: nil) }
 
   enum deactivation_reason: {
-    not_deactivated: 0,
     password_reset: 1,
     encryption_error: 2
   }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,6 +7,12 @@ class Profile < ActiveRecord::Base
   scope :active, -> { where(active: true) }
   scope :verified, -> { where.not(verified_at: nil) }
 
+  enum deactivation_reason: {
+    not_deactivated: 0,
+    password_reset: 1,
+    encryption_error: 2
+  }
+
   attr_reader :recovery_code
 
   def activate
@@ -16,8 +22,8 @@ class Profile < ActiveRecord::Base
     end
   end
 
-  def deactivate
-    update!(active: false)
+  def deactivate(reason)
+    update!(active: false, deactivation_reason: reason)
   end
 
   def decrypt_pii(user_access_key)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,13 @@ class User < ActiveRecord::Base
     profiles.find(&:active?)
   end
 
+  # This user's most recently activated profile that has also been deactivated
+  # due to a password reset, or nil if there is no such profile
+  def password_reset_profile
+    profile = profiles.order(activated_at: :desc).first
+    profile if profile&.password_reset?
+  end
+
   # To send emails asynchronously via ActiveJob.
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -6,6 +6,13 @@
     p = t('idv.messages.recovery_code')
     .mb1.py1.px2.inline-block.fs-20p.regular.monospace.bg-white.rounded = @recovery_code
 
+- if @has_password_reset_profile
+  .mb1.p2.border.rounded
+    h2.h3.mt0 = t('profile.index.reactivation.title')
+    p = t('profile.index.reactivation.instructions')
+    = link_to(t('profile.index.reactivation.reactivate_button'),
+        reactivate_profile_path, class: 'btn btn-primary')
+
 - if @decrypted_pii
   h2.h3.my0.mr1.inline-block = t('headings.profile.profile_info')
   = content_tag(:span, t('headings.profile.profile_info_tt'),

--- a/app/views/users/reactivate_profile/index.html.slim
+++ b/app/views/users/reactivate_profile/index.html.slim
@@ -1,0 +1,9 @@
+h2.h3 = t('forms.reactivate_profile.title')
+p = t('forms.reactivate_profile.instructions')
+
+= simple_form_for(@reactivate_profile_form, url: reactivate_profile_path,
+    html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
+    = f.error :base
+    = f.input :recovery_code, required: true
+    = f.input :password, required: true
+    = f.button :submit, t('forms.reactivate_profile.submit'), class: 'mb1'

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -20,6 +20,9 @@ en:
       requires_phone: requires you to enter your phone number.
       missing_field: 'Please fill in this field.'
       format_mismatch: 'Please match the requested format.'
+      no_password_reset_profile: 'No profile has been recently deactivated due to a password reset'
+      password_incorrect: 'Password is incorrect'
+      recovery_code_incorrect: 'Recovery code is incorrect'
     confirm_password_incorrect: The password you provided is incorrect.
     invalid_totp: Invalid code entered.  Please try again.
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -46,3 +46,7 @@ en:
           password: New password
         buttons:
           submit: Change password
+    reactivate_profile:
+      title: Reactivate Profile
+      instructions: Provide the information below to reactivate your account.
+      submit: Reactivate Profile

--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -9,6 +9,10 @@ en:
       email: Email address
       password: Password
       authentication_app: Authentication app
+      reactivation:
+        title: Reactivate Profile
+        instructions: Your profile was recently deactivated due to a password reset, reactivate your profile to get your awesome PII back.
+        reactivate_button: Reactivate your profile
     items:
       recovery_code: Recovery code
     links:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,9 @@ Rails.application.routes.draw do
   put '/idv/review' => 'idv/review#create'
 
   get '/privacy' => 'pages#privacy_policy'
-  get '/profile' => 'profile#index'
+  get '/profile' => 'profile#index', as: :profile
+  get '/profile/reactivate' => 'users/reactivate_profile#index', as: :reactivate_profile
+  post '/profile/reactivate' => 'users/reactivate_profile#create'
   get '/authenticator_start' => 'users/totp_setup#start'
   get '/authenticator_setup' => 'users/totp_setup#new'
   delete '/authenticator_setup' => 'users/totp_setup#disable', as: :disable_totp

--- a/db/migrate/20161117200501_add_deactivation_reason_to_profiles.rb
+++ b/db/migrate/20161117200501_add_deactivation_reason_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddDeactivationReasonToProfiles < ActiveRecord::Migration
+  def change
+    add_column :profiles, :deactivation_reason, :integer, limit: 4, null: false, default: 0
+  end
+end

--- a/db/migrate/20161117200501_add_deactivation_reason_to_profiles.rb
+++ b/db/migrate/20161117200501_add_deactivation_reason_to_profiles.rb
@@ -1,5 +1,5 @@
 class AddDeactivationReasonToProfiles < ActiveRecord::Migration
   def change
-    add_column :profiles, :deactivation_reason, :integer, limit: 4, null: false, default: 0
+    add_column :profiles, :deactivation_reason, :integer, limit: 4
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20161118150204) do
     t.text     "encrypted_pii"
     t.string   "ssn_signature",          limit: 64
     t.text     "encrypted_pii_recovery"
-    t.integer  "deactivation_reason",    limit: 4,  default: 0,     null: false
+    t.integer  "deactivation_reason",    limit: 4
   end
 
   add_index "profiles", ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20161118150204) do
     t.text     "encrypted_pii"
     t.string   "ssn_signature",          limit: 64
     t.text     "encrypted_pii_recovery"
+    t.integer  "deactivation_reason",    limit: 4,  default: 0,     null: false
   end
 
   add_index "profiles", ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -21,7 +21,11 @@ namespace :dev do
       first_name: 'Some',
       last_name: 'One'
     )
-    profile.encrypt_pii(loa3_user.user_access_key, pii)
+    recovery_code = profile.encrypt_pii(loa3_user.user_access_key, pii)
     profile.activate
+
+    Kernel.puts "===="
+    Kernel.puts "email=#{loa3_user.email} recovery_code=#{recovery_code}"
+    Kernel.puts "===="
   end
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -26,5 +26,23 @@ describe ProfileController do
         expect(response).to_not be_redirect
       end
     end
+
+    context 'when a profile has been deactivated by password reset' do
+      it 'renders the profile and shows a deactivation banner' do
+        user = create(
+          :user,
+          :signed_up,
+          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })]
+        )
+        user.active_profile.deactivate(:password_reset)
+
+        sign_in user
+
+        get :index
+
+        expect(response).to_not be_redirect
+        expect(assigns(:has_password_reset_profile)).to be(true)
+      end
+    end
   end
 end

--- a/spec/controllers/users/reactivate_profile_controller_spec.rb
+++ b/spec/controllers/users/reactivate_profile_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Users::ReactivateProfileController do
+  include Features::LocalizationHelper
+
+  describe '#create' do
+    subject(:action) do
+      post(
+        :create,
+        reactivate_profile_form: {
+          password: 'password',
+          recovery_code: 'recovery_code'
+        }
+      )
+    end
+
+    before do
+      stub_sign_in
+
+      form = instance_double('ReactivateProfileForm', submit: success)
+      expect(controller).to receive(:build_reactivate_profile_form).and_return(form)
+    end
+
+    context 'with a valid form' do
+      let(:success) { true }
+
+      it 'redirects to the profile page' do
+        action
+
+        expect(response).to redirect_to(profile_path)
+      end
+    end
+
+    context 'with an invalid form' do
+      let(:success) { false }
+
+      it 'renders the index page to show errors' do
+        action
+
+        expect(response).to render_template('users/reactivate_profile/index')
+      end
+    end
+  end
+end

--- a/spec/forms/reactivate_profile_form_spec.rb
+++ b/spec/forms/reactivate_profile_form_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe ReactivateProfileForm do
+  subject(:form) do
+    ReactivateProfileForm.new(user,
+                              recovery_code: recovery_code,
+                              password: password)
+  end
+
+  let(:user) { build_stubbed(:user) }
+  let(:recovery_code) { nil }
+  let(:password) { nil }
+
+  describe '#valid?' do
+    let(:password) { 'asd' }
+    let(:recovery_code) { '123' }
+    let(:valid_recovery_code?) { true }
+    let(:valid_password?) { true }
+
+    before do
+      allow(form).to receive(:valid_password?).and_return(valid_password?)
+      allow(form).to receive(:valid_recovery_code?).and_return(valid_recovery_code?)
+    end
+
+    context 'when required attributes are not present' do
+      let(:password) { nil }
+      let(:recovery_code) { nil }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:recovery_code]).to eq [t('errors.messages.blank')]
+        expect(subject.errors[:password]).to eq [t('errors.messages.blank')]
+      end
+    end
+
+    context 'when there is no profile that has had its password reset' do
+      let(:password_reset_profile) { nil }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to eq [t('errors.messages.no_password_reset_profile')]
+      end
+    end
+
+    context 'when recovery code does not match' do
+      let(:valid_recovery_code?) { false }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:recovery_code]).to eq [t('errors.messages.recovery_code_incorrect')]
+      end
+    end
+
+    context 'when password does not match' do
+      let(:valid_password?) { false }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:password]).to eq [t('errors.messages.password_incorrect')]
+      end
+    end
+  end
+
+  describe '#submit' do
+    before { expect(form).to receive(:valid?).and_return(valid?) }
+
+    let(:flash) { {} }
+
+    context 'with a valid form' do
+      let(:valid?) { true }
+
+      it 're-encrypts the PII and sets the recovery code in the flash' do
+        recovery_code = '555'
+        expect(form).to receive(:reencrypt_pii).and_return(recovery_code)
+
+        form.submit(flash)
+
+        expect(flash[:recovery_code]).to eq(recovery_code)
+      end
+    end
+
+    context 'with an invalid form' do
+      let(:valid?) { false }
+
+      it 'clears the password' do
+        form.submit(flash)
+
+        expect(form.password).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -141,9 +141,10 @@ describe Profile do
   describe '#deactivate' do
     it 'sets active flag to false' do
       profile = create(:profile, :active, user: user)
-      profile.deactivate
+      profile.deactivate(:password_reset)
 
       expect(profile).to_not be_active
+      expect(profile).to be_password_reset
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,4 +224,33 @@ describe User do
       expect(user.decorate).to be_a(UserDecorator)
     end
   end
+
+  describe '#password_reset_profile' do
+    let(:user) { create(:user) }
+
+    context 'with no profiles' do
+      it { expect(user.password_reset_profile).to be_nil }
+    end
+
+    context 'with an active profile' do
+      let(:active_profile) do
+        build(:profile, :active, :verified, activated_at: 1.day.ago, pii: { first_name: 'Jane' })
+      end
+
+      before do
+        user.profiles << [
+          active_profile,
+          build(:profile, :verified, activated_at: 5.days.ago, pii: { first_name: 'Susan' })
+        ]
+      end
+
+      it { expect(user.password_reset_profile).to be_nil }
+
+      context 'when the active profile is deactivated due to password reset' do
+        before { active_profile.deactivate(:password_reset) }
+
+        it { expect(user.password_reset_profile).to eq(active_profile) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Background:

When LOA3'd users reset their password, their LOA3'd data is still encrypted with that old password, so they need to use their recovery code to get it back, and then re-encrypt it with their current password.

Adds some new UI:

### Banner when profile needs to be reactivated

<img width="825" alt="login_gov_-_profile" src="https://cloud.githubusercontent.com/assets/458784/20445631/d09023ce-ada3-11e6-8ee7-b467442c8621.png">

### Page to reactivate profile

<img width="856" alt="login_gov" src="https://cloud.githubusercontent.com/assets/458784/20445636/d3ad2c78-ada3-11e6-9b94-d20a98d8e4d2.png">
