### PR TITLE
Validate all financial numbers are 8-30 chars

### DIFF
--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -6,7 +6,10 @@ module Idv
     FINANCE_TYPES = [:ccn, :mortgage, :home_equity_line, :auto_loan].freeze
 
     FINANCE_HTML_OPTIONS = {
-      ccn: { maxlength: 8 }
+      ccn: { maxlength: 8 },
+      mortgage: { minlength: 8 },
+      home_equity_line: { minlength: 8 },
+      auto_loan: { minlength: 8 }
     }.freeze
 
     attr_reader :idv_params, :finance_type, *FINANCE_TYPES

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -6,10 +6,22 @@ module Idv
     FINANCE_TYPES = [:ccn, :mortgage, :home_equity_line, :auto_loan].freeze
 
     FINANCE_HTML_OPTIONS = {
-      ccn: { maxlength: 8 },
-      mortgage: { minlength: 8 },
-      home_equity_line: { minlength: 8 },
-      auto_loan: { minlength: 8 }
+      ccn: {
+        minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+        maxlength: FormFinanceValidator::VALID_MINIMUM_LENGTH
+      },
+      mortgage: {
+        minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+      },
+      home_equity_line: {
+        minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+      },
+      auto_loan: {
+        minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+      }
     }.freeze
 
     attr_reader :idv_params, :finance_type, *FINANCE_TYPES

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -1,6 +1,7 @@
 module Idv
   class FinanceForm
     include ActiveModel::Model
+    include FormFinanceValidator
 
     FINANCE_TYPES = [:ccn, :mortgage, :home_equity_line, :auto_loan].freeze
 
@@ -10,18 +11,6 @@ module Idv
 
     attr_reader :idv_params, :finance_type, *FINANCE_TYPES
 
-    validates :finance_type, presence: true
-
-    FINANCE_TYPES.each do |type|
-      validates type, presence: true, if: ->(form) { form.finance_type == type }
-    end
-
-    validates :ccn,
-              format: { with: /\A\d{8}\z/, message: I18n.t('idv.errors.invalid_ccn') },
-              if: :ccn?
-
-    validate :validate_finance_type
-
     def initialize(idv_params)
       @idv_params = idv_params
       finance_type = FINANCE_TYPES.find { |param| idv_params.key? param }
@@ -29,6 +18,7 @@ module Idv
     end
 
     def submit(params)
+      @params = params
       finance_value = update_finance_values(params)
       return false unless valid?
 
@@ -51,20 +41,6 @@ module Idv
 
     attr_writer :finance_type, *FINANCE_TYPES
 
-    def ccn?
-      finance_type == :ccn
-    end
-
-    def validate_finance_type
-      return if valid_finance_type?(finance_type)
-
-      errors.add :finance_type, I18n.t('idv.errors.missing_finance')
-    end
-
-    def valid_finance_type?(type)
-      type.present? && FINANCE_TYPES.include?(type.to_sym)
-    end
-
     def update_finance_values(params)
       type = params[:finance_type]
       return false unless valid_finance_type?(type)
@@ -74,8 +50,8 @@ module Idv
     end
 
     def clear_idv_params_finance
-      FINANCE_TYPES.each do |f_param|
-        idv_params.delete f_param
+      FINANCE_TYPES.each do |finance_param|
+        idv_params.delete(finance_param)
       end
     end
   end

--- a/app/validators/form_finance_validator.rb
+++ b/app/validators/form_finance_validator.rb
@@ -1,8 +1,8 @@
 module FormFinanceValidator
   extend ActiveSupport::Concern
 
-  VALID_MINIMUM_LENGTH = '8'.freeze
-  VALID_MAXIMUM_LENGTH = '30'.freeze
+  VALID_MINIMUM_LENGTH = 8
+  VALID_MAXIMUM_LENGTH = 30
 
   included do
     attr_reader :params
@@ -56,6 +56,6 @@ module FormFinanceValidator
   end
 
   def valid_range
