### PR TITLE
Update confirm password page

### DIFF
--- a/app/views/mfa_confirmation/new.html.slim
+++ b/app/views/mfa_confirmation/new.html.slim
@@ -5,4 +5,5 @@ h1.h3.my0 = t('headings.passwords.confirm')
                   url: reauthn_user_password_path,
                   html: { autocomplete: 'off', role: 'form', method: 'post' }) do |f|
   = f.input :password, required: true
-  = f.button :submit, t('headings.passwords.confirm'), class: 'btn-wide mt2 mb4'
+  = f.button :submit, t('forms.buttons.continue'), class: 'btn-wide mt2'
+  .mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -53,7 +53,7 @@ en:
         why_verified: Why do I need a verified account?
     passwords:
       change: Change your password
-      confirm: Confirm your password to continue
+      confirm: Confirm your current password to continue
       forgot: Forgot your password?
     privacy_policy:
       authorities: Authorities

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -80,7 +80,7 @@ feature 'Changing authentication factor' do
     expect(current_path).to eq user_password_confirm_path
 
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
-    click_button t('headings.passwords.confirm')
+    click_button t('forms.buttons.continue')
 
     expect(current_path).to eq user_two_factor_authentication_path
 


### PR DESCRIPTION
**Why**: To add a cancel link and make heading more explicit

Before:
![screen shot 2016-12-12 at 4 16 15 pm](https://cloud.githubusercontent.com/assets/1178494/21117096/5522d70e-c086-11e6-9f64-2b98af22cc91.png)

After:
![screen shot 2016-12-12 at 4 15 25 pm](https://cloud.githubusercontent.com/assets/1178494/21117099/58bdcb08-c086-11e6-9a9b-472fbca600fd.png)
