### PR TITLE
Expose worker health status in an endpoint

### DIFF
--- a/.reek
+++ b/.reek
@@ -6,6 +6,7 @@ DuplicateMethodCall:
     - Remote#command
     - Remote#extract_trailing_options
     - Remote#parse_positional_arguments
+    - WorkerHealthChecker#status
 FeatureEnvy:
   exclude:
     - track_registration

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,15 @@
+class HealthController < ApplicationController
+  def workers
+    summary = worker_health_checker.summary
+
+    status = summary.all_healthy? ? :ok : :internal_error
+
+    render json: summary, status: status
+  end
+
+  protected
+
+  def worker_health_checker
+    @_worker_health_checker ||= WorkerHealthChecker
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   end
 
   # Non-devise-controller routes. Alphabetically sorted.
+  get '/api/health/workers' => 'health#workers'
   get '/api/saml/metadata' => 'saml_idp#metadata'
   match '/api/saml/logout' => 'saml_idp#logout',
         via: [:get, :post, :delete],

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe HealthController do
+  describe '#workers' do
+    before do
+      allow(controller).to receive(:worker_health_checker).
+        and_return(class_double('WorkerHealthChecker',
+                                summary: WorkerHealthChecker::Summary.new(statuses)))
+    end
+
+    subject(:action) { get :workers }
+
+    let(:all_healthy) { true }
+    let(:statuses) do
+      [
+        WorkerHealthChecker::Status.new('voice', 0.minutes.ago, true),
+        WorkerHealthChecker::Status.new('sms', 0.minutes.ago, true)
+      ]
+    end
+
+    it 'renders the responses as json' do
+      action
+
+      json = JSON.parse(response.body)
+
+      expect(json['all_healthy']).to eq(true)
+      expect(json['statuses'].first['queue']).to eq('voice')
+      expect(json['statuses'].first['healthy']).to eq(true)
+    end
+
+    context 'with all healthy statuses' do
+      it 'is a 200' do
+        action
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'with an unhealthy status' do
+      let(:statuses) do
+        [
+          WorkerHealthChecker::Status.new('voice', 0.minutes.ago, true),
+          WorkerHealthChecker::Status.new('sms', nil, false)
+        ]
+      end
+
+      it 'is a 500' do
+        action
+
+        expect(response.status).to eq(500)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
So that we can check if our jobs are running from outside our jobs

we had a failure recently where the entire sidekiq process was down, so the existing queue health check would not be able to report that so we need to expose our data another way