### PR TITLE
Add Previous Address to IdV profile form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,11 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: 4d0d90c06c102361d310e02edba8a64e4d25cc39
+  revision: 2b84e0ff1dc920b4a694dffbc43222acc25b3eff
   branch: master
   specs:
     proofer (1.0.0)
-      dotenv
 
 GIT
   remote: https://github.com/18F/saml_idp.git
@@ -221,7 +220,7 @@ GEM
       rails (>= 3.1.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    dotenv (2.1.2)
+    dotenv (2.2.0)
     dotiw (3.1.1)
       actionpack (>= 3)
       i18n

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -56,9 +56,7 @@ module Verify
     end
 
     def profile_params
-      params.require(:profile).permit(
-        :first_name, :last_name, :dob, :ssn, :address1, :address2, :city, :state, :zipcode
-      )
+      params.require(:profile).permit(*Pii::Attributes.members)
     end
   end
 end

--- a/app/controllers/verify/step_controller.rb
+++ b/app/controllers/verify/step_controller.rb
@@ -5,7 +5,6 @@ module Verify
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_needed
     before_action :confirm_idv_session_started
-    before_action :confirm_idv_attempts_allowed
 
     helper_method :step
 

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -2,7 +2,8 @@ module Pii
   Attributes = Struct.new(
     :first_name, :middle_name, :last_name,
     :address1, :address2, :city, :state, :zipcode,
-    :ssn, :dob, :phone
+    :ssn, :dob, :phone,
+    :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
   ) do
     def self.new_from_hash(hash)
       attrs = new

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -26,6 +26,21 @@ h1.h3.my0 = t('idv.titles.session.basic')
           pattern: '(\d{5}([\-]\d{4})?)',
           input_html: { class: 'zipcode', value: idv_profile_form.zipcode }
   .mb4
+    .mb3.pb-tiny.border-bottom.border-teal = t('profile.index.previous_address')
+    = f.input :prev_address1, label: t('idv.form.address1')
+    = f.input :prev_address2, label: t('idv.form.address2')
+    = f.input :prev_city, label: t('idv.form.city')
+    .clearfix.mxn1
+      .sm-col.sm-col-6.px1
+        = f.input :prev_state, collection: us_states_territories,
+          label: t('idv.form.state')
+      .sm-col.sm-col-4.px1
+        / using :tel for mobile numeric keypad
+        = f.input :prev_zipcode, as: :tel,
+          label: t('idv.form.zipcode'),
+          pattern: '(\d{5}([\-]\d{4})?)',
+          input_html: { class: 'zipcode', value: idv_profile_form.prev_zipcode }
+  .mb4
     .mt0.mb3.pb-tiny.border-bottom.border-teal = t('idv.form.personal_details')
     / using :tel for mobile numeric keypad
     = f.input :dob, as: :tel,

--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -9,6 +9,7 @@ en:
       full_name: Full name
       password: Password
       phone: Phone number
+      previous_address: Previous address
       reactivation:
         instructions: Your profile was recently deactivated due to a password reset, reactivate your profile to get your awesome PII back.
         reactivate_button: Reactivate your profile

--- a/config/locales/profile/es.yml
+++ b/config/locales/profile/es.yml
@@ -9,6 +9,7 @@ es:
       full_name: NOT TRANSLATED YET
       password: NOT TRANSLATED YET
       phone: NOT TRANSLATED YET
+      previous_address: NOT TRANSLATED YET
       reactivation:
         instructions: NOT TRANSLATED YET
         reactivate_button: NOT TRANSLATED YET

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -8,8 +8,7 @@ describe Verify::FinanceController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started,
-        :confirm_idv_attempts_allowed
+        :confirm_idv_session_started
       )
     end
   end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -11,8 +11,7 @@ describe Verify::PhoneController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started,
-        :confirm_idv_attempts_allowed
+        :confirm_idv_session_started
       )
     end
   end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -38,8 +38,7 @@ describe Verify::ReviewController do
         :before,
         :confirm_two_factor_authenticated,
         :confirm_idv_session_started,
-        :confirm_idv_steps_complete,
-        :confirm_idv_attempts_allowed
+        :confirm_idv_steps_complete
       )
     end
   end

