### PR TITLE
Adds fix for permissions with latest base image

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,8 +67,16 @@ namespace :deploy do
     end
   end
 
+  desc 'Modify permissions on /srv/idp'
+  task :mod_perms do
+    on roles(:web), in: :parallel do
+      execute :sudo, :chown, '-R', 'ubuntu:nogroup', deploy_to
+    end
+  end
+
   before 'assets:precompile', :browserify
   after 'deploy:updated', 'newrelic:notice_deployment'
   after 'deploy:log_revision', :deploy_json
+  after :deploy, 'deploy:mod_perms'
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -77,6 +77,6 @@ namespace :deploy do
   before 'assets:precompile', :browserify
   after 'deploy:updated', 'newrelic:notice_deployment'
   after 'deploy:log_revision', :deploy_json
-  after :deploy, 'deploy:mod_perms'
+  after 'deploy', 'deploy:mod_perms'
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/deploy/int.rb
+++ b/config/deploy/int.rb
@@ -1,0 +1,2 @@
+server 'int.login.gov', roles: %w(web db)
+server 'worker.int.login.gov', roles: %w(app job_creator)


### PR DESCRIPTION
### Why
Deploying with capistrano results in a nginx 500 error

### How
Modifies ownership of /srv directory post-deploy
Adds `INT` environment to available deployment stages

One **major** caveat is that capistrano's initial permissions on /srv/idp/current are *not* compatible with nginx/passenger and the site returns a 500 error while the `chown` task is running (10-30s). 
