### PR TITLE
Update key-affected data automatically on sign in

### DIFF
--- a/app/models/concerns/user_encrypted_email_overrides.rb
+++ b/app/models/concerns/user_encrypted_email_overrides.rb
@@ -66,4 +66,9 @@ module UserEncryptedEmailOverrides
       self.email_fingerprint = ''
     end
   end
+
+  def stale_encrypted_email?
+    return false unless email.present?
+    @_encrypted_email.stale?
+  end
 end

--- a/app/services/encrypted_email.rb
+++ b/app/services/encrypted_email.rb
@@ -30,7 +30,7 @@ class EncryptedEmail
   end
 
   def fingerprint
-    Pii::Fingerprinter.fingerprint(email)
+    Pii::Fingerprinter.fingerprint(email.downcase)
   end
 
   def stale?

--- a/app/services/key_rotator/hmac_fingerprinter.rb
+++ b/app/services/key_rotator/hmac_fingerprinter.rb
@@ -1,9 +1,12 @@
 module KeyRotator
   class HmacFingerprinter
-    def rotate(user, pii_attributes)
+    def rotate(user:, pii_attributes: nil, profile: nil)
       User.transaction do
         rotate_email_fingerprint(user)
-        rotate_ssn_signature(user.active_profile, pii_attributes)
+        if pii_attributes
+          profile ||= user.active_profile
+          rotate_ssn_signature(profile, pii_attributes)
+        end
       end
     end
 
@@ -15,7 +18,8 @@ module KeyRotator
     end
 
     def rotate_ssn_signature(profile, pii_attributes)
-      profile.update_columns(ssn_signature: Pii::Fingerprinter.fingerprint(pii_attributes.ssn))
+      signature = Pii::Fingerprinter.fingerprint(pii_attributes.ssn.to_s)
+      profile.update_columns(ssn_signature: signature)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
   config.include Features::SessionHelper, type: :feature
   config.include AnalyticsHelper
   config.include AwsKmsClientHelper
+  config.include KeyRotationHelper
 
   config.before(:suite) do
     Rails.application.load_seed

--- a/spec/services/encrypted_email_spec.rb
+++ b/spec/services/encrypted_email_spec.rb
@@ -18,11 +18,10 @@ describe EncryptedEmail do
     end
 
     it 'automatically decrypts using old key' do
-      allow(Figaro.env).to receive(:email_encryption_key_queue).and_return('["some-old-key"]')
-      old_uak = EncryptedEmail.new_user_access_key(key: 'some-old-key')
-      ee = EncryptedEmail.new_from_email(email, old_uak)
+      encrypted_with_old_key = encrypted_email
+      rotate_email_encryption_key
 
-      expect(EncryptedEmail.new(ee.encrypted).decrypted).to eq email
+      expect(EncryptedEmail.new(encrypted_with_old_key).decrypted).to eq email
     end
   end
 
@@ -41,11 +40,10 @@ describe EncryptedEmail do
 
   describe '#stale?' do
     it 'returns true when email was encrypted with old key' do
-      allow(Figaro.env).to receive(:email_encryption_key_queue).and_return('["some-old-key"]')
-      old_uak = EncryptedEmail.new_user_access_key(key: 'some-old-key')
-      ee = EncryptedEmail.new_from_email(email, old_uak)
+      encrypted_with_old_key = encrypted_email
+      rotate_email_encryption_key
 
-      expect(ee.stale?).to eq true
+      expect(EncryptedEmail.new(encrypted_with_old_key).stale?).to eq true
     end
 
     it 'returns false when email was encrypted with current key' do

--- a/spec/services/key_rotator/email_encryption_spec.rb
+++ b/spec/services/key_rotator/email_encryption_spec.rb
@@ -7,9 +7,7 @@ describe KeyRotator::EmailEncryption do
       user = create(:user)
       old_encrypted_email = user.encrypted_email
 
-      old_email_key = Figaro.env.email_encryption_key
-      allow(Figaro.env).to receive(:email_encryption_key_queue).and_return("[\"#{old_email_key}\"]")
-      allow(Figaro.env).to receive(:email_encryption_key).and_return('a-new-key')
+      rotate_email_encryption_key
 
       rotator.rotate(user)
 

--- a/spec/services/key_rotator/hmac_fingerprinter_spec.rb
+++ b/spec/services/key_rotator/hmac_fingerprinter_spec.rb
@@ -12,15 +12,23 @@ describe KeyRotator::HmacFingerprinter do
       old_ssn_signature = profile.ssn_signature
       old_email_fingerprint = user.email_fingerprint
 
-      old_hmac_key = Figaro.env.hmac_fingerprinter_key
-      allow(Figaro.env).to receive(:hmac_fingerprinter_key_queue).and_return(
-        "[\"#{old_hmac_key}\"]"
-      )
-      allow(Figaro.env).to receive(:hmac_fingerprinter_key).and_return('a-new-key')
+      rotate_hmac_key
 
-      rotator.rotate(user, pii_attributes)
+      rotator.rotate(user: user, pii_attributes: pii_attributes)
 
       expect(user.active_profile.ssn_signature).to_not eq old_ssn_signature
+      expect(user.email_fingerprint).to_not eq old_email_fingerprint
+    end
+
+    it 'changes email fingerprint if no active profile' do
+      rotator = described_class.new
+      user = create(:user)
+      old_email_fingerprint = user.email_fingerprint
+
+      rotate_hmac_key
+
+      rotator.rotate(user: user)
+
       expect(user.email_fingerprint).to_not eq old_email_fingerprint
     end
   end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -33,6 +33,21 @@ describe Pii::Cacher do
       expect(decrypted_pii[:ssn]).to eq '5678'
       expect(user_session[:decrypted_pii]).to eq decrypted_pii_json
     end
+
+    it 'updates fingerprints when keys are rotated' do
+      old_ssn_signature = profile.ssn_signature
+      old_email_fingerprint = user.email_fingerprint
+      old_encrypted_email = user.encrypted_email
+
+      rotate_all_keys
+
+      subject.save(user_access_key)
+      profile.reload
+
+      expect(user.email_fingerprint).to_not eq old_email_fingerprint
+      expect(user.encrypted_email).to_not eq old_encrypted_email
+      expect(profile.ssn_signature).to_not eq old_ssn_signature
+    end
   end
 
   describe '#fetch' do

--- a/spec/support/key_rotation_helper.rb
+++ b/spec/support/key_rotation_helper.rb
@@ -1,0 +1,22 @@
+module KeyRotationHelper
+  def rotate_hmac_key
+    old_hmac_key = Figaro.env.hmac_fingerprinter_key
+    allow(Figaro.env).to receive(:hmac_fingerprinter_key_queue).and_return(
+      "[\"#{old_hmac_key}\"]"
+    )
+    allow(Figaro.env).to receive(:hmac_fingerprinter_key).and_return('a-new-key')
+  end
+
+  def rotate_email_encryption_key
+    old_email_key = Figaro.env.email_encryption_key
+    allow(Figaro.env).to receive(:email_encryption_key_queue).and_return(
+      "[\"#{old_email_key}\"]"
+    )
+    allow(Figaro.env).to receive(:email_encryption_key).and_return('a-new-key')
+  end
+
+  def rotate_all_keys
+    rotate_email_encryption_key
+    rotate_hmac_key
+  end
+end


### PR DESCRIPTION
**Why**: Regular key rotation w/o bulk updates.

**How**: Stale keys are detected and affected data are updated to use current key.