### PR TITLE
Analytics: Track user before session times out

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -31,10 +31,9 @@ module Users
     end
 
     def timeout
-      if sign_out
-        analytics.track_event(Analytics::SESSION_TIMED_OUT)
-        flash[:timeout] = t('session_timedout')
-      end
+      analytics.track_event(Analytics::SESSION_TIMED_OUT)
+      sign_out
+      flash[:timeout] = t('session_timedout')
       redirect_to root_url
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -117,10 +117,13 @@ describe Users::SessionsController, devise: true do
     end
 
     it 'tracks the timeout' do
-      stub_analytics
       sign_in_as_user
+      current_user = controller.current_user
 
-      expect(@analytics).to receive(:track_event).with(Analytics::SESSION_TIMED_OUT)
+      analytics = instance_double(Analytics)
+      expect(Analytics).to receive(:new).
+        with(current_user, controller.request).and_return(analytics)
+      expect(analytics).to receive(:track_event).with(Analytics::SESSION_TIMED_OUT)
 
       get :timeout
     end


### PR DESCRIPTION
**Why**: In case we want to see whether or not a particular set of
users let their session time out more often than others.