### PR TITLE
translate mailer into spanish

### DIFF
--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -15,8 +15,8 @@ es:
           correo electrónico dentro de %{confirmation_period} de recibir este mensaje.
       footer: Tome en cuenta que este enlace expira en %{período de confirmación}.
       header: >
-          %{intro} Para confirmar su dirección de correo electrónico, haga clic en el enlace abajo
-          o puede copiar y pegar el enlace completo en su navegador.
+        %{intro} Para confirmar su dirección de correo electrónico, haga clic en el enlace abajo
+        o puede copiar y pegar el enlace completo en su navegador.
       link_text: Confirmar esta dirección de correo electrónico
     contact_request:
       subject: Solicitud de contacto
@@ -36,4 +36,4 @@ es:
         Ha solicitado que restablezca la contraseña de su cuenta. Para confirmar
         su solicitud, haga clic en el enlace abajo o puede copiar y pegar el enlace completo en su navegador.
       link_text: Restablecer su contraseña
-  sent_from: Enviado desde %{app}
+    sent_from: Enviado desde %{app}

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -1,26 +1,39 @@
 ---
 es:
   mailer:
-    about: NOT TRANSLATED YET
+    about: Sobre %{app}
     confirmation_instructions:
       first_sentence:
-        confirmed: NOT TRANSLATED YET
-        reset_requested: NOT TRANSLATED YET
-        unconfirmed: NOT TRANSLATED YET
-      footer: NOT TRANSLATED YET
-      header: NOT TRANSLATED YET
-      link_text: NOT TRANSLATED YET
+        confirmed: >
+          Para finalizar la actualización de tu cuenta de %{app}, debe confirmar dirección de
+          correo electrónico dentro de %{confirmation_period} de recibir este mensaje.
+        reset_requested: >
+          Su cuenta de %{app} ha sido restablecida por un representante de soporte técnico.
+          Para continuar, debe confirmar su dirección de correo electrónico.
+        unconfirmed: >
+          Para continuar creando su cuenta de %{app}, debe confirmar su dirección de
+          correo electrónico dentro de %{confirmation_period} de recibir este mensaje.
+      footer: Tome en cuenta que este enlace expira en %{período de confirmación}.
+      header: >
+          %{intro} Para confirmar su dirección de correo electrónico, haga clic en el enlace abajo
+          o puede copiar y pegar el enlace completo en su navegador.
+      link_text: Confirmar esta dirección de correo electrónico
     contact_request:
-      subject: NOT TRANSLATED YET
+      subject: Solicitud de contacto
     email_change_notice:
-      subject: NOT TRANSLATED YET
+      subject: Cambiar su direccion de correo electronico
     email_reuse_notice:
-      subject: NOT TRANSLATED YET
-    help: NOT TRANSLATED YET
-    no_reply: NOT TRANSLATED YET
-    privacy_policy: NOT TRANSLATED YET
+      subject: Confirmar su dirección de correo electrónico
+    help: >
+      Para obtener más ayuda, póngase en contacto con el centro de contacto de clientes de %{app} a través
+      del formulario web en %{link}.
+    no_reply: Por favor, no responda a este mensaje.
+    privacy_policy: Política de privacidad
     reset_password:
-      footer: NOT TRANSLATED YET
-      header: NOT TRANSLATED YET
-      link_text: NOT TRANSLATED YET
-    sent_from: NOT TRANSLATED YET
+      footer: >
+        Tome en cuenta que este enlace caduca en %{expires} horas.
+      header: >
+        Ha solicitado que restablezca la contraseña de su cuenta. Para confirmar
+        su solicitud, haga clic en el enlace abajo o puede copiar y pegar el enlace completo en su navegador.
+      link_text: Restablecer su contraseña
+  sent_from: Enviado desde %{app}


### PR DESCRIPTION
Why: Making app accessible to Spanish speaking folk.

Continued Spanish translation work.