### PR TITLE
Update email link style

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -4,10 +4,10 @@
 @import 'foundation-emails';
 
 .gray {
-  &:link,
-  &:visited,
+  &:active,
   &:hover,
-  &:active {
+  &:link,
+  &:visited {
     color: $gray;
   }
 }

--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -3,6 +3,15 @@
 
 @import 'foundation-emails';
 
+.gray {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    color: $gray;
+  }
+}
+
 .hr { margin: $hr-margin; }
 .lead { margin-bottom: 30px; }
 .mr-tiny { margin-right: 4px; }

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,4 +1,5 @@
 include ActionView::Helpers::DateHelper
+include ActionView::Helpers::UrlHelper
 
 UserDecorator = Struct.new(:user) do
   MAX_RECENT_EVENTS = 5
@@ -27,18 +28,27 @@ UserDecorator = Struct.new(:user) do
     )
   end
 
+  def app_link
+    link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray')
+  end
+
   def first_sentence_for_confirmation_email # rubocop:disable MethodLength
     if user.reset_requested_at.present?
-      I18n.t('mailer.confirmation_instructions.first_sentence.reset_requested', app: APP_NAME)
+      I18n.t(
+        'mailer.confirmation_instructions.first_sentence.reset_requested',
+        app: app_link
+      )
     elsif user.confirmed_at.present?
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.confirmed',
-        app: APP_NAME, confirmation_period: confirmation_period
+        app: app_link,
+        confirmation_period: confirmation_period
       )
     else
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.unconfirmed',
-        app: APP_NAME, confirmation_period: confirmation_period
+        app: app_link,
+        confirmation_period: confirmation_period
       )
     end
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,5 +1,4 @@
 include ActionView::Helpers::DateHelper
-include ActionView::Helpers::UrlHelper
 
 UserDecorator = Struct.new(:user) do
   MAX_RECENT_EVENTS = 5
@@ -26,31 +25,6 @@ UserDecorator = Struct.new(:user) do
     distance_of_time_in_words(
       current_time, current_time + Devise.confirm_within, true, accumulate_on: :hours
     )
-  end
-
-  def app_link
-    link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray')
-  end
-
-  def first_sentence_for_confirmation_email # rubocop:disable MethodLength
-    if user.reset_requested_at.present?
-      I18n.t(
-        'mailer.confirmation_instructions.first_sentence.reset_requested',
-        app: app_link
-      )
-    elsif user.confirmed_at.present?
-      I18n.t(
-        'mailer.confirmation_instructions.first_sentence.confirmed',
-        app: app_link,
-        confirmation_period: confirmation_period
-      )
-    else
-      I18n.t(
-        'mailer.confirmation_instructions.first_sentence.unconfirmed',
-        app: app_link,
-        confirmation_period: confirmation_period
-      )
-    end
   end
 
   def may_bypass_2fa?(session = {})

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -5,9 +5,9 @@ class CustomDeviseMailer < Devise::Mailer
   default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
 
   def confirmation_instructions(record, token, options = {})
-    user_decorator = record.decorate
-    @first_sentence = user_decorator.first_sentence_for_confirmation_email
-    @confirmation_period = user_decorator.confirmation_period
+    presenter = ConfirmationEmailPresenter.new(record, view_context)
+    @first_sentence = presenter.first_sentence
+    @confirmation_period = presenter.confirmation_period
     super
   end
 end

--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -1,0 +1,38 @@
+class ConfirmationEmailPresenter
+  def initialize(user, view)
+    @user = user
+    @view = view
+  end
+
+  def first_sentence # rubocop:disable MethodLength
+    if user.reset_requested_at.present?
+      I18n.t('mailer.confirmation_instructions.first_sentence.reset_requested', app: app_link)
+    elsif user.confirmed_at.present?
+      I18n.t(
+        'mailer.confirmation_instructions.first_sentence.confirmed',
+        app: app_link, confirmation_period: confirmation_period
+      )
+    else
+      I18n.t(
+        'mailer.confirmation_instructions.first_sentence.unconfirmed',
+        app: app_link, confirmation_period: confirmation_period
+      )
+    end
+  end
+
+  def app_link
+    view.link_to(APP_NAME, view.root_url, class: 'gray')
+  end
+
+  def confirmation_period
+    current_time = Time.zone.now
+
+    view.distance_of_time_in_words(
+      current_time, current_time + Devise.confirm_within, true, accumulate_on: :hours
+    )
+  end
+
+  private
+
+  attr_reader :user, :view
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -1,4 +1,4 @@
-p.lead= t('mailer.confirmation_instructions.header', intro: @first_sentence)
+p.lead == t('mailer.confirmation_instructions.header', intro: @first_sentence)
 
 
 table.button.expanded.large.radius

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -1,5 +1,5 @@
-p.lead= t('mailer.reset_password.header', app: APP_NAME)
-
+p.lead == t('mailer.reset_password.header',
+          app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
 
 table.button.expanded.large.radius
   tbody

--- a/app/views/user_mailer/email_changed.html.slim
+++ b/app/views/user_mailer/email_changed.html.slim
@@ -1,4 +1,4 @@
-p.lead = t('.intro', app: APP_NAME)
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
 
 table.spacer
   tbody
@@ -10,4 +10,6 @@ table.hr
     th
       | &nbsp;
 
-p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))
+p == t('.help',
+      app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+      link: link_to(contact_url, contact_url))

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -1,4 +1,4 @@
-p.lead = t('.intro', app: APP_NAME)
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
 
 table.spacer
   tbody
