### PR TITLE
Session Timeout Fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
     now = Time.zone.now
     session[:session_expires_at] = now + Devise.timeout_in
     session[:pinged_at] ||= now
+
+    flash.now[:timeout] = t('session_cleared') if request.query_parameters[:timeout]
   end
 
   def append_info_to_payload(payload)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -33,7 +33,9 @@ module Users
     def timeout
       analytics.track_event(Analytics::SESSION_TIMED_OUT)
       sign_out
-      flash[:timeout] = t('session_timedout')
+      flash[:timeout] = t('session_timedout',
+                          app: APP_NAME,
+                          minutes: Figaro.env.session_timeout_in_minutes)
       redirect_to root_url
     end
 

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -12,10 +12,10 @@ module SessionTimeoutWarningHelper
   end
 
   def timeout_refresh_url
-    url = URI(request.original_url)
-    query = Rack::Utils.parse_nested_query(url.query).with_indifferent_access
-    url.query = query.merge(timeout: true).to_query
-    url.to_s.html_safe
+    URI(request.original_url).tap do |url|
+      query = Rack::Utils.parse_nested_query(url.query).with_indifferent_access
+      url.query = query.merge(timeout: true).to_query
+    end.to_s
   end
 
   def auto_session_timeout_js

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -11,6 +11,13 @@ module SessionTimeoutWarningHelper
     (Figaro.env.session_timeout_warning_seconds || 30).to_i
   end
 
+  def timeout_refresh_url
+    url = URI(request.original_url)
+    query = Rack::Utils.parse_nested_query(url.query).with_indifferent_access
+    url.query = query.merge(timeout: true).to_query
+    url.to_s.html_safe
+  end
+
   def auto_session_timeout_js
     nonced_javascript_tag do
       render partial: 'session_timeout/ping',

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -25,7 +25,8 @@ module SessionTimeoutWarningHelper
              locals: {
                warning: warning,
                start: start,
-               frequency: frequency
+               frequency: frequency,
+               modal: modal
              }
     end
   end
@@ -43,6 +44,50 @@ module SessionTimeoutWarningHelper
 
   def time_left_in_session
     distance_of_time_in_words(warning)
