### PR TITLE
Improve Password Reset UX

### DIFF
--- a/.reek
+++ b/.reek
@@ -39,6 +39,9 @@ NilCheck:
     - user_not_found?
     - SamlIdpLogoutConcern#name_id
     - User#password_reset_profile
+RepeatedConditional:
+  exclude:
+    - Users::ResetPasswordsController
 TooManyConstants:
   exclude:
     - Analytics

--- a/app/controllers/forgot_password_controller.rb
+++ b/app/controllers/forgot_password_controller.rb
@@ -4,11 +4,9 @@ class ForgotPasswordController < ApplicationController
       redirect_to new_user_password_path
     else
       @resend_confirmation = params[:resend].present?
-      email = session.delete(:email)
+      @email = session.delete(:email)
 
-      @password_reset_email_form = PasswordResetEmailForm.new(email)
-
-      render :show, locals: { email: email }
+      @password_reset_email_form = PasswordResetEmailForm.new(@email)
     end
   end
 end

--- a/app/controllers/forgot_password_controller.rb
+++ b/app/controllers/forgot_password_controller.rb
@@ -1,0 +1,14 @@
+class ForgotPasswordController < ApplicationController
+  def show
+    if session[:email].blank?
+      redirect_to new_user_password_path
+    else
+      @resend_confirmation = params[:resend].present?
+      email = session.delete(:email)
+
+      @password_reset_email_form = PasswordResetEmailForm.new(email)
+
+      render :show, locals: { email: email }
+    end
+  end
+end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -79,7 +79,7 @@ module Users
     end
 
     def handle_successful_password_reset
-      resource.update(password: user_params[:password], confirmed_at: Time.current)
+      update_user
 
       mark_profile_inactive
 
@@ -98,6 +98,11 @@ module Users
       end
 
       render :edit
+    end
+
+    def update_user
+      resource.update(confirmed_at: Time.current) unless resource.confirmed?
+      resource.update(password: user_params[:password])
     end
 
     def mark_profile_inactive

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -27,7 +27,8 @@ class PasswordResetEmailForm
       success: success,
       errors: errors.messages.values.flatten,
       user_id: user.uuid,
-      role: user.role
+      role: user.role,
+      confirmed: user.confirmed?
     }
   end
 

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -2,10 +2,10 @@ class PasswordResetEmailForm
   include ActiveModel::Model
   include FormEmailValidator
 
-  attr_accessor :email
+  attr_reader :email
 
   def initialize(email)
-    self.email = email
+    @email = email
   end
 
   def resend

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -1,0 +1,37 @@
+class PasswordResetEmailForm
+  include ActiveModel::Model
+  include FormEmailValidator
+
+  attr_accessor :email
+
+  def initialize(email)
+    self.email = email
+  end
+
+  def resend
+    'true'
+  end
+
+  def submit
+    @success = valid?
+
+    result
+  end
+
+  private
+
+  attr_reader :success
+
+  def result
+    {
+      success: success,
+      errors: errors.messages.values.flatten,
+      user_id: user.uuid,
+      role: user.role
+    }
+  end
+
+  def user
+    @_user ||= User.find_with_email(email) || NonexistentUser.new
+  end
+end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -36,7 +36,8 @@ class ResetPasswordForm
       success: success,
       errors: errors.messages.values.flatten,
       user_id: user.uuid,
-      active_profile: user.active_profile.present?
+      active_profile: user.active_profile.present?,
+      confirmed: user.confirmed?
     }
   end
 end

--- a/app/models/nonexistent_user.rb
+++ b/app/models/nonexistent_user.rb
@@ -6,4 +6,8 @@ class NonexistentUser
   def role
     'nonexistent'
   end
+
+  def confirmed?
+    false
+  end
 end

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -2,20 +2,14 @@ RequestPasswordReset = Struct.new(:email) do
   def perform
     # To prevent revealing account existence, we don't treat a
     # "user not found" scenario as an error, unlike Devise's default
-    # behavior. That way, when the PasswordsController finishes processing
-    # the action, it will look like a successful transaction. We act as if
+    # behavior. That way, when ResetPasswordsController#create finishes
+    # processing, it will look like a successful transaction. We act as if
     # the password reset email was sent, when in fact it wasn't.
     # Similary, for security purposes, we don't want to allow password
     # recovery via email for admin and tech support users.
     return if user_not_found? || user_found_but_is_an_admin_or_tech?
 
-    if user.confirmed?
-      user.send_reset_password_instructions
-    else
-      # For a better UX, we resend the confirmation email instructions if the
-      # account has not been confirmed yet.
-      user.send_confirmation_instructions
-    end
+    user.send_reset_password_instructions
   end
 
   private

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -1,11 +1,6 @@
 RequestPasswordReset = Struct.new(:email) do
   def perform
