### PR TITLE
Allow resending OTP in reauthentication context

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -52,7 +52,7 @@ module TwoFactorAuthenticatable
   end
 
   def authentication_context?
-    context == 'authentication'
+    context == 'authentication' || context == 'reauthentication'
   end
 
   def confirmation_context?
@@ -71,7 +71,7 @@ module TwoFactorAuthenticatable
   # You can pass in any "type" with a corresponding I18n key in
   # devise.two_factor_authentication.invalid_#{type}
   def handle_invalid_otp(type: 'otp')
-    update_invalid_user if current_user.two_factor_enabled? && context == 'authentication'
+    update_invalid_user if current_user.two_factor_enabled? && authentication_context?
 
     flash.now[:error] = t("devise.two_factor_authentication.invalid_#{type}")
 
@@ -183,7 +183,7 @@ module TwoFactorAuthenticatable
   end
 
   def display_phone_to_deliver_to
-    if context == 'authentication'
+    if authentication_context?
       decorated_user.masked_two_factor_phone_number
     else
       user_session[:unconfirmed_phone]

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -6,7 +6,7 @@ class ReauthnRequiredController < ApplicationController
     return unless user_signed_in?
     return if recently_authenticated?
     store_location_for(:user, request.url)
-    user_session[:context] = 'authentication'
+    user_session[:context] = 'reauthentication'
     redirect_to user_password_confirm_url
   end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -58,7 +58,7 @@ module Users
     end
 
     def phone_to_deliver_to
-      return current_user.phone if context == 'authentication'
+      return current_user.phone if authentication_context?
 
       user_session[:unconfirmed_phone]
     end

--- a/spec/controllers/reauthn_required_controller_spec.rb
+++ b/spec/controllers/reauthn_required_controller_spec.rb
@@ -39,7 +39,7 @@ describe ReauthnRequiredController do
       it 'sets context to authentication' do
         get :show
 
-        expect(controller.user_session[:context]).to eq 'authentication'
+        expect(controller.user_session[:context]).to eq 'reauthentication'
       end
     end
   end


### PR DESCRIPTION
**Why**: It would be broken functionality otherwise.

**How**: Define a new context called `reauthentication` in the change
factor flow because `TwoFactorAuthenticable#check_already_authenticated`
should only be called in the initial authentication context.