### PR TITLE
Update URLs for "sign up" flow

### DIFF
--- a/app/controllers/sign_up/emails_controller.rb
+++ b/app/controllers/sign_up/emails_controller.rb
@@ -1,0 +1,17 @@
+module SignUp
+  class EmailsController < ApplicationController
+    def show
+      if session[:email].blank?
+        redirect_to sign_up_email_path
+      else
+        @resend_confirmation = params[:resend].present?
+
+        email = session.delete(:email)
+        @register_user_email_form = RegisterUserEmailForm.new
+        @register_user_email_form.user.email = email
+
+        render :show, locals: { email: email }
+      end
+    end
+  end
+end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -1,11 +1,11 @@
-module Users
+module SignUp
   class RegistrationsController < Devise::RegistrationsController
     include PhoneConfirmation
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
-    def start
+    def show
       analytics.track_event(Analytics::USER_REGISTRATION_INTRO_VISIT)
     end
 
@@ -15,7 +15,6 @@ module Users
       analytics.track_event(Analytics::USER_REGISTRATION_ENTER_EMAIL_VISIT)
     end
 
-    # POST /resource
     def create
       @register_user_email_form = RegisterUserEmailForm.new
 
@@ -43,9 +42,10 @@ module Users
       user = @register_user_email_form.user
       create_user_event(:account_created, user) unless @register_user_email_form.email_taken?
 
-      @resend_confirmation = params[:user][:resend]
+      resend_confirmation = params[:user][:resend]
+      session[:email] = user.email
 
-      render :verify_email, locals: { email: user.email }
+      redirect_to sign_up_verify_email_path(resend: resend_confirmation)
     end
 
     def disable_account_creation

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -17,4 +17,4 @@ p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
   = render decorated_session.return_to_service_provider_partial
   .sm-col-right.mxn1
     = link_to t('links.passwords.forgot'), new_password_path(resource_name), class: 'px1'
-    = link_to t('links.create_account'), new_user_start_path, class: 'px1 border-left border-silver'
+    = link_to t('links.create_account'), sign_up_start_path, class: 'px1 border-left border-silver'

--- a/app/views/sign_up/emails/show.html.slim
+++ b/app/views/sign_up/emails/show.html.slim
@@ -13,12 +13,12 @@
       = image_tag(asset_url('alert/ico-thumb.svg'), height: '16', alt: '',\
         class: 'mr2 align-bottom')
       = t('notices.resend_confirmation_email.success')
-  = simple_form_for(@register_user_email_form, url: user_registration_path,
+  = simple_form_for(@register_user_email_form, url: sign_up_register_path,
     html: { class: '' }) do |f|
-    = f.input :email, as: :hidden, value: email, wrapper: false
+    = f.input :email, as: :hidden, wrapper: false
     = f.input :resend, as: :hidden, wrapper: false
     | #{t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')}
     = f.button :submit, t('links.resend'), class: 'btn-link ml-tiny'
-  - link = link_to t('notices.use_diff_email.link'), new_user_registration_path
+  - link = link_to t('notices.use_diff_email.link'), sign_up_email_path
   p.m0 == t('notices.use_diff_email.text_html', link: link)
   p.my2.h5.italic = t('devise.registrations.close_window')

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -5,7 +5,7 @@ h1.h3.my0 = t('headings.registrations.enter_email')
 p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 = simple_form_for(@register_user_email_form,
     html: { autocomplete: 'off', role: 'form' },
-    url: user_registration_path) do |f|
+    url: sign_up_register_path) do |f|
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -18,7 +18,7 @@ h1.h3.my0 = decorated_session.registration_heading
     p.pb2.sm-pb3.mb2 = t('devise.registrations.start.bullet_3')
 .py1.sm-p0
   - ab_test(:demo) do |variant, _|
