### PR TITLE
Use flash.now for invalid passcode

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -59,7 +59,7 @@ module TwoFactorAuthenticatable
   def handle_invalid_otp(type: 'otp')
     update_invalid_user if current_user.two_factor_enabled? && context == 'authentication'
 
-    flash[:error] = t("devise.two_factor_authentication.invalid_#{type}")
+    flash.now[:error] = t("devise.two_factor_authentication.invalid_#{type}")
 
     if decorated_user.blocked_from_entering_2fa_code?
       handle_second_factor_locked_user

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -140,6 +140,22 @@ feature 'Two Factor Authentication' do
         expect(current_path).to eq root_path
       end
     end
+
+    context 'user enters correct OTP after incorrect OTP' do
+      it 'does not display error message' do
+        user = create(:user, :signed_up)
+        sign_in_before_2fa(user)
+        click_button t('forms.buttons.submit.default')
+
+        fill_in('code', with: 'bad-code')
+        click_button t('forms.buttons.submit.default')
+        fill_in('code', with: user.reload.direct_otp)
+        click_button t('forms.buttons.submit.default')
+
+        expect(page).
+          to_not have_content t('devise.two_factor_authentication.invalid_otp')
+      end
+    end
   end
 
   describe 'when the user is TOTP enabled' do


### PR DESCRIPTION
**Why**: So that the flash message doesn't carry over to the profile
page after entering the correct passcode.