### PR TITLE
Add fasterer gem and fix performance offenses

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,6 @@
+speedups:
+  # Disabled because argument is actually faster.
+  # See https://github.com/DamirSvrtan/fasterer/issues/37
+  fetch_with_argument_vs_block: false
+  # In UserDecorator#recent_events, sort is faster
+  sort_vs_sort_by: false

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development do
   gem 'brakeman', require: false
   gem 'bummr', require: false
   gem 'derailed'
+  gem 'fasterer', require: false
   gem 'guard-rspec', require: false
   gem 'overcommit', require: false
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.11.1)
+    colorize (0.8.1)
     concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
     crack (0.4.3)
@@ -233,6 +234,9 @@ GEM
       railties (>= 3.0.0)
     faker (1.7.2)
       i18n (~> 0.5)
+    fasterer (0.3.2)
+      colorize (~> 0.7)
+      ruby_parser (~> 3.7)
     ffi (1.9.14)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -470,6 +474,8 @@ GEM
     ruby-saml (1.4.2)
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
+    ruby_parser (3.8.4)
+      sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     safely_block (0.1.1)
       errbase
@@ -493,6 +499,7 @@ GEM
       rake
     secure_headers (3.6.1)
       useragent
+    sexp_processor (4.7.0)
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -650,6 +657,7 @@ DEPENDENCIES
   email_spec
   factory_girl_rails
   faker
+  fasterer
   figaro
   foundation_emails
   gibberish

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ lint: $(CONFIG)
 	bundle exec slim-lint app/views
 	@echo "--- reek ---"
 	bundle exec reek
+	@echo "--- fasterer ---"
+	bundle exec fasterer
 
 brakeman:
 	bundle exec brakeman

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -20,7 +20,7 @@ module Pii
       attrs = new
       return attrs unless pii_json.present?
       pii = JSON.parse(pii_json, symbolize_names: true)
-      pii.keys.each { |attr| attrs[attr] = pii[attr] }
+      pii.each_key { |attr| attrs[attr] = pii[attr] }
       attrs
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,8 @@ Rails.application.configure do
 
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
-    event.payload.except(:params).merge!(timestamp: event.time)
+    event.payload[:timestamp] = event.time
+    event.payload.except(:params)
   end
   config.lograge.ignore_actions = ['Users::SessionsController#active']
   config.lograge.formatter = Lograge::Formatters::Json.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,8 @@ Rails.application.configure do
   config.log_level = :info
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
-    event.payload.except(:params).merge!(timestamp: event.time)
+    event.payload[:timestamp] = event.time
+    event.payload.except(:params)
   end
   config.lograge.ignore_actions = ['Users::SessionsController#active']
   config.lograge.formatter = Lograge::Formatters::Json.new

--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -16,9 +16,7 @@ class ConfigValidator
   end
 
   def warning(bad_keys)
-    <<~HEREDOC
-      You have invalid values for #{bad_keys.uniq.to_sentence} in
-      config/application.yml. Please change them to true or false
-    HEREDOC
+    "You have invalid values for #{bad_keys.uniq.to_sentence} in " \
+    "config/application.yml. Please change them to true or false."
   end
 end

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -8,7 +8,8 @@ class ServiceProvider
   end
 
   def metadata
-    sp_attributes.merge!(fingerprint: fingerprint)
+    sp_attributes[:fingerprint] = fingerprint
+    sp_attributes
   end
 
   def encryption_opts

--- a/spec/presenters/two_factor_auth_code/totpable.spec.rb
+++ b/spec/presenters/two_factor_auth_code/totpable.spec.rb
@@ -14,7 +14,8 @@ describe TwoFactorAuthCode::Totpable do
 
     context 'when totp option is enabled' do
       let(:presenter) do
-        data = attributes_for(:generic_otp_presenter).merge!(totp_enabled: true)
+        data = attributes_for(:generic_otp_presenter)
+        data[:totp_enabled] = true
         TwoFactorAuthCode::PhoneDeliveryPresenter.new(data)
       end
 


### PR DESCRIPTION
**Why**: To warn about usage of less performant methods when faster
ones are available. See https://github.com/DamirSvrtan/fasterer

**How**:
- Use `Hash#[]=` instead of `merge!` with only one argument because the
latter is 5x slower
- Use String instead of Heredoc in `config_validator` because fasterer
was not able to parse it
- Use `Hash#each_key` instead `keys.each` because the former iterates
through the keys without allocating a new array
- Add `.fasterer.yml` config and disable two checks because I
obtained the opposite results when benchmarking our code
- Add `fasterer` to our `make lint` command