### PR TITLE
Nullify legacy recovery codes

### DIFF
--- a/db/migrate/20161122031010_nullify_old_recovery_codes.rb
+++ b/db/migrate/20161122031010_nullify_old_recovery_codes.rb
@@ -1,0 +1,16 @@
+class NullifyOldRecoveryCodes < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    User.all.each do |user|
+      if user.recovery_code.present? && user.recovery_code =~ /^\$2/
+        user.update!(recovery_code: nil)
+      end
+    end
+  end
+
+  def down
+    # no-op
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161121183402) do
+ActiveRecord::Schema.define(version: 20161122031010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
**Why**: Since they cannot be used, nullify old recovery codes
so that the next user login will generate a new one.