### PR TITLE
Add additional styling to financial input forms

### DIFF
--- a/app/assets/javascripts/app/idv-finance-helper.js
+++ b/app/assets/javascripts/app/idv-finance-helper.js
@@ -7,6 +7,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function removeError() {
+    const errorMessage = document.querySelector('.error-message');
+
+    if (errorMessage) {
+      errorMessage.parentNode.classList.remove('has-error');
+      errorMessage.parentNode.removeChild(errorMessage);
+    }
+  }
+
   function showInput(name) {
     const inputWrappers = document.querySelectorAll('.js-finance-wrapper');
     hideAll(inputWrappers);
@@ -23,9 +32,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (financeSelect) {
     const inputWrappers = document.querySelectorAll('.js-finance-wrapper');
     hideAll(inputWrappers);
-    showInput('blank');
+
+    showInput(financeSelect.value || 'blank');
+    submitButton.disabled = !financeSelect.value;
 
     financeSelect.addEventListener('change', () => {
+      removeError();
       showInput(financeSelect.value || 'blank');
       submitButton.disabled = !financeSelect.value;
     });

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -135,3 +135,118 @@ input::-webkit-inner-spin-button {
 .radio input:checked ~ .indicator {
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgOCA4IiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA4IDgiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTQsMUMyLjMsMSwxLDIuMywxLDRzMS4zLDMsMywzczMtMS4zLDMtM1M1LjcsMSw0LDF6Ii8+DQo8L3N2Zz4NCg==);
 }
+
+.select-alt {
+  color: $white;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+
+  select {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: $navy;
+    border-right: 1px solid $blue;
+    color: $white;
+    cursor: pointer;
+    display: inline-block;
+    font-weight: normal;
+    line-height: 1.5;
+    padding-right: 2.25rem;
+    width: 100%;
+  }
+
+  // Undo the Firefox inner focus ring
+  select:focus:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 $white;
+  }
+
+  select:active {
+    background-color: $navy;
+    color: $white;
+  }
+
+  // Hide the arrow in IE10 and up
+  select::-ms-expand {
+    display: none;
+  }
+
+  // Separator
+  &::before {
+    border-right: 1px solid $blue;
+    content: '';
+    height: -moz-calc(3rem - 2px);
+    height: -webkit-calc(3rem - 2px);
+    height: calc(3rem - 2px);
+    position: absolute;
+    right: 3rem;
+    top: 1px;
+    width: 0;
+  }
+
+  // Dropdown arrow
+  &::after {
+    border-bottom: .35rem solid transparent;
+    border-left: .35rem solid transparent;
+    border-right: .35rem solid transparent;
+    border-top: .35rem solid;
+    content: '';
+    display: inline-block;
+    height: 0;
+    margin-top: -.15rem;
+    pointer-events: none;
+    position: absolute;
+    right: 1.25rem;
+    top: 50%;
+    width: 0;
+  }
+}
+
+// Media query to target Firefox only
+@-moz-document url-prefix() {
+  // Firefox hack to hide the arrow
+  .select-alt select {
+    padding-right: 1rem;
+    text-indent: .01px;
+    text-overflow: '';
+  }
+
+  // <option> elements inherit styles from <select>, so reset them.
+  .select-alt option {
+    background-color: $white;
+  }
+}
+
+// IE9 hack to hide the arrow
+@media screen and (min-width:0\0) {
+  .select-alt select {
+    padding: .5rem 1.5rem .5rem 1rem;
+    z-index: 1;
+  }
+
+  .select-alt::after {
+    z-index: 5;
+  }
+
+  .select-alt::before {
+    background-color: $navy;
+    bottom: 0;
+    content: '';
+    display: block;
+    position: absolute;
+    right: 1rem;
+    top: 0;
+    width: 1.5rem;
+    z-index: 2;
+  }
+
+  .select-alt select:hover,
+  .select-alt select:focus,
+  .select-alt select:active {
+    background-color: $navy;
+    color: $white;
+  }
+}
+

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -2,20 +2,28 @@
 
 = render 'shared/progress_steps', active: 5
 h1.h3.my0 = t('idv.titles.session.finance')
-p.mt-tiny.mb0 = t('idv.messages.finance.intro')
+p.mt-tiny.mb0 = t('idv.messages.finance.intro_ccn')
 = simple_form_for(idv_finance_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
-  = f.error_notification
   = hidden_field_tag 'idv_finance_form[finance_type]', :ccn
-  - Idv::FinanceForm.ccn_inputs.each do |key, label, html_options|
-    = f.input key,
-              label: label,
-              required: false,
-              wrapper_html: { data: { type: key } },
-              input_html: html_options
+  .clearfix.mxn1
+    - Idv::FinanceForm.ccn_inputs.each do |key, label, html_options|
+      .px1
+        = f.label key, label: label, class: 'block bold'
+        p.mb1.italic = t('idv.messages.finance.hint')
+      .col.col-12.sm-col-8.px1
+        = f.input key,
+                  label: false,
+                  required: false,
+                  wrapper_html: { data: { type: key } },
+                  input_html: html_options
+    .col.col-12.sm-col-4.px1
+      = f.button :submit, t('forms.buttons.continue'), class: 'col-12 mb3'
 
-  p
-    = link_to t('idv.form.use_financial_account'), verify_finance_other_path
+- no_ccn_link = link_to t('idv.form.use_financial_account'), verify_finance_other_path
 
-  = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
-  .mt1 = link_to t('idv.messages.cancel_link'), verify_cancel_path
+.mb-tiny.bold = t('idv.messages.finance.no_ccn')
+p.mb3 = t('idv.messages.finance.no_ccn_info_html', link: no_ccn_link)
+
+.pt1.border-top
+  = link_to t('idv.messages.cancel_link'), verify_cancel_path

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -20,10 +20,11 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro_ccn')
     .col.col-12.sm-col-4.px1
       = f.button :submit, t('forms.buttons.continue'), class: 'col-12 mb3'
 
-- no_ccn_link = link_to t('idv.form.use_financial_account'), verify_finance_other_path
-
 .mb-tiny.bold = t('idv.messages.finance.no_ccn')
-p.mb3 = t('idv.messages.finance.no_ccn_info_html', link: no_ccn_link)
+p.mb3
+  = t('idv.messages.finance.no_ccn_info')
+  '
+  = link_to t('idv.form.use_financial_account'), verify_finance_other_path
 
 .pt1.border-top
   = link_to t('idv.messages.cancel_link'), verify_cancel_path

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -5,10 +5,11 @@ h1.h3.my0 = t('idv.titles.session.finance')
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
 = simple_form_for(idv_finance_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
-  = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
-    :first, :last,
-    { include_blank: t('idv.form.select_financial_account') },
-    class: 'col-12 mb2 js-finance-choice-select')
+  .select-alt.mb2
+    = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
+      :first, :last,
+      { include_blank: t('idv.form.select_financial_account') },
+      class: 'col-12 field js-finance-choice-select')
   .clearfix.mxn1
     .col.col-12.sm-col-8.px1
       = f.input :blank,
@@ -29,10 +30,11 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
                  disabled: true,
                  class: 'col-12 mb3 js-finance-submit'
 
-- no_account_link = link_to t('idv.form.use_ccn'), verify_finance_path
-
 .mb-tiny.bold = t('idv.messages.finance.no_account')
-p.mb3 = t('idv.messages.finance.no_account_info_html', link: no_account_link)
+p.mb3
+  = t('idv.messages.finance.no_account_info')
+  '
+  = link_to t('idv.form.use_ccn'), verify_finance_path
 
 .pt1.border-top
   = link_to t('idv.messages.cancel_link'), verify_cancel_path

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -2,33 +2,37 @@
 
 = render 'shared/progress_steps', active: 5
 h1.h3.my0 = t('idv.titles.session.finance')
-p.mt-tiny.mb0 = t('idv.messages.finance.intro')
+p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
 = simple_form_for(idv_finance_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
-  = f.error_notification
-  fieldset.mb3.border-none
-    legend.hide = t('idv.messages.finance.label')
-    = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
-      :first, :last,
-      { include_blank: t('idv.form.select_financial_account') },
-      class: 'js-finance-choice-select')
-  = f.input :blank,
-            label: t('idv.form.select_financial_account'),
-            disabled: true,
-            wrapper_html: { class: 'js-finance-wrapper', data: { type: :blank } }
-  - Idv::FinanceForm.finance_other_type_inputs.each do |key, label, html_options|
-    = f.input key,
-              label: label,
-              required: false,
-              wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
-              input_html: html_options
+  = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
+    :first, :last,
+    { include_blank: t('idv.form.select_financial_account') },
+    class: 'col-12 mb2 js-finance-choice-select')
+  .clearfix.mxn1
+    .col.col-12.sm-col-8.px1
+      = f.input :blank,
+                label: t('idv.form.select_financial_account'),
+                label_html: { class: 'hide' },
+                disabled: true,
+                wrapper_html: { class: 'js-finance-wrapper', data: { type: :blank } }
+      - Idv::FinanceForm.finance_other_type_inputs.each do |key, label, html_options|
+        = f.input key,
+                  label: label,
+                  label_html: { class: 'hide' },
+                  required: false,
+                  wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
+                  input_html: html_options
+    .col.col-12.sm-col-4.px1
+      = f.button :submit,
+                 t('forms.buttons.continue'),
+                 disabled: true,
+                 class: 'col-12 mb3 js-finance-submit'
 
