### PR TITLE
Refactor IdV into discrete confirmations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: d013230ddeba07d6f37a58c06351218bb5f525fe
+  revision: c671e7964a1e4693b500da6fdde7c023beda71b1
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -8,6 +8,7 @@ module IdvSession
   def confirm_idv_attempts_allowed
     if idv_attempter.exceeded?
       flash[:error] = t('idv.errors.hardfail')
+      analytics.track_event(Analytics::IDV_MAX_ATTEMPTS_EXCEEDED, request_path: request.path)
       redirect_to verify_fail_url
     elsif idv_attempter.reset_attempts?
       idv_attempter.reset
@@ -33,19 +34,5 @@ module IdvSession
 
   def idv_attempter
     @_idv_attempter ||= Idv::Attempter.new(current_user)
-  end
-
-  def idv_agent
-    @_agent ||= Proofer::Agent.new(
-      applicant: idv_session.applicant,
-      vendor: (idv_session.vendor || idv_vendor.pick),
-      kbv: false
-    )
-  end
-
-  def init_profile(resolution)
-    idv_session.resolution = resolution
-    idv_session.cache_applicant_profile_id(idv_session.applicant)
-    idv_session.cache_encrypted_pii(current_user.user_access_key)
   end
 end

--- a/app/controllers/verify/finance_other_controller.rb
+++ b/app/controllers/verify/finance_other_controller.rb
@@ -1,5 +1,7 @@
 module Verify
   class FinanceOtherController < StepController
+    before_action :confirm_step_needed
+
     helper_method :idv_finance_form
 
     def new
@@ -7,6 +9,10 @@ module Verify
     end
 
     private
+
+    def confirm_step_needed
+      redirect_to verify_phone_path if idv_session.financials_confirmation.try(:success?)
+    end
 
     def idv_finance_form
       @_idv_finance_form ||= Idv::FinanceForm.new(idv_session.params)

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -8,8 +8,9 @@ module Verify
     helper_method :idv_params
 
     def confirm_idv_steps_complete
-      redirect_to verify_finance_path unless idv_finance_complete?
-      redirect_to verify_phone_path unless idv_phone_complete?
+      return redirect_to(verify_session_path) unless idv_profile_complete?
+      return redirect_to(verify_finance_path) unless idv_finance_complete?
+      return redirect_to(verify_phone_path) unless idv_phone_complete?
     end
 
     def confirm_current_password
@@ -25,42 +26,31 @@ module Verify
     end
 
     def create
-      resolution = start_idv_session
-      track_idv_event(resolution)
-      process_resolution(resolution)
+      init_profile
+      redirect_to_next_step
+      analytics.track_event(Analytics::IDV_REVIEW_COMPLETE)
     end
 
     private
 
-    def track_idv_event(resolution)
-      result = {
-        success: resolution.success,
-        idv_attempts_exceeded: idv_attempter.exceeded?
-      }
-
-      analytics.track_event(Analytics::IDV_INITIAL, result)
-    end
-
-    def process_resolution(resolution)
-      if resolution.success
-        init_profile(resolution)
-        redirect_on_success
-      elsif idv_attempter.exceeded?
-        redirect_to verify_fail_path
-      else
-        redirect_to verify_retry_path
-      end
+    def idv_profile_complete?
+      idv_session.resolution.try(:success?)
     end
 
     def idv_finance_complete?
-      (idv_session.params.keys & Idv::FinanceForm::FINANCE_TYPES).any?
+      idv_session.financials_confirmation.try(:success?)
     end
 
     def idv_phone_complete?
-      idv_session.params[:phone].present?
+      idv_session.phone_confirmation.try(:success?)
     end
 
-    def redirect_on_success
+    def init_profile
+      idv_session.cache_applicant_profile_id(idv_session.applicant)
+      idv_session.cache_encrypted_pii(current_user.user_access_key)
+    end
+
+    def redirect_to_next_step
       if phone_confirmation_required?
         prompt_to_confirm_phone(phone: idv_params[:phone], otp_method: nil, context: 'idv')
       else
@@ -74,18 +64,6 @@ module Verify
 
     def phone_confirmation_required?
       idv_params[:phone] != current_user.phone
-    end
-
-    def start_idv_session
-      idv_session.applicant = idv_session.applicant_from_params
-      idv_session.vendor = idv_agent.vendor
-      submit_applicant
-    end
-
-    def submit_applicant
-      resolution = idv_agent.start(idv_session.applicant)
-      idv_attempter.increment
-      resolution
     end
 
     def valid_password?

