### PR TITLE
Fix accessibility issues w/r/t decorative `|` elem

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -15,7 +15,6 @@ p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
 
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial
-  .sm-col-right
-    = link_to t('links.passwords.forgot'), new_password_path(resource_name)
-    span.px1.silver = '|'
-    = link_to t('links.create_account'), new_user_start_path
+  .sm-col-right.mxn1
+    = link_to t('links.passwords.forgot'), new_password_path(resource_name), class: 'px1'
+    = link_to t('links.create_account'), new_user_start_path, class: 'px1 border-left border-silver'

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -16,8 +16,8 @@ nav.bg-white
           = t('shared.nav_auth.welcome')
           '
           span.bold = current_user.email
-          .mt-12p.h6
+          .mt-12p.h6.mxn1
             = link_to t('shared.nav_auth.my_account'), profile_path,
-              class: current_page?(profile_path) ? 'bold gray text-decoration-none' : ''
-            span.px1.silver = '|'
-            = link_to t('links.sign_out'), destroy_user_session_path
+              class: current_page?(profile_path) ? 'px1 bold gray text-decoration-none' : 'px1'
+            = link_to t('links.sign_out'), destroy_user_session_path,
+              class: 'px1 border-left border-silver'

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -5,7 +5,7 @@ feature 'Accessibility on IDV pages', :js do
   describe 'IDV pages' do
     include IdvHelper
 
-    pending 'home page' do
+    scenario 'home page' do
       sign_in_and_2fa_user
 
       visit '/idv'
@@ -22,7 +22,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'cancel idv' do
+    scenario 'cancel idv' do
       sign_in_and_2fa_user
 
       visit '/idv/cancel'
@@ -43,7 +43,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'phone info' do
+    scenario 'phone info' do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
@@ -54,7 +54,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'review page' do
+    scenario 'review page' do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
@@ -67,7 +67,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'recovery code / confirmation page' do
+    scenario 'recovery code / confirmation page' do
       user = sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -70,14 +70,14 @@ feature 'Accessibility on pages that require authentication', :js do
     end
   end
 
-  pending 'recovery code page' do
+  scenario 'recovery code page' do
     sign_in_and_2fa_user
     visit settings_recovery_code_path
 
     expect(page).to be_accessible
   end
 
-  pending 'profile page' do
+  scenario 'profile page' do
     sign_in_and_2fa_user
 
     visit profile_path
@@ -85,7 +85,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'edit email page' do
+  scenario 'edit email page' do
     sign_in_and_2fa_user
 
     visit '/edit/email'
@@ -93,7 +93,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'edit password page' do
+  scenario 'edit password page' do
     sign_in_and_2fa_user
 
     visit '/settings/password'
@@ -101,7 +101,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'edit phone page' do
+  scenario 'edit phone page' do
     sign_in_and_2fa_user
 
     visit '/edit/phone'
@@ -109,7 +109,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'generate new recovery code page' do
+  scenario 'generate new recovery code page' do
     sign_in_and_2fa_user
 
     visit '/settings/recovery-code'
@@ -117,7 +117,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'start set up of authenticator app page' do
+  scenario 'start set up of authenticator app page' do
     sign_in_and_2fa_user
 
     visit '/authenticator_start'
@@ -125,7 +125,7 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'set up authenticator app page' do
+  scenario 'set up authenticator app page' do
     sign_in_and_2fa_user
 
     visit '/authenticator_setup'

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -8,7 +8,7 @@ feature 'Accessibility on pages that do not require authentication', :js do
     expect(page).to be_accessible
   end
 
-  pending 'login / root path' do
+  scenario 'login / root path' do
     visit root_path
 
     expect(page).to be_accessible


### PR DESCRIPTION
**Why**:
* We were using `|` to separate menu items in two places
* Color of element was not dark enough for accessibility
* Converting this to CSS fixed accessibility issue

Shout out to accessibility guild and @brendansudol who helped come up with this solution