### PR TITLE
Stub User model in AddScryptCost migration

### DIFF
--- a/db/migrate/20161118150204_add_scrypt_cost.rb
+++ b/db/migrate/20161118150204_add_scrypt_cost.rb
@@ -1,4 +1,7 @@
 class AddScryptCost < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+  end
+
   def up
     add_column :users, :password_cost, :string
     add_column :users, :recovery_cost, :string


### PR DESCRIPTION
**Why**: To allow the migration to pass when it doesn’t yet know about
new methods in the model due to the way Rails loads files.