### PR TITLE
Fix broken link

### DIFF
--- a/app/views/verify/activated.html.slim
+++ b/app/views/verify/activated.html.slim
@@ -3,4 +3,4 @@
 h1.h3.my0 = t('idv.titles.activated')
 p.mt-tiny.mb0 = t('idv.messages.activated_html',
                   link: link_to(t('idv.messages.activated_link'), contact_path))
-= link_to 'Back', idv_url
+= link_to t('forms.buttons.back'), verify_path

--- a/spec/views/verify/activated.html.slim_spec.rb
+++ b/spec/views/verify/activated.html.slim_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'verify/activated.html.slim' do
+  it 'has a back link' do
+    render
+
+    expect(rendered).to have_link(
+      t('forms.buttons.back'), href: verify_path
+    )
+  end
+end


### PR DESCRIPTION
**Why**: `idv_url` is no longer a route name

Closes https://github.com/18F/identity-idp/issues/898