### PR TITLE
Remove second autoLogout() call

### DIFF
--- a/app/assets/javascripts/app/utils/countdown-timer.js
+++ b/app/assets/javascripts/app/utils/countdown-timer.js
@@ -1,5 +1,4 @@
 import msFormatter from './ms-formatter';
-import autoLogout from './auto-logout';
 
 export default (targetSelector, timeLeft = 0, interval = 1000) => {
   const countdownTarget = document.querySelector(targetSelector);
@@ -11,7 +10,6 @@ export default (targetSelector, timeLeft = 0, interval = 1000) => {
     countdownTarget.innerHTML = msFormatter(remaining);
 
     if (remaining <= 0) {
-      autoLogout();
       return;
     }
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -52,7 +52,7 @@ html lang="#{I18n.locale}"
   #session-timeout-cntnr
   - if current_user
     = auto_session_timeout_js
-  -else
+  - else
     = auto_session_expired_js
 
   - if FeatureManagement.enable_i18n_mode?


### PR DESCRIPTION
**Why**:
We were being logged out twice and clearing the flash, so we
were not able to show the "you've been logged out" banner

---

Before:

I could not reliably get the "you've been signed out" banner to appear, because with `autoLogout` being called twice (once in `_ping.js.erb` and once inside the countdown timer) there were two requests to `/timeout` and the flash message set inside `/timeout` was being cleared by the second request

After:

With only one call to `/timeout`, this reliably appears:

![screen_shot_2016-12-08_at_10_21_51_am](https://cloud.githubusercontent.com/assets/458784/21028933/3abc927a-bd4c-11e6-9529-07787aa67348.png)
