### PR TITLE
Reworks how fallback OTP options are displayed

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -72,7 +72,6 @@ input::-webkit-inner-spin-button {
 .checkbox,
 .radio {
   cursor: pointer;
-  display: inline-block;
   padding-left: 24px;
   position: relative;
 }

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -11,7 +11,7 @@ body { -webkit-font-smoothing: antialiased; }
 .ls-05 { letter-spacing: .5px; }
 .ls-5 { letter-spacing: 5px; }
 
-.fs-12p { font-size: 12px; }
+.fs-14p { font-size: .875rem; }
 .fs-20p { font-size: 20px; }
 
 // given how similar & coupled these are, single line preferred

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -11,7 +11,6 @@ body { -webkit-font-smoothing: antialiased; }
 .ls-05 { letter-spacing: .5px; }
 .ls-5 { letter-spacing: 5px; }
 
-.fs-14p { font-size: .875rem; }
 .fs-20p { font-size: 20px; }
 
 // given how similar & coupled these are, single line preferred

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -167,8 +167,7 @@ module TwoFactorAuthenticatable
   end
 
   def resend_otp_code_path
-    otp_send_path(otp_delivery_selection_form:
-    {
+    otp_send_path(otp_delivery_selection_form: {
       otp_method: @delivery_method,
       resend: true
     })

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -155,6 +155,7 @@ module TwoFactorAuthenticatable
     @code_value = current_user.direct_otp if FeatureManagement.prefill_otp_codes?
     @delivery_method = params[:delivery_method]
     @reenter_phone_number_path = reenter_phone_number_path
+    @resend_otp_code_path = resend_otp_code_path
   end
 
   def display_phone_to_deliver_to
@@ -163,6 +164,14 @@ module TwoFactorAuthenticatable
     else
       user_session[:unconfirmed_phone]
     end
+  end
+
+  def resend_otp_code_path
+    otp_send_path(otp_delivery_selection_form:
+    {
+      otp_method: @delivery_method,
+      resend: true
+    })
   end
 
   def reenter_phone_number_path

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -168,9 +168,9 @@ module TwoFactorAuthenticatable
 
   def resend_otp_code_path
     otp_send_path(otp_delivery_selection_form: {
-      otp_method: @delivery_method,
-      resend: true
-    })
+                    otp_method: @delivery_method,
+                    resend: true
+                  })
   end
 
   def reenter_phone_number_path

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -34,8 +34,6 @@ module Devise
 
     def handle_valid_delivery_method(method)
       send_user_otp(method)
-      resent_message = t("notices.send_code.#{method}")
-      flash[:success] = resent_message if session[:code_sent].present?
       session[:code_sent] = 'true'
       redirect_to login_two_factor_path(delivery_method: method, reauthn: reauthn?)
     end

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -5,6 +5,11 @@ module TwoFactorAuthentication
 
     prepend_before_action :authenticate_scope!
 
+    def show
+      @delivery_method = 'recovery-code'
+      @delivery_method
+    end
+
     def create
       result = RecoveryCodeForm.new(current_user, params[:code]).submit
 

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -7,7 +7,6 @@ module TwoFactorAuthentication
 
     def show
       @delivery_method = 'recovery-code'
-      @delivery_method
     end
 
     def create

--- a/app/helpers/otp_helper.rb
+++ b/app/helpers/otp_helper.rb
@@ -7,7 +7,7 @@ module OtpHelper
     end
   end
 
-  def alternative_2fa_links
+  def fallback_2fa_links
     case @delivery_method
     when 'sms'
       "#{voice_fallback_link}#{totp_option_link}."
@@ -15,6 +15,8 @@ module OtpHelper
       "#{sms_fallback_link}#{totp_option_link}."
     when 'recovery-code'
       t('devise.two_factor_authentication.recovery_code_help', phone: phone_fallback_link)
+    else
+      ''
     end
   end
 

--- a/app/helpers/otp_helper.rb
+++ b/app/helpers/otp_helper.rb
@@ -1,0 +1,44 @@
+module OtpHelper
+  def phone_confirmation_instructions
+    if @delivery_method == 'sms'
+      t('instructions.2fa.confirm_code_sms', number: @phone_number)
+    elsif @delivery_method == 'voice'
+      t('instructions.2fa.confirm_code_voice', number: @phone_number)
+    end
+  end
+
+  def alternative_2fa_links
+    case @delivery_method
+    when 'sms'
+      "#{voice_fallback_link}#{totp_option_link}."
+    when 'voice'
+      "#{sms_fallback_link}#{get_totp_option_link}."
+    when 'recovery-code'
+      t('devise.two_factor_authentication.recovery_code_help', phone: phone_fallback_link)
+    end
+  end
+
+  private
+
+  def totp_option_link
+    auth_app_path = link_to(t('devise.two_factor_authentication.totp_name'),
+                            login_two_factor_authenticator_path)
+    t('links.phone_confirmation.auth_app', link: auth_app_path) if current_user.totp_enabled?
+  end
+
+  def phone_fallback_link
+    link_to(t('links.phone_confirmation.name'), user_two_factor_authentication_path)
+  end
+
+  def voice_fallback_link
+    t('links.phone_confirmation.sms_unavailable',
+      link: link_to(t('links.phone_confirmation.fallback_to_voice'),
+                    otp_send_path(otp_delivery_selection_form: { otp_method: :voice })))
+  end
+
+  def sms_fallback_link
+    t('links.phone_confirmation.voice_unavailable',
+      link: link_to(t('links.phone_confirmation.fallback_to_sms'),
+                    otp_send_path(otp_delivery_selection_form: { otp_method: :sms })))
+  end
+end

--- a/app/helpers/otp_helper.rb
+++ b/app/helpers/otp_helper.rb
@@ -12,18 +12,25 @@ module OtpHelper
     when 'sms'
       "#{voice_fallback_link}#{totp_option_link}."
     when 'voice'
-      "#{sms_fallback_link}#{get_totp_option_link}."
+      "#{sms_fallback_link}#{totp_option_link}."
     when 'recovery-code'
       t('devise.two_factor_authentication.recovery_code_help', phone: phone_fallback_link)
     end
   end
 
+  def authenticator_link
+    link_to(t('devise.two_factor_authentication.totp_name'), login_two_factor_authenticator_path)
+  end
+
+  def recovery_code_fallback_link
+    link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),
+            login_two_factor_recovery_code_path)
+  end
+
   private
 
   def totp_option_link
