### PR TITLE
Use Capybara's #find to enter the password

### DIFF
--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -127,7 +127,7 @@ module Features
       sign_up_with(email)
       open_email(email)
       visit_in_email(t('mailer.confirmation_instructions.link_text'))
-      fill_in 'password_form_password', with: password
+      find('#password_form_password').set(password)
       click_button t('forms.buttons.submit.default')
       fill_in 'Phone', with: '202-555-1212'
       click_button t('forms.buttons.send_passcode')


### PR DESCRIPTION
**Why**: Sometimes, there is a delay long enough between when Capybara
clicks the confirmation link in the user's email and when the password
page appears, that causes `sign_up_and_2fa_as_a_user_would` to fail
intermittently on Travis.

**How**: Modify the spec such that Capybara waits (up to the
`default_max_wait_time`) for the element to appear. This can be done
by using the `find` method (which incorporates waiting by default,
unlike `fill_in`) or adding a presence expectation for any element on
the screen before attempting to fill in the password field. I opted for
the former.