### PR TITLE
Outline OpenID Connect 1.0 discovery endpoint

### DIFF
--- a/app/controllers/openid_connect/configuration_controller.rb
+++ b/app/controllers/openid_connect/configuration_controller.rb
@@ -1,0 +1,34 @@
+module OpenidConnect
+  class ConfigurationController < ApplicationController
+    def index
+      render json: {
+        jwks_uri: '', # TODO
+        scopes_supported: '', # TODO
+        response_types_supported: %w(code),
+        grant_types_supported: %w(authorization_code),
+        acr_values_supported: Saml::Idp::Constants::VALID_AUTHN_CONTEXTS,
+        subject_types_supported: %w(pairwise),
+        service_documentation: '' # TODO
+      }.merge(url_configuration).merge(crypto_configuration)
+    end
+
+    private
+
+    def url_configuration
+      {
+        issuer: root_url,
+        authorization_endpoint: openid_connect_authorize_url,
+        token_endpoint: openid_connect_token_url,
+        userinfo_endpoint: openid_connect_userinfo_url
+      }
+    end
+
+    def crypto_configuration
+      {
+        id_token_signing_alg_values_supported: %w(RS256),
+        token_endpoint_auth_methods_supported: %w(private_key_jwt),
+        token_endpoint_auth_signing_alg_values_supported: %w(RS256)
+      }
+    end
+  end
+end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -2,11 +2,6 @@ class OpenidConnectAuthorizeForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
 
-  VALID_ACR_VALUES = [
-    Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-    Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
-  ].freeze
-
   attr_reader :acr_values,
               :client_id,
               :nonce,
@@ -70,7 +65,7 @@ class OpenidConnectAuthorizeForm
 
   def parse_acr_values(acr_values)
     return [] if acr_values.blank?
-    acr_values.split(' ').compact & VALID_ACR_VALUES
+    acr_values.split(' ').compact & Saml::Idp::Constants::VALID_AUTHN_CONTEXTS
   end
 
   def validate_acr_values

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   end
 
   # Non-devise-controller routes. Alphabetically sorted.
+  get '/.well-known/openid-configuration' => 'openid_connect/configuration#index'
   get '/api/health/workers' => 'health/workers#index'
   get '/api/saml/metadata' => 'saml_idp#metadata'
   match '/api/saml/logout' => 'saml_idp#logout',

--- a/spec/controllers/openid_connect/configuration_controller_spec.rb
+++ b/spec/controllers/openid_connect/configuration_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe OpenidConnect::ConfigurationController do
+  describe '#index' do
+    let(:json_response) { JSON.parse(response.body).with_indifferent_access }
+
+    it 'renders information about the OpenID Connect integration' do
+      get :index
+
+      aggregate_failures do
+        expect(json_response[:issuer]).to eq(root_url)
+        expect(json_response[:authorization_endpoint]).to eq(openid_connect_authorize_url)
+        expect(json_response[:token_endpoint]).to eq(openid_connect_token_url)
+        expect(json_response[:userinfo_endpoint]).to eq(openid_connect_userinfo_url)
+        expect(json_response[:response_types_supported]).to eq(%w(code))
+        expect(json_response[:grant_types_supported]).to eq(%w(authorization_code))
+        expected_loa = [
+          Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+        ]
+        expect(json_response[:acr_values_supported]).to match_array(expected_loa)
+        expect(json_response[:subject_types_supported]).to eq(%w(pairwise))
+        expect(json_response[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
+        expect(json_response[:token_endpoint_auth_methods_supported]).to eq(%w(private_key_jwt))
+        expect(json_response[:token_endpoint_auth_signing_alg_values_supported]).to eq(%w(RS256))
+      end
+    end
+
+    it 'renders all keys' do
+      get :index
+
+      pending 'additional details'
+
+      aggregate_failures do
+        expect(json_response[:jwks_uri]).to be_present
+        expect(json_response[:scopes_supported]).to be_present
+        expect(json_response[:service_documentation]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To support OpenID Connect 1.0

---

Very basic outline, <del>WIP while I implement this and check all the various fields</del>

See https://github.com/18F/identity-idp/pull/938 first, incremental diff: https://github.com/18F/identity-idp/compare/margolis-openid-userinfo...margolis-openid-connect-discovery