### PR TITLE
Add vendor reasons to proofing step analytics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: c671e7964a1e4693b500da6fdde7c023beda71b1
+  revision: 4d0d90c06c102361d310e02edba8a64e4d25cc39
   branch: master
   specs:
     proofer (1.0.0)
@@ -221,7 +221,7 @@ GEM
       rails (>= 3.1.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    dotenv (2.1.1)
+    dotenv (2.1.2)
     dotiw (3.1.1)
       actionpack (>= 3)
       i18n

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -29,6 +29,10 @@ module Idv
       vendor_validator.errors if form_valid?
     end
 
+    def vendor_reasons
+      vendor_validator.reasons if form_valid?
+    end
+
     def vendor_params
       finance_type = idv_form.finance_type
       { finance_type => idv_form.idv_params[finance_type] }
@@ -37,7 +41,8 @@ module Idv
     def result
       {
         success: success,
-        errors: errors
+        errors: errors,
+        vendor: { reasons: vendor_reasons }
       }
     end
   end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -28,6 +28,10 @@ module Idv
       vendor_validator.errors if form_valid?
     end
 
+    def vendor_reasons
+      vendor_validator.reasons if form_valid?
+    end
+
     def update_idv_session
       idv_session.phone_confirmation = true
       idv_session.params = idv_form.idv_params

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -40,11 +40,17 @@ module Idv
       idv_session.resolution.try(:errors)
     end
 
+    def vendor_reasons
+      resolution = idv_session.resolution
+      resolution.vendor_resp.reasons if resolution
+    end
+
     def analytics_result
       {
         success: complete?,
         idv_attempts_exceeded: attempts_exceeded?,
-        errors: errors
+        errors: errors,
+        vendor: { reasons: vendor_reasons }
       }
     end
 

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -58,7 +58,7 @@ module Idv
     end
 
     def analytics_result
-      { success: complete?, errors: errors }
+      { success: complete?, errors: errors, vendor: { reasons: vendor_reasons } }
     end
 
     def track_event

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -9,6 +9,10 @@ module Idv
       @vendor_params = vendor_params
     end
 
+    def reasons
+      result.vendor_resp.reasons
+    end
+
     def validate
       raise NotImplementedError "Must implement validate for #{self}"
     end

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -77,7 +77,7 @@ describe Verify::FinanceController do
 
         put :create, idv_finance_form: { finance_type: :ccn, ccn: '12345678' }
 
-        result = { success: true, errors: {} }
+        result = { success: true, errors: {}, vendor: { reasons: ['Good number'] } }
 
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_FINANCE_CONFIRMATION, result
@@ -135,7 +135,8 @@ describe Verify::FinanceController do
 
         result = {
           success: true,
-          errors: {}
+          errors: {},
+          vendor: { reasons: ['Good number'] }
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -150,7 +151,8 @@ describe Verify::FinanceController do
 
         result = {
           success: false,
-          errors: { ccn: ['The ccn could not be verified.'] }
+          errors: { ccn: ['The ccn could not be verified.'] },
+          vendor: { reasons: ['Bad number'] }
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -166,7 +168,8 @@ describe Verify::FinanceController do
 
         result = {
           success: false,
-          errors: { ccn: ['Credit card number should be only last 8 digits.'] }
+          errors: { ccn: ['Credit card number should be only last 8 digits.'] },
+          vendor: { reasons: nil }
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -89,7 +89,8 @@ describe Verify::SessionsController do
           result = {
             success: false,
             idv_attempts_exceeded: false,
-            errors: { ssn: [t('idv.errors.duplicate_ssn')] }
+            errors: { ssn: [t('idv.errors.duplicate_ssn')] },
+            vendor: { reasons: nil }
           }
 
           expect(@analytics).to receive(:track_event).
@@ -140,7 +141,8 @@ describe Verify::SessionsController do
             idv_attempts_exceeded: false,
             errors: {
               first_name: ['Unverified first name.']
-            }
+            },
+            vendor: { reasons: ['The name was suspicious'] }
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -166,7 +168,8 @@ describe Verify::SessionsController do
           result = {
             success: true,
             idv_attempts_exceeded: false,
-            errors: {}
+            errors: {},
+            vendor: { reasons: ['Everything looks good'] }
           }
 
           expect(@analytics).to have_received(:track_event).

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -24,7 +24,8 @@ describe Idv::FinancialsStep do
 
       result = {
         success: false,
-        errors: { ccn: [t('idv.errors.invalid_ccn')] }
+        errors: { ccn: [t('idv.errors.invalid_ccn')] },
+        vendor: { reasons: nil }
       }
 
       expect(step.submit).to eq result
@@ -36,7 +37,8 @@ describe Idv::FinancialsStep do
 
       result = {
         success: true,
-        errors: {}
+        errors: {},
+        vendor: { reasons: ['Good number'] }
       }
 
       expect(step.submit).to eq result
@@ -49,7 +51,8 @@ describe Idv::FinancialsStep do
 
       result = {
         success: false,
-        errors: { ccn: ['The ccn could not be verified.'] }
+        errors: { ccn: ['The ccn could not be verified.'] },
+        vendor: { reasons: ['Bad number'] }
       }
 
       expect(step.submit).to eq result

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -45,7 +45,8 @@ describe Idv::ProfileStep do
       result = {
         success: true,
         idv_attempts_exceeded: false,
-        errors: {}
+        errors: {},
+        vendor: { reasons: ['Everything looks good'] }
       }
 
       expect_analytics_result(result)
@@ -62,7 +63,8 @@ describe Idv::ProfileStep do
         idv_attempts_exceeded: false,
         errors: {
           ssn: ['Unverified SSN.']
-        }
+        },
+        vendor: { reasons: ['The SSN was suspicious'] }
       }
 
       expect_analytics_result(result)
@@ -79,7 +81,8 @@ describe Idv::ProfileStep do
         idv_attempts_exceeded: false,
         errors: {
           first_name: ['Unverified first name.']
-        }
+        },
+        vendor: { reasons: ['The name was suspicious'] }
       }
 
       expect_analytics_result(result)
@@ -98,7 +101,8 @@ describe Idv::ProfileStep do
       result = {
         success: false,
         idv_attempts_exceeded: true,
-        errors: {}
+        errors: {},
+        vendor: { reasons: nil }
       }
 
       expect_analytics_result(result)


### PR DESCRIPTION
**Why**: Track vendor rationales for success/failure in each
verification step.