### PR TITLE
Improve IDV form mobile UX

### DIFF
--- a/app/assets/javascripts/app/form-field-format.js
+++ b/app/assets/javascripts/app/form-field-format.js
@@ -12,8 +12,8 @@ function formatForm() {
     ['.home_equity_line', new NumericFormatter()],
     ['.mfa', new NumericFormatter()],
     ['.mortgage', new NumericFormatter()],
+    ['.phone', new PhoneFormatter()],
     ['.ssn', new SocialSecurityNumberFormatter()],
-    ['[type=tel]', new PhoneFormatter()],
     ['.zipcode', new ZipCodeFormatter()],
   ];
 

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -23,7 +23,7 @@ textarea {
   font-weight: $bold-font-weight;
 
   &[type=number],
-  &[type=tel] {
+  &.phone {
     font-family: $monospace-font-family;
   }
 }

--- a/app/views/users/phones/edit.html.slim
+++ b/app/views/users/phones/edit.html.slim
@@ -4,7 +4,7 @@
 h1.h3.my0 = t('headings.edit_info.phone')
 = simple_form_for(@update_user_phone_form, url: manage_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
-  = f.input :phone, as: :tel, required: true, input_html: { value: nil },
+  = f.input :phone, as: :tel, required: true, input_html: { class: 'phone', value: nil },
     label: t('profile.index.phone')
   = f.button :submit, t('forms.buttons.submit.confirm_change'), class: 'mt2'
 .mt1 = link_to t('forms.buttons.cancel'), profile_path

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -12,7 +12,7 @@ p.mt-tiny.mb0#2fa-description
     strong.left = t('devise.two_factor_authentication.otp_phone_label')
     span.ml1.italic = t('devise.two_factor_authentication.otp_phone_label_info')
     = f.input :phone, as: :tel, label: false, required: true,
-        input_html: { 'aria-describedby' => '2fa-description' }
+        input_html: { 'aria-describedby' => '2fa-description', class: 'phone' }
   .mb3
     = label_tag 'two_factor_setup_form[otp_method]',
       t('devise.two_factor_authentication.otp_method.title'),

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -21,18 +21,22 @@ h1.h3.my0 = t('idv.titles.session.basic')
         = f.input :state, collection: us_states_territories,
           label: t('idv.form.state'), required: true
       .sm-col.sm-col-4.px1
-        = f.input :zipcode, label: t('idv.form.zipcode'), required: true,
+        / using :tel for mobile numeric keypad
+        = f.input :zipcode, as: :tel,
+          label: t('idv.form.zipcode'), required: true,
           pattern: '(\d{5}([\-]\d{4})?)',
           input_html: { class: 'zipcode', value: idv_profile_form.zipcode }
   .mb4
-    .mt0.mb3.pb-tiny.border-bottom.border-teal = t('profile.index.dob')
-    = f.input :dob, label: t('idv.form.dob'), required: true,
+    .mt0.mb3.pb-tiny.border-bottom.border-teal = t('idv.form.personal_details')
+    / using :tel for mobile numeric keypad
+    = f.input :dob, as: :tel,
+      label: t('idv.form.dob'), required: true,
       pattern: '(0[1-9]|1[012])/(0[1-9]|1[0-9]|2[0-9]|3[01])/[0-9]{4}',
-      input_html: { class: 'dob', value: idv_profile_form.dob,
-        'aria-describedby': 'dob-instructs' }
+      input_html: { class: 'dob', value: idv_profile_form.dob, 'aria-describedby': 'dob-instructs' }
     #dob-instructs.hide Must be in mm/dd/yyyy format
   .mb4
-    = f.input :ssn,
+    / using :tel for mobile numeric keypad
+    = f.input :ssn, as: :tel,
       label: t('idv.form.ssn_label_html', tooltip: tooltip(t('tooltips.ssn'))),
       required: true,
       pattern: '^\d{3}-?\d{2}-?\d{4}$',

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -26,6 +26,7 @@ en:
       last_name: Last name
       mortgage: Mortgage loan account number
       password: Password
+      personal_details: Personal details
       phone: Phone
       ssn_label_html: Social Security Number %{tooltip}
       state: State

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -26,6 +26,7 @@ es:
       last_name: NOT TRANSLATED YET
       mortgage: NOT TRANSLATED YET
       password: NOT TRANSLATED YET
+      personal_details: NOT TRANSLATED YET
       phone: NOT TRANSLATED YET
       ssn_label_html: NOT TRANSLATED YET
       state: NOT TRANSLATED YET


### PR DESCRIPTION
**Why**: A couple of small copy updates, and using `type=tel` as a workaround on several fields to allow for the numeric keypad to be triggered for mobile users. See associated issue for more details on that decision.