### PR TITLE
Simplify attribute encryption integration test

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -206,8 +206,7 @@ feature 'Sign in' do
       email = 'test@example.com'
       password = 'salty pickles'
 
-      sign_up_and_2fa_as_a_user_would(email, password)
-      visit destroy_user_session_path
+      create(:user, :signed_up, email: email, password: password)
 
       user = User.find_with_email(email)
       encrypted_email = user.encrypted_email

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -121,20 +121,6 @@ module Features
       Capybara.session_name = old_session
     end
 
-    def sign_up_and_2fa_as_a_user_would(email, password)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
-      sign_up_with(email)
-      open_email(email)
-      visit_in_email(t('mailer.confirmation_instructions.link_text'))
-      find('#password_form_password').set(password)
-      click_button t('forms.buttons.submit.default')
-      fill_in 'Phone', with: '202-555-1212'
-      click_button t('forms.buttons.send_passcode')
-      click_button t('forms.buttons.submit.default')
-      click_button t('forms.buttons.continue')
-    end
-
     def sign_in_with_totp_enabled_user
       user = create(:user, :signed_up, password: VALID_PASSWORD)
       @secret = user.generate_totp_secret


### PR DESCRIPTION
**Why**: Having Capybara simulate the account creation flow
was causing intermittent failures in Travis. It turns out we
don't need to simulate the flow to test this feature. We only
need to create the user using FactoryGirl.