### PR TITLE
Use same validations for zipcode and ssn on server

### DIFF
--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -11,6 +11,15 @@ module Idv
 
     validate :ssn_is_unique, :dob_is_sane
 
+    validates_format_of :zipcode,
+                        with: /\A\d{5}(-?\d{4})?\z/,
+                        message: I18n.t('idv.errors.pattern_mismatch.zipcode'),
+                        allow_blank: true
+    validates_format_of :ssn,
+                        with: /\A\d{3}-?\d{2}-?\d{4}\z/,
+                        message: I18n.t('idv.errors.pattern_mismatch.ssn'),
+                        allow_blank: true
+
     delegate :user_id, :first_name, :last_name, :phone, :email, :dob, :ssn, :address1,
              :address2, :city, :state, :zipcode, to: :pii_attributes
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -90,8 +90,8 @@ feature 'IdV session' do
 
       visit verify_session_path
 
-      first_ssn_value = '666661234'
-      second_ssn_value = '666669876'
+      first_ssn_value = '666-66-1234'
+      second_ssn_value = '666-66-9876'
       first_ccn_value = '12345678'
       second_ccn_value = '99998888'
       mortgage_value = '99990000'
@@ -266,7 +266,7 @@ feature 'IdV session' do
 
       user_access_key = user.unlock_user_access_key(user_password)
       decrypted_pii = user.active_profile.decrypt_pii(user_access_key)
-      expect(decrypted_pii.ssn).to eq '666661234'
+      expect(decrypted_pii.ssn).to eq '666-66-1234'
     end
 
     scenario 'KBV with some incorrect answers' do

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Idv::ProfileForm do
   let(:password) { 'a really long sekrit' }
+  let(:ssn) { '123-11-1234' }
   let(:user) { create(:user, password: password) }
   let(:subject) { Idv::ProfileForm.new({}, user) }
   let(:profile_attrs) do
@@ -31,36 +32,36 @@ describe Idv::ProfileForm do
     context 'when ssn is already taken by another profile' do
       it 'is invalid' do
         diff_user = create(:user)
-        create(:profile, pii: { ssn: '1234' }, user: diff_user)
+        create(:profile, pii: { ssn: ssn }, user: diff_user)
 
-        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq false
+        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq false
         expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
       end
 
       it 'recognizes fingerprint regardless of HMAC key age' do
         diff_user = create(:user)
-        create(:profile, pii: { ssn: '1234' }, user: diff_user)
+        create(:profile, pii: { ssn: ssn }, user: diff_user)
 
         rotate_hmac_key
 
-        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq false
+        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq false
         expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
       end
     end
 
     context 'when ssn is already taken by same profile' do
       it 'is valid' do
-        create(:profile, pii: { ssn: '1234' }, user: user)
+        create(:profile, pii: { ssn: ssn }, user: user)
 
-        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq true
+        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq true
       end
 
       it 'recognizes fingerprint regardless of HMAC key age' do
-        create(:profile, pii: { ssn: '1234' }, user: user)
+        create(:profile, pii: { ssn: ssn }, user: user)
 
         rotate_hmac_key
 
-        expect(subject.submit(profile_attrs.merge(ssn: '1234'))).to eq true
+        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq true
       end
     end
   end
@@ -83,13 +84,47 @@ describe Idv::ProfileForm do
     end
   end
 
+  describe 'zipcode validity' do
+    it 'accepts 9 numbers with optional `-` delimiting the 5th and 6th position' do
+      %w(12345 123454567 12345-1234).each do |valid_zip|
+        expect(
+          subject.submit(profile_attrs.merge(zipcode: valid_zip))
+        ).to eq true
+      end
+    end
+
+    it 'populates error for :zipcode when invalid' do
+      %w(1234 123Ac-1234 1234B).each do |invalid_zip|
+        subject.submit(profile_attrs.merge(zipcode: invalid_zip))
+        expect(subject.errors[:zipcode]).to eq [I18n.t('idv.errors.pattern_mismatch.zipcode')]
+      end
+    end
+  end
+
+  describe 'ssn validity' do
+    it 'accepts 9 numbers with optional `-` delimiters' do
+      %w(123411111 123-11-1123).each do |valid_ssn|
+        expect(
+          subject.submit(profile_attrs.merge(ssn: valid_ssn))
+        ).to eq true
+      end
+    end
+
+    it 'populates errors for :ssn when invalid' do
+      %w(1234 123-1-1111 abc-11-1123).each do |invalid_ssn|
+        subject.submit(profile_attrs.merge(ssn: invalid_ssn))
+        expect(subject.errors[:ssn]).to eq [I18n.t('idv.errors.pattern_mismatch.ssn')]
+      end
+    end
+  end
+
   describe '#submit' do
     it 'returns true on success' do
       expect(subject.submit(profile_attrs)).to eq true
     end
 
     it 'returns false on failure' do
-      expect(subject.submit(ssn: '1234', first_name: 'Joe')).to eq false
+      expect(subject.submit(ssn: ssn, first_name: 'Joe')).to eq false
     end
   end
 end

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -42,7 +42,7 @@ module IdvHelper
   def fill_out_idv_form_ok
     fill_in 'profile_first_name', with: 'Some'
     fill_in 'profile_last_name', with: 'One'
-    fill_in 'profile_ssn', with: '666661234'
+    fill_in 'profile_ssn', with: '666-66-1234'
     fill_in 'profile_dob', with: '01/02/1980'
     fill_in 'profile_address1', with: '123 Main St'
     fill_in 'profile_city', with: 'Nowhere'
@@ -53,7 +53,7 @@ module IdvHelper
   def fill_out_idv_form_fail
     fill_in 'profile_first_name', with: 'Bad'
     fill_in 'profile_last_name', with: 'User'
-    fill_in 'profile_ssn', with: '6666'
+    fill_in 'profile_ssn', with: '666-66-6666'
     fill_in 'profile_dob', with: '01/02/1900'
     fill_in 'profile_address1', with: '123 Main St'
     fill_in 'profile_city', with: 'Nowhere'


### PR DESCRIPTION
**Why**: Currently, if a user is using a browser that doesn't support
html5 pattern matching and has javascript disabled, they won't receive
the proper error messages when submitting an IDV form with a malformed
zipcode or social security number