### PR TITLE
Add endpoint to track Twilio voice status callbacks

### DIFF
--- a/app/controllers/voice/status_controller.rb
+++ b/app/controllers/voice/status_controller.rb
@@ -1,0 +1,22 @@
+module Voice
+  class StatusController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def create # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      analytics.track_event(
+        Analytics::OTP_VOICE_STATUS,
+        call_id: params[:CallSid],
+        call_status: params[:CallStatus],
+        api_version: params[:ApiVersion],
+        direction: params[:Direction],
+        to_city: params[:ToCity],
+        to_state: params[:ToState],
+        to_zip: params[:ToZip],
+        to_country: params[:ToCountry],
+        duration: params[:CallDuration].to_f
+      )
+
+      render nothing: true
+    end
+  end
+end

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -17,7 +17,8 @@ class VoiceOtpSenderJob < ActiveJob::Base
   def send_otp(twilio_service, code, phone)
     twilio_service.place_call(
       to: phone,
-      url: BasicAuthUrl.build(voice_otp_url(code: code))
+      url: BasicAuthUrl.build(voice_otp_url(code: code)),
+      status_callback: BasicAuthUrl.build(voice_status_url)
     )
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -45,6 +45,7 @@ class Analytics
   IDV_REVIEW_VISIT = 'IdV: review info visited'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   OTP_DELIVERY_SELECTION = 'OTP: Delivery Selection'.freeze
+  OTP_VOICE_STATUS = 'OTP: voice status change'.freeze
   MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   MULTI_FACTOR_AUTH_ENTER_OTP_VISIT = 'Multi-Factor Authentication: enter OTP visited'.freeze
   MULTI_FACTOR_AUTH_MAX_ATTEMPTS = 'Multi-Factor Authentication: max attempts reached'.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
         via: [:get, :post],
         as: :voice_otp,
         defaults: { format: :xml }
+  post '/api/voice/status' => 'voice/status#create'
 
   get '/contact' => 'contact#new', as: :contact
   post '/contact' => 'contact#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
         via: [:get, :post],
         as: :voice_otp,
         defaults: { format: :xml }
-  post '/api/voice/status' => 'voice/status#create'
+  post '/api/voice/status' => 'voice/status#create', as: :voice_status
 
   get '/contact' => 'contact#new', as: :contact
   post '/contact' => 'contact#create'

--- a/spec/controllers/voice/status_controller_spec.rb
+++ b/spec/controllers/voice/status_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Voice::StatusController do
+  describe '#create' do
+    it 'tracks voice analytics' do
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).with(
+        Analytics::OTP_VOICE_STATUS,
+        call_id: '1234',
+        call_status: 'completed',
+        api_version: '1.0',
+        direction: 'outbound-api',
+        to_city: 'Washington',
+        to_state: 'DC',
+        to_zip: '20500',
+        to_country: 'USA',
+        duration: 5
+      )
+
+      post :create,
+           CallSid: '1234',
+           CallStatus: 'completed',
+           ApiVersion: '1.0',
+           Direction: 'outbound-api',
+           ToCity: 'Washington',
+           ToState: 'DC',
+           ToZip: '20500',
+           ToCountry: 'USA',
+           CallDuration: '5'
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So we can gather additional data for analytics

---

The keys in this come from: https://www.twilio.com/docs/api/twiml/twilio_request

And I picked some that seemed PII-free (the location stuff may be more sensitive than we want to record, happy to remove it)

cc @monfresh @brendansudol as our analytics gurus

We can also record the outgoing phone number if we want to, since we only have 1 right now it didn't seem necessary

--

Next steps: if we want this, we need to go into the Twilio console and set this endpoint as a callback:

<img width="880" alt="phone_number__202__888-2212___dashboard___twilio" src="https://cloud.githubusercontent.com/assets/458784/20947398/d7083ef2-bbc3-11e6-9619-b1e9cddd31bb.png">
