### PR TITLE
Track Financial and Phone IdV step attempts separately

### DIFF
--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -1,6 +1,7 @@
 module Verify
   class FinanceController < StepController
     before_action :confirm_step_needed
+    before_action :confirm_step_allowed
 
     helper_method :idv_finance_form
 
@@ -11,15 +12,22 @@ module Verify
     def create
       result = step.submit
       analytics.track_event(Analytics::IDV_FINANCE_CONFIRMATION, result)
+      increment_step_attempts
 
       if result[:success]
         redirect_to verify_phone_url
+      elsif step_attempts_exceeded?
+        redirect_to_fail_path
       else
         render_form
       end
     end
 
     private
+
+    def step_name
+      :financials
+    end
 
     def step
       @_step ||= Idv::FinancialsStep.new(

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -1,6 +1,7 @@
 module Verify
   class PhoneController < StepController
     before_action :confirm_step_needed
+    before_action :confirm_step_allowed
 
     helper_method :idv_phone_form
 
@@ -11,15 +12,22 @@ module Verify
     def create
       result = step.submit
       analytics.track_event(Analytics::IDV_PHONE_CONFIRMATION, result.to_h)
+      increment_step_attempts
 
       if result.success?
         redirect_to verify_review_url
+      elsif step_attempts_exceeded?
+        redirect_to_fail_path
       else
         render :new
       end
     end
 
     private
+
+    def step_name
+      :phone
+    end
 
     def step
       @_step ||= Idv::PhoneStep.new(

--- a/app/controllers/verify/step_controller.rb
+++ b/app/controllers/verify/step_controller.rb
@@ -8,5 +8,28 @@ module Verify
     before_action :confirm_idv_attempts_allowed
 
     helper_method :step
+
+    private
+
+    def step_name
+      raise NotImplementedError, 'must implement step_name method'
+    end
+
+    def increment_step_attempts
+      idv_session.step_attempts[step_name] += 1
+    end
+
+    def step_attempts_exceeded?
+      idv_session.step_attempts[step_name] >= Idv::Attempter.idv_max_attempts
+    end
+
+    def confirm_step_allowed
+      redirect_to_fail_path if step_attempts_exceeded?
+    end
+
+    def redirect_to_fail_path
+      flash[:max_attempts_exceeded] = true
+      redirect_to verify_fail_path
+    end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -21,12 +21,16 @@ class VerifyController < ApplicationController
   end
 
   def fail
-    redirect_to verify_url unless idv_attempter.exceeded?
+    redirect_to verify_url unless ok_to_fail?
   end
 
   private
 
   def active_profile?
     current_user.active_profile.present?
+  end
+
+  def ok_to_fail?
+    idv_attempter.exceeded? || flash[:max_attempts_exceeded]
   end
 end

--- a/app/services/idv/attempter.rb
+++ b/app/services/idv/attempter.rb
@@ -1,5 +1,9 @@
 module Idv
   class Attempter
+    def self.idv_max_attempts
+      (Figaro.env.idv_max_attempts || 3).to_i
+    end
+
     def initialize(current_user)
       @current_user = current_user
     end
@@ -23,7 +27,7 @@ module Idv
       return false if window_expired?
 
       # too many attempts in the window
-      attempts >= idv_max_attempts && !window_expired?
+      attempts >= self.class.idv_max_attempts && !window_expired?
     end
 
     def window_expired?
@@ -43,10 +47,6 @@ module Idv
     private
 
     attr_reader :current_user
-
-    def idv_max_attempts
-      (Figaro.env.idv_max_attempts || 3).to_i
-    end
 
     def idv_attempt_window
       (Figaro.env.idv_attempt_window_in_hours || 24).to_i.hours

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -9,13 +9,14 @@ module Idv
       :profile_id,
       :recovery_code,
       :resolution,
+      :step_attempts,
       :vendor
     ].freeze
 
     def initialize(user_session, current_user)
       @user_session = user_session
       @current_user = current_user
-      @user_session[:idv] ||= { params: {} }
+      @user_session[:idv] ||= new_idv_session
     end
 
     def method_missing(method_sym, *arguments, &block)
@@ -75,6 +76,10 @@ module Idv
     private
 
     attr_accessor :user_session, :current_user
+
+    def new_idv_session
+      { params: {}, step_attempts: { financials: 0, phone: 0 } }
+    end
 
     def move_pii_to_user_session
       user_session[:decrypted_pii] = session.delete(:decrypted_pii)

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Verify::FinanceController do
-  let(:max_attempts) { (Figaro.env.idv_max_attempts || 3).to_i }
+  let(:max_attempts) { Idv::Attempter.idv_max_attempts }
 
   describe 'before_actions' do
     it 'includes authentication before_action' do
@@ -22,6 +22,15 @@ describe Verify::FinanceController do
       get :new
 
       expect(response).to redirect_to verify_phone_path
+    end
+
+    it 'redirects to fail when step attempts are exceeded' do
+      stub_subject
+      subject.idv_session.step_attempts[:financials] = max_attempts
+
+      get :new
+
+      expect(response).to redirect_to verify_fail_path
     end
   end
 

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Verify::SessionsController do
-  let(:max_attempts) { (Figaro.env.idv_max_attempts || 3).to_i }
+  let(:max_attempts) { Idv::Attempter.idv_max_attempts }
   let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
   let(:user_attrs) do
     {

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -4,6 +4,7 @@ feature 'IdV session' do
   include IdvHelper
 
   let(:user_password) { Features::SessionHelper::VALID_PASSWORD }
+  let(:max_attempts_less_one) { Idv::Attempter.idv_max_attempts - 1 }
 
   context 'landing page' do
     before do
@@ -54,7 +55,7 @@ feature 'IdV session' do
     scenario 'allows 3 attempts in 24 hours' do
       user = sign_in_and_2fa_user
 
-      2.times do
+      max_attempts_less_one.times do
         visit verify_session_path
         complete_idv_profile_fail
 
@@ -79,6 +80,44 @@ feature 'IdV session' do
 
       user.reload
       expect(user.idv_attempted_at).to_not be_nil
+    end
+
+    scenario 'finance step redirects to fail after max attempts' do
+      sign_in_and_2fa_user
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_idv_continue
+
+      max_attempts_less_one.times do
+        fill_out_financial_form_fail
+        click_idv_continue
+
+        expect(current_path).to eq verify_finance_path
+      end
+
+      fill_out_financial_form_fail
+      click_idv_continue
+      expect(current_path).to eq verify_fail_path
+    end
+
+    scenario 'phone step redirects to fail after max attempts' do
+      sign_in_and_2fa_user
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_idv_continue
+      fill_out_financial_form_ok
+      click_idv_continue
+
+      max_attempts_less_one.times do
+        fill_out_phone_form_fail
+        click_idv_continue
+
+        expect(current_path).to eq verify_phone_path
+      end
+
+      fill_out_phone_form_fail
+      click_idv_continue
+      expect(current_path).to eq verify_fail_path
     end
 
     scenario 'successful steps are not re-entrant, but are sticky on failure', js: true do

--- a/spec/services/idv/attempter_spec.rb
+++ b/spec/services/idv/attempter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Idv::Attempter do
   let(:current_user) { build(:user) }
   let(:subject) { Idv::Attempter.new(current_user) }
-  let(:max_attempts) { (Figaro.env.idv_max_attempts || 3).to_i }
+  let(:max_attempts) { Idv::Attempter.idv_max_attempts }
 
   describe '#reset' do
     it 'resets idv_attempts to zero for user' do

--- a/spec/support/idv_helper.rb
+++ b/spec/support/idv_helper.rb
@@ -25,6 +25,10 @@ module IdvHelper
     fill_in :idv_finance_form_ccn, with: '12345678'
   end
 
+  def fill_out_financial_form_fail
+    fill_in :idv_finance_form_ccn, with: '00000000'
+  end
+
   def fill_out_phone_form_ok(phone = '415-555-0199')
     fill_in :idv_phone_form_phone, with: phone
   end


### PR DESCRIPTION
**Why**: A single IdV session has multiple steps, and
each step requires separate vendor confirmation, and therefore
separate tracking for the number of attempts-before-fail.

**How**: We continue to track `idv_attempts` on the User model,
which basically refers to the number of idv sessions allowed
in a 24-hour period. The new `step_attempts` track each step
after the initial profile resolution.