### PR TITLE
Fix javascript ms formatter

### DIFF
--- a/app/assets/javascripts/app/utils/ms-formatter.js
+++ b/app/assets/javascripts/app/utils/ms-formatter.js
@@ -3,7 +3,7 @@ function formatMinutes(minutes) {
 }
 
 function formatSeconds(seconds) {
-  return seconds < 10 ? `0{seconds}` : seconds;
+  return seconds < 10 ? `0${seconds}` : seconds;
 }
 
 export default (milliseconds) => {


### PR DESCRIPTION
**Why**: Interpolation typo

Found this was broken while investigating other timeout stuff.

![img](https://cloud.githubusercontent.com/assets/458784/20991903/cade58c8-bc95-11e6-96a5-505e450250b0.png)

I was going to add a features spec that just used `page.evaluate_script` but unfortunately due the way we compile JS, I could not figure out how to grab this function from inside the IIFE that we compile things to.

Is it time to add node tests or something to get better test coverage of stuff like this?