### PR TITLE
Improve logic for allowing access to Verify pages

### DIFF
--- a/.reek
+++ b/.reek
@@ -42,6 +42,7 @@ NilCheck:
 RepeatedConditional:
   exclude:
     - Users::ResetPasswordsController
+    - VerifyController
 TooManyConstants:
   exclude:
     - Analytics

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -2,9 +2,10 @@ class VerifyController < ApplicationController
   include IdvSession
 
   before_action :confirm_two_factor_authenticated
+  before_action :confirm_idv_needed, only: [:cancel, :fail, :retry]
 
   def index
-    if current_user.active_profile.present?
+    if active_profile?
       redirect_to verify_activated_path
     else
       analytics.track_event(Analytics::IDV_INTRO_VISIT)
@@ -13,5 +14,19 @@ class VerifyController < ApplicationController
 
   def retry
     flash.now[:error] = I18n.t('idv.errors.fail')
+  end
+
+  def activated
+    redirect_to verify_url unless active_profile?
+  end
+
+  def fail
+    redirect_to verify_url unless idv_attempter.exceeded?
+  end
+
+  private
+
+  def active_profile?
+    current_user.active_profile.present?
   end
 end

--- a/app/views/verify/activated.html.slim
+++ b/app/views/verify/activated.html.slim
@@ -3,4 +3,3 @@
 h1.h3.my0 = t('idv.titles.activated')
 p.mt-tiny.mb0 = t('idv.messages.activated_html',
                   link: link_to(t('idv.messages.activated_link'), contact_path))
-= link_to 'Back', idv_url

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -22,4 +22,114 @@ describe VerifyController do
       get :index
     end
   end
+
+  describe '#activated' do
+    context 'user has an active profile' do
+      it 'allows direct access' do
+        profile = create(:profile, :active)
+
+        stub_sign_in(profile.user)
+
+        get :activated
+
+        expect(response).to render_template(:activated)
+      end
+    end
+
+    context 'user does not have an active profile' do
+      it 'does not allow direct access' do
+        stub_sign_in
+
+        get :activated
+
+        expect(response).to redirect_to verify_url
+      end
+    end
+  end
+
+  describe '#cancel' do
+    context 'user has an active profile' do
+      it 'does not allow direct access and redirects to activated url' do
+        profile = create(:profile, :active)
+
+        stub_sign_in(profile.user)
+
+        get :cancel
+
+        expect(response).to redirect_to verify_activated_url
+      end
+    end
+
+    context 'user does not have an active profile' do
+      it 'allows direct access' do
+        stub_sign_in
+
+        get :cancel
+
+        expect(response).to render_template(:cancel)
+      end
+    end
+  end
+
+  describe '#fail' do
+    context 'user has an active profile' do
+      it 'does not allow direct access and redirects to activated url' do
+        profile = create(:profile, :active)
+
+        stub_sign_in(profile.user)
+
+        get :fail
+
+        expect(response).to redirect_to verify_activated_url
+      end
+    end
+
+    context 'user does not have an active profile and has not exceeded IdV attempts' do
+      it 'does not allow direct access and redirects to the main IdV page' do
+        stub_sign_in
+
+        get :fail
+
+        expect(response).to redirect_to verify_url
+      end
+    end
+
+    context 'user does not have an active profile and has exceeded IdV attempts' do
+      it 'allows direct access' do
+        profile = create(:profile)
+        user = profile.user
+        user.update(idv_attempts: 3, idv_attempted_at: Time.zone.now)
+
+        stub_sign_in(user)
+
+        get :fail
+
+        expect(response).to render_template(:fail)
+      end
+    end
+  end
+
+  describe '#retry' do
+    context 'user has an active profile' do
+      it 'does not allow direct access and redirects to activated url' do
+        profile = create(:profile, :active)
+
+        stub_sign_in(profile.user)
+
+        get :retry
+
+        expect(response).to redirect_to verify_activated_url
+      end
+    end
+
+    context 'user does not have an active profile' do
+      it 'allows direct access' do
+        stub_sign_in
+
+        get :retry
+
+        expect(response).to render_template(:retry)
+      end
+    end
+  end
 end

--- a/spec/views/verify/activated.html.slim_spec.rb
+++ b/spec/views/verify/activated.html.slim_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'verify/activated.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('idv.titles.activated'))
+
+    render
+  end
+
+  it 'has a localized heading' do
+    render
+
+    expect(rendered).to have_selector('h1', text: t('idv.titles.activated'))
+  end
+end


### PR DESCRIPTION
**Why**:
- Users who have already completed identity verification should not
be able to directly access the `/verify/cancel`, `/verify/fail`, and
`/verify/retry` pages because those are only meant for people who have
not verified yet.
- Users who have not already been verified should not be able to access
the `/verify/activated` page because that is only meant for those who
already have an active profile.
- Only users who have exceeded the max allowable proofing attempts
should be allowed to access the `/verify/fail` page.
- The "Back" link on the `/verify/activated` page that points to the
`/verify` endpoint doesn't make sense because it will send right back
to the `/verify/activated` page. I removed the link because the only
place where it makes sense to link back to is the profile page, which
is already accessible via the "My account" link or the login.gov logo.