### PR TITLE
Fixes error persistence on email confirmation page

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -37,7 +37,6 @@ module Users
 
       @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, token)
       @confirmable = User.confirm_by_token(token) if @confirmable.confirmed?
-
       @password_form = PasswordForm.new(@confirmable)
 
       yield
@@ -101,12 +100,12 @@ module Users
     end
 
     def process_expired_confirmation_token
-      flash[:error] = resource.decorate.confirmation_period_expired_error
+      flash.now[:error] = resource.decorate.confirmation_period_expired_error
       render :new
     end
 
     def process_invalid_confirmation_token
-      flash[:error] = t('errors.messages.confirmation_invalid_token')
+      flash.now[:error] = t('errors.messages.confirmation_invalid_token')
       render :new
     end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'Sign Up' do
+  context 'confirmation token error message does not persist on success' do
+    scenario 'with no or invalid token' do
+      visit '/users/confirmation?confirmation_token='
+      expect(page).to have_content t('errors.messages.confirmation_invalid_token')
+
+      sign_up
+
+      expect(page).not_to have_content t('errors.messages.confirmation_invalid_token')
+    end
+  end
+end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -21,9 +21,14 @@ module Features
       click_button t('links.sign_in')
     end
 
-    def sign_up_and_set_password
+    def sign_up
       user = create(:user, :unconfirmed)
       confirm_last_user
+      user
+    end
+
+    def sign_up_and_set_password
+      user = sign_up
       fill_in 'password_form_password', with: VALID_PASSWORD
       click_button t('forms.buttons.submit.default')
       user
@@ -69,7 +74,7 @@ module Features
     end
 
     def confirm_last_user
-      @raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
+      @raw_confirmation_token = Devise.token_generator.generate(User, :confirmation_token)
 
       User.last.update(
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current


### PR DESCRIPTION
**Why**:
It's confusing to have both success and confirmation message show to the
user at once

**How**:
Use `flash.now` instead of `flash` in the confirmations_controller, as
the former does not persist through a redirect