### PR TITLE
User can only view recovery code 1x during sign up

### DIFF
--- a/app/controllers/concerns/recovery_code_concern.rb
+++ b/app/controllers/concerns/recovery_code_concern.rb
@@ -1,0 +1,12 @@
+module RecoveryCodeConcern
+  delegate :active_profile, to: :current_user
+
+  def create_new_code
+    if active_profile.present?
+      Pii::ReEncryptor.new(current_user, user_session).perform
+      active_profile.recovery_code
+    else
+      RecoveryCodeGenerator.new(current_user).create
+    end
+  end
+end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -139,7 +139,8 @@ module TwoFactorAuthenticatable
     elsif @updating_existing_number
       profile_path
     elsif decorated_user.should_acknowledge_recovery_code?(session)
-      settings_recovery_code_url
+      user_session[:first_time_recovery_code_view] = 'true'
+      sign_up_recovery_code_path
     else
       after_sign_in_path_for(current_user)
     end

--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -1,0 +1,25 @@
+module SignUp
+  class RecoveryCodesController < ApplicationController
+    include RecoveryCodeConcern
+
+    before_action :confirm_two_factor_authenticated
+    before_action :confirm_has_not_already_viewed_recovery_code
+
+    def show
+      user_session.delete(:first_time_recovery_code_view)
+      @code = create_new_code
+      analytics.track_event(Analytics::USER_REGISTRATION_RECOVERY_CODE_VISIT)
+    end
+
+    def update
+      redirect_to after_sign_in_path_for(current_user)
+    end
+
+    private
+
+    def confirm_has_not_already_viewed_recovery_code
+      return if user_session[:first_time_recovery_code_view].present?
+      redirect_to after_sign_in_path_for(current_user)
+    end
+  end
+end

--- a/app/controllers/two_factor_authentication/recovery_code_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_controller.rb
@@ -1,34 +1,13 @@
 module TwoFactorAuthentication
   class RecoveryCodeController < ApplicationController
+    include RecoveryCodeConcern
+
     before_action :confirm_two_factor_authenticated
 
     def show
       @code = create_new_code
-      analytics.track_event(Analytics::USER_REGISTRATION_RECOVERY_CODE_VISIT)
-    end
-
-    def acknowledge
-      redirect_to after_sign_in_path_for(current_user)
-    end
-
-    private
-
-    def create_new_code
-      if current_user.active_profile.present?
-        reencrypt_pii_recovery
-      else
-        generator = RecoveryCodeGenerator.new(current_user)
-        generator.create
-      end
-    end
-
-    def reencrypt_pii_recovery
-      profile = current_user.active_profile
-      cacher = Pii::Cacher.new(current_user, user_session)
-      pii_attributes = cacher.fetch
-      profile.encrypt_recovery_pii(pii_attributes)
-      profile.save!
-      profile.recovery_code
+      analytics.track_event(Analytics::PROFILE_RECOVERY_CODE_CREATE)
+      render '/sign_up/recovery_codes/show'
     end
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -56,6 +56,7 @@ class Analytics
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
+  PROFILE_RECOVERY_CODE_CREATE = 'Profile: Created new recovery code'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -8,7 +8,6 @@ module Pii
     def perform
       profile.encrypt_recovery_pii(pii_attributes)
       profile.save!
-      profile.recovery_code
     end
 
     private

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -1,0 +1,30 @@
+module Pii
+  class ReEncryptor
+    def initialize(user, user_session)
+      @user = user
+      @user_session = user_session
+    end
+
+    def perform
+      profile.encrypt_recovery_pii(pii_attributes)
+      profile.save!
+      profile.recovery_code
+    end
+
+    private
+
+    attr_reader :user, :user_session
+
+    def pii_attributes
+      cacher.fetch
+    end
+
+    def cacher
+      @_cacher ||= Pii::Cacher.new(user, user_session)
+    end
+
+    def profile
+      user.active_profile
+    end
+  end
+end

--- a/app/views/sign_up/recovery_codes/show.html.slim
+++ b/app/views/sign_up/recovery_codes/show.html.slim
@@ -4,5 +4,5 @@
 h1.h3.my0 = t('headings.recovery_code')
 p.mt-tiny.mb0 = t('instructions.recovery_code')
 .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @code
