### PR TITLE
Optimize encrypted attribute accessors

### DIFF
--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -54,16 +54,12 @@ module UserEncryptedAttributeOverrides
 
   def email=(email)
     set_encrypted_attribute(name: :email, value: email, default: '')
-    self.email_fingerprint = if email.present?
-                               @_encrypted[:email].fingerprint
-                             else
-                               ''
-                             end
+    self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''
   end
 
   def stale_encrypted_email?
     return false unless email.present?
-    @_encrypted[:email].stale?
+    encrypted_attributes[:email].stale?
   end
 
   def phone
@@ -76,44 +72,47 @@ module UserEncryptedAttributeOverrides
 
   def stale_encrypted_phone?
     return false unless phone.present?
-    @_encrypted[:phone].stale?
+    encrypted_attributes[:phone].stale?
   end
 
   private
+
+  def encrypted_attributes
+    @_encrypted_attributes ||= {}
+  end
 
   def get_encrypted_attribute(name:, default:)
     getter = encrypted_attribute_name(name)
     encrypted_string = self[getter]
     return default unless encrypted_string.present?
-    build_encrypted_attribute(name, encrypted_string)
-    @_encrypted[name].decrypted
+    encrypted_attribute = encrypted_attributes[name]
+    return encrypted_attribute.decrypted if encrypted_attribute.present?
+    build_encrypted_attribute(name, encrypted_string).decrypted
   end
 
   def build_encrypted_attribute(name, encrypted_string)
-    @_encrypted ||= {}
-    @_encrypted[name] = EncryptedAttribute.new(
+    encrypted_attribute = EncryptedAttribute.new(
       encrypted_string,
       cost: attribute_cost,
       user_access_key: attribute_user_access_key
     )
-    self.attribute_user_access_key ||= @_encrypted[name].user_access_key
+    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
+    encrypted_attributes[name] = encrypted_attribute
   end
 
   def set_encrypted_attribute(name:, value:, default:)
-    @_encrypted ||= {}
     setter = encrypted_attribute_name(name)
     new_value = default
     if value.present?
-      build_encrypted_attribute_from_plain(name, value)
-      new_value = @_encrypted[name].encrypted
+      new_value = build_encrypted_attribute_from_plain(name, value).encrypted
     end
     self[setter] = new_value
   end
 
   def build_encrypted_attribute_from_plain(name, plain_value)
     self.attribute_user_access_key ||= new_attribute_user_access_key
-    @_encrypted[name] = EncryptedAttribute.new_from_decrypted(
-      plain_value,
+    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
+      plain_value.downcase.strip,
       attribute_user_access_key
     )
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,6 @@ Devise.setup do |config|
   include Mailable
   require 'devise/orm/active_record'
   config.allow_unconfirmed_access_for = 0.days
-  config.case_insensitive_keys = [:email]
   config.confirm_within = 24.hours
   config.expire_all_remember_me_on_sign_out = true
   config.mailer = 'CustomDeviseMailer'
@@ -18,7 +17,6 @@ Devise.setup do |config|
   config.sign_out_via = :delete
   config.skip_session_storage = [:http_auth]
   config.stretches = Rails.env.test? ? 1 : 12
-  config.strip_whitespace_keys = [:email]
   config.timeout_in = Figaro.env.session_timeout_in_minutes.to_i.minutes
 
   # ==> Two Factor Authentication

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -253,4 +253,20 @@ describe User do
       end
     end
   end
+
+  describe 'encrypted attributes' do
+    context 'input is MixEd CaSe with whitespace' do
+      it 'normalizes email' do
+        user = create(:user, email: 'FoO@example.org    ')
+
+        expect(user.email).to eq 'foo@example.org'
+      end
+
+      it 'normalizes phone' do
+        user = create(:user, phone: '  555 555 5555    ')
+
+        expect(user.phone).to eq '555 555 5555'
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Encrypted attribute accessors are called many times, needlessly causing delays due to encryption overhead.
    
**How**: Now that `email` is a virtual method that we handle ourselves, configure Devise to skip the downcasing and whitespace validations. Refactor get/set methods to prefer memoized `EncryptedAttribute` objects.