### PR TITLE
Make dev port more easily configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # bin/ directory.
 
 CONFIG = config/application.yml
+PORT ?= 3000
 
 all: check
 
@@ -31,6 +32,6 @@ fast_test: $(CONFIG)
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 
 run: $(CONFIG)
-	foreman start
+	foreman start -p $(PORT)
 
 .PHONY: setup all lint run test check brakeman

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec rails server
+web: bundle exec rails server -p ${PORT:-3000}
 worker: bundle exec sidekiq --config config/sidekiq.yml
 mail: bundle exec mailcatcher -f

--- a/README.md
+++ b/README.md
@@ -129,9 +129,7 @@ Email messages will be visible in MailCatcher at `http://localhost:1080/`.
 
 If you would like to run the application on a different port:
 
-* Add a `.env` file locally
-* Set the `PORT` key to your desired port value in `.env`
-* Change the numbers for `mailer_domain_name` and `domain_name` in `config/application.yml`
+* Change the port number for `mailer_domain_name` and `domain_name` in `config/application.yml`
 * Run the app on your desired port like `make run PORT=1234`
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ more information.
 
 ### Viewing the app locally
 
-Once it is up and running, the app will be accessible
-at `http://localhost:3000/`. Email messages will be visible in MailCatcher
-at `http://localhost:1080/`.
+Once it is up and running, the app will be accessible at
+`http://localhost:3000/` by default.
+
+Email messages will be visible in MailCatcher at `http://localhost:1080/`.
+
+If you would like to run the application on a different port:
+
+* Add a `.env` file locally
+* Set the `PORT` key to your desired port value in `.env`
+* Change the numbers for `mailer_domain_name` and `domain_name` in `config/application.yml`
+* Run the app on your desired port like `make run PORT=1234`
 
 ### Running Tests
 


### PR DESCRIPTION
**Why**: Sometimes we will want to test the idp app locally against
another app that must be run on port 3000, so good to have it easily
configurable.