### PR TITLE
Improve finance form mobile UX

### DIFF
--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -1,16 +1,20 @@
 import { PhoneFormatter, SocialSecurityNumberFormatter, TextField } from 'field-kit';
 import DateFormatter from './modules/date-formatter';
-import OtpCodeFormatter from './modules/otp-code-formatter';
+import NumericFormatter from './modules/numeric-formatter';
 import ZipCodeFormatter from './modules/zip-code-formatter';
 
 
 function formatForm() {
   const formats = [
+    ['.auto_loan', new NumericFormatter()],
+    ['.ccn', new NumericFormatter()],
     ['.dob', new DateFormatter()],
-    ['[type=tel]', new PhoneFormatter()],
+    ['.home_equity_line', new NumericFormatter()],
+    ['.mfa', new NumericFormatter()],
+    ['.mortgage', new NumericFormatter()],
     ['.ssn', new SocialSecurityNumberFormatter()],
+    ['[type=tel]', new PhoneFormatter()],
     ['.zipcode', new ZipCodeFormatter()],
-    ['.mfa', new OtpCodeFormatter()],
   ];
 
   formats.forEach(function(f) {
@@ -28,6 +32,13 @@ function formatForm() {
 
       // removes focus set by field-kit bug https://github.com/square/field-kit/issues/62
       if (el !== '.mfa') document.activeElement.blur();
+
+      // max lengths
+      if (el === '.mfa') {
+        field.formatter().maximumLength = 6;
+      } else if (el === '.ccn') {
+        field.formatter().maximumLength = 8;
+      }
     }
   });
 }

--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -32,13 +32,6 @@ function formatForm() {
 
       // removes focus set by field-kit bug https://github.com/square/field-kit/issues/62
       if (el !== '.mfa') document.activeElement.blur();
-
-      // max lengths
-      if (el === '.mfa') {
-        field.formatter().maximumLength = 6;
-      } else if (el === '.ccn') {
-        field.formatter().maximumLength = 8;
-      }
     }
   });
 }

--- a/app/assets/javascripts/app/modules/numeric-formatter.js
+++ b/app/assets/javascripts/app/modules/numeric-formatter.js
@@ -2,13 +2,11 @@ import { Formatter } from 'field-kit';
 
 
 const DIGITS_PATTERN = /^\d*$/;
-const maxLength = 6;
 
 
-class OtpCodeFormatter extends Formatter {
+class NumericFormatter extends Formatter {
   constructor() {
     super();
-    this.maximumLength = maxLength;
   }
 
   isChangeValid(change, error) {
@@ -20,4 +18,4 @@ class OtpCodeFormatter extends Formatter {
 }
 
 
-export default OtpCodeFormatter;
+export default NumericFormatter;

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -8,21 +8,25 @@ module Idv
     FINANCE_HTML_OPTIONS = {
       ccn: {
         class: 'ccn',
+        pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_CCN_LENGTH,
         maxlength: FormFinanceValidator::VALID_CCN_LENGTH
       },
       mortgage: {
         class: 'mortgage',
+        pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       },
       home_equity_line: {
         class: 'home_equity_line',
+        pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       },
       auto_loan: {
         class: 'auto_loan',
+        pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       }

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -7,18 +7,22 @@ module Idv
 
     FINANCE_HTML_OPTIONS = {
       ccn: {
+        class: 'ccn',
         minlength: FormFinanceValidator::VALID_CCN_LENGTH,
         maxlength: FormFinanceValidator::VALID_CCN_LENGTH
       },
       mortgage: {
+        class: 'mortgage',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       },
       home_equity_line: {
+        class: 'home_equity_line',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       },
       auto_loan: {
+        class: 'auto_loan',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
         maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
       }

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -15,7 +15,7 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag(:code, '', value: @code_value, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs')
+      'aria-describedby': 'code-instructs', maxlength: 6)
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -15,7 +15,7 @@ p.mt-tiny.mb0#code-instructs == t('instructions.2fa.confirm_code',
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag(:code, '', value: @code_value, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs', maxlength: 6)
+      'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length)
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 - resend_uri = otp_send_path(otp_delivery_selection_form: { otp_method: @delivery_method,

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -12,7 +12,7 @@ p.mt-tiny.mb0#code-instructs = t('instructions.2fa.totp_intro_html', \
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs', maxlength: 6
+      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 .mt3.mb1

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -12,7 +12,7 @@ p.mt-tiny.mb0#code-instructs = t('instructions.2fa.totp_intro_html', \
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs'
+      'aria-describedby': 'code-instructs', maxlength: 6
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 .mt3.mb1

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -9,6 +9,6 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
   = label_tag 'code', t('forms.totp_setup.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, pattern: '[0-9]*',
-      class: 'block col-12 field monospace mfa', maxlength: 6
+      class: 'block col-12 field monospace mfa', maxlength: Devise.otp_length
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 .mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -9,6 +9,6 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
   = label_tag 'code', t('forms.totp_setup.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, pattern: '[0-9]*',
-      class: 'block col-12 field monospace mfa'
+      class: 'block col-12 field monospace mfa', maxlength: 6
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 .mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -19,7 +19,8 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
               label: label,
               required: false,
               wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
-              input_html: html_options
+              input_html: html_options,
+              pattern: '[0-9]*'
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
   .mt1 = link_to t('idv.messages.cancel_link'), verify_cancel_path
 

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -19,8 +19,7 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro')
               label: label,
               required: false,
               wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
-              input_html: html_options,
-              pattern: '[0-9]*'
+              input_html: html_options
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
   .mt1 = link_to t('idv.messages.cancel_link'), verify_cancel_path
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -195,6 +195,20 @@ feature 'IdV session' do
       )
     end
 
+    scenario 'credit card field only allows numbers', js: true do
+      _user = sign_in_and_2fa_user
+
+      visit verify_session_path
+
+      fill_out_idv_form_ok
+      click_button 'Continue'
+
+      find('#idv_finance_form_finance_type_ccn', visible: false).trigger('click')
+      find('#idv_finance_form_ccn').native.send_keys('abcd1234')
+
+      expect(find('#idv_finance_form_ccn').value).to eq '1234'
+    end
+
     context 'Idv phone and user phone are different' do
       it 'prompts to confirm phone' do
         user = sign_in_and_2fa_user


### PR DESCRIPTION
**Why**: To provide users with a proper numeric keyboard on mobile, and add supporting javascript to limit input to numbers only - with a maximum length where specified.

![image](https://cloud.githubusercontent.com/assets/1178494/21369028/043c6c6c-c6d3-11e6-82ad-0c2f375b05d9.png)