-  p
-    = link_to t('idv.form.use_ccn'), verify_finance_path
+- no_account_link = link_to t('idv.form.use_ccn'), verify_finance_path
 
-  = f.button :submit,
-             t('forms.buttons.continue'),
-             disabled: true,
-             class: 'btn btn-primary btn-wide js-finance-submit'
+.mb-tiny.bold = t('idv.messages.finance.no_account')
+p.mb3 = t('idv.messages.finance.no_account_info_html', link: no_account_link)
 
-  .mt1 = link_to t('idv.messages.cancel_link'), verify_cancel_path
+.pt1.border-top
+  = link_to t('idv.messages.cancel_link'), verify_cancel_path

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -31,8 +31,8 @@ en:
       select_financial_account: Select a financial account…
       ssn_label_html: Social Security Number %{tooltip}
       state: State
-      use_ccn: Provide credit card number
-      use_financial_account: Provide financial account number
+      use_ccn: Provide credit card number >
+      use_financial_account: Enter one of these here >
       zipcode: ZIP Code
     index:
       cancel_link: No, I don’t have it
@@ -90,10 +90,19 @@ en:
         accurate. To learn more about the information we need from you and how it’s used
         to verify your identity, please see our troubleshooting page.
       finance:
-        label: Select which type of financial information you would like to provide.
-        intro: >
-          You are not sharing account balances or transaction details, and we
-          will never charge any fees.
+        hint: "You can use Mastercard, Visa, Diner's Club, or JCB."
+        intro_ccn: >
+          Help us verify your identity by providing the last 8 digits of one of your
+          credit cards.
+        intro_account: >
+          Help us verify your identity by providing an auto loan, mortgage, or home equity loan
+          number.
+        no_ccn: Don't have a credit card handy?
+        no_ccn_info_html: You can also veridy with an auto loan, mortgage, or home equity loan
+          number. %{link}
+        no_account: Want to use a credit card instead?
+        no_account_info_html: Help us verify your identity by providing the last 8 digits of your
+          credit card. %{link}
       hardfail: We can’t verify your identity right now.
       hardfail2: You can try again in %{hours} hours.
       hardfail3: >