-    VALID_MINIMUM_LENGTH.to_i..VALID_MAXIMUM_LENGTH.to_i
+    VALID_MINIMUM_LENGTH..VALID_MAXIMUM_LENGTH
   end
 end

--- a/app/validators/form_finance_validator.rb
+++ b/app/validators/form_finance_validator.rb
@@ -47,7 +47,7 @@ module FormFinanceValidator
 
   def validate_finance_value_length
     return if finance_value.blank?
-    return if valid_range.include?(finance_value.size)
+    return if valid_range.include?(finance_value.length)
     errors.add finance_type, I18n.t('idv.errors.finance_number_length')
   end
 

--- a/app/validators/form_finance_validator.rb
+++ b/app/validators/form_finance_validator.rb
@@ -1,0 +1,61 @@
+module FormFinanceValidator
+  extend ActiveSupport::Concern
+
+  VALID_MINIMUM_LENGTH = '8'.freeze
+  VALID_MAXIMUM_LENGTH = '30'.freeze
+
+  included do
+    attr_reader :params
+
+    validates :finance_type, presence: true
+
+    validates(
+      :ccn,
+      format: { with: /\A\d{8}\z/, message: I18n.t('idv.errors.invalid_ccn') },
+      if: :ccn?
+    )
+
+    validate :validate_finance_type
+    validate :validate_finance_value_presence
+    validate :validate_finance_value_length, if: :not_ccn?
+  end
+
+  private
+
+  def ccn?
+    finance_type == :ccn
+  end
+
+  def not_ccn?
+    !ccn?
+  end
+
+  def validate_finance_type
+    return if valid_finance_type?(finance_type)
+    errors.add :finance_type, I18n.t('idv.errors.missing_finance')
+  end
+
+  def valid_finance_type?(type)
+    type.present? && Idv::FinanceForm::FINANCE_TYPES.include?(type.to_sym)
+  end
+
+  def validate_finance_value_presence
+    return unless valid_finance_type?(finance_type)
+    return if finance_value.present?
+    errors.add finance_type, I18n.t('errors.messages.blank')
+  end
+
+  def validate_finance_value_length
+    return if finance_value.blank?
+    return if valid_range.include?(finance_value.size)
+    errors.add finance_type, I18n.t('idv.errors.finance_number_length')
+  end
+
+  def finance_value
+    params[finance_type]
+  end
+
+  def valid_range
+    VALID_MINIMUM_LENGTH.to_i..VALID_MAXIMUM_LENGTH.to_i
+  end
+end

--- a/app/validators/form_finance_validator.rb
+++ b/app/validators/form_finance_validator.rb
@@ -48,7 +48,14 @@ module FormFinanceValidator
   def validate_finance_value_length
     return if finance_value.blank?
     return if valid_range.include?(finance_value.length)
-    errors.add finance_type, I18n.t('idv.errors.finance_number_length')
+    errors.add(
+      finance_type,
+      I18n.t(
+        'idv.errors.finance_number_length',
+        minimum: VALID_MINIMUM_LENGTH,
+        maximum: VALID_MAXIMUM_LENGTH
+      )
+    )
   end
 
   def finance_value

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -5,7 +5,7 @@ en:
       bad_dob: Your date of birth must be a valid date.
       duplicate_ssn: An account already exists with the information you provided.
       fail: Sorry, we can’t verify your identity based on the information you submitted.
-      finance_number_length: Number must be between 8 and 30 digits.
+      finance_number_length: Number must be between %{minimum} and %{maximum} digits.
       hardfail: We were unable to verify your identity at this time.
       incorrect_password: The password you entered is not correct.
       invalid_ccn: Credit card number should be only last 8 digits.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -38,28 +38,28 @@ en:
         bullet_2: Mailing address
         bullet_3: Date of birth
         bullet_4: Social Security Number
