### PR TITLE
Remove (logged in user) header links

### DIFF
--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -5,5 +5,7 @@ footer.footer.bg-navy.white
       .sm-col-right.caps
         = link_to t('links.help'), help_path,
           class: 'white text-decoration-none mr3'
+        = link_to t('links.contact'), contact_path,
+          class: 'white text-decoration-none mr3'
         = link_to t('links.privacy_policy'), privacy_path,
           class: 'white text-decoration-none'

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -7,10 +7,6 @@ nav.bg-white
             alt: APP_NAME,
             class: 'align-bottom',
             width: 170), root_path, class: 'inline-block'
-        .mt-12p.h6.sm-show.caps
-          = link_to t('shared.nav_auth.about'), root_path, class: 'mr3 gray'
-          = link_to t('shared.nav_auth.news'), root_path, class: 'mr3 gray'
-          = link_to t('shared.nav_auth.contact'), root_path, class: 'mr3 gray'
       - if user_fully_authenticated?
         .sm-col-right.sm-right-align
           = t('shared.nav_auth.welcome')

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -2,6 +2,7 @@ en:
   links:
     back_to_sp: '‹ Back to %{sp}'
     create_account: Create account
+    contact: Contact
     help: Help
     privacy_policy: Privacy Policy
     resend: Send again

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -5,8 +5,5 @@ en:
     footer_lite:
       gsa: U.S. General Services Administration
     nav_auth:
-      about: About
-      news: News
-      contact: Contact
       welcome: Welcome
       my_account: My account


### PR DESCRIPTION
**Why**:
* Old links didn't go anywhere
* We are now linking to HELP and CONTACT in footer (for all users)

![screen shot 2016-11-29 at 11 55 20 am](https://cloud.githubusercontent.com/assets/601515/20726553/f3998bd2-b62a-11e6-9ada-7ede061bc2a3.png)
