### PR TITLE
Add badges to profile page indicating for LOA1 vs LOA3

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -35,8 +35,12 @@ UserDecorator = Struct.new(:user) do
     masked_number(user.phone)
   end
 
+  def identity_verified?
+    user.active_profile.present?
+  end
+
   def identity_not_verified?
-    !user.active_profile.present?
+    !identity_verified?
   end
 
   def active_identity_for(service_provider)
@@ -69,6 +73,22 @@ UserDecorator = Struct.new(:user) do
     events = user.events.order('updated_at DESC').limit(MAX_RECENT_EVENTS).map(&:decorate)
     identities = user.identities.order('last_authenticated_at DESC').map(&:decorate)
     (events + identities).sort { |thing_a, thing_b| thing_b.happened_at <=> thing_a.happened_at }
+  end
+
+  def verified_account_partial
+    if identity_verified?
+      'profile/verified_account_badge'
+    else
+      'shared/null'
+    end
+  end
+
+  def basic_account_partial
+    if identity_not_verified?
+      'profile/basic_account_badge'
+    else
+      'shared/null'
+    end
   end
 
   private

--- a/app/views/profile/_basic_account_badge.html.slim
+++ b/app/views/profile/_basic_account_badge.html.slim
@@ -1,0 +1,3 @@
+.h6.right.border.rounded.p1.regular
+  = t('headings.profile.basic_account')
+  = tooltip(t('tooltips.verified_account'))

--- a/app/views/profile/_verified_account_badge.html.slim
+++ b/app/views/profile/_verified_account_badge.html.slim
@@ -1,0 +1,1 @@
+.h6.regular.right.border.rounded.p1.regular = t('headings.profile.verified_account')

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -17,6 +17,7 @@
     class: 'h5 blue sans-serif underline hint--top hint--no-animate',
     tabindex: 0,
     'aria-label': t('tooltips.profile_idv'))
+  = render partial: current_user.decorate.verified_account_partial
   .mt2.mb4
     .py-12p.border-top
       .clearfix.mxn1
@@ -43,7 +44,9 @@
         .sm-col.sm-col-5.px1 = t('.phone')
         .sm-col.sm-col-7.px1 = @decrypted_pii.phone
 
-h2.h3.my0 = t('headings.profile.login_info')
+h2.h3.my0
+  = t('headings.profile.login_info')
+  = render partial: current_user.decorate.basic_account_partial
 .mt2.mb4
   .py-12p.border-top
     .clearfix.mxn1

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -66,9 +66,11 @@ en:
       security_practices: Our security practices
     profile:
       account_history: Account history
+      basic_account: Basic Account
       login_info: Account information
       profile_info: Profile information
       two_factor: Two-factor authentication
+      verified_account: Verified Account
     recovery_code: Make sure you can always sign in
     registrations:
       enter_email: Start creating an account

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -66,9 +66,11 @@ es:
       security_practices: NOT TRANSLATED YET
     profile:
       account_history: NOT TRANSLATED YET
+      basic_account: NOT TRANSLATED YET
       login_info: NOT TRANSLATED YET
       profile_info: NOT TRANSLATED YET
       two_factor: NOT TRANSLATED YET
+      verified_account: NOT TRANSLATED YET
     recovery_code: NOT TRANSLATED YET
     registrations:
       enter_email: NOT TRANSLATED YET

--- a/config/locales/tooltips/en.yml
+++ b/config/locales/tooltips/en.yml
@@ -12,3 +12,7 @@ en:
     two_factor: >
       Two-factor authentication makes signing in more secure by requiring a
       mobile device as well as a password.
+    verified_account: >
+      For your security, some government agencies require customer accounts to
+      be verified using Personally Identifiable Information (PII) such as
+      Social Security Number and proof of address.

--- a/config/locales/tooltips/es.yml
+++ b/config/locales/tooltips/es.yml
@@ -5,3 +5,4 @@ es:
     profile_info: NOT TRANSLATED YET
     ssn: NOT TRANSLATED YET
     two_factor: NOT TRANSLATED YET
+    verified_account: NOT TRANSLATED YET

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -118,4 +118,42 @@ describe UserDecorator do
       expect(user_decorator.recent_events).to eq [event.decorate, identity.decorate]
     end
   end
+
+  context 'badge partials' do
+    let(:verified_profile) do
+      build(:profile, :active, :verified, pii: { ssn: '1111', dob: '1920-01-01' })
+    end
+
+    describe '#verified_account_partial' do
+      subject(:partial) { UserDecorator.new(user).verified_account_partial }
+
+      context 'with an unverified account' do
+        let(:user) { build(:user) }
+
+        it { expect(partial).to eq('shared/null') }
+      end
+
+      context 'with a verified account' do
+        let(:user) { build(:user, profiles: [verified_profile]) }
+
+        it { expect(partial).to eq('profile/verified_account_badge') }
+      end
+    end
+
+    describe '#basic_account_partial' do
+      subject(:partial) { UserDecorator.new(user).basic_account_partial }
+
+      context 'with an unverified account' do
+        let(:user) { build(:user) }
+
+        it { expect(partial).to eq('profile/basic_account_badge') }
+      end
+
+      context 'with a verified account' do
+        let(:user) { build(:user, profiles: [verified_profile]) }
+
+        it { expect(partial).to eq('shared/null') }
+      end
+    end
+  end
 end

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 feature 'User profile' do
+  context 'account status badges' do
+    before do
+      sign_in_live_with_2fa(profile.user)
+    end
+
+    context 'LOA1 account' do
+      let(:profile) { create(:profile) }
+
+      it 'shows a "Basic Account" badge with a tooltip' do
+        expect(page).to have_content(t('headings.profile.basic_account'))
+        expect(page).to have_css("[aria-label='#{t('tooltips.verified_account')}']")
+      end
+    end
+
+    context 'LOA3 account' do
+      let(:profile) { create(:profile, :active, :verified, pii: { ssn: '111', dob: '1920-01-01' }) }
+
+      it 'shows a "Verified Account" badge with no tooltip' do
+        expect(page).to have_content(t('headings.profile.verified_account'))
+      end
+    end
+  end
+
   context 'user clicks the delete account button' do
     xit 'deletes the account and signs the user out with a flash message' do
       pending 'temporarily disabled until we figure out the MBUN to SSN mapping'


### PR DESCRIPTION
**Why**:
To help show the state of profiles to users

<img width="840" alt="screenshot_12_22_16__11_38_am 2" src="https://cloud.githubusercontent.com/assets/458784/21433390/aed421ae-c83d-11e6-85bb-4875fe8e1225.png">

<img width="841" alt="screenshot_12_22_16__11_38_am" src="https://cloud.githubusercontent.com/assets/458784/21433394/b0b77886-c83d-11e6-8d67-61b910ef458d.png">
