### PR TITLE
Update `sp_initiated_login_url` for micro-purchase

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -66,7 +66,7 @@ development:
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
     acs_url: 'http://localhost:3000/auth/saml/callback'
     assertion_consumer_logout_service_url: 'http://localhost:3000/auth/saml/logout'
-    sp_initiated_login_url: 'http://localhost:3000/login'
+    sp_initiated_login_url: 'http://localhost:3000/admin/sign_in'
     block_encryption: 'aes256-cbc'
     cert: 'sp_micropurchase'
     agency: 'TTS Acquisition'
@@ -184,7 +184,7 @@ production:
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
     acs_url: 'http://localhost:3000/auth/saml/callback'
     assertion_consumer_logout_service_url: 'http://localhost:3000/auth/saml/logout'
-    sp_initiated_login_url: 'http://localhost:3000/login'
+    sp_initiated_login_url: 'http://localhost:3000/admin/sign_in'
     block_encryption: 'aes256-cbc'
     cert: 'sp_micropurchase'
     agency: 'TTS Acquisition'
@@ -196,7 +196,7 @@ production:
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:micropurchase-staging':
     acs_url: 'https://micropurchase-staging.18f.gov/auth/saml/callback'
     assertion_consumer_logout_service_url: 'https://micropurchase-staging.gov/auth/saml/logout'
-    sp_initiated_login_url: 'https://micropurchase-staging.18f.gov/login'
+    sp_initiated_login_url: 'https://micropurchase-staging.18f.gov/admin/sign_in'
     block_encryption: 'aes256-cbc'
     cert: 'sp_micropurchase'
     logo: '18f.svg'
@@ -209,7 +209,7 @@ production:
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:micropurchase-production':
     acs_url: 'https://micropurchase.18f.gov/auth/saml/callback'
     assertion_consumer_logout_service_url: 'https://micropurchase.gov/auth/saml/logout'
-    sp_initiated_login_url: 'https://micropurchase.18f.gov/login'
+    sp_initiated_login_url: 'https://micropurchase.18f.gov/admin/sign_in'
     block_encryption: 'aes256-cbc'
     cert: 'sp_micropurchase'
     agency: 'TTS Acquisition'

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -187,6 +187,7 @@ production:
     sp_initiated_login_url: 'http://localhost:3000/admin/sign_in'
     block_encryption: 'aes256-cbc'
     cert: 'sp_micropurchase'
+    logo: '18f.svg'
     agency: 'TTS Acquisition'
     friendly_name: 'Micro-purchase Dev'
     return_to_sp_url: 'http://localhost:3000'


### PR DESCRIPTION
**Why**: This path was copied from the rails demo service provider but
is not a path that exists in the micro-purchase app.