### PR TITLE
Revert "Use client_secret_jwt for OpenID Connect (#1030)"

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -59,8 +59,8 @@ class OpenidConnectTokenForm
 
     service_provider = ServiceProvider.new(client_id)
 
-    JWT.decode(client_assertion, service_provider.metadata[:client_secret], true,
-               algorithm: 'HS256', verify_iat: true,
+    JWT.decode(client_assertion, service_provider.ssl_cert.public_key, true,
+               algorithm: 'RS256', verify_iat: true,
                iss: client_id, verify_iss: true,
                sub: client_id, verify_sub: true,
                aud: openid_connect_token_url, verify_aud: true)

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -28,7 +28,7 @@ class OpenidConnectConfigurationPresenter
   def crypto_configuration
     {
       id_token_signing_alg_values_supported: %w(RS256),
-      token_endpoint_auth_methods_supported: %w(client_secret_jwt),
+      token_endpoint_auth_methods_supported: %w(private_key_jwt),
       token_endpoint_auth_signing_alg_values_supported: %w(RS256)
     }
   end

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -40,7 +40,7 @@ test:
 
   'urn:gov:gsa:openidconnect:test':
     redirect_uri: 'gov.gsa.openidconnect.test://result'
-    client_secret: '158bec72671f0c6ca0c00d155a379b4a'
+    cert: 'saml_test_sp'
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':
@@ -101,7 +101,7 @@ development:
 
   'urn:gov:gsa:openidconnect:development':
     redirect_uri: 'gov.gsa.openidconnect.development://result'
-    client_secret: '61ba81524248cba6e4ba0e9038547d84'
+    cert: 'saml_test_sp'
 
 production:
   'https://idp.dev.login.gov':

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe OpenidConnect::TokenController do
         exp: 5.minutes.from_now.to_i
       }
 
-      client_secret = ServiceProvider.new(client_id).metadata[:client_secret]
+      client_private_key = OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read)
 
-      JWT.encode(jwt_payload, client_secret, 'HS256')
+      JWT.encode(jwt_payload, client_private_key, 'RS256')
     end
 
     before do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -4,7 +4,6 @@ feature 'OpenID Connect' do
   context 'happy path' do
     it 'renders an authorization that redirects' do
       client_id = 'urn:gov:gsa:openidconnect:test'
-      service_provider = ServiceProvider.new(client_id)
       state = SecureRandom.hex
       nonce = SecureRandom.hex
 
@@ -40,7 +39,7 @@ feature 'OpenID Connect' do
         exp: 5.minutes.from_now.to_i
       }
 
-      client_assertion = JWT.encode(jwt_payload, service_provider.metadata[:client_secret], 'HS256')
+      client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
       client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
       page.driver.post openid_connect_token_path,
@@ -81,6 +80,14 @@ feature 'OpenID Connect' do
   def sp_public_key
     @sp_public_key ||= begin
       OpenSSL::X509::Certificate.new(File.read(Rails.root.join('certs/saml.crt'))).public_key
+    end
+  end
+
+  def client_private_key
+    @client_public_key ||= begin
+      OpenSSL::PKey::RSA.new(
+        File.read(Rails.root.join('keys/saml_test_sp.key'))
+      )
     end
   end
 end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe OpenidConnectTokenForm do
   let(:grant_type) { 'authorization_code' }
   let(:code) { SecureRandom.hex }
   let(:client_assertion_type) { OpenidConnectTokenForm::CLIENT_ASSERTION_TYPE }
-  let(:client_assertion) { JWT.encode(jwt_payload, client_secret, 'HS256') }
+  let(:client_assertion) { JWT.encode(jwt_payload, client_private_key, 'RS256') }
 
-  let(:client_secret) { ServiceProvider.new(client_id).metadata[:client_secret] }
   let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
   let(:nonce) { SecureRandom.hex }
   let(:jwt_payload) do
@@ -32,6 +31,7 @@ RSpec.describe OpenidConnectTokenForm do
     }
   end
 
+  let(:client_private_key) { OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read) }
   let(:server_public_key) { RequestKeyManager.private_key.public_key }
 
   let(:user) { create(:user) }
@@ -110,8 +110,8 @@ RSpec.describe OpenidConnectTokenForm do
         end
       end
 
-      context 'signed by the wrong hmackey' do
-        let(:client_secret) { 'wrong wrong wrong' }
+      context 'signed by the wrong key' do
+        let(:client_private_key) { OpenSSL::PKey::RSA.new(2048) }
 
         it 'is invalid' do
           expect(valid?).to eq(false)

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OpenidConnectConfigurationPresenter do
           to match_array(Saml::Idp::Constants::VALID_AUTHN_CONTEXTS)
         expect(configuration[:subject_types_supported]).to eq(%w(pairwise))
         expect(configuration[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
-        expect(configuration[:token_endpoint_auth_methods_supported]).to eq(%w(client_secret_jwt))
+        expect(configuration[:token_endpoint_auth_methods_supported]).to eq(%w(private_key_jwt))
         expect(configuration[:token_endpoint_auth_signing_alg_values_supported]).to eq(%w(RS256))
 
         claims = %w(iss sub) + OpenidConnectAttributeScoper::CLAIMS


### PR DESCRIPTION
Turns out the previous PR was a little premature: https://github.com/18F/identity-idp/pull/1030#event-947226362

---

This reverts commit d58a86017f7fdde3eb050c096317210207dcc13a.

**Why**:
client_secret_jwt requires storing the client secret in a recoverable
manner, which is not ideal