-        header: Basic information
-        subheader: We need to know some personal details
+        header: Personal information
+        subheader: 'We’ll start with some personal details like your:'
       section_2:
         bullet_1: Last 8 digits of a credit card
         bullet_2: Auto loan account number
         bullet_3: Mortgage loan account number
         bullet_4: Home equity line of credit account number
         footnote: >
-          You are not sharing any account balances or transaction details, and
-          we will never charge any fees.
+          You will never be charged any money and are not sharing any account balances or other
+          financial information with us. We only check the account number to help verify you.
         header: Financial information
-        subheader: 'We need one of the following:'
+        subheader: 'We need one of the following financial account numbers:'
       section_3:
-        bullet_1: Be in your name, or a family member’s name
+        bullet_1: Be in your name or the name of someone in your household
         bullet_2_html: >
-          <strong>Not</strong> be a virtual phone, such as Google Voice or Skype
+          <strong>Not</strong> be a virtual phone, like Google Voice or Skype
         bullet_3_html: >
           <strong>Not</strong> be a pay-as-you-go phone
         header: Phone line in your name
         subheader: >
           We use telephone company records to verify your identity. The phone
-          number you give us:
+          number you give us should:
       subheader: To verify your identity, we’ll ask you to answer a few questions
     messages:
       activated_html: >
@@ -93,7 +93,7 @@ en:
         to find answers to common questions about verification.
       hardfail4: You can also go to %{sp} for more help in accessing services.
       phone:
-        in_your_name: in your name, or your spouse’s name
+        in_your_name: in your name or the name of someone in your household
         intro: >
           To help us verify your identity, please give us a phone number that
           belongs to you and that meets the criteria below:
@@ -103,7 +103,7 @@ en:
         same_as_2fa: >
           This phone number can be the same one you used to set up your one-time
           password as long as it meets the criteria above.
-        virtual: a Google voice number, Skype account or virtual phone
+        virtual: a virtual phone, like Google Voice or Skype
       questions:
         intro: Question %{number}
       recovery_code: >

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -5,6 +5,7 @@ en:
       bad_dob: Your date of birth must be a valid date.
       duplicate_ssn: An account already exists with the information you provided.
       fail: Sorry, we can’t verify your identity based on the information you submitted.
+      finance_number_length: Number must be between 8 and 30 digits.
       hardfail: We were unable to verify your identity at this time.
       incorrect_password: The password you entered is not correct.
       invalid_ccn: Credit card number should be only last 8 digits.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -38,28 +38,28 @@ en:
         bullet_2: Mailing address
         bullet_3: Date of birth
         bullet_4: Social Security Number
-        header: Personal information
-        subheader: 'We’ll start with some personal details like your:'
+        header: Basic information
+        subheader: We need to know some personal details
       section_2:
         bullet_1: Last 8 digits of a credit card
         bullet_2: Auto loan account number
         bullet_3: Mortgage loan account number
         bullet_4: Home equity line of credit account number
         footnote: >
-          You will never be charged any money and are not sharing any account balances or other
-          financial information with us. We only check the account number to help verify you.
+          You are not sharing any account balances or transaction details, and
+          we will never charge any fees.
         header: Financial information
-        subheader: 'We need one of the following financial account numbers:'
+        subheader: 'We need one of the following:'
       section_3:
-        bullet_1: Be in your name or the name of someone in your household
+        bullet_1: Be in your name, or a family member’s name
         bullet_2_html: >
-          <strong>Not</strong> be a virtual phone, like Google Voice or Skype
+          <strong>Not</strong> be a virtual phone, such as Google Voice or Skype
         bullet_3_html: >
           <strong>Not</strong> be a pay-as-you-go phone
         header: Phone line in your name
         subheader: >
           We use telephone company records to verify your identity. The phone
-          number you give us should:
+          number you give us:
       subheader: To verify your identity, we’ll ask you to answer a few questions
     messages:
       activated_html: >