-    auth_app_path = link_to(t('devise.two_factor_authentication.totp_name'),
-                            login_two_factor_authenticator_path)
-    t('links.phone_confirmation.auth_app', link: auth_app_path) if current_user.totp_enabled?
+    t('links.phone_confirmation.auth_app', link: authenticator_link) if !current_user.totp_enabled?
   end
 
   def phone_fallback_link

--- a/app/helpers/otp_helper.rb
+++ b/app/helpers/otp_helper.rb
@@ -30,7 +30,7 @@ module OtpHelper
   private
 
   def totp_option_link
-    t('links.phone_confirmation.auth_app', link: authenticator_link) if !current_user.totp_enabled?
+    t('links.phone_confirmation.auth_app', link: authenticator_link) if current_user.totp_enabled?
   end
 
   def phone_fallback_link

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -29,3 +29,5 @@ p.mt-tiny.mb0#2fa-description
 .mt3
   p.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')
   p.mb1.italic == t('devise.two_factor_authentication.recovery_code_fallback.text', link: link)
+
+= render 'shared/cancel'

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -7,7 +7,7 @@ p.mt2.mb0#2fa-description
 = simple_form_for(@otp_delivery_selection_form,
     url: otp_send_path,
     method: :get,
-    role: 'form', html: {class: 'mt2 sm-mt2'}) do |f|
+    role: 'form', html: { class: 'mt2 sm-mt2' }) do |f|
   - if reauthn?
     = f.input :reauthn, as: :hidden, input_html: { value: 'true' }
   .mb2

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -13,11 +13,11 @@ p.mt2.mb0#2fa-description
   .mb2
     fieldset.border-none.mxn2
       legend.hide = t('devise.two_factor_authentication.otp_method.title')
-      label.radio.mb2.mr3
+      label.radio.mb2.mr3.block
         = f.radio_button :otp_method, 'sms', checked: true
         span.indicator
         = t('devise.two_factor_authentication.otp_method.sms')