--- a/app/controllers/verify/step_controller.rb
+++ b/app/controllers/verify/step_controller.rb
@@ -6,5 +6,7 @@ module Verify
     before_action :confirm_idv_needed
     before_action :confirm_idv_session_started
     before_action :confirm_idv_attempts_allowed
+
+    helper_method :step
   end
 end

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -2,6 +2,8 @@ module Idv
   class ProfileForm
     include ActiveModel::Model
 
+    attr_reader :user
+
     def self.model_name
       ActiveModel::Name.new(self, nil, 'Profile')
     end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -39,12 +39,15 @@ class Analytics
   EMAIL_CONFIRMATION_RESEND = 'Email Confirmation requested due to invalid token'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
   IDV_BASIC_INFO_SUBMITTED = 'IdV: basic info submitted'.freeze
-  IDV_INITIAL = 'IdV: initial resolution'.freeze
+  IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FINANCE_CCN_VISIT = 'IdV: finance ccn visited'.freeze
+  IDV_FINANCE_CONFIRMATION = 'IdV: finance confirmation'.freeze
   IDV_FINANCE_OTHER_VISIT = 'IdV: finance other visited'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze
+  IDV_PHONE_CONFIRMATION = 'IdV: phone confirmation'.freeze
   IDV_PHONE_RECORD_VISIT = 'IdV: phone of record visited'.freeze
+  IDV_REVIEW_COMPLETE = 'IdV: review complete'.freeze
   IDV_REVIEW_VISIT = 'IdV: review info visited'.freeze
   INVALID_AUTHENTICITY_TOKEN = 'Invalid Authenticity Token'.freeze
   OTP_DELIVERY_SELECTION = 'OTP: Delivery Selection'.freeze

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -1,0 +1,13 @@
+module Idv
+  class Agent
+    delegate :vendor, :start, :submit_phone, :submit_financials, :submit_answers, to: :agent
+
+    def initialize(vendor:, applicant:)
+      self.agent = Proofer::Agent.new(applicant: applicant, vendor: vendor, kbv: false)
+    end
+
+    private
+
+    attr_accessor :agent
+  end
+end

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -1,0 +1,32 @@
+module Idv
+  class FinancialsStep < Step
+    def complete?
+      idv_form.finance_type && idv_session.financials_confirmation.try(:success?) ? true : false
+    end
+
+    private
+
+    def vendor_validate
+      result = vendor_validator.validate
+      idv_session.params = idv_form.idv_params if complete?
+      result
+    end
+
+    def vendor_validator_class
+      Idv::FinancialsValidator
+    end
+
+    def analytics_event
+      Analytics::IDV_FINANCE_CONFIRMATION
+    end
+
+    def vendor_errors
+      idv_session.financials_confirmation.try(:errors)
+    end
+
+    def vendor_params
+      finance_type = idv_form.finance_type
+      { finance_type => idv_form.idv_params[finance_type] }
+    end
+  end
+end

--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -1,0 +1,9 @@
+module Idv
+  class FinancialsValidator < VendorValidator
+    def validate
+      session_id = idv_session.resolution.session_id
+      idv_session.financials_confirmation = idv_agent.submit_financials(vendor_params, session_id)
+      idv_session.financials_confirmation.success?
+    end
+  end
+end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -1,0 +1,36 @@
+module Idv
+  class PhoneStep < Step
+    def complete?
+      idv_form.phone && idv_session.phone_confirmation.try(:success?) ? true : false
+    end
+
+    private
+
+    def vendor_validator_class
+      Idv::PhoneValidator
+    end
+
+    def vendor_params
+      idv_form.phone
+    end
+
+    def vendor_validate
+      result = vendor_validator.validate
+      update_idv_session if complete?
+      result
+    end
+
+    def vendor_errors
+      idv_session.phone_confirmation.try(:errors)
+    end
+
+    def update_idv_session
+      idv_session.params = idv_form.idv_params
+      idv_session.applicant.phone = idv_form.phone
+    end
+
+    def analytics_event
+      Analytics::IDV_PHONE_CONFIRMATION
+    end
+  end
+end

