### PR TITLE
Check duplicate SSN against old HMAC fingerprints

### DIFF
--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -45,8 +45,8 @@ module Idv
       end
     end
 
-    def ssn_signature
-      Pii::Fingerprinter.fingerprint(ssn) if ssn
+    def ssn_signature(key = Pii::Fingerprinter.current_key)
+      Pii::Fingerprinter.fingerprint(ssn, key) if ssn
     end
 
     def ssn_is_unique
@@ -54,7 +54,19 @@ module Idv
     end
 
     def ssn_is_duplicate?
-      Profile.where.not(user_id: @user.id).where(ssn_signature: ssn_signature).any?
+      return true if any_matching_ssn_signatures?(ssn_signature)
+      return true if ssn_is_duplicate_with_old_key?
+    end
+
+    def ssn_is_duplicate_with_old_key?
+      signatures = KeyRotator::Utils.old_keys(:hmac_fingerprinter_key_queue).map do |key|
+        ssn_signature(key)
+      end
+      any_matching_ssn_signatures?(signatures)
+    end
+
+    def any_matching_ssn_signatures?(signatures)
+      Profile.where.not(user_id: @user.id).where(ssn_signature: signatures).any?
     end
 
     def dob_is_sane

--- a/app/services/pii/fingerprinter.rb
+++ b/app/services/pii/fingerprinter.rb
@@ -1,6 +1,10 @@
 module Pii
   class Fingerprinter
-    def self.fingerprint(text, key = Figaro.env.hmac_fingerprinter_key)
+    def self.current_key
+      Figaro.env.hmac_fingerprinter_key
+    end
+
+    def self.fingerprint(text, key = current_key)
       digest = OpenSSL::Digest::SHA256.new
       OpenSSL::HMAC.hexdigest(digest, key, text)
     end

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -36,11 +36,29 @@ describe Idv::ProfileForm do
         expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq false
         expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
       end
+
+      it 'recognizes fingerprint regardless of HMAC key age' do
+        diff_user = create(:user)
+        create(:profile, pii: { ssn: '1234' }, user: diff_user)
+
+        rotate_hmac_key
+
+        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq false
+        expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
+      end
     end
 
     context 'when ssn is already taken by same profile' do
       it 'is valid' do
         create(:profile, pii: { ssn: '1234' }, user: user)
+
+        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq true
+      end
+
+      it 'recognizes fingerprint regardless of HMAC key age' do
+        create(:profile, pii: { ssn: '1234' }, user: user)
+
+        rotate_hmac_key
 
         expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq true
       end


### PR DESCRIPTION
**Why**: We support HMAC fingerprint key rotation, so
we must check duplicate SSN signature against old keys.