### PR TITLE
Refactor Resend Email Confirmation flow

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -44,8 +44,8 @@ module SignUp
       return process_already_confirmed_user if @user.confirmed?
 
       @confirmation_token = params[:confirmation_token]
-      flash.now[:error] = unsuccessful_confirmation_error
-      render '/sign_up/email_resend/new'
+      flash[:error] = unsuccessful_confirmation_error
+      redirect_to sign_up_email_resend_path
     end
 
     def process_already_confirmed_user

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -18,6 +18,9 @@ describe SignUp::EmailConfirmationsController do
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
       get :create, confirmation_token: nil
+
+      expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
+      expect(response).to redirect_to sign_up_email_resend_path
     end
 
     it 'tracks blank email confirmation token' do
@@ -32,6 +35,9 @@ describe SignUp::EmailConfirmationsController do
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
       get :create, confirmation_token: ''
+
+      expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
+      expect(response).to redirect_to sign_up_email_resend_path
     end
 
     it 'tracks confirmation token as a single-quoted empty string' do
@@ -46,6 +52,9 @@ describe SignUp::EmailConfirmationsController do
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
       get :create, confirmation_token: "''"
+
+      expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
+      expect(response).to redirect_to sign_up_email_resend_path
     end
 
     it 'tracks confirmation token as a double-quoted empty string' do
@@ -60,6 +69,9 @@ describe SignUp::EmailConfirmationsController do
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
       get :create, confirmation_token: '""'
+
+      expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
+      expect(response).to redirect_to sign_up_email_resend_path
     end
 
     it 'tracks already confirmed token' do
@@ -93,6 +105,10 @@ describe SignUp::EmailConfirmationsController do
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
       get :create, confirmation_token: 'foo'
+
+      expect(flash[:error]).
+        to eq t('errors.messages.confirmation_period_expired', period: '24 hours')
+      expect(response).to redirect_to sign_up_email_resend_path
     end
   end
 

--- a/spec/controllers/sign_up/email_resend_controller_spec.rb
+++ b/spec/controllers/sign_up/email_resend_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SignUp::EmailResendController do
+  describe '#create' do
+    context 'user exists and is not confirmed' do
+      it 'sends confirmation email to user and redirects to root' do
+        user = create(:user, :unconfirmed)
+
+        user_params = { user: { email: user.email } }
+
+        expect { post :create, user_params }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        expect(response).to redirect_to root_url
+        expect(flash[:notice]).to eq t('devise.confirmations.send_paranoid_instructions')
+      end
+    end
+
+    context 'user does not exist' do
+      it 'does not send an email and displays the same message as if the user existed' do
+        user_params = { user: { email: 'nonexistent@test.com' } }
+
+        expect { post :create, user_params }.
+          to change { ActionMailer::Base.deliveries.count }.by(0)
+
+        expect(response).to redirect_to root_url
+        expect(flash[:notice]).to eq t('devise.confirmations.send_paranoid_instructions')
+      end
+    end
+  end
+end

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -22,7 +22,10 @@ describe SignUp::PasswordsController do
 
       post :create, password_form: { password: 'NewVal!dPassw0rd' }, confirmation_token: token
 
-      expect(user.reload.valid_password?('NewVal!dPassw0rd')).to eq true
+      user.reload
+      expect(user.valid_password?('NewVal!dPassw0rd')).to eq true
+      expect(user.confirmed?).to eq true
+      expect(user.reset_requested_at).to be_nil
     end
 
     it 'tracks an invalid password event' do

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -12,21 +12,17 @@ feature 'Accessibility on pages that require authentication', :js do
 
   describe 'user confirmation page' do
     scenario 'valid confirmation token' do
-      email = 'test@example.com'
-      sign_up_with(email)
-      open_email(email)
-      visit_in_email(t('mailer.confirmation_instructions.link_text'))
+      create(:user, :unconfirmed)
+      confirm_last_user
 
       expect(current_path).to eq(sign_up_create_email_confirmation_path)
       expect(page).to be_accessible
     end
 
     scenario 'invalid confirmation token' do
-      email = 'test@example.com'
-      sign_up_with(email)
       visit sign_up_create_email_confirmation_path(confirmation_token: '123456')
 
-      expect(current_path).to eq(sign_up_create_email_confirmation_path)
+      expect(current_path).to eq(sign_up_email_resend_path)
       expect(page).to be_accessible
     end
   end

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -19,61 +19,6 @@ feature 'Email confirmation during sign up' do
     expect(page).to_not have_content t('devise.confirmations.confirmed_but_must_set_password')
   end
 
