### PR TITLE
Remove unused "bypass_2fa" code

### DIFF
--- a/.reek
+++ b/.reek
@@ -16,6 +16,7 @@ FeatureEnvy:
     - reauthn?
     - mark_profile_inactive
     - EncryptedSidekiqRedis#zrem
+    - UserDecorator#should_acknowledge_recovery_code?
 IrresponsibleModule:
   enabled: false
 ManualDispatch:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,7 @@ class ApplicationController < ActionController::Base
   def confirm_two_factor_authenticated
     authenticate_user!(force: true)
 
-    return if decorated_user.may_bypass_2fa?(session) || user_fully_authenticated?
+    return if user_fully_authenticated?
 
     return prompt_to_set_up_2fa unless current_user.two_factor_enabled?
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -27,10 +27,6 @@ UserDecorator = Struct.new(:user) do
     )
   end
 
-  def may_bypass_2fa?(session = {})
-    omniauthed?(session)
-  end
-
   def masked_two_factor_phone_number
     masked_number(user.phone)
   end
@@ -69,7 +65,6 @@ UserDecorator = Struct.new(:user) do
     sp_session = session[:sp]
 
     user.recovery_code.blank? &&
-      !omniauthed?(session) &&
       (sp_session.blank? || sp_session[:loa3] == false)
   end
 
@@ -96,12 +91,6 @@ UserDecorator = Struct.new(:user) do
   end
 
   private
-
-  def omniauthed?(session)
-    return false if session[:omniauthed] != true
-
-    session.delete(:omniauthed)
-  end
 
   def masked_number(number)
     "***-***-#{number[-4..-1]}"

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -64,8 +64,7 @@ UserDecorator = Struct.new(:user) do
   def should_acknowledge_recovery_code?(session)
     sp_session = session[:sp]
 
-    user.recovery_code.blank? &&
-      (sp_session.blank? || sp_session[:loa3] == false)
+    user.recovery_code.blank? && (sp_session.blank? || sp_session[:loa3] == false)
   end
 
   def recent_events

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -46,7 +46,7 @@ describe ApplicationController do
       end
     end
 
-    context 'when the user is not signed in' do
+    context 'not signed in' do
       it 'redirects to sign in page' do
         get :index
 
@@ -54,51 +54,10 @@ describe ApplicationController do
       end
     end
 
-    context 'when the user may bypass 2FA' do
-      it 'returns nil' do
-        sign_in_as_user
-
-        user_decorator = instance_double(UserDecorator)
-
-        allow(UserDecorator).to receive(:new).with(subject.current_user).
-          and_return(user_decorator)
-        allow(user_decorator).to receive(:may_bypass_2fa?).
-          and_return(true)
-
-        get :index
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-
-    context 'when the user may not bypass 2FA and is already two-factor authenticated' do
-      it 'returns nil' do
-        sign_in_as_user
-
-        user_decorator = instance_double(UserDecorator)
-
-        allow(UserDecorator).to receive(:new).with(subject.current_user).
-          and_return(user_decorator)
-        allow(user_decorator).to receive(:may_bypass_2fa?).
-          and_return(false)
-
-        get :index
-
-        expect(response.body).to eq 'Hello'
-      end
-    end
-
-    context 'when the user may not bypass 2FA and is not 2FA-enabled' do
+    context 'is not 2FA-enabled' do
       it 'redirects to phone_setup_url with a flash message' do
         user = create(:user)
         sign_in user
-
-        user_decorator = instance_double(UserDecorator)
-
-        allow(UserDecorator).to receive(:new).with(subject.current_user).
-          and_return(user_decorator)
-        allow(user_decorator).to receive(:may_bypass_2fa?).
-          and_return(false)
 
         get :index
 
@@ -106,16 +65,9 @@ describe ApplicationController do
       end
     end
 
-    context 'when the user may not bypass 2FA and is 2FA-enabled' do
+    context 'is 2FA-enabled' do
       it 'prompts user to enter their OTP' do
         sign_in_before_2fa
-
-        user_decorator = instance_double(UserDecorator)
-
-        allow(UserDecorator).to receive(:new).with(subject.current_user).
-          and_return(user_decorator)
-        allow(user_decorator).to receive(:may_bypass_2fa?).
-          and_return(false)
 
         get :index
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -47,25 +47,6 @@ describe UserDecorator do
     end
   end
 
-  describe '#may_bypass_2fa?' do
-    it 'returns true when the user is omniauthed' do
-      user = instance_double(User)
-      allow(user).to receive(:two_factor_enabled?).and_return(true)
-
-      user_decorator = UserDecorator.new(user)
-      session = { omniauthed: true }
-
-      expect(user_decorator.may_bypass_2fa?(session)).to eq true
-    end
-
-    it 'returns false when the user is not omniauthed' do
-      user = instance_double(User)
-      user_decorator = UserDecorator.new(user)
-
-      expect(user_decorator.may_bypass_2fa?).to eq false
-    end
-  end
-
   describe '#active_identity_for' do
     it 'returns Identity matching ServiceProvider' do
       sp = ServiceProvider.new('http://sp.example.com')
@@ -83,11 +64,11 @@ describe UserDecorator do
   end
 
   describe '#should_acknowledge_recovery_code?' do
-    context 'user has no recovery code and is not omniauthed' do
+    context 'user has no recovery code' do
       context 'service provider with loa1' do
         it 'returns true' do
           user_decorator = UserDecorator.new(User.new)
-          session = { omniauthed: false, sp: { loa3: false } }
+          session = { sp: { loa3: false } }
 
           expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
         end
@@ -96,7 +77,7 @@ describe UserDecorator do
       context 'no service provider' do
         it 'returns true' do
           user_decorator = UserDecorator.new(User.new)
-          session = { omniauthed: false }
+          session = {}
 
           expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq true
         end
@@ -109,16 +90,9 @@ describe UserDecorator do
         expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
       end
 
-      it 'returns false when the user is omniauthed' do
-        user_decorator = UserDecorator.new(User.new)
-        session = { omniauthed: true }
-
-        expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
-      end
-
       it 'returns false if the user is loa3' do
         user_decorator = UserDecorator.new(User.new)
-        session = { omniauthed: false, sp: { loa3: true } }
+        session = { sp: { loa3: true } }
 
         expect(user_decorator.should_acknowledge_recovery_code?(session)).to eq false
       end


### PR DESCRIPTION
**Why**: At some point in the past, there was a feature related to
bypassing 2fa for certain users, but we no longer want to support that
feature.