-    # To prevent revealing account existence, we don't treat a
-    # "user not found" scenario as an error, unlike Devise's default
-    # behavior. That way, when ResetPasswordsController#create finishes
-    # processing, it will look like a successful transaction. We act as if
-    # the password reset email was sent, when in fact it wasn't.
-    # Similary, for security purposes, we don't want to allow password
+    # For security purposes, we don't want to allow password
     # recovery via email for admin and tech support users.
     return if user_not_found? || user_found_but_is_an_admin_or_tech?
 

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -3,7 +3,7 @@
 h1.h3.my0 = t('headings.passwords.forgot')
 p.mt-tiny.mb0#email-description
   = t('instructions.password.forgot')
-= simple_form_for(resource,
+= simple_form_for(@password_reset_email_form,
                   url: user_password_path,
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
 

--- a/app/views/forgot_password/show.html.slim
+++ b/app/views/forgot_password/show.html.slim
@@ -5,20 +5,20 @@
     class: 'absolute top-n16 left-0 right-0 mx-auto')
   h1.mt1.mb-12p.h3 = t('headings.verify_email')
   p.mb3
-    | #{t('notices.signed_up_but_unconfirmed.first_paragraph_start')}
+    | #{t('notices.forgot_password.first_paragraph_start')}
       <strong>#{email}</strong>
-      #{t('notices.signed_up_but_unconfirmed.first_paragraph_end')}
+      #{t('notices.forgot_password.first_paragraph_end')}
   - if @resend_confirmation
     .alert.alert-success.alert-no-icon role="alert"
       = image_tag(asset_url('alert/ico-thumb.svg'), height: '16', alt: '',\
         class: 'mr2 align-bottom')
-      = t('notices.resend_confirmation_email.success')
-  = simple_form_for(@register_user_email_form, url: sign_up_register_path,
-    html: { class: '' }) do |f|
+      = t('notices.forgot_password.resend_email_success')
+  = simple_form_for(@password_reset_email_form, url: user_password_path,
+    html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
     = f.input :email, as: :hidden, wrapper: false
     = f.input :resend, as: :hidden, wrapper: false
-    | #{t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')}
+    | #{t('notices.forgot_password.no_email_sent_explanation_start')}
     = f.button :submit, t('links.resend'), class: 'btn-link ml-tiny'
-  - link = link_to t('notices.use_diff_email.link'), sign_up_email_path
-  p.m0 == t('notices.use_diff_email.text_html', link: link)
-  p.my2.h5.italic = t('devise.registrations.close_window')
+  - link = link_to t('notices.forgot_password.use_diff_email.link'), sign_up_email_path
+  p.m0 == t('notices.forgot_password.use_diff_email.text_html', link: link)
+  p.my2.h5.italic = t('instructions.forgot_password.close_window')

--- a/app/views/forgot_password/show.html.slim
+++ b/app/views/forgot_password/show.html.slim
@@ -6,7 +6,7 @@
   h1.mt1.mb-12p.h3 = t('headings.verify_email')
   p.mb3
     | #{t('notices.forgot_password.first_paragraph_start')}
-      <strong>#{email}</strong>
+      <strong>#{@email}</strong>
       #{t('notices.forgot_password.first_paragraph_end')}
   - if @resend_confirmation
     .alert.alert-success.alert-no-icon role="alert"

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -72,7 +72,6 @@ en:
     recovery_code: Make sure you can always sign in
     registrations:
       enter_email: Start creating an account
-      verify_email: Check your email
     search: Search for a user
     session_timeout_warning: Need more time?
     sign_in_with_sp: Sign in to continue to %{sp}
@@ -80,3 +79,5 @@ en:
     totp_setup:
       new: Scan the QR code with your device
       start: Set up two-factor authentication
+    verify_email: Check your email
+

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -80,4 +80,3 @@ en:
       new: Scan the QR code with your device
       start: Set up two-factor authentication
     verify_email: Check your email
-

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -72,7 +72,6 @@ es:
     recovery_code: NOT TRANSLATED YET
     registrations:
       enter_email: NOT TRANSLATED YET
-      verify_email: NOT TRANSLATED YET
     search: NOT TRANSLATED YET
     session_timeout_warning: NOT TRANSLATED YET
     sign_in_with_sp: NOT TRANSLATED YET
@@ -80,3 +79,4 @@ es:
     totp_setup:
       new: NOT TRANSLATED YET
       start: NOT TRANSLATED YET
+    verify_email: NOT TRANSLATED YET

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -9,6 +9,8 @@ en:
         set up in your app, enter the code corresponding to <strong>%{email}</strong> at
         <strong>%{app}</strong>.
       wrong_number: Entered the wrong phone number? %{link}
+    forgot_password:
+      close_window: You can close this browser window once you have reset your password.
     password:
       forgot: >
         If you don’t know your current password, you can reset it. Type the email address

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -6,6 +6,8 @@ es:
       resend: NOT TRANSLATED YET
       totp_intro_html: NOT TRANSLATED YET
       wrong_number: NOT TRANSLATED YET
+    forgot_password:
+      close_window: NOT TRANSLATED YET
     password:
       forgot: NOT TRANSLATED YET
       info:

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -4,9 +4,17 @@ en:
     dap_html: >
       <!-- We participate in the US government’s analytics program. -->
       <!-- See the data at analytics.usa.gov. -->
+    forgot_password:
+      use_diff_email:
+        link: create a new account
+        text_html: Or, %{link} using a different email address.
+      first_paragraph_end: >
+        with a link to reset your password. Follow the link to continue
+        resetting your password.
+      first_paragraph_start: We sent an email to
+      no_email_sent_explanation_start: Didn’t get an email?
+      resend_email_success: We have resent your password reset email.
     password_changed: You changed your password.
-    password_reset: >
-      Check your email in a few minutes for instructions on how to reset your password.
     phone_confirmation_successful: You confirmed your phone number. Now your account is more secure!
     resend_confirmation_email:
       success: We have resent your confirmation email.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -2,8 +2,16 @@
 es:
   notices:
     dap_html: NOT TRANSLATED YET
+    forgot_password:
+      use_diff_email:
+        link: NOT TRANSLATED YET
+        text_html: NOT TRANSLATED YET
+      first_paragraph_end: >
+        NOT TRANSLATED YET
+      first_paragraph_start: NOT TRANSLATED YET
+      no_email_sent_explanation_start: NOT TRANSLATED YET
+      resend_email_success: NOT TRANSLATED YET
     password_changed: NOT TRANSLATED YET
-    password_reset: NOT TRANSLATED YET
     phone_confirmation_successful: NOT TRANSLATED YET
     resend_confirmation_email:
       success: NOT TRANSLATED YET

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -23,11 +23,11 @@ en:
     registrations:
       new: Sign up for a account
       start: Get started
-      verify_email: Check your email
     totp_setup:
       new: Enter the secure one-time passcode
       start: Set up two-factor authentication
     two_factor_setup: Two-factor authentication setup
     two_factor_verification: Choose OTP delivery method
+    verify_email: Check your email
     visitors:
       index: Welcome

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -23,11 +23,11 @@ es:
     registrations:
       new: NOT TRANSLATED YET
       start: NOT TRANSLATED YET
-      verify_email: NOT TRANSLATED YET
     totp_setup:
       new: NOT TRANSLATED YET
       start: NOT TRANSLATED YET
     two_factor_setup: NOT TRANSLATED YET
     two_factor_verification: NOT TRANSLATED YET
+    verify_email: NOT TRANSLATED YET
     visitors:
       index: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
   get '/contact' => 'contact#new', as: :contact
   post '/contact' => 'contact#create'
 
+  get '/forgot_password' => 'forgot_password#show'
+
   get '/help' => 'pages#help'
 
   get '/manage/email' => 'users/emails#edit'

--- a/spec/controllers/forgot_password_controller_spec.rb
+++ b/spec/controllers/forgot_password_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ForgotPasswordController do
+  describe '#show' do
+    context 'email in session' do
+      it 'renders the page and deletes the email from the session' do
+        session[:email] = 'test@example.com'
+
+        get :show
+
+        expect(session[:email]).to be_nil
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'no email in session' do
+      it 'redirects to the new user password path' do
+        session[:email] = nil
+
+        get :show
+
+        expect(response).to redirect_to(new_user_password_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -203,6 +203,44 @@ describe Users::ResetPasswordsController, devise: true do
         expect(response).to redirect_to new_user_session_path
       end
     end
+
+    context 'unconfirmed user submits valid new password' do
+      it 'confirms the user' do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+
+        raw_reset_token, db_confirmation_token =
+          Devise.token_generator.generate(User, :reset_password_token)
+
+        user = create(
+          :user,
+          :unconfirmed,
+          reset_password_token: db_confirmation_token,
+          reset_password_sent_at: Time.current
+        )
+
+        stub_email_notifier(user)
+
+        password = 'a really long passw0rd'
+        params = { password: password, reset_password_token: raw_reset_token }
+
+        put :update, reset_password_form: params
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: user.uuid,
+          active_profile: false
+        }
+
+        expect(@analytics).to have_received(:track_event).
+          with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
+
+        expect(user.reload.confirmed?).to eq true
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
   end
 
   describe '#create' do
@@ -210,14 +248,20 @@ describe Users::ResetPasswordsController, devise: true do
       it 'tracks event using anonymous user' do
         stub_analytics
 
-        nonexistent_user = instance_double(NonexistentUser, uuid: '123', role: 'nonexistent')
-        allow(NonexistentUser).to receive(:new).and_return(nonexistent_user)
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: 'nonexistent-uuid',
+          role: 'nonexistent'
+        }
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_EMAIL,
-               user_id: nonexistent_user.uuid, role: nonexistent_user.role)
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        put :create, user: { email: 'nonexistent@example.com' }
+        expect { put :create, password_reset_email_form: { email: 'nonexistent@example.com' } }.
+          to change { ActionMailer::Base.deliveries.count }.by(0)
+
+        expect(response).to redirect_to forgot_password_path
       end
     end
 