-= button_to(t('forms.buttons.continue'), acknowledge_recovery_code_path,
+= button_to(t('forms.buttons.continue'), sign_up_recovery_code_path,
   class: 'btn btn-primary btn-wide mb1')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,8 +56,6 @@ Rails.application.routes.draw do
         as: :voice_otp,
         defaults: { format: :xml }
 
-  post '/acknowledge_recovery_code' => 'two_factor_authentication/recovery_code#acknowledge'
-
   delete '/authenticator_setup' => 'users/totp_setup#disable', as: :disable_totp
   get '/authenticator_setup' => 'users/totp_setup#new'
   patch '/authenticator_setup' => 'users/totp_setup#confirm'
@@ -100,7 +98,9 @@ Rails.application.routes.draw do
 
   get '/settings/password' => 'users/edit_password#edit'
   patch '/settings/password' => 'users/edit_password#update'
-  get '/settings/recovery-code' => 'two_factor_authentication/recovery_code#show'
+  get '/settings/recovery_code' => 'two_factor_authentication/recovery_code#show'
+  get '/sign_up/recovery_code' => 'sign_up/recovery_codes#show'
+  post '/sign_up/recovery_code' => 'sign_up/recovery_codes#update'
 
   post '/sign_up/create_password' => 'sign_up/passwords#create', as: :sign_up_create_password
   get '/sign_up/email/confirm' => 'sign_up/email_confirmations#create',

--- a/spec/controllers/sign_up/recovery_codes_controller_spec.rb
+++ b/spec/controllers/sign_up/recovery_codes_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe SignUp::RecoveryCodesController do
+  describe '#update' do
+    it 'redirects to the profile page' do
+      stub_sign_in
+      subject.current_user.recovery_code = 'foo'
+
+      patch :update
+
+      expect(response).to redirect_to profile_path
+    end
+  end
+end

--- a/spec/controllers/sign_up/recovery_codes_controller_spec.rb
+++ b/spec/controllers/sign_up/recovery_codes_controller_spec.rb
@@ -13,6 +13,14 @@ describe SignUp::RecoveryCodesController do
 
       get :show
     end
+
+    it 'redirects the user on subsequent views' do
+      stub_sign_in
+      subject.user_session[:first_time_recovery_code_view] = 'true'
+
+      expect(get :show).not_to redirect_to(profile_path)
+      expect(get :show).to redirect_to(profile_path)
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/sign_up/recovery_codes_controller_spec.rb
+++ b/spec/controllers/sign_up/recovery_codes_controller_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 describe SignUp::RecoveryCodesController do
+  describe '#show' do
+    it 'tracks an analytics event' do
+      stub_analytics
+      stub_sign_in
+      subject.user_session[:first_time_recovery_code_view] = 'true'
+
+      expect(@analytics).to receive(:track_event).with(
+        Analytics::USER_REGISTRATION_RECOVERY_CODE_VISIT
+      )
+
+      get :show
+    end
+  end
+
   describe '#update' do
     it 'redirects to the profile page' do
       stub_sign_in

--- a/spec/controllers/sign_up/recovery_codes_controller_spec.rb
+++ b/spec/controllers/sign_up/recovery_codes_controller_spec.rb
@@ -18,8 +18,8 @@ describe SignUp::RecoveryCodesController do
       stub_sign_in
       subject.user_session[:first_time_recovery_code_view] = 'true'
 
-      expect(get :show).not_to redirect_to(profile_path)
-      expect(get :show).to redirect_to(profile_path)
+      expect(get(:show)).not_to redirect_to(profile_path)
+      expect(get(:show)).to redirect_to(profile_path)
     end
   end
 

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -22,25 +22,5 @@ describe TwoFactorAuthentication::RecoveryCodeController do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
-
-    context 'LOA3 user' do
-      it 're-encrypts PII using new code' do
-        profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
-        user = profile.user
-        stub_sign_in(user)
-
-        generator = RecoveryCodeGenerator.new(user)
-        allow(RecoveryCodeGenerator).to receive(:new).and_return(generator)
-
-        user.unlock_user_access_key(user.password)
-        cacher = Pii::Cacher.new(user, subject.user_session)
-        cacher.save(user.user_access_key, profile)
-        allow(Pii::Cacher).to receive(:new).and_return(cacher)
-
-        expect(user.active_profile).to receive(:save!).and_call_original
-
-        get :show
-      end
-    end
   end
 end

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -13,15 +13,6 @@ describe TwoFactorAuthentication::RecoveryCodeController do
       get :show
     end
 
-    it 'redirects to the profile page' do
-      stub_sign_in
-      subject.current_user.recovery_code = 'foo'
-
-      post :acknowledge
-
-      expect(response).to redirect_to profile_path
-    end
-
     context 'when there is no session (signed out or locked out), and the user reloads the page' do
       it 'redirects to the home page' do
         expect(controller.user_session).to be_nil

--- a/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_controller_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 describe TwoFactorAuthentication::RecoveryCodeController do
   describe '#show' do
+    it 'tracks an analytics event' do
+      stub_analytics
+      stub_sign_in
+
+      expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_RECOVERY_CODE_CREATE)
+
+      get :show
+    end
+
     it 'generates a new recovery code' do
       stub_sign_in
       generator = instance_double(RecoveryCodeGenerator)

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 feature 'View recovery code during sign up flow' do
-  scenario 'user can view recovery code' do
-    sign_up_and_view_recovery_code
-
-    expect(current_path).to eq('/sign_up/recovery_code')
-  end
-
   scenario 'user refreshes recovery code page' do
     sign_up_and_view_recovery_code
 

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature 'View recovery code during sign up flow' do
+  scenario 'user can view recovery code' do
+    sign_up_and_view_recovery_code
+
+    expect(current_path).to eq('/sign_up/recovery_code')
+  end
+
+  scenario 'user refreshes recovery code page' do
+    sign_up_and_view_recovery_code
+
+    visit sign_up_recovery_code_path
+
+    expect(current_path).to eq(profile_path)
+  end
+
+  def sign_up_and_view_recovery_code
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    sign_up_and_set_password
+    fill_in 'Phone', with: '202-555-1212'
+    click_button t('forms.buttons.send_passcode')
+    click_button t('forms.buttons.submit.default')
+  end
+end

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -20,7 +20,7 @@ feature 'Phone confirmation during sign up' do
       click_button t('forms.buttons.submit.default')
 
       expect(@user.reload.phone_confirmed_at).to be_present
