### PR TITLE
Add verified_at to asserted SAML attributes

### DIFF
--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -48,10 +48,15 @@ class AttributeAsserter
       next unless VALID_ATTRIBUTES.include? attr
       attrs[attr] = { getter: attribute_getter_function(attr) }
     end
+    attrs[:verified_at] = { getter: verified_at_getter_function }
   end
 
   def uuid_getter_function
     ->(principal) { principal.decorate.active_identity_for(service_provider).uuid }
+  end
+
+  def verified_at_getter_function
+    ->(principal) { principal.active_profile.verified_at.iso8601 }
   end
 
   def attribute_getter_function(attr)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -162,6 +162,10 @@ describe SamlIdpController do
           node_value = xmldoc.attribute_value_for(attr)
           expect(node_value).to eq(pii[attr])
         end
+
+        expect(xmldoc.attribute_value_for('verified_at')).to eq(
+          user.active_profile.verified_at.iso8601
+        )
       end
     end
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -50,7 +50,7 @@ describe AttributeAsserter do
 
         it 'includes all requested attributes + uuid' do
           expect(user.asserted_attributes.keys).
-            to eq([:uuid, :email, :phone, :first_name])
+            to eq([:uuid, :email, :phone, :first_name, :verified_at])
         end
 
         it 'creates getter function' do
@@ -71,8 +71,8 @@ describe AttributeAsserter do
         end
 
         context 'authn request does not specify bundle' do
-          it 'only returns uuid' do
-            expect(user.asserted_attributes.keys).to eq [:uuid]
+          it 'only returns uuid and verified_at' do
+            expect(user.asserted_attributes.keys).to eq [:uuid, :verified_at]
           end
         end
 
@@ -83,7 +83,7 @@ describe AttributeAsserter do
 
           it 'uses authn request bundle' do
             expect(user.asserted_attributes.keys).
-              to eq([:uuid, :email, :first_name, :last_name, :ssn, :phone])
+              to eq([:uuid, :email, :first_name, :last_name, :ssn, :phone, :verified_at])
           end
         end
       end
@@ -95,8 +95,8 @@ describe AttributeAsserter do
           subject.build
         end
 
-        it 'contains UUID only' do
-          expect(user.asserted_attributes.keys).to eq([:uuid])
+        it 'contains uuid and verified_at only' do
+          expect(user.asserted_attributes.keys).to eq([:uuid, :verified_at])
         end
       end
 
@@ -109,7 +109,7 @@ describe AttributeAsserter do
         end
 
         it 'silently skips invalid attribute name' do
-          expect(user.asserted_attributes.keys).to eq([:uuid, :email])
+          expect(user.asserted_attributes.keys).to eq([:uuid, :email, :verified_at])
         end
       end
     end
@@ -132,7 +132,7 @@ describe AttributeAsserter do
           subject.build
         end
 
-        it 'only includes uuid + email' do
+        it 'only includes uuid + email (no verified_at)' do
           expect(user.asserted_attributes.keys).to eq [:uuid, :email]
         end
 


### PR DESCRIPTION
**Why**: SPs may benefit from knowing the timestamp of when
asserted attributes were last verified.

Addresses https://github.com/18F/identity-idp/issues/905#issuecomment-273247275