### PR TITLE
Remove deploy information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,42 +160,6 @@ $ RAILS_ASSET_HOST=localhost:3000 rake spec:user_flows
 
 Then, visit http://localhost:3000/user_flows in your browser!
 
-### Deploying
-
-We currently run a demo environment at https://idp.demo.login.gov.
-Core developers can deploy to those hosts with [Capistrano](http://capistranorb.com)
-using the following command:
-
-```
-$ cap <env/stage> deploy
-```
-
-You will need to provide a copy of your SSH public key and you may need to
-provide your IP address if you are not in a GSA building or on the GSA VPN.
-Post a message in the Slack channel if you need help.
-
-Note: server secrets are currently manually configured. If you deploy to an
-environment, make sure to update any required configuration in application.yml
-and be sure any worker hosts are also updated.
-
-To restart the web server (on a web host, from /srv/idp/current)
-
-```
-$ touch tmp/restart.txt
-```
-
-To get status of the background workers (on a worker host):
-
-```
-$ sudo monit status
-```
-
-To restart the background workers:
-
-```
-$ sudo monit restart sidekiq_idp_production0
-```
-
 ### Why 'Upaya'?
 
 "skill in means" https://en.wikipedia.org/wiki/Upaya


### PR DESCRIPTION
**Why**:
* Stuff that is only relevant to internal devs should be in the private
  wiki