### PR TITLE
Use session encryption key as salt

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,7 +1,7 @@
 class SessionEncryptor
   def self.build_user_access_key
-    env = Figaro.env
-    UserAccessKey.new(password: env.session_encryption_key, salt: env.password_pepper)
+    key = Figaro.env.session_encryption_key
+    UserAccessKey.new(password: key, salt: key)
   end
 
   cattr_reader :user_access_key do

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,6 @@ Devise.setup do |config|
   config.mailer_sender = email_with_name(Figaro.env.email_from, Figaro.env.email_from)
   config.paranoid = true
   config.password_length = 8..128
-  config.pepper = Figaro.env.password_pepper
   config.reconfirmable = true
   config.reset_password_within = 6.hours
   config.secret_key = Figaro.env.secret_key_base


### PR DESCRIPTION
**Why**: Reduces dependency on system-wide password_pepper
which makes rotating the session_encryption_key much easier.