### PR TITLE
Consolidate Email Update analytics

### DIFF
--- a/app/controllers/users/edit_email_controller.rb
+++ b/app/controllers/users/edit_email_controller.rb
@@ -9,7 +9,11 @@ module Users
     def update
       @update_user_email_form = UpdateUserEmailForm.new(current_user)
 
-      if @update_user_email_form.submit(user_params)
+      result = @update_user_email_form.submit(user_params)
+
+      analytics.track_event(Analytics::EMAIL_CHANGE_REQUEST, result)
+
+      if result[:success]
         process_updates
         bypass_sign_in current_user
       else
@@ -25,19 +29,10 @@ module Users
 
     def process_updates
       if @update_user_email_form.email_changed?
-        track_email_change
         flash[:notice] = t('devise.registrations.email_update_needs_confirmation')
       end
 
       redirect_to profile_url
-    end
-
-    def track_email_change
-      if @update_user_email_form.email_taken?
-        analytics.track_event(Analytics::EMAIL_CHANGED_TO_EXISTING)
-      else
-        analytics.track_event(Analytics::EMAIL_CHANGE_REQUESTED)
-      end
     end
   end
 end

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -17,16 +17,16 @@ class UpdateUserEmailForm
   def submit(params)
     email = params[:email].downcase
 
-    if email != @user.email
-      @email_changed = true
-      self.email = email
-    end
+    self.email = email
 
     if valid_form?
-      @user.update(params)
+      @success = true
+      @user.update(email: email)
     else
-      process_errors
+      @success = process_errors
     end
+
+    result
   end
 
   def valid_form?
@@ -34,12 +34,12 @@ class UpdateUserEmailForm
   end
 
   def email_changed?
-    email_changed == true
+    valid? && email != @user.email
   end
 
   private
 
-  attr_reader :email_changed
+  attr_reader :email_changed, :success
 
   def process_errors
     return false unless email_taken? && valid?
@@ -47,5 +47,14 @@ class UpdateUserEmailForm
     @user.skip_confirmation_notification!
     UserMailer.signup_with_your_email(email).deliver_later
     true
+  end
+
+  def result
+    {
+      success: success,
+      errors: errors.messages.values.flatten,
+      email_already_exists: email_taken?,
+      email_changed: email_changed?
+    }
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -33,8 +33,7 @@ class Analytics
   # rubocop:disable Metrics/LineLength
   AUTHENTICATION_MAX_2FA_ATTEMPTS = 'Authentication: user reached max 2FA attempts'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
-  EMAIL_CHANGE_REQUESTED = 'Email Change: requested'.freeze
-  EMAIL_CHANGED_TO_EXISTING = 'Email Change: user attempted to change their email to an existing email'.freeze
+  EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze
   EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
   IDV_FAILED = 'IdV: failed'.freeze

--- a/spec/controllers/users/edit_email_controller_spec.rb
+++ b/spec/controllers/users/edit_email_controller_spec.rb
@@ -10,21 +10,27 @@ describe Users::EditEmailController do
     let(:new_email) { 'new_email@example.com' }
 
     context 'user changes email' do
-      before do
+      it 'lets user know they need to confirm their new email' do
         stub_sign_in(user)
 
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, update_user_email_form: { email: new_email }
-      end
+        analytics_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: false,
+          email_changed: true
+        }
 
-      it 'lets user know they need to confirm their new email' do
+        put :update, update_user_email_form: { email: new_email }
+
         expect(response).to redirect_to profile_url
         expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
         expect(response).to render_template('devise/mailer/confirmation_instructions')
         expect(user.reload.email).to eq 'old_email@example.com'
-        expect(@analytics).to have_received(:track_event).with(Analytics::EMAIL_CHANGE_REQUESTED)
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
 
@@ -33,10 +39,23 @@ describe Users::EditEmailController do
 
       it 'displays an error message and does not delete the email' do
         stub_sign_in(user)
+
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        analytics_hash = {
+          success: false,
+          errors: [t('valid_email.validations.email.invalid')],
+          email_already_exists: false,
+          email_changed: false
+        }
+
         put :update, update_user_email_form: { email: '' }
 
         expect(response.body).to have_content invalid_email_message
         expect(user.reload.email).to be_present
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
 
