### PR TITLE
Sign user out when reached max password attempts

### DIFF
--- a/.reek
+++ b/.reek
@@ -2,6 +2,7 @@ Attribute:
   enabled: false
 DuplicateMethodCall:
   exclude:
+    - MfaConfirmationController#handle_invalid_password
     - needs_to_confirm_email_change?
     - Remote#command
     - Remote#extract_trailing_options

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -2,7 +2,7 @@ class MfaConfirmationController < ApplicationController
   before_action :confirm_two_factor_authenticated
 
   def new
-    session[:password_attempts] = 0 unless session[:password_attempts]
+    session[:password_attempts] ||= 0
   end
 
   def create

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -1,12 +1,15 @@
 class MfaConfirmationController < ApplicationController
   before_action :confirm_two_factor_authenticated
 
+  def new
+    session[:password_attempts] = 0 unless session[:password_attempts]
+  end
+
   def create
     if current_user.valid_password?(password)
-      redirect_to user_two_factor_authentication_path(reauthn: true)
+      handle_valid_password
     else
-      flash[:error] = t('errors.confirm_password_incorrect')
-      redirect_to user_password_confirm_path
+      handle_invalid_password
     end
   end
 
@@ -14,5 +17,27 @@ class MfaConfirmationController < ApplicationController
 
   def password
     params.require(:user)[:password]
+  end
+
+  def handle_valid_password
+    redirect_to user_two_factor_authentication_path(reauthn: true)
+    session[:password_attempts] = 0
+  end
+
+  def handle_invalid_password
+    session[:password_attempts] += 1
+
+    if session[:password_attempts] < Figaro.env.password_max_attempts.to_i
+      flash[:error] = t('errors.confirm_password_incorrect')
+      redirect_to user_password_confirm_path
+    else
+      handle_max_password_attempts_reached
+    end
+  end
+
+  def handle_max_password_attempts_reached
+    analytics.track_event(Analytics::PASSWORD_MAX_ATTEMPTS)
+    sign_out
+    redirect_to root_url, alert: t('errors.max_password_attempts_reached')
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -51,6 +51,7 @@ class Analytics
   MULTI_FACTOR_AUTH_PHONE_SETUP = 'Multi-Factor Authentication: phone setup'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze
   PASSWORD_CREATION = 'Password Creation'.freeze
+  PASSWORD_MAX_ATTEMPTS = 'Password Max Attempts Reached'.freeze
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -19,6 +19,8 @@ mailer_domain_name: 'http://localhost:3000'
 # https://github.com/dropbox/zxcvbn#usage
 min_password_score: '3'
 
+password_max_attempts: '3'
+
 # If a queue does not have a healthy job after this many seconds, report it as unhealthy
 queue_health_check_dead_interval_seconds: '240'
 

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -15,6 +15,7 @@ Figaro.require_keys(
   'otp_delivery_blocklist_findtime',
   'otp_delivery_blocklist_maxretry',
   'otp_valid_for',
+  'password_max_attempts',
   'password_pepper',
   'password_strength_enabled',
   'queue_health_check_dead_interval_seconds',

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -29,3 +29,7 @@ en:
       requires_phone: requires you to enter your phone number.
       weak_password: Your password is not strong enough. %{feedback}
     not_authorized: You are not authorized to perform this action.
+    max_password_attempts_reached: >
+      We signed you out due to failing to provide your correct password.
+      If you forgot your password, click on the "Forgot your password?" link
+      below.

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -1,46 +1,100 @@
 require 'rails_helper'
 
 describe MfaConfirmationController do
-  describe 'GET /reauthn' do
+  describe '#new' do
     it 'presents the password confirmation form' do
       stub_sign_in
 
       get :new
 
       expect(response.status).to eq 200
+      expect(session[:password_attempts]).to eq 0
+    end
+
+    it 'does not reset password attempts if already set' do
+      stub_sign_in
+      session[:password_attempts] = 1
+
+      get :new
+
+      expect(session[:password_attempts]).to eq 1
     end
   end
 
-  describe 'PUT /reauthn' do
+  describe '#create' do
     let(:user) { build(:user, password: 'password') }
 
     before do
       stub_sign_in(user)
+      session[:password_attempts] = 1
     end
 
     context 'password is empty' do
-      it 'redirects with error message' do
+      it 'redirects with error message and increments password attempts' do
         post :create, user: { password: '' }
 
         expect(response).to redirect_to(user_password_confirm_path)
         expect(flash[:error]).to eq t('errors.confirm_password_incorrect')
+        expect(session[:password_attempts]).to eq 2
       end
     end
 
     context 'password is wrong' do
-      it 'redirects with error message' do
+      it 'redirects with error message and increments password attempts' do
         post :create, user: { password: 'wrong' }
 
         expect(response).to redirect_to(user_password_confirm_path)
         expect(flash[:error]).to eq t('errors.confirm_password_incorrect')
+        expect(session[:password_attempts]).to eq 2
       end
     end
 
     context 'password is correct' do
-      it 'redirects to 2FA' do
+      it 'redirects to 2FA and resets password attempts' do
         post :create, user: { password: 'password' }
 
         expect(response).to redirect_to(user_two_factor_authentication_path(reauthn: true))
+        expect(session[:password_attempts]).to eq 0
+      end
+    end
+  end
+
+  describe 'password attempts counter' do
+    context 'max password attempts reached' do
+      it 'signs the user out' do
+        user = build(:user, :signed_up)
+        sign_in user
+        session[:password_attempts] = 0
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        max_allowed_attempts = Figaro.env.password_max_attempts.to_i
+        max_allowed_attempts.times do
+          post :create, user: { password: 'wrong' }
+        end
+
+        expect(response).to redirect_to(root_path)
+        expect(controller.current_user).to be_nil
+        expect(flash[:alert]).to eq t('errors.max_password_attempts_reached')
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::PASSWORD_MAX_ATTEMPTS)
+      end
+    end
+
+    context 'last password attempt is correct' do
+      it 'does not sign the user out' do
+        user = build_stubbed(:user, password: 'password')
+        stub_sign_in user
+        session[:password_attempts] = 0
+
+        max_allowed_attempts = Figaro.env.password_max_attempts.to_i
+        (max_allowed_attempts - 1).times do
+          post :create, user: { password: 'wrong' }
+        end
+
+        post :create, user: { password: 'password' }
+
+        expect(response).to redirect_to user_two_factor_authentication_path(reauthn: true)
       end
     end
   end


### PR DESCRIPTION
**Why**:
If a user is already signed in, and is trying to change their password,
email, or phone, they will be prompted to enter their current password
before they can make the changes. If an incorrect password is being
entered repeatedly, it is most likely due to a malicious person taking
over the user's machine that they left unattended. In that case, for the
user's security, we sign the user out.

The max attempts count is configurable, and has been set to 3 for now,
to match the OTP max attempts.