### PR TITLE
Update copy for the "we logged you out" flash banner

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -33,7 +33,9 @@ module Users
     def timeout
       analytics.track_event(Analytics::SESSION_TIMED_OUT)
       sign_out
-      flash[:timeout] = t('session_timedout')
+      flash[:timeout] = t('session_timedout',
+                          app: APP_NAME,
+                          minutes: Figaro.env.session_timeout_in_minutes)
       redirect_to root_url
     end
 

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -37,6 +37,6 @@ en:
   session_expired_html: Please %{link} the page to log in.
   session_expired_link: refresh
   session_timedout: >
-    We signed you out due to inactivity. This helps keep your account safe.
-    Please sign in again.
+    We signed you out. For your security, %{app} automatically ends your session
+    when you haven’t moved to a new page for %{minutes} minutes.
   session_timeout_warning: Your session will end in %{time_left_in_session} due to inactivity.

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -104,7 +104,9 @@ describe Users::SessionsController, devise: true do
 
       get :timeout
 
-      expect(flash[:timeout]).to eq t('session_timedout')
+      expect(flash[:timeout]).to eq t('session_timedout',
+                                      app: APP_NAME,
+                                      minutes: Figaro.env.session_timeout_in_minutes)
       expect(subject.current_user).to be_nil
     end
 


### PR DESCRIPTION
**Why**: To make it clearer

after:

![img](https://cloud.githubusercontent.com/assets/458784/21150077/cecf2058-c12b-11e6-85f0-e45983748a57.png)

We may want to tweak the copy further, as the bit about typing is not accurate.