### PR TITLE
Use timing regex to account for CI slip

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -128,8 +128,7 @@ feature 'Two Factor Authentication' do
         end
 
         expect(page).to have_content t('titles.account_locked')
-        expect(page).to have_content('4:54')
-        expect(page).to have_content('4:53')
+        expect(page).to have_content(/4:5\d/)
 
         # let lockout period expire
         user.update(


### PR DESCRIPTION
**Why**: Specs that rely on timing are notoriously
brittle in CI environments because they are run in parallel
and can suffer from network load.