-      label.radio.mb0
+      label.radio.mb0.block
         = f.radio_button :otp_method, 'voice'
         span.indicator
         = t('devise.two_factor_authentication.otp_method.voice')

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -2,18 +2,18 @@
 
 
 h1.h3.my0 = t('headings.choose_otp_delivery')
-p.mt-tiny.mb0#2fa-description
+p.mt2.mb0#2fa-description
   = t('devise.two_factor_authentication.choose_otp_delivery', phone: @phone_number)
 = simple_form_for(@otp_delivery_selection_form,
     url: otp_send_path,
     method: :get,
-    role: 'form', class: 'mt3 sm-mt4') do |f|
+    role: 'form', html: {class: 'mt2 sm-mt2'}) do |f|
   - if reauthn?
     = f.input :reauthn, as: :hidden, input_html: { value: 'true' }
-  .mb3
-    fieldset.border-none
+  .mb2
+    fieldset.border-none.mxn2
       legend.hide = t('devise.two_factor_authentication.otp_method.title')
-      label.radio.mb0.mr3
+      label.radio.mb2.mr3
         = f.radio_button :otp_method, 'sms', checked: true
         span.indicator
         = t('devise.two_factor_authentication.otp_method.sms')
@@ -21,13 +21,16 @@ p.mt-tiny.mb0#2fa-description
         = f.radio_button :otp_method, 'voice'
         span.indicator
         = t('devise.two_factor_authentication.otp_method.voice')
+
+  p.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn btn-primary btn-wide'
 
-- link = link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),
-  login_two_factor_recovery_code_path)
+- if current_user.totp_enabled?
+  .mt3
+    p == t('links.totp_confirmation', link: authenticator_link)
 
 .mt3
-  p.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')
-  p.mb1.italic == t('devise.two_factor_authentication.recovery_code_fallback.text', link: link)
+  p.mb3 == t('devise.two_factor_authentication.recovery_code_fallback.text',
+             link: recovery_code_fallback_link)
 
 = render 'shared/cancel'

--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -27,10 +27,9 @@ p.mt2.mb0#2fa-description
 
 - if current_user.totp_enabled?
   .mt3
-    p == t('links.totp_confirmation', link: authenticator_link)
+    p == t('links.totp_option', link: authenticator_link)
 
 .mt3
-  p.mb3 == t('devise.two_factor_authentication.recovery_code_fallback.text',
-             link: recovery_code_fallback_link)
+  = render 'shared/otp_fallbacks'
 
 = render 'shared/cancel'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -42,7 +42,7 @@ html lang="#{I18n.locale}"
     .site-wrap
       = render 'shared/i18n_mode' if FeatureManagement.enable_i18n_mode?
       = render 'shared/usa_banner'
-      - if signed_in?
+      - if user_fully_authenticated?
         = render 'shared/nav_auth'
       - else
         = render decorated_session.nav_partial

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,0 +1,3 @@
+.mt2
+  hr
+  = link_to t('links.cancel'), destroy_user_session_path, class: 'fs-14p'

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,3 +1,3 @@
 .mt2
   hr
-  = link_to t('links.cancel'), destroy_user_session_path, class: 'fs-14p'
+  = link_to t('links.cancel'), destroy_user_session_path, class: 'h5'

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -17,5 +17,3 @@ nav.bg-white
                 class: current_page?(profile_path) ? 'px1 bold gray text-decoration-none' : 'px1'
               = link_to t('links.sign_out'), destroy_user_session_path,
                 class: 'px1 border-left border-silver'
-        - else
-          = link_to t('links.cancel'), destroy_user_session_path

--- a/app/views/shared/_otp_fallbacks.html.slim
+++ b/app/views/shared/_otp_fallbacks.html.slim
@@ -1,6 +1,5 @@
-p.mt2 == alternative_2fa_links
+p.mt2 == fallback_2fa_links
 
 - unless @delivery_method == 'recovery-code'
   p == t('devise.two_factor_authentication.recovery_code_fallback.text',
-       link: link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),
-       login_two_factor_recovery_code_path))
+       link: recovery_code_fallback_link)

