### PR TITLE
Show session cleared message via redirect+flash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,8 +18,7 @@ class ApplicationController < ActionController::Base
     now = Time.zone.now
     session[:session_expires_at] = now + Devise.timeout_in
     session[:pinged_at] ||= now
-
-    flash.now[:timeout] = t('notices.session_cleared') if request.query_parameters[:timeout]
+    redirect_on_timeout
   end
 
   def append_info_to_payload(payload)
@@ -44,6 +43,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def redirect_on_timeout
+    request_params = request.query_parameters
+    return unless request_params[:timeout]
+    flash[:timeout] = t('notices.session_cleared')
+    redirect_to url_for(request_params.except(:timeout))
+  end
 
   def decorated_user
     @_decorated_user ||= current_user.decorate

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -112,13 +112,12 @@ feature 'Sign in' do
     it 'refreshes the current page after session expires', js: true do
       allow(Devise).to receive(:timeout_in).and_return(1)
 
-      visit sign_up_email_path
+      visit sign_up_email_path(foo: 'bar')
       fill_in 'Email', with: 'test@example.com'
 
       expect(page).to have_content(t('notices.session_cleared'))
-
       expect(page).to have_field('Email', with: '')
-      expect(page).to have_current_path(sign_up_email_path(timeout: true))
+      expect(current_url).to match Regexp.escape(sign_up_email_path(foo: 'bar'))
     end
 
     it 'does not refresh the page after the session expires', js: true do


### PR DESCRIPTION
**Why**: Using flash.now + render means the timeout parameter
persists, making the message "sticky" on reload.