### PR TITLE
Updates int IdP URL and adds NPM cache clean task

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -74,6 +74,13 @@ namespace :deploy do
     end
   end
 
+  desc 'Clean NPM cache'
+  task :clean_npm_cache do
+    on roles(:app, :web), in: :parallel do
+      execute :npm, 'cache clean'
+    end
+  end
+
   before 'assets:precompile', :browserify
   after 'deploy:updated', 'newrelic:notice_deployment'
   after 'deploy:log_revision', :deploy_json

--- a/config/deploy/int.rb
+++ b/config/deploy/int.rb
@@ -1,2 +1,2 @@
-server 'int.login.gov', roles: %w(web db)
+server 'idp.int.login.gov', roles: %w(web db)
 server 'worker.int.login.gov', roles: %w(app job_creator)


### PR DESCRIPTION
### Why
The most recent deploy to `int` resulted in NPM install errors with the recommended solution to clean the NPM cache. 

### How
Updates int URL to idp.int.login.gov
Adds npm cache clean task