### PR TITLE
Update URLs for email confirmation steps

### DIFF
--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -1,0 +1,20 @@
+module UnconfirmedUserConcern
+  def with_unconfirmed_user
+    token = params[:confirmation_token]
+    @user = User.find_or_initialize_with_error_by(:confirmation_token, token)
+    @user = User.confirm_by_token(token) if @user.confirmed?
+    @password_form = PasswordForm.new(@user)
+
+    yield
+  end
+
+  def after_confirmation_path_for(user)
+    if !user_signed_in?
+      new_user_session_url
+    elsif user.two_factor_enabled?
+      profile_path
+    else
+      phone_setup_url
+    end
+  end
+end

--- a/app/controllers/sign_up/confirmations_controller.rb
+++ b/app/controllers/sign_up/confirmations_controller.rb
@@ -1,23 +1,10 @@
 module SignUp
   class ConfirmationsController < Devise::ConfirmationsController
     include ValidEmailParameter
+    include UnconfirmedUserConcern
 
     def new
       @user = User.new
-    end
-
-    def confirm
-      with_unconfirmed_user do
-        result = @password_form.submit(permitted_params)
-
-        analytics.track_event(Analytics::PASSWORD_CREATION, result)
-
-        if result[:success]
-          process_successful_password_creation
-        else
-          process_unsuccessful_password_creation
-        end
-      end
     end
 
     def show
@@ -35,27 +22,6 @@ module SignUp
     end
 
     protected
-
-    def with_unconfirmed_user
-      token = params[:confirmation_token]
-
-      @user = User.find_or_initialize_with_error_by(:confirmation_token, token)
-      @user = User.confirm_by_token(token) if @user.confirmed?
-      @password_form = PasswordForm.new(@user)
-
-      yield
-    end
-
-    def process_successful_password_creation
-      @user.confirm
-      @user.update(reset_requested_at: nil, password: permitted_params[:password])
-      sign_in_and_redirect_user
-    end
-
-    def process_unsuccessful_password_creation
-      @confirmation_token = params[:confirmation_token]
-      render :show
-    end
 
     def process_successful_confirmation
       if !@user.confirmed?
@@ -99,27 +65,6 @@ module SignUp
         @user.decorate.confirmation_period_expired_error
       else
         t('errors.messages.confirmation_invalid_token')
-      end
-    end
-
-    private
-
-    def permitted_params
-      params.require(:password_form).permit(:confirmation_token, :password)
-    end
-
-    def sign_in_and_redirect_user
-      sign_in @user
-      redirect_to after_confirmation_path_for(@user)
-    end
-
-    def after_confirmation_path_for(user)
-      if !user_signed_in?
-        new_user_session_url
-      elsif user.two_factor_enabled?
-        profile_path
-      else
-        phone_setup_url
       end
     end
   end

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -29,7 +29,7 @@ module SignUp
 
     def process_unsuccessful_password_creation
       @confirmation_token = params[:confirmation_token]
-      render :show
+      render 'sign_up/confirmations/show'
     end
 
     def sign_in_and_redirect_user

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -1,0 +1,40 @@
+module SignUp
+  class PasswordsController < ApplicationController
+    include UnconfirmedUserConcern
+
+    def create
+      with_unconfirmed_user do
+        result = @password_form.submit(permitted_params)
+        analytics.track_event(Analytics::PASSWORD_CREATION, result)
+
+        if result[:success]
+          process_successful_password_creation
+        else
+          process_unsuccessful_password_creation
+        end
+      end
+    end
+
+    private
+
+    def permitted_params
+      params.require(:password_form).permit(:confirmation_token, :password)
+    end
+
+    def process_successful_password_creation
+      @user.confirm
+      @user.update(reset_requested_at: nil, password: permitted_params[:password])
+      sign_in_and_redirect_user
+    end
+
+    def process_unsuccessful_password_creation
+      @confirmation_token = params[:confirmation_token]
+      render :show
+    end
+
+    def sign_in_and_redirect_user
+      sign_in @user
+      redirect_to after_confirmation_path_for(@user)
+    end
+  end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -11,12 +11,12 @@ table.button.expanded.large.radius
               td
                 center
                   = link_to t('mailer.confirmation_instructions.link_text'), \
