### PR TITLE
OpenID Connect scopes specify userinfo attributes

### DIFF
--- a/app/controllers/openid_connect/configuration_controller.rb
+++ b/app/controllers/openid_connect/configuration_controller.rb
@@ -3,12 +3,13 @@ module OpenidConnect
     def index
       render json: {
         jwks_uri: '', # TODO
-        scopes_supported: '', # TODO
+        scopes_supported: OpenidConnectAttributeScoper::VALID_SCOPES,
         response_types_supported: %w(code),
         grant_types_supported: %w(authorization_code),
         acr_values_supported: Saml::Idp::Constants::VALID_AUTHN_CONTEXTS,
         subject_types_supported: %w(pairwise),
-        service_documentation: '' # TODO
+        service_documentation: '', # TODO
+        claims_supported: claims_supported
       }.merge(url_configuration).merge(crypto_configuration)
     end
 
@@ -29,6 +30,10 @@ module OpenidConnect
         token_endpoint_auth_methods_supported: %w(private_key_jwt),
         token_endpoint_auth_signing_alg_values_supported: %w(RS256)
       }
+    end
+
+    def claims_supported
+      %w(iss sub) + OpenidConnectAttributeScoper::CLAIMS
     end
   end
 end

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -1,0 +1,42 @@
+class OpenidConnectAttributeScoper
+  VALID_SCOPES = %w(
+    address
+    email
+    openid
+    phone
+    profile
+  ).freeze
+
+  ATTRIBUTE_SCOPE_MAP = {
+    email: 'email',
+    email_verified: 'email',
+    address: 'address',
+    phone: 'phone',
+    phone_verified: 'phone',
+    given_name: 'profile',
+    family_name: 'profile',
+    middle_name: 'profile',
+    birthdate: 'profile'
+  }.with_indifferent_access.freeze
+
+  CLAIMS = ATTRIBUTE_SCOPE_MAP.keys
+
+  attr_reader :scopes
+
+  def initialize(scope)
+    @scopes = parse_scope(scope)
+  end
+
+  def filter(user_info)
+    user_info.select do |key, _v|
+      !ATTRIBUTE_SCOPE_MAP.key?(key) || scopes.include?(ATTRIBUTE_SCOPE_MAP[key])
+    end
+  end
+
+  private
+
+  def parse_scope(scope)
+    return [] if scope.blank?
+    scope.split(' ').compact & VALID_SCOPES
+  end
+end

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -8,6 +8,7 @@ en:
       errors:
         bad_client_id: Bad client_id
         no_valid_acr_values: No acceptable acr_values found
+        no_valid_scope: No valid scope values found
         redirect_uri_invalid: redirect_uri is invalid
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
     token:

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -8,6 +8,7 @@ es:
       errors:
         bad_client_id: NOT TRANSLATED YET
         no_valid_acr_values: NOT TRANSLATED YET
+        no_valid_scope: NOT TRANSLATED YET
         redirect_uri_invalid: NOT TRANSLATED YET
         redirect_uri_no_match: NOT TRANSLATED YET
     token:

--- a/db/migrate/20170201154458_add_scope_to_identities.rb
+++ b/db/migrate/20170201154458_add_scope_to_identities.rb
@@ -1,0 +1,5 @@
+class AddScopeToIdentities < ActiveRecord::Migration
+  def change
+    add_column :identities, :scope, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170127204804) do
+ActiveRecord::Schema.define(version: 20170201154458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20170127204804) do
     t.string   "nonce"
     t.integer  "ial",                               default: 1
     t.string   "access_token"
+    t.string   "scope"
   end
 
   add_index "identities", ["access_token"], name: "index_identities_on_access_token", unique: true, using: :btree

--- a/spec/controllers/openid_connect/configuration_controller_spec.rb
+++ b/spec/controllers/openid_connect/configuration_controller_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe OpenidConnect::ConfigurationController do
         expect(json_response[:userinfo_endpoint]).to eq(openid_connect_userinfo_url)
         expect(json_response[:response_types_supported]).to eq(%w(code))
         expect(json_response[:grant_types_supported]).to eq(%w(authorization_code))
