### PR TITLE
Set id_token JWTs to expire along with session

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -34,8 +34,7 @@ class OpenidConnectUserInfoPresenter
   def loa3_data
     @loa3_data ||= begin
       if loa3_session?
-        session = session_store.send(:load_session_from_redis, identity.session_uuid) || {}
-        Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+        Pii::SessionStore.new(identity.session_uuid).load
       else
         Pii::Attributes.new_from_hash({})
       end

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -3,8 +3,9 @@ class IdTokenBuilder
 
   attr_reader :identity
 
-  def initialize(identity)
+  def initialize(identity, custom_expiration: nil)
     @identity = identity
+    @custom_expiration = custom_expiration
   end
 
   def id_token
@@ -25,8 +26,7 @@ class IdTokenBuilder
   def id_token_timestamp_values
     now = Time.zone.now.to_i
     {
-      # TODO: match expiration to Rails session expiration
-      exp: (now + 10.minutes.to_i),
+      exp: @custom_expiration || expires,
       iat: now,
       nbf: now
     }
@@ -42,5 +42,10 @@ class IdTokenBuilder
     else
       raise "Unknown ial #{ial}"
     end
+  end
+
+  def expires
+    ttl = Pii::SessionStore.new(identity.session_uuid).ttl
+    Time.zone.now.to_i + ttl
   end
 end

--- a/app/services/pii/session_store.rb
+++ b/app/services/pii/session_store.rb
@@ -1,0 +1,45 @@
+# Provides a way to access already-decrypted and cached PII from the redis
+# in an out-of-band fashion (using only the session UUID) instead of having access
+# to the user_session from Devise/Warden
+# Should only be used outside of a normal browser session (such as the OpenID Connect API)
+# See Pii::Cacher for accessing PII inside of a normal browser session
+module Pii
+  class SessionStore
+    attr_reader :session_uuid
+
+    def initialize(session_uuid)
+      @session_uuid = session_uuid
+    end
+
+    def ttl
+      uuid = session_uuid
+      session_store.instance_eval { redis.ttl(prefixed(uuid)) }
+    end
+
+    def load
+      session = session_store.send(:load_session_from_redis, session_uuid) || {}
+      Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+    end
+
+    # @api private
+    # Only used for convenience in tests
+    # @param [Pii::Attributes] pii
+    def put(pii, expiration = 5.minutes)
+      session_data = {
+        'warden.user.user.session' => {
+          decrypted_pii: pii.to_h.to_json
+        }
+      }
+
+      session_store.
+        send(:set_session, {}, session_uuid, session_data, expire_after: expiration.to_i)
+    end
+
+    private
+
+    def session_store
+      config = Rails.application.config
+      config.session_store.new({}, config.session_options)
+    end
+  end
+end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe OpenidConnectTokenForm do
     subject(:response) { form.response }
 
     context 'with valid params' do
+      before do
+        Pii::SessionStore.new(code).put({}, 5.minutes.to_i)
+      end
+
       it 'has a properly-encoded id_token' do
         id_token = response[:id_token]
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -21,23 +21,18 @@ RSpec.describe OpenidConnectUserInfoPresenter do
     end
 
     context 'when there is decrypted loa3 session data in redis' do
-      let(:session_data) do
+      let(:pii) do
         {
-          'warden.user.user.session' => {
-            decrypted_pii: {
-              first_name: 'John',
-              middle_name: 'Jones',
-              last_name: 'Smith',
-              dob: '1970-01-01',
-              zipcode: '12345'
-            }.to_json
-          }
+          first_name: 'John',
+          middle_name: 'Jones',
+          last_name: 'Smith',
+          dob: '1970-01-01',
+          zipcode: '12345'
         }
       end
 
       before do
-        presenter.send(:session_store).
-          send(:set_session, {}, session_uuid, session_data, expire_after: 5.minutes.to_i)
+        Pii::SessionStore.new(session_uuid).put(pii, 5.minutes.to_i)
       end
 
       context 'when the identity has loa3 access' do

--- a/spec/services/id_token_verifier_spec.rb
+++ b/spec/services/id_token_verifier_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe IdTokenVerifier do
   describe '#identity' do
     context 'with a valid id_token' do
       before { identity.save! }
-      let(:id_token) { IdTokenBuilder.new(identity).id_token }
+      let(:id_token) do
+        IdTokenBuilder.new(identity, custom_expiration: 10.minutes.from_now.to_i).id_token
+      end
 
       it 'returns the identity record' do
         expect(verifier.identity).to eq(identity)

--- a/spec/services/pii/session_store_spec.rb
+++ b/spec/services/pii/session_store_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Pii::SessionStore do
+  let(:session_uuid) { SecureRandom.uuid }
+
+  subject(:store) { Pii::SessionStore.new(session_uuid) }
+
+  describe '#ttl' do
+    it 'returns the remaining time-to-live of the session data in redis' do
+      store.put({ dob: '1970-01-01' }, 5.minutes.to_i)
+
+      expect(store.ttl).to eq(5.minutes.to_i)
+    end
+  end
+
+  describe '#load' do
+    it 'loads PII from the session' do
+      store.put({ dob: '1970-01-01' }, 5.minutes.to_i)
+
+      pii = store.load
+      expect(pii).to be_kind_of(Pii::Attributes)
+      expect(pii.dob).to eq('1970-01-01')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To prevent stale id_tokens from trying to access PII