### PR TITLE
Remove progress bar when regenerating recovery code

### DIFF
--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -6,7 +6,11 @@ module SignUp
     before_action :confirm_has_not_already_viewed_recovery_code
 
     def show
-      user_session.delete(:first_time_recovery_code_view)
+      if user_session[:first_time_recovery_code_view].present?
+        @show_progress_bar = true
+        user_session.delete(:first_time_recovery_code_view)
+      end
+
       @code = create_new_code
       analytics.track_event(Analytics::USER_REGISTRATION_RECOVERY_CODE_VISIT)
     end

--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -6,9 +6,8 @@ module SignUp
     before_action :confirm_has_not_already_viewed_recovery_code
 
     def show
-      if user_session[:first_time_recovery_code_view].present?
+      if user_session.delete(:first_time_recovery_code_view).present?
         @show_progress_bar = true
-        user_session.delete(:first_time_recovery_code_view)
       end
 
       @code = create_new_code

--- a/app/views/sign_up/recovery_codes/show.html.slim
+++ b/app/views/sign_up/recovery_codes/show.html.slim
@@ -1,6 +1,7 @@
 - title t('titles.recovery_code')
 
-= render 'shared/progress_steps', active: 3
+- if @show_progress_bar
+  = render 'shared/progress_steps', active: 3
 h1.h3.my0 = t('headings.recovery_code')
 p.mt-tiny.mb0 = t('instructions.recovery_code')
 .mt4.mb4.py2.px3.inline-block.fs-20p.border.border-dashed.monospace = @code

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -5,7 +5,7 @@ feature 'View recovery code during sign up flow' do
     sign_up_and_view_recovery_code
 
     expect(page).to have_css('.step-3.active')
-  end  
+  end
 
   scenario 'user refreshes recovery code page' do
     sign_up_and_view_recovery_code

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'View recovery code during sign up flow' do
+  scenario 'user sees progress bar on recovery code page' do
+    sign_up_and_view_recovery_code
+
+    expect(page).to have_css('.step-3.active')
+  end  
+
   scenario 'user refreshes recovery code page' do
     sign_up_and_view_recovery_code
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -64,5 +64,13 @@ feature 'User profile' do
 
       expect(current_path).to eq profile_path
     end
+
+    it 'does not display progress bar' do
+      sign_in_and_2fa_user
+
+      click_link t('profile.links.regenerate_recovery_code')
+
+      expect(page).to_not have_css('.step-3.active')
+    end
   end
 end

--- a/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
+++ b/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
@@ -37,6 +37,8 @@ describe 'sign_up/recovery_codes/show.html.slim' do
   end
 
   it 'displays the correct progress step' do
+    @show_progress_bar = true
+
     render
 
     expect(rendered).to have_css('.step-3.active')

--- a/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
+++ b/spec/views/sign_up/recovery_codes/show.html.slim_spec.rb
@@ -36,7 +36,7 @@ describe 'sign_up/recovery_codes/show.html.slim' do
     expect(rendered).to have_content 'foo'
   end
 
-  it 'displays the correct progress step' do
+  it 'displays the correct progress step when @show_progress_bar is true' do
     @show_progress_bar = true
 
     render


### PR DESCRIPTION
**Why**: Progress bar should only be displayed on initial sign up.