### PR TITLE
Use underscores, not dashes, in URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,13 +16,13 @@ Rails.application.routes.draw do
     post '/' => 'users/sessions#create', as: :user_session
     get '/active' => 'users/sessions#active'
 
-    get '/login/two-factor/authenticator' => 'two_factor_authentication/totp_verification#show'
-    post '/login/two-factor/authenticator' => 'two_factor_authentication/totp_verification#create'
-    get '/login/two-factor/recovery-code' => 'two_factor_authentication/recovery_code_verification#show'
-    post '/login/two-factor/recovery-code' => 'two_factor_authentication/recovery_code_verification#create'
-    get  '/login/two-factor/:delivery_method' => 'two_factor_authentication/otp_verification#show',
+    get '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#show'
+    post '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#create'
+    get '/login/two_factor/recovery_code' => 'two_factor_authentication/recovery_code_verification#show'
+    post '/login/two_factor/recovery_code' => 'two_factor_authentication/recovery_code_verification#create'
+    get  '/login/two_factor/:delivery_method' => 'two_factor_authentication/otp_verification#show',
          as: :login_two_factor
-    post '/login/two-factor/:delivery_method' => 'two_factor_authentication/otp_verification#create',
+    post '/login/two_factor/:delivery_method' => 'two_factor_authentication/otp_verification#create',
          as: :login_otp
 
     get '/otp/send' => 'devise/two_factor_authentication#send_code'

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -182,13 +182,13 @@ feature 'Two Factor Authentication' do
 
       click_link t('devise.two_factor_authentication.totp_fallback.sms_link_text')
 
-      expect(current_path).to eq '/login/two-factor/sms'
+      expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
 
       visit login_two_factor_authenticator_path
 
       click_link t('devise.two_factor_authentication.totp_fallback.voice_link_text')
 
-      expect(current_path).to eq '/login/two-factor/voice'
+      expect(current_path).to eq login_two_factor_path(delivery_method: 'voice')
     end
   end
 


### PR DESCRIPTION
**Why**: Consistency