### PR TITLE
Allow locale switching via URL param

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ If you would like to run the application on a different port:
 * Change the port number for `mailer_domain_name` and `domain_name` in `config/application.yml`
 * Run the app on your desired port like `make run PORT=1234`
 
+If you would like to see the Spanish translations on a particular page, add
+`?locale=es` to the end of the URL, such as `http://localhost:3000/?locale=es`.
+Currently, you'll need to add `?locale=es` to each URL manually. We are working
+on a more robust and user-friendly way to switch between locales.
+
 ### Running Tests
 
 Make sure you have [PhantomJS](http://phantomjs.org) installed prior to running

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   helper_method :decorated_user, :reauthn?, :user_fully_authenticated?
 
   prepend_before_action :session_expires_at
+  before_action :set_locale
 
   layout 'card'
 
@@ -103,5 +104,9 @@ class ApplicationController < ActionController::Base
 
   def skip_session_expiration
     @skip_session_expiration = true
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end


### PR DESCRIPTION
**Why**: To make it easier to switch between English and Spanish, and
to see what has and has not yet been translated.

**How**: Add a before action in ApplicationController to set the locale
based on the URL param if it is present, or fall back to the default.

Note that eventually, we might implement something more user friendly,
such as fetching the locale from the domain name, such as login.gov.es
or es.login.gov, or perhaps in the path, like login.gov/es/profile.