### PR TITLE
Make footer and privacy links open in new window

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -10,7 +10,7 @@ h1.h3.my0 = decorated_session.new_session_heading
   = f.input :password, required: true
   = f.button :submit, t('links.next'), class: 'btn-wide'
 
-- link = link_to t('notices.sign_in_consent.link'), privacy_path
+- link = link_to t('notices.sign_in_consent.link'), privacy_path, target: '_blank'
 p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
 
 .clearfix.pt1.border-top

--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -4,8 +4,8 @@ footer.footer.bg-navy.white
       .sm-col = t('shared.footer_lite.gsa')
       .sm-col-right.caps
         = link_to t('links.help'), help_path,
-          class: 'white text-decoration-none mr3'
+          class: 'white text-decoration-none mr3', target: '_blank'
         = link_to t('links.contact'), contact_path,
-          class: 'white text-decoration-none mr3'
+          class: 'white text-decoration-none mr3', target: '_blank'
         = link_to t('links.privacy_policy'), privacy_path,
-          class: 'white text-decoration-none'
+          class: 'white text-decoration-none', target: '_blank'

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -9,7 +9,7 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
   .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')
-  - link = link_to t('notices.terms_of_service.link'), privacy_path
+  - link = link_to t('notices.terms_of_service.link'), privacy_path, target: '_blank'
   p.mb-40p == t('notices.terms_of_service.text', link: link)
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -34,6 +34,8 @@ describe 'devise/sessions/new.html.slim' do
 
     expect(rendered).
       to have_link(t('notices.sign_in_consent.link'), href: privacy_path)
+
+    expect(rendered).to have_selector("a[href='#{privacy_path}'][target='_blank']")
   end
 
   context 'when @sp_name is set' do

--- a/spec/views/shared/_footer_lite.html.slim_spec.rb
+++ b/spec/views/shared/_footer_lite.html.slim_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'shared/_footer_lite.html.slim' do
+  context 'user is signed out' do
+    it 'contains link to help page' do
+      render
+
+      expect(rendered).to have_link(t('links.help'), href: help_path)
+      expect(rendered).to have_selector("a[href='#{help_path}'][target='_blank']")
+    end
+
+    it 'contains link to contact page' do
+      render
+
+      expect(rendered).to have_link(t('links.contact'), href: contact_path)
+      expect(rendered).to have_selector("a[href='#{contact_path}'][target='_blank']")
+    end
+
+    it 'contains link to privacy page' do
+      render
+
+      expect(rendered).to have_link(t('links.privacy_policy'), href: privacy_path)
+      expect(rendered).to have_selector("a[href='#{privacy_path}'][target='_blank']")
+    end
+
+    it 'contains GSA text' do
+      render
+
+      expect(rendered).to have_content(t('shared.footer_lite.gsa'))
+    end
+  end
+end

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -17,6 +17,8 @@ describe 'sign_up/registrations/new.html.slim' do
 
     expect(rendered).
       to have_link(t('notices.terms_of_service.link'), href: privacy_path)
+
+    expect(rendered).to have_selector("a[href='#{privacy_path}'][target='_blank']")
   end
 
   it 'sets form autocomplete to off' do


### PR DESCRIPTION
**Why**: To allow users to go back to where they came from without
having to add a 'Back' button or 'Cancel' link on all of these
pages.