--- a/spec/features/idv/previous_address_spec.rb
+++ b/spec/features/idv/previous_address_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+feature 'IdV with previous address filled in' do
+  include IdvHelper
+
+  let(:bad_zipcode) { '00000' }
+  let(:current_address) { '123 Main St' }
+  let(:previous_address) { '456 Other Ave' }
+
+  def expect_to_stay_on_verify_session_page
+    expect(current_path).to eq verify_session_path
+    expect(page).to have_selector("input[value='#{bad_zipcode}']")
+  end
+
+  def expect_bad_previous_address_to_fail
+    fill_out_idv_form_ok
+    fill_out_idv_previous_address_fail
+    click_idv_continue
+
+    expect_to_stay_on_verify_session_page
+  end
+
+  def expect_bad_current_address_to_fail
+    fill_out_idv_previous_address_ok
+    fill_out_idv_form_fail
+    click_idv_continue
+
+    expect_to_stay_on_verify_session_page
+  end
+
+  def expect_current_address_in_profile(user)
+    fill_out_idv_form_ok
+    fill_out_idv_previous_address_ok
+    click_idv_continue
+
+    expect(current_path).to eq verify_finance_path
+
+    fill_out_financial_form_ok
+    click_idv_continue
+
+    fill_out_phone_form_ok(user.phone)
+    click_idv_continue
+
+    expect(current_path).to eq verify_review_path
+    expect(page).to have_content(current_address)
+    expect(page).to_not have_content(previous_address)
+  end
+
+  it 'fails when either address has bad value, prefers current address in profile' do
+    user = sign_in_and_2fa_user
+    visit verify_session_path
+
+    expect_bad_previous_address_to_fail
+    expect_bad_current_address_to_fail
+    expect_current_address_in_profile(user)
+  end
+end

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -94,6 +94,40 @@ describe Idv::ProfileStep do
       expect(idv_session.profile_confirmation).to eq false
     end
 
+    it 'fails with invalid ZIP code on current address' do
+      step = build_step(user_attrs.merge(zipcode: '00000'))
+
+      errors = { zipcode: ['Unverified ZIP code.'] }
+
+      result = instance_double(FormResponse)
+      extra = {
+        idv_attempts_exceeded: false,
+        vendor: { reasons: ['The ZIP code was suspicious'] }
+      }
+
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+      expect(step.submit).to eq result
+      expect(idv_session.profile_confirmation).to eq false
+    end
+
+    it 'fails with invalid ZIP code on previous address' do
+      step = build_step(user_attrs.merge(prev_zipcode: '00000'))
+
+      errors = { zipcode: ['Unverified ZIP code.'] }
+
+      result = instance_double(FormResponse)
+      extra = {
+        idv_attempts_exceeded: false,
+        vendor: { reasons: ['The ZIP code was suspicious'] }
+      }
+
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+      expect(step.submit).to eq result
+      expect(idv_session.profile_confirmation).to eq false
+    end
+
     it 'increments attempts count if the form is valid' do
       step = build_step(user_attrs)
       expect { step.submit }.to change(user, :idv_attempts).by(1)

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -18,7 +18,21 @@ module IdvHelper
     fill_in 'profile_address1', with: '123 Main St'
     fill_in 'profile_city', with: 'Nowhere'
     select 'Kansas', from: 'profile_state'
-    fill_in 'profile_zipcode', with: '66044'
+    fill_in 'profile_zipcode', with: '00000'
+  end
+
+  def fill_out_idv_previous_address_ok
+    fill_in 'profile_prev_address1', with: '456 Other Ave'
+    fill_in 'profile_prev_city', with: 'Elsewhere'
+    select 'Missouri', from: 'profile_prev_state'
+    fill_in 'profile_prev_zipcode', with: '12345'
+  end
+
+  def fill_out_idv_previous_address_fail
+    fill_in 'profile_prev_address1', with: '456 Other Ave'
+    fill_in 'profile_prev_city', with: 'Elsewhere'
+    select 'Missouri', from: 'profile_prev_state'
+    fill_in 'profile_prev_zipcode', with: '00000'
   end
 
   def fill_out_financial_form_ok


### PR DESCRIPTION
**Why**: Give users who recently moved more opportunities for
successful profile resolution.

**How**: Added fields to form (currently all visible)
and logic to (a) send previous address to proofing vendor and (b)
store current address on profile on success.