-        expected_loa = [
-          Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
-        ]
-        expect(json_response[:acr_values_supported]).to match_array(expected_loa)
+        expect(json_response[:acr_values_supported]).
+          to match_array(Saml::Idp::Constants::VALID_AUTHN_CONTEXTS)
         expect(json_response[:subject_types_supported]).to eq(%w(pairwise))
         expect(json_response[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
         expect(json_response[:token_endpoint_auth_methods_supported]).to eq(%w(private_key_jwt))
         expect(json_response[:token_endpoint_auth_signing_alg_values_supported]).to eq(%w(RS256))
+
+        claims = %w(iss sub) + OpenidConnectAttributeScoper::CLAIMS
+        expect(json_response[:claims_supported]).to match_array(claims)
       end
     end
 
@@ -33,7 +33,6 @@ RSpec.describe OpenidConnect::ConfigurationController do
 
       aggregate_failures do
         expect(json_response[:jwks_uri]).to be_present
-        expect(json_response[:scopes_supported]).to be_present
         expect(json_response[:service_documentation]).to be_present
       end
     end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -11,7 +11,7 @@ feature 'OpenID Connect' do
         client_id: client_id,
         response_type: 'code',
         acr_values: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-        scope: 'openid profile',
+        scope: 'openid email',
         redirect_uri: 'gov.gsa.openidconnect.test://result',
         state: state,
         prompt: 'select_account',
@@ -73,6 +73,7 @@ feature 'OpenID Connect' do
 
       userinfo_response = JSON.parse(page.body).with_indifferent_access
       expect(userinfo_response[:sub]).to eq(sub)
+      expect(userinfo_response[:email]).to be_present
     end
   end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -108,6 +108,15 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it { expect(valid?).to eq(false) }
     end
 
+    context 'when scope does not contain valid scopes' do
+      let(:scope) { 'foo bar baz' }
+      it 'has errors' do
+        expect(valid?).to eq(false)
+        expect(form.errors[:scope]).
+          to include(t('openid_connect.authorization.errors.no_valid_scope'))
+      end
+    end
+
     context 'redirect_uri' do
       context 'without a redirect_uri' do
         let(:redirect_uri) { nil }

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -4,7 +4,13 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   include Rails.application.routes.url_helpers
 
   let(:session_uuid) { SecureRandom.uuid }
-  let(:identity) { build(:identity, session_uuid: session_uuid, user: build(:user)) }
+  let(:scope) { 'openid email address phone profile' }
+  let(:identity) do
+    build(:identity,
+          session_uuid: session_uuid,
+          user: build(:user),
+          scope: scope)
+  end
 
   subject(:presenter) { OpenidConnectUserInfoPresenter.new(identity) }
 
@@ -27,7 +33,12 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           middle_name: 'Jones',
           last_name: 'Smith',
           dob: '1970-01-01',
-          zipcode: '12345'
+          address1: '123 Fake St',
+          address2: 'Apt 456',
+          city: 'Washington',
+          state: 'DC',
+          zipcode: '12345',
+          phone: '+1 (555) 555-5555'
         }
       end
 
@@ -38,13 +49,41 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       context 'when the identity has loa3 access' do
         before { identity.ial = 3 }
 
-        it 'returns loa3 attributes' do
-          aggregate_failures do
-            expect(user_info[:given_name]).to eq('John')
-            expect(user_info[:middle_name]).to eq('Jones')
-            expect(user_info[:family_name]).to eq('Smith')
-            expect(user_info[:birthdate]).to eq('1970-01-01')
-            expect(user_info[:postal_code]).to eq('12345')
+        context 'when the scope includes all attributes' do
+          it 'returns loa3 attributes' do
+            aggregate_failures do
+              expect(user_info[:given_name]).to eq('John')
+              expect(user_info[:middle_name]).to eq('Jones')
+              expect(user_info[:family_name]).to eq('Smith')
+              expect(user_info[:birthdate]).to eq('1970-01-01')
+              expect(user_info[:phone]).to eq('+1 (555) 555-5555')
+              expect(user_info[:phone_verified]).to eq(true)
+              expect(user_info[:address]).to eq(
+                formatted: "123 Fake St Apt 456\nWashington, DC 12345",
+                street_address: '123 Fake St Apt 456',
+                locality: 'Washington',
+                region: 'DC',
+                postal_code: '12345'
+              )
+            end
+          end
+        end
+
+        context 'when the scope only includes minimal attributes' do
+          let(:scope) { 'openid email phone' }
+
+          it 'returns attributes allowed by the scope' do
+            aggregate_failures do
+              expect(user_info[:email]).to eq(identity.user.email)
+              expect(user_info[:email_verified]).to eq(true)
+              expect(user_info[:given_name]).to eq(nil)
+              expect(user_info[:family_name]).to eq(nil)
+              expect(user_info[:middle_name]).to eq(nil)
+              expect(user_info[:birthdate]).to eq(nil)
+              expect(user_info[:phone]).to eq('+1 (555) 555-5555')
+              expect(user_info[:phone_verified]).to eq(true)
+              expect(user_info[:address]).to eq(nil)
+            end
           end
         end
       end
@@ -58,7 +97,9 @@ RSpec.describe OpenidConnectUserInfoPresenter do
             expect(user_info[:family_name]).to eq(nil)
             expect(user_info[:middle_name]).to eq(nil)
             expect(user_info[:birthdate]).to eq(nil)
-            expect(user_info[:postal_code]).to eq(nil)
+            expect(user_info[:phone]).to eq(nil)
+            expect(user_info[:phone_verified]).to eq(nil)
+            expect(user_info[:address]).to eq(nil)
           end
         end
       end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -25,16 +25,30 @@ describe IdentityLinker do
       expect(identity_attributes).to include new_attributes
     end
 
-    it 'can take an optional nonce and session_uuid to specify attributes' do
+    it 'can take an optional nonce, session_uuid, ial, and scope to specify attributes' do
       session_uuid = SecureRandom.hex
       nonce = SecureRandom.hex
+      ial = 3
+      scope = 'openid profile email'
 
-      IdentityLinker.new(user, 'test.host').link_identity(session_uuid: session_uuid, nonce: nonce)
+      IdentityLinker.new(user, 'test.host').link_identity(
+        session_uuid: session_uuid,
+        nonce: nonce,
+        ial: ial,
+        scope: scope
+      )
       user.reload
 
       last_identity = user.last_identity
       expect(last_identity.nonce).to eq(nonce)
       expect(last_identity.session_uuid).to eq(session_uuid)
+      expect(last_identity.ial).to eq(ial)
+      expect(last_identity.scope).to eq(scope)
+    end
+
+    it 'rejects bad attributes names' do
+      expect { IdentityLinker.new(user, 'test.host').link_identity(foobar: true) }.
+        to raise_error(ArgumentError)
     end
 
     it 'fails when given a nil provider' do

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe OpenidConnectAttributeScoper do
+  subject(:scoper) { OpenidConnectAttributeScoper.new(scope) }
+
+  describe '#filter' do
+    subject(:filtered) { scoper.filter(user_info) }
+
+    let(:scope) { 'openid' }
+    let(:user_info) do
+      {
+        sub: 'abcdef',
+        iss: 'https://login.gov',
+        email: 'foo@example.com',
+        email_verified: true,
+        given_name: 'John',
+        family_name: 'Jones',
+        middle_name: 'Joe',
+        birthdate: '1970-01-01',
+        phone: '+1 (555) 555-5555',
+        phone_verified: true,
+        address: {
+          formatted: "123 Fake St\nWashington, DC 12345",
+          street_address: '123 Fake St',
+          locality: 'Washington',
+          region: 'DC',
+          postal_code: '12345'
+        }
+      }
+    end
+
+    context 'minimum scope' do
+      let(:scope) { 'openid' }
+
+      it 'is only sub and iss' do
+        expect(filtered).to eq(
+          sub: 'abcdef',
+          iss: 'https://login.gov'
+        )
+      end
+    end
+
+    context 'with address scope' do
+      let(:scope) { 'openid address' }
+
+      it 'includes the address attribute' do
+        expect(filtered[:address]).to be_present
+      end
+    end
+
+    context 'with email scope' do
+      let(:scope) { 'openid email' }
+
+      it 'includes the email and email_verified attributes' do
+        expect(filtered[:email]).to be_present
+        expect(filtered[:email_verified]).to eq(true)
+      end
+    end
+
+    context 'with phone scope' do
+      let(:scope) { 'openid phone' }
+
+      it 'includes the phone and email_verified attributes' do
+        expect(filtered[:phone]).to be_present
+        expect(filtered[:phone_verified]).to eq(true)
+      end
+    end
+
+    context 'with profile scope' do
+      let(:scope) { 'openid profile' }
+
+      it 'includes name attributes and birthdate' do
+        expect(filtered[:given_name]).to be_present
+        expect(filtered[:family_name]).to be_present
+        expect(filtered[:middle_name]).to be_present
+        expect(filtered[:birthdate]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: OpenID Connect 1.0 spec

--

Next: presenting this list of attributes on the authorization screen