### PR TITLE
Test accessibility of pages using axe-matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ end
 
 group :test do
   gem 'capybara-screenshot', github: 'mattheworiordan/capybara-screenshot'
+  gem 'axe-matchers'
   gem 'codeclimate-test-reporter', require: false
   gem 'database_cleaner'
   gem 'email_spec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     ast (2.3.0)
     aws-sdk-core (2.6.14)
       jmespath (~> 1.0)
+    axe-matchers (1.3.2)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -190,6 +193,7 @@ GEM
     dotiw (3.1.1)
       actionpack (>= 3)
       i18n
+    dumb_delegator (0.8.0)
     easy_translate (0.5.0)
       json
       thread
@@ -600,6 +604,7 @@ PLATFORMS
 DEPENDENCIES
   american_date
   aws-sdk-core
+  axe-matchers
   better_errors
   binding_of_caller
   brakeman

--- a/spec/features/accessibility/accessibility_spec.rb
+++ b/spec/features/accessibility/accessibility_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+require 'axe/rspec'
+
+feature 'Accessibility on all pages', :js do
+  scenario 'contact page' do
+    visit contact_path
+
+    expect(page).to be_accessible
+  end
+
+  pending 'login / root path' do
+    visit root_path
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'new user start registration page' do
+    visit new_user_start_path
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'new user registration page' do
+    visit new_user_registration_path
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'user registration page' do
+    email = 'test@example.com'
+    sign_up_with(email)
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'user confirmation page' do
+    email = 'test@example.com'
+    sign_up_with(email)
+    open_email(email)
+    visit_in_email(t('mailer.confirmation_instructions.link_text'))
+
+    expect(page).to be_accessible
+  end
+
+  pending 'phone 2fa setup page' do
+    sign_up_and_set_password
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'enter 2fa phone OTP code page' do
+    sign_up_and_set_password
+    fill_in 'Phone', with: '555-555-5555'
+    click_button t('forms.buttons.send_passcode')
+
+    expect(page).to be_accessible
+  end
+
+  scenario 'recovery code page' do
+    sign_up_and_set_password
+    fill_in 'Phone', with: '555-555-5555'
+    click_button t('forms.buttons.send_passcode')
+    click_button t('forms.buttons.submit.default') # enter 2FA code
+
+    expect(page).to be_accessible
+  end
+
+  pending 'profile page' do
+    sign_in_and_2fa_user
+
+    visit profile_path
+
+    expect(page).to be_accessible
+  end
+
+  pending 'edit email page' do
+    sign_in_and_2fa_user
+
+    visit '/edit/email'
+
+    expect(page).to be_accessible
+  end
+
+  pending 'edit password page' do
+    sign_in_and_2fa_user
+
+    visit '/settings/password'
+
+    expect(page).to be_accessible
+  end
+
+  pending 'edit phone page' do
+    sign_in_and_2fa_user
+
+    visit '/edit/phone'
+
+    expect(page).to be_accessible
+  end
+
+  pending 'generate new recovery code page' do
+    sign_in_and_2fa_user
+
+    visit '/settings/recovery-code'
+
+    expect(page).to be_accessible
+  end
+
+  pending 'start set up of authenticator app page' do
+    sign_in_and_2fa_user
+
+    visit '/authenticator_start'
+
+    expect(page).to be_accessible
+  end
+
+  pending 'set up authenticator app page' do
+    sign_in_and_2fa_user
+
+    visit '/authenticator_setup'
+
+    expect(page).to be_accessible
+  end
+end


### PR DESCRIPTION
**Why**:
* Test suite should fail when there are accessibility errors.
* This ensures that our app is 508 compliant.
* Ref: https://github.com/dequelabs/axe-matchers.
* Next step is to make all of these pending tests pass :)