-      expect(current_path).to eq settings_recovery_code_path
+      expect(current_path).to eq sign_up_recovery_code_path
 
       click_button t('forms.buttons.continue')
 

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Pii::ReEncryptor do
+  describe '#perform' do
+    it 're-encrypts PII using new code' do
+      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
+      user = profile.user
+      generator = RecoveryCodeGenerator.new(user)
+      allow(RecoveryCodeGenerator).to receive(:new).and_return(generator)
+
+      user.unlock_user_access_key(user.password)
+      user_session = {}
+      cacher = Pii::Cacher.new(user, user_session)
+      cacher.save(user.user_access_key, profile)
+      allow(Pii::Cacher).to receive(:new).and_return(cacher)
+
+      expect(user.active_profile).to receive(:save!).and_call_original
+
+      Pii::ReEncryptor.new(user, user_session).perform
+    end
+  end
+end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 describe Pii::ReEncryptor do
   describe '#perform' do
     it 're-encrypts PII using new code' do
-      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
-      user = profile.user
-      generator = RecoveryCodeGenerator.new(user)
-      allow(RecoveryCodeGenerator).to receive(:new).and_return(generator)
+      profile = build_stubbed(:profile, :active, :verified, pii: { ssn: '1234' })
+      user = build_stubbed(:user, profiles: [profile])
+      user_session = {
+        decrypted_pii: { ssn: '1234' }.to_json
+      }
 
-      user.unlock_user_access_key(user.password)
-      user_session = {}
-      cacher = Pii::Cacher.new(user, user_session)
-      cacher.save(user.user_access_key, profile)
-      allow(Pii::Cacher).to receive(:new).and_return(cacher)
+      pii_attributes = Pii::Attributes.new
+      pii_attributes[:ssn] = '1234'
 
+      expect(user.active_profile).to receive(:encrypt_recovery_pii).
+        with(pii_attributes).and_call_original
       expect(user.active_profile).to receive(:save!).and_call_original
 
       Pii::ReEncryptor.new(user, user_session).perform

--- a/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
+++ b/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'two_factor_authentication/recovery_code/show.html.slim' do
+describe 'sign_up/recovery_codes/show.html.slim' do
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('titles.recovery_code'))
 
@@ -25,7 +25,7 @@ describe 'two_factor_authentication/recovery_code/show.html.slim' do
     expect(rendered).
       to have_xpath("//input[@value='#{t('forms.buttons.continue')}']")
     expect(rendered).
-      to have_xpath("//form[@action='#{acknowledge_recovery_code_path}']")
+      to have_xpath("//form[@action='#{sign_up_recovery_code_path}']")
   end
 
   it 'displays the recovery code' do


### PR DESCRIPTION
**Why**: Re-visiting the page creates a new recovery code, which is
potentially confusing. Once someone has seen the recovery code during
the sign up flow, they will be redirected to the profile page if the pae
refreshes for any reason.

Note that this is *not* the behavior for the regular "create recovery
code" page that someone accesses after signup. In order to create
different behavior, I separated the two views into separate controllers.