### PR TITLE
Consolidate "Continue" locales

### DIFF
--- a/app/views/idv/confirmations/index.html.slim
+++ b/app/views/idv/confirmations/index.html.slim
@@ -3,5 +3,5 @@
 h1.h3.my0 = t('idv.titles.complete')
 p.mt-tiny.mb0 = t('idv.messages.recovery_code')
 .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @recovery_code
-= button_to(t('forms.buttons.acknowledge_recovery_code'), \
+= button_to(t('forms.buttons.continue'),
   idv_confirmations_continue_path, class: 'btn btn-primary btn-wide mb1')

--- a/app/views/idv/finance/new.html.slim
+++ b/app/views/idv/finance/new.html.slim
@@ -15,7 +15,7 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
         = r.text
   = f.input :finance_account, required: true,
     label: @finance_account_label, label_html: { class: 'js-finance-label' }
-  = f.button :submit, t('idv.messages.finance.continue'), class: 'btn btn-primary btn-wide'
+  = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
   .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -18,7 +18,7 @@ p = t('idv.messages.phone.same_as_2fa')
 = simple_form_for(idv_phone_form, url: idv_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.input :phone, required: true
-  = f.button :submit, t('forms.buttons.submit.continue'), class: 'btn btn-primary btn-wide'
+  = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
   .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -40,7 +40,7 @@ h1.h3.my0 = t('idv.titles.session.basic')
       class: 'mt1 h5 blue sans-serif underline hint--top',
       tabindex: 0, 'aria-label': t('tooltips.placeholder'))
   .mt5
-    button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.submit.continue')
+    button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.continue')
     .mt1 = link_to t('idv.messages.cancel_link'), idv_cancel_path
 
 == javascript_include_tag 'misc/page-unload-warning'

--- a/app/views/two_factor_authentication/recovery_code/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code/show.html.slim
@@ -4,5 +4,5 @@
 h1.h3.my0 = t('headings.recovery_code')
 p.mt-tiny.mb0 = t('instructions.recovery_code')
 .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @code
-= button_to(t('forms.buttons.acknowledge_recovery_code'), \
-  acknowledge_recovery_code_path, class: 'btn btn-primary btn-wide mb1')
+= button_to(t('forms.buttons.continue'), acknowledge_recovery_code_path,
+  class: 'btn btn-primary btn-wide mb1')

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -1,7 +1,6 @@
 en:
   forms:
     buttons:
-      acknowledge_recovery_code: Continue
       continue: Continue
       continue_browsing: Keep me signed in
       sign_out: Sign me out
@@ -12,7 +11,6 @@ en:
       setup_totp: Set up authentication app
       submit:
         default: Submit
-        continue: Continue
         next: Next
         update: Update
       cancel: Cancel

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -68,7 +68,6 @@ en:
         intro: >
           You are not sharing account balances or transaction details, and we
           will never charge any fees.
-        continue: Continue
       phone:
         intro: >
           To help us verify your identity, please give us a phone number that belongs

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -35,7 +35,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
 
       visit '/idv/finance'
 
@@ -47,7 +47,7 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
 
       expect(current_path).to eq idv_phone_path
@@ -58,10 +58,10 @@ feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
       fill_out_phone_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
 
       expect(current_path).to eq idv_review_path
       expect(page).to be_accessible
@@ -71,10 +71,10 @@ feature 'Accessibility on IDV pages', :js do
       user = sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
       fill_out_phone_form_ok(user.phone)
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_submit_default
 
@@ -85,7 +85,7 @@ feature 'Accessibility on IDV pages', :js do
     def fill_out_and_submit_finance_form
       find('#idv_finance_form_finance_type_ccn', visible: false).trigger('click')
       fill_in :idv_finance_form_finance_account, with: '12345678'
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
     end
   end
 end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -35,20 +35,19 @@ feature 'IdV session' do
       visit idv_session_path
 
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       expect(page).to have_content(t('idv.form.ccn'))
 
       fill_out_financial_form_ok
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
       fill_out_phone_form_ok(user.phone)
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_in :user_password, with: user_password
       click_button t('forms.buttons.submit.default')
 
       expect(current_url).to eq idv_confirmations_url
       expect(page).to have_content(t('idv.titles.complete'))
-
-      click_button t('forms.buttons.acknowledge_recovery_code')
+      click_acknowledge_recovery_code
 
       expect(current_url).to eq(profile_url)
       expect(page).to have_content('Some One')
@@ -104,30 +103,30 @@ feature 'IdV session' do
       expect(page).to_not have_selector("input[value='#{first_ssn_value}']")
 
       fill_out_idv_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
 
       expect(page).to_not have_selector("input[value='#{first_ccn_value}']")
 
       fill_out_financial_form_ok
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
 
       visit idv_session_path
 
       expect(page).to have_selector("input[value='#{first_ssn_value}']")
 
       fill_in 'profile_ssn', with: second_ssn_value
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
 
       expect(current_url).to eq idv_finance_url
       expect(page).to have_content(t('idv.form.ccn'))
       expect(page).to have_selector("input[value='#{first_ccn_value}']")
 
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
 
       visit idv_finance_path
       find('#idv_finance_form_finance_type_mortgage').set(true)
       fill_in :idv_finance_form_finance_account, with: mortgage_value
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
 
       expect(current_url).to eq idv_phone_url
 
@@ -136,18 +135,18 @@ feature 'IdV session' do
       expect(page).to have_selector("input[value='#{mortgage_value}']")
 
       fill_in :idv_finance_form_finance_account, with: second_ccn_value
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
 
       expect(page).to_not have_selector("input[value='#{first_phone_formatted}']")
 
       fill_out_phone_form_ok(first_phone_value)
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       visit idv_phone_path
 
       expect(page).to have_selector("input[value='#{first_phone_formatted}']")
 
       fill_out_phone_form_ok(second_phone_value)
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
 
       expect(page).to have_content(t('idv.titles.review'))
       expect(page).to have_content(second_ssn_value)
@@ -257,11 +256,11 @@ feature 'IdV session' do
       expect(page).to have_content(t('idv.form.first_name'))
 
       fill_out_idv_form_fail
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_out_financial_form_ok
-      click_button t('idv.messages.finance.continue')
+      click_button t('forms.buttons.continue')
       fill_out_phone_form_ok
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       fill_in :user_password, with: user_password
       click_button t('forms.buttons.submit.default')
 
@@ -274,7 +273,7 @@ feature 'IdV session' do
     fill_out_idv_form_fail
     click_button 'Continue'
     fill_out_financial_form_ok
-    click_button t('idv.messages.finance.continue')
+    click_button t('forms.buttons.continue')
     fill_out_phone_form_ok(user.phone)
     click_button 'Continue'
     fill_in :user_password, with: user_password
@@ -283,11 +282,11 @@ feature 'IdV session' do
 
   def complete_idv_profile_with_phone(phone)
     fill_out_idv_form_ok
-    click_button t('forms.buttons.submit.continue')
+    click_button t('forms.buttons.continue')
     fill_out_financial_form_ok
-    click_button t('idv.messages.finance.continue')
+    click_button t('forms.buttons.continue')
     fill_out_phone_form_ok(phone)
-    click_button t('forms.buttons.submit.continue')
+    click_button t('forms.buttons.continue')
     fill_in :user_password, with: user_password
     click_submit_default
     # choose default SMS delivery method for confirming this new number

--- a/spec/features/idv/interrupted_session_spec.rb
+++ b/spec/features/idv/interrupted_session_spec.rb
@@ -20,7 +20,7 @@ feature 'Interrupted IdV session' do
         end
 
         fill_out_idv_form_ok
-        click_button t('forms.buttons.submit.continue')
+        click_button t('forms.buttons.continue')
 
         expect(page).to have_content(t('idv.form.ccn'))
       end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -185,7 +185,7 @@ feature 'Two Factor Authentication' do
       fill_in 'code', with: code
       click_button t('forms.buttons.submit.default')
 
-      click_button t('forms.buttons.acknowledge_recovery_code')
+      click_button t('forms.buttons.continue')
 
       expect(current_path).to eq profile_path
     end
@@ -201,7 +201,7 @@ feature 'Two Factor Authentication' do
       click_button t('forms.buttons.submit.default')
       fill_in 'code', with: user.reload.direct_otp
       click_button t('forms.buttons.submit.default')
-      click_button t('forms.buttons.acknowledge_recovery_code')
+      click_button t('forms.buttons.continue')
 
       expect(current_path).to eq profile_path
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -130,7 +130,7 @@ feature 'Sign in' do
       click_link(t('links.sign_out'))
 
       Timecop.travel(Devise.timeout_in + 1.minute) do
-        expect(page).to_not have_content(t('forms.buttons.submit.continue'))
+        expect(page).to_not have_content(t('forms.buttons.continue'))
 
         fill_in_credentials_and_click_sign_in(user.email, user.password)
         expect(page).to have_content t('errors.invalid_authenticity_token')

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -60,7 +60,7 @@ feature 'User profile' do
 
       expect(user.reload.recovery_code).to_not eq old_code
 
-      click_button t('forms.buttons.acknowledge_recovery_code')
+      click_button t('forms.buttons.continue')
 
       expect(current_path).to eq profile_path
     end

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -22,7 +22,7 @@ feature 'Phone confirmation during sign up' do
       expect(@user.reload.phone_confirmed_at).to be_present
       expect(current_path).to eq settings_recovery_code_path
 
-      click_button t('forms.buttons.acknowledge_recovery_code')
+      click_button t('forms.buttons.continue')
 
       expect(current_path).to eq profile_path
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -86,7 +86,7 @@ module Features
       # Enter 2FA code
       click_button t('forms.buttons.submit.default')
       # Acknowledge recovery code
-      click_button t('forms.buttons.submit.continue')
+      click_button t('forms.buttons.continue')
       user
     end
 

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -72,16 +72,16 @@ module IdvHelper
 
   def complete_idv_profile_ok(user)
     fill_out_idv_form_ok
-    click_button t('forms.buttons.submit.continue')
+    click_button t('forms.buttons.continue')
     fill_out_financial_form_ok
-    click_button t('idv.messages.finance.continue')
+    click_button t('forms.buttons.continue')
     fill_out_phone_form_ok(user.phone)
-    click_button t('forms.buttons.submit.continue')
+    click_button t('forms.buttons.continue')
     fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
     click_submit_default
   end
 
   def click_acknowledge_recovery_code
-    click_button t('forms.buttons.acknowledge_recovery_code')
+    click_button t('forms.buttons.continue')
   end
 end

--- a/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/recovery_code/show.html.slim_spec.rb
@@ -23,7 +23,7 @@ describe 'two_factor_authentication/recovery_code/show.html.slim' do
     render
 
     expect(rendered).
-      to have_xpath("//input[@value='#{t('forms.buttons.acknowledge_recovery_code')}']")
+      to have_xpath("//input[@value='#{t('forms.buttons.continue')}']")
     expect(rendered).
       to have_xpath("//form[@action='#{acknowledge_recovery_code_path}']")
   end


### PR DESCRIPTION
**Why**: We had the string "Continue" defined in 4 places, easier to
have it just once.