### PR TITLE
Specify cert for example client in development

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -101,6 +101,7 @@ development:
 
   'urn:gov:gsa:openidconnect:development':
     redirect_uri: 'gov.gsa.openidconnect.development://result'
+    cert: 'saml_test_sp'
 
 production:
   'https://idp.dev.login.gov':


### PR DESCRIPTION
**Why**: OpenID Connect 1.0 Example iOS client