### PR TITLE
Make sure the 2FA pages don't error without a session

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -19,6 +19,10 @@ module TwoFactorAuthenticatable
   end
 
   def check_already_authenticated
+    unless user_session
+      redirect_to new_user_session_path
+      return
+    end
     return unless context == 'authentication'
 
     redirect_to profile_path if user_fully_authenticated?

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -89,6 +89,16 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
         end
       end
     end
+
+    context 'when there is no session (signed out or locked out), and the user reloads the page' do
+      it 'redirects to the home page' do
+        expect(controller.user_session).to be_nil
+
+        get :show
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe '#send_code' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -42,6 +42,16 @@ describe TwoFactorAuthentication::OtpVerificationController, devise: true do
 
       get :show, delivery_method: 'sms'
     end
+
+    context 'when there is no session (signed out or locked out), and the user reloads the page' do
+      it 'redirects to the home page' do
+        expect(controller.user_session).to be_nil
+
+        get :show, delivery_method: 'sms'
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -22,6 +22,16 @@ describe TwoFactorAuthentication::RecoveryCodeController do
       expect(response).to redirect_to profile_path
     end
 
+    context 'when there is no session (signed out or locked out), and the user reloads the page' do
+      it 'redirects to the home page' do
+        expect(controller.user_session).to be_nil
+
+        get :show
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
     context 'LOA3 user' do
       it 're-encrypts PII using new code' do
         profile = create(:profile, :active, :verified, pii: { ssn: '1234' })

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 describe TwoFactorAuthentication::RecoveryCodeVerificationController, devise: true do
+  describe '#show' do
+    context 'when there is no session (signed out or locked out), and the user reloads the page' do
+      it 'redirects to the home page' do
+        expect(controller.user_session).to be_nil
+
+        get :show
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
   describe '#create' do
     context 'when the user enters a valid recovery code' do
       before do


### PR DESCRIPTION
**Why**:
Currently, viewing the 2FA URL /login/two-factor/authenticator
without a session (which can also occur after clicking "refresh"
when the session times out on the OTP lockout page) causes a 500.
This is bad, and we can handle it by redirecting.