### PR TITLE
Remember last used OTP delivery method

### DIFF
--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -13,7 +13,7 @@ module PhoneConfirmation
 
   def prompt_to_choose_delivery_method
     phone_number = user_session[:unconfirmed_phone]
-    @otp_delivery_selection_form = OtpDeliverySelectionForm.new
+    @otp_delivery_selection_form = OtpDeliverySelectionForm.new(current_user)
 
     @presenter = TwoFactorAuthCode::OtpDeliveryPresenter.new(
       reenter_phone_number_path: manage_phone_path,

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -5,11 +5,20 @@ class OtpDeliverySelectionForm
 
   validates :otp_method, inclusion: { in: %w(sms voice) }
 
+  def initialize(user)
+    @user = user
+  end
+
   def submit(params)
     self.otp_method = params[:otp_method]
     self.resend = params[:resend]
 
     @success = valid?
+
+    if success && otp_delivery_preference_changed?
+      user_attributes = { otp_delivery_preference: otp_method }
+      UpdateUser.new(user: user, attributes: user_attributes).call
+    end
 
     result
   end
@@ -18,7 +27,11 @@ class OtpDeliverySelectionForm
 
   attr_writer :otp_method
   attr_accessor :resend
-  attr_reader :success
+  attr_reader :success, :user
+
+  def otp_delivery_preference_changed?
+    otp_method != user.otp_delivery_preference
+  end
 
   def result
     {

--- a/app/forms/two_factor_setup_form.rb
+++ b/app/forms/two_factor_setup_form.rb
@@ -16,12 +16,21 @@ class TwoFactorSetupForm
 
     @success = valid?
 
+    if success && otp_delivery_preference_changed?
+      user_attributes = { otp_delivery_preference: otp_method }
+      UpdateUser.new(user: user, attributes: user_attributes).call
+    end
+
     result
   end
 
   private
 
-  attr_reader :success
+  attr_reader :success, :user
+
+  def otp_delivery_preference_changed?
+    otp_method != user.otp_delivery_preference
+  end
 
   def result
     {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ActiveRecord::Base
   include UserEncryptedAttributeOverrides
 
   enum role: { user: 0, tech: 1, admin: 2 }
+  enum otp_delivery_preference: { sms: 0, voice: 1 }
 
   has_one_time_password
 

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -1,0 +1,14 @@
+class UpdateUser
+  def initialize(user:, attributes:)
+    @user = user
+    @attributes = attributes
+  end
+
+  def call
+    user.update!(attributes)
+  end
+
+  private
+
+  attr_reader :user, :attributes
+end

--- a/db/migrate/20170131172556_add_otp_delivery_preference_to_user.rb
+++ b/db/migrate/20170131172556_add_otp_delivery_preference_to_user.rb
@@ -1,0 +1,5 @@
+class AddOtpDeliveryPreferenceToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :otp_delivery_preference, :integer, default: 0, index: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20170201154458) do
     t.text     "encrypted_email",                           default: "", null: false
     t.string   "attribute_cost"
     t.text     "encrypted_phone"
+    t.integer  "otp_delivery_preference",                   default: 0,  null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -39,7 +39,7 @@ feature 'Accessibility on pages that require authentication', :js do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq(user_two_factor_authentication_path)
+      expect(current_path).to eq(login_two_factor_path(delivery_method: 'sms'))
       expect(page).to be_accessible
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -19,7 +19,7 @@ feature 'saml api' do
         sign_in_before_2fa(user)
         visit authnrequest_get
 
-        expect(current_path).to eq(user_two_factor_authentication_path)
+        expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
       end
     end
 
@@ -132,7 +132,7 @@ feature 'saml api' do
       sign_in_before_2fa(user)
       visit '/test/saml'
 
-      expect(current_path).to eq(user_two_factor_authentication_path)
+      expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
     end
 
     it 'adds acs_url domain names for current Rails env to CSP form_action' do

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -55,7 +55,7 @@ feature 'Changing authentication factor' do
       old_phone = user.phone
       visit manage_phone_path
       update_phone_number
-      choose_sms_delivery
+      submit_otp
 
       Timecop.travel(Figaro.env.reauthn_window.to_i + 1) do
         click_link t('forms.two_factor.try_again'), href: manage_phone_path
@@ -144,10 +144,6 @@ feature 'Changing authentication factor' do
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_button t('forms.buttons.continue')
 
-    expect(current_path).to eq user_two_factor_authentication_path
-
-    click_submit_default
-
     expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
   end
 
@@ -168,6 +164,10 @@ feature 'Changing authentication factor' do
     expect(current_path).to eq login_two_factor_authenticator_path
 
     fill_in 'code', with: generate_totp_code(@secret)
+    click_submit_default
+  end
+
+  def submit_otp
     click_submit_default
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -148,7 +148,7 @@ feature 'Sign in' do
         expect(page).to have_content t('errors.invalid_authenticity_token')
 
         fill_in_credentials_and_submit(user.email, user.password)
-        expect(current_path).to eq user_two_factor_authentication_path
+        expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
       end
     end
 

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe UpdateUser do
+  describe '#call' do
+    it 'updates the user with the passed in attributes' do
+      user = build(:user, otp_delivery_preference: 'sms')
+      attributes = { otp_delivery_preference: 'voice' }
+      updater = UpdateUser.new(user: user, attributes: attributes)
+
+      updater.call
+
+      expect(user.otp_delivery_preference).to eq 'voice'
+      expect(user.voice?).to eq true
+    end
+  end
+end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -21,8 +21,8 @@ module ControllerHelper
     sign_in create(:user, :signed_up, :tech_support, password: VALID_PASSWORD)
   end
 
-  def sign_in_before_2fa
-    sign_in_as_user
+  def sign_in_before_2fa(user = create(:user, :signed_up))
+    sign_in_as_user(user)
     controller.current_user.send_new_otp
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -50,6 +50,7 @@ module Features
     end
 
     def sign_in_before_2fa(user = create(:user))
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       login_as(user, scope: :user, run_callbacks: false)
 
       if user.phone.present?
@@ -105,7 +106,6 @@ module Features
     def sign_in_live_with_2fa(user = user_with_2fa)
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)
-      click_submit_default
       click_submit_default
       user
     end

--- a/spec/views/users/two_factor_authentication/show.html.slim_spec.rb
+++ b/spec/views/users/two_factor_authentication/show.html.slim_spec.rb
@@ -6,7 +6,7 @@ describe 'users/two_factor_authentication/show.html.slim' do
     let(:presenter_data) { attributes_for(:generic_otp_presenter) }
 
     before do
-      @otp_delivery_selection_form = OtpDeliverySelectionForm.new
+      @otp_delivery_selection_form = OtpDeliverySelectionForm.new(user)
       allow(view).to receive(:reauthn?).and_return(false)
       allow(view).to receive(:current_user).and_return(user)
 


### PR DESCRIPTION
**Why**: For a better UX so that the user doesn't have to keep
choosing between SMS and Phone call each time.

**How**:
- Add an `enum` field to the Users table to hold the OTP delivery
preference, which defaults to 'sms'.
- During initial 2FA setup (during account creation), if the user
chooses Phone call, their `otp_delivery_preference` gets updated to
'voice'
- When the user signs in, the OTP is automatically sent via their
current `otp_delivery_preference` method. They no longer see the
intermediate screen that asks them to choose SMS or Phone call.
- During sign in, if a user's current setting is 'sms', but they
click on "call me instead", that updates their `otp_delivery_preference`
to 'voice', and vice-versa.

Note that this PR does not update that change factor flow to remove
the intermediate OTP delivery method screen because I wanted to keep
this PR as small as possible. The change factor flow will be addressed
in a separate PR.