### PR TITLE
Bring back ahoy gem to track visits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'rails', '~> 4.2.6'
 
-gem 'redis-session-store'
+gem 'ahoy_matey'
 gem 'american_date'
 gem 'aws-sdk-core'
 gem 'browserify-rails'
@@ -26,6 +26,7 @@ gem 'proofer', github: '18F/identity-proofer-gem', branch: 'master'
 gem 'valid_email'
 gem 'rack-attack'
 gem 'readthis'
+gem 'redis-session-store'
 gem 'rqrcode'
 gem 'ruby-saml'
 gem 'saml_idp', git: 'https://github.com/18F/saml_idp.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,17 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    ahoy_matey (1.5.3)
+      addressable
+      browser (~> 2.0)
+      geocoder
+      rack-attack (< 6)
+      railties
+      referer-parser (>= 0.3.0)
+      request_store
+      safely_block (>= 0.1.1)
+      user_agent_parser
+      uuidtools
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     akami (1.3.1)
@@ -106,6 +117,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     brakeman (3.4.1)
+    browser (2.3.0)
     browserify-rails (3.4.0)
       addressable (>= 2.4.0)
       railties (>= 4.0.0, < 5.1)
@@ -206,6 +218,7 @@ GEM
       mail (~> 2.6.3)
     encryptor (3.0.0)
     equalizer (0.0.11)
+    errbase (0.0.3)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
@@ -224,6 +237,7 @@ GEM
       thor (~> 0.14)
     formatador (0.2.5)
     foundation_emails (2.2.1.0)
+    geocoder (1.4.0)
     get_process_mem (0.2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -412,6 +426,8 @@ GEM
       codeclimate-engine-rb (~> 0.4.0)
       parser (~> 2.3.1, >= 2.3.1.2)
       rainbow (~> 2.0)
+    referer-parser (0.3.0)
+    request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rotp (3.2.0)
@@ -450,6 +466,8 @@ GEM
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
+    safely_block (0.1.1)
+      errbase
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -552,9 +570,11 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.1)
     uniform_notifier (1.10.0)
+    user_agent_parser (2.3.0)
     useragent (0.16.8)
     uuid (2.3.8)
       macaddr (~> 1.0)
+    uuidtools (2.1.5)
     valid_email (0.0.13)
       activemodel
       mail (~> 2.6.1)
@@ -595,6 +615,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ahoy_matey
   american_date
   aws-sdk-core
   axe-matchers

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -6,17 +6,20 @@ class Analytics
 
   def track_event(event, attributes = {})
     analytics_hash = {
-      event: event,
-      properties: attributes.except(:user_id),
+      event_properties: attributes.except(:user_id),
       user_id: attributes[:user_id] || uuid
     }
 
-    ANALYTICS_LOGGER.info(analytics_hash.merge!(request_attributes))
+    ahoy.track(event, analytics_hash.merge!(request_attributes))
   end
 
   private
 
   attr_reader :user, :request
+
+  def ahoy
+    @ahoy ||= Rails.env.test? ? FakeAhoyTracker.new : Ahoy::Tracker.new(request: request)
+  end
 
   def request_attributes
     {

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,9 @@
+Ahoy.mount = false
+Ahoy.throttle = false
+# Period of inactivity before a new visit is created
+Ahoy.visit_duration = 30.minutes
+
+module Ahoy
+  class Store < Ahoy::Stores::LogStore
+  end
+end

--- a/config/initializers/analytics_logger.rb
+++ b/config/initializers/analytics_logger.rb
@@ -1,8 +1,0 @@
-logger = Logger.new("#{Rails.root}/log/events.log")
-
-logger.formatter = lambda do |_severity, timestamp, _app_name, message|
-  message[:timestamp] = timestamp
-  "#{::JSON.dump(message)}\n"
-end
-
-ANALYTICS_LOGGER = logger

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -9,6 +9,10 @@ describe Analytics do
     }
   end
 
+  let(:ahoy) { instance_double(FakeAhoyTracker) }
+
+  before { allow(FakeAhoyTracker).to receive(:new).and_return(ahoy) }
+
   describe '#track_event' do
     it 'identifies the user and sends the event to the backend' do
       user = build_stubbed(:user, uuid: '123')
@@ -16,13 +20,12 @@ describe Analytics do
       analytics = Analytics.new(user, FakeRequest.new)
 
       analytics_hash = {
-        event: 'Trackable Event',
-        properties: {},
+        event_properties: {},
         user_id: user.uuid
       }
 
-      expect(ANALYTICS_LOGGER).to receive(:info).
-        with(analytics_hash.merge(request_attributes))
+      expect(ahoy).to receive(:track).
+        with('Trackable Event', analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event')
     end
@@ -34,13 +37,12 @@ describe Analytics do
       analytics = Analytics.new(current_user, FakeRequest.new)
 
       analytics_hash = {
-        event: 'Trackable Event',
-        properties: {},
+        event_properties: {},
         user_id: tracked_user.uuid
       }
 
-      expect(ANALYTICS_LOGGER).to receive(:info).
-        with(analytics_hash.merge(request_attributes))
+      expect(ahoy).to receive(:track).
+        with('Trackable Event', analytics_hash.merge(request_attributes))
 
       analytics.track_event('Trackable Event', user_id: tracked_user.uuid)
     end

--- a/spec/support/fake_ahoy_tracker.rb
+++ b/spec/support/fake_ahoy_tracker.rb
@@ -1,0 +1,5 @@
+class FakeAhoyTracker
+  def track(_name, _properties = {}, _options = {})
+    # no-op
+  end
+end


### PR DESCRIPTION
**Why**: To be able to associate visits with users, so we can track
them from unauthenticated to authenticated state, and to make it easier
to count unique visits.