### PR TITLE
Add context to 2fa radio buttons

### DIFF
--- a/app/views/users/two_factor_authentication/show.html.slim
+++ b/app/views/users/two_factor_authentication/show.html.slim
@@ -2,17 +2,16 @@
 
 
 h1.h3.my0 = t('headings.choose_otp_delivery')
-p.mt-tiny.mb0#2fa-description
-  = t('devise.two_factor_authentication.choose_otp_delivery', phone: @phone_number)
 = simple_form_for(@otp_delivery_selection_form,
     url: otp_send_path,
     method: :get,
-    role: 'form', html: { class: 'mt2 sm-mt3' }) do |f|
+    role: 'form', html: { class: 'mt0' }) do |f|
   - if reauthn?
     = f.input :reauthn, as: :hidden, input_html: { value: 'true' }
   .mb3
-    fieldset.p0.border-none
-      legend.hide = t('devise.two_factor_authentication.otp_method.title')
+    fieldset.m0.p0.border-none
+      legend.mt-tiny.mb2.sm-mb3 = t('devise.two_factor_authentication.choose_otp_delivery',
+                                    phone: @phone_number)
       label.radio-btn.col-12.sm-col-5.sm-mr2.mb2.sm-mb0
         .radio
           = f.radio_button :otp_method, 'sms', checked: true

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -2,7 +2,7 @@
 
 = render 'shared/progress_steps', active: 3
 h1.h3.my0 = t('devise.two_factor_authentication.two_factor_setup')
-p.mt-tiny.mb0#2fa-description
+p.mt-tiny.mb0
   = t('devise.two_factor_authentication.otp_setup_html')
 = simple_form_for(@two_factor_setup_form,
     html: { autocomplete: 'off', role: 'form' },
@@ -12,11 +12,11 @@ p.mt-tiny.mb0#2fa-description
     strong.left = t('devise.two_factor_authentication.otp_phone_label')
     span.ml1.italic = t('devise.two_factor_authentication.otp_phone_label_info')
   = f.input :phone, as: :tel, label: false, required: true,
-      input_html: { 'aria-describedby' => '2fa-description', class: 'phone sm-col-8 mb4' }
+      input_html: { class: 'phone sm-col-8 mb4' }
   .mb3
-    h2.h4 = t('devise.two_factor_authentication.otp_method.title')
-    fieldset.p0.border-none
-      legend.mb2 = t('devise.two_factor_authentication.otp_method.instruction')
+    fieldset.m0.p0.border-none
+      legend.mb1.h4.serif.bold = t('devise.two_factor_authentication.otp_method.title')
+      p = t('devise.two_factor_authentication.otp_method.instruction')
       label.radio-btn.col-12.sm-col-5.sm-mr2.mb2.sm-mb0
         .radio
           = radio_button_tag 'two_factor_setup_form[otp_method]', :sms,


### PR DESCRIPTION
**Why**: To link radio buttons to instructions for screen readers.