--- a/app/views/shared/_otp_fallbacks.html.slim
+++ b/app/views/shared/_otp_fallbacks.html.slim
@@ -1,0 +1,6 @@
+p.mt2 == alternative_2fa_links
+
+- unless @delivery_method == 'recovery-code'
+  p == t('devise.two_factor_authentication.recovery_code_fallback.text',
+       link: link_to(t('devise.two_factor_authentication.recovery_code_fallback.link'),
+       login_two_factor_recovery_code_path))

--- a/app/views/two_factor_authentication/_phone_confirmation_fallback.html.slim
+++ b/app/views/two_factor_authentication/_phone_confirmation_fallback.html.slim
@@ -1,7 +1,0 @@
-p.mb1
-  - if @delivery_method == 'sms'
-    = link_to t('links.phone_confirmation.fallback_to_voice'),
-      otp_send_path(otp_delivery_selection_form: { otp_method: :voice })
-  - elsif @delivery_method == 'voice'
-    = link_to t('links.phone_confirmation.fallback_to_sms'),
-      otp_send_path(otp_delivery_selection_form: { otp_method: :sms })

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -19,7 +19,7 @@ p.mt2.mb0#code-instructs
       'aria-describedby': 'code-instructs')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
-  p.mb1.fs-14p
+  p.mb1.h5
     = link_to(t('links.phone_confirmation.resend_code'), @resend_otp_code_path)
 
   - if user_session[:unconfirmed_phone]

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -4,8 +4,9 @@
   = render 'shared/progress_steps', active: 3
 
 h1.h3.my0 = t('devise.two_factor_authentication.header_text')
-p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
-  number: "<strong>#{@phone_number}</strong>")
+
+p.mt-tiny.mb0#code-instructs
+  = phone_confirmation_instructions
 
 = form_tag(:login_otp, method: :post, role: 'form', class: 'mt3 sm-mt4') do
   = hidden_field_tag(:reauthn, reauthn?)
@@ -18,14 +19,14 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
       'aria-describedby': 'code-instructs')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
-- resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,
-                                                            resend: true })
-- resend_link = link_to(t('links.two_factor_authentication.resend_code'), resend_uri)
-
-.mt3.mb1
-  = render 'two_factor_authentication/phone_confirmation_fallback'
-  p.mb1 == t('instructions.2fa.resend', link: resend_link)
+  p.mb1.fs-14p
+    = link_to(t('links.phone_confirmation.resend_code'), @resend_otp_code_path)
 
   - if user_session[:unconfirmed_phone]
     - update_number_link = link_to(t('forms.two_factor.try_again'), @reenter_phone_number_path)
     p.mb1 == t('instructions.2fa.wrong_number', link: update_number_link)
+
+.mt3.mb1
+  = render 'shared/otp_fallbacks'
+
+= render 'shared/cancel'

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -5,10 +5,10 @@
 
 h1.h3.my0 = t('devise.two_factor_authentication.header_text')
 
-p.mt-tiny.mb0#code-instructs
+p.mt2.mb0#code-instructs
   = phone_confirmation_instructions
 
-= form_tag(:login_otp, method: :post, role: 'form', class: 'mt3 sm-mt4') do
+= form_tag(:login_otp, method: :post, role: 'form', class: 'mt2 sm-mt3') do
   = hidden_field_tag(:reauthn, reauthn?)
   = label_tag 'code', \
     t('simple_form.required.html') + t('forms.two_factor.code'), \

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -10,4 +10,6 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
       class: 'block bold'
     = block_text_field_tag :code, '', required: true
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
-.mt1 = link_to t('forms.buttons.cancel'), user_two_factor_authentication_path
+
+= render 'shared/otp_fallbacks'
+= render 'shared/cancel'

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -23,3 +23,5 @@ p.mt-tiny.mb0#code-instructs = t('instructions.2fa.totp_intro_html', \
 
   == t('devise.two_factor_authentication.totp_fallback.text', sms_link: sms_link,
     voice_link: voice_link)
+
+= render 'shared/cancel'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -97,6 +97,11 @@ ignore_unused:
   - 'experiments.*'
   - 'event_types.*'
   - 'zxcvbn.*'
