### PR TITLE
Redirects users from /users to /users/sign_up

### DIFF
--- a/app/views/session_timeout/_expired.html.slim
+++ b/app/views/session_timeout/_expired.html.slim
@@ -5,4 +5,4 @@
         = image_tag(asset_url('clock.svg'), class: 'modal-ico')
         h3.mt0.mb2 = t('headings.session_timeout_warning')
         p.mb3 = t('session_expired_html', link: link_to(t('session_expired_link'), '.'))
-        = link_to t('forms.buttons.continue'), '.', class: 'btn btn-primary'
+        = link_to t('forms.buttons.continue'), request.original_url, class: 'btn btn-primary'

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -92,12 +92,16 @@ feature 'Sign in' do
   end
 
   context 'signed out' do
-    it 'displays session timeout modal when session times out', js: true do
+    it 'keeps the user on the current page after session times out', js: true do
       allow(Devise).to receive(:timeout_in).and_return(0)
 
-      visit root_path
+      visit new_user_registration_path
 
       expect(page).to have_css('#session-expired-msg')
+
+      find_link(t('forms.buttons.continue')).trigger('click')
+
+      expect(page).to have_current_path(new_user_registration_path)
     end
 
     it 'does not display timeout modal when session not timed out', js: true do


### PR DESCRIPTION
**Why**:
When a user sits on the users/sign_up page for too long, they are
directed to the /users page, which is not defined. Instead, redirect
them back to the sign_up page.