@@ -226,13 +270,22 @@ describe Users::ResetPasswordsController, devise: true do
         stub_analytics
 
         tech_user = build_stubbed(:user, :tech_support)
-        fingerprint = Pii::Fingerprinter.fingerprint('tech@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(tech_user)
+        allow(User).to receive(:find_with_email).with(tech_user.email).and_return(tech_user)
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: tech_user.uuid,
+          role: 'tech'
+        }
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_EMAIL, user_id: tech_user.uuid, role: 'tech')
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        put :create, user: { email: 'TECH@example.com' }
+        expect { put :create, password_reset_email_form: { email: tech_user.email } }.
+          to change { ActionMailer::Base.deliveries.count }.by(0)
+
+        expect(response).to redirect_to forgot_password_path
       end
     end
 
@@ -241,13 +294,98 @@ describe Users::ResetPasswordsController, devise: true do
         stub_analytics
 
         admin = build_stubbed(:user, :admin)
-        fingerprint = Pii::Fingerprinter.fingerprint('admin@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(admin)
+        allow(User).to receive(:find_with_email).with(admin.email).and_return(admin)
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: admin.uuid,
+          role: 'admin'
+        }
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::PASSWORD_RESET_EMAIL, user_id: admin.uuid, role: 'admin')
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        put :create, user: { email: 'ADMIN@example.com' }
+        expect { put :create, password_reset_email_form: { email: admin.email } }.
+          to change { ActionMailer::Base.deliveries.count }.by(0)
+
+        expect(response).to redirect_to forgot_password_path
+      end
+    end
+
+    context 'user exists' do
+      it 'sends password reset email to user and tracks event' do
+        stub_analytics
+
+        user = build(:user, :signed_up, role: :user)
+        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: user.uuid,
+          role: 'user'
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
+
+        expect { put :create, password_reset_email_form: { email: user.email } }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        expect(response).to redirect_to forgot_password_path
+      end
+    end
+
+    context 'user exists but is unconfirmed' do
+      it 'sends password reset email to user and tracks event' do
+        stub_analytics
+
+        user = create(:user, :unconfirmed, role: :user)
+
+        analytics_hash = {
+          success: true,
+          errors: [],
+          user_id: user.uuid,
+          role: 'user'
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
+
+        expect { put :create, password_reset_email_form: { email: user.email } }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        expect(ActionMailer::Base.deliveries.last.subject).
+          to eq t('devise.mailer.reset_password_instructions.subject')
+
+        expect(response).to redirect_to forgot_password_path
+      end
+    end
+
+    context 'email is invalid' do
+      it 'displays an error and tracks event' do
+        form = instance_double(PasswordResetEmailForm)
+        expect(PasswordResetEmailForm).to receive(:new).with('foo').and_return(form)
+
+        stub_analytics
+
+        analytics_hash = {
+          success: false,
+          errors: [t('valid_email.validations.email.invalid')],
+          user_id: 'nonexistent-uuid',
+          role: 'nonexistent'
+        }
+
+        expect(form).to receive(:submit).and_return(analytics_hash)
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
+
+        expect { put :create, password_reset_email_form: { email: 'foo' } }.
+          to change { ActionMailer::Base.deliveries.count }.by(0)
+
+        expect(response).to render_template :new
       end
     end
   end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -256,7 +256,8 @@ describe Users::ResetPasswordsController, devise: true do
 
   describe '#create' do
     context 'no user matches email' do
-      it 'tracks event using anonymous user' do
+      it 'redirects to forgot_password_path to prevent revealing account existence ' \
+        'and tracks event using nonexistent user' do
         stub_analytics
 
         analytics_hash = {

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -7,48 +7,36 @@ feature 'Password Recovery' do
     fill_in_credentials_and_submit(user.email, password)
   end
 
-  context 'user can reset their password via email', email: true do
-    before do
+  context 'user enters valid email in forgot password form', email: true do
+    it 'redirects to forgot_password path and sends an email to the user' do
       user = create(:user, :signed_up)
 
       visit root_path
       click_link t('links.passwords.forgot')
       fill_in 'Email', with: user.email
       click_button t('forms.buttons.continue')
-    end
 
-    it 'uses a relevant email subject' do
+      expect(current_path).to eq forgot_password_path
+
       expect(last_email.subject).to eq t('devise.mailer.reset_password_instructions.' \
-                                         'subject')
-    end
-
-    it 'includes a link to customer service in the email' do
+                                          'subject')
       expect(last_email.html_part.body).to include contact_url
-    end
-
-    it 'displays a localized notice' do
-      expect(page).to have_content t('notices.password_reset')
-    end
-
-    it 'includes a link to reset the password in the email' do
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
-
-      expect(current_path).to eq edit_user_password_path
-    end
-
-    it 'specifies how long the user has to reset the password based on Devise settings' do
       expect(last_email.html_part.body).to have_content(
         t(
           'mailer.reset_password.footer',
           expires: (Devise.reset_password_within / 3600)
         )
       )
+
+      open_last_email
+      click_email_link_matching(/reset_password_token/)
+
+      expect(current_path).to eq edit_user_password_path
     end
   end
 
-  context 'user with only email confirmation resets password', email: true do
-    before do
+  context 'user has confirmed email, but not set a password yet', email: true do
+    it 'shows the reset password form and confirms user after setting a password' do
       user = create(:user, :unconfirmed)
       confirm_last_user
       reset_email
@@ -56,15 +44,22 @@ feature 'Password Recovery' do
       fill_in 'Email', with: user.email
       click_button t('forms.buttons.continue')
       open_last_email
-      click_email_link_matching(/confirmation_token/)
-    end
+      click_email_link_matching(/reset_password_token/)
 
-    it 'shows the password form' do
-      expect(page).to have_content t('forms.confirmation.show_hdr')
+      expect(current_path).to eq edit_user_password_path
+
+      fill_in 'New password', with: 'NewVal!dPassw0rd'
+      click_button t('forms.passwords.edit.buttons.submit')
+
+      expect(current_path).to eq new_user_session_path
+
+      fill_in_credentials_and_submit(user.email, 'NewVal!dPassw0rd')
+
+      expect(current_path).to eq phone_setup_path
     end
   end
 
-  context 'user with email confirmation resends confirmation', email: true do
+  context 'user who has only confirmed email resends confirmation', email: true do
     before do
       user = create(:user, :unconfirmed)
       confirm_last_user
@@ -81,7 +76,7 @@ feature 'Password Recovery' do
     end
   end
 
-  context 'user with password confirmation resets password', email: true do
+  context 'user has confirmed email and set a password, then resets password', email: true do
     before do
       @user = create(:user)
       visit new_user_password_path
@@ -143,53 +138,11 @@ feature 'Password Recovery' do
     end
   end
 
-  scenario 'user submits email address with invalid format' do
-    invalid_addresses = [
-      'user@domain-without-suffix',
-      'Buy Medz 0nl!ne http://pharma342.onlinestore.com'
-    ]
-    allow(ValidateEmail).to receive(:mx_valid?).and_return(false)
-
-    visit new_user_password_path
-
-    invalid_addresses.each do |email|
-      fill_in 'Email', with: email
-      click_button t('forms.buttons.continue')
-
-      expect(page).to have_content t('valid_email.validations.email.invalid')
-    end
-  end
-
-  scenario 'user submits email address with invalid domain name' do
-    invalid_addresses = [
-      'foo@bar.com',
-      'foo@example.com'
-    ]
-    allow(ValidateEmail).to receive(:mx_valid?).and_return(false)
-
-    visit new_user_password_path
-
-    invalid_addresses.each do |email|
-      fill_in 'Email', with: email
-      click_button t('forms.buttons.continue')
-
-      expect(page).to have_content t('valid_email.validations.email.invalid')
-    end
-  end
-
   scenario 'user submits blank email address' do
     visit new_user_password_path
     click_button t('forms.buttons.continue')
 
     expect(page).to have_content t('valid_email.validations.email.invalid')
-  end
-
-  scenario 'user is unable to determine if account exists' do
-    visit new_user_password_path
-    fill_in 'Email', with: 'no_account_exists@gmail.com'
-    click_button t('forms.buttons.continue')
-
-    expect(page).to have_content(t('notices.password_reset'))
   end
 
   context 'user can reset their password' do
@@ -317,51 +270,6 @@ feature 'Password Recovery' do
     expect(page).to have_content t('devise.passwords.token_expired')
 
     expect(current_path).to eq new_user_password_path
-  end
-
-  scenario 'unconfirmed user requests reset instructions', email: true do
-    user = create(:user, :unconfirmed)
-
-    visit new_user_password_path
-    fill_in 'Email', with: user.email
-    click_button t('forms.buttons.continue')
-
-    expect(last_email.subject).
-      to eq t('devise.mailer.confirmation_instructions.subject')
-  end
-
-  scenario 'user enters non-existent email address into password reset form' do
-    visit new_user_password_path
-    fill_in 'user_email', with: 'ThisEmailAddressShall@NeverExist.com'
-    click_button t('forms.buttons.continue')
-
-    expect(page).to have_content t('notices.password_reset')
-    expect(page).not_to(have_content('not found'))
-    expect(page).not_to(have_content(t('simple_form.error_notification.default_message')))
-  end
-
-  scenario 'tech user enters email address into password reset form' do
-    reset_email
-    user = create(:user, :signed_up, :tech_support)
-
-    visit new_user_password_path
-    fill_in 'user_email', with: user.email
-    click_button t('forms.buttons.continue')
-
-    expect(page).to have_content t('notices.password_reset')
-    expect(ActionMailer::Base.deliveries).to be_empty
-  end
-
-  scenario 'admin user enters email address into password reset form' do
-    reset_email
-    user = create(:user, :signed_up, :admin)
-
-    visit new_user_password_path
-    fill_in 'user_email', with: user.email
-    click_button t('forms.buttons.continue')
-
-    expect(page).to have_content t('notices.password_reset')
-    expect(ActionMailer::Base.deliveries).to be_empty
   end
 
   def recovery_code_from_pii(user, pii)

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -48,7 +48,7 @@ feature 'Password Recovery' do
 
       expect(current_path).to eq edit_user_password_path
 
-      fill_in 'New password', with: 'NewVal!dPassw0rd'
+      fill_in t('forms.passwords.edit.labels.password'), with: 'NewVal!dPassw0rd'
       click_button t('forms.passwords.edit.buttons.submit')
 
       expect(current_path).to eq new_user_session_path

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe PasswordResetEmailForm do
+  subject { PasswordResetEmailForm.new('test@example.com') }
+
+  it_behaves_like 'email validation'
+
+  describe '#submit' do
+    context 'when email is valid and user exists' do
+      it 'returns hash with properties about the event and the user' do
+        user = build(:user, :signed_up)
+        subject = PasswordResetEmailForm.new(user.email)
+
+        result = {
+          success: true,
+          errors: [],
+          user_id: user.uuid,
+          role: user.role
+        }
+
+        expect(subject.submit).to eq result
+        expect(subject.email).to eq user.email
+        expect(subject).to respond_to(:resend)
+      end
+    end
+
+    context 'when email is valid and user does not exist' do
+      it 'returns hash with properties about the event and the nonexistent user' do
+        result = {
+          success: true,
+          errors: [],
+          user_id: 'nonexistent-uuid',
+          role: 'nonexistent'
+        }
+
+        expect(subject.submit).to eq result
+      end
+    end
+
+    context 'when email is invalid' do
+      it 'returns hash with properties about the event and the nonexistent user' do
+        subject = PasswordResetEmailForm.new('invalid')
+
+        result = {
+          success: false,
+          errors: [t('valid_email.validations.email.invalid')],
+          user_id: 'nonexistent-uuid',
+          role: 'nonexistent'
+        }
+
+        expect(subject.submit).to eq result
+      end
+    end
+  end
+end

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -15,7 +15,8 @@ describe PasswordResetEmailForm do
           success: true,
           errors: [],
           user_id: user.uuid,
-          role: user.role
+          role: user.role,
+          confirmed: true
         }
 
         expect(subject.submit).to eq result
