### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,11 +19,10 @@ gem 'httparty'
 gem 'lograge'
 gem 'newrelic_rpm'
 gem 'omniauth-saml'
-gem 'phony_rails'
 gem 'pg'
+gem 'phony_rails'
 gem 'premailer-rails'
 gem 'proofer', github: '18F/identity-proofer-gem', branch: 'master'
-gem 'valid_email'
 gem 'rack-attack'
 gem 'readthis'
 gem 'redis-session-store'
@@ -42,9 +41,10 @@ gem 'split', require: 'split/dashboard'
 gem 'twilio-ruby'
 gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication', ref: '1d6abe3'
 gem 'uglifier', '>= 1.3.0'
+gem 'valid_email'
 gem 'whenever', require: false
-gem 'xmlenc', '~> 0.6.4'
 gem 'xml-simple'
+gem 'xmlenc', '~> 0.6.4'
 gem 'zxcvbn-js'
 
 group :deploy do
@@ -57,10 +57,10 @@ end
 
 group :development do
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'brakeman', require: false
   gem 'bummr', require: false
   gem 'derailed'
-  gem 'binding_of_caller'
   gem 'guard-rspec', require: false
   gem 'overcommit', require: false
   gem 'quiet_assets'
@@ -82,16 +82,16 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara-screenshot', github: 'mattheworiordan/capybara-screenshot'
   gem 'axe-matchers'
+  gem 'capybara-screenshot', github: 'mattheworiordan/capybara-screenshot'
   gem 'codeclimate-test-reporter', require: false
   gem 'database_cleaner'
   gem 'email_spec'
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'poltergeist'
-  gem 'rack_session_access'
   gem 'rack-test'
+  gem 'rack_session_access'
   gem 'shoulda-matchers', '~> 3.0', require: false
   gem 'test_after_commit'
   gem 'timecop'

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -18,9 +18,6 @@ module Idv
       submit_profile
     end
 
-    def dupe
-    end
-
     private
 
     def submit_profile

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -11,16 +11,7 @@ class IdvController < ApplicationController
     end
   end
 
-  def cancel
-  end
-
-  def fail
-  end
-
   def retry
     flash.now[:error] = I18n.t('idv.errors.fail')
-  end
-
-  def activated
   end
 end

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -1,9 +1,6 @@
 class MfaConfirmationController < ApplicationController
   before_action :confirm_two_factor_authenticated
 
-  def new
-  end
-
   def create
     if current_user.valid_password?(password)
       redirect_to user_two_factor_authentication_path(reauthn: true)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,10 +2,4 @@ class PagesController < ApplicationController
   def page_not_found
     render layout: false, status: 404
   end
-
-  def privacy_policy
-  end
-
-  def help
-  end
 end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -29,9 +29,6 @@ module SignUp
       end
     end
 
-    def destroy_confirm
-    end
-
     protected
 
     def permitted_params

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -5,9 +5,6 @@ module TwoFactorAuthentication
 
     prepend_before_action :authenticate_scope!
 
-    def show
-    end
-
     def create
       result = RecoveryCodeForm.new(current_user, params[:code]).submit
 

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -2,9 +2,6 @@ module TwoFactorAuthentication
   class TotpVerificationController < DeviseController
     include TwoFactorAuthenticatable
 
-    def show
-    end
-
     def create
       result = TotpVerificationForm.new(current_user, params[:code].strip).submit
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -2,9 +2,6 @@ module Users
   class TotpSetupController < ApplicationController
     before_action :confirm_two_factor_authenticated
 
-    def start
-    end
-
     def new
       user_session[:new_totp_secret] = current_user.generate_totp_secret if new_totp_secret.nil?
 

--- a/app/services/worker_health_checker.rb
+++ b/app/services/worker_health_checker.rb
@@ -18,8 +18,7 @@ module WorkerHealthChecker
   # Empty job that we put in each background queue to make sure the queue is running
   # Relies on the Middleware to mark the queue as healthy
   class DummyJob < ActiveJob::Base
-    def perform
-    end
+    def perform; end
   end
 
   Status = Struct.new(:queue, :last_run_at, :healthy) do

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -4,8 +4,7 @@ class FakeSms
   cattr_accessor :messages
   self.messages = []
 
-  def initialize(_account_sid, _auth_token)
-  end
+  def initialize(_account_sid, _auth_token); end
 
   def messages
     self

--- a/spec/support/fake_voice_call.rb
+++ b/spec/support/fake_voice_call.rb
@@ -4,8 +4,7 @@ class FakeVoiceCall
   cattr_accessor :calls
   self.calls = []
 
-  def initialize(_account_sid, _auth_token)
-  end
+  def initialize(_account_sid, _auth_token); end
 
   def calls
     self


### PR DESCRIPTION
**Why**: To be able to run `make lint` without errors

**How**:
- Alphabetize gems within each group
- Put empty method definitions in a single line