### PR TITLE
Show focus rect on "Show password" checkbox

### DIFF
--- a/app/assets/javascripts/app/pw-toggle.js
+++ b/app/assets/javascripts/app/pw-toggle.js
@@ -11,15 +11,25 @@ function togglePw() {
         <div class="top-0 right-0 absolute">
           <label class="checkbox" for="pw-toggle-${i}">
             <input id="pw-toggle-${i}" type="checkbox">
-            <span class="indicator"></span>
+            <span class="indicator" id="pw-indicator-${i}"></span>
             Show password
           </label>
         </div>`;
       input.insertAdjacentHTML('afterend', el);
 
       const toggle = document.getElementById(`pw-toggle-${i}`);
+      const indicator = document.getElementById(`pw-indicator-${i}`);
+
       toggle.addEventListener('change', function() {
         input.type = toggle.checked ? 'text' : 'password';
+      });
+
+      toggle.addEventListener('focusin', function() {
+        indicator.className = 'indicator indicator-focused';
+      });
+
+      toggle.addEventListener('focusout', function() {
+        indicator.className = 'indicator';
       });
     }
   }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -104,6 +104,10 @@ input::-webkit-inner-spin-button {
   width: 1rem;
 }
 
+.indicator-focused {
+  outline: -webkit-focus-ring-color auto 5px;
+}
+
 .checkbox input:checked ~ .indicator,
 .radio input:checked ~ .indicator, {
   background-color: $blue;

--- a/spec/features/accessibility/form_controls_spec.rb
+++ b/spec/features/accessibility/form_controls_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'form controls are accessible', :js do
+  it 'highlights show password when focused' do
+    visit root_path
+    checkbox = find('label.checkbox')
+
+    # Indicator should not be highlighted on page load
+    expect(checkbox).to_not have_css('span.indicator-focused')
+
+    # Checkbox is focused, indicator should be focused
+    page.evaluate_script('document.getElementById("pw-toggle-0").focus()')
+    expect(checkbox).to have_css('span.indicator-focused')
+    
+    # Focus is moved off checkbox, indicator shouldn't have focus
+    page.evaluate_script('document.getElementById("pw-toggle-0").blur()')
+    expect(checkbox).to_not have_css('span.indicator-focused')
+  end
+end


### PR DESCRIPTION
**Why**:
- Required by 508 standards to not lose focus on a page
- Focus is lost when using the site with a keyboard,
 on the "Show password" checkbox

**How**:
- Use javascript to add additional class to indicator
 span being used as checkbox on focus in.
 Class is removed on focus out

<img width="556" alt="login_gov_-_welcome" src="https://cloud.githubusercontent.com/assets/5296248/22084559/97b6f44e-dd9e-11e6-9b19-c1e7de76ffb4.png">
