### PR TITLE
translate valid email into spanish

### DIFF
--- a/config/locales/valid_email/es.yml
+++ b/config/locales/valid_email/es.yml
@@ -2,4 +2,4 @@ es:
   valid_email:
     validations:
       email:
-        invalid: NOT TRANSLATED YET
+        invalid: El formato de dirección de correo electrónico o el dominio ingresado no es válido. Corrija la dirección y vuelva a ingresarla.


### PR DESCRIPTION
Why: Making app accessible to Spanish speaking folk.

Continued Spanish translation work.