### PR TITLE
Hide Sign Out till 2FA complete

### DIFF
--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -20,4 +20,4 @@ nav.bg-white
             = link_to t('shared.nav_auth.my_account'), profile_path,
               class: current_page?(profile_path) ? 'bold gray text-decoration-none' : ''
             span.px1.silver = '|'
-          = link_to t('links.sign_out'), destroy_user_session_path
+            = link_to t('links.sign_out'), destroy_user_session_path

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -48,12 +48,6 @@ feature 'Phone confirmation during sign up' do
     it 'informs the user that the OTP code is sent to the phone' do
       expect(page).to have_content(t('instructions.2fa.confirm_code', number: '+1 (555) 555-5555'))
     end
-
-    it 'allows user to enter new number if they Sign Out before confirming' do
-      click_link(t('links.sign_out'))
-      signin(@user.reload.email, @user.password)
-      expect(current_path).to eq phone_setup_path
-    end
   end
 
   context "visitor tries to sign up with another user's phone for OTP" do


### PR DESCRIPTION
**Why**: The UX is not "signed in" until 2FA is complete.