### PR TITLE
Add remote script

### DIFF
--- a/.reek
+++ b/.reek
@@ -3,6 +3,9 @@ Attribute:
 DuplicateMethodCall:
   exclude:
     - needs_to_confirm_email_change?
+    - Remote#command
+    - Remote#extract_trailing_options
+    - Remote#parse_positional_arguments
 FeatureEnvy:
   exclude:
     - track_registration
@@ -12,6 +15,9 @@ FeatureEnvy:
     - mark_profile_inactive
 IrresponsibleModule:
   enabled: false
+NestedIterators:
+  exclude:
+  - Remote#build_parser
 NilCheck:
   exclude:
     - AdminConstraint#user_is_admin?
@@ -33,6 +39,10 @@ TooManyStatements:
   max_statements: 6
   exclude:
     - Users::PhoneConfirmationController
+    - Remote#build_parser
+    - Remote#execute
+    - Remote#extract_trailing_options
+    - Remote#parse
 TooManyMethods:
   exclude:
     - Users::ConfirmationsController
@@ -61,6 +71,12 @@ UtilityFunction:
     - SessionDecorator#new_session_heading
     - WorkerHealthChecker::Middleware#call
     - UserEncryptedEmailOverrides#create_fingerprint
+    - Remote#build_parser
+    - Remote#command
+    - Remote#default_config
+    - Remote#extract_trailing_options
+    - Remote#host
+    - Remote#parse_positional_arguments
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/bin/remote
+++ b/bin/remote
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path(File.join('..', 'lib'), File.dirname(__FILE__))
+
+require 'remote'
+
+Remote.new.run(ARGV)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,16 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "b78936e578167c6d25902e399c5e624cacc6219d83cca53806a0d7f1ab8f3161",
+      "file": "lib/remote.rb",
+      "line": 69,
+      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
+      "confidence": "Medium",
+      "note": "intentionally shelling out"
+    }
+  ],
+  "updated": "2016-11-25 13:18:43 -0500",
+  "brakeman_version": "3.4.1"
+}

--- a/lib/remote.rb
+++ b/lib/remote.rb
@@ -1,0 +1,113 @@
+require 'ostruct'
+require 'optparse'
+
+# rubocop:disable Rails/Exit
+class Remote
+  def run(argv)
+    config = parse(argv)
+
+    execute(config)
+  end
+
+  def parse(argv)
+    config = default_config
+
+    parser = build_parser(config)
+    config.command = extract_trailing_options(argv)
+    parser.parse!(argv)
+    parse_positional_arguments(config, argv)
+
+    if config.show_help || !config.stage
+      Kernel.puts parser
+      Kernel.exit 0
+    end
+
+    config
+  end
+
+  def default_config
+    OpenStruct.new(
+      stage: nil,
+      command: nil,
+      subhost: nil,
+      show_help: false
+    )
+  end
+
+  def extract_trailing_options(argv)
+    separator_index = argv.index('--')
+
+    return unless separator_index
+
+    argv.delete_at(separator_index)
+    trailing = []
+    trailing << argv.delete_at(separator_index) while argv[separator_index]
+    trailing
+  end
+
+  def parse_positional_arguments(config, argv)
+    config.stage = argv.shift if !config.stage && argv.first
+
+    config.command = argv.first if !config.command && argv.first
+
+    config.command ||= 'console'
+  end
+
+  def execute(config)
+    remote_host = host(config)
+    ssh_command = ['ssh', '-t', "ubuntu@#{remote_host}"]
+
+    local_command = ['cd /srv/idp/current; ']
+    local_command << command(config)
+    local_command.flatten!
+
+    Kernel.puts [ssh_command.join(' '), local_command.map(&:inspect)].join(' ')
+
+    exec(*ssh_command, *local_command)
+  end
+
+  def host(config)
+    [config.subhost, config.stage, 'login.gov'].compact.join('.')
+  end
+
+  def command(config)
+    if config.command == 'console'
+      'RAILS_ENV=production bundle exec rails console'
+    elsif config.command == 'shell'
+      'bash --login'
+    else
+      config.command
+    end
+  end
+
+  def build_parser(config) # rubocop:disable Metrics/MethodLength
+    OptionParser.new do |opts|
+      opts.banner = <<-EOS
+    Usage: #{$PROGRAM_NAME} stage (command)
+           #{$PROGRAM_NAME} stage -- command to run
+      EOS
+
+      opts.on('-s', '--stage=STAGE', 'Stage/environment to connect to, default: dev') do |stage|
+        config.stage = stage
+      end
+
+      command_banner = <<-EOS
+    Specify the command to run, defaults to console
+            console    - opens a Rails console
+            shell      - opens a Bash shell in the current directory
+    EOS
+
+      opts.on('-c', '--command=COMMAND', command_banner) do |command|
+        config.command = command
+      end
+
+      opts.on('-w', '--worker', 'Connect to a worker host') do
+        config.subhost = 'worker'
+      end
+
+      opts.on('-h', '--help', 'Prints this help') do
+        config.show_help = true
+      end
+    end
+  end
+end