@@ -47,6 +66,13 @@ describe Users::EditEmailController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
+        analytics_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: true,
+          email_changed: true
+        }
+
         put :update, update_user_email_form: { email: second_user.email.upcase }
 
         expect(response).to redirect_to profile_url
@@ -54,7 +80,7 @@ describe Users::EditEmailController do
         expect(response).to render_template('user_mailer/signup_with_your_email')
         expect(last_email.subject).to eq t('mailer.email_reuse_notice.subject')
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::EMAIL_CHANGED_TO_EXISTING)
+          with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
 
@@ -63,9 +89,21 @@ describe Users::EditEmailController do
 
       it 'displays error about invalid email' do
         stub_sign_in(user)
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        analytics_hash = {
+          success: false,
+          errors: [t('valid_email.validations.email.invalid')],
+          email_already_exists: false,
+          email_changed: false
+        }
+
         put :update, update_user_email_form: { email: 'foo' }
 
         expect(response.body).to have_content(t('valid_email.validations.email.invalid'))
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
 
@@ -74,10 +112,23 @@ describe Users::EditEmailController do
 
       it 'redirects to profile page without any messages' do
         stub_sign_in(user)
+
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: false,
+          email_changed: false
+        }
+
         put :update, update_user_email_form: { email: user.email }
 
         expect(response).to redirect_to profile_url
         expect(flash.keys).to be_empty
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
   end

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -9,7 +9,14 @@ describe UpdateUserEmailForm do
     it 'is false when the submitted email is the same as the current email' do
       result = subject.submit(email: 'OLD@example.com')
 
-      expect(result).to be true
+      result_hash = {
+        success: true,
+        errors: [],
+        email_already_exists: false,
+        email_changed: false
+      }
+
+      expect(result).to eq result_hash
       expect(subject.email_changed?).to eq false
     end
   end
@@ -30,7 +37,14 @@ describe UpdateUserEmailForm do
 
         result = subject.submit(email: 'ANOTHER@example.com')
 
-        expect(result).to be true
+        result_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: true,
+          email_changed: true
+        }
+
+        expect(result).to eq result_hash
         expect(subject.email_changed?).to eq true
         expect(user.unconfirmed_email).to be_nil
         expect(user.email).to eq 'old@example.com'
@@ -44,9 +58,16 @@ describe UpdateUserEmailForm do
 
         result = subject.submit(email: 'new@example.com')
 
+        result_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: false,
+          email_changed: true
+        }
+
         expect(user.unconfirmed_email).to eq 'new@example.com'
         expect(user.email).to eq 'old@example.com'
-        expect(result).to be true
+        expect(result).to eq result_hash
         expect(subject.email_changed?).to eq true
       end
     end
@@ -57,16 +78,15 @@ describe UpdateUserEmailForm do
 
         result = subject.submit(email: 'TAKEN@gmail.com')
 
-        expect(result).to be true
+        result_hash = {
+          success: true,
+          errors: [],
+          email_already_exists: true,
+          email_changed: true
+        }
+
+        expect(result).to eq result_hash
         expect(subject.email).to eq 'taken@gmail.com'
-      end
-    end
-
-    context 'when email is not already taken' do
-      it 'is valid' do
-        result = subject.submit(email: 'not_taken@gmail.com')
-
-        expect(result).to be true
       end
     end
 
@@ -74,9 +94,14 @@ describe UpdateUserEmailForm do
       it 'returns false and adds errors to the form object' do
         result = subject.submit(email: 'invalid_email')
 
-        expect(result).to be false
-        expect(subject.errors[:email]).
-          to eq [t('valid_email.validations.email.invalid')]
+        result_hash = {
+          success: false,
+          errors: [t('valid_email.validations.email.invalid')],
+          email_already_exists: false,
+          email_changed: false
+        }
+
+        expect(result).to eq result_hash
       end
     end
   end


### PR DESCRIPTION
**Why**: To keep analytics reporting consistent.