### PR TITLE
Create separate timeout behavior for fully vs partially signed in

### DIFF
--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -18,7 +18,8 @@ module SessionTimeoutWarningHelper
              locals: {
                warning: warning,
                start: start,
-               frequency: frequency
+               frequency: frequency,
+               modal: modal
              }
     end
   end
@@ -36,6 +37,14 @@ module SessionTimeoutWarningHelper
 
   def time_left_in_session
     distance_of_time_in_words(warning)
+  end
+
+  def modal
+    if user_fully_authenticated?
+      FullySignedInModalPresenter.new(time_left_in_session)
+    else
+      PartiallySignedInModalPresenter.new(time_left_in_session)
+    end
   end
 end
 

--- a/app/presenters/fully_signed_in_modal_presenter.rb
+++ b/app/presenters/fully_signed_in_modal_presenter.rb
@@ -1,0 +1,14 @@
+class FullySignedInModalPresenter < SessionTimeoutWarningModalPresenter
+  def message
+    t('notices.timeout_warning.signed_in.message_html',
+      time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
+  end
+
+  def continue
+    t('notices.timeout_warning.signed_in.continue')
+  end
+
+  def sign_out
+    t('notices.timeout_warning.signed_in.sign_out')
+  end
+end

--- a/app/presenters/partially_signed_in_modal_presenter.rb
+++ b/app/presenters/partially_signed_in_modal_presenter.rb
@@ -1,0 +1,14 @@
+class PartiallySignedInModalPresenter < SessionTimeoutWarningModalPresenter
+  def message
+    t('notices.timeout_warning.partially_signed_in.message_html',
+      time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
+  end
+
+  def continue
+    t('notices.timeout_warning.partially_signed_in.continue')
+  end
+
+  def sign_out
+    t('notices.timeout_warning.partially_signed_in.sign_out')
+  end
+end

--- a/app/presenters/session_timeout_warning_modal_presenter.rb
+++ b/app/presenters/session_timeout_warning_modal_presenter.rb
@@ -1,0 +1,22 @@
+class SessionTimeoutWarningModalPresenter
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TranslationHelper
+
+  attr_reader :time_left_in_session
+
+  def initialize(time_left_in_session)
+    @time_left_in_session = time_left_in_session
+  end
+
+  def message
+    raise NotImplementedError
+  end
+
+  def continue
+    raise NotImplementedError
+  end
+
+  def sign_out
+    raise NotImplementedError
+  end
+end

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -1,7 +1,7 @@
 var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
-var warning_info = "<%= j render('session_timeout/warning') %>";
+var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
 
 function ping() {
   var request = new XMLHttpRequest();

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -4,9 +4,8 @@
       .mx-auto.p4.cntnr-skinny.border-box.bg-white.rounded.relative
         = image_tag(asset_url('clock.svg'), class: 'modal-ico')
         h3.mt0.mb2 = t('headings.session_timeout_warning')
-        p.mb3 == t('session_timeout_warning',
-                 time_left_in_session: content_tag(:span, time_left_in_session, id: 'countdown'))
-        = link_to t('forms.buttons.continue_browsing'),
+        p.mb3 = modal.message
+        = link_to modal.continue,
           request.original_url, class: 'btn btn-primary'
-        = link_to t('forms.buttons.sign_out'),
+        = link_to modal.sign_out,
           destroy_user_session_path, class: 'ml2 btn btn-outline'

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -5,7 +5,6 @@ en:
       back: Back
       cancel: Cancel
       continue: Continue
-      continue_browsing: Keep me signed in
       disable: Disable
       edit: Edit
       enable: Enable
@@ -15,7 +14,6 @@ en:
       send: Send
       send_passcode: Send passcode
       setup_totp: Set up authentication app
-      sign_out: Sign me out
       submit:
         default: Submit
         next: Next

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -13,6 +13,19 @@ en:
     send_code:
       sms: We sent you a one-time passcode via text message.
       voice: We will call you with your one-time passcode.
+    timeout_warning:
+      signed_in:
+        continue: Keep me signed in
+        sign_out: Sign me out now
+        message_html: >
+          For your security, in %{time_left_in_session} we will automatically
+          sign you out unless you tell us to keep you signed in.
+      partially_signed_in:
+        continue: Continue signing in
+        sign_out: Cancel signing in
+        message_html: >
+          For your security, in %{time_left_in_session} we will automatically
+          cancel your sign in.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}
@@ -39,4 +52,3 @@ en:
   session_timedout: >
     We signed you out. For your security, %{app} automatically ends your session
     when you haven’t moved to a new page for %{minutes} minutes.
-  session_timeout_warning: Your session will end in %{time_left_in_session} due to inactivity.

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -78,13 +78,13 @@ feature 'Sign in' do
     end
 
     scenario 'user can continue browsing' do
-      find_link(t('forms.buttons.continue_browsing')).trigger('click')
+      find_link(t('notices.timeout_warning.signed_in.continue')).trigger('click')
 
       expect(current_path).to eq profile_path
     end
 
     scenario 'user has option to sign out' do
-      click_link(t('forms.buttons.sign_out'))
+      click_link(t('notices.timeout_warning.signed_in.sign_out'))
 
       expect(page).to have_content t('devise.sessions.signed_out')
       expect(current_path).to eq new_user_session_path
@@ -92,7 +92,7 @@ feature 'Sign in' do
   end
 
   context 'user only signs in via email and password', js: true do
-    it 'displays the session timeout warning' do
+    it 'displays the session timeout warning with partially signed in copy' do
       allow(Figaro.env).to receive(:session_check_frequency).and_return('1')
       allow(Figaro.env).to receive(:session_check_delay).and_return('2')
       allow(Figaro.env).to receive(:session_timeout_warning_seconds).
@@ -103,6 +103,8 @@ feature 'Sign in' do
       visit user_two_factor_authentication_path
 
       expect(page).to have_css('#session-timeout-msg')
+      expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.continue'))
+      expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.sign_out'))
     end
   end
 

--- a/spec/presenters/fully_signed_in_modal_presenter_spec.rb
+++ b/spec/presenters/fully_signed_in_modal_presenter_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe FullySignedInModalPresenter do
+  subject(:presenter) { FullySignedInModalPresenter.new(10) }
+
+  it 'implements SessionTimeoutWarningModalPresenter' do
+    SessionTimeoutWarningModalPresenter.instance_methods(false).each do |method|
+      expect(presenter.send(method)).to be
+    end
+  end
+end

--- a/spec/presenters/partially_signed_in_modal_presenter_spec.rb
+++ b/spec/presenters/partially_signed_in_modal_presenter_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe PartiallySignedInModalPresenter do
+  subject(:presenter) { PartiallySignedInModalPresenter.new(10) }
+
+  it 'implements SessionTimeoutWarningModalPresenter' do
+    SessionTimeoutWarningModalPresenter.instance_methods(false).each do |method|
+      expect(presenter.send(method)).to be
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
'sign out' is confusing language when users aren't fully signed in,
so we can be more specific

--

![img](https://cloud.githubusercontent.com/assets/458784/21150141/f68ddd96-c12b-11e6-83f7-62a215551cd7.png)

![img](https://cloud.githubusercontent.com/assets/458784/21150052/b7dc2738-c12b-11e6-9799-5691aaa3676f.png)