### PR TITLE
Refactor IdV analytics

### DIFF
--- a/app/controllers/idv/questions_controller.rb
+++ b/app/controllers/idv/questions_controller.rb
@@ -6,7 +6,11 @@ module Idv
     before_action :confirm_idv_vendor_session_started
 
     def index
-      render_next_question
+      if FeatureManagement.proofing_requires_kbv?
+        render_next_question
+      else
+        redirect_to idv_confirmations_path
+      end
     end
 
     def create
@@ -17,20 +21,65 @@ module Idv
     private
 
     def render_next_question
-      questions = idv_session.resolution.questions
-      question_number = idv_session.question_number
       if more_questions?
         @question_sequence = question_number + 1
         @question = questions[question_number]
       else
-        redirect_to idv_confirmations_path
+        submit_answers
+        track_kbv_event
+        process_submission
       end
     end
 
     def more_questions?
-      questions = idv_session.questions
-      question_number = idv_session.question_number
       questions && question_number < questions.count
+    end
+
+    def questions
+      idv_session.questions
+    end
+
+    def question_number
+      idv_session.question_number
+    end
+
+    def submit_answers
+      @_submission ||= begin
+        resolution = idv_session.resolution
+        idv_agent.submit_answers(resolution.questions, resolution.session_id)
+      end
+    end
+
+    def track_kbv_event
+      result = {
+        kbv_passed: correct_answers?,
+        idv_attempts_exceeded: idv_attempter.exceeded?,
+        new_phone_added: idv_session.params['phone_confirmed_at'].present?
+      }
+      analytics.track_event(Analytics::IDV_FINAL, result)
+    end
+
+    def correct_answers?
+      submit_answers.success?
+    end
+
+    def process_submission
+      if correct_answers?
+        redirect_to idv_confirmations_path
+      else
+        finish_proofing_failure
+      end
+    end
+
+    def finish_proofing_failure
+      # do not store PII that failed.
+      idv_session.profile.destroy
+      idv_session.clear
+      if idv_attempter.exceeded?
+        redirect_to idv_fail_url
+      else
+        redirect_to idv_retry_url
+      end
     end
   end
 end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -26,10 +26,20 @@ module Idv
 
     def create
       resolution = start_idv_session
+      track_idv_event(resolution)
       process_resolution(resolution)
     end
 
     private
+
+    def track_idv_event(resolution)
+      result = {
+        success: resolution.success,
+        idv_attempts_exceeded: idv_attempter.exceeded?
+      }
+
+      analytics.track_event(Analytics::IDV_INITIAL, result)
+    end
 
     def process_resolution(resolution)
       if resolution.success
@@ -63,7 +73,7 @@ module Idv
     end
 
     def phone_confirmation_required?
-      !idv_params[:phone_confirmed_at] || idv_params[:phone] != current_user.phone
+      idv_params[:phone] != current_user.phone
     end
 
     def start_idv_session

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -34,12 +34,12 @@ class Analytics
   EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze
   EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
-  IDV_FAILED = 'IdV: failed'.freeze
+  IDV_INITIAL = 'IdV: initial resolution'.freeze
+  IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FINANCE_VISIT = 'IdV: finance visited'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze
   IDV_PHONE_RECORD_VISIT = 'IdV: phone of record visited'.freeze
   IDV_REVIEW_VISIT = 'IdV: review info visited'.freeze
-  IDV_SUCCESSFUL = 'IdV: successful'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   INVALID_SERVICE_PROVIDER = 'Invalid Service Provider'.freeze
   OTP_DELIVERY_SELECTION = 'OTP: Delivery Selection'.freeze

--- a/spec/services/idv/attempter_spec.rb
+++ b/spec/services/idv/attempter_spec.rb
@@ -4,6 +4,17 @@ describe Idv::Attempter do
   let(:current_user) { build(:user) }
   let(:subject) { Idv::Attempter.new(current_user) }
 
+  describe '#reset' do
+    it 'resets idv_attempts to zero for user' do
+      user = create(:user, idv_attempts: 3)
+      attempter = Idv::Attempter.new(user)
+
+      attempter.reset
+
+      expect(user.idv_attempts).to eq 0
+    end
+  end
+
   describe '#window_expired?' do
     context 'inside window' do
       before do

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -84,4 +84,24 @@ module IdvHelper
   def click_acknowledge_recovery_code
     click_button t('forms.buttons.acknowledge_recovery_code')
   end
+
+  def stub_idv_session
+    stub_sign_in(user)
+    idv_session = Idv::Session.new(subject.user_session, user)
+    idv_session.vendor = :mock
+    idv_session.applicant = applicant
+    idv_session.resolution = resolution
+    idv_session.profile_id = profile.id
+    idv_session.question_number = 0
+    allow(subject).to receive(:idv_session).and_return(idv_session)
+  end
+
+  # rubocop:disable Rails/DynamicFindBy
+  def complete_idv_session(answer_correctly)
+    Proofer::Vendor::Mock::ANSWERS.each do |ques, answ|
+      resolution.questions.find_by_key(ques).answer = answer_correctly ? answ : 'wrong'
+      subject.idv_session.question_number += 1
+    end
+  end
+  # rubocop:enable Rails/DynamicFindBy
 end


### PR DESCRIPTION
**Why**:
- To better track IdV analytics. Previously, we were only tracking
failures in the KBV scenario.

**How**:
- Add an analytics call to ReviewController to track success and
failure for the initial IdV submission (prior to KBV and/or phone
confirmation)
- Move most of the code in ConfirmationsController to
QuestionsController since it only applies when KBV is on
- Check if KBV is on in QuestionsController#index. If not, redirect
directly to ConfirmationsController. Previously, we were checking if
questions were available even when KBV was turned off.
- Add an analytics call in QuestionsController to track success and
failure when KBV is on
- Only call analytics in ConfirmationsController if KBV is off to
prevent duplicate events when KBV is on.
commit 378a1c191f3d7d342bdf4295153c6fa271fad9ec