### PR TITLE
Adds consistent cancel link to 2fa sign in views

### DIFF
--- a/app/views/devise/two_factor_authentication/show.html.slim
+++ b/app/views/devise/two_factor_authentication/show.html.slim
@@ -29,3 +29,5 @@ p.mt-tiny.mb0#2fa-description
 .mt3
   p.mb1.italic = t('devise.two_factor_authentication.otp_sms_disclaimer')
   p.mb1.italic == t('devise.two_factor_authentication.recovery_code_fallback.text', link: link)
+
+= render 'shared/cancel'

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,0 +1,2 @@
+.mt2.pt1.border-top
+  = link_to t('links.cancel'), destroy_user_session_path, class: 'h5'

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -29,3 +29,5 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
   - if user_session[:unconfirmed_phone]
     - update_number_link = link_to(t('forms.two_factor.try_again'), @reenter_phone_number_path)
     p.mb1 == t('instructions.2fa.wrong_number', link: update_number_link)
+
+= render 'shared/cancel'

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -10,4 +10,5 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
       class: 'block bold'
     = block_text_field_tag :code, '', required: true
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
-.mt1 = link_to t('forms.buttons.cancel'), user_two_factor_authentication_path
+
+= render 'shared/cancel'

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -23,3 +23,5 @@ p.mt-tiny.mb0#code-instructs = t('instructions.2fa.totp_intro_html', \
 
   == t('devise.two_factor_authentication.totp_fallback.text', sms_link: sms_link,
     voice_link: voice_link)
+
+= render 'shared/cancel'

--- a/spec/support/shared_examples_for_otp_forms.rb
+++ b/spec/support/shared_examples_for_otp_forms.rb
@@ -1,0 +1,8 @@
+shared_examples_for 'an otp form' do
+  describe 'tertiary form actions' do
+    it 'allows the user to cancel out of the sign in process' do
+      render
+      expect(rendered).to have_link(t('links.cancel'), destroy_user_session_path)
+    end
+  end
+end

--- a/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
+++ b/spec/views/devise/two_factor_authentication/show.html.slim_spec.rb
@@ -7,7 +7,10 @@ describe 'devise/two_factor_authentication/show.html.slim' do
     before do
       @otp_delivery_selection_form = OtpDeliverySelectionForm.new
       allow(view).to receive(:reauthn?).and_return(false)
+      allow(view).to receive(:current_user).and_return(user)
     end
+
+    it_behaves_like 'an otp form'
 
     it 'has a localized heading' do
       render
@@ -16,7 +19,6 @@ describe 'devise/two_factor_authentication/show.html.slim' do
     end
 
     it 'allows the user to select OTP delivery method' do
-      allow(view).to receive(:current_user).and_return(user)
       render
 
       expect(rendered).to have_content t('devise.two_factor_authentication.otp_method.sms')
@@ -24,7 +26,6 @@ describe 'devise/two_factor_authentication/show.html.slim' do
     end
 
     it 'informs the user that an OTP will be sent to their number' do
-      allow(view).to receive(:current_user).and_return(user)
       @phone_number = '***-***-1234'
 
       render

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -10,6 +10,8 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       @delivery_method = 'sms'
     end
 
+    it_behaves_like 'an otp form'
+
     it 'has a localized title' do
       expect(view).to receive(:title).with(t('titles.enter_2fa_code'))
 

--- a/spec/views/two_factor_authentication/recovery_code_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/recovery_code_verification/show.html.slim_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'two_factor_authentication/recovery_code_verification/show.html.slim' do
+  it_behaves_like 'an otp form'
+
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('titles.enter_2fa_code'))
 

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -3,20 +3,19 @@ require 'rails_helper'
 describe 'two_factor_authentication/totp_verification/show.html.slim' do
   let(:user) { build_stubbed(:user, :signed_up, otp_secret_key: 123) }
 
-  it 'prompts to enter code from app' do
+  before do
     allow(view).to receive(:current_user).and_return(user)
-
     render
+  end
 
+  it_behaves_like 'an otp form'
+
+  it 'prompts to enter code from app' do
     expect(rendered).to have_content 'Enter the code from your authenticator app.'
     expect(rendered).to have_content "enter the code corresponding to #{user.email}"
   end
 
   it 'allows the user to fallback to SMS and voice' do
-    allow(view).to receive(:current_user).and_return(user)
-
-    render
-
     expect(rendered).
       to have_link(t('devise.two_factor_authentication.totp_fallback.sms_link_text'),
                    href: otp_send_path(otp_delivery_selection_form: { otp_method: 'sms' }))


### PR DESCRIPTION
**Why**: So users have a simple way to bail out during the process