+  # HI! These are incorrectly reported as being unused. If they ever get removed,
+  # make sure to delete them from here
+  - 'links.phone_confirmation.fallback_to_sms'
+  - 'links.phone_confirmation.fallback_to_voice'
+  ##
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -101,7 +101,7 @@ en:
       choose_delivery_confirmation: >
         How would you like to receive your confirmation passcode for %{phone}?
       choose_otp_delivery: >
-        Please select how you would like to receive your one-time passcode for %{phone}
+        We will send it to %{phone}
       contact_administrator: Please contact your system administrator.
       header_text: Enter your passcode
       invalid_otp: >
@@ -113,9 +113,9 @@ en:
         passcode incorrectly too many times.
       otp_method:
         instruction: You can change your choice the next time you sign in
-        sms: Text message (SMS)
+        sms: Text message
         title: How would you like to receive your passcode?
-        voice: Phone call
+        voice: Voice call
       otp_phone_label: Phone number
       otp_phone_label_info: Mobile or landline okay
       otp_setup_html: >
@@ -135,10 +135,10 @@ en:
       recovery_code_help: Don't want to use a recovery code? Use
         your %{phone} instead.
       totp_fallback:
-        sms_link_text: text message
         text: >
           If you can’t use your authenticator app right now, you can get a
-          passcode  %{voice_link} or %{sms_link}.
+          passcode via %{voice_link} or %{sms_link}.
+        sms_link_text: text message
         voice_link_text: phone call
       totp_name: authenticator app
       totp_header_text: Enter your authenticator code

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -127,17 +127,20 @@ en:
       please_try_again_html: Please try again in %{time_remaining}.
       recovery_code_fallback:
         link: recovery code
-        text: Don’t have access to your phone? Use a %{link} instead.
+        text: Phone not available? Use your personal %{link} instead.
       recovery_code_header_text: Enter your recovery code
       recovery_code_prompt: >
         You can use this recovery code once. If you still need a code after
         signing in, go to your account settings page to get a new one.
+      recovery_code_help: Don't want to use a recovery code? Use
+        your %{phone} instead.
       totp_fallback:
-        sms_link_text: receive a code via text message
+        sms_link_text: text message
         text: >
-          If you can’t use your authenticator app right now you can %{sms_link}
-          or %{voice_link}.
-        voice_link_text: with a phone call
+          If you can’t use your authenticator app right now, you can get a
+          passcode  %{voice_link} or %{sms_link}.
+        voice_link_text: phone call
+      totp_name: authenticator app
       totp_header_text: Enter your authenticator code
       totp_info: Use any authenticator app to scan the QR code below.
       two_factor_setup: Add a phone number

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   headings:
-    choose_otp_delivery: Choose how you’d like to receive a one-time passcode
+    choose_otp_delivery: Choose how you’d like to receive a passcode
     confirmations:
       new: Send another confirmation email
     contact: Contact us

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -2,7 +2,7 @@
 en:
   instructions:
     2fa:
-      confirm_code_voice: We just called you at %{number} with the code.
+      confirm_code_voice: We are calling you at %{number} with the code.
       confirm_code_sms: We sent it in a text message to %{number}.
       totp_intro_html: >
         It should be in your authenticator app. If you have several accounts

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -2,11 +2,11 @@
 en:
   instructions:
     2fa:
-      confirm_code: We sent it to %{number}.
-      resend: Didn’t receive a code? %{link}
+      confirm_code_voice: We just called you at %{number} with the code.
+      confirm_code_sms: We sent it in a text message to %{number}.
       totp_intro_html: >
-        Enter the code from your authenticator app. If you have several accounts
-        set up in your app, enter the code corresponding to <strong>%{email}</strong> at
+        It should be in your authenticator app. If you have several accounts
+        set up, look for the one corresponding to <strong>%{email}</strong> at
         <strong>%{app}</strong>.
       wrong_number: Entered the wrong phone number? %{link}
     password:

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -17,6 +17,7 @@ en:
       resend_code: Send a new code
       fallback_to_sms: text message
       fallback_to_voice: phone call
+    totp_confirmation: You can also get a passcode via %{link}.
     privacy_policy: Privacy Policy
     resend: Send again
     sign_in: Sign in

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -10,12 +10,15 @@ en:
     passwords:
       forgot: Forgot your password?
     phone_confirmation:
