### PR TITLE
Check for invalid base64 values in Figaro config

### DIFF
--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -1,24 +1,69 @@
 class ConfigValidator
-  def validate(env = ENV)
-    bad_keys = keys_with_bad_values(env, candidate_keys(env))
+  include Pii::Encodable
+
+  def initialize(env = ENV)
+    @env = env
+    @candidate_keys = keys_without_figaro_prefix
+  end
+
+  def validate
+    bad_keys = keys_with_bad_boolean_values + keys_with_bad_base64_encoding
     return unless bad_keys.any?
     raise warning(bad_keys).tr("\\\n", ' ')
   end
 
   private
 
-  def candidate_keys(env)
+  attr_reader :env, :candidate_keys
+
+  def keys_without_figaro_prefix
     env.keys.delete_if { |key| key.starts_with?(Figaro::Application::FIGARO_ENV_PREFIX) }
   end
 
-  def keys_with_bad_values(env, keys)
-    keys.keep_if { |key| %w(yes no).include?(env[key]) }
+  def keys_with_bad_boolean_values
+    candidate_keys.select { |key| %w(yes no).include?(env[key]) }
+  end
+
+  def keys_with_bad_base64_encoding
+    candidate_keys.select { |key| bad_base64_encoding?(key) }
+  end
+
+  def bad_base64_encoding?(key)
+    requires_base64_encoding?(key) && !valid_base64_encoding?(env[key])
+  end
+
+  def requires_base64_encoding?(key)
+    %w(attribute_encryption_key email_encryption_key).include?(key)
   end
 
   def warning(bad_keys)
     <<~HEREDOC
       You have invalid values for #{bad_keys.uniq.to_sentence} in
-      config/application.yml. Please change them to true or false
+      #{config_location}.#{bad_boolean_keys_instructions} #{bad_base64_keys_instructions}
     HEREDOC
+  end
+
+  def config_location
+    return 'config/application.yml' if File.exist?(Rails.root.join('config/application.yml'))
+
+    'your ENV configuration'
+  end
+
+  def bad_boolean_keys_instructions
+    return if keys_with_bad_boolean_values.empty?
+    " Please change #{bad_boolean_keys_text} to 'true' or 'false'."
+  end
+
+  def bad_base64_keys_instructions
+    return if keys_with_bad_base64_encoding.empty?
+    "Please change #{bad_base64_keys_text} to a valid base64 encoded value."
+  end
+
+  def bad_boolean_keys_text
+    keys_with_bad_boolean_values.uniq.to_sentence
+  end
+
+  def bad_base64_keys_text
+    keys_with_bad_base64_encoding.uniq.to_sentence
   end
 end

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -1,24 +1,98 @@
 require 'rails_helper'
 
 describe ConfigValidator do
-  describe '#validator' do
-    it 'raises if one or more candidate key values is set to yes or no' do
-      bad_key = 'bad_key'
-      other_bad_key = 'other_bad_key'
-      noncandidate_key = '_FIGARO_KEY'
-      good_key = 'good_key'
+  describe '#validate' do
+    context 'config/application.yml exists on the server and boolean keys are set to yes or no' do
+      it 'raises an error and provides instructions for fixing the keys in the config file' do
+        bad_key = 'bad_key'
+        other_bad_key = 'other_bad_key'
+        noncandidate_key = '_FIGARO_KEY'
+        good_key = 'good_key'
 
-      env = {
-        bad_key => 'yes',
-        other_bad_key => 'no',
-        noncandidate_key => 'yes',
-        good_key => 'foo'
-      }
+        env = {
+          bad_key => 'yes',
+          other_bad_key => 'no',
+          noncandidate_key => 'yes',
+          good_key => 'foo'
+        }
 
-      expect { ConfigValidator.new.validate(env) }.to raise_error(
-        RuntimeError,
-        /You have invalid values for #{bad_key} and #{other_bad_key}/
-      )
+        error_message = "You have invalid values for #{bad_key} and #{other_bad_key} in " \
+                        "config/application.yml. Please change #{bad_key} and #{other_bad_key} " \
+                        "to 'true' or 'false'."
+
+        expect { ConfigValidator.new(env).validate }.to raise_error(
+          RuntimeError, /#{error_message}/
+        )
+      end
+    end
+
+    context 'application.yml does not exist on the server and boolean keys are set to yes or no' do
+      it 'raises an error and provides instructions for fixing boolean keys in the ENV config' do
+        allow(File).to receive(:exist?).
+          with(Rails.root.join('config/application.yml')).and_return(false)
+
+        bad_key = 'bad_key'
+        other_bad_key = 'other_bad_key'
+        noncandidate_key = '_FIGARO_KEY'
+        good_key = 'good_key'
+
+        env = {
+          bad_key => 'yes',
+          other_bad_key => 'no',
+          noncandidate_key => 'yes',
+          good_key => 'foo'
+        }
+
+        error_message = "You have invalid values for #{bad_key} and #{other_bad_key} in " \
+                        "your ENV configuration. Please change #{bad_key} and #{other_bad_key} " \
+                        "to 'true' or 'false'."
+
+        expect { ConfigValidator.new(env).validate }.to raise_error(
+          RuntimeError, /#{error_message}/
+        )
+      end
+    end
+
+    context 'keys that should be base64 encoded are not' do
+      it 'raises an error and provides instructions for fixing the keys' do
+        noncandidate_key = '_FIGARO_attribute_encryption_key'
+
+        env = {
+          'attribute_encryption_key' => 'bad_key',
+          'email_encryption_key' => 'bad_base64_value',
+          noncandidate_key => 'bad_base64_value'
+        }
+
+        error_message = 'You have invalid values for attribute_encryption_key ' \
+                        'and email_encryption_key in config/application.yml. ' \
+                        'Please change attribute_encryption_key and ' \
+                        'email_encryption_key to a valid base64 encoded value.'
+
+        expect { ConfigValidator.new(env).validate }.to raise_error(
+          RuntimeError, /#{error_message}/
+        )
+      end
+    end
+
+    context 'both bad boolean and bad base64 keys are present' do
+      it 'raises an error and provides instructions for fixing both types of keys' do
+        noncandidate_key = '_FIGARO_bad_boolean_key'
+
+        env = {
+          'attribute_encryption_key' => 'bad_base64_value',
+          'bad_boolean_key' => 'yes',
+          noncandidate_key => 'yes'
+        }
+
+        error_message = "You have invalid values for bad_boolean_key and " \
+                        "attribute_encryption_key in config/application.yml. " \
+                        "Please change bad_boolean_key to 'true' or 'false'. Please change " \
+                        "attribute_encryption_key to a valid base64 encoded value."
+
+        expect { ConfigValidator.new(env).validate }.to raise_error(
+          RuntimeError, /#{error_message}/
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: Our last deployment to dev resulted in an irreperable issue:
emails of existing users who signed in after the deployment were set
to an empty string, preventing them from ever being able to sign in
again.

This was caused by the `email_encryption_key` being set by the Chef
config to an invalid default value, and wasn't changed before
deployment.

Adding this check in the ConfigValidator will allow us to catch these
types of critical errors before it's too late.