### PR TITLE
Adds sp.qa.login.gov to SPs

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -126,10 +126,23 @@ production:
     sp_initiated_login_url: 'https://sp.dev.login.gov/login'
     block_encryption: 'aes256-cbc'
     cert: 'sp_rails_demo'
-    agency: 'dev_agency'
-    friendly_name: 'Dev Agency'
+    agency: 'A Gov Agency'
+    friendly_name: 'Demo SP Application'
     logo: 'generic.svg'
     return_to_sp_url: 'https://sp.dev.login.gov'
+    attribute_bundle:
+      - email
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-qa':
+    acs_url: 'https://sp.qa.login.gov/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://sp.qa.login.gov/auth/saml/logout'
+    sp_initiated_login_url: 'https://sp.qa.login.gov/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    agency: 'A Gov Agency'
+    friendly_name: 'Demo SP Application'
+    logo: 'generic.svg'
+    return_to_sp_url: 'https://sp.qa.login.gov'
     attribute_bundle:
       - email
 
@@ -139,8 +152,8 @@ production:
     sp_initiated_login_url: 'https://sp.demo.login.gov/login'
     block_encryption: 'aes256-cbc'
     cert: 'sp_rails_demo'
-    agency: 'demo_agency'
-    friendly_name: 'Demo Agency'
+    agency: 'A Gov Agency'
+    friendly_name: 'Demo SP Application'
     logo: 'generic.svg'
     return_to_sp_url: 'https://sp.demo.login.gov'
     attribute_bundle:


### PR DESCRIPTION
#### Why
sp.qa.login.gov was not configured as a valid service provider

#### How
Configures sp.qa.login.gov (urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-qa) as a valid service provider
Updates agency and friendly names to be more user-friendly. 