### PR TITLE
Uses nonces in IE shims to satisfy the CSP

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,12 +25,12 @@ html lang="#{I18n.locale}"
     link rel='mask-icon' href='/safari-pinned-tab.svg' color='#e21c3d'
     meta name='theme-color' content='#ffffff'
 
-    <!--[if lt IE 10]>
+    <!--[if IE 9]>
       = stylesheet_link_tag 'ie9.css', media: 'all'
-    <!--[elseif lt IE 9]>
-      <script src='https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js'></script>
-      = stylesheet_link_tag 'ie8.css', media: 'all'
-      <script src='https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js'></script>
+    <![endif]-->
+
+    <!--[if lt IE 9]>
+      = render 'shared/ie_fallbacks'
     <![endif]-->
 
     - if Figaro.env.google_analytics_key.present?

--- a/app/views/shared/_ie_fallbacks.html.slim
+++ b/app/views/shared/_ie_fallbacks.html.slim
@@ -1,0 +1,5 @@
+- nonce = content_security_policy_script_nonce
+
+<script nonce="#{nonce}" src='https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js'></script>
+= stylesheet_link_tag 'ie8.css', media: 'all'
+<script nonce="#{nonce}" src='https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js'></script>


### PR DESCRIPTION
**Why**: To conform to our content security policy settings, and to
prevent ugly page errors and non functional js on > IE 9

**How**: Add `nonce` attribute, fix conditional IE comments. Breaks out
file because of line length lint errors + cleanliness