### PR TITLE
start spanish translations

### DIFF
--- a/config/locales/activerecord/es.yml
+++ b/config/locales/activerecord/es.yml
@@ -5,5 +5,5 @@ es:
         app_setting:
           attributes:
             value:
-              cannot_disable_2fa_in_prod: NOT TRANSLATED YET
-              invalid: NOT TRANSLATED YET
+              cannot_disable_2fa_in_prod: La autenticación de dos factores no se puede desactivar en la producción
+              invalid: El valor tiene que ser '1' o '0'

--- a/config/locales/contact/es.yml
+++ b/config/locales/contact/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   contact:
     intro: Yo quiero...

--- a/config/locales/contact/es.yml
+++ b/config/locales/contact/es.yml
@@ -1,12 +1,11 @@
----
 es:
   contact:
-    intro: NOT TRANSLATED YET
+    intro: Yo quiero...
     labels:
-      comments: NOT TRANSLATED YET
-      comments_note: NOT TRANSLATED YET
-      email_or_tel: NOT TRANSLATED YET
-    learn_more: NOT TRANSLATED YET
+      comments: Comentarios
+      comments_note: Opcional, pero muy útil
+      email_or_tel: Dirección de correo electrónico o número de teléfono
+    learn_more: Aprender más acerca de %{app}
     messages:
-      thanks: NOT TRANSLATED YET
-    tell_experience: NOT TRANSLATED YET
+      thanks: ¡Gracias! Estaremos en contacto pronto
+    tell_experience: Decirle acerca de mi experiencia con %{app}

--- a/config/locales/experiments/es.yml
+++ b/config/locales/experiments/es.yml
@@ -1,6 +1,5 @@
----
 es:
   experiments:
     demo:
-      create_account: NOT TRANSLATED YET
-      get_started: NOT TRANSLATED YET
+      create_account: Empezar
+      get_started: Empezar

--- a/config/locales/experiments/es.yml
+++ b/config/locales/experiments/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   experiments:
     demo:


### PR DESCRIPTION
Why: Making app accessible to Spanish speaking folk.