### PR TITLE
Refactor code related to FinanceController#create

### DIFF
--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -9,7 +9,10 @@ module Verify
     end
 
     def create
-      if step.complete
+      result = step.submit
+      analytics.track_event(Analytics::IDV_FINANCE_CONFIRMATION, result)
+
+      if result[:success]
         redirect_to verify_phone_url
       else
         render_form
@@ -22,7 +25,6 @@ module Verify
       @_step ||= Idv::FinancialsStep.new(
         idv_form: idv_finance_form,
         idv_session: idv_session,
-        analytics: analytics,
         params: step_params
       )
     end
@@ -32,7 +34,7 @@ module Verify
     end
 
     def confirm_step_needed
-      redirect_to verify_phone_path if idv_session.financials_confirmation.try(:success?)
+      redirect_to verify_phone_path if idv_session.financials_confirmation == true
     end
 
     def render_form

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -38,7 +38,7 @@ module Verify
     end
 
     def idv_finance_complete?
-      idv_session.financials_confirmation.try(:success?)
+      idv_session.financials_confirmation == true
     end
 
     def idv_phone_complete?

--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -1,9 +1,15 @@
 module Idv
   class FinancialsValidator < VendorValidator
-    def validate
-      session_id = idv_session.resolution.session_id
-      idv_session.financials_confirmation = idv_agent.submit_financials(vendor_params, session_id)
-      idv_session.financials_confirmation.success?
+    delegate :success?, :errors, to: :result
+
+    private
+
+    def result
+      @_result ||= idv_agent.submit_financials(vendor_params, session_id)
+    end
+
+    def session_id
+      idv_session.resolution.session_id
     end
   end
 end

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -3,7 +3,7 @@ module Idv
   class Step
     include VendorValidated
 
-    def initialize(analytics:, idv_form:, idv_session:, params:)
+    def initialize(analytics: nil, idv_form:, idv_session:, params:)
       @idv_form = idv_form
       @idv_session = idv_session
       @analytics = analytics
@@ -33,7 +33,7 @@ module Idv
     attr_accessor :analytics, :idv_form, :idv_session, :params, :form_result
 
     def form_validate(params)
-      self.form_result = idv_form.submit(params)
+      @form_result ||= idv_form.submit(params)
     end
 
     def errors

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -15,7 +15,7 @@ describe Verify::FinanceController do
   describe '#new' do
     it 'redirects to review when step is complete' do
       stub_subject
-      subject.idv_session.financials_confirmation = Proofer::Confirmation.new success: true
+      subject.idv_session.financials_confirmation = true
 
       get :new
 
@@ -141,6 +141,8 @@ describe Verify::FinanceController do
 
     context 'when the form is invalid' do
       it 'tracks the form errors and does not make a vendor API call' do