@@ -10,4 +10,6 @@ table.hr
     th
       | &nbsp;
 
-p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))
+p == t('.help',
+      app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+      link: link_to(contact_url, contact_url))

--- a/app/views/user_mailer/signup_with_your_email.html.slim
+++ b/app/views/user_mailer/signup_with_your_email.html.slim
@@ -1,4 +1,4 @@
-p.lead = t('.intro', app: APP_NAME)
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
 
 
 table.button.expanded.large.radius
@@ -27,6 +27,9 @@ table.hr
     th
       | &nbsp;
 
-p = t('.reset_password', app: APP_NAME)
+p == t('.reset_password',
+      app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
 
-p == t('.help', app: APP_NAME, link: link_to(contact_url, contact_url))
+p == t('.help',
+      app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+      link: link_to(contact_url, contact_url))

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -28,7 +28,7 @@ en:
       intro: >
         Your request to create a %{app} account using this email address cannot
         be granted because this email address is already in use. If you requested this
-        change, please use the following link to log in to login.gov:
+        change, please use the following link to log in to %{app}:
       link_text: Go to %{app}
       reset_password: >
         If you cannot remember your password, you can reset it at %{app}.

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -47,50 +47,6 @@ describe UserDecorator do
     end
   end
 
-  describe '#first_sentence_for_confirmation_email' do
-    context 'when user.reset_requested_at is present' do
-      it 'lets the user know their account was reset by a tech rep' do
-        user = build_stubbed(:user, reset_requested_at: Time.zone.now)
-        user_decorator = UserDecorator.new(user)
-
-        expect(user_decorator.first_sentence_for_confirmation_email).to eq(
-          I18n.t(
-            'mailer.confirmation_instructions.first_sentence.reset_requested',
-            app: APP_NAME
-          )
-        )
-      end
-    end
-
-    context 'when user.reset_requested_at is nil and user is confirmed' do
-      it 'lets the user know how to finish updating their account' do
-        user = build_stubbed(:user, confirmed_at: Time.zone.now)
-        user_decorator = UserDecorator.new(user)
-
-        expect(user_decorator.first_sentence_for_confirmation_email).to eq(
-          I18n.t(
-            'mailer.confirmation_instructions.first_sentence.confirmed',
-            app: APP_NAME, confirmation_period: user_decorator.confirmation_period
-          )
-        )
-      end
-    end
-
-    context 'when user.reset_requested_at is nil and user is not confirmed' do
-      it 'lets the user know how to finish creating their account' do
-        user = build_stubbed(:user, confirmed_at: nil)
-        user_decorator = UserDecorator.new(user)
-
-        expect(user_decorator.first_sentence_for_confirmation_email).to eq(
-          I18n.t(
-            'mailer.confirmation_instructions.first_sentence.unconfirmed',
-            app: APP_NAME, confirmation_period: user_decorator.confirmation_period
-          )
-        )
-      end
-    end
-  end
-
   describe '#may_bypass_2fa?' do
     it 'returns true when the user is omniauthed' do
       user = instance_double(User)

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -28,36 +28,43 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
 
   it 'mentions updating an account when user has already been confirmed' do
     user = build_stubbed(:user, confirmed_at: Time.zone.now)
+    presenter = ConfirmationEmailPresenter.new(user, self)
     assign(:resource, user)
-    assign(:first_sentence, user.decorate.first_sentence_for_confirmation_email)
+    assign(:first_sentence, presenter.first_sentence)
     render
 
     expect(rendered).to have_content(
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.confirmed',
-        app: APP_NAME, confirmation_period: user.decorate.confirmation_period
+        app: APP_NAME, confirmation_period: presenter.confirmation_period
       )
     )
+
+    expect(rendered).to have_xpath("//p[contains(@class, 'lead')]/a[text()='#{APP_NAME}']")
   end
 
   it 'mentions creating an account when user is not yet confirmed' do
     user = build_stubbed(:user, confirmed_at: nil)
+    presenter = ConfirmationEmailPresenter.new(user, self)
     assign(:resource, user)
-    assign(:first_sentence, user.decorate.first_sentence_for_confirmation_email)
+    assign(:first_sentence, presenter.first_sentence)
     render
 
     expect(rendered).to have_content(
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.unconfirmed',
-        app: APP_NAME, confirmation_period: user.decorate.confirmation_period
+        app: APP_NAME, confirmation_period: presenter.confirmation_period
       )
     )
+
+    expect(rendered).to have_xpath("//p[contains(@class, 'lead')]/a[text()='#{APP_NAME}']")
   end
 
   it 'mentions resetting the account when account has been reset by tech support' do
     user = build_stubbed(:user, reset_requested_at: Time.zone.now)
+    presenter = ConfirmationEmailPresenter.new(user, self)
     assign(:resource, user)
-    assign(:first_sentence, user.decorate.first_sentence_for_confirmation_email)
+    assign(:first_sentence, presenter.first_sentence)
     render
 
     expect(rendered).to have_content(
@@ -66,5 +73,7 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
         app: APP_NAME
       )
     )
+
+    expect(rendered).to have_xpath("//p[contains(@class, 'lead')]/a[text()='#{APP_NAME}']")
   end
 end


### PR DESCRIPTION
**Why**: To override Gmail automatically converting login.gov into a link