### PR TITLE
Fix `aria-labelledby` issues

### DIFF
--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -14,3 +14,9 @@
   .sm-left-align { text-align: left; }
   .sm-right-align { text-align: right; }
 }
+
+.sr-only {
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -14,9 +14,3 @@
   .sm-left-align { text-align: left; }
   .sm-right-align { text-align: right; }
 }
-
-.sr-only {
-  clip: rect(1px 1px 1px 1px); // IE6, IE7
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute !important;
-}

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -16,7 +16,7 @@
 }
 
 .sr-only {
-  position: absolute !important;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px 1px 1px 1px); // IE6, IE7
   clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
 }

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -11,10 +11,8 @@ p.mt-tiny.mb0#2fa-description
   - if reauthn?
     = f.input :reauthn, as: :hidden, input_html: { value: 'true' }
   .mb3
-    = label_tag 'otp_method',
-      t('devise.two_factor_authentication.otp_method.title'),
-      class: 'hide block bold', id: 'otp-description'
-    div role="radiogroup" aria-labelledby="otp-description"
+    fieldset.border-white
+      legend.sr-only = t('devise.two_factor_authentication.otp_method.title')
       label.radio.mb0.mr3
         = f.radio_button :otp_method, 'sms', checked: true
         span.indicator

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -13,15 +13,16 @@ p.mt-tiny.mb0#2fa-description
   .mb3
     = label_tag 'otp_method',
       t('devise.two_factor_authentication.otp_method.title'),
-      class: 'hide block bold'
-    label.radio.mb0.mr3
-      = f.radio_button :otp_method, 'sms', checked: true
-      span.indicator
-      = t('devise.two_factor_authentication.otp_method.sms')
-    label.radio.mb0
-      = f.radio_button :otp_method, 'voice'
-      span.indicator
-      = t('devise.two_factor_authentication.otp_method.voice')
+      class: 'hide block bold', id: 'otp-description'
+    div role="radiogroup" aria-labelledby="otp-description"
+      label.radio.mb0.mr3
+        = f.radio_button :otp_method, 'sms', checked: true
+        span.indicator
+        = t('devise.two_factor_authentication.otp_method.sms')
+      label.radio.mb0
+        = f.radio_button :otp_method, 'voice'
+        span.indicator
+        = t('devise.two_factor_authentication.otp_method.voice')
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn btn-primary btn-wide'
 
 - link = link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -12,7 +12,7 @@ p.mt-tiny.mb0#2fa-description
     = f.input :reauthn, as: :hidden, input_html: { value: 'true' }
   .mb3
     fieldset.border-white
-      legend.sr-only = t('devise.two_factor_authentication.otp_method.title')
+      legend.hide = t('devise.two_factor_authentication.otp_method.title')
       label.radio.mb0.mr3
         = f.radio_button :otp_method, 'sms', checked: true
         span.indicator

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -19,8 +19,9 @@ p.mt-tiny.mb0#2fa-description
       class: 'block bold'
     = label_tag 'two_factor_setup_form[otp_method]',
       t('devise.two_factor_authentication.otp_method.instruction'),
-      class: 'block', id: 'otp-description'
-    div role="radiogroup" aria-labelledby="otp-description"
+      class: 'block'
+    fieldset.border-white
+      legend.sr-only = t('devise.two_factor_authentication.otp_method.instruction')
       label.radio.mb0.mr3
         = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,
           checked: true

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -19,15 +19,16 @@ p.mt-tiny.mb0#2fa-description
       class: 'block bold'
     = label_tag 'two_factor_setup_form[otp_method]',
       t('devise.two_factor_authentication.otp_method.instruction'),
-      class: 'block'
-    label.radio.mb0.mr3
-      = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,
-        checked: true
-      span.indicator
-      = t('devise.two_factor_authentication.otp_method.sms')
-    label.radio.mb0
-      = radio_button_tag 'two_factor_setup_form[otp_method]', :voice
-      span.indicator
-      = t('devise.two_factor_authentication.otp_method.voice')
+      class: 'block', id: 'otp-description'
+    div role="radiogroup" aria-labelledby="otp-description"
+      label.radio.mb0.mr3
+        = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,
+          checked: true
+        span.indicator#sms-otp-description
+        = t('devise.two_factor_authentication.otp_method.sms')
+      label.radio.mb0
+        = radio_button_tag 'two_factor_setup_form[otp_method]', :voice
+        span.indicator#voice-otp-description
+        = t('devise.two_factor_authentication.otp_method.voice')
   = f.button :submit, t('forms.buttons.send_passcode')
   p.mt3.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')

