### PR TITLE
translate forms into spanish

### DIFF
--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -2,40 +2,46 @@
 es:
   forms:
     buttons:
-      back: NOT TRANSLATED YET
-      continue: NOT TRANSLATED YET
-      disable: NOT TRANSLATED YET
-      edit: NOT TRANSLATED YET
-      enable: NOT TRANSLATED YET
-      resend_confirmation: NOT TRANSLATED YET
-      search: NOT TRANSLATED YET
-      send: NOT TRANSLATED YET
-      send_passcode: NOT TRANSLATED YET
-      setup_totp: NOT TRANSLATED YET
+      back: Atrás
+      continue: Continuar
+      disable: Inhabilitar
+      edit: Editar
+      enable: Habilitar
+      resend_confirmation: Reenviar instrucciones de confirmación
+      search: Buscar
+      send: Enviar
+      send_passcode: Enviar contraseña
+      setup_totp: Configurar la aplicación de autenticación
       submit:
-        confirm_change: NOT TRANSLATED YET
-        default: NOT TRANSLATED YET
-        update: NOT TRANSLATED YET
+        confirm_change: Confirm change
+        default: Enviar
+        update: Actualización
     confirmation:
-      show_hdr: NOT TRANSLATED YET
+      show_hdr: Crear una contraseña segura
     passwords:
       edit:
         buttons:
-          submit: NOT TRANSLATED YET
+          submit: Cambia la contraseña
         labels:
-          password: NOT TRANSLATED YET
+          password: Nueva contraseña
     reactivate_profile:
-      instructions: NOT TRANSLATED YET
-      submit: NOT TRANSLATED YET
-      title: NOT TRANSLATED YET
+      instructions: Proveer la siguiente información para reactivar su cuenta.
+      submit: Reactivar perfil
+      title: Reactivar perfil
     registration:
       labels:
-        email: NOT TRANSLATED YET
+        email: Dirección de correo electrónico
     totp_setup:
-      code: NOT TRANSLATED YET
-      totp_info: NOT TRANSLATED YET
-      totp_intro: NOT TRANSLATED YET
+      code: Código de acceso único
+    totp_info:
+      Para habilitar la autenticación de dos factores, utilice el código QR para conectar
+      esta cuenta a su aplicación de autenticación.
+    totp_intro:
+      Para recibir una contraseña de un solo uso, puede elijir una aplicación de
+      autenticación de dos factores para iniciar sesión en su cuenta. Si es así, necesitará
+      conectar su cuenta de login.gov a la aplicación que elija. Cada vez que inicie sesión,
+      tendrá que abrir la aplicación y recuperar un código.
     two_factor:
-      code: NOT TRANSLATED YET
-      recovery_code: NOT TRANSLATED YET
-      try_again: NOT TRANSLATED YET
+      code: Código de acceso único
+      recovery_code: Código de recuperación
+      try_again: Inténtalo de nuevo

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -33,14 +33,14 @@ es:
         email: Dirección de correo electrónico
     totp_setup:
       code: Código de acceso único
-    totp_info:
-      Para habilitar la autenticación de dos factores, utilice el código QR para conectar
-      esta cuenta a su aplicación de autenticación.
-    totp_intro:
-      Para recibir una contraseña de un solo uso, puede elijir una aplicación de
-      autenticación de dos factores para iniciar sesión en su cuenta. Si es así, necesitará
-      conectar su cuenta de login.gov a la aplicación que elija. Cada vez que inicie sesión,
-      tendrá que abrir la aplicación y recuperar un código.
+      totp_info: >
+        Para habilitar la autenticación de dos factores, utilice el código QR para conectar
+        esta cuenta a su aplicación de autenticación.
+      totp_intro: >
+        Para recibir una contraseña de un solo uso, puede elijir una aplicación de
+        autenticación de dos factores para iniciar sesión en su cuenta. Si es así, necesitará
+        conectar su cuenta de login.gov a la aplicación que elija. Cada vez que inicie sesión,
+        tendrá que abrir la aplicación y recuperar un código.
     two_factor:
       code: Código de acceso único
       recovery_code: Código de recuperación


### PR DESCRIPTION
Why: Making app accessible to Spanish speaking folk.

Continue to translation work.