### PR TITLE
Remove words that do not match \w+

### DIFF
--- a/config/us-constitution.lexicon
+++ b/config/us-constitution.lexicon
@@ -552,7 +552,6 @@ is
 island
 issue
 it
-it's
 its
 iv
 ix

--- a/spec/services/random_phrase_spec.rb
+++ b/spec/services/random_phrase_spec.rb
@@ -16,4 +16,12 @@ describe RandomPhrase do
       expect(phrase.to_s).to match(/\A(\w+) (\w+) (\w+)\z/)
     end
   end
+
+  describe '#dictionary' do
+    it 'has only words that match \w+' do
+      RandomPhrase.dictionary.each do |word|
+        expect(word).to match(/\A(\w+)\z/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Can break regex-based tests and provides confusing UX.