-                    confirmation_url(@resource, confirmation_token: @token), target: '_blank', \
+                    user_confirmation_url(confirmation_token: @token), target: '_blank', \
                     class: 'float-center', align: 'center'
       td.expander
 
-p = link_to confirmation_url(@resource, confirmation_token: @token), \
-    confirmation_url(@resource, confirmation_token: @token), target: '_blank'
+p = link_to user_confirmation_url(confirmation_token: @token), \
+    user_confirmation_url(confirmation_token: @token), target: '_blank'
 
 table.spacer
   tbody

--- a/app/views/sign_up/confirmations/new.html.slim
+++ b/app/views/sign_up/confirmations/new.html.slim
@@ -4,7 +4,7 @@
 h1.h3.my0 = t('headings.confirmations.new')
 = simple_form_for(@user,
                   as: :user,
-                  url: confirmation_path(:user),
+                  url: sign_up_register_again_url,
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.input :email, required: true
   = f.button :submit, t('forms.buttons.resend_confirmation'), class: 'mt2 mb1'

--- a/app/views/sign_up/confirmations/show.html.slim
+++ b/app/views/sign_up/confirmations/show.html.slim
@@ -10,7 +10,7 @@ p.mb0
   = t('instructions.password.info.point_2')
 = simple_form_for(@password_form,
     url: sign_up_create_password_path,
-    method: :patch,
+    method: :post,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.input :password, required: true,
       input_html: { 'aria-describedby': 'password-description' }

--- a/app/views/sign_up/confirmations/show.html.slim
+++ b/app/views/sign_up/confirmations/show.html.slim
@@ -9,7 +9,7 @@ p.my2#password-description
 p.mb0
   = t('instructions.password.info.point_2')
 = simple_form_for(@password_form,
-    url: confirm_path,
+    url: sign_up_create_password_path,
     method: :patch,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.input :password, required: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,7 @@ Rails.application.routes.draw do
 
   # Devise handles login itself. It's first in the chain to avoid a redirect loop during
   # authentication failure.
-  devise_for :users, skip: [:sessions, :registrations], controllers: {
-    confirmations: 'users/confirmations',
+  devise_for :users, skip: [:confirmations, :sessions, :registrations], controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',
     passwords: 'users/passwords'
   }
@@ -22,11 +21,13 @@ Rails.application.routes.draw do
     post '/sign_up/register' => 'sign_up/registrations#create', as: :sign_up_register
     get '/sign_up/start' => 'sign_up/registrations#show', as: :sign_up_start
     get '/sign_up/verify_email' => 'sign_up/emails#show', as: :sign_up_verify_email
+    get '/sign_up/create_password' => 'sign_up/confirmations#show', as: :user_confirmation
+    get '/sign_up/enter_email_again' => 'sign_up/confirmations#new', as: :new_user_confirmation
+    post '/sign_up/register_again' => 'sign_up/confirmations#create', as: :sign_up_register_again
+    patch '/sign_up/create_password' => 'sign_up/confirmations#confirm'
 
     get 'active'  => 'users/sessions#active'
     get 'timeout' => 'users/sessions#timeout'
-
-    patch '/confirm' => 'users/confirmations#confirm'
 
     get '/phone_setup' => 'devise/two_factor_authentication_setup#index'
     patch '/phone_setup' => 'devise/two_factor_authentication_setup#set'
@@ -65,6 +66,7 @@ Rails.application.routes.draw do
         via: [:get, :post, :delete],
         as: :destroy_user_session
   match '/api/saml/auth' => 'saml_idp#auth', via: [:get, :post]
+
   match '/api/voice/otp/:code' => 'voice/otp#show',
         via: [:get, :post],
         as: :voice_otp,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
     get '/sign_up/create_password' => 'sign_up/confirmations#show', as: :user_confirmation
     get '/sign_up/enter_email_again' => 'sign_up/confirmations#new', as: :new_user_confirmation
     post '/sign_up/register_again' => 'sign_up/confirmations#create', as: :sign_up_register_again
-    patch '/sign_up/create_password' => 'sign_up/confirmations#confirm'
+    post '/sign_up/create_password' => 'sign_up/passwords#create', as: :sign_up_create_password
 
     get 'active'  => 'users/sessions#active'
     get 'timeout' => 'users/sessions#timeout'

--- a/spec/controllers/sign_up/confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/confirmations_controller_spec.rb
@@ -117,67 +117,6 @@ describe SignUp::ConfirmationsController, devise: true do
     end
   end
 
-  describe 'initial password creation' do
-    it 'tracks a valid password event' do
-      user = create(:user, :unconfirmed)
-      token, = Devise.token_generator.generate(User, :confirmation_token)
-      user.update(
-        confirmation_token: token, confirmation_sent_at: Time.current
-      )
-
-      stub_analytics
-
-      analytics_hash = {
-        success: true,
-        errors: [],
-        user_id: user.uuid
-      }
-
-      expect(@analytics).to receive(:track_event).
-        with(Analytics::PASSWORD_CREATION, analytics_hash)
-
-      patch :confirm, password_form: { password: 'NewVal!dPassw0rd' }, confirmation_token: token
-
-      expect(user.reload.valid_password?('NewVal!dPassw0rd')).to eq true
-    end
-
-    it 'tracks an invalid password event' do
-      user = create(:user, :unconfirmed)
-      token, = Devise.token_generator.generate(User, :confirmation_token)
-      user.update(
-        confirmation_token: token, confirmation_sent_at: Time.current
-      )
-
-      stub_analytics
-
-      analytics_hash = {
-        success: false,
-        errors: ['is too short (minimum is 8 characters)'],
-        user_id: user.uuid
-      }
-
-      expect(@analytics).to receive(:track_event).
-        with(Analytics::PASSWORD_CREATION, analytics_hash)
-
-      patch :confirm, password_form: { password: 'NewVal' }, confirmation_token: token
-    end
-
-    it 'calls PasswordForm#submit' do
-      form = instance_double(PasswordForm)
-      allow(PasswordForm).to receive(:new).and_return(form)
-
-      analytics_hash = {
-        success: true,
-        errors: []
-      }
-
-      expect(form).to receive(:submit).with(password: 'password').
-        and_return(analytics_hash)
-
-      patch :confirm, password_form: { password: 'password' }, confirmation_token: 'foo'
-    end
-  end
-
   describe 'User confirms new email' do
     it 'tracks the event' do
       user = create(:user, :signed_up)

--- a/spec/controllers/sign_up/confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/confirmations_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Users::ConfirmationsController, devise: true do
+describe SignUp::ConfirmationsController, devise: true do
   describe 'Invalid email confirmation tokens' do
     before do
       stub_analytics

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe SignUp::PasswordsController do
+  describe '#create' do
+    it 'tracks a valid password event' do
+      user = create(:user, :unconfirmed)
+      token, = Devise.token_generator.generate(User, :confirmation_token)
+      user.update(
+        confirmation_token: token, confirmation_sent_at: Time.current
+      )
+
+      stub_analytics
+
+      analytics_hash = {
+        success: true,
+        errors: [],
+        user_id: user.uuid
+      }
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::PASSWORD_CREATION, analytics_hash)
+
+      post :create, password_form: { password: 'NewVal!dPassw0rd' }, confirmation_token: token
+
+      expect(user.reload.valid_password?('NewVal!dPassw0rd')).to eq true
+    end
+
+    it 'tracks an invalid password event' do
+      user = create(:user, :unconfirmed)
+      token, = Devise.token_generator.generate(User, :confirmation_token)
+      user.update(
+        confirmation_token: token, confirmation_sent_at: Time.current
+      )
+
+      stub_analytics
+
+      analytics_hash = {
+        success: false,
+        errors: ['is too short (minimum is 8 characters)'],
+        user_id: user.uuid
+      }
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::PASSWORD_CREATION, analytics_hash)
+
+      post :create, password_form: { password: 'NewVal' }, confirmation_token: token
+    end
+
+    it 'calls PasswordForm#submit' do
+      form = instance_double(PasswordForm)
+      allow(PasswordForm).to receive(:new).and_return(form)
+
+      analytics_hash = {
+        success: true,
+        errors: []
+      }
+
+      expect(form).to receive(:submit).with(password: 'password').
+        and_return(analytics_hash)
+
+      post :create, password_form: { password: 'password' }, confirmation_token: 'foo'
+    end
+  end
+end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Sign Up' do
   context 'confirmation token error message does not persist on success' do
     scenario 'with no or invalid token' do
-      visit '/users/confirmation?confirmation_token='
+      visit user_confirmation_url(confirmation_token: '')
       expect(page).to have_content t('errors.messages.confirmation_invalid_token')
 
       sign_up

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -25,7 +25,7 @@ feature 'Email confirmation during sign up' do
     expect(user.reset_requested_at).to be_nil
   end
 
-  scenario 'user cannot access users/confirmations' do
+  scenario 'user cannot access sign_up/confirmations' do
     visit user_confirmation_path
 
     expect(page).to have_content t('errors.messages.confirmation_invalid_token')
@@ -51,7 +51,7 @@ feature 'Email confirmation during sign up' do
 
   scenario 'visitor signs up but confirms with an invalid token' do
     create(:user, :unconfirmed)
-    visit '/users/confirmation?confirmation_token=invalid_token'
+    visit user_confirmation_path(confirmation_token: 'invalid_token')
 
     expect(page).to have_content t('errors.messages.confirmation_invalid_token')
     expect(current_path).to eq user_confirmation_path
@@ -123,10 +123,11 @@ feature 'Email confirmation during sign up' do
       sign_up_and_set_password
 
       visit destroy_user_session_url
-      visit "/users/confirmation?confirmation_token=#{@raw_confirmation_token}"
+      visit user_confirmation_url(confirmation_token: @raw_confirmation_token)
 
-      expect(page).
-        to have_content t('devise.confirmations.already_confirmed', action: 'Please sign in.')
+      expect(page).to have_content(
+        t('devise.confirmations.already_confirmed', action: 'Please sign in.')
+      )
       expect(current_url).to eq new_user_session_url
     end
   end

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -8,7 +8,7 @@ feature 'Visitor sets password during signup' do
     click_button t('forms.buttons.submit.default')
 
     expect(page).to have_content t('errors.messages.blank')
-    expect(current_url).to eq confirm_url
+    expect(current_url).to eq user_confirmation_url
   end
 
   context 'password field is blank when JS is on', js: true do
@@ -81,7 +81,7 @@ feature 'Visitor sets password during signup' do
       click_button t('forms.buttons.submit.default')
 
       expect(page).to have_content('characters')
-      expect(current_url).to eq confirm_url
+      expect(current_url).to eq user_confirmation_url
     end
 
     scenario 'visitor gets password help message' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -80,7 +80,7 @@ module Features
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current
       )
       visit "/sign_up/create_password?confirmation_token=#{@raw_confirmation_token}"