--- a/app/services/idv/phone_validator.rb
+++ b/app/services/idv/phone_validator.rb
@@ -1,0 +1,9 @@
+module Idv
+  class PhoneValidator < VendorValidator
+    def validate
+      session_id = idv_session.resolution.session_id
+      idv_session.phone_confirmation = idv_agent.submit_phone(vendor_params, session_id)
+      idv_session.phone_confirmation.success?
+    end
+  end
+end

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -1,0 +1,55 @@
+module Idv
+  class ProfileStep < Step
+    def complete?
+      idv_session.resolution.try(:success?) ? true : false
+    end
+
+    def complete
+      return track_event if attempts_exceeded?
+      idv_session.params.merge!(params)
+      vendor_validate if form_validate(params)[:success]
+      track_event
+      complete?
+    end
+
+    def attempts_exceeded?
+      attempter.exceeded?
+    end
+
+    private
+
+    def attempter
+      @_idv_attempter ||= Idv::Attempter.new(idv_form.user)
+    end
+
+    def vendor_params
+      idv_session.applicant_from_params
+    end
+
+    def vendor_validate
+      result = vendor_validator.validate
+      attempter.increment
+      result
+    end
+
+    def vendor_validator_class
+      Idv::ProfileValidator
+    end
+
+    def vendor_errors
+      idv_session.resolution.try(:errors)
+    end
+
+    def analytics_result
+      {
+        success: complete?,
+        idv_attempts_exceeded: attempts_exceeded?,
+        errors: errors
+      }
+    end
+
+    def analytics_event
+      Analytics::IDV_BASIC_INFO_SUBMITTED
+    end
+  end
+end

--- a/app/services/idv/profile_validator.rb
+++ b/app/services/idv/profile_validator.rb
@@ -1,0 +1,10 @@
+module Idv
+  class ProfileValidator < VendorValidator
+    def validate
+      idv_session.applicant = vendor_params
+      idv_session.vendor = idv_agent.vendor
+      idv_session.resolution = idv_agent.start(vendor_params)
+      idv_session.resolution.success?
+    end
+  end
+end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,7 +1,8 @@
 module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = [
-      :resolution, :vendor, :applicant, :params, :profile_id, :recovery_code
+      :resolution, :vendor, :applicant, :params, :profile_id, :recovery_code,
+      :financials_confirmation, :phone_confirmation
     ].freeze
 
     def initialize(user_session, current_user)

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -1,0 +1,68 @@
+# abstract base class for Idv Steps
+module Idv
+  class Step
+    include VendorValidated
+
+    def initialize(analytics:, idv_form:, idv_session:, params:)
+      @idv_form = idv_form
+      @idv_session = idv_session
+      @analytics = analytics
+      @params = params
+    end
+
+    def complete
+      form_valid? && vendor_valid?
+      track_event
+      complete?
+    end
+
+    def form_valid?
+      form_validate(params)
+    end
+
+    def vendor_valid?
+      vendor_validate
+    end
+
+    def complete?
+      raise NotImplementedError "Must implement complete? method for #{self}"
+    end
+
+    private
+
+    attr_accessor :analytics, :idv_form, :idv_session, :params, :form_result
+
+    def form_validate(params)
+      self.form_result = idv_form.submit(params)
+    end
+
+    def errors
+      errors = idv_form.errors.messages.dup
+      return errors unless vendor_errors
+      merge_vendor_errors(errors)
+    end
+
+    def merge_vendor_errors(errors)
+      vendor_errors.each_with_object(errors) do |(key, value), errs|
+        value = [value] unless value.is_a?(Array)
+        errs[key] = value
+      end
+    end
+
+    def vendor_validator
+      vendor_validator_class.new(idv_session: idv_session, vendor_params: vendor_params)
+    end
+
+    def analytics_event
+      raise NotImplementedError "Must implement analytics_event for #{self}"
+    end
+
+    def analytics_result
+      { success: complete?, errors: errors }
+    end
+
+    def track_event
+      analytics.track_event(analytics_event, analytics_result)
+    end
+  end
+end