@@ -30,7 +31,8 @@ describe PasswordResetEmailForm do
           success: true,
           errors: [],
           user_id: 'nonexistent-uuid',
-          role: 'nonexistent'
+          role: 'nonexistent',
+          confirmed: false
         }
 
         expect(subject.submit).to eq result
@@ -45,7 +47,8 @@ describe PasswordResetEmailForm do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           user_id: 'nonexistent-uuid',
-          role: 'nonexistent'
+          role: 'nonexistent',
+          confirmed: false
         }
 
         expect(subject.submit).to eq result

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -19,7 +19,8 @@ describe ResetPasswordForm, type: :model do
           success: false,
           errors: ['token_expired'],
           user_id: '123',
-          active_profile: false
+          active_profile: false,
+          confirmed: true
         }
 
         expect(form.submit(password: password)).to eq result
@@ -39,7 +40,8 @@ describe ResetPasswordForm, type: :model do
           success: false,
           errors: ['is too short (minimum is 8 characters)'],
           user_id: '123',
-          active_profile: false
+          active_profile: false,
+          confirmed: true
         }
 
         expect(form.submit(password: password)).to eq result
@@ -59,7 +61,8 @@ describe ResetPasswordForm, type: :model do
           success: true,
           errors: [],
           user_id: '123',