-      # visit user_confirmation_url(confirmation_token: @raw_confirmation_token)
+      # visit user_confirmation_path(confirmation_token: @raw_confirmation_token)
     end
 
     def sign_up_and_2fa

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -74,13 +74,12 @@ module Features
     end
 
     def confirm_last_user
-      @raw_confirmation_token = Devise.token_generator.generate(User, :confirmation_token)
+      @raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
 
       User.last.update(
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current
       )
-      visit "/sign_up/create_password?confirmation_token=#{@raw_confirmation_token}"
-      # visit user_confirmation_path(confirmation_token: @raw_confirmation_token)
+      visit user_confirmation_path(confirmation_token: @raw_confirmation_token)
     end
 
     def sign_up_and_2fa

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -79,7 +79,8 @@ module Features
       User.last.update(
         confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.current
       )
-      visit "/users/confirmation?confirmation_token=#{@raw_confirmation_token}"
+      visit "/sign_up/create_password?confirmation_token=#{@raw_confirmation_token}"
+      # visit user_confirmation_url(confirmation_token: @raw_confirmation_token)
     end
 
     def sign_up_and_2fa

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -21,8 +21,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     render
 
     expect(rendered).to have_link(
-      'http://test.host/users/confirmation?confirmation_token=foo',
-      href: 'http://test.host/users/confirmation?confirmation_token=foo'
+      'http://test.host/sign_up/create_password?confirmation_token=foo',
+      href: 'http://test.host/sign_up/create_password?confirmation_token=foo'
     )
   end
 

--- a/spec/views/sign_up/confirmations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/confirmations/show.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'users/confirmations/show.html.slim' do
+describe 'sign_up/confirmations/show.html.slim' do
   before do
     user = build_stubbed(:user, :signed_up)
     @password_form = PasswordForm.new(user)


### PR DESCRIPTION
**Why**:
* URLs were not consistent
* Felt mysterious because they were coming from Devise
* Now they are explicit and user-friendly