-      fallback_to_sms: Send me a text message with the code instead
-      fallback_to_voice: Call me with the code instead
+      name: phone
+      auth_app: ' or %{link}'
+      voice_unavailable: If you can't take voice calls right now, you can get a passcode via %{link}
+      sms_unavailable: If you can't get text messages right now, you can get a passcode via %{link}
+      resend_code: Send a new code
+      fallback_to_sms: text message
+      fallback_to_voice: phone call
     privacy_policy: Privacy Policy
     resend: Send again
     sign_in: Sign in
     sign_out: Sign out
     cancel: Cancel
-    two_factor_authentication:
-      resend_code: Send a new one

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -17,7 +17,7 @@ en:
       resend_code: Send a new code
       fallback_to_sms: text message
       fallback_to_voice: phone call
-    totp_confirmation: You can also get a passcode via %{link}.
+    totp_option: You can also get a passcode via %{link}.
     privacy_policy: Privacy Policy
     resend: Send again
     sign_in: Sign in

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -10,9 +10,6 @@ en:
     phone_confirmation_successful: You confirmed your phone number. Now your account is more secure!
     resend_confirmation_email:
       success: We have resent your confirmation email.
-    send_code:
-      sms: We sent you a one-time passcode via text message.
-      voice: We will call you with your one-time passcode.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}

--- a/spec/controllers/devise/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/devise/two_factor_authentication_controller_spec.rb
@@ -148,15 +148,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
           expect(flash[:success]).to eq nil
         end
       end
-
-      context 'multiple requests' do
-        it 'notifies the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
-          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
-
-          expect(flash[:success]).to eq t('notices.send_code.sms')
-        end
-      end
     end
 
     context 'when selecting voice OTP delivery' do
@@ -203,15 +194,6 @@ describe Devise::TwoFactorAuthenticationController, devise: true do
           get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
 
           expect(flash[:success]).to eq nil
-        end
-      end
-
-      context 'multiple requests' do
-        it 'notifies the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-
-          expect(flash[:success]).to eq t('notices.send_code.voice')
         end
       end
     end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -92,9 +92,10 @@ feature 'Two Factor Authentication' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
       click_button t('forms.buttons.submit.default')
-      click_link t('links.two_factor_authentication.resend_code')
+      click_link t('links.phone_confirmation.resend_code')
 
-      expect(page).to have_content(t('notices.send_code.sms'))
+      expect(page).to have_content(t('instructions.2fa.confirm_code_sms',
+                                     number: '***-***-1212'))
     end
 
     scenario 'user does not have to focus on OTP field', js: true do

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -28,7 +28,7 @@ feature 'Phone confirmation during sign up' do
     end
 
     it 'allows user to resend confirmation code' do
-      click_link t('links.two_factor_authentication.resend_code')
+      click_link t('links.phone_confirmation.resend_code')
 
       expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
     end
@@ -46,7 +46,8 @@ feature 'Phone confirmation during sign up' do
     end
 
     it 'informs the user that the OTP code is sent to the phone' do
-      expect(page).to have_content(t('instructions.2fa.confirm_code', number: '+1 (555) 555-5555'))
+      expect(page).to have_content(t('instructions.2fa.confirm_code_sms',
+                                     number: '+1 (555) 555-5555'))
     end
   end
 
@@ -60,7 +61,8 @@ feature 'Phone confirmation during sign up' do
 
     it 'pretends the phone is valid and prompts to confirm the number' do
       expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
-      expect(page).to have_content(t('instructions.2fa.confirm_code', number: '+1 (202) 555-1212'))
+      expect(page).to have_content(t('instructions.2fa.confirm_code_sms',
+                                     number: '+1 (202) 555-1212'))
     end
 
     it 'does not confirm the new number with an invalid code' do