+  end
+
+  def modal
+    if user_fully_authenticated?
+      FullySignedInModal.new(time_left_in_session)
+    else
+      PartiallySignedInModal.new(time_left_in_session)
+    end
+  end
+
+  FullySignedInModal = Struct.new(:time_left_in_session) do
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::TranslationHelper
+
+    def message
+      t('notices.timeout_warning.signed_in.message_html',
+        time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
+    end
+
+    def continue
+      t('notices.timeout_warning.signed_in.continue')
+    end
+
+    def sign_out
+      t('notices.timeout_warning.signed_in.sign_out')
+    end
+  end
+
+  PartiallySignedInModal = Struct.new(:time_left_in_session) do
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::TranslationHelper
+
+    def message
+      t('notices.timeout_warning.partially_signed_in.message_html',
+        time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
+    end
+
+    def continue
+      t('notices.timeout_warning.partially_signed_in.continue')
+    end
+
+    def sign_out
+      t('notices.timeout_warning.partially_signed_in.sign_out')
+    end
   end
 end
 

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -72,10 +72,7 @@ module SessionTimeoutWarningHelper
     end
   end
 
-  PartiallySignedInModal = Struct.new(:time_left_in_session) do
-    include ActionView::Helpers::TagHelper
-    include ActionView::Helpers::TranslationHelper
-
+  class PartiallySignedInModal < FullySignedInModal
     def message
       t('notices.timeout_warning.partially_signed_in.message_html',
         time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))

--- a/app/views/session_timeout/_expire_session.js.erb
+++ b/app/views/session_timeout/_expire_session.js.erb
@@ -1,14 +1,7 @@
 var sessionTimeoutIn = <%= session_timeout_in %> * 1000;
-var modal = "<%= j render('session_timeout/expired') %>";
 
-function displaySessionTimeoutModal() {
-  var inputs = document.querySelectorAll('input[type="submit"]'), i;
-  for (i = 0; i < inputs.length; ++i) {
-    inputs[i].disabled = true;
-  }
-
-  var container = document.getElementById('session-timeout-cntnr');
-  container.insertAdjacentHTML('afterbegin', modal);
+function refreshPage() {
+  document.location = "<%= j timeout_refresh_url %>";
 }
 
-setTimeout(displaySessionTimeoutModal, sessionTimeoutIn);
+setTimeout(refreshPage, sessionTimeoutIn);

--- a/app/views/session_timeout/_expired.html.slim
+++ b/app/views/session_timeout/_expired.html.slim
@@ -1,9 +1,0 @@
-#session-expired-msg
-  .modal-cntnr
-    .px2.py4.modal-inner
-      .mx-auto.p4.cntnr-skinny.border-box.bg-white.rounded.relative
-        = image_tag(asset_url('clock.svg'), class: 'modal-ico')
-        h3.mt0.mb2 = t('headings.session_timeout_warning')
-        p.mb3 = t('session_expired_html', \
-                link: link_to(t('session_expired_link'), request.original_url))
-        = link_to t('forms.buttons.continue'), request.original_url, class: 'btn btn-primary'

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,7 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
-var warning_info = "<%= j render('session_timeout/warning') %>";
+var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 
 function ping() {
   var request = new XMLHttpRequest();

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -4,9 +4,8 @@
       .mx-auto.p4.cntnr-skinny.border-box.bg-white.rounded.relative
         = image_tag(asset_url('clock.svg'), class: 'modal-ico')
         h3.mt0.mb2 = t('headings.session_timeout_warning')
-        p.mb3 == t('session_timeout_warning',
-                 time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
-        = link_to t('forms.buttons.continue_browsing'),
+        p.mb3 = modal.message
+        = link_to modal.continue,
           request.original_url, class: 'btn btn-primary'
-        = link_to t('forms.buttons.sign_out'),
+        = link_to modal.sign_out,
           destroy_user_session_path, class: 'ml2 btn btn-outline'

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -5,7 +5,6 @@ en:
       back: Back
       cancel: Cancel
       continue: Continue
-      continue_browsing: Keep me signed in
       disable: Disable
       edit: Edit
       enable: Enable
@@ -15,7 +14,6 @@ en:
       send: Send
       send_passcode: Send passcode
       setup_totp: Set up authentication app
-      sign_out: Sign me out
       submit:
         default: Submit
         next: Next

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -13,6 +13,19 @@ en:
     send_code:
       sms: We sent you a one-time passcode via text message.
       voice: We will call you with your one-time passcode.
+    timeout_warning:
+      signed_in:
+        continue: Keep me signed in
+        sign_out: Sign me out now
+        message_html: >
+          For your security, in %{time_left_in_session} we will automatically
+          sign you out unless you tell us to keep you signed in.
+      partially_signed_in:
+        continue: Continue signing in
+        sign_out: Cancel signing in
+        message_html: >
+          For your security, in %{time_left_in_session} we will automatically
+          cancel your sign in.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -34,8 +34,7 @@ en:
     use_diff_email:
       link: use a different email address
       text_html: Or, %{link}
-  session_expired_html: Please %{link} the page to log in.
-  session_expired_link: refresh
   session_timedout: >
     We signed you out. For your security, %{app} automatically ends your session when you’re idle or
     haven’t typed anything within %{minutes} minutes.
+  session_cleared: We cleared your information for your security.

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -37,6 +37,5 @@ en:
   session_expired_html: Please %{link} the page to log in.
   session_expired_link: refresh
   session_timedout: >
-    We signed you out due to inactivity. This helps keep your account safe.
-    Please sign in again.
-  session_timeout_warning: Your session will end in %{time_left_in_session} due to inactivity.
+    We signed you out. For your security, %{app} automatically ends your session when you’re idle or
+    haven’t typed anything within %{minutes} minutes.

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -104,7 +104,7 @@ describe Users::SessionsController, devise: true do
 
       get :timeout
 
-      expect(flash[:timeout]).to eq t('session_timedout')
+      expect(flash[:timeout]).to eq t('session_timedout', app: 'login.gov', minutes: 8)
       expect(subject.current_user).to be_nil
     end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -78,13 +78,13 @@ feature 'Sign in' do
     end
 
     scenario 'user can continue browsing' do
-      find_link(t('forms.buttons.continue_browsing')).trigger('click')
+      find_link(t('notices.timeout_warning.signed_in.continue')).trigger('click')
 
       expect(current_path).to eq profile_path
     end
 
     scenario 'user has option to sign out' do
-      click_link(t('forms.buttons.sign_out'))
+      click_link(t('notices.timeout_warning.signed_in.sign_out'))
 
       expect(page).to have_content t('devise.sessions.signed_out')
       expect(current_path).to eq new_user_session_path
@@ -92,7 +92,7 @@ feature 'Sign in' do
   end
 
   context 'user only signs in via email and password', js: true do
-    it 'displays the session timeout warning' do
+    it 'displays the session timeout warning with partially signed in copy' do
       allow(Figaro.env).to receive(:session_check_frequency).and_return('1')
       allow(Figaro.env).to receive(:session_check_delay).and_return('2')
       allow(Figaro.env).to receive(:session_timeout_warning_seconds).
@@ -103,6 +103,8 @@ feature 'Sign in' do
       visit user_two_factor_authentication_path
 
       expect(page).to have_css('#session-timeout-msg')
+      expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.continue'))
+      expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.sign_out'))
     end
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -107,27 +107,23 @@ feature 'Sign in' do
   end
 
   context 'signed out' do
-    it 'links to current page after session expires', js: true do
-      allow(Devise).to receive(:timeout_in).and_return(0)
+    it 'refreshes the current page after session expires', js: true do
+      allow(Devise).to receive(:timeout_in).and_return(1)
 
-      [t('forms.buttons.continue'), t('session_expired_link')].each do |link|
-        visit sign_up_email_path
-        fill_in 'Email', with: 'test@example.com'
+      visit sign_up_email_path
+      fill_in 'Email', with: 'test@example.com'
 
-        expect(page).to have_css('#session-expired-msg')
+      expect(page).to have_content(t('session_cleared'))
 
-        find_link(link).trigger('click')
-
-        expect(page).to have_field('Email', with: '')
-        expect(page).to have_current_path(sign_up_email_path)
-      end
+      expect(page).to have_field('Email', with: '')
+      expect(page).to have_current_path(sign_up_email_path(timeout: true))
     end
 
-    it 'does not display timeout modal when session not timed out', js: true do
+    it 'does not refresh the page after the session expires', js: true do
       allow(Devise).to receive(:timeout_in).and_return(60)
 
       visit root_path
-      expect(page).not_to have_css('#session-expired-msg')
+      expect(page).to_not have_content(t('session_cleared'))
     end
   end
 
@@ -155,15 +151,16 @@ feature 'Sign in' do
       end
     end
 
-    it 'displays the session timeout modal, does not allow the user to submit', js: true do
-      allow(Devise).to receive(:timeout_in).and_return(0)
+    it 'refreshes the page (which clears the form) and notifies the user', js: true do
+      allow(Devise).to receive(:timeout_in).and_return(1)
       user = create(:user)
       visit root_path
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
 
-      expect(page).to have_css('#session-expired-msg')
-      expect(page).to have_css('[type=submit][disabled]')
+      expect(page).to have_content(t('session_cleared'))
+      expect(find_field('Email').value).to be_blank
+      expect(find_field('Password').value).to be_blank
     end
   end
 

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/application.html.slim' do
 
   before do
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
+    allow(view.request).to receive(:original_url).and_return('http://test.host/foobar')
   end
 
   context 'when i18n mode enabled' do


### PR DESCRIPTION
This has 3 big changes (hence 3 commits) that correspond to updates in this flowchart diagram:

![img](https://cloud.githubusercontent.com/assets/458784/21068651/56b3e276-be28-11e6-90eb-6e8aa9e940a3.png)


1. Update copy when we've logged you
 out
  - as @monfresh points out, this may need some tweaking because the "you haven't typed anything" part is not true

<img width="857" alt="login_gov_-_welcome" src="https://cloud.githubusercontent.com/assets/458784/21150077/cecf2058-c12b-11e6-85f0-e45983748a57.png">


2. Replace the "need more time?" modal (that locked the screen) with behavior that refreshes the current page and notifies the user that we did so

<img width="1024" alt="login_gov_-_welcome" src="https://cloud.githubusercontent.com/assets/458784/21149989/8468fb24-c12b-11e6-85cf-1b83a8e490bd.png">


3. The 'need more time?' modal now has different copy for fully vs partially authenticated (2fa vs not) sessions

  - fully signed in:

<img width="901" alt="login_gov_-_profile" src="https://cloud.githubusercontent.com/assets/458784/21150141/f68ddd96-c12b-11e6-83f7-62a215551cd7.png">


  - partially signed in:

<img width="778" alt="login_gov_-_choose_otp_delivery_method" src="https://cloud.githubusercontent.com/assets/458784/21150052/b7dc2738-c12b-11e6-9799-5691aaa3676f.png">