--- a/app/services/idv/vendor_validated.rb
+++ b/app/services/idv/vendor_validated.rb
@@ -1,0 +1,21 @@
+module Idv
+  module VendorValidated
+    extend ActiveSupport::Concern
+
+    def vendor_validate
+      raise NotImplementedError "Must implement vendor_validate method for #{self}"
+    end
+
+    def vendor_validator_class
+      raise NotImplementedError "Must implement vendor_validator_class method for #{self}"
+    end
+
+    def vendor_params
+      raise NotImplementedError "Must implement vendor_params method for #{self}"
+    end
+
+    def vendor_errors
+      raise NotImplementedError "Must implement vendor_errors method for #{self}"
+    end
+  end
+end

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -1,0 +1,28 @@
+# abstract base class for proofing vendor validation
+module Idv
+  class VendorValidator
+    attr_reader :idv_session, :vendor_params
+
+    def initialize(idv_session:, vendor_params:)
+      @idv_session = idv_session
+      @vendor_params = vendor_params
+    end
+
+    def validate
+      raise NotImplementedError "Must implement validate for #{self}"
+    end
+
+    private
+
+    def idv_vendor
+      @_idv_vendor ||= Idv::Vendor.new
+    end
+
+    def idv_agent
+      @_agent ||= Idv::Agent.new(
+        applicant: idv_session.applicant,
+        vendor: (idv_session.vendor || idv_vendor.pick)
+      )
+    end
+  end
+end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 include Features::LocalizationHelper
 
 describe Verify::PhoneController do
+  let(:good_phone) { '+1 (555) 555-0000' }
+  let(:bad_phone) { '+1 (555) 555-5555' }
+
   describe 'before_actions' do
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
@@ -13,51 +16,121 @@ describe Verify::PhoneController do
     end
   end
 
+  describe '#new' do
+    it 'redirects to review when step is complete' do
+      user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
+      stub_subject(user)
+      subject.idv_session.phone_confirmation = Proofer::Confirmation.new success: true
+
+      get :new
+
+      expect(response).to redirect_to verify_review_path
+    end
+  end
+
   describe '#create' do
     context 'when form is invalid' do
       render_views
 
-      it 'renders #new' do
+      before do
         user = build(:user, phone: '+1 (415) 555-0130')
         stub_subject(user)
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
 
+      it 'renders #new' do
         put :create, idv_phone_form: { phone: '703' }
 
         expect(response.body).to have_content invalid_phone_message
         expect(subject.idv_session.params).to be_empty
       end
-    end
 
-    context 'when form is valid and submitted phone is same as user phone' do
-      it 'redirects to review page and sets phone_confirmed_at' do
-        user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
-        stub_subject(user)
+      it 'tracks form error' do
+        put :create, idv_phone_form: { phone: '703' }
 
-        put :create, idv_phone_form: { phone: '+1 (415) 555-0130' }
-
-        expect(response).to redirect_to verify_review_path
-
-        expected_params = {
-          phone: '+1 (415) 555-0130',
-          phone_confirmed_at: user.phone_confirmed_at
+        result = {
+          success: false,
+          errors: {
+            phone: [invalid_phone_message]
+          }
         }
-        expect(subject.idv_session.params).to eq expected_params
+
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::IDV_PHONE_CONFIRMATION, result
+        )
+        expect(subject.idv_session.phone_confirmation).to be_nil
       end
     end
 
-    context 'when form is valid and submitted phone is different from user phone' do
-      it 'redirects to review page and does not set phone_confirmed_at' do
-        user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
+    context 'when form is valid' do
+      before do
+        stub_analytics
+        allow(@analytics).to receive(:track_event)
+      end
+
+      it 'tracks event with valid phone' do
+        user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
         stub_subject(user)
 
-        put :create, idv_phone_form: { phone: '+1 (415) 555-0160' }
+        put :create, idv_phone_form: { phone: good_phone }
 
-        expect(response).to redirect_to verify_review_path
+        result = { success: true, errors: {} }
 
-        expected_params = {
-          phone: '+1 (415) 555-0160'
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::IDV_PHONE_CONFIRMATION, result
+        )
+      end
+
+      it 'tracks event with invalid phone' do
+        user = build(:user, phone: bad_phone, phone_confirmed_at: Time.zone.now)
+        stub_subject(user)
+
+        put :create, idv_phone_form: { phone: bad_phone }
+
+        result = {
+          success: false,
+          errors: {
+            phone: ['The phone number could not be verified.']
+          }
         }
-        expect(subject.idv_session.params).to eq expected_params
+
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::IDV_PHONE_CONFIRMATION, result
+        )
+      end
+
+      context 'when same as user phone' do
+        it 'redirects to review page and sets phone_confirmed_at' do
+          user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
+          stub_subject(user)
+
+          put :create, idv_phone_form: { phone: good_phone }
+
+          expect(response).to redirect_to verify_review_path
+
+          expected_params = {
+            phone: good_phone,
+            phone_confirmed_at: user.phone_confirmed_at
+          }
+          expect(subject.idv_session.params).to eq expected_params
+        end
+      end
+
+      context 'when different from user phone' do
+        it 'redirects to review page and does not set phone_confirmed_at' do
+          user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
+          stub_subject(user)
+
+          put :create, idv_phone_form: { phone: good_phone }
+
+          expect(response).to redirect_to verify_review_path
+
+          expected_params = {
+            phone: good_phone
+          }
+          expect(subject.idv_session.params).to eq expected_params
+        end
       end
     end
   end