-    = link_to t(variant), new_user_registration_path, class: 'btn btn-primary btn-wide mb4'
+    = link_to t(variant), sign_up_email_path, class: 'btn btn-primary btn-wide mb4'
 .clearfix.pt1.border-top
   - auth_link = link_to t('links.sign_in'), new_user_session_path
   .sm-col-right == t('instructions.registration.already_have_account', link: auth_link)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,10 +18,10 @@ Rails.application.routes.draw do
     get '/reauthn' => 'mfa_confirmation#new', as: :user_password_confirm
     post '/reauthn' => 'mfa_confirmation#create', as: :reauthn_user_password
 
-    post '/users' => 'users/registrations#create', as: :user_registration
-    get '/users/sign_up' => 'users/registrations#new', as: :new_user_registration
-
-    get '/start' => 'users/registrations#start', as: :new_user_start
+    get '/sign_up/enter_email' => 'sign_up/registrations#new', as: :sign_up_email
+    post '/sign_up/register' => 'sign_up/registrations#create', as: :sign_up_register
+    get '/sign_up/start' => 'sign_up/registrations#show', as: :sign_up_start
+    get '/sign_up/verify_email' => 'sign_up/emails#show', as: :sign_up_verify_email
 
     get 'active'  => 'users/sessions#active'
     get 'timeout' => 'users/sessions#timeout'

