### PR TITLE
Specify ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
+ruby '~> 2.3.3'
+
 gem 'rails', '~> 4.2.6'
 
 gem 'ahoy_matey'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,5 +713,8 @@ DEPENDENCIES
   zonebie
   zxcvbn-js
 
+RUBY VERSION
+   ruby 2.3.3p222
+
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
Heroku uses the Gemfile spec to determine which ruby version to install. By default, it installs 2.2.x series release, which is a minor version point off.