### PR TITLE
Add "human detection" to voice OTP phone call

### DIFF
--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -24,15 +24,22 @@ class VoiceOtpSenderJob < ActiveJob::Base
     repeat = message_repeat(code)
 
     twimlet_menu(
-      repeat,
+      message_initial,
       1 => twimlet_menu(
         repeat,
         1 => twimlet_menu(
           repeat,
-          1 => twimlet_menu(repeat, 1 => twimlet_message(message_final(code)))
+          1 => twimlet_menu(
+            repeat,
+            1 => twimlet_menu(repeat, 1 => twimlet_message(message_final(code)))
+          )
         )
       )
     )
+  end
+
+  def message_initial
+    I18n.t('jobs.voice_otp_sender_job.message_initial')
   end
 
   def message_repeat(code)

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -6,9 +6,11 @@ en:
 
         If you did not request this change, please contact %{app} at %{support_url}
     voice_otp_sender_job:
+      message_initial: >
+        Hello! Press 1 to hear your login.gov one time passcode.
       message_repeat: >
-        Hello! Your login.gov one time passcode is, %{code},
-        again, your passcode is, %{code}. Press 1 to repeat your code.
+        Your login.gov one time passcode is, %{code}, again, your passcode is,
+        %{code}. Press 1 to repeat your passcode.
       message_final: >
-        Hello! Your login.gov one time passcode is, %{code},
-        again, your passcode is, %{code}, goodbye!
+        Your login.gov one time passcode is, %{code}, again, your passcode is,
+        %{code}, goodbye!


### PR DESCRIPTION
**Why**:
So we don't read our OTPs into people's voicemails

**How**:
Replace intial message that reads the code with one that
prompts users to press 1 to hear the code

----

Expands on https://github.com/18F/identity-idp/pull/767 to add human detection