@@ -93,7 +93,7 @@ en:
         to find answers to common questions about verification.
       hardfail4: You can also go to %{sp} for more help in accessing services.
       phone:
-        in_your_name: in your name or the name of someone in your household
+        in_your_name: in your name, or your spouse’s name
         intro: >
           To help us verify your identity, please give us a phone number that
           belongs to you and that meets the criteria below:
@@ -103,7 +103,7 @@ en:
         same_as_2fa: >
           This phone number can be the same one you used to set up your one-time
           password as long as it meets the criteria above.
-        virtual: a virtual phone, like Google Voice or Skype
+        virtual: a Google voice number, Skype account or virtual phone
       questions:
         intro: Question %{number}
       recovery_code: >

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -5,6 +5,7 @@ es:
       bad_dob: NOT TRANSLATED YET
       duplicate_ssn: NOT TRANSLATED YET
       fail: NOT TRANSLATED YET
+      finance_number_length: NOT TRANSLATED YET
       hardfail: NOT TRANSLATED YET
       incorrect_password: NOT TRANSLATED YET
       invalid_ccn: NOT TRANSLATED YET

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -165,7 +165,7 @@ feature 'IdV session' do
       visit verify_session_path
 
       fill_out_idv_form_ok
-      click_button 'Continue'
+      click_button t('forms.buttons.continue')
 
       expect(page).to have_css('.js-finance-wrapper', text: t('idv.form.mortgage'), visible: false)
 
@@ -173,6 +173,19 @@ feature 'IdV session' do
 
       expect(page).to have_css('.js-finance-wrapper', text: t('idv.form.mortgage'), visible: true)
       expect(page).to have_content(t('idv.form.ccn'))
+    end
+
+    scenario 'enters invalid finance value' do
+      _user = sign_in_and_2fa_user
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_button t('forms.buttons.continue')
+      find('#idv_finance_form_finance_type_mortgage').set(true)
+
+      fill_in :idv_finance_form_mortgage, with: '1234567'
+      click_button t('forms.buttons.continue')
+
+      expect(page).to have_content(t('idv.errors.finance_number_length'))
     end
 
     context 'Idv phone and user phone are different' do

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -181,7 +181,7 @@ feature 'IdV session' do
       fill_out_idv_form_ok
       click_button t('forms.buttons.continue')
       find('#idv_finance_form_finance_type_mortgage').set(true)
-      short_value = "1" * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
+      short_value = '1' * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
 
       fill_in :idv_finance_form_mortgage, with: short_value
       click_button t('forms.buttons.continue')

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -181,11 +181,18 @@ feature 'IdV session' do
       fill_out_idv_form_ok
       click_button t('forms.buttons.continue')
       find('#idv_finance_form_finance_type_mortgage').set(true)
+      short_value = "1" * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
 
-      fill_in :idv_finance_form_mortgage, with: '1234567'
+      fill_in :idv_finance_form_mortgage, with: short_value
       click_button t('forms.buttons.continue')
 
-      expect(page).to have_content(t('idv.errors.finance_number_length'))
+      expect(page).to have_content(
+        t(
+          'idv.errors.finance_number_length',
+          minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+          maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+        )
+      )
     end
 
     context 'Idv phone and user phone are different' do

--- a/spec/forms/idv/finance_form_spec.rb
+++ b/spec/forms/idv/finance_form_spec.rb
@@ -59,20 +59,18 @@ describe Idv::FinanceForm do
     context 'any non-ccn financial value is less than the minimum allowed digits' do
       it 'fails' do
         finance_types = Idv::FinanceForm::FINANCE_TYPES
-        short_value = "1" * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
+        short_value = '1' * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
 
         finance_types.each do |type|
           next if type == :ccn
           params = { type => short_value, finance_type: type }
 
           expect(subject.submit(params)).to eq false
-          expect(subject.errors[type]).to eq([
-            t(
-              'idv.errors.finance_number_length',
-              minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
-              maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
-            )
-          ])
+          expect(subject.errors[type]).to eq([t(
+            'idv.errors.finance_number_length',
+            minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+            maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+          )])
         end
       end
     end