+        expect(Idv::FinancialsValidator).to_not receive(:new)
+
         put :create, idv_finance_form: { finance_type: :ccn, ccn: '123' }
 
         result = {
@@ -151,7 +153,7 @@ describe Verify::FinanceController do
         expect(@analytics).to have_received(:track_event).
           with(Analytics::IDV_FINANCE_CONFIRMATION, result)
 
-        expect(subject.idv_session.financials_confirmation).to be_nil
+        expect(subject.idv_session.financials_confirmation).to eq false
       end
     end
   end

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -141,7 +141,7 @@ describe Verify::FinanceController do
 
     context 'when the form is invalid' do
       it 'tracks the form errors and does not make a vendor API call' do
-        expect(Idv::FinancialsValidator).to_not receive(:new)
+        allow(Idv::FinancialsValidator).to receive(:new)
 
         put :create, idv_finance_form: { finance_type: :ccn, ccn: '123' }
 
@@ -152,8 +152,8 @@ describe Verify::FinanceController do
 
         expect(@analytics).to have_received(:track_event).
           with(Analytics::IDV_FINANCE_CONFIRMATION, result)
-
         expect(subject.idv_session.financials_confirmation).to eq false
+        expect(Idv::FinancialsValidator).to_not have_received(:new)
       end
     end
   end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -29,7 +29,7 @@ describe Verify::ReviewController do
     happy_args = { success: true, session_id: 'some-id' }
     idv_session.resolution = Proofer::Resolution.new happy_args
     idv_session.phone_confirmation = Proofer::Confirmation.new happy_args
-    idv_session.financials_confirmation = Proofer::Confirmation.new happy_args
+    idv_session.financials_confirmation = true
     idv_session
   end
 
@@ -78,7 +78,7 @@ describe Verify::ReviewController do
 
     context 'user has missed finance step' do
       before do
-        idv_session.financials_confirmation.success = false
+        idv_session.financials_confirmation = false
       end
 
       it 'redirects to finance step' do

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -11,76 +11,49 @@ describe Idv::FinancialsStep do
   let(:idv_finance_form) { Idv::FinanceForm.new(idv_session.params) }
 
   def build_step(params)
-    @analytics = FakeAnalytics.new
-    allow(@analytics).to receive(:track_event)
-
     described_class.new(
       idv_form: idv_finance_form,
       idv_session: idv_session,
-      analytics: @analytics,
       params: params
     )
   end
 
-  def expect_analytics_result(result)
-    expect(@analytics).to have_received(:track_event).
-      with(Analytics::IDV_FINANCE_CONFIRMATION, result)
-  end
-
-  describe '#complete' do
+  describe '#submit' do
     it 'returns false for invalid params' do
       step = build_step(finance_type: :ccn, ccn: '1234')
-
-      expect(step.complete).to eq false
 
       result = {
         success: false,
         errors: { ccn: [t('idv.errors.invalid_ccn')] }
       }
 
-      expect_analytics_result(result)
+      expect(step.submit).to eq result
+      expect(idv_session.financials_confirmation).to eq false
     end
 
     it 'returns true for mock-happy CCN' do
       step = build_step(finance_type: :ccn, ccn: '12345678')
-
-      expect(step.complete).to eq true
 
       result = {
         success: true,
         errors: {}
       }
 
-      expect_analytics_result(result)
+      expect(step.submit).to eq result
+      expect(idv_session.financials_confirmation).to eq true
+      expect(idv_session.params).to eq idv_finance_form.idv_params
     end
 
     it 'returns false for mock-sad CCN' do
       step = build_step(finance_type: :ccn, ccn: '00000000')
-
-      expect(step.complete).to eq false
 
       result = {
         success: false,
         errors: { ccn: ['The ccn could not be verified.'] }
       }
 
-      expect_analytics_result(result)
-    end
-  end
-
-  describe '#complete?' do
-    it 'returns true for mock-happy CCN' do
-      step = build_step(finance_type: :ccn, ccn: '12345678')
-      step.complete
-
-      expect(step.complete?).to eq true
-    end
-
-    it 'returns false for mock-sad CCN' do
-      step = build_step(finance_type: :ccn, ccn: '00000000')
-      step.complete
-
-      expect(step.complete?).to eq false
+      expect(step.submit).to eq result
+      expect(idv_session.financials_confirmation).to eq false
     end
   end
 end

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe Idv::FinancialsValidator do
+  let(:user) { build(:user) }
+
+  let(:idv_session) do
+    idvs = Idv::Session.new({}, user)
+    idvs.vendor = :mock
+    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
+    idvs
+  end
+
+  let(:session_id) { idv_session.resolution.session_id }
+
+  let(:params) do
+    { ccn: '123-45-6789' }
+  end
+
+  let(:confirmation) { instance_double(Proofer::Confirmation) }
+
+  subject { Idv::FinancialsValidator.new(idv_session: idv_session, vendor_params: params) }
+
+  def stub_agent_calls
+    agent = instance_double(Idv::Agent)
+    allow(Idv::Agent).to receive(:new).
+      with(applicant: idv_session.applicant, vendor: :mock).
+      and_return(agent)
+    expect(agent).to receive(:submit_financials).
+      with(params, idv_session.resolution.session_id).and_return(confirmation)
+  end
+
+  describe '#success?' do
+    it 'returns Proofer::Confirmation#success?' do
+      stub_agent_calls
+
+      expect(confirmation).to receive(:success?).and_return('yay!')
+
+      expect(subject.success?).to eq 'yay!'
+    end
+  end
+
+  describe '#error' do
+    it 'returns Proofer::Confirmation#errors' do
+      stub_agent_calls
+
+      expect(confirmation).to receive(:errors).and_return('foobar')
+
+      expect(subject.errors).to eq 'foobar'
+    end
+  end
+end

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -33,9 +33,11 @@ describe Idv::FinancialsValidator do
     it 'returns Proofer::Confirmation#success?' do
       stub_agent_calls
 
-      expect(confirmation).to receive(:success?).and_return('yay!')
+      success_string = 'true'
 
-      expect(subject.success?).to eq 'yay!'
+      expect(confirmation).to receive(:success?).and_return(success_string)
+
+      expect(subject.success?).to eq success_string
     end
   end
 
@@ -43,9 +45,11 @@ describe Idv::FinancialsValidator do
     it 'returns Proofer::Confirmation#errors' do
       stub_agent_calls
 
-      expect(confirmation).to receive(:errors).and_return('foobar')
+      error_string = 'mucho errors'
 
-      expect(subject.errors).to eq 'foobar'
+      expect(confirmation).to receive(:errors).and_return(error_string)
+
+      expect(subject.errors).to eq error_string
     end
   end
 end


### PR DESCRIPTION
**Why**:
- Make it more readable and easier to understand
- Adhere to our controller design principles
- Adhere to Single Responsibility Principle
- Make it easier to test

**How**:
- Refactor `FinancialsStep` class such that the only public method
called is `#submit`, and have it return a hash that the controller
can use to determine how to proceed, and to capture analytics for
this event.
- Remove the idv_session manipulation from the vendor validation class
and from the private methods of the `FinancialsStep` class, and
into the `submit` method.
- Write the `submit` method in an easy-to-follow narrative that shows
the sequence of events, and consequences of the result of the operation
all in the same place. In this case, the operation is the form
submission, and we must ask whether or not the submission was
successful. We determine if the submission was successful by asking if
both the form validations and the vendor validations passed. If it was
successful, then we update the idv_session and set the
financials_confirmation to `true`, otherwise, we set the confirmation
to false, then we return the result in the form of a hash with
`success` and `errors` keys, where the errors are the combined errors
from the form and vendor validations. All we need to know about this
operation and its side effects are in this one method. We don't need
to look elsewhere to understand the flow of events. If we want to dig
deeper, then we can look into the classes that handle the form or vendor
validations, and see how they operate, but it's not necessary to
understand what is happening. We trust that they are doing the right
thing when we ask them if they are valid or not.
- Add an `#errors` method to the vendor validator and update
`FinancialsStep#vendor_errors` to return those errors as opposed to
fetching them from the idv_session, where they may or may not exist.
- Update the way a controller can determine if the Financials step was
completed by setting `idv_session.financials_confirmation` explicity to
`true` or `false` to adhere to the "Tell, Don't Ask" principle.