### PR TITLE
Add Help Center page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,4 +5,7 @@ class PagesController < ApplicationController
 
   def privacy_policy
   end
+
+  def help
+  end
 end

--- a/app/views/pages/help.html.slim
+++ b/app/views/pages/help.html.slim
@@ -1,0 +1,81 @@
+- title t('titles.help')
+
+h1 = t('titles.help')
+
+h2 = t('headings.help.creating_account.title')
+
+h3 = t('headings.help.creating_account.confirmation_email')
+
+p = t('pages.help.creating_account.confirmation_email')
+
+h3 = t('headings.help.creating_account.confirmation_passcode')
+
+p = t('pages.help.creating_account.confirmation_passcode')
+
+h3 = t('headings.help.creating_account.mobile_phone')
+
+p = t('pages.help.creating_account.mobile_phone')
+
+h3 = t('headings.help.creating_account.dont_want_to_use')
+
+p = t('pages.help.creating_account.dont_want_to_use.paragraph_1')
+
+p = t('pages.help.creating_account.dont_want_to_use.paragraph_2')
+
+h2 = t('headings.help.verifying_account.title')
+
+h3 = t('headings.help.verifying_account.what_verification')
+
+h3 = t('headings.help.verifying_account.why_verified')
+
+h3 = t('headings.help.verifying_account.how_verify')
+
+h3 = t('headings.help.verifying_account.what_verify')
+
+h3 = t('headings.help.verifying_account.personal_info')
+
+h3 = t('headings.help.verifying_account.financial_info')
+
+h3 = t('headings.help.verifying_account.ss_number')
+
+h3 = t('headings.help.verifying_account.cant_verify')
+
+h3 = t('headings.help.verifying_account.account_not_verified')
+
+h3 = t('headings.help.verifying_account.phone_number')
+
+h2 = t('headings.help.signing_in.title')
+
+h3 = t('headings.help.signing_in.forgot_email')
+
+h3 = t('headings.help.signing_in.forgot_password')
+
+h3 = t('headings.help.signing_in.miss_passcode')
+
+h3 = t('headings.help.signing_in.lose_phone')
+
+h3 = t('headings.help.signing_in.log_out')
+
+h3 = t('headings.help.signing_in.forgot_codes')
+
+h2 = t('headings.help.changing_settings.title')
+
+h3 = t('headings.help.changing_settings.change_password')
+
+h3 = t('headings.help.changing_settings.change_email')
+
+h3 = t('headings.help.changing_settings.edit_profile')
+
+h2 = t('headings.help.privacy_security.title')
+
+h3 = t('headings.help.privacy_security.protect_data')
+
+h3 = t('headings.help.privacy_security.2fa')
+
+h3 = t('headings.help.privacy_security.third_party')
+
+h3 = t('headings.help.privacy_security.remove_saved')
+
+h2 = t('headings.help.questions.title')
+
+p = t('pages.help.questions.paragraph_1')

--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -2,6 +2,8 @@ footer.footer.bg-navy.white
   .container.p2.h6
     .clearfix
       .sm-col = t('shared.footer_lite.gsa')
-      .sm-col-right
+      .sm-col-right.caps
+        = link_to t('links.help'), help_path,
+          class: 'white text-decoration-none mr3'
         = link_to t('links.privacy_policy'), privacy_path,
-          class: 'caps white text-decoration-none'
+          class: 'white text-decoration-none'

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -12,6 +12,46 @@ en:
     sign_in_without_sp: Sign in
     sign_in_with_sp: Sign in to continue to %{sp}
     choose_otp_delivery: Choose how you’d like to receive a one-time passcode
+    help:
+      creating_account:
+        title: Creating your account 
+        confirmation_email: I didn't receive a confirmation email from login.gov.
+        confirmation_passcode: I didn't receive a confirmation passcode on my phone.
+        mobile_phone: Do I need a mobile phone to use login.gov?
+        dont_want_to_use: I don't want to use login.gov to access government services.
+      verifying_account:
+        title: Verifying your account
+        what_verification: What is account verification?
+        why_verified: Why do I need a verified account?
+        how_verify: How do you verify my account?
+        what_verify: What do I need to verify my account?
+        personal_info: Why are you asking for personal information?
+        financial_info: Why are you asking for financial information?
+        ss_number: Why are you asking for my Social Security Number?
+        cant_verify: Why can't you verify my account?
+        account_not_verified: What happens if my account can't be verified?
+        phone_number: What type of phone number should I enter?
+      signing_in:
+        title: Signing into your account
+        forgot_email: I forgot which email address I used to create an account.
+        forgot_password: What do I do if my password doesn't work or I forgot it?
+        miss_passcode: What happens if I miss the phone call or the text message with my one-time passcode?
+        lose_phone: If I lose my phone, can I still sign in?
+        log_out: What happens if the system logs me out?
+        forgot_codes: I can't remember where my recovery codes are.
+      changing_settings:
+        title: Changing your settings
+        change_password: How do I change my password?
+        change_email: How do I change my email address?
+        edit_profile: Why can't I edit my profile information?
+      privacy_security:
+        title: Keeping your account private and secure
+        protect_data: How does login.gov protect my data?
+        2fa: What is two-factor authentication? (2FA)?
+        third_party: What are third-party vendors? What do they do with my information?
+        remove_saved: Can I remove a saved password or login information from my browser?
+      questions:
+        title: Still have questions?
     passwords:
       change: Change your password
       forgot: Forgot your password?

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -2,6 +2,7 @@ en:
   links:
     back_to_sp: '‹ Back to %{sp}'
     create_account: Create account