--- a/spec/lib/remote_spec.rb
+++ b/spec/lib/remote_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+require 'remote'
+
+RSpec.describe Remote do
+  subject(:remote) { Remote.new }
+
+  describe '#parse' do
+    subject(:parse) { remote.parse(argv) }
+
+    context 'without any args' do
+      let(:argv) { [] }
+
+      it 'prints help and exits' do
+        expect(Kernel).to receive(:puts)
+        expect(Kernel).to receive(:exit).with(0)
+
+        parse
+      end
+    end
+
+    context 'with just a stage' do
+      let(:argv) { ['qa'] }
+
+      it 'sets the stage' do
+        expect(parse.stage).to eq('qa')
+      end
+
+      it 'defaults to the console command' do
+        expect(parse.command).to eq('console')
+      end
+    end
+
+    context 'with a stage and a command' do
+      let(:argv) { %w(demo shell) }
+
+      it 'sets the stage' do
+        expect(parse.stage).to eq('demo')
+      end
+
+      it 'sets the command' do
+        expect(parse.command).to eq('shell')
+      end
+    end
+
+    context 'with the --worker flag' do
+      let(:argv) { ['--worker', 'qa'] }
+
+      it 'sets the subhost to worker' do
+        expect(parse.subhost).to eq('worker')
+      end
+    end
+
+    context 'specifying stage and command as flags' do
+      let(:argv) { ['--stage', 'demo', '--command', 'echo hi'] }
+
+      it 'sets the stage and command' do
+        expect(parse.stage).to eq('demo')
+        expect(parse.command).to eq('echo hi')
+      end
+    end
+
+    context 'with a command after a --' do
+      let(:argv) { ['qa', '--', 'echo', 'hi'] }
+
+      it 'extracts the command' do
+        expect(parse.command).to eq(%w(echo hi))
+      end
+    end
+  end
+
+  describe '#command' do
+    let(:config) { OpenStruct.new(command: command) }
+
+    context 'with console' do
+      let(:command) { 'console' }
+
+      it 'opens a rails console' do
+        expect(remote.command(config)).
+          to eq('RAILS_ENV=production bundle exec rails console')
+      end
+    end
+
+    context 'with shell' do
+      let(:command) { 'shell' }
+
+      it 'opens a bash shell' do
+        expect(remote.command(config)).to eq('bash --login')
+      end
+    end
+
+    context 'with a custom command' do
+      let(:command) { 'echo hi' }
+
+      it 'is that custom command' do
+        expect(remote.command(config)).to eq('echo hi')
+      end
+    end
+  end
+
+  describe '#execute' do
+    let(:config) do
+      OpenStruct.new(
+        host: 'demo',
+        command: 'echo hi'
+      )
+    end
+
+    before { expect(Kernel).to receive(:puts) }
+
+    subject(:exec_args) do
+      exec_args = nil
+      expect(remote).to receive(:exec) do |*args|
+        exec_args = args
+      end
+
+      remote.execute(config)
+
+      exec_args
+    end
+
+    it 'runs ssh -t' do
+      expect(exec_args.first(2)).to eq(['ssh', '-t'])
+    end
+
+    it 'logs in as the ubuntu user' do
+      expect(exec_args[2]).to start_with('ubuntu@')
+    end
+
+    it 'runs from the current directory' do
+      expect(exec_args[3]).to eq('cd /srv/idp/current; ')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: makes running commands on our various servers easier

I wrote this for me but not sure if anybody else might find it useful too? The config values in here are all present in the various `config/deploy/*.rb` files so I don't think it's a problem to hardcode them here?

--

Example usage:

```bash
# opens a rails console
./bin/remote qa

# opens a bash shell
./bin/remote qa shell

# opens a bash shell on a worker host
./bin/remote qa shell --worker

# runs some command remotely
./bin/remote qa -- tail -f log/production.log
```