### PR TITLE
Removes noisy puts statement

### DIFF
--- a/lib/tasks/user_flows.rake
+++ b/lib/tasks/user_flows.rake
@@ -1,17 +1,11 @@
-begin
-  require 'rspec/core/rake_task'
-
-
+unless Rails.env.production?
   namespace :spec do
     desc 'Executes user flow specs'
     RSpec::Core::RakeTask.new('user_flows') do |t|
-      t.rspec_opts = %w[--tag user_flow 
+      t.rspec_opts = %w[--tag user_flow
                         --order defined
                         --require ./lib/rspec/formatters/user_flow_formatter.rb
                         --format UserFlowFormatter]
     end
   end
-
-rescue LoadError
-  puts 'RSpec not present in current gemset -- not loaded'
 end


### PR DESCRIPTION
### Why
We have a special rake task for running user flow specs, but only when RSpec is present.

### How
Removes noisy `puts` statement and fails silently since Rails.logger isn't available. 