### PR TITLE
Fix OTP field autofocus

### DIFF
--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -27,7 +27,7 @@ function formatForm() {
       }
 
       // removes focus set by field-kit bug https://github.com/square/field-kit/issues/62
-      document.activeElement.blur();
+      if (el !== '.mfa') document.activeElement.blur();
     }
   });
 }

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -97,6 +97,14 @@ feature 'Two Factor Authentication' do
       expect(page).to have_content(t('notices.send_code.sms'))
     end
 
+    scenario 'user does not have to focus on OTP field', js: true do
+      user = create(:user, :signed_up)
+      sign_in_before_2fa(user)
+      click_button t('forms.buttons.submit.default')
+
+      expect(page.evaluate_script('document.activeElement.id')).to eq 'code'
+    end
+
     scenario 'user does not see progress steps' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)


### PR DESCRIPTION
**Why**: Due to a [bug](https://github.com/square/field-kit/issues/62) in field-kit which places certain fields in focus we currently have to manually clear the focus.  Since we want autofocus on OTP fields, the existing fix is now only applied to non-OTP fields.

This issue occurs in Safari and IE.