--- a/spec/helpers/otp_helper_spec.rb
+++ b/spec/helpers/otp_helper_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe OtpHelper do
+  describe '#phone_confirmation_instructions' do
+    let(:number) { '***-***-1212' }
+    context 'with SMS as the delivery method' do
+      it 'returns SMS instructions' do
+        helper.instance_variable_set(:@delivery_method, 'sms')
+        helper.instance_variable_set(:@phone_number, number)
+
+        output = t('instructions.2fa.confirm_code_sms', number: number)
+        expect(helper.phone_confirmation_instructions).to eq(output)
+      end
+    end
+
+    context 'with voice as the delivery method' do
+      it 'returns voice instructions' do
+        helper.instance_variable_set(:@delivery_method, 'voice')
+        helper.instance_variable_set(:@phone_number, number)
+
+        output = t('instructions.2fa.confirm_code_voice', number: number)
+
+        expect(helper.phone_confirmation_instructions).to eq(output)
+      end
+    end
+  end
+
+  describe '#fallback_2fa_links' do
+    before do
+      allow(helper).to receive(:current_user).and_return(User.new)
+    end
+
+    context 'with totp enabled' do
+      before do
+        allow(helper.current_user).to receive(:totp_enabled?).and_return(true)
+      end
+
+      it 'returns voice and optional auth app links when delivery is sms' do
+        helper.instance_variable_set(:@delivery_method, 'sms')
+
+        expect(helper.fallback_2fa_links).to match(/phone call/)
+        expect(helper.send(:totp_option_link)).not_to be_blank
+      end
+
+      it 'returns sms and optional auth app links when delivery is voice' do
+        helper.instance_variable_set(:@delivery_method, 'voice')
+
+        expect(helper.fallback_2fa_links).to match(/text message/)
+        expect(helper.send(:totp_option_link)).not_to be_blank
+      end
+    end
+
+    context 'without totp enabled' do
+      it 'returns voice link when delivery is sms' do
+        helper.instance_variable_set(:@delivery_method, 'sms')
+
+        expect(helper.fallback_2fa_links).to match(/phone call/)
+        expect(helper.send(:totp_option_link)).to be_blank
+      end
+
+      it 'returns sms link when delivery is voice' do
+        helper.instance_variable_set(:@delivery_method, 'voice')
+
+        expect(helper.fallback_2fa_links).to match(/text message/)
+        expect(helper.send(:totp_option_link)).to be_blank
+      end
+    end
+  end
+
+  it 'returns a link to the phone delivery page if method is recovery code' do
+    helper.instance_variable_set(:@delivery_method, 'recovery-code')
+    output = helper.fallback_2fa_links
+
+    expect(output).to have_xpath("//a[@href='#{user_two_factor_authentication_path}']")
+  end
+
+  it 'returns an empty string by default' do
+    expect(helper.fallback_2fa_links).to be_blank
+  end
+end

--- a/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
@@ -5,32 +5,31 @@ describe 'devise/two_factor_authentication/show.html.slim' do
     let(:user) { build_stubbed(:user, :signed_up) }
 
     before do
+      @phone_number = '***-***-1234'
       @otp_delivery_selection_form = OtpDeliverySelectionForm.new
       allow(view).to receive(:reauthn?).and_return(false)
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
     end
 
     it 'has a localized heading' do
-      render
-
       expect(rendered).to have_content t('headings.choose_otp_delivery')
     end
 
     it 'allows the user to select OTP delivery method' do
-      allow(view).to receive(:current_user).and_return(user)
-      render
-
       expect(rendered).to have_content t('devise.two_factor_authentication.otp_method.sms')
       expect(rendered).to have_content t('devise.two_factor_authentication.otp_method.voice')
     end
 
     it 'informs the user that an OTP will be sent to their number' do
-      allow(view).to receive(:current_user).and_return(user)
-      @phone_number = '***-***-1234'
+      content = "We will send it to #{@phone_number}"
+      expect(rendered).to have_content(t('headings.choose_otp_delivery'))
+      expect(rendered).to have_content content
+    end
 
-      render
-
-      expect(rendered).to have_content 'Please select how you would like to ' \
-      'receive your one-time passcode for ***-***-1234'
+    it 'provides the user with a link to cancel out of the process' do
+      expect(rendered).to have_link(t('links.cancel'), href: destroy_user_session_path)
     end
   end
 end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/application.html.slim' do
 
   before do
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
+    allow(view).to receive(:current_user).and_return(User.new)
   end
 
   context 'when i18n mode enabled' do

