### PR TITLE
Encrypt user email

### DIFF
--- a/.reek
+++ b/.reek
@@ -60,6 +60,7 @@ UtilityFunction:
     - SessionDecorator#registration_bullet_1
     - SessionDecorator#new_session_heading
     - WorkerHealthChecker::Middleware#call
+    - UserEncryptedEmailOverrides#create_fingerprint
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -5,7 +5,7 @@ module Users
     def create
       RequestPasswordReset.new(downcased_email).perform
 
-      analytics_user = User.find_by(email: downcased_email) || NonexistentUser.new
+      analytics_user = User.find_with_email(downcased_email) || NonexistentUser.new
       analytics.track_event(
         Analytics::PASSWORD_RESET_EMAIL, user_id: analytics_user.uuid, role: analytics_user.role
       )

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -48,7 +48,7 @@ module Users
 
     def track_registration(form)
       if form.email_taken?
-        existing_user = User.find_by(email: form.email)
+        existing_user = User.find_with_email(form.email)
         analytics.track_event(
           Analytics::USER_REGISTRATION_EXISTING_EMAIL, user_id: existing_user.uuid
         )

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -49,7 +49,7 @@ module Users
     end
 
     def track_authentication_attempt(email)
-      user = User.find_by(email: email.downcase) || AnonymousUser.new
+      user = User.find_with_email(email) || AnonymousUser.new
 
       properties = {
         success?: current_user.present?, user_id: user.uuid

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -51,6 +51,6 @@ class RegisterUserEmailForm
   end
 
   def existing_user
-    @_user ||= User.find_by(email: email)
+    @_user ||= User.find_with_email(email)
   end
 end

--- a/app/models/concerns/user_encrypted_email_overrides.rb
+++ b/app/models/concerns/user_encrypted_email_overrides.rb
@@ -1,0 +1,65 @@
+module UserEncryptedEmailOverrides
+  extend ActiveSupport::Concern
+
+  # override some Devise methods to support our use of encrypted_email
+
+  class_methods do
+    def find_first_by_auth_conditions(tainted_conditions, opts = {})
+      if tainted_conditions[:email].present?
+        opts[:email_fingerprint] = create_fingerprint(tainted_conditions.delete(:email))
+      end
+      to_adapter.find_first(devise_parameter_filter.filter(tainted_conditions).merge(opts))
+    end
+
+    def find_with_email(email)
+      email_fingerprint = create_fingerprint(email)
+      find_by(email_fingerprint: email_fingerprint)
+    end
+
+    def create_fingerprint(email)
+      Pii::Fingerprinter.fingerprint(email.downcase)
+    end
+  end
+
+  # Override Devise::Models::Confirmable in order to
+  # use email_fingerprint_changed instead of email_changed.
+  # This is necessary because email is no longer an ActiveRecord
+  # attribute and all the *_changed and *_was magic no longer works.
+  def postpone_email_change?
+    postpone = self.class.reconfirmable &&
+               email_fingerprint_changed? &&
+               !@bypass_confirmation_postpone &&
+               email_fingerprint.present? &&
+               (!@skip_reconfirmation_in_callback || email_fingerprint_was.present?)
+    @bypass_confirmation_postpone = false
+    postpone
+  end
+
+  # Override Devise::Models::Confirmable as above,
+  # this time using encrypted_email instead to get the plaintext old email.
+  def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
+    @reconfirmation_required = true
+    self.unconfirmed_email = email
+    old_email = EncryptedEmail.new(encrypted_email_was).decrypted
+    self.email = old_email
+    self.confirmation_token = nil
+    generate_confirmation_token
+  end
+
+  def email
+    return '' unless encrypted_email.present?
+    @_encrypted_email ||= EncryptedEmail.new(encrypted_email)
+    @_encrypted_email.decrypted
+  end
+
+  def email=(email)
+    if email.present?
+      @_encrypted_email = EncryptedEmail.new_from_email(email)
+      self.encrypted_email = @_encrypted_email.encrypted
+      self.email_fingerprint = @_encrypted_email.fingerprint
+    else
+      self.encrypted_email = ''
+      self.email_fingerprint = ''
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,11 +13,13 @@ class User < ActiveRecord::Base
     :trackable,
     :two_factor_authenticatable,
     :omniauthable,
+    authentication_keys: [:email],
     omniauth_providers: [:saml]
   )
 
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides
+  include UserEncryptedEmailOverrides
 
   enum role: { user: 0, tech: 1, admin: 2 }
 