--- a/app/views/devise/two_factor_authentication_setup/index.html.slim
+++ b/app/views/devise/two_factor_authentication_setup/index.html.slim
@@ -21,7 +21,7 @@ p.mt-tiny.mb0#2fa-description
       t('devise.two_factor_authentication.otp_method.instruction'),
       class: 'block'
     fieldset.border-white
-      legend.sr-only = t('devise.two_factor_authentication.otp_method.instruction')
+      legend.hide = t('devise.two_factor_authentication.otp_method.instruction')
       label.radio.mb0.mr3
         = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,
           checked: true

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -6,7 +6,8 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
 = simple_form_for(idv_finance_form, url: idv_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   = f.error_notification
-  .mb3.js-finance-choice-cntnr role="radiogroup" aria-labelledby="finance-type"
+  fieldset.mb3.js-finance-choice-cntnr.border-white
+    legend.sr-only = t('idv.messages.finance.label')
     = f.collection_radio_buttons(:finance_type, Idv::FinanceForm.finance_type_choices,
       :first, :last, required: true, item_wrapper_class: 'mb1', item_wrapper_tag: :div) do |r|
       = r.label(class: 'radio')

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -6,7 +6,7 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
 = simple_form_for(idv_finance_form, url: idv_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   = f.error_notification
-  .mb3.js-finance-choice-cntnr
+  .mb3.js-finance-choice-cntnr role="radiogroup" aria-labelledby="finance-type"
     = f.collection_radio_buttons(:finance_type, Idv::FinanceForm.finance_type_choices,
       :first, :last, required: true, item_wrapper_class: 'mb1', item_wrapper_tag: :div) do |r|
       = r.label(class: 'radio')

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -7,7 +7,7 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   = f.error_notification
   fieldset.mb3.js-finance-choice-cntnr.border-white
-    legend.sr-only = t('idv.messages.finance.label')
+    legend.hide = t('idv.messages.finance.label')
     = f.collection_radio_buttons(:finance_type, Idv::FinanceForm.finance_type_choices,
       :first, :last, required: true, item_wrapper_class: 'mb1', item_wrapper_tag: :div) do |r|
       = r.label(class: 'radio')

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -35,7 +35,7 @@ h1.h3.my0 = t('idv.titles.session.basic')
     .mt0.mb3.pb-tiny.border-bottom.border-teal
       | #{t('profile.index.ssn')}#{tooltip(t('tooltips.placeholder'))}
     = f.input :ssn, label: t('idv.form.ssn'), required: true, pattern: '^\d{3}-?\d{2}-?\d{4}$',
-      input_html: { class: 'ssn', 'aria-labelledby': 'label-ssn', value: idv_profile_form.ssn },
+      input_html: { class: 'ssn', value: idv_profile_form.ssn },
       hint: content_tag(:span, t('idv.form.tin'),
       class: 'mt1 h5 blue sans-serif underline hint--top',
       tabindex: 0, 'aria-label': t('tooltips.placeholder'))

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -86,6 +86,7 @@ en:
         accurate. To learn more about the information we need from you and how it’s used
         to verify your identity, please see our troubleshooting page.
       finance:
+        label: Select which type of financial information you would like to provide.
         intro: >
           You are not sharing account balances or transaction details, and we
           will never charge any fees.

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -13,7 +13,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'basic info' do
+    scenario 'basic info' do
       sign_in_and_2fa_user
 
       visit '/idv/session'
@@ -31,7 +31,7 @@ feature 'Accessibility on IDV pages', :js do
       expect(page).to be_accessible
     end
 
-    pending 'finance info' do
+    scenario 'finance info' do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -32,14 +32,14 @@ feature 'Accessibility on pages that require authentication', :js do
   end
 
   describe '2FA pages' do
-    pending 'phone setup page' do
+    scenario 'phone setup page' do
       sign_up_and_set_password
 
       expect(current_path).to eq(phone_setup_path)
       expect(page).to be_accessible
     end
 
-    pending 'two factor auth page' do
+    scenario 'two factor auth page' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
 


### PR DESCRIPTION
**Why**:
* 508 compliance
* For radio buttons, was getting error:
  "Radio inputs with the same name attribute value must be part of a
  group"
* Ref: https://dequeuniversity.com/rules/axe/2.0/radiogroup
* For other form, there was an invalid aria attr (did not correspond
  to an `id` in the markup)