--- a/spec/controllers/sign_up/emails_controller_spec.rb
+++ b/spec/controllers/sign_up/emails_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SignUp::EmailsController do
+  describe '#show' do
+    context 'email in session' do
+      it 'renders the page and deletes the email from the session' do
+        stub_analytics
+        session[:email] = 'test@example.com'
+
+        get :show
+
+        expect(session[:email]).to be_nil
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'no email in session' do
+      it 'redirects to the new user registration path' do
+        stub_analytics
+        session[:email] = nil
+
+        get :show
+
+        expect(response).to redirect_to(sign_up_email_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/sign_up/emails_controller_spec.rb
+++ b/spec/controllers/sign_up/emails_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe SignUp::EmailsController do
   describe '#show' do
     context 'email in session' do
       it 'renders the page and deletes the email from the session' do
-        stub_analytics
         session[:email] = 'test@example.com'
 
         get :show
@@ -16,7 +15,6 @@ RSpec.describe SignUp::EmailsController do
 
     context 'no email in session' do
       it 'redirects to the new user registration path' do
-        stub_analytics
         session[:email] = nil
 
         get :show

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-include Features::MailerHelper
-include Features::LocalizationHelper
-include Features::ActiveJobHelper
+describe SignUp::RegistrationsController, devise: true do
+  include Features::MailerHelper
+  include Features::LocalizationHelper
+  include Features::ActiveJobHelper
 
-describe Users::RegistrationsController, devise: true do
   describe '#new' do
     context 'When registrations are disabled' do
       it 'prevents users from visiting sign up page' do
@@ -58,6 +58,15 @@ describe Users::RegistrationsController, devise: true do
 
         expect(subject).to have_received(:create_user_event).with(:account_created, user)
       end
+
+      it 'sets the email in the session and redirects to sign_up_verify_email_path' do
+        stub_analytics
+
+        post :create, user: { email: 'test@test.com' }
+
+        expect(session[:email]).to eq('test@test.com')
+        expect(response).to redirect_to(sign_up_verify_email_path)
+      end
     end
 
     it 'tracks successful user registration with existing email' do
@@ -96,14 +105,14 @@ describe Users::RegistrationsController, devise: true do
     end
   end
 
-  describe '#start' do
+  describe '#show' do
     it 'tracks page visit' do
       stub_analytics
 
       expect(@analytics).to receive(:track_event).
         with(Analytics::USER_REGISTRATION_INTRO_VISIT)
 
-      get :start
+      get :show
     end
   end
 end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -60,8 +60,6 @@ describe SignUp::RegistrationsController, devise: true do
       end
 
       it 'sets the email in the session and redirects to sign_up_verify_email_path' do
-        stub_analytics
-
         post :create, user: { email: 'test@test.com' }
 
         expect(session[:email]).to eq('test@test.com')

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -6,7 +6,7 @@ feature 'Accessibility on pages that require authentication', :js do
     email = 'test@example.com'
     sign_up_with(email)
 
-    expect(current_path).to eq(user_registration_path)
+    expect(current_path).to eq(sign_up_verify_email_path)
     expect(page).to be_accessible
   end
 

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -21,13 +21,13 @@ feature 'Accessibility on pages that do not require authentication', :js do
   end
 
   scenario 'new user start registration page' do
-    visit new_user_start_path
+    visit sign_up_start_path
 
     expect(page).to be_accessible
   end
 
   scenario 'new user registration page' do
-    visit new_user_registration_path
+    visit sign_up_email_path
 
     expect(page).to be_accessible
   end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -190,7 +190,7 @@ feature 'saml api', devise: true do
 
         xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
-        visit new_user_registration_path
+        visit sign_up_email_path
 
         user = sign_up_and_2fa
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -111,7 +111,7 @@ feature 'Sign in' do
       allow(Devise).to receive(:timeout_in).and_return(0)
 
       [t('forms.buttons.continue'), t('session_expired_link')].each do |link|
-        visit new_user_registration_path
+        visit sign_up_email_path
         fill_in 'Email', with: 'test@example.com'
 
         expect(page).to have_css('#session-expired-msg')
@@ -119,7 +119,7 @@ feature 'Sign in' do
         find_link(link).trigger('click')
 
         expect(page).to have_field('Email', with: '')
-        expect(page).to have_current_path(new_user_registration_path)
+        expect(page).to have_current_path(sign_up_email_path)
       end
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -5,7 +5,7 @@ module Features
     VALID_PASSWORD = 'Val!d Pass w0rd'.freeze
 
     def sign_up_with(email)
-      visit new_user_registration_path
+      visit sign_up_email_path
       fill_in 'Email', with: email
       click_button t('forms.buttons.submit.default')
     end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -25,7 +25,7 @@ describe 'devise/sessions/new.html.slim' do
 
     expect(rendered).
       to have_link(
-        t('links.create_account'), href: new_user_start_path
+        t('links.create_account'), href: sign_up_start_path
       )
   end
 

--- a/spec/views/sign_up/emails/show.html.slim_spec.rb
+++ b/spec/views/sign_up/emails/show.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'users/registrations/verify_email.html.slim' do
+describe 'sign_up/emails/show.html.slim' do
   before do
     allow(view).to receive(:email).and_return('foo@bar.com')
     @register_user_email_form = RegisterUserEmailForm.new

--- a/spec/views/sign_up/registrations/destroy_confirm.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/destroy_confirm.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'users/registrations/destroy_confirm.html.slim' do
+describe 'sign_up/registrations/destroy_confirm.html.slim' do
   before do
     user = build_stubbed(:user, :signed_up)
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'users/registrations/new.html.slim' do
+describe 'sign_up/registrations/new.html.slim' do
   before do
     @register_user_email_form = RegisterUserEmailForm.new
     allow(view).to receive(:controller_name).and_return('registrations')

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'users/registrations/start.html.slim' do
+describe 'sign_up/registrations/show.html.slim' do
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('titles.registrations.start'))
 
@@ -17,7 +17,7 @@ describe 'users/registrations/start.html.slim' do
     render
 
     expect(rendered).
-      to have_link(t('experiments.demo.get_started'), href: new_user_registration_path)
+      to have_link(t('experiments.demo.get_started'), href: sign_up_email_path)
   end
 
   context 'when @sp_name is not set' do


### PR DESCRIPTION
**Why**:
* These URLs are more consistent and friendly
* These URLs are more Rails-y on the backend
* Now, reloading the page after you enter your email does not result in
  a 404. Instead, you are redirected back to "enter email" page