### PR TITLE
Bypass acknowledge recovery code step for LOA3

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -29,7 +29,8 @@ module SamlIdpAuthConcern
   end
 
   def add_sp_metadata_to_session
-    session[:sp] = { logo: current_sp_metadata[:logo],
+    session[:sp] = { loa3: loa3_requested?,
+                     logo: current_sp_metadata[:logo],
                      return_url: current_sp_metadata[:return_to_sp_url],
                      name: current_sp_metadata[:friendly_name] ||
                            current_sp_metadata[:agency] }

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -66,7 +66,11 @@ UserDecorator = Struct.new(:user) do
   end
 
   def should_acknowledge_recovery_code?(session)
-    user.recovery_code.blank? && !omniauthed?(session)
+    sp_session = session[:sp]
+
+    user.recovery_code.blank? &&
+      !omniauthed?(session) &&
+      (sp_session.blank? || sp_session[:loa3] == false)
   end
 
   def recent_events

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -284,9 +284,12 @@ describe SamlIdpController do
       end
 
       it 'stores SP metadata in session' do
-        expect(session[:sp]).to eq(logo: 'generic.svg',
-                                   return_url: 'http://localhost:3000',
-                                   name: 'Your friendly Government Agency')
+        expect(session[:sp]).to eq(
+          loa3: false,
+          logo: 'generic.svg',
+          return_url: 'http://localhost:3000',
+          name: 'Your friendly Government Agency'
+        )
       end
 
       context 'after successful assertion' do

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -83,25 +83,45 @@ describe UserDecorator do
   end
 
   describe '#should_acknowledge_recovery_code?' do
-    it 'returns true when the user has no recovery code and is not omniauthed' do
-      user_decorator = UserDecorator.new(User.new)
-      session = { omniauthed: false }
+    context 'user has no recovery code and is not omniauthed' do
+      context 'service provider with loa1' do
+        it 'returns true' do
+          user_decorator = UserDecorator.new(User.new)
+          session = { omniauthed: false, sp: { loa3: false } }
 
-      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
-    end
+          expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
+        end
+      end
 
-    it 'returns false when the user has a recovery code' do
-      user_decorator = UserDecorator.new(User.new(recovery_code: 'foo'))
-      session = { omniauthed: false }
+      context 'no service provider' do
+        it 'returns true' do
+          user_decorator = UserDecorator.new(User.new)
+          session = { omniauthed: false }
 
-      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
-    end
+          expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
+        end
+      end
 
-    it 'returns false when the user is omniauthed' do
-      user_decorator = UserDecorator.new(User.new)
-      session = { omniauthed: true }
+      it 'returns false when the user has a recovery code' do
+        user_decorator = UserDecorator.new(User.new(recovery_code: 'foo'))
+        session = {}
 
-      expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+        expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+      end
+
+      it 'returns false when the user is omniauthed' do
+        user_decorator = UserDecorator.new(User.new)
+        session = { omniauthed: true }
+
+        expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+      end
+
+      it 'returns false if the user is loa3' do
+        user_decorator = UserDecorator.new(User.new)
+        session = { omniauthed: false, sp: { loa3: true } }
+
+        expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
+      end
     end
   end
 

--- a/spec/features/saml/idp_initiated_slo_spec.rb
+++ b/spec/features/saml/idp_initiated_slo_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 include SamlAuthHelper
 include IdvHelper
 
-feature 'IDP-initiated logout', devise: true do
+feature 'IDP-initiated logout' do
   let(:user) { create(:user, :signed_up) }
 
   context 'when logged in to single SP' do

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'LOA1 Single Sign On' do
+  include SamlAuthHelper
+
+  context 'First time registration' do
+    it 'prompts user to acknowledge recovery code before being redirected to the sp' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      saml_authn_request = auth_request.create(saml_settings)
+
+      visit saml_authn_request
+      sign_up_and_set_password
+      fill_in 'Phone', with: '202-555-1212'
+      select_sms_delivery
+      enter_2fa_code
+      click_acknowledge_recovery_code
+
+      expect(current_url).to eq saml_authn_request
+    end
+  end
+end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'LOA3 Single Sign On' do
+  include SamlAuthHelper
+  include IdvHelper
+
+  context 'First time registration' do
+    it 'redirects to original SAML Authn Request after IdV is complete' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
+      visit saml_authn_request
+
+      xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+
+      visit sign_up_email_path
+      user = sign_up_and_set_password
+      fill_in 'Phone', with: '202-555-1212'
+      select_sms_delivery
+      enter_2fa_code
+
+      expect(current_path).to eq verify_path
+      click_on 'Yes'
+      complete_idv_profile_ok(user.reload)
+      click_acknowledge_recovery_code
+
+      expect(current_url).to eq saml_authn_request
+
+      user_access_key = user.unlock_user_access_key(Features::SessionHelper::VALID_PASSWORD)
+      profile_phone = user.active_profile.decrypt_pii(user_access_key).phone
+
+      expect(xmldoc.phone_number.children.children.to_s).to eq(profile_phone)
+    end
+  end
+end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 include SamlAuthHelper
 include IdvHelper
 
-feature 'saml api', devise: true do
+feature 'saml api' do
   let(:user) { create(:user, :signed_up) }
 
   context 'SAML Assertions' do
@@ -30,24 +30,6 @@ feature 'saml api', devise: true do
       end
 
       it 'prompts the user to set up 2FA' do
-        expect(current_path).to eq phone_setup_path
-      end
-
-      it 'prompts the user to confirm phone after setting up 2FA' do
-        fill_in 'Phone', with: '202-555-1212'
-        click_button t('forms.buttons.send_passcode')
-
-        expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
-      end
-    end
-
-    context 'first time registration' do
-      before do
-        sign_up_and_set_password
-        visit authnrequest_get
-      end
-
-      it 'prompts user to set up 2FA after confirming email and setting password' do
         expect(current_path).to eq phone_setup_path
       end
 
@@ -222,37 +204,6 @@ feature 'saml api', devise: true do
         visit destroy_user_session_url
         expect(page.current_path).to eq('/')
         Timecop.return
-      end
-    end
-  end
-
-  context 'visiting /api/saml/auth' do
-    context 'with LOA3 authn_context' do
-      it 'redirects to original SAML Authn Request after IdV is complete' do
-        include IdvHelper
-
-        saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
-        visit saml_authn_request
-
-        xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
-
-        visit sign_up_email_path
-
-        user = sign_up_and_2fa
-
-        expect(current_path).to eq verify_path
-
-        click_on 'Yes'
-
-        complete_idv_profile_ok(user.reload)
-        click_acknowledge_recovery_code
-
-        expect(current_url).to eq saml_authn_request
-
-        user_access_key = user.unlock_user_access_key(Features::SessionHelper::VALID_PASSWORD)
-        profile_phone = user.active_profile.decrypt_pii(user_access_key).phone
-
-        expect(xmldoc.phone_number.children.children.to_s).to eq(profile_phone)
       end
     end
   end

--- a/spec/features/saml/sp_initiated_slo_spec.rb
+++ b/spec/features/saml/sp_initiated_slo_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 include SamlAuthHelper
 include IdvHelper
 
-feature 'SP-initiated logout', devise: true do
+feature 'SP-initiated logout' do
   let(:user) { create(:user, :signed_up) }
 
   context 'when logged in to a single SP' do

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Changing authentication factor' do
   describe 'requires re-authenticating' do
-    let!(:user) { sign_up_and_2fa }
+    let!(:user) { sign_up_and_2fa_loa1_user }
 
     scenario 'editing password' do
       visit manage_password_path

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -55,7 +55,7 @@ feature 'Email confirmation during sign up' do
 
   context 'confirmed user is signed in and tries to confirm again' do
     it 'redirects the user to the profile' do
-      sign_up_and_2fa
+      sign_up_and_2fa_loa1_user
 
       visit sign_up_create_email_confirmation_url(confirmation_token: @raw_confirmation_token)
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -10,6 +10,16 @@ module Features
       click_button t('forms.buttons.submit.default')
     end
 
+    def sign_up_and_2fa_loa1_user
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      user = sign_up_and_set_password
+      fill_in 'Phone', with: '202-555-1212'
+      select_sms_delivery
+      enter_2fa_code
+      click_acknowledge_recovery_code
+      user
+    end
+
     def signin(email, password)
       visit new_user_session_path
       fill_in_credentials_and_submit(email, password)
@@ -84,17 +94,12 @@ module Features
       )
     end
 
-    def sign_up_and_2fa
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      user = sign_up_and_set_password
-      fill_in 'Phone', with: '202-555-1212'
-      # Select SMS delivery
+    def select_sms_delivery
       click_button t('forms.buttons.send_passcode')
-      # Enter 2FA code
+    end
+
+    def enter_2fa_code
       click_button t('forms.buttons.submit.default')
-      # Acknowledge recovery code
-      click_button t('forms.buttons.continue')
-      user
     end
 
     def sign_in_live_with_2fa(user = user_with_2fa)
@@ -128,6 +133,10 @@ module Features
       sign_in_user(user)
       fill_in 'code', with: generate_totp_code(@secret)
       click_submit_default
+    end
+
+    def click_acknowledge_recovery_code
+      click_button t('forms.buttons.continue')
     end
   end
 end

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -48,10 +48,6 @@ module IdvHelper
     click_submit_default
   end
 
-  def click_acknowledge_recovery_code
-    click_button t('forms.buttons.continue')
-  end
-
   def stub_idv_session
     stub_sign_in(user)
     idv_session = Idv::Session.new(subject.user_session, user)


### PR DESCRIPTION
**Why**:
We should LOA3 users the recovery code after the IDV flow. No need to
show them twice.