### PR TITLE
Adds spec for /api/service_provider endpoint

### DIFF
--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -52,6 +52,23 @@ describe ServiceProviderController do
         expect(sp.valid?).to eq true
         expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
       end
+
+      context 'with CSRF protection enabled' do
+        before do
+          ActionController::Base.allow_forgery_protection = true
+        end
+
+        after do
+          ActionController::Base.allow_forgery_protection = false
+        end
+
+        it 'does not redirect after invalid CSRF token' do
+          post :update
+
+          expect(response.status).to_not eq(302)
+          expect(response.status).to eq(200)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Why
The Dashboard integration was failing due to CSRF protection.

### How
Removes protect_from_forgery on Service Providers controller.

cc @pkarman