### PR TITLE
Use client_id + client_secret for OpenID Connect

### DIFF
--- a/app/controllers/openid_connect/configuration_controller.rb
+++ b/app/controllers/openid_connect/configuration_controller.rb
@@ -26,7 +26,7 @@ module OpenidConnect
     def crypto_configuration
       {
         id_token_signing_alg_values_supported: %w(RS256),
-        token_endpoint_auth_methods_supported: %w(private_key_jwt),
+        token_endpoint_auth_methods_supported: %w(client_secret_post),
         token_endpoint_auth_signing_alg_values_supported: %w(RS256)
       }
     end

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -41,6 +41,7 @@ test:
   'urn:gov:gsa:openidconnect:test':
     redirect_uri: 'gov.gsa.openidconnect.test://result'
     cert: 'saml_test_sp'
+    client_secret: '158bec72671f0c6ca0c00d155a379b4a'
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':
@@ -102,6 +103,7 @@ development:
   'urn:gov:gsa:openidconnect:development':
     redirect_uri: 'gov.gsa.openidconnect.development://result'
     cert: 'saml_test_sp'
+    client_secret: '61ba81524248cba6e4ba0e9038547d84'
 
 production:
   'https://idp.dev.login.gov':

--- a/spec/controllers/openid_connect/configuration_controller_spec.rb
+++ b/spec/controllers/openid_connect/configuration_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OpenidConnect::ConfigurationController do
         expect(json_response[:acr_values_supported]).to match_array(expected_loa)
         expect(json_response[:subject_types_supported]).to eq(%w(pairwise))
         expect(json_response[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
-        expect(json_response[:token_endpoint_auth_methods_supported]).to eq(%w(private_key_jwt))
+        expect(json_response[:token_endpoint_auth_methods_supported]).to eq(%w(client_secret_post))
         expect(json_response[:token_endpoint_auth_signing_alg_values_supported]).to eq(%w(RS256))
       end
     end

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -8,27 +8,16 @@ RSpec.describe OpenidConnect::TokenController do
       post :create,
            grant_type: grant_type,
            code: code,
-           client_assertion_type: OpenidConnectTokenForm::CLIENT_ASSERTION_TYPE,
-           client_assertion: client_assertion
+           client_id: client_id,
+           client_secret: service_provider.metadata[:client_secret],
+           redirect_url: service_provider.metadata[:redirect_url]
     end
 
     let(:user) { create(:user) }
     let(:grant_type) { 'authorization_code' }
     let(:code) { SecureRandom.hex }
     let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
-    let(:client_assertion) do
-      jwt_payload = {
-        iss: client_id,
-        sub: client_id,
-        aud: openid_connect_token_url,
-        jti: SecureRandom.hex,
-        exp: 5.minutes.from_now.to_i
-      }
-
-      client_private_key = OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read)
-
-      JWT.encode(jwt_payload, client_private_key, 'RS256')
-    end
+    let(:service_provider) { ServiceProvider.new(client_id) }
 
     before do
       IdentityLinker.new(user, client_id).link_identity(session_uuid: code, ial: 1)


### PR DESCRIPTION
**Why**: It's simpler

--

We may not want to go down this route (instead of the JWT options), but I used it for prototyping with the AppAuth client library so I'm posting it as a WIP