### PR TITLE
Fix cut off text in Safari

### DIFF
--- a/app/assets/stylesheets/variables/_web.scss
+++ b/app/assets/stylesheets/variables/_web.scss
@@ -46,7 +46,7 @@ $space-6: 5rem !default;
 $form-field-font-size: 1rem !default;
 $form-field-font-size-sm: 1.25rem !default;
 $form-field-height: 3rem !default;
-$form-field-padding-y: .75rem !default;
+$form-field-padding-y: .5rem !default;
 $form-field-padding-x: 1rem !default;
 
 $button-font-size: 1rem !default;


### PR DESCRIPTION
**Why**: The bottom of certain letters were cut off in input boxes (Safari).

**Before:**
![image](https://cloud.githubusercontent.com/assets/1178494/21439119/31d2dc82-c85a-11e6-80e3-d1889668a49e.png)


**After:**
![image](https://cloud.githubusercontent.com/assets/1178494/21439072/f89add20-c859-11e6-96d5-75445d326e49.png)
