### PR TITLE
Add /api/service_provider endpoint

### DIFF
--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -1,0 +1,12 @@
+class ServiceProviderController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  def update
+    if FeatureManagement.use_dashboard_service_providers?
+      ServiceProviderUpdater.new.run
+      SecureHeadersWhitelister.new.run
+    end
+
+    render json: { status: 'If the feature is enabled, service providers have been updated.' }
+  end
+end

--- a/app/services/secure_headers_whitelister.rb
+++ b/app/services/secure_headers_whitelister.rb
@@ -2,7 +2,7 @@ class SecureHeadersWhitelister
   def run
     whitelisted_domains = domains(acs_urls(SERVICE_PROVIDERS.values))
     SecureHeaders::Configuration.override(:saml) do |config|
-      config.csp[:form_action] += whitelisted_domains
+      config.csp[:form_action].concat whitelisted_domains
     end
   end
 
@@ -13,6 +13,6 @@ class SecureHeadersWhitelister
   end
 
   def domains(acs_urls)
-    acs_urls.map { |url| url.split('//')[1].split('/')[0] }.uniq
+    acs_urls.grep(%r{://}).map { |url| url.split('//')[1].split('/')[0] }.uniq
   end
 end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -4,10 +4,8 @@ class ServiceProviderUpdater
       service_provider = HashWithIndifferentAccess.new(service_provider)
       issuer = service_provider['issuer']
       SERVICE_PROVIDERS[issuer] = service_provider
-
       VALID_SERVICE_PROVIDERS << issuer
     end
-    SecureHeadersWhitelister.new.run
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
         as: :destroy_user_session
   match '/api/saml/auth' => 'saml_idp#auth', via: [:get, :post]
 
+  post '/api/service_provider' => 'service_provider#update'
+
   match '/api/voice/otp/:code' => 'voice/otp#show',
         via: [:get, :post],
         as: :voice_otp,

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe ServiceProviderController do
+  include SamlAuthHelper
+
+  describe '#update' do
+    let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }
+    let(:dashboard_service_providers) do
+      [
+        {
+          issuer: dashboard_sp_issuer,
+          agency: 'a service provider',
+          friendly_name: 'a friendly service provider',
+          description: 'user friendly login.gov dashboard',
+          acs_url: 'http://sp.example.org/saml/login',
+          assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
+          block_encryption: 'aes256-cbc',
+          cert: saml_test_sp_cert
+        }
+      ]
+    end
+
+    context 'feature on' do
+      before do
+        allow(Figaro.env).to receive(:use_dashboard_service_providers).and_return('true')
+        allow_any_instance_of(ServiceProviderUpdater).to receive(:dashboard_service_providers).
+          and_return(dashboard_service_providers)
+        SERVICE_PROVIDERS.delete dashboard_sp_issuer
+        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
+      end
+
+      after do
+        SERVICE_PROVIDERS.delete dashboard_sp_issuer
+        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
+      end
+
+      it 'returns 200' do
+        post :update
+
+        expect(response.status).to eq 200
+      end
+
+      it 'updates SERVICE_PROVIDERS' do
+        expect(SERVICE_PROVIDERS[dashboard_sp_issuer]).to eq nil
+
+        post :update
+
+        sp = ServiceProvider.new(dashboard_sp_issuer)
+
+        expect(sp.metadata[:agency]).to eq dashboard_service_providers.first[:agency]
+        expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
+        expect(sp.valid?).to eq true
+        expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
+      end
+    end
+  end
+end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 describe ServiceProviderUpdater do
   include SamlAuthHelper
 
+  let(:fake_dashboard_url) { 'http://dashboard.example.org' }
   let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }
-  let(:array_of_sps) do
+  let(:dashboard_service_providers) do
     [
       {
         issuer: dashboard_sp_issuer,
@@ -19,23 +20,54 @@ describe ServiceProviderUpdater do
     ]
   end
 
-  before do
-    allow(subject).to receive(:dashboard_service_providers).and_return(array_of_sps)
-  end
-
   describe '#run' do
-    it 'updates global var registry of Service Providers' do
-      expect(SERVICE_PROVIDERS[dashboard_sp_issuer]).to eq nil
-      expect(VALID_SERVICE_PROVIDERS).to_not include dashboard_sp_issuer
+    before do
+      allow(Figaro.env).to receive(:dashboard_url).and_return(fake_dashboard_url)
+    end
 
-      subject.run
+    context 'dashboard is available' do
+      before do
+        stub_request(:get, fake_dashboard_url).to_return(
+          status: 200,
+          body: dashboard_service_providers.to_json
+        )
+        SERVICE_PROVIDERS.delete dashboard_sp_issuer
+        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
+      end
 
-      sp = ServiceProvider.new(dashboard_sp_issuer)
+      after do
+        SERVICE_PROVIDERS.delete dashboard_sp_issuer
+        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
+      end
 
-      expect(sp.metadata[:agency]).to eq array_of_sps.first[:agency]
-      expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
-      expect(sp.valid?).to eq true
-      expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
+      it 'updates global var registry of Service Providers' do
+        expect(SERVICE_PROVIDERS[dashboard_sp_issuer]).to eq nil
+        expect(VALID_SERVICE_PROVIDERS).to_not include dashboard_sp_issuer
+
+        subject.run
+
+        sp = ServiceProvider.new(dashboard_sp_issuer)
+
+        expect(sp.metadata[:agency]).to eq dashboard_service_providers.first[:agency]
+        expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
+        expect(sp.valid?).to eq true
+        expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
+      end
+    end
+
+    context 'dashboard is not available' do
+      it 'logs error and does not affect registry' do
+        allow(subject).to receive(:log_error)
+
+        valid_service_providers = VALID_SERVICE_PROVIDERS.dup
+
+        stub_request(:get, fake_dashboard_url).to_return(status: 500)
+
+        subject.run
+
+        expect(subject).to have_received(:log_error)
+        expect(valid_service_providers).to eq VALID_SERVICE_PROVIDERS
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: Allow HTTP request to trigger re-read from dashboard.