@@ -66,6 +139,9 @@ describe Verify::PhoneController do
     user_session = {}
     stub_sign_in(user)
     idv_session = Idv::Session.new(user_session, user)
+    idv_session.resolution = Proofer::Resolution.new success: true, session_id: 'some-id'
+    idv_session.applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
+    idv_session.vendor = subject.idv_vendor.pick
     allow(subject).to receive(:confirm_idv_session_started).and_return(true)
     allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     allow(subject).to receive(:idv_session).and_return(idv_session)

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe Idv::FinancialsStep do
+  let(:user) { build(:user) }
+  let(:idv_session) do
+    idvs = Idv::Session.new({}, user)
+    idvs.vendor = :mock
+    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
+    idvs
+  end
+  let(:idv_finance_form) { Idv::FinanceForm.new(idv_session.params) }
+
+  def build_step(params)
+    @analytics = FakeAnalytics.new
+    allow(@analytics).to receive(:track_event)
+
+    described_class.new(
+      idv_form: idv_finance_form,
+      idv_session: idv_session,
+      analytics: @analytics,
+      params: params
+    )
+  end
+
+  def expect_analytics_result(result)
+    expect(@analytics).to have_received(:track_event).
+      with(Analytics::IDV_FINANCE_CONFIRMATION, result)
+  end
+
+  describe '#complete' do
+    it 'returns false for invalid params' do
+      step = build_step(finance_type: :ccn, ccn: '1234')
+
+      expect(step.complete).to eq false
+
+      result = {
+        success: false,
+        errors: { ccn: [t('idv.errors.invalid_ccn')] }
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'returns true for mock-happy CCN' do
+      step = build_step(finance_type: :ccn, ccn: '12345678')
+
+      expect(step.complete).to eq true
+
+      result = {
+        success: true,
+        errors: {}
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'returns false for mock-sad CCN' do
+      step = build_step(finance_type: :ccn, ccn: '00000000')
+
+      expect(step.complete).to eq false
+
+      result = {
+        success: false,
+        errors: { ccn: ['The ccn could not be verified.'] }
+      }
+
+      expect_analytics_result(result)
+    end
+  end
+
+  describe '#complete?' do
+    it 'returns true for mock-happy CCN' do
+      step = build_step(finance_type: :ccn, ccn: '12345678')
+      step.complete
+
+      expect(step.complete?).to eq true
+    end
+
+    it 'returns false for mock-sad CCN' do
+      step = build_step(finance_type: :ccn, ccn: '00000000')
+      step.complete
+
+      expect(step.complete?).to eq false
+    end
+  end
+end

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+describe Idv::PhoneStep do
+  include Features::LocalizationHelper
+
+  let(:user) { build(:user) }
+  let(:idv_session) do
+    idvs = Idv::Session.new({}, user)
+    idvs.vendor = :mock
+    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
+    idvs.applicant = Proofer::Applicant.new first_name: 'Some'
+    idvs
+  end
+  let(:idv_phone_form) { Idv::PhoneForm.new(idv_session.params, user) }
+
+  def build_step(params)
+    @analytics = FakeAnalytics.new
+    allow(@analytics).to receive(:track_event)
+
+    described_class.new(
+      idv_form: idv_phone_form,
+      idv_session: idv_session,
+      analytics: @analytics,
+      params: params
+    )
+  end
+
+  def expect_analytics_result(result)
+    expect(@analytics).to have_received(:track_event).with(
+      Analytics::IDV_PHONE_CONFIRMATION, result
+    )
+  end
+
+  describe '#complete' do
+    it 'returns false for invalid-looking phone' do
+      step = build_step(phone: '555')
+
+      expect(step.complete).to eq false
+
+      result = {
+        success: false,
+        errors: {
+          phone: [invalid_phone_message]
+        }
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'returns true for mock-happy phone' do
+      step = build_step(phone: '555-555-0000')
+
+      expect(step.complete).to eq true
+
+      result = {
+        success: true,
+        errors: {}
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'returns false for mock-sad phone' do
+      step = build_step(phone: '555-555-5555')
+
+      expect(step.complete).to eq false
+
+      result = {
+        success: false,
+        errors: {
+          phone: ['The phone number could not be verified.']
+        }
+      }
+
+      expect_analytics_result(result)
+    end
+  end
+
+  describe '#complete?' do
+    it 'returns true for mock-happy phone' do
+      step = build_step(phone: '555-555-0000')
+      step.complete
+
+      expect(step.complete?).to eq true
+    end
+
+    it 'returns false for mock-sad phone' do
+      step = build_step(phone: '555-555-5555')
+      step.complete
+
+      expect(step.complete?).to eq false
+    end
+  end
+end

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+describe Idv::ProfileStep do
+  let(:user) { create(:user) }
+  let(:idv_session) { Idv::Session.new({}, user) }
+  let(:idv_profile_form) { Idv::ProfileForm.new(idv_session.params, user) }
+  let(:user_attrs) do
+    {
+      first_name: 'Some',
+      last_name: 'One',
+      ssn: '666-66-1234',
+      dob: '19720329',
+      address1: '123 Main St',
+      address2: '',
+      city: 'Somewhere',
+      state: 'KS',
+      zipcode: '66044'
+    }
+  end
+
+  def build_step(params)
+    @analytics = FakeAnalytics.new
+    allow(@analytics).to receive(:track_event)
+
+    described_class.new(
+      idv_form: idv_profile_form,
+      idv_session: idv_session,
+      analytics: @analytics,
+      params: params
+    )
+  end
+
+  def expect_analytics_result(result)
+    expect(@analytics).to have_received(:track_event).
+      with(Analytics::IDV_BASIC_INFO_SUBMITTED, result)
+  end
+
+  describe '#complete' do
+    it 'succeeds with good params' do
+      step = build_step(user_attrs)
+
+      expect(step.complete).to eq true
+      expect(step.complete?).to eq true
+
+      result = {
+        success: true,
+        idv_attempts_exceeded: false,
+        errors: {}
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'fails with invalid SSN' do
+      step = build_step(user_attrs.merge(ssn: '666-66-6666'))
+
+      expect(step.complete).to eq false
+      expect(step.complete?).to eq false
+
+      result = {
+        success: false,
+        idv_attempts_exceeded: false,
+        errors: {
+          ssn: ['Unverified SSN.']
+        }
+      }
+
+      expect_analytics_result(result)
+    end
+
+    it 'fails with invalid first name' do
+      step = build_step(user_attrs.merge(first_name: 'Bad'))
+
+      expect(step.complete).to eq false
+      expect(step.complete?).to eq false
+
+      result = {
+        success: false,
+        idv_attempts_exceeded: false,
+        errors: {
+          first_name: ['Unverified first name.']
+        }
+      }
+
+      expect_analytics_result(result)
+    end
+  end
+
+  describe '#attempts_exceeded?' do
+    it 'tracks resolution attempts' do
+      user.idv_attempts = 3
+      user.idv_attempted_at = Time.zone.now
+      step = build_step(user_attrs)
+
+      step.complete
+      expect(step.attempts_exceeded?).to eq true
+
+      result = {
+        success: false,
+        idv_attempts_exceeded: true,
+        errors: {}
+      }
+
+      expect_analytics_result(result)
+    end
+  end
+end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -70,7 +70,7 @@ module Features
     end
 
     def user_with_2fa
-      create(:user, :signed_up, phone: '+1 (555) 555-5556', password: VALID_PASSWORD)
+      create(:user, :signed_up, phone: '+1 (555) 555-0000', password: VALID_PASSWORD)
     end
 
     def confirm_last_user

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -29,13 +29,21 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: phone
   end
 
+  def fill_out_phone_form_fail
+    fill_in :idv_phone_form_phone, with: '(555) 555-5555'
+  end
+
+  def click_idv_continue
+    click_button t('forms.buttons.continue')
+  end
+
   def complete_idv_profile_ok(user)
     fill_out_idv_form_ok
-    click_button t('forms.buttons.continue')
+    click_idv_continue
     fill_out_financial_form_ok
-    click_button t('forms.buttons.continue')
+    click_idv_continue
     fill_out_phone_form_ok(user.phone)
-    click_button t('forms.buttons.continue')
+    click_idv_continue
     fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
     click_submit_default
   end


### PR DESCRIPTION
**Why**: Our vendor API supports distinct confirmations for profile resolution,
financials and phone. Performing confirmation at each step provides better UX.