### PR TITLE
Adds int environment entries to service_providers.yml

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -168,6 +168,19 @@ production:
     attribute_bundle:
       - email
 
+  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-int':
+    acs_url: 'https://sp.int.login.gov/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://sp.int.login.gov/auth/saml/logout'
+    sp_initiated_login_url: 'https://sp.int.login.gov/login'
+    block_encryption: 'aes256-cbc'
+    cert: 'sp_rails_demo'
+    agency: 'A Gov Agency'
+    friendly_name: 'Demo SP Application'
+    logo: 'generic.svg'
+    return_to_sp_url: 'https://sp.int.login.gov'
+    attribute_bundle:
+      - email
+
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo':
     acs_url: 'https://sp.demo.login.gov/auth/saml/callback'
     assertion_consumer_logout_service_url: 'https://sp.demo.login.gov/auth/saml/logout'

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -231,6 +231,15 @@ production:
     attribute_bundle:
       - email
 
+  'https://dashboard.int.login.gov':
+    acs_url: 'https://dashboard.int.login.gov/users/auth/saml/callback'
+    assertion_consumer_logout_service_url: 'https://dashboard.int.login.gov/users/auth/saml/logout'
+    sp_initiated_login_url: 'https://dashboard.int.login.gov/users/auth/saml'
+    block_encryption: 'aes256-cbc'
+    cert: 'identity_dashboard_cert'
+    attribute_bundle:
+      - email
+
   'https://dashboard.qa.login.gov':
     acs_url: 'https://dashboard.qa.login.gov/users/auth/saml/callback'
     assertion_consumer_logout_service_url: 'https://dashboard.qa.login.gov/users/auth/saml/logout'


### PR DESCRIPTION
### Why
Because we don't have entries  for `int`

### How
Adds entries to service_providers.yml for `int`