### PR TITLE
Catch error when recovery code cannot decrypt PII

### DIFF
--- a/app/forms/reactivate_profile_form.rb
+++ b/app/forms/reactivate_profile_form.rb
@@ -55,7 +55,7 @@ class ReactivateProfileForm
   end
 
   def validate_recovery_code
-    return if recovery_code.blank? || valid_recovery_code?
+    return if recovery_code.blank? || (valid_recovery_code? && recovery_code_decrypts?)
     errors.add :recovery_code, :recovery_code_incorrect
   end
 
@@ -66,6 +66,12 @@ class ReactivateProfileForm
 
   def valid_password?
     user.valid_password?(password)
+  end
+
+  def recovery_code_decrypts?
+    decrypted_pii.present?
+  rescue Pii::EncryptionError => _err
+    false
   end
 
   def valid_recovery_code?

--- a/app/views/partials/personal_key/_key.slim
+++ b/app/views/partials/personal_key/_key.slim
@@ -7,7 +7,7 @@
     = t('users.recovery_code.header')
   .navy.monospace
     - code.split(' ').each do |word|
-      p.bold.mb0.h3
+      p.bold.mb0.h3 data-recovery='word'
         = word
 
   .left.h5.mt2

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -85,6 +85,7 @@ h2.h3.my0
           = link_to authenticator_start_url, class: btn_cls do
             span.hide = t('.authentication_app')
             = t('forms.buttons.enable')
+- unless @has_password_reset_profile
   .py-12p.border-top.border-bottom
     .clearfix.mxn1
       .sm-col.sm-col-10.px1 =  t('profile.items.recovery_code')

--- a/spec/forms/reactivate_profile_form_spec.rb
+++ b/spec/forms/reactivate_profile_form_spec.rb
@@ -16,10 +16,12 @@ describe ReactivateProfileForm do
     let(:recovery_code) { '123' }
     let(:valid_recovery_code?) { true }
     let(:valid_password?) { true }
+    let(:recovery_code_decrypts?) { true }
 
     before do
       allow(form).to receive(:valid_password?).and_return(valid_password?)
       allow(form).to receive(:valid_recovery_code?).and_return(valid_recovery_code?)
+      allow(form).to receive(:recovery_code_decrypts?).and_return(recovery_code_decrypts?)
     end
 
     context 'when required attributes are not present' do

--- a/spec/views/profile/index.html.slim_spec.rb
+++ b/spec/views/profile/index.html.slim_spec.rb
@@ -42,15 +42,39 @@ describe 'profile/index.html.slim' do
     end
   end
 
-  it 'contains a recovery code section' do
-    user = User.new
-    allow(view).to receive(:current_user).and_return(user)
+  context 'when has_password_reset_profile is false' do
+    before do
+      assign(:has_password_reset_profile, false)
+    end
 
-    render
+    it 'contains a recovery code section' do
+      user = User.new
+      allow(view).to receive(:current_user).and_return(user)
 
-    expect(rendered).to have_content t('profile.items.recovery_code')
-    expect(rendered).
-      to have_link(t('profile.links.regenerate_recovery_code'), href: manage_recovery_code_path)
+      render
+
+      expect(rendered).to have_content t('profile.items.recovery_code')
+      expect(rendered).
+        to have_link(t('profile.links.regenerate_recovery_code'), href: manage_recovery_code_path)
+    end
+  end
+
+  context 'when has_password_reset_profile is true' do
+    before do
+      assign(:has_password_reset_profile, true)
+    end
+
+    it 'lacks a recovery code section' do
+      user = User.new
+      allow(view).to receive(:current_user).and_return(user)
+
+      render
+
+      expect(rendered).to_not have_content t('profile.items.recovery_code')
+      expect(rendered).to_not have_link(
+        t('profile.links.regenerate_recovery_code'), href: manage_recovery_code_path
+      )
+    end
   end
 
   it 'contains account history' do


### PR DESCRIPTION
**Why**: Generating a new recovery code will render the de-activated
profile useless.

**How**: Catch the exception thrown when a valid recovery
code cannot be used to decrypt the PII, and prevent users from
unintentionally creating a new recovery code when they have a
de-activated profile.

TODO: Some messaging needed to allow the user to definitively say "No, I don't have my recovery code and I'm sorry but I'll need to re-verify my account."

<img width="653" alt="screen shot 2017-01-26 at 4 23 54 pm" src="https://cloud.githubusercontent.com/assets/1205061/22353393/c58c6988-e3e5-11e6-9a45-3597debb7a4e.png">
