### PR TITLE
Bring back identities.ial column to preserve ial

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -5,6 +5,8 @@ module OpenidConnect
     def index
       @authorize_form = OpenidConnectAuthorizeForm.new(params)
 
+      return redirect_to verify_url if identity_needs_verification?
+
       success = @authorize_form.valid?
       analytics.track_event(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
                             success: success,
@@ -32,6 +34,12 @@ module OpenidConnect
       analytics.track_event(Analytics::OPENID_CONNECT_DECLINE, client_id: @authorize_form.client_id)
 
       render nothing: true # TODO: should we try to redirect back with an error?
+    end
+
+    private
+
+    def identity_needs_verification?
+      @authorize_form.loa3_requested? && decorated_user.identity_not_verified?
     end
   end
 end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class OpenidConnectAuthorizeForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
@@ -61,6 +62,10 @@ class OpenidConnectAuthorizeForm
     }
   end
 
+  def loa3_requested?
+    ial == 3
+  end
+
   private
 
   def parse_acr_values(acr_values)
@@ -97,7 +102,20 @@ class OpenidConnectAuthorizeForm
 
   def link_identity_to_client_id(current_user, rails_session_id)
     identity_linker = IdentityLinker.new(current_user, client_id)
-    identity_linker.link_identity(nonce: nonce, session_uuid: rails_session_id)
+    identity_linker.link_identity(
+      nonce: nonce,
+      session_uuid: rails_session_id,
+      ial: ial
+    )
+  end
+
+  def ial
+    case acr_values.sort.max
+    when Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+      1
+    when Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+      3
+    end
   end
 
   def success_redirect_uri(rails_session_id)
@@ -117,3 +135,4 @@ class OpenidConnectAuthorizeForm
     @_service_provider ||= ServiceProvider.new(client_id)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -20,7 +20,6 @@ class OpenidConnectUserInfoPresenter
 
   private
 
-  # TODO: only return loa1 attributes for loa1 sessions
   def loa3_attributes
     {
       given_name: loa3_data.first_name,
@@ -34,9 +33,17 @@ class OpenidConnectUserInfoPresenter
 
   def loa3_data
     @loa3_data ||= begin
-      session = session_store.send(:load_session_from_redis, identity.session_uuid) || {}
-      Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+      if loa3_session?
+        session = session_store.send(:load_session_from_redis, identity.session_uuid) || {}
+        Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+      else
+        Pii::Attributes.new_from_hash({})
+      end
     end
+  end
+
+  def loa3_session?
+    identity.ial == 3
   end
 
   def session_store

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -12,7 +12,7 @@ class IdTokenBuilder
       iss: root_url,
       aud: identity.service_provider,
       sub: identity.uuid,
-      acr: '', # TODO: the ACR from the request
+      acr: acr,
       nonce: identity.nonce,
       jti: '', # a unique identifier for the token which can be used to prevent reuse of the token
     }.merge(id_token_timestamp_values)
@@ -30,5 +30,17 @@ class IdTokenBuilder
       iat: now,
       nbf: now
     }
+  end
+
+  def acr
+    ial = identity.ial
+    case ial
+    when 1
+      Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+    when 3
+      Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+    else
+      raise "Unknown ial #{ial}"
+    end
   end
 end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -1,10 +1,10 @@
 IdentityLinker = Struct.new(:user, :provider) do
   attr_reader :identity
 
-  def link_identity(nonce: nil, session_uuid: nil)
+  def link_identity(nonce: nil, session_uuid: nil, ial: nil)
     find_or_create_identity
 
-    identity.update!(identity_attributes(nonce: nonce, session_uuid: session_uuid))
+    identity.update!(identity_attributes(nonce: nonce, session_uuid: session_uuid, ial: ial))
   end
 
   private
@@ -16,12 +16,13 @@ IdentityLinker = Struct.new(:user, :provider) do
     )
   end
 
-  def identity_attributes(nonce: nil, session_uuid: nil)
+  def identity_attributes(nonce: nil, session_uuid: nil, ial: nil)
     session_uuid ||= SecureRandom.uuid
     {
       last_authenticated_at: Time.current,
       session_uuid: session_uuid,
-      nonce: nonce
+      nonce: nonce,
+      ial: ial
     }
   end
 end

--- a/app/views/openid_connect/authorization/index.html.slim
+++ b/app/views/openid_connect/authorization/index.html.slim
@@ -1,6 +1,5 @@
 p = t('openid_connect.authorization.index.allow_prompt')
 
-
 = button_to t('openid_connect.authorization.index.allow'),
             openid_connect_allow_path,
             params: @authorize_form.params,

