### PR TITLE
Fixes re-auth bug

### DIFF
--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -3,7 +3,7 @@ module SignUp
     include RecoveryCodeConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :confirm_has_not_already_viewed_recovery_code
+    before_action :confirm_has_not_already_viewed_recovery_code, only: [:show]
 
     def show
       if user_session.delete(:first_time_recovery_code_view).present?
@@ -15,7 +15,7 @@ module SignUp
     end
 
     def update
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to(session[:saml_request_url] || profile_path)
     end
 
     private

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -50,27 +50,4 @@ feature 'User profile' do
       end
     end
   end
-
-  describe 'Regenerating recovery code' do
-    it 'displays new code and takes user back to profile page after continuing' do
-      user = sign_in_and_2fa_user
-      old_code = user.recovery_code
-
-      click_link t('profile.links.regenerate_recovery_code')
-
-      expect(user.reload.recovery_code).to_not eq old_code
-
-      click_button t('forms.buttons.continue')
-
-      expect(current_path).to eq profile_path
-    end
-
-    it 'does not display progress bar' do
-      sign_in_and_2fa_user
-
-      click_link t('profile.links.regenerate_recovery_code')
-
-      expect(page).to_not have_css('.step-3.active')
-    end
-  end
 end


### PR DESCRIPTION
**Why**:
* Canceling out of password reset then creating new personal key
caused re-auth
* This was because of a check introduced for recovery codes that made
  sure the user had not already viewed recovery code. IF they had, it
  redirected them to the `after_sign_in_path_for(user)`, which returns
  `stored_location_for(user)`, the path that is saved when someone needs
  to reauthn.