### PR TITLE
Clicking site logo during 2fa signs user out

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,9 @@ module Users
     include ::ActionView::Helpers::DateHelper
 
     skip_before_action :session_expires_at, only: [:active]
+    skip_before_action :require_no_authentication, only: [:new]
     before_action :confirm_two_factor_authenticated, only: [:update]
+    before_action :check_user_needs_redirect, only: [:new]
 
     def new
       analytics.track_event(Analytics::SIGN_IN_PAGE_VISIT)
@@ -40,6 +42,14 @@ module Users
     end
 
     private
+
+    def check_user_needs_redirect
+      if user_fully_authenticated?
+        redirect_to after_sign_in_path_for(current_user)
+      elsif current_user
+        sign_out
+      end
+    end
 
     def now
       @_now ||= Time.zone.now

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -235,4 +235,13 @@ feature 'Two Factor Authentication' do
       expect(current_path).to eq profile_path
     end
   end
+
+  describe 'clicking the logo image during 2fa process' do
+    it 'returns them to the home page' do
+      user = build_stubbed(:user, :signed_up)
+      sign_in_user(user)
+      find("img[alt='login.gov']").click
+      expect(current_path).to eq root_path
+    end
+  end
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -33,6 +33,7 @@ module ControllerHelper
     allow(controller).to receive(:user_session).and_return(authn_at: Time.zone.now)
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:confirm_two_factor_authenticated).and_return(true)
+    allow(controller).to receive(:user_fully_authenticated?).and_return(true)
     user
   end
 


### PR DESCRIPTION
**Why**: Currently, clicking the logo during the 2fa process redirect
the user back to the same page, a behavior that confusing. This doesn't
change the behavior of clicking the logo once the user has authenticated
fully