### PR TITLE
Email -> Email address

### DIFF
--- a/config/locales/contact/en.yml
+++ b/config/locales/contact/en.yml
@@ -4,7 +4,7 @@ en:
     learn_more: Learn more about %{app}
     tell_experience: Tell you about my %{app} experience
     labels:
-      email_or_tel: Email address or telephone
+      email_or_tel: Email address or phone number
       comments: Comments
       comments_note: Optional, but very helpful
     messages:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -6,7 +6,7 @@ en:
       weak_password: Your password is not strong enough. %{feedback}
       already_confirmed: was already confirmed, please try signing in
       confirmation_period_expired: >
-        You have taken longer than %{period} to confirm your email.
+        You have taken longer than %{period} to confirm your email address.
         Please click "Resend confirmation instructions."
       confirmation_invalid_token: >
         The confirmation link you clicked on is no longer valid.  This may have been caused by

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -2,8 +2,8 @@ en:
   event_types:
     account_created: Account created
     phone_confirmed: Phone confirmed
-    phone_changed: Phone changed
-    email_changed: Email changed
+    phone_changed: Phone number changed
+    email_changed: Email address changed
     authenticator_enabled: Authenticator app enabled
     authenticator_disabled: Authenticator app disabled
     authenticated_at: Signed in at %{service_provider}

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -12,12 +12,12 @@ en:
     email_reuse_notice:
       subject: Confirm your email address
     email_change_notice:
-      subject: Change your email
+      subject: Change your email address
     confirmation_instructions:
       header: >
         %{intro} To confirm your email address, please click on the link
         below or copy and paste the entire link into your browser.
-      link_text: Confirm this email
+      link_text: Confirm this email address
       first_sentence:
         reset_requested: >
           Your %{app} account has been reset by a tech support representative.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -5,7 +5,7 @@ en:
       show: Create a password for your account
     contact: Contact us
     edit_info:
-      email: Edit your email
+      email: Edit your email address
       password: Edit your password
       phone: Edit your phone number
     enter_2fa_code: Enter the secure one-time passcode

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -3,7 +3,7 @@ en:
     contact_request:
       comments_header: "Comments:"
       comments: No comments left
-      email_or_phone: "Email or phone:"
+      email_or_phone: "Email address or phone number:"
       'no': no
       talk_about_experience: Talk about experience?
       want_to_learn: Learn more?

--- a/config/locales/valid_email/en.yml
+++ b/config/locales/valid_email/en.yml
@@ -2,4 +2,4 @@ en:
   valid_email:
     validations:
       email:
-        invalid: Invalid email format or domain entered. Correct the address and re-enter it.
+        invalid: Invalid email address format or domain entered. Correct the address and re-enter it.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -87,11 +87,13 @@ describe UserMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.html_part.body).
-        to have_content("Email or phone:#{details['email_or_tel']}")
+      expect(mail.html_part.body).to have_content(
+        "#{t('user_mailer.contact_request.email_or_phone')}#{details['email_or_tel']}"
+      )
 
-      expect(mail.html_part.body).
-        to have_content("Comments:#{details['comments']}")
+      expect(mail.html_part.body).to have_content(
+        "#{t('user_mailer.contact_request.comments_header')}#{details['comments']}"
+      )
     end
   end
 end


### PR DESCRIPTION
**Why**:
* An email is not an email address
* When we mean "email address", we should be explicit
* We already do this in most places, this just fixes some text we missed