### PR TITLE
Add analytics for IdV Basic Info form submission

### DIFF
--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -21,7 +21,10 @@ module Verify
     private
 
     def submit_profile
-      if idv_profile_form.submit(profile_params)
+      result = idv_profile_form.submit(profile_params)
+      analytics.track_event(Analytics::IDV_BASIC_INFO_SUBMITTED, result)
+
+      if result[:success]
         redirect_to verify_finance_path
       elsif duplicate_ssn_error?
         flash[:error] = dupe_ssn_msg

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -39,13 +39,16 @@ module Idv
     def submit(params)
       params.each { |key, val| pii_attributes[key] = val }
       profile.ssn_signature = ssn_signature
-      valid?
+      @success = valid?
+      result
     end
 
     private
 
     attr_writer :first_name, :last_name, :phone, :email, :dob, :ssn, :address1,
                 :address2, :city, :state, :zipcode
+
+    attr_reader :success
 
     def initialize_params(params)
       params.each do |key, value|
@@ -94,6 +97,13 @@ module Idv
       Date.parse(dob.to_s)
     rescue
       nil
+    end
+
+    def result
+      {
+        success: success,
+        errors: errors.messages
+      }
     end
   end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -37,6 +37,7 @@ class Analytics
   EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze
   EMAIL_CONFIRMATION = 'Email Confirmation'.freeze
   IDV_BASIC_INFO_VISIT = 'IdV: basic info visited'.freeze
+  IDV_BASIC_INFO_SUBMITTED = 'IdV: basic info submitted'.freeze
   IDV_INITIAL = 'IdV: initial resolution'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FINANCE_CCN_VISIT = 'IdV: finance ccn visited'.freeze


### PR DESCRIPTION
**Why**: To capture success and failure rates, and what kind of errors
are being generated, such as when someone tries to proof with an
existing SSN, or if they don't fill out a required field, or enter an
invalid format for certain fields.