### PR TITLE
Make sure active profiles are verified

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ActiveRecord::Base
   end
 
   def active_profile
-    profiles.find(&:active?)
+    @_active_profile ||= profiles.verified.find(&:active?)
   end
 
   # This user's most recently activated profile that has also been deactivated

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -69,6 +69,7 @@ namespace :dev do
             ssn: "666-#{num_created}" # doesn't need to be legit 9 digits, just unique
           )
           recovery_code = profile.encrypt_pii(user.user_access_key, pii)
+          profile.verified_at = Time.zone.now
           profile.activate
 
           Rails.logger.warn "email=#{email_addr} recovery_code=#{recovery_code}"

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -12,7 +12,7 @@ describe VerifyController do
     end
 
     it 'does not track page visit if profile is active' do
-      profile = create(:profile, :active)
+      profile = create(:profile, :active, :verified)
 
       stub_sign_in(profile.user)
       stub_analytics
@@ -26,7 +26,7 @@ describe VerifyController do
   describe '#activated' do
     context 'user has an active profile' do
       it 'allows direct access' do
-        profile = create(:profile, :active)
+        profile = create(:profile, :active, :verified)
 
         stub_sign_in(profile.user)
 
@@ -50,7 +50,7 @@ describe VerifyController do
   describe '#cancel' do
     context 'user has an active profile' do
       it 'does not allow direct access and redirects to activated url' do
-        profile = create(:profile, :active)
+        profile = create(:profile, :active, :verified)
 
         stub_sign_in(profile.user)
 
@@ -74,7 +74,7 @@ describe VerifyController do
   describe '#fail' do
     context 'user has an active profile' do
       it 'does not allow direct access and redirects to activated url' do
-        profile = create(:profile, :active)
+        profile = create(:profile, :active, :verified)
 
         stub_sign_in(profile.user)
 
@@ -112,7 +112,7 @@ describe VerifyController do
   describe '#retry' do
     context 'user has an active profile' do
       it 'does not allow direct access and redirects to activated url' do
-        profile = create(:profile, :active)
+        profile = create(:profile, :active, :verified)
 
         stub_sign_in(profile.user)
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -154,7 +154,7 @@ describe UserDecorator do
       end
 
       context 'with a verified account' do
-        let(:user) { build(:user, profiles: [verified_profile]) }
+        let(:user) { create(:user, profiles: [verified_profile]) }
 
         it { expect(partial).to eq('profile/verified_account_badge') }
       end
@@ -170,7 +170,7 @@ describe UserDecorator do
       end
 
       context 'with a verified account' do
-        let(:user) { build(:user, profiles: [verified_profile]) }
+        let(:user) { create(:user, profiles: [verified_profile]) }
 
         it { expect(partial).to eq('shared/null') }
       end


### PR DESCRIPTION
**Why**: We expect active_profile.verified_at to not be nil

--

I hit a bug with a nil verified_at in development, it turns out we expect this to always be set for active profiles, so I updated our code to match that assumption and fixed a few tests.