### PR TITLE
Remove question marks from analytics hash keys

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -18,7 +18,7 @@ module Devise
 
       analytics.track_event(Analytics::OTP_DELIVERY_SELECTION, result.merge(context: context))
 
-      if result[:success?]
+      if result[:success]
         handle_valid_delivery_method(delivery_params[:otp_method])
       else
         redirect_to user_two_factor_authentication_path(reauthn: reauthn?)

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -12,7 +12,7 @@ module TwoFactorAuthentication
 
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(analytics_properties))
 
-      if result[:success?]
+      if result[:success]
         handle_valid_otp
       else
         handle_invalid_otp

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -13,7 +13,7 @@ module TwoFactorAuthentication
 
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'recovery code'))
 
-      if result[:success?]
+      if result[:success]
         handle_valid_otp
       else
         handle_invalid_otp(type: 'recovery_code')

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -10,7 +10,7 @@ module TwoFactorAuthentication
 
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'totp'))
 
-      if result[:success?]
+      if result[:success]
         handle_valid_otp
       else
         handle_invalid_otp

--- a/app/controllers/users/edit_password_controller.rb
+++ b/app/controllers/users/edit_password_controller.rb
@@ -13,7 +13,7 @@ module Users
 
       analytics.track_event(Analytics::PASSWORD_CHANGED, result)
 
-      if result[:success?]
+      if result[:success]
         handle_success
       else
         render :edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -58,7 +58,7 @@ module Users
       user = User.find_with_email(email) || AnonymousUser.new
 
       properties = {
-        success?: user_signed_in_and_not_locked_out?(user),
+        success: user_signed_in_and_not_locked_out?(user),
         user_id: user.uuid,
         user_locked_out: user_locked_out?(user)
       }

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -22,9 +22,9 @@ class OtpDeliverySelectionForm
 
   def result
     {
-      success?: success,
+      success: success,
       delivery_method: otp_method,
-      resend?: resend,
+      resend: resend,
       errors: errors.full_messages
     }
   end

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -20,7 +20,7 @@ class OtpVerificationForm
 
   def result
     {
-      success?: success
+      success: success
     }
   end
 end

--- a/app/forms/recovery_code_form.rb
+++ b/app/forms/recovery_code_form.rb
@@ -23,7 +23,7 @@ class RecoveryCodeForm
 
   def result
     {
-      success?: success
+      success: success
     }
   end
 end

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -20,7 +20,7 @@ class TotpVerificationForm
 
   def result
     {
-      success?: success
+      success: success
     }
   end
 end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -22,7 +22,7 @@ class UpdateUserPasswordForm
 
   def result
     {
-      success?: success,
+      success: success,
       errors: errors.full_messages
     }
   end

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -118,9 +118,9 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         stub_analytics
 
         analytics_hash = {
-          success?: true,
+          success: true,
           delivery_method: 'sms',
-          resend?: nil,
+          resend: nil,
           errors: [],
           context: 'authentication'
         }
