### PR TITLE
Fix account lockout spec

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -128,8 +128,8 @@ feature 'Two Factor Authentication' do
         end
 
         expect(page).to have_content t('titles.account_locked')
-        expect(page).to have_content('4 minutes and 54 seconds')
-        expect(page).to have_content('4 minutes and 53 seconds')
+        expect(page).to have_content('4:54')
+        expect(page).to have_content('4:53')
 
         # let lockout period expire
         user.update(


### PR DESCRIPTION
**Why**: The PR that changed this spec was merged after another PR
that changed the countdown text, but Travis wasn't triggered, so we
weren't alerted about the failure until after the fact.