### PR TITLE
UI lipstick

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -2,7 +2,7 @@ $ico-size: 1.5rem;
 $ico-offset: -10px;
 
 .alert {
-  background-color: #fff4db;
+  background-color: $blue-light;
   border-radius: $space-1;
   color: #5b616a;
   font-size: $sm-h6;
@@ -13,7 +13,7 @@ $ico-offset: -10px;
   position: relative;
 
   &::before {
-    background-image: url(image-path('alert/ico-warning.svg'));
+    background-image: none;
     background-repeat: no-repeat;
     content: '';
     height: $ico-size;
@@ -39,9 +39,9 @@ $ico-offset: -10px;
 }
 
 .alert-warning {
-  background-color: #fff1d2;
+  background-color: #fff4db;
 
   &::before { background-image: url(image-path('alert/ico-warning.svg')); }
 }
 
-.alert-blank::before { content: none; }
+.alert-no-icon::before { content: none; }

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -7,11 +7,9 @@
     .mb1.py1.px2.inline-block.fs-20p.regular.monospace.bg-white.rounded = @recovery_code
 
 - if @has_password_reset_profile
-  .mb1.p2.border.rounded
-    h2.h3.mt0 = t('profile.index.reactivation.title')
+  .mb4.alert.alert-warning
     p = t('profile.index.reactivation.instructions')
-    = link_to(t('profile.index.reactivation.reactivate_button'),
-        reactivate_profile_path, class: 'btn btn-primary')
+    p.mb0 = link_to t('profile.index.reactivation.reactivate_button'), reactivate_profile_path
 
 - if @decrypted_pii
   h2.h3.my0.mr1.inline-block = t('headings.profile.profile_info')

--- a/app/views/users/reactivate_profile/index.html.slim
+++ b/app/views/users/reactivate_profile/index.html.slim
@@ -1,9 +1,10 @@
-h2.h3 = t('forms.reactivate_profile.title')
-p = t('forms.reactivate_profile.instructions')
+- title t('titles.reactivate_profile')
 
+h1.h3.my0 = t('forms.reactivate_profile.title')
+p.mt-tiny.mb0 = t('forms.reactivate_profile.instructions')
 = simple_form_for(@reactivate_profile_form, url: reactivate_profile_path,
-    html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
-    = f.error :base
-    = f.input :recovery_code, required: true
-    = f.input :password, required: true
-    = f.button :submit, t('forms.reactivate_profile.submit'), class: 'mb1'
+  html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
+  = f.error :base
+  = f.input :recovery_code, required: true
+  = f.input :password, required: true
+  = f.button :submit, t('forms.reactivate_profile.submit'), class: 'mb1'

--- a/app/views/users/registrations/verify_email.html.slim
+++ b/app/views/users/registrations/verify_email.html.slim
@@ -8,9 +8,8 @@
     | #{t('notices.signed_up_but_unconfirmed.first_paragraph_start')}
       <strong>#{email}</strong>
       #{t('notices.signed_up_but_unconfirmed.first_paragraph_end')}
-
   - if @resend_confirmation
-    .alert.alert-success.alert-blank role="alert"
+    .alert.alert-success.alert-no-icon role="alert"
       = image_tag(asset_url('alert/ico-thumb.svg'), height: '16', alt: '',\
         class: 'mr2 align-bottom')
       = t('notices.resend_confirmation_email.success')

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -47,6 +47,6 @@ en:
         buttons:
           submit: Change password
     reactivate_profile:
-      title: Reactivate Profile
+      title: Reactivate profile
       instructions: Provide the information below to reactivate your account.
-      submit: Reactivate Profile
+      submit: Reactivate profile

--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -10,7 +10,6 @@ en:
       password: Password
       authentication_app: Authentication app
       reactivation:
-        title: Reactivate Profile
         instructions: Your profile was recently deactivated due to a password reset, reactivate your profile to get your awesome PII back.
         reactivate_button: Reactivate your profile
     items:

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -16,6 +16,7 @@ en:
       confirm: Confirm the password for your account
     privacy_policy: Privacy
     profile: Profile
+    reactivate_profile: Reactivate profile
     recovery_code: Just in case
     registrations:
       new: Sign up for a account


### PR DESCRIPTION
**Why**:
* tweak default alert styling (when no modifiers applied,
  instead of getting 'warning' icon out of box)
* make "alert with no icon" class name more descriptive
* consistentify the 'reactivate profile' alert and page w/ form
  (cc: @zachmargolis)