### PR TITLE
Adds cancel link to header when not 2FA'd

### DIFF
--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -7,13 +7,15 @@ nav.bg-white
             alt: APP_NAME,
             class: 'align-bottom',
             width: 170), root_path, class: 'inline-block'
-      - if user_fully_authenticated?
-        .sm-col-right.sm-right-align
-          = t('shared.nav_auth.welcome')
-          '
-          span.bold = current_user.email
-          .mt-12p.h6.mxn1
-            = link_to t('shared.nav_auth.my_account'), profile_path,
-              class: current_page?(profile_path) ? 'px1 bold gray text-decoration-none' : 'px1'
-            = link_to t('links.sign_out'), destroy_user_session_path,
-              class: 'px1 border-left border-silver'
+      .sm-col-right.sm-right-align
+        - if user_fully_authenticated?
+            = t('shared.nav_auth.welcome')
+            '
+            span.bold = current_user.email
+            .mt-12p.h6.mxn1
+              = link_to t('shared.nav_auth.my_account'), profile_path,
+                class: current_page?(profile_path) ? 'px1 bold gray text-decoration-none' : 'px1'
+              = link_to t('links.sign_out'), destroy_user_session_path,
+                class: 'px1 border-left border-silver'
+        - else
+          = link_to t('links.cancel'), destroy_user_session_path

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -15,5 +15,6 @@ en:
     resend: Send again
     sign_in: Sign in
     sign_out: Sign out
+    cancel: Cancel
     two_factor_authentication:
       resend_code: Send a new one

--- a/spec/views/shared/_nav_auth.html.slim_spec.rb
+++ b/spec/views/shared/_nav_auth.html.slim_spec.rb
@@ -17,6 +17,10 @@ describe 'shared/_nav_auth.html.slim' do
       expect(rendered).to have_link(t('shared.nav_auth.my_account'), href: profile_path)
     end
 
+    it 'does not contain link to cancel the auth process' do
+      expect(rendered).not_to have_link(t('links.cancel'), href: destroy_user_session_path)
+    end
+
     it 'contains sign out link' do
       expect(rendered).to have_link(t('links.sign_out'), href: destroy_user_session_path)
     end
@@ -40,6 +44,10 @@ describe 'shared/_nav_auth.html.slim' do
 
     it 'does not contain sign out link' do
       expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+    end
+
+    it 'does contain a link to cancel' do
+      expect(rendered).to have_link(t('links.cancel'), href: destroy_user_session_path)
     end
   end
 end


### PR DESCRIPTION
**Why**:
Users might like a way to cancel out of their authentication process