--- a/app/services/create_omniauth_user.rb
+++ b/app/services/create_omniauth_user.rb
@@ -19,8 +19,9 @@ class CreateOmniauthUser
   def perform
     return unless valid?
 
-    User.find_or_create_by(email: email) do |user|
-      user.update(confirmed_at: Time.current)
+    ee = EncryptedEmail.new_from_email(email)
+    User.find_or_create_by(email_fingerprint: ee.fingerprint) do |user|
+      user.update(confirmed_at: Time.current, encrypted_email: ee.encrypted)
     end
   end
 end

--- a/app/services/email_notifier.rb
+++ b/app/services/email_notifier.rb
@@ -10,7 +10,7 @@ EmailNotifier = Struct.new(:user) do
   private
 
   def email_changed?
-    changed_attributes.fetch('email', false)
+    changed_attributes.fetch('email_fingerprint', false)
   end
 
   def changed_attributes
@@ -18,6 +18,6 @@ EmailNotifier = Struct.new(:user) do
   end
 
   def old_email
-    changed_attributes['email'].first
+    EncryptedEmail.new(changed_attributes['encrypted_email'].first).decrypted
   end
 end

--- a/app/services/encrypted_email.rb
+++ b/app/services/encrypted_email.rb
@@ -1,0 +1,46 @@
+class EncryptedEmail
+  def self.build_user_access_key
+    env = Figaro.env
+    UserAccessKey.new(
+      password: env.email_encryption_key,
+      salt: env.password_pepper,
+      cost: env.email_encryption_cost
+    )
+  end
+
+  cattr_reader :user_access_key do
+    build_user_access_key
+  end
+
+  def self.new_from_email(email)
+    encryptor = Pii::PasswordEncryptor.new
+    encrypted_email = encryptor.encrypt(email, user_access_key)
+    new(encrypted_email, email)
+  end
+
+  def initialize(encrypted_email, email = nil)
+    self.encrypted_email = encrypted_email
+    self.email = email.present? ? email : decrypt
+  end
+
+  def encrypted
+    encrypted_email
+  end
+
+  def decrypted
+    email
+  end
+
+  def fingerprint
+    Pii::Fingerprinter.fingerprint(email)
+  end
+
+  private
+
+  attr_accessor :email, :encrypted_email
+
+  def decrypt
+    encryptor = Pii::PasswordEncryptor.new
+    encryptor.decrypt(encrypted_email, self.class.user_access_key)
+  end
+end

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -29,6 +29,6 @@ RequestPasswordReset = Struct.new(:email) do
   end
 
   def user
-    @_user ||= User.find_by(email: email)
+    @_user ||= User.find_with_email(email)
   end
 end

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -20,6 +20,6 @@ module FormEmailValidator
   def email_is_unique
     return if persisted? && email == @user.email
 
-    @email_taken = true if User.exists?(email: email)
+    @email_taken = true if User.find_with_email(email)
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -52,6 +52,8 @@ development:
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
   domain_name: 'localhost:3000'
+  email_encryption_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
+  email_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
   enable_test_routes: 'true'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
   idp_sso_target_url: 'https://upaya-mockidp.18f.gov/saml/auth'
@@ -89,9 +91,11 @@ production:
   aws_kms_key_id: 'change-me'
   aws_region: 'change-me'
   domain_name: 'xxx.xxx'
+  email_encryption_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
+  email_encryption_key: 'rake secret'
   enable_test_routes: 'false'
   google_analytics_key: 'UA-XXXXXXXXX-YY'
-  hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
+  hmac_fingerprinter_key: 'rake secret'
   idp_sso_target_url: 'xxx.xxx/saml/auth'
   logins_per_ip_limit: '20'
   logins_per_ip_period: '8'
@@ -128,6 +132,8 @@ test:
   aws_region: 'us-east-1'
   domain_name: 'www.example.com'
   ducksboard_uid: '8VEQre2c8b62mQV0sa'
