### PR TITLE
Refactor code related to PhoneController#create

### DIFF
--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -9,7 +9,10 @@ module Verify
     end
 
     def create
-      if step.complete
+      result = step.submit
+      analytics.track_event(Analytics::IDV_PHONE_CONFIRMATION, result.to_h)
+
+      if result.success?
         redirect_to verify_review_url
       else
         render :new
@@ -32,7 +35,7 @@ module Verify
     end
 
     def confirm_step_needed
-      redirect_to verify_review_path if idv_session.phone_confirmation.try(:success?)
+      redirect_to verify_review_path if idv_session.phone_confirmation == true
     end
 
     def idv_phone_form

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -42,7 +42,7 @@ module Verify
     end
 
     def idv_phone_complete?
-      idv_session.phone_confirmation.try(:success?)
+      idv_session.phone_confirmation == true
     end
 
     def init_profile

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -1,0 +1,17 @@
+class FormResponse
+  def initialize(success:, errors:, extra: {})
+    @success = success
+    @errors = errors
+    @extra = extra
+  end
+
+  attr_reader :errors
+
+  def success?
+    @success
+  end
+
+  def to_h
+    { success: @success, errors: @errors }.merge!(@extra)
+  end
+end

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -1,7 +1,7 @@
 class FormResponse
   def initialize(success:, errors:, extra: {})
     @success = success
-    @errors = errors
+    @errors = errors.to_hash
     @extra = extra
   end
 
@@ -12,6 +12,10 @@ class FormResponse
   end
 
   def to_h
-    { success: @success, errors: @errors }.merge!(@extra)
+    { success: success, errors: errors }.merge!(extra)
   end
+
+  private
+
+  attr_reader :success, :extra
 end

--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -1,7 +1,5 @@
 module Idv
   class FinancialsValidator < VendorValidator
-    delegate :success?, :errors, to: :result
-
     private
 
     def result

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -1,10 +1,20 @@
 module Idv
   class PhoneStep < Step
-    def complete?
-      idv_form.phone && idv_session.phone_confirmation.try(:success?) ? true : false
+    def submit
+      if complete?
+        update_idv_session
+      else
+        idv_session.phone_confirmation = false
+      end
+
+      FormResponse.new(success: complete?, errors: errors)
     end
 
     private
+
+    def complete?
+      form_valid? && vendor_validator.success?
+    end
 
     def vendor_validator_class
       Idv::PhoneValidator
@@ -14,23 +24,14 @@ module Idv
       idv_form.phone
     end
 
-    def vendor_validate
-      result = vendor_validator.validate
-      update_idv_session if complete?
-      result
-    end
-
     def vendor_errors
-      idv_session.phone_confirmation.try(:errors)
+      vendor_validator.errors if form_valid?
     end
 
     def update_idv_session
+      idv_session.phone_confirmation = true
       idv_session.params = idv_form.idv_params
       idv_session.applicant.phone = idv_form.phone
-    end
-
-    def analytics_event
-      Analytics::IDV_PHONE_CONFIRMATION
     end
   end
 end

--- a/app/services/idv/phone_validator.rb
+++ b/app/services/idv/phone_validator.rb
@@ -1,9 +1,13 @@
 module Idv
   class PhoneValidator < VendorValidator
-    def validate
-      session_id = idv_session.resolution.session_id
-      idv_session.phone_confirmation = idv_agent.submit_phone(vendor_params, session_id)
-      idv_session.phone_confirmation.success?
+    private
+
+    def result
+      @_result ||= idv_agent.submit_phone(vendor_params, session_id)
+    end
+
+    def session_id
+      idv_session.resolution.session_id
     end
   end
 end

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -1,6 +1,7 @@
 # abstract base class for proofing vendor validation
 module Idv
   class VendorValidator
+    delegate :success?, :errors, to: :result
     attr_reader :idv_session, :vendor_params
 
     def initialize(idv_session:, vendor_params:)

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -28,7 +28,7 @@ describe Verify::ReviewController do
     idv_session = Idv::Session.new(subject.user_session, user)
     happy_args = { success: true, session_id: 'some-id' }
     idv_session.resolution = Proofer::Resolution.new happy_args
-    idv_session.phone_confirmation = Proofer::Confirmation.new happy_args
+    idv_session.phone_confirmation = true
     idv_session.financials_confirmation = true
     idv_session
   end
@@ -66,7 +66,7 @@ describe Verify::ReviewController do
 
     context 'user has missed phone step' do
       before do
