### PR TITLE
Update `service_providers.yml` for micro-purchase

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -174,7 +174,19 @@ production:
       - email
 
 # Micro-purchase
-  'urn:gov:gsa:saml:2.0.profiles:sp:sso:micropurchase-staging':
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
+    acs_url: 'http://localhost:3000/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'http://localhost:3000/auth/saml/logout'
+    sp_initiated_login_url: 'http://localhost:3000/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_micropurchase'
+    agency: 'TTS Acquisition'
+    friendly_name: 'Micro-purchase Dev'
+    return_to_sp_url: 'http://localhost:3000'
+    attribute_bundle:
+      - email
+
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:micropurchase-staging':
     acs_url: 'https://micropurchase-staging.18f.gov/auth/saml/callback'
     assertion_consumer_logout_service_url: 'https://micropurchase-staging.gov/auth/saml/logout'
     sp_initiated_login_url: 'https://micropurchase-staging.18f.gov/login'


### PR DESCRIPTION
**Why**:
* Need `localhost-micropurchase` in prod block to test against prod
* Need consistent capitalization of SAML for staging to work
* Compare with https://github.com/18F/micropurchase/blob/1836b349918b73f6de7461fe86df21cd0db9d771/config/secrets.yml#L19