### PR TITLE
Add custom HTML5 validation messages

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -1,8 +1,25 @@
+const I18n = window.LoginGov.I18n;
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   if (form && window.onbeforeunload) {
     form.addEventListener('submit', () => {
       if (form.checkValidity()) window.onbeforeunload = false;
+    });
+
+    const fields = ['dob', 'ssn', 'zipcode'];
+
+    fields.forEach(function(f) {
+      const input = document.querySelector(`.${f}`);
+      if (input) {
+        input.addEventListener('input', () => {
+          if (input.validity.patternMismatch){
+            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${f}`)); 
+          } else {
+            input.setCustomValidity('');
+          }
+        });
+      }
     });
   }
 });

--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -13,8 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const input = document.querySelector(`.${f}`);
       if (input) {
         input.addEventListener('input', () => {
-          if (input.validity.patternMismatch){
-            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${f}`)); 
+          if (input.validity.patternMismatch) {
+            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${f}`));
           } else {
             input.setCustomValidity('');
           }

--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -3,6 +3,9 @@ window.LoginGov = window.LoginGov || {};
 <% keys = [
   'errors.messages.format_mismatch',
   'errors.messages.missing_field',
+  'idv.errors.pattern_mismatch.dob',
+  'idv.errors.pattern_mismatch.ssn',
+  'idv.errors.pattern_mismatch.zipcode',
   'instructions.password.strength.i',
   'instructions.password.strength.ii',
   'instructions.password.strength.iii',

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -84,6 +84,7 @@ search:
 
 ## Do not consider these keys missing:
 ignore_missing:
+  - 'idv.errors.pattern_mismatch.*'
   - 'zxcvbn.*'
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
@@ -96,6 +97,7 @@ ignore_unused:
   - 'errors.not_authorized'
   - 'experiments.*'
   - 'event_types.*'
+  - 'idv.errors.pattern_mismatch.*'
   - 'zxcvbn.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -10,6 +10,10 @@ en:
       incorrect_password: The password you entered is not correct.
       invalid_ccn: Credit card number should be only last 8 digits.
       missing_finance: You must provide a financial account number.
+      pattern_mismatch:
+        dob: Your date of birth must be entered in as mm/dd/yyyy
+        ssn: 'Your Social Security Number must be entered in as ###-##-####'
+        zipcode: 'Your zipcode must be entered in as #####-####'
     form:
       address1: Street address 1
       address2: Street address 2 (optional)

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -10,6 +10,10 @@ es:
       incorrect_password: NOT TRANSLATED YET
       invalid_ccn: NOT TRANSLATED YET
       missing_finance: NOT TRANSLATED YET
+      pattern_mismatch:
+        dob: NOT TRANSLATED YET
+        ssn: NOT TRANSLATED YET
+        zipcode: NOT TRANSLATED YET
     form:
       address1: NOT TRANSLATED YET
       address2: NOT TRANSLATED YET


### PR DESCRIPTION
**Why**: To provide more guidance on proper formatting vs. a generic message.

**Before:**
![image](https://cloud.githubusercontent.com/assets/1178494/21435113/e687c92c-c845-11e6-9bd0-d59a432e36c0.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/1178494/21435145/0a3da314-c846-11e6-909e-3ce7cd633d10.png)
