### PR TITLE
Remove inactive Service Providers via dashboard

### DIFF
--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,14 +1,22 @@
 class ServiceProviderUpdater
   def run
     dashboard_service_providers.each do |service_provider|
-      service_provider = HashWithIndifferentAccess.new(service_provider)
-      issuer = service_provider['issuer']
-      SERVICE_PROVIDERS[issuer] = service_provider
-      VALID_SERVICE_PROVIDERS << issuer
+      update_local_caches(HashWithIndifferentAccess.new(service_provider))
     end
   end
 
   private
+
+  def update_local_caches(service_provider)
+    issuer = service_provider['issuer']
+    if service_provider['active'] == true
+      SERVICE_PROVIDERS[issuer] = service_provider
+      VALID_SERVICE_PROVIDERS << issuer
+    else
+      SERVICE_PROVIDERS.delete(issuer)
+      VALID_SERVICE_PROVIDERS.delete(issuer)
+    end
+  end
 
   def url
     Figaro.env.dashboard_url

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -15,7 +15,8 @@ describe ServiceProviderController do
           acs_url: 'http://sp.example.org/saml/login',
           assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
           block_encryption: 'aes256-cbc',
-          cert: saml_test_sp_cert
+          cert: saml_test_sp_cert,
+          active: true
         }
       ]
     end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -152,7 +152,8 @@ feature 'saml api' do
         {
           issuer: dashboard_sp_issuer,
           acs_url: 'http://sp.example.org/saml/login',
-          cert: saml_test_sp_cert
+          cert: saml_test_sp_cert,
+          active: true
         }
       ]
     end


### PR DESCRIPTION
**Why**: The local cache of SERVICE_PROVIDERS was not
updating when Service Providers were deactivated on the dashboard.

See https://github.com/18F/identity-dashboard/pull/57