### PR TITLE
Log a message in WorkerHealthChecker.check

### DIFF
--- a/app/services/worker_health_checker.rb
+++ b/app/services/worker_health_checker.rb
@@ -50,6 +50,7 @@ module WorkerHealthChecker
   # Called on an interval to check background queue health and report errors to NewRelic
   # @see deploy/schedule.rb
   def check
+    Rails.logger.info(source: "#{self}.check", event: 'checking background queues')
     statuses.reject(&:healthy?).each do |status|
       NewRelic::Agent.notice_error(
         QueueHealthError.new("Background queue #{status.queue} is unhealthy")

--- a/spec/services/worker_health_checker_spec.rb
+++ b/spec/services/worker_health_checker_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe WorkerHealthChecker do
         expect(NewRelic::Agent).to_not receive(:notice_error)
         check
       end
+
+      it 'logs a message so we can audit that the job is running in our logs' do
+        expect(Rails.logger).to receive(:info).
+          with(hash_including(event: 'checking background queues'))
+
+        check
+      end
     end
 
     context 'successful jobs have run in some queues' do


### PR DESCRIPTION
**Why**: So we can audit that the cronjob is actually running

cc @jgrevich 