### PR TITLE
Raise error if can't decrypt attribute w/ any key

### DIFF
--- a/.reek
+++ b/.reek
@@ -106,6 +106,9 @@ UtilityFunction:
       - saml_settings
       - sign_up_and_2fa
       - raw_xml_response
+      - rotate_attribute_encryption_key
+      - rotate_attribute_encryption_key_with_invalid_queue
+      - rotate_hmac_key
       - sign_in_user
       - stub_auth
       - stub_sign_in

--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -41,9 +41,7 @@ class EncryptedAttribute
     encryptor = Pii::PasswordEncryptor.new
     decrypted = try_decrypt_with_uak(encryptor) if user_access_key.present?
     return decrypted if decrypted
-    decrypted = try_decrypt_with_all_keys(encryptor, cost)
-    return decrypted if decrypted
-    raise Pii::EncryptionError, 'unable to decrypt attribute with any key'
+    try_decrypt_with_all_keys(encryptor, cost)
   end
 
   def try_decrypt(encryptor, key, cost)
@@ -58,6 +56,8 @@ class EncryptedAttribute
       decrypted = try_decrypt(encryptor, key, cost) or next
       return decrypted
     end
+
+    raise Pii::EncryptionError, 'unable to decrypt attribute with any key'
   end
 
   def try_decrypt_with_uak(encryptor)

--- a/spec/services/encrypted_attribute_spec.rb
+++ b/spec/services/encrypted_attribute_spec.rb
@@ -23,6 +23,14 @@ describe EncryptedAttribute do
 
       expect(EncryptedAttribute.new(encrypted_with_old_key).decrypted).to eq email
     end
+
+    it 'raises an error if unable to decrypt with any keys' do
+      encrypted_with_old_key = encrypted_email
+      rotate_attribute_encryption_key_with_invalid_queue
+
+      expect { EncryptedAttribute.new(encrypted_with_old_key) }.
+        to raise_error Pii::EncryptionError, 'unable to decrypt attribute with any key'
+    end
   end
 
   describe '#new_from_decrypted' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -120,5 +120,19 @@ module Features
       yield
       Capybara.session_name = old_session
     end
+
+    def sign_up_and_2fa_as_a_user_would(email, password)
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+
+      sign_up_with(email)
+      open_email(email)
+      visit_in_email(t('mailer.confirmation_instructions.link_text'))
+      fill_in 'password_form_password', with: password
+      click_button t('forms.buttons.submit.default')
+      fill_in 'Phone', with: '202-555-1212'
+      click_button t('forms.buttons.send_passcode')
+      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
+    end
   end
 end

--- a/spec/support/key_rotation_helper.rb
+++ b/spec/support/key_rotation_helper.rb
@@ -12,7 +12,7 @@ module KeyRotationHelper
     env = Figaro.env
     old_key = env.attribute_encryption_key
     allow(env).to receive(:attribute_encryption_key_queue).and_return(
-      "[\"#{old_key}\"]"
+      "[\"a-new-key\", \"#{old_key}\"]"
     )
     allow(env).to receive(:attribute_encryption_key).and_return('a-new-key')
   end
@@ -20,5 +20,13 @@ module KeyRotationHelper
   def rotate_all_keys
     rotate_attribute_encryption_key
     rotate_hmac_key
+  end
+
+  def rotate_attribute_encryption_key_with_invalid_queue
+    env = Figaro.env
+    allow(env).to receive(:attribute_encryption_key_queue).and_return(
+      '["key-that-was-never-used-in-the-past"]'
+    )
+    allow(env).to receive(:attribute_encryption_key).and_return('a-new-key')
   end
 end


### PR DESCRIPTION
**Why**: If for some reason, the `attribute_encryption_key` was rotated,
but the `attribute_encryption_key_queue` was not updated to include the
previous key, then we want to make sure to raise an error to prevent
the following scenario that happened during the most recent deployment
to dev: Any existing user who signed in after the deployment had their
email reset to an empty string, preventing them from ever being able to
sign back in.

This was due to `EncryptedAttribute#try_decrypt_with_all_keys` returning
the array of keys in `attribute_encryption_key_queue` when it was not
able to decrypt with any of the keys.

**How**:
- If no valid decryption keys are found, raise an error. Do this by
changing `EncryptedAttribute#try_decrypt_with_all_keys` so that it
uses `each_with_object` to return an empty string if no keys match.
- Add a unit test for the scenario where the queue does not contain any
previous keys.
- Add an integration test to make sure the User's email does not get
set to an empty string.
- Update the example config documentation to explain that the queue must
always contain at least the current key, and should contain the current
key by default.