### PR TITLE
Simplify logged out behavior in 2FA controllers

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -2,13 +2,17 @@ module TwoFactorAuthenticatable
   extend ActiveSupport::Concern
 
   included do
-    prepend_before_action :authenticate_user!
+    before_action :authenticate_user
     before_action :handle_two_factor_authentication
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
   end
 
   private
+
+  def authenticate_user
+    authenticate_user!(force: true)
+  end
 
   def handle_second_factor_locked_user
     analytics.track_event(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
@@ -19,10 +23,6 @@ module TwoFactorAuthenticatable
   end
 
   def check_already_authenticated
-    unless user_session
-      redirect_to new_user_session_path
-      return
-    end
     return unless context == 'authentication'
 
     redirect_to profile_path if user_fully_authenticated?

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -5,7 +5,7 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
     it 'includes the appropriate before_actions' do
       expect(subject).to have_actions(
         :before,
-        :authenticate_user!,
+        :authenticate_user,
         :handle_two_factor_authentication,
         :check_already_authenticated
       )


### PR DESCRIPTION
**Why**: Clearer code, follow-up to #839

Takes @monfresh's [suggestion](https://github.com/18F/identity-idp/pull/839#issuecomment-266057923) from the previous PR and refactor.

The tests for this behavior were added in the previous PR, which is why there aren't any big test changes here.