### PR TITLE
Fix UserAccessKey caching in EncryptedEmail

### DIFF
--- a/app/models/concerns/user_encrypted_email_overrides.rb
+++ b/app/models/concerns/user_encrypted_email_overrides.rb
@@ -1,6 +1,8 @@
 module UserEncryptedEmailOverrides
   extend ActiveSupport::Concern
 
+  attr_accessor :email_user_access_key
+
   # override some Devise methods to support our use of encrypted_email
 
   class_methods do
@@ -49,12 +51,14 @@ module UserEncryptedEmailOverrides
   def email
     return '' unless encrypted_email.present?
     @_encrypted_email ||= EncryptedEmail.new(encrypted_email)
+    self.email_user_access_key ||= @_encrypted_email.user_access_key
     @_encrypted_email.decrypted
   end
 
   def email=(email)
     if email.present?
-      @_encrypted_email = EncryptedEmail.new_from_email(email)
+      self.email_user_access_key ||= EncryptedEmail.new_user_access_key
+      @_encrypted_email = EncryptedEmail.new_from_email(email, email_user_access_key)
       self.encrypted_email = @_encrypted_email.encrypted
       self.email_fingerprint = @_encrypted_email.fingerprint
     else

--- a/db/migrate/20161118150205_add_user_email_fingerprint.rb
+++ b/db/migrate/20161118150205_add_user_email_fingerprint.rb
@@ -23,9 +23,10 @@ class AddUserEmailFingerprint < ActiveRecord::Migration
   end
 
   def encrypt_user_emails
+    user_access_key = EncryptedEmail.new_user_access_key
     User.where(encrypted_email: '').each do |user|
       email_address = user.email.present? ? user.email : user.id.to_s
-      ee = EncryptedEmail.new_from_email(email_address)
+      ee = EncryptedEmail.new_from_email(email_address, user_access_key)
       # must use raw SQL here to change data during the migration transaction.
       execute "UPDATE users SET encrypted_email='#{ee.encrypted}', email_fingerprint='#{ee.fingerprint}' WHERE id=#{user.id}"
     end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -194,14 +194,15 @@ describe Users::SessionsController, devise: true do
     end
 
     context 'LOA1 user' do
-      it 'hashes password exactly once' do
+      it 'hashes password exactly once, hashes email access key exactly once' do
         allow(FeatureManagement).to receive(:use_kms?).and_return(false)
         encrypted_key_maker = EncryptedKeyMaker.new
         allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker)
         user = create(:user, :signed_up)
 
-        expect(UserAccessKey).to receive(:new).exactly(:once).and_call_original
-        expect(encrypted_key_maker).to receive(:unlock).exactly(:once).and_call_original
+        expect(UserAccessKey).to receive(:new).exactly(:twice).and_call_original
+        expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
+        expect(EncryptedEmail).to receive(:new_user_access_key).exactly(:once).and_call_original
 
         post :create, user: { email: user.email.upcase, password: user.password }
       end
@@ -212,14 +213,15 @@ describe Users::SessionsController, devise: true do
         allow(FeatureManagement).to receive(:use_kms?).and_return(false)
       end
 
-      it 'hashes password exactly once' do
+      it 'hashes password exactly once, hashes email access key exactly once' do
         encrypted_key_maker = EncryptedKeyMaker.new
         allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker)
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
 
-        expect(UserAccessKey).to receive(:new).exactly(:once).and_call_original
-        expect(encrypted_key_maker).to receive(:unlock).exactly(:once).and_call_original
+        expect(UserAccessKey).to receive(:new).exactly(:twice).and_call_original
+        expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
+        expect(EncryptedEmail).to receive(:new_user_access_key).exactly(:once).and_call_original
 
         post :create, user: { email: user.email.upcase, password: user.password }
       end

--- a/spec/services/encrypted_email_spec.rb
+++ b/spec/services/encrypted_email_spec.rb
@@ -5,7 +5,7 @@ describe EncryptedEmail do
   let(:fingerprint) { Pii::Fingerprinter.fingerprint(email) }
   let(:encrypted_email) do
     encryptor = Pii::PasswordEncryptor.new
-    encryptor.encrypt(email, EncryptedEmail.user_access_key)
+    encryptor.encrypt(email, EncryptedEmail.new_user_access_key)
   end
 
   describe '#new' do


### PR DESCRIPTION
**Why**: Caching the UAK as a class variable
caused bugs on deployment to existing databases.

**How**: For migration, allow explicit UAK to be passed to
EncryptedEmail.new_with_email. During normal app use,
a new UAK is generated for every instance, and cached per-User.