-          active_profile: false
+          active_profile: false,
+          confirmed: true
         }
 
         expect(form.submit(password: password)).to eq result
@@ -79,7 +82,8 @@ describe ResetPasswordForm, type: :model do
           success: false,
           errors: ['is too short (minimum is 8 characters)', 'token_expired'],
           user_id: '123',
-          active_profile: false
+          active_profile: false,
+          confirmed: true
         }
 
         expect(form.submit(password: password)).to eq result
@@ -105,7 +109,8 @@ describe ResetPasswordForm, type: :model do
               ' Add another word or two.' \
               ' Uncommon words are better.'],
             user_id: nil,
-            active_profile: false
+            active_profile: false,
+            confirmed: true
           }
 
           expect(form.submit(password: password)).

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -4,10 +4,9 @@ describe RequestPasswordReset do
   describe '#perform' do
     context 'when the user is not found' do
       it 'does not send any emails' do
-        user = instance_double(User, admin?: false, tech?: false)
+        user = build_stubbed(:user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
-        expect(user).to_not receive(:send_confirmation_instructions)
 
         RequestPasswordReset.new('nonexistent@example.com').perform
       end
@@ -15,57 +14,49 @@ describe RequestPasswordReset do
 
     context 'when the user is an admin' do
       it 'does not send any emails' do
-        user = instance_double(User, admin?: true, tech?: false)
+        user = build_stubbed(:user, :admin)
 
-        fingerprint = Pii::Fingerprinter.fingerprint('admin@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
+        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
-        expect(user).to_not receive(:send_confirmation_instructions)
 
-        RequestPasswordReset.new('admin@example.com').perform
+        RequestPasswordReset.new(user.email).perform
       end
     end
 
     context 'when the user is a tech support person' do
       it 'does not send any emails' do
-        user = instance_double(User, admin?: false, tech?: true)
+        user = build_stubbed(:user, :tech_support)
 
-        fingerprint = Pii::Fingerprinter.fingerprint('tech@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
+        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
 
         expect(user).to_not receive(:send_reset_password_instructions)
-        expect(user).to_not receive(:send_confirmation_instructions)
 
-        RequestPasswordReset.new('tech@example.com').perform
+        RequestPasswordReset.new(user.email).perform
       end
     end
 
     context 'when the user is found, not privileged, and confirmed' do
       it 'sends password reset instructions' do
-        user = instance_double(User, admin?: false, tech?: false, confirmed?: true)
+        user = build_stubbed(:user)
 
-        fingerprint = Pii::Fingerprinter.fingerprint('user@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
+        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
 
         expect(user).to receive(:send_reset_password_instructions)
-        expect(user).to_not receive(:send_confirmation_instructions)
 
-        RequestPasswordReset.new('user@example.com').perform
+        RequestPasswordReset.new(user.email).perform
       end
     end
 
     context 'when the user is found, not privileged, and not yet confirmed' do
-      it 'sends confirmation instructions' do
-        user = instance_double(User, admin?: false, tech?: false, confirmed?: false)
+      it 'sends password reset instructions' do
+        user = build_stubbed(:user, :unconfirmed)
 
-        fingerprint = Pii::Fingerprinter.fingerprint('user@example.com')
-        allow(User).to receive(:find_by).with(email_fingerprint: fingerprint).and_return(user)
+        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
 
-        expect(user).to_not receive(:send_reset_password_instructions)
-        expect(user).to receive(:send_confirmation_instructions)
+        expect(user).to receive(:send_reset_password_instructions)
 
-        RequestPasswordReset.new('user@example.com').perform
+        RequestPasswordReset.new(user.email).perform
       end
     end
   end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -13,7 +13,7 @@ describe RequestPasswordReset do
     end
 
     context 'when the user is an admin' do
-      it 'does not send any emails' do
+      it 'does not send any emails, to prevent password recovery via email for privileged users' do
         user = build_stubbed(:user, :admin)
 
         allow(User).to receive(:find_with_email).with(user.email).and_return(user)
@@ -25,7 +25,7 @@ describe RequestPasswordReset do
     end
 
     context 'when the user is a tech support person' do
-      it 'does not send any emails' do
+      it 'does not send any emails, to prevent password recovery via email for privileged users' do
         user = build_stubbed(:user, :tech_support)
 
         allow(User).to receive(:find_with_email).with(user.email).and_return(user)

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'devise/passwords/new.html.slim' do
   before do
-    allow(view).to receive(:resource).and_return(User.new)
+    @password_reset_email_form = PasswordResetEmailForm.new('')
   end
 
   it 'has a localized title' do

--- a/spec/views/forgot_password/show.html.slim_spec.rb
+++ b/spec/views/forgot_password/show.html.slim_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe 'forgot_password/show.html.slim' do
+  before do
+    allow(view).to receive(:email).and_return('foo@bar.com')
+    @password_reset_email_form = PasswordResetEmailForm.new('foo@bar.com')
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.verify_email'))
+
+    render
+  end
+
+  it 'has a localized header' do
+    render
+
+    expect(rendered).to have_selector('h1', text: t('headings.verify_email'))
+  end
+
+  it 'contains link to resend the password reset email' do
+    render
+
+    expect(rendered).to have_button(t('links.resend'))
+    expect(rendered).
+      to have_xpath("//form[@action='#{user_password_path}']")
+    expect(rendered).
+      to have_xpath("//form[@method='post']")
+  end
+
+  it 'provides an explanation to the user' do
+    render
+
+    expect(rendered).to have_content t('notices.forgot_password.first_paragraph_start')
+    expect(rendered).to have_content 'foo@bar.com'
+    expect(rendered).to have_content t('notices.forgot_password.first_paragraph_end')
+    expect(rendered).to have_content t('notices.forgot_password.no_email_sent_explanation_start')
+    expect(rendered).to have_content t('instructions.forgot_password.close_window')
+    expect(rendered).to_not have_content t('notices.forgot_password.resend_email_success')
+  end
+
+  it 'contains a link to create a new account' do
+    render
+
+    expect(rendered).
+      to have_link(t('notices.forgot_password.use_diff_email.link'), href: sign_up_email_path)
+  end
+
+  it 'displays a notice if @resend_confirmation is present' do
+    @resend_confirmation = true
+
+    render
+
+    expect(rendered).to have_content t('notices.forgot_password.resend_email_success')
+  end
+end

--- a/spec/views/forgot_password/show.html.slim_spec.rb
+++ b/spec/views/forgot_password/show.html.slim_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'forgot_password/show.html.slim' do
   before do
-    allow(view).to receive(:email).and_return('foo@bar.com')
+    @email = 'foo@bar.com'
     @password_reset_email_form = PasswordResetEmailForm.new('foo@bar.com')
   end
 

--- a/spec/views/sign_up/emails/show.html.slim_spec.rb
+++ b/spec/views/sign_up/emails/show.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'sign_up/emails/show.html.slim' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title).with(t('titles.registrations.verify_email'))
+    expect(view).to receive(:title).with(t('titles.verify_email'))
 
     render
   end
@@ -15,7 +15,7 @@ describe 'sign_up/emails/show.html.slim' do
   it 'has a localized header' do
     render
 
-    expect(rendered).to have_selector('h1', text: t('headings.registrations.verify_email'))
+    expect(rendered).to have_selector('h1', text: t('headings.verify_email'))
   end
 
   it 'contains link to resend confirmation page' do


### PR DESCRIPTION
**Why**: When a user goes to reset their password, after they submit
their email, they were sent back to the sign in page with a flash
message. This is not consistent with what happens when you submit your
email when creating an account, i.e. you are given a chance to send
the email again, along with detailed instructions.

This PR makes the experience of resetting a password consistent with
the account creation.

**How**:
- In order to prevent revealing whether or not an email exists in our
database, we must present the same password reset experience regardless
of the scenario and state of the user. This means that we should always
send the password reset email, even if the user is unconfirmed. This
means we only need to show the new
`app/views/forgot_password/show.html.slim` page that I added in this PR.

- Related to the above, since we're now sending password reset emails to
unconfirmed users, we confirm them after resetting their password, since
we've essentially confirmed that they own that email address. It doesn't
matter whether the confirmation comes via a confirmation email or a
password reset email.

- Remove the `ValidEmailParameter` concern from
`ResetPasswordsController`, and use a form object instead with our
existing `FormEmailValidator`, to keep email validation consistent
everywhere, and for better analytics. The concern was not including the
domains in our banned list (see `valid_email.yml`).

- Move the title and headings localizations of the `sign_up/emails/show`
view to a top-level key since this will be the same across all views
that are a result of submitting an email field that causes an email to
be sent, including the new forgot password view that was added here.

- Replace feature specs for edge cases with controller specs