### PR TITLE
Remove confusing last sentence for error message

### DIFF
--- a/app/views/idv/sessions/dupe.html.slim
+++ b/app/views/idv/sessions/dupe.html.slim
@@ -5,5 +5,3 @@ h1.h3.my0 = t('idv.titles.dupe')
 p.mb1 = t('idv.messages.dupe_ssn1')
 p.mb1 = t('idv.messages.dupe_ssn2_html',
         link: link_to(t('idv.messages.dupe_ssn2_link'), destroy_user_session_path))
-p.mb1 = t('idv.messages.dupe_ssn3_html',
-        link: link_to(t('idv.messages.dupe_ssn3_link'), new_user_password_path))

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -63,8 +63,6 @@ en:
         an account, but with a different email address.
       dupe_ssn2_html: Please %{link} with the email address you originally used.
       dupe_ssn2_link: sign out now and sign back in
-      dupe_ssn3_html: If you can’t remember your original login information, you can %{link}.
-      dupe_ssn3_link: try recovering it here
       review_and_continue: Review my info and try again
       finance:
         intro: >


### PR DESCRIPTION
**Why**:
* The error message should not include a link to the forgot
  password page because the user is already signed in
* Clicking that link will take the user to their profile page.
* If a user is going through proofing, that means they're already signed
  in, so it doesn't make sense to say "If you can’t remember your
  original login information, you can try recovering it here."