### PR TITLE
Add default bundle for identity-dashboard

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -79,6 +79,8 @@ development:
     sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
     block_encryption: 'aes256-cbc'
     cert: 'identity_dashboard_cert'
+    attribute_bundle:
+      - email
 
 production:
   'https://idp.dev.login.gov':


### PR DESCRIPTION
**Why**: Development should work out-of-the-box.

See https://github.com/18F/identity-dashboard/issues/41