--- a/spec/views/shared/_nav_auth.html.slim_spec.rb
+++ b/spec/views/shared/_nav_auth.html.slim_spec.rb
@@ -45,9 +45,5 @@ describe 'shared/_nav_auth.html.slim' do
     it 'does not contain sign out link' do
       expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
     end
-
-    it 'does contain a link to cancel' do
-      expect(rendered).to have_link(t('links.cancel'), href: destroy_user_session_path)
-    end
   end
 end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -8,6 +8,10 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       allow(view).to receive(:current_user).and_return(User.new)
       controller.request.path_parameters[:delivery_method] = 'sms'
       @delivery_method = 'sms'
+      @resend_otp_code_path = otp_send_path(otp_delivery_selection_form: {
+                                              otp_method: 'sms',
+                                              resend: true
+                                            })
     end
 
     it 'has a localized title' do
@@ -22,13 +26,27 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       expect(rendered).to have_content t('devise.two_factor_authentication.header_text')
     end
 
-    it 'informs the user that an OTP has been sent to their number' do
-      user = build_stubbed(:user, :signed_up)
-      @phone_number = user.decorate.masked_two_factor_phone_number
+    context 'user chooses either sms or voice delivery' do
+      it 'informs the user that an OTP has been sent to their number via sms' do
+        user = build_stubbed(:user, :signed_up)
+        @phone_number = user.decorate.masked_two_factor_phone_number
 
-      render
+        render
 
-      expect(rendered).to have_content t('instructions.2fa.confirm_code', number: '***-***-1212')
+        expect(rendered).to have_content t('instructions.2fa.confirm_code_sms',
+                                           number: '***-***-1212')
+      end
+
+      it 'informs the user that an OTP has been sent to their number via voice' do
+        user = build_stubbed(:user, :signed_up)
+        @delivery_method = 'voice'
+        @phone_number = user.decorate.masked_two_factor_phone_number
+
+        render
+
+        expect(rendered).to have_content t('instructions.2fa.confirm_code_voice',
+                                           number: '***-***-1212')
+      end
     end
 
     it 'allows user to resend code' do
@@ -36,10 +54,22 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       expect(rendered).
         to have_link(
-          t('links.two_factor_authentication.resend_code'),
-          href: otp_send_path(otp_delivery_selection_form: { otp_method: 'sms',
-                                                             resend: true })
+          t('links.phone_confirmation.resend_code'), href: @resend_otp_code_path
         )
+    end
+
+    it 'allows the user to use an authenticator app if enabled' do
+      allow(view.current_user).to receive(:totp_enabled?).and_return(true)
+      render
+
+      expect(rendered).to have_link(t('devise.two_factor_authentication.totp_name'),
+                                    href: login_two_factor_authenticator_path)
+    end
+
+    it 'does not show the authenticator link if not enabled' do
+      render
+      expect(rendered).not_to have_link(t('devise.two_factor_authentication.totp_name'),
+                                        href: login_two_factor_authenticator_path)
     end
 
     context 'when @code_value is set' do

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -8,8 +8,9 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
 
     render
 
-    expect(rendered).to have_content 'Enter the code from your authenticator app.'
-    expect(rendered).to have_content "enter the code corresponding to #{user.email}"
+    expect(rendered).to have_content(t('devise.two_factor_authentication.totp_header_text'))
+    expect(rendered).to have_content(t('instructions.2fa.totp_intro_html'))
+    #expect(rendered).to have_content "enter the code corresponding to #{user.email}"
   end
 
   it 'allows the user to fallback to SMS and voice' do

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -9,8 +9,7 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
     render
 
     expect(rendered).to have_content(t('devise.two_factor_authentication.totp_header_text'))
-    expect(rendered).to have_content(t('instructions.2fa.totp_intro_html'))
-    #expect(rendered).to have_content "enter the code corresponding to #{user.email}"
+    expect(rendered).to have_content "look for the one corresponding to #{user.email} at login.gov"
   end
 
   it 'allows the user to fallback to SMS and voice' do


### PR DESCRIPTION
**Why**:

To provide users with an easy and consistent way to both select
their OTP code method, and bail out and start over.