### PR TITLE
Remove words, use only numbers in countdowns

### DIFF
--- a/app/assets/javascripts/app/utils/ms-formatter.js
+++ b/app/assets/javascripts/app/utils/ms-formatter.js
@@ -1,15 +1,9 @@
-function pluralize(word, count) {
-  return `${word}${count !== 1 ? 's' : ''}`;
-}
-
 function formatMinutes(minutes) {
-  if (!minutes) return 0;
-
-  return `${minutes} ${pluralize('minute', minutes)}`;
+  return minutes || 0;
 }
 
 function formatSeconds(seconds) {
-  return `${seconds} ${pluralize('second', seconds)}`;
+  return seconds < 10 ? `0{seconds}` : seconds;
 }
 
 export default (milliseconds) => {
@@ -20,5 +14,5 @@ export default (milliseconds) => {
   const displayMinutes = formatMinutes(minutes);
   const displaySeconds = formatSeconds(remainingSeconds);
 
-  return `${displayMinutes} and ${displaySeconds}`;
+  return `${displayMinutes}:${displaySeconds}`;
 };

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -73,8 +73,8 @@ feature 'Sign in' do
       ajax_headers = { 'name' => 'X-Requested-With', 'value' => 'XMLHttpRequest' }
 
       expect(request_headers).to include ajax_headers
-      expect(page).to have_content('7 minutes and 59 seconds')
-      expect(page).to have_content('7 minutes and 58 seconds')
+      expect(page).to have_content('7:59')
+      expect(page).to have_content('7:58')
     end
 
     scenario 'user can continue browsing' do


### PR DESCRIPTION
**Why**:
Translating and formating complex time strings is going to be messy.
Numbers should be sufficient for most users