-  scenario 'it sets reset_requested_at to nil after password confirmation' do
-    user = sign_up_and_set_password
-
-    expect(user.reset_requested_at).to be_nil
-  end
-
-  scenario 'user cannot access sign_up/confirmations' do
-    visit sign_up_create_email_confirmation_path
-
-    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
-  end
-
-  scenario 'user cannot submit a blank confirmation token' do
-    visit sign_up_create_email_confirmation_path(confirmaton_token: nil)
-
-    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
-  end
-
-  scenario 'user cannot submit an empty single-quoted string as a token' do
-    visit sign_up_create_email_confirmation_path(confirmation_token: '')
-
-    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
-  end
-
-  scenario 'user cannot submit an empty double-quoted string as a token' do
-    visit sign_up_create_email_confirmation_path(confirmation_token: '%22%22')
-
-    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
-  end
-
-  scenario 'visitor signs up but confirms with an invalid token' do
-    create(:user, :unconfirmed)
-    visit sign_up_create_email_confirmation_path(confirmation_token: 'invalid_token')
-
-    expect(page).to have_content t('errors.messages.confirmation_invalid_token')
-    expect(current_path).to eq sign_up_create_email_confirmation_path
-  end
-
-  scenario 'visitor signs up but confirms with an expired token' do
-    user = create(:user, :unconfirmed)
-    raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
-
-    user.update(
-      confirmation_token: raw_confirmation_token,
-      confirmation_sent_at: Time.current - Devise.confirm_within - 2.days
-    )
-
-    visit sign_up_create_email_confirmation_url(confirmation_token: raw_confirmation_token)
-
-    expect(current_path).to eq sign_up_create_email_confirmation_path
-    expect(page).to have_content t(
-      'errors.messages.confirmation_period_expired', period: '24 hours'
-    )
-  end
-
   context 'user signs up twice without confirming email' do
     it 'sends the user the confirmation email again' do
       email = 'test@example.com'

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -19,12 +19,6 @@ feature 'Visit requests confirmation instructions again during sign up' do
     expect(unread_emails_for(user.email)).to be_present
   end
 
-  scenario 'user is unable to determine if account exists' do
-    fill_in 'Email', with: 'no_account_exists@example.com'
-    click_button t('forms.buttons.resend_confirmation')
-    expect(page).to have_content t('devise.confirmations.send_paranoid_instructions')
-  end
-
   scenario 'user enters email with invalid format' do
     invalid_addresses = [
       'user@domain-without-suffix',
@@ -60,13 +54,5 @@ feature 'Visit requests confirmation instructions again during sign up' do
     click_button t('forms.buttons.resend_confirmation')
 
     expect(page).to have_content t('valid_email.validations.email.invalid')
-  end
-
-  scenario 'confirmations new page has localized title' do
-    expect(page).to have_title t('titles.confirmations.new')
-  end
-
-  scenario 'confirmations new page has localized heading' do
-    expect(page).to have_content t('headings.confirmations.new')
   end
 end

--- a/spec/views/sign_up/email_resend/new.html.slim_spec.rb
+++ b/spec/views/sign_up/email_resend/new.html.slim_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'sign_up/email_resend/new.html.slim' do
+  before do
+    @user = User.new
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('titles.confirmations.new'))
+
+    render
+  end
+
+  it 'has a localized header' do
+    render
+
+    expect(rendered).to have_selector('h1', text: t('headings.confirmations.new'))
+  end
+end


### PR DESCRIPTION
**Why**:
- The `/sign_up/enter_email/resend` route was being visited directly in
some feature specs, but there weren't any other specs that verified
that the user ended up on that endpoint, which made it look like the
endpoint wasn't being used. Technically, it wasn't being used since
the view contents were being rendered directly in
`EmailConfirmationsController#process_unsuccessful_confirmation`

- Some tests were duplicated between controller and feature specs

**How**:
- Instead of rendering the `/sign_up/email_resend/new` view when a user
tries to confirm their email with an invalid or expired token, we
redirect to the `/sign_up/enter_email/resend` endpoint. That way, the
URL changes to reflect the contents of the page. This then allows us
to have tests that visit this endpoint directly since we've tested how
a user can end up there.

- Remove feature specs that were already covered by controller tests
- Replace other feature specs with controller and view specs