### PR TITLE
Refactor Phone Confirmation analytics

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -107,13 +107,11 @@ module TwoFactorAuthenticatable
 
   def phone_changed
     create_user_event(:phone_changed)
-    analytics.track_event(Analytics::PHONE_CHANGE_SUCCESSFUL)
     SmsSenderNumberChangeJob.perform_later(old_phone)
   end
 
   def phone_confirmed
     create_user_event(:phone_confirmed)
-    analytics.track_event('User confirmed their phone number')
   end
 
   def update_phone_attributes

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -28,8 +28,13 @@ module TwoFactorAuthentication
     def analytics_properties
       {
         context: context,
-        method: params[:delivery_method]
+        method: params[:delivery_method],
+        confirmation_for_phone_change: confirmation_for_phone_change?
       }
+    end
+
+    def confirmation_for_phone_change?
+      context == 'confirmation' && current_user.phone.present?
     end
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -51,7 +51,6 @@ class Analytics
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
-  PHONE_CHANGE_SUCCESSFUL = 'Phone Number Change: successful'.freeze
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -33,7 +33,8 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
       stub_analytics
       analytics_hash = {
         context: 'authentication',
-        method: 'sms'
+        method: 'sms',
+        confirmation_for_phone_change: false
       }
 
       expect(@analytics).to receive(:track_event).
@@ -49,8 +50,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         sign_in_before_2fa
 
         properties = {
-          context: 'authentication',
           success?: false,
+          confirmation_for_phone_change: false,
+          context: 'authentication',
           method: 'sms'
         }
 
@@ -82,8 +84,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         sign_in_before_2fa
 
         properties = {
-          context: 'authentication',
           success?: false,
+          confirmation_for_phone_change: false,
+          context: 'authentication',
           method: 'sms'
         }
 
@@ -119,8 +122,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
       it 'tracks the valid authentication event' do
         properties = {
-          context: 'authentication',
           success?: true,
+          confirmation_for_phone_change: false,
+          context: 'authentication',
           method: 'sms'
         }
 
@@ -202,17 +206,14 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks the update event' do
             properties = {
-              context: 'confirmation',
               success?: true,
+              confirmation_for_phone_change: true,
+              context: 'confirmation',
               method: 'sms'
             }
 
             expect(@analytics).to have_received(:track_event).
               with(Analytics::MULTI_FACTOR_AUTH, properties)
-
-            expect(@analytics).to have_received(:track_event).
-              with(Analytics::PHONE_CHANGE_SUCCESSFUL)
-
             expect(subject).to have_received(:create_user_event).with(:phone_changed)
             expect(subject).to have_received(:create_user_event).exactly(:once)
           end
@@ -249,8 +250,9 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks an event' do
             properties = {
-              context: 'confirmation',
               success?: false,
+              confirmation_for_phone_change: true,
+              context: 'confirmation',
               method: 'sms'
             }
 
@@ -282,9 +284,10 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks the confirmation event' do
             properties = {
-              context: 'confirmation',
               success?: true,
-              method: 'sms'
+              context: 'confirmation',
+              method: 'sms',
+              confirmation_for_phone_change: false
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -332,17 +335,21 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         end
 
         it 'tracks the OTP verification event' do
+          properties = {
+            success?: true,
+            confirmation_for_phone_change: false,
+            context: 'idv',
+            method: 'sms'
+          }
+
           expect(@analytics).to have_received(:track_event).
-            with(Analytics::MULTI_FACTOR_AUTH, context: 'idv', success?: true, method: 'sms')
+            with(Analytics::MULTI_FACTOR_AUTH, properties)
 
           expect(subject).to have_received(:create_user_event).with(:phone_confirmed)
         end
 
         it 'does not track a phone change event' do
           expect(subject).to_not have_received(:create_user_event).with(:phone_changed)
-
-          expect(@analytics).to_not have_received(:track_event).
-            with(Analytics::PHONE_CHANGE_SUCCESSFUL)
         end
 
         it 'updates idv session phone_confirmed_at attribute' do
@@ -393,8 +400,15 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         end
 
         it 'tracks an event' do
+          properties = {
+            success?: false,
+            confirmation_for_phone_change: false,
+            context: 'idv',
+            method: 'sms'
+          }
+
           expect(@analytics).to have_received(:track_event).
-            with(Analytics::MULTI_FACTOR_AUTH, context: 'idv', success?: false, method: 'sms')
+            with(Analytics::MULTI_FACTOR_AUTH, properties)
         end
       end
     end


### PR DESCRIPTION
**Why**: To better capture phone confirmation events

**How**:
- Remove the 'User confirmed their phone number' event because that can
be queried via the properties of the MULTI_FACTOR_AUTH event.
- Track successful phone changes by adding a new property in the
MULTI_FACTOR_AUTH event, as opposed to having a separate event