+  email_encryption_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
+  email_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
   enable_test_routes: 'true'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
   idp_sso_target_url: 'http://identityprovider.example.com/saml/auth'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,6 +3,8 @@ require File.expand_path('../../../lib/figaro_yaml_validator', __FILE__)
 Figaro.require_keys(
   'allow_third_party_auth',
   'domain_name',
+  'email_encryption_cost',
+  'email_encryption_key',
   'enable_test_routes',
   'hmac_fingerprinter_key',
   'idp_sso_target_url',

--- a/db/migrate/20161118150205_add_user_email_fingerprint.rb
+++ b/db/migrate/20161118150205_add_user_email_fingerprint.rb
@@ -1,0 +1,40 @@
+class AddUserEmailFingerprint < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    add_column :users, :email_fingerprint, :string, default: ''
+    add_column :users, :encrypted_email, :text, default: ''
+    encrypt_user_emails
+    change_column_null :users, :email_fingerprint, false
+    change_column_null :users, :encrypted_email, false
+    add_index :users, :email_fingerprint, unique: true
+    remove_column :users, :email
+  end
+
+  def down
+    add_column :users, :email, :string
+    add_index :users, :email, unique: true
+    decrypt_user_emails
+    change_column_null :users, :email, false
+    remove_column :users, :email_fingerprint
+    remove_column :users, :encrypted_email
+  end
+
+  def encrypt_user_emails
+    User.where(encrypted_email: '').each do |user|
+      ee = EncryptedEmail.new_from_email(user.email)
+      user.update!(
+        encrypted_email: ee.encrypted,
+        email_fingerprint: ee.fingerprint
+      )
+    end
+  end
+
+  def decrypt_user_emails
+    User.where(email: nil).each do |user|
+      ee = EncryptedEmail.new(user.encrypted_email)
+      user.update!(email: ee.decrypted)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118150204) do
+ActiveRecord::Schema.define(version: 20161118150205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 20161118150204) do
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                         limit: 255, default: "", null: false
     t.string   "encrypted_password",            limit: 255, default: ""
     t.string   "reset_password_token",          limit: 255
     t.datetime "reset_password_sent_at"
@@ -123,10 +122,12 @@ ActiveRecord::Schema.define(version: 20161118150204) do
     t.string   "recovery_salt"
     t.string   "password_cost"
     t.string   "recovery_cost"
+    t.string   "email_fingerprint",                         default: "", null: false
+    t.text     "encrypted_email",                           default: "", null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true, using: :btree
   add_index "users", ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true, using: :btree
   add_index "users", ["otp_secret_key"], name: "index_users_on_otp_secret_key", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -3,7 +3,9 @@ namespace :dev do
   task prime: 'db:setup' do
     pw = 'salty pickles'
     %w(test1@test.com test2@test.com).each_with_index do |email, index|
-      User.find_or_create_by!(email: email) do |user|
+      ee = EncryptedEmail.new_from_email(email)
+      User.find_or_create_by!(email_fingerprint: fingerprint(email)) do |user|
+        user.encrypted_email = ee.encrypted
         user.skip_confirmation!
         user.reset_password(pw, pw)
         user.phone = format('+1 (415) 555-01%02d', index)
@@ -12,7 +14,7 @@ namespace :dev do
       end
     end
 
