### PR TITLE
Allow accessibility tests to be skipped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ brakeman:
 test: $(CONFIG)
 	bundle exec rspec
 
+fast_test: $(CONFIG)
+	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
+
 run: $(CONFIG)
 	foreman start
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ To run all the tests:
 $ make test
 ```
 
+To run a subset of tests excluding slow tests (such as accessibility specs):
+```
+$ make fast_test
+```
+
 See RSpec [docs](https://relishapp.com/rspec/rspec-core/docs/command-line) for
 more information.
 


### PR DESCRIPTION
**Why**: Because they take 24 seconds to run, and we don't need to
check accessibility tests all the time when developing locally.

**How**: Add a `fast_test` command to the Makefile that skips tests
tagged with `accessibility`.