### PR TITLE
Rename vars in ConfirmationsController

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -2,8 +2,12 @@ module Users
   class ConfirmationsController < Devise::ConfirmationsController
     include ValidEmailParameter
 
+    def new
+      @user = User.new
+    end
+
     def confirm
-      with_unconfirmed_confirmable do
+      with_unconfirmed_user do
         result = @password_form.submit(permitted_params)
 
         analytics.track_event(Analytics::PASSWORD_CREATION, result)
@@ -17,8 +21,8 @@ module Users
     end
 
     def show
-      with_unconfirmed_confirmable do
-        result = EmailConfirmationTokenValidator.new(@confirmable).submit
+      with_unconfirmed_user do
+        result = EmailConfirmationTokenValidator.new(@user).submit
 
         analytics.track_event(Analytics::EMAIL_CONFIRMATION, result)
 
@@ -32,24 +36,23 @@ module Users
 
     protected
 
-    def with_unconfirmed_confirmable
+    def with_unconfirmed_user
       token = params[:confirmation_token]
 
-      @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, token)
-      @confirmable = User.confirm_by_token(token) if @confirmable.confirmed?
-      @password_form = PasswordForm.new(@confirmable)
+      @user = User.find_or_initialize_with_error_by(:confirmation_token, token)
+      @user = User.confirm_by_token(token) if @user.confirmed?
+      @password_form = PasswordForm.new(@user)
 
       yield
     end
 
     def set_view_variables
       @confirmation_token = params[:confirmation_token]
-      self.resource = @confirmable
     end
 
     def process_successful_password_creation
-      @confirmable.confirm
-      @confirmable.update(reset_requested_at: nil, password: permitted_params[:password])
+      @user.confirm
+      @user.update(reset_requested_at: nil, password: permitted_params[:password])
       sign_in_and_redirect_user
     end
 
@@ -59,7 +62,7 @@ module Users
     end
 
     def process_successful_confirmation
-      if !@confirmable.confirmed?
+      if !@user.confirmed?
         process_valid_confirmation_token
       else
         process_confirmed_user
@@ -73,19 +76,19 @@ module Users
     end
 
     def process_confirmed_user
-      create_user_event(:email_changed, @confirmable)
+      create_user_event(:email_changed, @user)
 
       flash[:notice] = t('devise.confirmations.confirmed')
-      redirect_to after_confirmation_path_for(@confirmable)
-      EmailNotifier.new(@confirmable).send_email_changed_email
+      redirect_to after_confirmation_path_for(@user)
+      EmailNotifier.new(@user).send_email_changed_email
     end
 
     def process_unsuccessful_confirmation
-      return process_already_confirmed_user if @confirmable.confirmed?
+      return process_already_confirmed_user if @user.confirmed?
 
       set_view_variables
 
-      if resource.confirmation_period_expired?
+      if @user.confirmation_period_expired?
         process_expired_confirmation_token
       else
         process_invalid_confirmation_token
@@ -100,7 +103,7 @@ module Users
     end
 
     def process_expired_confirmation_token
-      flash.now[:error] = resource.decorate.confirmation_period_expired_error
+      flash.now[:error] = @user.decorate.confirmation_period_expired_error
       render :new
     end
 
@@ -109,10 +112,10 @@ module Users
       render :new
     end
 
-    def after_confirmation_path_for(resource)
+    def after_confirmation_path_for(user)
       if !user_signed_in?
         new_user_session_url
-      elsif resource.two_factor_enabled?
+      elsif user.two_factor_enabled?
         profile_path
       else
         phone_setup_url
@@ -122,13 +125,12 @@ module Users
     private
 
     def permitted_params
-      params.require(:password_form).
-        permit(:confirmation_token, :password)
+      params.require(:password_form).permit(:confirmation_token, :password)
     end
 
     def sign_in_and_redirect_user
-      sign_in @confirmable
-      redirect_to after_confirmation_path_for(@confirmable)
+      sign_in @user
+      redirect_to after_confirmation_path_for(@user)
     end
   end
 end

--- a/app/views/users/confirmations/new.html.slim
+++ b/app/views/users/confirmations/new.html.slim
@@ -2,9 +2,9 @@
 
 
 h1.h3.my0 = t('headings.confirmations.new')
-= simple_form_for(resource,
-                  as: resource_name,
-                  url: confirmation_path(resource_name),
+= simple_form_for(@user,
+                  as: :user,
+                  url: confirmation_path(:user),
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.input :email, required: true
   = f.button :submit, t('forms.buttons.resend_confirmation'), class: 'mt2 mb1'


### PR DESCRIPTION
**Why**:
* This was using generalized names from Devise
* Since we are overriding these methods, we don't need to conform to
  Devise's language
* This is clearer
* Next step is some URL refactoring related to this