### PR TITLE
Read Service Provider config from dashboard

### DIFF
--- a/app/services/secure_headers_whitelister.rb
+++ b/app/services/secure_headers_whitelister.rb
@@ -1,0 +1,18 @@
+class SecureHeadersWhitelister
+  def run
+    whitelisted_domains = domains(acs_urls(SERVICE_PROVIDERS.values))
+    SecureHeaders::Configuration.override(:saml) do |config|
+      config.csp[:form_action] += whitelisted_domains
+    end
+  end
+
+  private
+
+  def acs_urls(provider_attributes)
+    provider_attributes.map { |hash| hash['acs_url'] }.compact
+  end
+
+  def domains(acs_urls)
+    acs_urls.map { |url| url.split('//')[1].split('/')[0] }.uniq
+  end
+end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,0 +1,40 @@
+class ServiceProviderUpdater
+  def run
+    dashboard_service_providers.each do |service_provider|
+      service_provider = HashWithIndifferentAccess.new(service_provider)
+      issuer = service_provider['issuer']
+      SERVICE_PROVIDERS[issuer] = service_provider
+
+      VALID_SERVICE_PROVIDERS << issuer
+    end
+    SecureHeadersWhitelister.new.run
+  end
+
+  private
+
+  def url
+    Figaro.env.dashboard_url
+  end
+
+  def dashboard_service_providers
+    body = dashboard_response.body
+    return parse_service_providers(body) if dashboard_response.code == 200
+    log_error "Failed to parse response from #{url}: #{body}"
+    []
+  rescue
+    log_error "Failed to contact #{url}"
+    []
+  end
+
+  def parse_service_providers(body)
+    JSON.parse(body)
+  end
+
+  def dashboard_response
+    @_dashboard_response ||= HTTParty.get(url)
+  end
+
+  def log_error(msg)
+    Rails.logger.error msg
+  end
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -44,7 +44,8 @@ session_check_frequency: '30'
 stale_session_window: '180'
 
 support_email: 'hello@login.gov'
-
+use_dashboard_service_providers: 'false'
+dashboard_url: 'https://dashboard.demo.login.gov'
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
 
 development:
@@ -54,6 +55,7 @@ development:
   attribute_encryption_key_queue: '["old-key-one", "old-key-two"]'
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
+  dashboard_url: 'http://localhost:3001/api/service_providers'
   domain_name: 'localhost:3000'
   enable_test_routes: 'true'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
@@ -84,6 +86,7 @@ development:
   telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   twilio_record_voice: 'true'
+  use_dashboard_service_providers: 'true'
   use_kms: 'false'
   valid_service_providers: '["https://rp1.serviceprovider.com/auth/saml/metadata", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails", "https://dashboard.login.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase", "urn:gov:gsa:openidconnect:development"]'
   enable_i18n_mode: 'false'

--- a/config/initializers/_service_providers.rb
+++ b/config/initializers/_service_providers.rb
@@ -1,4 +1,10 @@
 SERVICE_PROVIDERS = YAML.load_file("#{Rails.root}/config/service_providers.yml").
                     fetch(Rails.env, {})
 
-VALID_SERVICE_PROVIDERS = JSON.parse(Figaro.env.valid_service_providers)
+VALID_SERVICE_PROVIDERS = JSON.parse(Figaro.env.valid_service_providers).to_set
+
+# merge from dashboard
+require 'feature_management'
+if FeatureManagement.use_dashboard_service_providers?
+  Thread.new { ServiceProviderUpdater.new.run }
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -59,12 +59,4 @@ SecureHeaders::Configuration.default do |config|
   # }
 end
 
-SecureHeaders::Configuration.override(:saml) do |config|
-  provider_attributes = SERVICE_PROVIDERS.values
-
-  acs_urls = provider_attributes.map { |hash| hash['acs_url'] }.compact
-
-  whitelisted_domains = acs_urls.map { |url| url.split('//')[1].split('/')[0] }
-
-  whitelisted_domains.each { |domain| config.csp[:form_action] << domain }
-end
+SecureHeadersWhitelister.new.run

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -24,4 +24,8 @@ class FeatureManagement
   def self.use_kms?
     Figaro.env.use_kms == 'true'
   end
+
+  def self.use_dashboard_service_providers?
+    Figaro.env.use_dashboard_service_providers == 'true'
+  end
 end

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -29,8 +29,11 @@ class ServiceProvider
       sp_cert = sp_attributes[:cert]
       return if sp_cert.blank?
 
-      cert_file = File.read(Rails.root.join("certs/sp/#{sp_cert}.crt"))
-      OpenSSL::X509::Certificate.new(cert_file)
+      cert_file = Rails.root.join("certs/sp/#{sp_cert}.crt")
+
+      return OpenSSL::X509::Certificate.new(sp_cert) unless File.exist?(cert_file)
+
+      OpenSSL::X509::Certificate.new(File.read(cert_file))
     end
   end
 

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -68,4 +68,26 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#use_dashboard_service_providers?' do
+    context 'when enabled' do
+      before do
+        allow(Figaro.env).to receive(:use_dashboard_service_providers).and_return('true')
+      end
+
+      it 'enables the feature' do
+        expect(FeatureManagement.use_dashboard_service_providers?).to eq(true)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Figaro.env).to receive(:use_dashboard_service_providers).and_return('false')
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.use_dashboard_service_providers?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe ServiceProviderUpdater do
+  include SamlAuthHelper
+
+  let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }
+  let(:array_of_sps) do
+    [
+      {
+        issuer: dashboard_sp_issuer,
+        agency: 'a service provider',
+        friendly_name: 'a friendly service provider',
+        description: 'user friendly login.gov dashboard',
+        acs_url: 'http://sp.example.org/saml/login',
+        assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
+        block_encryption: 'aes256-cbc',
+        cert: saml_test_sp_cert
+      }
+    ]
+  end
+
+  before do
+    allow(subject).to receive(:dashboard_service_providers).and_return(array_of_sps)
+  end
+
+  describe '#run' do
+    it 'updates global var registry of Service Providers' do
+      expect(SERVICE_PROVIDERS[dashboard_sp_issuer]).to eq nil
+      expect(VALID_SERVICE_PROVIDERS).to_not include dashboard_sp_issuer
+
+      subject.run
+
+      sp = ServiceProvider.new(dashboard_sp_issuer)
+
+      expect(sp.metadata[:agency]).to eq array_of_sps.first[:agency]
+      expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
+      expect(sp.valid?).to eq true
+      expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Allow self-service Service Provider definitions
via the identity-dashboard.

**How**: Reads definitions at app start up from a configured URL.

NOTE a future PR will create a secure endpoint to trigger this read during runtime.