@@ -175,9 +175,9 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         stub_analytics
 
         analytics_hash = {
-          success?: true,
+          success: true,
           delivery_method: 'voice',
-          resend?: nil,
+          resend: nil,
           errors: [],
           context: 'authentication'
         }

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -50,7 +50,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         sign_in_before_2fa
 
         properties = {
-          success?: false,
+          success: false,
           confirmation_for_phone_change: false,
           context: 'authentication',
           method: 'sms'
@@ -84,7 +84,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
         sign_in_before_2fa
 
         properties = {
-          success?: false,
+          success: false,
           confirmation_for_phone_change: false,
           context: 'authentication',
           method: 'sms'
@@ -122,7 +122,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
       it 'tracks the valid authentication event' do
         properties = {
-          success?: true,
+          success: true,
           confirmation_for_phone_change: false,
           context: 'authentication',
           method: 'sms'
@@ -206,7 +206,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks the update event' do
             properties = {
-              success?: true,
+              success: true,
               confirmation_for_phone_change: true,
               context: 'confirmation',
               method: 'sms'
@@ -250,7 +250,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks an event' do
             properties = {
-              success?: false,
+              success: false,
               confirmation_for_phone_change: true,
               context: 'confirmation',
               method: 'sms'
@@ -284,7 +284,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
           it 'tracks the confirmation event' do
             properties = {
-              success?: true,
+              success: true,
               context: 'confirmation',
               method: 'sms',
               confirmation_for_phone_change: false
@@ -336,7 +336,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
         it 'tracks the OTP verification event' do
           properties = {
-            success?: true,
+            success: true,
             confirmation_for_phone_change: false,
             context: 'idv',
             method: 'sms'
@@ -401,7 +401,7 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
         it 'tracks an event' do
           properties = {
-            success?: false,
+            success: false,
             confirmation_for_phone_change: false,
             context: 'idv',
             method: 'sms'

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -8,7 +8,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
         form = instance_double(RecoveryCodeForm)
         allow(RecoveryCodeForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)
-        allow(form).to receive(:submit).and_return(success?: true)
+        allow(form).to receive(:submit).and_return(success: true)
       end
 
       it 'redirects to the profile' do
@@ -25,7 +25,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
 
       it 'tracks the valid authentication event' do
         stub_analytics
-        analytics_hash = { success?: true, method: 'recovery code' }
+        analytics_hash = { success: true, method: 'recovery code' }
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::MULTI_FACTOR_AUTH, analytics_hash)
@@ -40,7 +40,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
         form = instance_double(RecoveryCodeForm)
         allow(RecoveryCodeForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)
-        allow(form).to receive(:submit).and_return(success?: false)
+        allow(form).to receive(:submit).and_return(success: false)
       end
 
       it 'calls handle_invalid_otp' do
@@ -58,7 +58,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: tr
 
       it 'tracks the max attempts event' do
         properties = {
-          success?: false,
+          success: false,
           method: 'recovery code'
         }
 

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -28,7 +28,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
       it 'tracks the valid authentication event' do
         stub_analytics
         expect(@analytics).to receive(:track_event).
-          with(Analytics::MULTI_FACTOR_AUTH, success?: true, method: 'totp')
+          with(Analytics::MULTI_FACTOR_AUTH, success: true, method: 'totp')
 
         post :create, code: generate_totp_code(@secret)
       end
@@ -64,7 +64,7 @@ describe TwoFactorAuthentication::TotpVerificationController, devise: true do
         stub_analytics
 
         expect(@analytics).to receive(:track_event).exactly(3).times.
-          with(Analytics::MULTI_FACTOR_AUTH, success?: false, method: 'totp')
+          with(Analytics::MULTI_FACTOR_AUTH, success: false, method: 'totp')
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
         3.times { post :create, code: '12345' }

--- a/spec/controllers/users/edit_password_controller_spec.rb
+++ b/spec/controllers/users/edit_password_controller_spec.rb
@@ -27,7 +27,7 @@ describe Users::EditPasswordController do
         patch :update, update_user_password_form: params
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_CHANGED, success?: true, errors: [])
+          with(Analytics::PASSWORD_CHANGED, success: true, errors: [])
         expect(response).to redirect_to profile_url
         expect(flash[:notice]).to eq t('notices.password_changed')
       end
@@ -77,7 +77,7 @@ describe Users::EditPasswordController do
         ]
 
         expect(@analytics).to have_received(:track_event).
-          with(Analytics::PASSWORD_CHANGED, success?: false, errors: errors)
+          with(Analytics::PASSWORD_CHANGED, success: false, errors: errors)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -132,7 +132,7 @@ describe Users::SessionsController, devise: true do
 
       stub_analytics
       analytics_hash = {
-        success?: true,
+        success: true,
         user_id: user.uuid,
         user_locked_out: false
       }
@@ -148,7 +148,7 @@ describe Users::SessionsController, devise: true do
 
       stub_analytics
       analytics_hash = {
-        success?: false,
+        success: false,
         user_id: user.uuid,
         user_locked_out: false
       }
@@ -162,7 +162,7 @@ describe Users::SessionsController, devise: true do
     it 'tracks the authentication attempt for nonexistent user' do
       stub_analytics
       analytics_hash = {
-        success?: false,
+        success: false,
         user_id: 'anonymous-uuid',
         user_locked_out: false
       }
@@ -182,7 +182,7 @@ describe Users::SessionsController, devise: true do
 
       stub_analytics
       analytics_hash = {
-        success?: false,
+        success: false,
         user_id: user.uuid,
         user_locked_out: true
       }
@@ -242,7 +242,7 @@ describe Users::SessionsController, devise: true do
 
         stub_analytics
         analytics_hash = {
-          success?: true,
+          success: true,
           user_id: user.uuid,
           user_locked_out: false
         }

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -18,9 +18,9 @@ describe OtpDeliverySelectionForm do
         result = subject.submit(otp_method: 'sms', resend: true)
 
         result_hash = {
-          success?: true,
+          success: true,
           delivery_method: 'sms',
-          resend?: true,
+          resend: true,
           errors: []
         }
 
@@ -33,9 +33,9 @@ describe OtpDeliverySelectionForm do
         result = subject.submit(otp_method: 'foo')
 
         result_hash = {
-          success?: false,
+          success: false,
           delivery_method: 'foo',
-          resend?: nil,
+          resend: nil,
           errors: subject.errors.full_messages
         }
 

--- a/spec/forms/recovery_code_form_spec.rb
+++ b/spec/forms/recovery_code_form_spec.rb
@@ -10,7 +10,7 @@ describe RecoveryCodeForm do
         result = RecoveryCodeForm.new(user, raw_code).submit
 
         result_hash = {
-          success?: true
+          success: true
         }
 
         expect(result).to eq result_hash
@@ -26,7 +26,7 @@ describe RecoveryCodeForm do
         result = RecoveryCodeForm.new(user, 'foo').submit
 
         result_hash = {
-          success?: false
+          success: false
         }
 
         expect(result).to eq result_hash

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -15,7 +15,7 @@ describe UpdateUserPasswordForm, type: :model do
         result = subject.submit(params)
 
         result_hash = {
-          success?: false,
+          success: false,
           errors: subject.errors.full_messages
         }
 
@@ -32,7 +32,7 @@ describe UpdateUserPasswordForm, type: :model do
         result = subject.submit(params)
 
         result_hash = {
-          success?: true,
+          success: true,
           errors: []
         }
 


### PR DESCRIPTION
**Why**: For widespread compatibility and consistency. If I recall
correctly, when I was exploring ELK, Kibana was not able to filter
using keys that ended in a question mark.