### PR TITLE
Change sign-in button text to "Next"

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -8,7 +8,7 @@ h1.h3.my0 = decorated_session.new_session_heading
                   html: { autocomplete: 'off', role: 'form' }) do |f|
   = f.input :email, required: true
   = f.input :password, required: true
-  = f.button :submit, t('links.sign_in'), class: 'btn-wide'
+  = f.button :submit, t('links.next'), class: 'btn-wide'
 
 - link = link_to t('notices.sign_in_consent.link'), privacy_path
 p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -6,13 +6,13 @@ en:
     create_account: Create account
     edit: Edit
     help: Help
+    next: Next
     passwords:
       forgot: Forgot your password?
     phone_confirmation:
       fallback_to_sms: Send me a text message with the code instead
       fallback_to_voice: Call me with the code instead
     privacy_policy: Privacy Policy
-    next: Next
     resend: Send again
     sign_in: Sign in
     sign_out: Sign out

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -12,6 +12,7 @@ en:
       fallback_to_sms: Send me a text message with the code instead
       fallback_to_voice: Call me with the code instead
     privacy_policy: Privacy Policy
+    next: Next
     resend: Send again
     sign_in: Sign in
     sign_out: Sign out

--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -102,7 +102,7 @@ feature 'SP-initiated authentication with login.gov', devise: true, user_flow: t
 
       context 'with valid credentials entered' do
         before do
-          fill_in_credentials_and_click_sign_in(@user.email, @user.password)
+          fill_in_credentials_and_submit(@user.email, @user.password)
         end
 
         it 'prompts for 2FA delivery method' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -132,10 +132,10 @@ feature 'Sign in' do
       Timecop.travel(Devise.timeout_in + 1.minute) do
         expect(page).to_not have_content(t('forms.buttons.continue'))
 
-        fill_in_credentials_and_click_sign_in(user.email, user.password)
+        fill_in_credentials_and_submit(user.email, user.password)
         expect(page).to have_content t('errors.invalid_authenticity_token')
 
-        fill_in_credentials_and_click_sign_in(user.email, user.password)
+        fill_in_credentials_and_submit(user.email, user.password)
         expect(current_path).to eq user_two_factor_authentication_path
       end
     end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -4,9 +4,7 @@ feature 'Password Recovery' do
   def reset_password_and_sign_back_in(user, password = 'a really long password')
     fill_in 'New password', with: password
     click_button t('forms.passwords.edit.buttons.submit')
-    fill_in 'Email', with: user.email
-    fill_in 'user_password', with: password
-    click_button t('links.sign_in')
+    fill_in_credentials_and_submit(user.email, password)
   end
 
   context 'user can reset their password via email', email: true do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -12,13 +12,13 @@ module Features
 
     def signin(email, password)
       visit new_user_session_path
-      fill_in_credentials_and_click_sign_in(email, password)
+      fill_in_credentials_and_submit(email, password)
     end
 
-    def fill_in_credentials_and_click_sign_in(email, password)
+    def fill_in_credentials_and_submit(email, password)
       fill_in 'Email', with: email
       fill_in 'Password', with: password
-      click_button t('links.sign_in')
+      click_button t('links.next')
     end
 
     def sign_up


### PR DESCRIPTION
**Why** Entering email and password correctly does not complete sign in. The user must still finish 2FA. Changing the button text from "sign up" to "next" acknowledges that it is a multistep process. 