### PR TITLE
Fix migration failure due to config name change

### DIFF
--- a/db/migrate/20161214221229_reencrypt_email_with_salt.rb
+++ b/db/migrate/20161214221229_reencrypt_email_with_salt.rb
@@ -1,29 +1,27 @@
 class ReencryptEmailWithSalt < ActiveRecord::Migration
   def up
-    rotate(Figaro.env.password_pepper, Figaro.env.email_encryption_key)
+    new_salt = Figaro.env.attribute_encryption_key
+    rotate(Figaro.env.password_pepper, new_salt)
   end
 
   def down
-    rotate(Figaro.env.email_encryption_key, Figaro.env.password_pepper)
+    old_salt = Figaro.env.attribute_encryption_key
+    rotate(old_salt, Figaro.env.password_pepper)
   end
 
   def rotate(old_salt, new_salt)
-    key = Figaro.env.email_encryption_key
-    cost = Figaro.env.email_encryption_cost
+    key = Figaro.env.attribute_encryption_key
+    cost = Figaro.env.attribute_cost
     encryptor = Pii::PasswordEncryptor.new
 
     User.find_in_batches.with_index do |users, batch|
       puts "Updating batch #{batch}"
       users.each do |user|
-        begin
-          old_uak = UserAccessKey.new(password: key, salt: old_salt, cost: cost)
-          new_uak = UserAccessKey.new(password: key, salt: new_salt, cost: cost)
-          plain_email = encryptor.decrypt(user.encrypted_email, old_uak)
-          ee = EncryptedEmail.new_from_email(plain_email, new_uak)
-          user.update_columns(encrypted_email: ee.encrypted, email_encryption_cost: cost)
-        rescue Pii::EncryptionError => err 
-          puts "Skipping #{user.id} - error rotating encrypted email: #{err}"
-        end
+        old_uak = UserAccessKey.new(password: key, salt: old_salt, cost: cost)
+        new_uak = UserAccessKey.new(password: key, salt: new_salt, cost: cost)
+        plain_email = encryptor.decrypt(user.encrypted_email, old_uak)
+        ee = EncryptedAttribute.new_from_decrypted(plain_email, new_uak)
+        user.update_columns(encrypted_email: ee.encrypted, email_encryption_cost: cost)
       end
     end
   end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -202,7 +202,7 @@ feature 'Sign in' do
   end
 
   context 'attribute_encryption_key is changed but queue does not contain any previous keys' do
-    it 'allows the user to sign back in' do
+    it 'throws an exception and does not overwrite User email' do
       email = 'test@example.com'
       password = 'salty pickles'
 


### PR DESCRIPTION
**Why**: Two Figaro environment variables changed names,
and a related class name also changed.

**How**: Add fallback config names and a class definition
for the old class name.