-    loa3_user = User.find_by(email: 'test2@test.com')
+    loa3_user = User.find_by(email_fingerprint: fingerprint('test2@test.com'))
     loa3_user.unlock_user_access_key(pw)
     profile = Profile.new(user: loa3_user)
     pii = Pii::Attributes.new_from_hash(
@@ -27,5 +29,9 @@ namespace :dev do
     Kernel.puts "===="
     Kernel.puts "email=#{loa3_user.email} recovery_code=#{recovery_code}"
     Kernel.puts "===="
+  end
+
+  def fingerprint(email)
+    Pii::Fingerprinter.fingerprint(email)
   end
 end

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -68,7 +68,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
   describe '#show' do
     context 'when resource is not fully authenticated yet' do
       before do
-        stub_sign_in_before_2fa(User.new(phone: '+1 (703) 555-1212'))
+        stub_sign_in_before_2fa(build(:user, phone: '+1 (703) 555-1212'))
       end
 
       it 'renders the :show view' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -18,7 +18,7 @@ describe Idv::PhoneController do
       render_views
 
       it 'renders #new' do
-        user = User.new(phone: '+1 (415) 555-0130')
+        user = build(:user, phone: '+1 (415) 555-0130')
         stub_subject(user)
 
         put :create, idv_phone_form: { phone: '703' }
@@ -30,7 +30,7 @@ describe Idv::PhoneController do
 
     context 'when form is valid and submitted phone is same as user phone' do
       it 'redirects to review page and sets phone_confirmed_at' do
-        user = User.new(phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
+        user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
         stub_subject(user)
 
         put :create, idv_phone_form: { phone: '+1 (415) 555-0130' }
@@ -47,7 +47,7 @@ describe Idv::PhoneController do
 
     context 'when form is valid and submitted phone is different from user phone' do
       it 'redirects to review page and does not set phone_confirmed_at' do
-        user = User.new(phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
+        user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
         stub_subject(user)
 
         put :create, idv_phone_form: { phone: '+1 (415) 555-0160' }

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -12,7 +12,7 @@ describe MfaConfirmationController do
   end
 
   describe 'PUT /reauthn' do
-    let(:user) { User.new(password: 'password') }
+    let(:user) { build(:user, password: 'password') }
 
     before do
       stub_sign_in(user)

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -4,7 +4,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
   describe '#create' do
     context 'when the user enters a valid recovery code' do
       before do
-        stub_sign_in_before_2fa(User.new(recovery_code: 'foo'))
+        stub_sign_in_before_2fa(build(:user, recovery_code: 'foo'))
         form = instance_double(RecoveryCodeForm)
         allow(RecoveryCodeForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)
@@ -36,7 +36,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
 
     context 'when the user enters an invalid recovery code' do
       before do
-        stub_sign_in_before_2fa(User.new(phone: '+1 (703) 555-1212'))
+        stub_sign_in_before_2fa(build(:user, phone: '+1 (703) 555-1212'))
         form = instance_double(RecoveryCodeForm)
         allow(RecoveryCodeForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -226,7 +226,8 @@ describe Users::PasswordsController, devise: true do
         stub_analytics
 
         tech_user = build_stubbed(:user, :tech_support)
-        allow(User).to receive(:find_by).with(email: 'tech@example.com').and_return(tech_user)
+        fingerprint = Pii::Fingerprinter.fingerprint('tech@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(tech_user)
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, user_id: tech_user.uuid, role: 'tech')
@@ -240,7 +241,8 @@ describe Users::PasswordsController, devise: true do
         stub_analytics
 
         admin = build_stubbed(:user, :admin)
-        allow(User).to receive(:find_by).with(email: 'admin@example.com').and_return(admin)
+        fingerprint = Pii::Fingerprinter.fingerprint('admin@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(admin)
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, user_id: admin.uuid, role: 'admin')

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -151,7 +151,7 @@ describe UserDecorator do
 
   describe '#recent_events' do
     it 'interleaves identities and events' do
-      user_decorator = UserDecorator.new(User.new)
+      user_decorator = UserDecorator.new(build(:user))
       identity = create(
         :identity,
         last_authenticated_at: Time.zone.now - 1,

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe UpdateUserEmailForm do
-  subject { UpdateUserEmailForm.new(User.new(email: 'old@gmail.com')) }
+  subject { UpdateUserEmailForm.new(User.new(email: 'old@example.com')) }
 
   it_behaves_like 'email validation'
 
   describe '#email_changed?' do
     it 'is false when the submitted email is the same as the current email' do
-      result = subject.submit(email: 'OLD@gmail.com')
+      result = subject.submit(email: 'OLD@example.com')
 
       expect(result).to be true
       expect(subject.email_changed?).to eq false
@@ -17,35 +17,35 @@ describe UpdateUserEmailForm do
   describe '#submit' do
     context "when the user attempts to change their email to another user's email" do
       it 'sends an email alerting the other user' do
-        user = create(:user, email: 'old@gmail.com')
+        user = create(:user, email: 'old@example.com')
         subject = UpdateUserEmailForm.new(user)
-        _second_user = create(:user, :signed_up, email: 'another@gmail.com')
+        _second_user = create(:user, :signed_up, email: 'another@example.com')
 
         expect(user).to receive(:skip_confirmation_notification!).and_call_original
 
         mailer = instance_double(ActionMailer::MessageDelivery)
         expect(UserMailer).to receive(:signup_with_your_email).
-          with('another@gmail.com').and_return(mailer)
+          with('another@example.com').and_return(mailer)
         expect(mailer).to receive(:deliver_later)
 
-        result = subject.submit(email: 'ANOTHER@gmail.com')
+        result = subject.submit(email: 'ANOTHER@example.com')
 
         expect(result).to be true
         expect(subject.email_changed?).to eq true
         expect(user.unconfirmed_email).to be_nil
-        expect(user.email).to eq 'old@gmail.com'
+        expect(user.email).to eq 'old@example.com'
       end
     end
 
     context 'when the user changes their email to a nonexistent email' do
       it "updates the user's unconfirmed_email" do
-        user = create(:user, email: 'old@gmail.com')
+        user = create(:user, email: 'old@example.com')
         subject = UpdateUserEmailForm.new(user)
 
         result = subject.submit(email: 'new@example.com')
 
         expect(user.unconfirmed_email).to eq 'new@example.com'
-        expect(user.email).to eq 'old@gmail.com'
+        expect(user.email).to eq 'old@example.com'
         expect(result).to be true
         expect(subject.email_changed?).to eq true
       end

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -32,7 +32,8 @@ describe EmailNotifier do
       it 'notifies the old email address of the email change' do
         user = create(:user, :signed_up)
         old_email = user.email
-        user.update!(email: 'new@example.com')
+        user.email = 'new@example.com'
+        user.save!
         user.confirm
 
         expect(UserMailer).to receive(:email_changed).with(old_email).and_return(mailer)

--- a/spec/services/encrypted_email_spec.rb
+++ b/spec/services/encrypted_email_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe EncryptedEmail do
+  let(:email) { 'someone@example.com' }
+  let(:fingerprint) { Pii::Fingerprinter.fingerprint(email) }
+  let(:encrypted_email) do
+    encryptor = Pii::PasswordEncryptor.new
+    encryptor.encrypt(email, EncryptedEmail.user_access_key)
+  end
+
+  describe '#new' do
+    it 'automatically decrypts' do
+      ee = EncryptedEmail.new(encrypted_email)
+
+      expect(ee.decrypted).to eq email
+      expect(ee.encrypted).to eq encrypted_email
+      expect(ee.fingerprint).to eq fingerprint
+    end
+  end
+
+  describe '#new_from_email' do
+    it 'automatically encrypts' do
+      ee = EncryptedEmail.new_from_email(email)
+
+      expect(ee.decrypted).to eq email
+
+      ee2 = EncryptedEmail.new(ee.encrypted)
+
+      expect(ee2.encrypted).to eq ee.encrypted
+      expect(ee2.decrypted).to eq ee.decrypted
+    end
+  end
+end

--- a/spec/services/idv/attempter_spec.rb
+++ b/spec/services/idv/attempter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::Attempter do
-  let(:current_user) { User.new }
+  let(:current_user) { build(:user) }
   let(:subject) { Idv::Attempter.new(current_user) }
 
   describe '#window_expired?' do

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::Session do
-  let(:user) { User.new }
+  let(:user) { build(:user) }
   let(:user_session) { {} }
 
   subject { described_class.new(user_session, user) }

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -17,7 +17,8 @@ describe RequestPasswordReset do
       it 'does not send any emails' do
         user = instance_double(User, admin?: true, tech?: false)
 
-        allow(User).to receive(:find_by).with(email: 'admin@example.com').and_return(user)
+        fingerprint = Pii::Fingerprinter.fingerprint('admin@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
         expect(user).to_not receive(:send_confirmation_instructions)
@@ -30,7 +31,8 @@ describe RequestPasswordReset do
       it 'does not send any emails' do
         user = instance_double(User, admin?: false, tech?: true)
 
-        allow(User).to receive(:find_by).with(email: 'tech@example.com').and_return(user)
+        fingerprint = Pii::Fingerprinter.fingerprint('tech@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
         expect(user).to_not receive(:send_confirmation_instructions)
@@ -43,7 +45,8 @@ describe RequestPasswordReset do
       it 'sends password reset instructions' do
         user = instance_double(User, admin?: false, tech?: false, confirmed?: true)
 
-        allow(User).to receive(:find_by).with(email: 'user@example.com').and_return(user)
+        fingerprint = Pii::Fingerprinter.fingerprint('user@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
 
         expect(user).to receive(:send_reset_password_instructions)
         expect(user).to_not receive(:send_confirmation_instructions)
@@ -56,7 +59,8 @@ describe RequestPasswordReset do
       it 'sends confirmation instructions' do
         user = instance_double(User, admin?: false, tech?: false, confirmed?: false)
 
-        allow(User).to receive(:find_by).with(email: 'user@example.com').and_return(user)
+        fingerprint = Pii::Fingerprinter.fingerprint('user@example.com')
+        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
         expect(user).to receive(:send_confirmation_instructions)

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -27,7 +27,7 @@ module ControllerHelper
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end
 
-  def stub_sign_in(user = User.new(password: VALID_PASSWORD))
+  def stub_sign_in(user = build(:user, password: VALID_PASSWORD))
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
@@ -36,7 +36,7 @@ module ControllerHelper
     user
   end
 
-  def stub_sign_in_before_2fa(user = User.new(password: VALID_PASSWORD))
+  def stub_sign_in_before_2fa(user = build(:user, password: VALID_PASSWORD))
     allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:current_user).and_return(user)


### PR DESCRIPTION
**Why**: Email is PII

**How**: Add 2 columns, email_fingerprint and encrypted_email.

* Use email_fingerprint for quick lookups at authentication time.
* Use encrypted_email for get/set symmetrically encrypted email string.
* Override a few Devise methods to provide compatability with all
the Devise goodness.