-        idv_session.phone_confirmation.success = false
+        idv_session.phone_confirmation = false
       end
 
       it 'redirects to phone step' do

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 describe FormResponse do
+  describe '.new' do
+    it 'raises an error if errors is not a Hash' do
+      errors = ['bar', [{ foo: 'bar' }], ['foobar']]
+
+      errors.each do |error|
+        expect { FormResponse.new(success: true, errors: error) }.
+          to raise_error NoMethodError
+      end
+    end
+  end
+
   describe '#success?' do
     context 'when the success argument is true' do
       it 'returns true' do

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe FormResponse do
+  describe '#success?' do
+    context 'when the success argument is true' do
+      it 'returns true' do
+        response = FormResponse.new(success: true, errors: {})
+
+        expect(response.success?).to eq true
+      end
+    end
+
+    context 'when the success argument is false' do
+      it 'returns false' do
+        response = FormResponse.new(success: false, errors: {})
+
+        expect(response.success?).to eq false
+      end
+    end
+  end
+
+  describe '#errors' do
+    it 'returns the value of the errors argument' do
+      errors = { foo: 'bar' }
+      response = FormResponse.new(success: true, errors: errors)
+
+      expect(response.errors).to eq errors
+    end
+  end
+
+  describe '#to_h' do
+    context 'when the extra argument is nil' do
+      it 'returns a hash with success and errors keys' do
+        errors = { foo: 'bar' }
+        response = FormResponse.new(success: true, errors: errors)
+        response_hash = {
+          success: true,
+          errors: errors
+        }
+
+        expect(response.to_h).to eq response_hash
+      end
+    end
+
+    context 'when the extra argument is present' do
+      it 'returns a hash with success and errors keys, and any keys from the extra hash' do
+        errors = { foo: 'bar' }
+        extra = { user_id: 1, context: 'confirmation' }
+        response = FormResponse.new(success: true, errors: errors, extra: extra)
+        response_hash = {
+          success: true,
+          errors: errors,
+          user_id: 1,
+          context: 'confirmation'
+        }
+
+        expect(response.to_h).to eq response_hash
+      end
+    end
+  end
+end

--- a/spec/services/idv/phone_validator_spec.rb
+++ b/spec/services/idv/phone_validator_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Idv::PhoneValidator do
+  let(:user) { build(:user) }
+
+  let(:idv_session) do
+    idvs = Idv::Session.new({}, user)
+    idvs.vendor = :mock
+    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
+    idvs
+  end
+
+  let(:session_id) { idv_session.resolution.session_id }
+
+  let(:params) do
+    { phone: '202-555-1212' }
+  end
+
+  let(:confirmation) { instance_double(Proofer::Confirmation) }
+
+  subject { Idv::PhoneValidator.new(idv_session: idv_session, vendor_params: params) }
+
+  def stub_agent_calls
+    agent = instance_double(Idv::Agent)
+    allow(Idv::Agent).to receive(:new).
+      with(applicant: idv_session.applicant, vendor: :mock).
+      and_return(agent)
+    expect(agent).to receive(:submit_phone).
+      with(params, idv_session.resolution.session_id).and_return(confirmation)
+  end
+
+  describe '#success?' do
+    it 'returns Proofer::Confirmation#success?' do
+      stub_agent_calls
+
+      success_string = 'true'
+
+      expect(confirmation).to receive(:success?).and_return(success_string)
+
+      expect(subject.success?).to eq success_string
+    end
+  end
+
+  describe '#error' do
+    it 'returns Proofer::Confirmation#errors' do
+      stub_agent_calls
+
+      error_string = 'mucho errors'
+
+      expect(confirmation).to receive(:errors).and_return(error_string)
+
+      expect(subject.errors).to eq error_string
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Same reason as the Finance-related refactor, so I'll copy
and paste the same commit message, with some additional comments.

- Make it more readable and easier to understand
- Reduce the cognitive load on the developer who is trying to read the
  code for the first time
- Adhere to our controller design principles
- Adhere to Single Responsibility Principle
- Make it easier to test

**How**:
- Refactor `PhoneStep` class such that the only public method
called is `#submit`, and have it return a `FormResponse` object that
the controller can use to determine how to proceed, and to capture
analytics for this event.
- Remove the idv_session manipulation from the vendor validation class
and from the private methods of the `PhoneStep` class, and
into the `submit` method.
- Write the `submit` method in an easy-to-follow narrative that shows
the sequence of events, and consequences of the result of the operation
all in the same place. In this case, the operation is the form
submission, and we must ask whether or not the submission was
successful. We determine if the submission was successful by asking if
both the form validations and the vendor validations passed. If it was
successful, then we update the idv_session and set the
phone_confirmation to `true`, otherwise, we set the confirmation
to false, then we return the result in the form of a `FormResponse`
object that responds to `success?` and `errors`, and where the errors
are the combined errors from the form and vendor validations.
All we need to know about this operation and its side effects are in
this one method, whereas before, you had to jump back and forth between
multiple files to understand the entire operation. Now, we don't need
to look elsewhere to understand the flow of events. If we want to dig
deeper, then we can look into the classes that handle the form or vendor
validations, and see how they operate, but it's not necessary to
understand what is happening. We trust that they are doing the right
thing when we ask them if they are valid or not.
- Add an `#errors` method to the vendor validator and update
`PhoneStep#vendor_errors` to return those errors as opposed to
fetching them from the idv_session, where they may or may not exist.
- Update the way a controller can determine if the Phone step was
completed by setting `idv_session.phone_confirmation` explicity to
`true` or `false` to adhere to the "Tell, Don't Ask" principle.