### PR TITLE
Consolidate Phone Setup analytics

### DIFF
--- a/app/controllers/devise/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_setup_controller.rb
@@ -16,10 +16,13 @@ module Devise
     def set
       @two_factor_setup_form = TwoFactorSetupForm.new(resource)
 
-      if @two_factor_setup_form.submit(params[:two_factor_setup_form])
+      result = @two_factor_setup_form.submit(params[:two_factor_setup_form])
+
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
+
+      if result[:success]
         process_valid_form
       else
-        analytics.track_event(Analytics::SETUP_2FA_INVALID_PHONE)
         render :index
       end
     end
@@ -35,15 +38,10 @@ module Devise
     end
 
     def process_valid_form
-      update_metrics
       prompt_to_confirm_phone(
         phone: @two_factor_setup_form.phone,
         otp_method: @two_factor_setup_form.otp_method
       )
-    end
-
-    def update_metrics
-      analytics.track_event(Analytics::SETUP_2FA_VALID_PHONE)
     end
   end
 end

--- a/app/forms/two_factor_setup_form.rb
+++ b/app/forms/two_factor_setup_form.rb
@@ -12,8 +12,22 @@ class TwoFactorSetupForm
     self.phone = params[:phone].phony_formatted(
       format: :international, normalize: :US, spaces: ' '
     )
-    self.otp_method = params[:otp_method] == 'voice' ? :voice : :sms
+    self.otp_method = params[:otp_method]
 
-    valid?
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_reader :success
+
+  def result
+    {
+      success: success,
+      error: errors.messages.values.flatten.first,
+      otp_method: otp_method
+    }
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -48,6 +48,7 @@ class Analytics
   MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   MULTI_FACTOR_AUTH_ENTER_OTP_VISIT = 'Multi-Factor Authentication: enter OTP visited'.freeze
   MULTI_FACTOR_AUTH_MAX_ATTEMPTS = 'Multi-Factor Authentication: max attempts reached'.freeze
+  MULTI_FACTOR_AUTH_PHONE_SETUP = 'Multi-Factor Authentication: phone setup'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze
   PASSWORD_CREATION = 'Password Creation'.freeze
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
@@ -57,8 +58,6 @@ class Analytics
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
-  SETUP_2FA_INVALID_PHONE = '2FA setup: invalid phone number'.freeze
-  SETUP_2FA_VALID_PHONE = '2FA setup: valid phone number'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   TOTP_SETUP_INVALID_CODE = 'TOTP Setup: invalid code'.freeze
   TOTP_SETUP_VALID_CODE = 'TOTP Setup: valid code'.freeze

--- a/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_setup_controller_spec.rb
@@ -19,9 +19,16 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
       allow(subject).to receive(:authorize_otp_setup).and_return(true)
 
       stub_analytics
-      expect(@analytics).to receive(:track_event).with('2FA setup: invalid phone number')
+      result = {
+        success: false,
+        error: t('errors.messages.improbable_phone'),
+        otp_method: 'sms'
+      }
 
-      patch :set, two_factor_setup_form: { phone: '703-555-010' }
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
+
+      patch :set, two_factor_setup_form: { phone: '703-555-010', otp_method: :sms }
 
       expect(response).to render_template(:index)
     end
@@ -31,7 +38,14 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         sign_in(user)
 
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('2FA setup: valid phone number')
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'voice'
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
 
         patch(
           :set,
@@ -54,12 +68,20 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         sign_in(user)
 
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('2FA setup: valid phone number')
+
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'sms'
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
 
         patch(
           :set,
           two_factor_setup_form: { phone: '703-555-0100',
-                                   sms: 'Confirm with text message' }
+                                   otp_method: :sms }
         )
 
         expect(response).to redirect_to(
@@ -77,11 +99,18 @@ describe Devise::TwoFactorAuthenticationSetupController, devise: true do
         sign_in(user)
 
         stub_analytics
-        expect(@analytics).to receive(:track_event).with('2FA setup: valid phone number')
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'sms'
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
 
         patch(
           :set,
-          two_factor_setup_form: { phone: '703-555-0100' }
+          two_factor_setup_form: { phone: '703-555-0100', otp_method: :sms }
         )
 
         expect(response).to redirect_to(

--- a/spec/forms/two_factor_setup_form_spec.rb
+++ b/spec/forms/two_factor_setup_form_spec.rb
@@ -29,7 +29,7 @@ describe TwoFactorSetupForm, type: :model do
       end
 
       it 'sets otp_method to "voice"' do
-        expect(subject.otp_method).to eq(:voice)
+        expect(subject.otp_method).to eq('voice')
       end
     end
 
@@ -40,7 +40,7 @@ describe TwoFactorSetupForm, type: :model do
       end
 
       it 'sets otp_method to "sms"' do
-        expect(subject.otp_method).to eq(:sms)
+        expect(subject.otp_method).to eq('sms')
       end
     end
   end
@@ -50,41 +50,58 @@ describe TwoFactorSetupForm, type: :model do
       it 'is valid' do
         user = build_stubbed(:user, :signed_up, phone: '+1 (202) 555-1213')
         allow(User).to receive(:exists?).with(phone: user.phone).and_return(true)
+        form = TwoFactorSetupForm.new(user)
 
-        subject.phone = user.phone
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'sms'
+        }
 
-        expect(subject.valid?).to be true
+        expect(form.submit(phone: user.phone, otp_method: 'sms')).
+          to eq result
       end
     end
 
     context 'when phone is not already taken' do
       it 'is valid' do
-        subject.phone = '+1 (703) 555-1212'
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'sms'
+        }
 
-        expect(subject.valid?).to be true
+        expect(subject.submit(phone: '+1 (703) 555-1212', otp_method: 'sms')).
+          to eq result
       end
     end
 
     context 'when phone is same as current user' do
-      before do
-        user.phone = valid_phone
-      end
-
       it 'is valid' do
-        subject.phone = user.phone
+        user = build_stubbed(:user, phone: valid_phone)
+        form = TwoFactorSetupForm.new(user)
 
-        expect(subject.valid?).to be true
+        result = {
+          success: true,
+          error: nil,
+          otp_method: 'sms'
+        }
+
+        expect(form.submit(phone: valid_phone, otp_method: 'sms')).
+          to eq result
       end
     end
 
-    context 'when phone is nil' do
+    context 'when phone is empty' do
       it 'does not add already taken errors' do
-        subject.phone = nil
-        subject.valid?
+        result = {
+          success: false,
+          error: t('errors.messages.improbable_phone'),
+          otp_method: 'sms'
+        }
 
-        expect(subject.errors[:phone].uniq).
-          to eq [t('errors.messages.improbable_phone')]
-        expect(subject.valid?).to be false
+        expect(subject.submit(phone: '', otp_method: 'sms')).
+          to eq result
       end
     end
   end


### PR DESCRIPTION
**Why**: To have one event for both pass and fail scenarios.