@@ -141,6 +150,6 @@ en:
       review: Review and submit
       session:
         basic: First, tell us about yourself
-        finance: Next, we will check your personal information against financial records
+        finance: Provide a financial account number
         phone: What is your phone number?
         review: Review and submit

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -98,11 +98,11 @@ en:
           Help us verify your identity by providing an auto loan, mortgage, or home equity loan
           number.
         no_ccn: Don't have a credit card handy?
-        no_ccn_info_html: You can also veridy with an auto loan, mortgage, or home equity loan
-          number. %{link}
+        no_ccn_info: You can also verify with an auto loan, mortgage, or home equity loan
+          number.
         no_account: Want to use a credit card instead?
-        no_account_info_html: Help us verify your identity by providing the last 8 digits of your
-          credit card. %{link}
+        no_account_info: Help us verify your identity by providing the last 8 digits of your
+          credit card.
       hardfail: We can’t verify your identity right now.
       hardfail2: You can try again in %{hours} hours.
       hardfail3: >

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -71,8 +71,13 @@ es:
       dupe_ssn2_link: NOT TRANSLATED YET
       fail: NOT TRANSLATED YET
       finance:
-        label: NOT TRANSLATED YET
-        intro: NOT TRANSLATED YET
+        hint: NOT TRANSLATED YET
+        intro_ccn: NOT TRANSLATED YET
+        intro_account: NOT TRANSLATED YET
+        no_ccn: NOT TRANSLATED YET
+        no_ccn_info_html: NOT TRANSLATED YET
+        no_account: NOT TRANSLATED YET
+        no_account_info_html: NOT TRANSLATED YET
       hardfail: NOT TRANSLATED YET
       hardfail2: NOT TRANSLATED YET
       hardfail3: NOT TRANSLATED YET

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -75,9 +75,9 @@ es:
         intro_ccn: NOT TRANSLATED YET
         intro_account: NOT TRANSLATED YET
         no_ccn: NOT TRANSLATED YET
-        no_ccn_info_html: NOT TRANSLATED YET
+        no_ccn_info: NOT TRANSLATED YET
         no_account: NOT TRANSLATED YET
-        no_account_info_html: NOT TRANSLATED YET
+        no_account_info: NOT TRANSLATED YET
       hardfail: NOT TRANSLATED YET
       hardfail2: NOT TRANSLATED YET
       hardfail3: NOT TRANSLATED YET


### PR DESCRIPTION
**Why**: To match the latest visual design.  Refer to https://github.com/18F/identity-idp/pull/925 for the current state of the design.

**Credit card:**
![screen shot 2017-01-10 at 1 54 07 pm](https://cloud.githubusercontent.com/assets/1178494/21820766/0e5c66b2-d73f-11e6-824a-07d2c0be9788.png)

**Financial accounts:**
![screen shot 2017-01-10 at 2 09 23 pm](https://cloud.githubusercontent.com/assets/1178494/21820780/19c8ba14-d73f-11e6-8a5c-2942a46aa4bd.png)