### PR TITLE
Update edit phone form

### DIFF
--- a/app/views/users/phones/edit.html.slim
+++ b/app/views/users/phones/edit.html.slim
@@ -4,6 +4,7 @@
 h1.h3.my0 = t('headings.edit_info.phone')
 = simple_form_for(@update_user_phone_form, url: manage_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
-  = f.input :phone, as: :tel, required: true
-  = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
+  = f.input :phone, as: :tel, required: true, input_html: { value: nil },
+    label: t('profile.index.phone')
+  = f.button :submit, t('forms.buttons.submit.confirm_change'), class: 'mt2'
 .mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -15,6 +15,7 @@ en:
       send_passcode: Send passcode
       setup_totp: Set up authentication app
       submit:
+        confirm_change: Confirm change
         default: Submit
         next: Next
         update: Update

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -10,7 +10,7 @@ en:
     edit_info:
       email: Change your email
       password: Change your password
-      phone: Change your phone number
+      phone: Enter your new phone number
     help:
       changing_settings:
         change_email: How do I change my email address?

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -91,7 +91,7 @@ feature 'Changing authentication factor' do
 
   def update_phone_number_and_choose_sms_delivery
     fill_in 'update_user_phone_form[phone]', with: '703-555-0100'
-    click_button t('forms.buttons.submit.update')
+    click_button t('forms.buttons.submit.confirm_change')
     click_submit_default
   end
 

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -16,7 +16,7 @@ feature 'User edit' do
 
     visit manage_phone_path
     fill_in 'Phone', with: ''
-    click_button 'Update'
+    click_button t('forms.buttons.submit.confirm_change')
 
     expect(page).to have_content t('errors.messages.improbable_phone')
   end


### PR DESCRIPTION
**Why**: To implement clearer language, and to remove the prepopulated phone number.

**Before:**
<img width="535" alt="screen shot 2016-11-22 at 3 54 37 pm" src="https://cloud.githubusercontent.com/assets/1060893/20541607/00c0b13c-b0cc-11e6-9eae-148a435fbba1.png">

**After:**
![screen shot 2016-12-16 at 3 30 07 pm](https://cloud.githubusercontent.com/assets/1178494/21277487/928b09b0-c3a4-11e6-82af-96615f33c632.png)