+    help: Help
     privacy_policy: Privacy Policy
     resend: Send again
     sign_out: Sign out

--- a/config/locales/pages/en.yml
+++ b/config/locales/pages/en.yml
@@ -3,6 +3,39 @@ en:
     page_not_found:
       header: The page you were looking for doesn’t exist.
       body: You might want to double-check your link and try again. (404)
+    help:
+      creating_account:
+        confirmation_email: >
+          Lorem ipsum dolor sit amet, elit omnium has an, dolorem officiis
+          praesent ea quo, in vis unum fugit postulant. Duo ad meis definitionem,
+          cum ne nonumes nusquam. Quidam maiorum eos ei, prima invenire sapientem
+          est ut. Pro no persius eleifend, eruditi efficiendi his ad. An quem
+          ocurreret vituperata duo.
+        confirmation_passcode: > 
+          Eu diam efficiantur quo, vis suas ubique omittantur
+          in, sensibus abhorreant argumentum ne ius. Id prima mutat has, diam
+          iriure ut nec. Eam dicit nullam cu. Ius eu meis magna vulputate, no
+          persius legimus expetenda vis. Qui adhuc nusquam mnesarchum at.
+        mobile_phone: >
+          Lorem ipsum dolor sit amet, elit omnium has an, dolorem officiis
+          praesent ea quo, in vis unum fugit postulant. Duo ad meis definitionem,
+          cum ne nonumes nusquam. Quidam maiorum eos ei, prima invenire sapientem
+          est ut. Pro no persius eleifend, eruditi efficiendi his ad. An quem
+          ocurreret vituperata duo.
+        dont_want_to_use: 
+          paragraph_1: >
+            Eu diam efficiantur quo, vis suas ubique omittantur in, sensibus
+            abhorreant argumentum ne ius. Id prima mutat has, diam iriure ut nec.
+            Eam dicit nullam cu. Ius eu meis magna vulputate, no persius legimus
+            expetenda vis. Qui adhuc nusquam mnesarchum at.
+          paragraph_2: >
+            Lorem ipsum dolor sit amet, elit omnium has an, dolorem officiis
+            praesent ea quo, in vis unum fugit postulant. Duo ad meis definitionem,
+            cum ne nonumes nusquam. Quidam maiorum eos ei, prima invenire sapientem
+            est ut. Pro no persius eleifend, eruditi efficiendi his ad. An quem
+            ocurreret vituperata duo.
+      questions:
+        paragraph_1: Send an email (link to contact form) or call 1 (844) USLOGIN.
     privacy_policy:
       paragraph_1: >
         By using login.gov, you agree that you understand and consent to the

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -10,6 +10,7 @@ en:
       phone: Edit your phone number
     enter_2fa_code: Enter the secure one-time passcode
     account_locked: Account locked
+    help: Help Center
     passwords:
       change: Change the password for your account
       forgot: Reset the password for your account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
   get '/idv/review' => 'idv/review#new'
   put '/idv/review' => 'idv/review#create'
 
+  get '/help' => 'pages#help'
   get '/privacy' => 'pages#privacy_policy'
   get '/profile' => 'profile#index', as: :profile
   get '/profile/reactivate' => 'users/reactivate_profile#index', as: :reactivate_profile

--- a/spec/views/pages/help.html.slim_spec.rb
+++ b/spec/views/pages/help.html.slim_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'pages/help.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.help'))
+
+    render
+  end
+end


### PR DESCRIPTION
**What**:
- Lays the foundation for the page users will visit to find answers to their questions about login.gov.

**How**:
- Adds `/help`
- Adds translation strings for each section and question on the page
- Adds a bit of placeholder text to be replaced once there is copy
- Adds "Help" link to footer

![screen shot 2016-11-21 at 2 42 20 pm](https://cloud.githubusercontent.com/assets/126935/20503693/c158cd28-aff8-11e6-868e-82ffdf987b00.png)
![screen shot 2016-11-21 at 2 44 15 pm](https://cloud.githubusercontent.com/assets/126935/20503770/067c9be6-aff9-11e6-98c2-c097d1380ae0.png)

