### PR TITLE
Remove the browser "are you sure you want to leave this page?" popup

### DIFF
--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -20,5 +20,3 @@ p = t('idv.messages.phone.same_as_2fa')
   = f.input :phone, required: true
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
 = render 'shared/cancel', link: verify_cancel_path
-
-== javascript_include_tag 'misc/page-unload-warning'


### PR DESCRIPTION
**Why**:
It conflicts with our "keep me signed in" page refresh button

--

There are 2 other pages `verify/review/new` and `verify/sessions/new` that include the same partial, should we remove it everywhere for consistency? The partial explicitly sets a truthy `window.onbeforeunload` so the browsers will create the 'are you sure you want to leave?' popup.

I don't see the reason we would want the browser popup ever, I think it just gets in the way