--- a/db/migrate/20170125153626_add_ial_to_identities_again.rb
+++ b/db/migrate/20170125153626_add_ial_to_identities_again.rb
@@ -1,0 +1,5 @@
+class AddIalToIdentitiesAgain < ActiveRecord::Migration
+  def change
+    add_column :identities, :ial, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170111142846) do
+ActiveRecord::Schema.define(version: 20170125153626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,8 +53,9 @@ ActiveRecord::Schema.define(version: 20170111142846) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "session_uuid",          limit: 255
-    t.string   "uuid",                              null: false
+    t.string   "uuid",                                          null: false
     t.string   "nonce"
+    t.integer  "ial",                               default: 1
   end
 
   add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe OpenidConnect::TokenController do
     end
 
     before do
-      IdentityLinker.new(user, client_id).link_identity(session_uuid: code)
+      IdentityLinker.new(user, client_id).link_identity(session_uuid: code, ial: 1)
     end
 
     context 'with valid params' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -61,7 +61,7 @@ feature 'OpenID Connect' do
       expect(sub).to be_present
       expect(decoded_id_token[:nonce]).to eq(nonce)
       expect(decoded_id_token[:aud]).to eq(client_id)
-      # expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
+      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
       expect(decoded_id_token[:iss]).to eq(root_url)
 
       page.driver.get openid_connect_userinfo_path,

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(identity.session_uuid).to eq(rails_session_id)
         expect(identity.nonce).to eq(nonce)
       end
+
+      it 'sets the max ial/loa from the request on the identity' do
+        result
+
+        identity = user.identities.where(service_provider: client_id).first
+        expect(identity.ial).to eq(3)
+      end
     end
 
     context 'with invalid params' do
@@ -144,6 +151,28 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
     it 'is parsed into an array of valid ACR values' do
       expect(form.acr_values).to eq(%w(http://idmanagement.gov/ns/assurance/loa/1))
+    end
+  end
+
+  describe '#loa3_requested?' do
+    subject(:loa3_requested?) { form.loa3_requested? }
+    context 'with loa1' do
+      let(:acr_values) { Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF }
+      it { expect(loa3_requested?).to eq(false) }
+    end
+
+    context 'with loa3' do
+      let(:acr_values) { Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF }
+      it { expect(loa3_requested?).to eq(true) }
+    end
+
+    context 'with loa1 and loa3' do
+      it { expect(loa3_requested?).to eq(true) }
+    end
+
+    context 'with a malformed loa' do
+      let(:acr_values) { 'foobarbaz' }
+      it { expect(loa3_requested?).to eq(false) }
     end
   end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OpenidConnectTokenForm do
   let(:user) { create(:user) }
 
   before do
-    IdentityLinker.new(user, client_id).link_identity(nonce: nonce, session_uuid: code)
+    IdentityLinker.new(user, client_id).link_identity(nonce: nonce, session_uuid: code, ial: 1)
   end
 
   describe '#valid?' do

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -40,20 +40,24 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           send(:set_session, {}, session_uuid, session_data, expire_after: 5.minutes.to_i)
       end
 
-      it 'returns loa3 attributes' do
-        aggregate_failures do
-          expect(user_info[:given_name]).to eq('John')
-          expect(user_info[:middle_name]).to eq('Jones')
-          expect(user_info[:family_name]).to eq('Smith')
-          expect(user_info[:birthdate]).to eq('1970-01-01')
-          expect(user_info[:postal_code]).to eq('12345')
+      context 'when the identity has loa3 access' do
+        before { identity.ial = 3 }
+
+        it 'returns loa3 attributes' do
+          aggregate_failures do
+            expect(user_info[:given_name]).to eq('John')
+            expect(user_info[:middle_name]).to eq('Jones')
+            expect(user_info[:family_name]).to eq('Smith')
+            expect(user_info[:birthdate]).to eq('1970-01-01')
+            expect(user_info[:postal_code]).to eq('12345')
+          end
         end
       end
 
       context 'when the identity only has loa1 access' do
-        it 'does not return loa3 attributes' do
-          pending 'loa1/loa3 access controls'
+        before { identity.ial = 1 }
 
+        it 'does not return loa3 attributes' do
           aggregate_failures do
             expect(user_info[:given_name]).to eq(nil)
             expect(user_info[:family_name]).to eq(nil)

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe IdTokenBuilder do
   let(:identity) do
     build(:identity,
           nonce: SecureRandom.hex,
-          uuid: SecureRandom.uuid)
+          uuid: SecureRandom.uuid,
+          ial: 3)
   end
 
   subject(:builder) { IdTokenBuilder.new(identity) }
@@ -42,9 +43,7 @@ RSpec.describe IdTokenBuilder do
     end
 
     it 'sets the acr to the request acr' do
-      pending 'actually setting the acr value'
-
-      expect(decoded_payload[:acr]).to_not eq('')
+      expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF)
     end
 
     it 'sets the jti to something meaningful' do

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -22,7 +22,7 @@ describe IdentityLinker do
 
       expect(last_identity.session_uuid).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)
       expect(last_identity.last_authenticated_at).to be_present
-      expect(identity_attributes).to eq new_attributes
+      expect(identity_attributes).to include new_attributes
     end
 
     it 'can take an optional nonce and session_uuid to specify attributes' do


### PR DESCRIPTION
**Why**: OpenID Connect spec

--

This column used to exist but we removed it, I'm bringing it back :)