### PR TITLE
Refactor 2FA Max attempts analytics

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -3,7 +3,6 @@ module TwoFactorAuthenticatable
 
   included do
     prepend_before_action :authenticate_user!
-    before_action :verify_user_is_not_second_factor_locked
     before_action :handle_two_factor_authentication
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
@@ -11,12 +10,8 @@ module TwoFactorAuthenticatable
 
   private
 
-  def verify_user_is_not_second_factor_locked
-    handle_second_factor_locked_user if decorated_user.blocked_from_entering_2fa_code?
-  end
-
   def handle_second_factor_locked_user
-    analytics.track_event(Analytics::AUTHENTICATION_MAX_2FA_ATTEMPTS)
+    analytics.track_event(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
     render 'two_factor_authentication/shared/max_login_attempts_reached'
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,8 +5,6 @@ module Users
     skip_before_action :session_expires_at, only: [:active]
     before_action :confirm_two_factor_authenticated, only: [:update]
 
-    after_action :cache_active_profile, only: [:create]
-
     def new
       analytics.track_event(Analytics::SIGN_IN_PAGE_VISIT)
       super
@@ -14,7 +12,15 @@ module Users
 
     def create
       track_authentication_attempt(params[:user][:email])
+
+      if current_user && user_locked_out?(current_user)
+        render 'two_factor_authentication/shared/max_login_attempts_reached'
+        sign_out
+        return
+      end
+
       super
+      cache_active_profile
     end
 
     def active
@@ -52,7 +58,9 @@ module Users
       user = User.find_with_email(email) || AnonymousUser.new
 
       properties = {
-        success?: current_user.present?, user_id: user.uuid
+        success?: user_signed_in_and_not_locked_out?(user),
+        user_id: user.uuid,
+        user_locked_out: user_locked_out?(user)
       }
 
       analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)
@@ -66,6 +74,16 @@ module Users
         current_user.active_profile.deactivate(:encryption_error)
         analytics.track_event(Analytics::PROFILE_ENCRYPTION_INVALID, error: err.message)
       end
+    end
+
+    def user_signed_in_and_not_locked_out?(user)
+      return false unless current_user.present?
+
+      !user_locked_out?(user)
+    end
+
+    def user_locked_out?(user)
+      UserDecorator.new(user).blocked_from_entering_2fa_code?
     end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -70,11 +70,11 @@ UserDecorator = Struct.new(:user) do
   end
 
   def blocked_from_entering_2fa_code?
-    user.second_factor_locked_at && !blocked_from_2fa_period_expired?
+    user.second_factor_locked_at.present? && !blocked_from_2fa_period_expired?
   end
 
   def no_longer_blocked_from_entering_2fa_code?
-    user.second_factor_locked_at && blocked_from_2fa_period_expired?
+    user.second_factor_locked_at.present? && blocked_from_2fa_period_expired?
   end
 
   def should_acknowledge_recovery_code?(session)

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -2,4 +2,8 @@ class AnonymousUser
   def uuid
     'anonymous-uuid'
   end
+
+  def second_factor_locked_at
+    nil
+  end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -30,8 +30,6 @@ class Analytics
     user.uuid
   end
 
-  # rubocop:disable Metrics/LineLength
-  AUTHENTICATION_MAX_2FA_ATTEMPTS = 'Authentication: user reached max 2FA attempts'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze
   EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
@@ -47,10 +45,10 @@ class Analytics
   OTP_DELIVERY_SELECTION = 'OTP: Delivery Selection'.freeze
   MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   MULTI_FACTOR_AUTH_ENTER_OTP_VISIT = 'Multi-Factor Authentication: enter OTP visited'.freeze
+  MULTI_FACTOR_AUTH_MAX_ATTEMPTS = 'Multi-Factor Authentication: max attempts reached'.freeze
   PAGE_NOT_FOUND = 'Page Not Found'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze
   PASSWORD_CREATION = 'Password Creation'.freeze
-  PASSWORD_RESET_DEACTIVATED_ACCOUNT = 'Password Reset: deactivated verified profile via password reset'.freeze
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
@@ -70,5 +68,4 @@ class Analytics
   USER_REGISTRATION_INTRO_VISIT = 'User Registration: intro visited'.freeze
   USER_REGISTRATION_PHONE_SETUP_VISIT = 'User Registration: phone setup visited'.freeze
   USER_REGISTRATION_RECOVERY_CODE_VISIT = 'User Registration: recovery code visited'.freeze
-  # rubocop:enable Metrics/LineLength
 end

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -6,7 +6,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
       expect(subject).to have_actions(
         :before,
         :authenticate_user!,
-        :verify_user_is_not_second_factor_locked,
         :handle_two_factor_authentication,
         :check_already_authenticated
       )

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -91,7 +91,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
         expect(@analytics).to receive(:track_event).exactly(3).times.
           with(Analytics::MULTI_FACTOR_AUTH, properties)
-        expect(@analytics).to receive(:track_event).with(Analytics::AUTHENTICATION_MAX_2FA_ATTEMPTS)
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
         3.times { post :create, code: '12345', delivery_method: 'sms' }
       end

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -55,6 +55,21 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_recovery_code')
       end
+
+      it 'tracks the max attempts event' do
+        properties = {
+          success?: false,
+          method: 'recovery code'
+        }
+
+        stub_analytics
+
+        expect(@analytics).to receive(:track_event).exactly(3).times.
+          with(Analytics::MULTI_FACTOR_AUTH, properties)
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
+
+        3.times { post :create, code: 'foo' }
+      end
     end
   end
 end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -65,7 +65,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
 
         expect(@analytics).to receive(:track_event).exactly(3).times.
           with(Analytics::MULTI_FACTOR_AUTH, success?: false, method: 'totp')
-        expect(@analytics).to receive(:track_event).with(Analytics::AUTHENTICATION_MAX_2FA_ATTEMPTS)
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
         3.times { post :create, code: '12345' }
       end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -123,7 +123,7 @@ feature 'Two Factor Authentication' do
         user = create(:user, :signed_up)
         user.update(second_factor_locked_at: Time.zone.now - 1.minute)
         allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
-        sign_in_before_2fa(user)
+        signin(user.email, user.password)
 
         expect(page).to have_content t('devise.two_factor_authentication.' \
                                        'max_login_attempts_reached')

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -4,7 +4,6 @@
 #   expect(subject).to have_actions(
 #     :before,
 #     :authenticate_scope!,
-#     :verify_user_is_not_second_factor_locked,
 #     :handle_two_factor_authentication,
 #     :check_already_authenticated
 #   )
@@ -21,7 +20,6 @@
 #   expect(subject).to have_actions(
 #     :before,
 #     :authenticate_scope!,
-#     :verify_user_is_not_second_factor_locked,
 #     :handle_two_factor_authentication,
 #     [:check_already_authenticated, only: :new]
 #   )


### PR DESCRIPTION
**Why**: We were incorrectly reporting a Max Attempts Reached event
when the user attempted to sign in while locked out. The event should
only be triggered when the user enters an incorrect 2FA code too many
times.

**How**:
- Remove `verify_user_is_not_second_factor_locked` from
`TwoFactorAuthenticatable`, and put that logic in SessionsController,
since a user should not get past the sign in screen if locked out.
- Add a property to the signin analytics to show if the user is
currently locked out or not.