### PR TITLE
Use `rackup` in Procfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN bundle install --without deployment deploy --jobs 20 --retry 5
 COPY . /upaya
 
 EXPOSE 3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["rackup", "config.ru", "--host", "0.0.0.0", "--port", "3000"]

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec rails server -p ${PORT:-3000}
+web: bundle exec rackup config.ru --port ${PORT:-3000}
 worker: bundle exec sidekiq --config config/sidekiq.yml
 mail: bundle exec mailcatcher -f

--- a/config.ru
+++ b/config.ru
@@ -8,6 +8,5 @@ STDOUT.sync = true
 
 require ::File.expand_path('../config/environment', __FILE__)
 
-use Rails::Rack::Debugger
 use Rack::ContentLength
 run Rails.application

--- a/config.ru
+++ b/config.ru
@@ -7,4 +7,7 @@
 STDOUT.sync = true
 
 require ::File.expand_path('../config/environment', __FILE__)
+
+use Rails::Rack::Debugger
+use Rack::ContentLength
 run Rails.application


### PR DESCRIPTION
Addresses #906

This also explicitly uses port 3000, which otherwise can vary between servers.
(foreman defaults PORT envvar to 5000; rack defaults to 9292 on its own, etc)