@@ -80,7 +78,7 @@ describe Idv::FinanceForm do
     context 'any non-ccn financial value is over the max allowed digits' do
       it 'fails' do
         finance_types = Idv::FinanceForm::FINANCE_TYPES
-        long_value = "1" * (FormFinanceValidator::VALID_MAXIMUM_LENGTH + 1)
+        long_value = '1' * (FormFinanceValidator::VALID_MAXIMUM_LENGTH + 1)
 
         finance_types.each do |type|
           next if type == :ccn
@@ -91,13 +89,11 @@ describe Idv::FinanceForm do
           }
 
           expect(subject.submit(params)).to eq false
-          expect(subject.errors[symbolized_type]).to eq([
-            t(
-              'idv.errors.finance_number_length',
-              minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
-              maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
-            )
-          ])
+          expect(subject.errors[symbolized_type]).to eq([t(
+            'idv.errors.finance_number_length',
+            minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+            maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+          )])
         end
       end
     end

--- a/spec/forms/idv/finance_form_spec.rb
+++ b/spec/forms/idv/finance_form_spec.rb
@@ -56,38 +56,48 @@ describe Idv::FinanceForm do
       end
     end
 
-    context 'any non-ccn financial value is less than 8 digits' do
+    context 'any non-ccn financial value is less than the minimum allowed digits' do
       it 'fails' do
         finance_types = Idv::FinanceForm::FINANCE_TYPES
+        short_value = "1" * (FormFinanceValidator::VALID_MINIMUM_LENGTH - 1)
 
         finance_types.each do |type|
           next if type == :ccn
-          params = { type => '1234567', finance_type: type }
+          params = { type => short_value, finance_type: type }
 
           expect(subject.submit(params)).to eq false
-          expect(subject.errors[type]).to eq(
-            [t('idv.errors.finance_number_length')]
-          )
+          expect(subject.errors[type]).to eq([
+            t(
+              'idv.errors.finance_number_length',
+              minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+              maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+            )
+          ])
         end
       end
     end
 
-    context 'any non-ccn financial value is over 30 digits' do
+    context 'any non-ccn financial value is over the max allowed digits' do
       it 'fails' do
         finance_types = Idv::FinanceForm::FINANCE_TYPES
+        long_value = "1" * (FormFinanceValidator::VALID_MAXIMUM_LENGTH + 1)
 
         finance_types.each do |type|
           next if type == :ccn
           symbolized_type = type.to_sym
           params = {
-            symbolized_type => '1234567891234678912345678912345689',
+            symbolized_type => long_value,
             finance_type: symbolized_type
           }
 
           expect(subject.submit(params)).to eq false
-          expect(subject.errors[symbolized_type]).to eq(
-            [t('idv.errors.finance_number_length')]
-          )
+          expect(subject.errors[symbolized_type]).to eq([
+            t(
+              'idv.errors.finance_number_length',
+              minimum: FormFinanceValidator::VALID_MINIMUM_LENGTH,
+              maximum: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+            )
+          ])
         end
       end
     end

--- a/spec/forms/idv/finance_form_spec.rb
+++ b/spec/forms/idv/finance_form_spec.rb
@@ -62,11 +62,10 @@ describe Idv::FinanceForm do
 
         finance_types.each do |type|
           next if type == :ccn
-          symbolized_type = type.to_sym
-          params = { symbolized_type => '1234567', finance_type: symbolized_type }
+          params = { type => '1234567', finance_type: type }
 
           expect(subject.submit(params)).to eq false
-          expect(subject.errors[symbolized_type]).to eq(
+          expect(subject.errors[type]).to eq(
             [t('idv.errors.finance_number_length')]
           )
         end


### PR DESCRIPTION
**Why**: all financial account numbers are minimum 8 characters, max 30.