### PR TITLE
Replace the logged out "Need more time?" modal

### DIFF
--- a/.reek
+++ b/.reek
@@ -52,6 +52,7 @@ TooManyStatements:
 TooManyMethods:
   exclude:
     - Users::ConfirmationsController
+    - ApplicationController
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
     now = Time.zone.now
     session[:session_expires_at] = now + Devise.timeout_in
     session[:pinged_at] ||= now
+
+    flash.now[:timeout] = t('notices.session_cleared') if request.query_parameters[:timeout]
   end
 
   def append_info_to_payload(payload)
@@ -91,5 +93,9 @@ class ApplicationController < ActionController::Base
 
   def prompt_to_enter_otp
     redirect_to user_two_factor_authentication_url
+  end
+
+  def skip_session_expiration
+    @skip_session_expiration = true
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  before_action :skip_session_expiration
+
   def page_not_found
     render layout: false, status: 404
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -4,6 +4,7 @@ module SignUp
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     before_action :require_no_authentication
+    before_action :skip_session_expiration, only: [:show]
     prepend_before_action :disable_account_creation, only: [:new, :create]
 
     def show

--- a/app/views/session_timeout/_expire_session.js.erb
+++ b/app/views/session_timeout/_expire_session.js.erb
@@ -1,14 +1,7 @@
 var sessionTimeoutIn = <%= session_timeout_in %> * 1000;
-var modal = "<%= j render('session_timeout/expired') %>";
 
-function displaySessionTimeoutModal() {
-  var inputs = document.querySelectorAll('input[type="submit"]'), i;
-  for (i = 0; i < inputs.length; ++i) {
-    inputs[i].disabled = true;
-  }
-
-  var container = document.getElementById('session-timeout-cntnr');
-  container.insertAdjacentHTML('afterbegin', modal);
+function refreshPage() {
+  document.location = "<%= j timeout_refresh_url %>";
 }
 
-setTimeout(displaySessionTimeoutModal, sessionTimeoutIn);
+setTimeout(refreshPage, sessionTimeoutIn);

--- a/app/views/session_timeout/_expired.html.slim
+++ b/app/views/session_timeout/_expired.html.slim
@@ -1,9 +1,0 @@
-#session-expired-msg
-  .modal-cntnr
-    .px2.py4.modal-inner
-      .mx-auto.p4.cntnr-skinny.border-box.bg-white.rounded.relative
-        = image_tag(asset_url('clock.svg'), class: 'modal-ico')
-        h3.mt0.mb2 = t('headings.session_timeout_warning')
-        p.mb3 = t('session_expired_html', \
-                link: link_to(t('session_expired_link'), request.original_url))
-        = link_to t('forms.buttons.continue'), request.original_url, class: 'btn btn-primary'

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -26,6 +26,7 @@ en:
         message_html: >
           For your security, in %{time_left_in_session} we will automatically
           cancel your sign in.
+    session_cleared: We cleared your information for your security.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}
@@ -47,8 +48,6 @@ en:
     use_diff_email:
       link: use a different email address
       text_html: Or, %{link}
-  session_expired_html: Please %{link} the page to log in.
-  session_expired_link: refresh
   session_timedout: >
     We signed you out. For your security, %{app} automatically ends your session
     when you haven’t moved to a new page for %{minutes} minutes.

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -14,8 +14,36 @@ describe SessionTimeoutWarningHelper do
         to eq distance_of_time_in_words(time_between_warning_and_timeout)
     end
   end
-end
 
-def time_between_warning_and_timeout
-  Figaro.env.session_timeout_warning_seconds.to_i
+  def time_between_warning_and_timeout
+    Figaro.env.session_timeout_warning_seconds.to_i
+  end
+
+  describe '#timeout_refresh_url' do
+    before { expect(helper).to receive(:request).and_return(double(original_url: original_url)) }
+
+    context 'with no query in the request url' do
+      let(:original_url) { 'http://test.host/foo/bar' }
+
+      it 'adds timeout=true params' do
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true')
+      end
+    end
+
+    context 'with params request url' do
+      let(:original_url) { 'http://test.host/foo/bar?key=value' }
+
+      it 'adds timeout=true param' do
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?key=value&timeout=true')
+      end
+    end
+
+    context 'with timeout=true in the query params already' do
+      let(:original_url) { 'http://test.host/foo/bar?timeout=true' }
+
+      it 'is the same' do
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true')
+      end
+    end
+  end
 end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/application.html.slim' do
 
   before do
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
+    allow(view.request).to receive(:original_url).and_return('http://test.host/foobar')
   end
 
   context 'when i18n mode enabled' do
@@ -32,6 +33,24 @@ describe 'layouts/application.html.slim' do
       render
 
       expect(view).to_not render_template(partial: '_i18n_mode')
+    end
+  end
+
+  context 'session expiration' do
+    it 'renders a javascript page refresh' do
+      render
+
+      expect(view).to render_template(partial: 'session_timeout/_expire_session')
+    end
+
+    context 'with skip_session_expiration' do
+      before { assign(:skip_session_expiration, true) }
+
+      it 'does not render a javascript page refresh' do
+        render
+
+        expect(view).to_not render_template(partial: 'session_timeout/_expire_session')
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: There's no action to take. We now refresh the page to renew
the CSRF, and then show a flash telling the user what happened.

after:

![img](https://cloud.githubusercontent.com/assets/458784/21149989/8468fb24-c12b-11e6-85cf-1b83a8e490bd.png)