### PR TITLE
Allow TOTP-enabled users to change their factors

### DIFF
--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -20,7 +20,11 @@ class MfaConfirmationController < ApplicationController
   end
 
   def handle_valid_password
-    redirect_to user_two_factor_authentication_path(reauthn: true)
+    if current_user.totp_enabled?
+      redirect_to login_two_factor_authenticator_path(reauthn: true)
+    else
+      redirect_to user_two_factor_authentication_path(reauthn: true)
+    end
     session[:password_attempts] = 0
   end
 

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -7,6 +7,8 @@ p.mt-tiny.mb0#code-instructs = t('instructions.2fa.totp_intro_html', \
       app: APP_NAME)
 
 = form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'mt3 sm-mt4') do
+  - if reauthn?
+    = hidden_field_tag 'reauthn', 'true'
   = label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -134,5 +134,14 @@ module Features
       click_button t('forms.buttons.submit.default')
       click_button t('forms.buttons.continue')
     end
+
+    def sign_in_with_totp_enabled_user
+      user = create(:user, :signed_up, password: VALID_PASSWORD)
+      @secret = user.generate_totp_secret
+      user.update(otp_secret_key: @secret)
+      sign_in_user(user)
+      fill_in 'code', with: generate_totp_code(@secret)
+      click_submit_default
+    end
   end
 end

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
 
   before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:reauthn?).and_return(false)
     render
   end
 


### PR DESCRIPTION
**Why**: They deserve the same experience as users who have not enabled
an authenticator app.