### PR TITLE
translate voice into spanish

### DIFF
--- a/config/locales/voice/es.yml
+++ b/config/locales/voice/es.yml
@@ -1,5 +1,7 @@
 es:
   voice:
     otp:
-      message: NOT TRANSLATED YET
-      repeat_instructions: NOT TRANSLATED YET
+      message: >
+        ¡Hola! Su código de acceso de login.gov es, %{code},
+        nuevamente, su código de acceso es %{code}.
+      repeat_instructions: Presione 1 para repetir este mensaje.


### PR DESCRIPTION
Why: Making app accessible to Spanish speaking folk.

Continued Spanish translation work.