### PR TITLE
Improve email encryption error checking

### DIFF
--- a/app/services/pii/cipher.rb
+++ b/app/services/pii/cipher.rb
@@ -37,7 +37,13 @@ module Pii
       cipher.iv = iv(unpacked_payload)
       cipher.auth_tag = tag(unpacked_payload)
       cipher.auth_data = 'PII'
+      try_decipher(unpacked_payload)
+    end
+
+    def try_decipher(unpacked_payload)
       cipher.update(ciphertext(unpacked_payload)) + cipher.final
+    rescue OpenSSL::Cipher::CipherError => err
+      raise EncryptionError, 'failed to decipher payload: ' + err.to_s
     end
 
     def unpack_payload(payload)

--- a/app/services/pii/encryptor.rb
+++ b/app/services/pii/encryptor.rb
@@ -35,7 +35,7 @@ module Pii
       begin
         payload = cipher.decrypt(payload, cek)
       rescue OpenSSL::Cipher::CipherError => err
-        raise EncryptionError, err
+        raise EncryptionError, err.inspect
       end
       raise EncryptionError, 'payload is invalid' unless sane_payload?(payload)
       plaintext, fingerprint = split_into_segments(payload)

--- a/app/services/user_access_key.rb
+++ b/app/services/user_access_key.rb
@@ -56,6 +56,7 @@ class UserAccessKey
   end
 
   def unlock(random_key)
+    raise Pii::EncryptionError, 'Cannot unlock with nil random_key' unless random_key.present?
     self.unlocked = true
     self.random_r = random_key
     hash_e

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20161122031010) do
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
+    t.string   "email_plain",                   limit: 255, default: ""
     t.string   "encrypted_password",            limit: 255, default: ""
     t.string   "reset_password_token",          limit: 255
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
**Why**: Misconfiguration on deploy can erase existing email addresses forever.

**How**: Take a more conservative approach by renaming the plain text column for now.