### PR TITLE
Support PKCE in OpenID Connect

### DIFF
--- a/.reek
+++ b/.reek
@@ -39,6 +39,9 @@ NilCheck:
     - user_not_found?
     - SamlIdpLogoutConcern#name_id
     - User#password_reset_profile
+LongParameterList:
+  exclude:
+    - IdentityLinker#optional_attributes
 RepeatedConditional:
   exclude:
     - Users::ResetPasswordsController

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -5,6 +5,8 @@ class OpenidConnectAuthorizeForm
 
   SIMPLE_ATTRS = %i(
     client_id
+    code_challenge
+    code_challenge_method
     nonce
     prompt
     redirect_uri
@@ -25,6 +27,7 @@ class OpenidConnectAuthorizeForm
 
   validates_inclusion_of :response_type, in: %w(code)
   validates_inclusion_of :prompt, in: %w(select_account)
+  validates_inclusion_of :code_challenge_method, in: %w(S256), if: :code_challenge
 
   validate :validate_acr_values
   validate :validate_client_id
@@ -40,7 +43,7 @@ class OpenidConnectAuthorizeForm
     end
   end
 
-  def params
+  def params # rubocop:disable Metrics/MethodLength
     {
       acr_values: acr_values.join(' '),
       client_id: client_id,
@@ -49,8 +52,10 @@ class OpenidConnectAuthorizeForm
       redirect_uri: redirect_uri,
       response_type: response_type,
       scope: scope.join(' '),
-      state: state
-    }
+      state: state,
+      code_challenge: code_challenge,
+      code_challenge_method: code_challenge_method
+    }.select { |_key, value| value.present? }
   end
 
   def submit(user, rails_session_id)
@@ -112,7 +117,8 @@ class OpenidConnectAuthorizeForm
       nonce: nonce,
       session_uuid: rails_session_id,
       ial: ial,
-      scope: scope.join(' ')
+      scope: scope.join(' '),
+      code_challenge: code_challenge
     )
   end
 

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -27,7 +27,7 @@ IdentityLinker = Struct.new(:user, :provider) do
     }
   end
 
-  def optional_attributes(nonce: nil, ial: nil, scope: nil)
-    { nonce: nonce, ial: ial, scope: scope }
+  def optional_attributes(nonce: nil, ial: nil, scope: nil, code_challenge: nil)
+    { nonce: nonce, ial: ial, scope: scope, code_challenge: code_challenge }
   end
 end

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -13,7 +13,9 @@ en:
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
     token:
       errors:
+        invalid_authentication: Client must authenticate via PKCE or private_key_jwt, missing either code_challenge or client_assertion
         invalid_code: invalid code
+        invalid_code_verifier: code_verifier did not match code_challenge
     user_info:
       errors:
         no_authorization: No Authorization header provided

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -13,7 +13,9 @@ es:
         redirect_uri_no_match: NOT TRANSLATED YET
     token:
       errors:
+        invalid_authentication: NOT TRANSLATED YET
         invalid_code: NOT TRANSLATED YET
+        invalid_code_verifier: NOT TRANSLATED YET
     user_info:
       errors:
         no_authorization: NOT TRANSLATED YET

--- a/db/migrate/20170203150129_add_code_challenge_to_identities.rb
+++ b/db/migrate/20170203150129_add_code_challenge_to_identities.rb
@@ -1,0 +1,5 @@
+class AddCodeChallengeToIdentities < ActiveRecord::Migration
+  def change
+    add_column :identities, :code_challenge, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201154458) do
+ActiveRecord::Schema.define(version: 20170203150129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20170201154458) do
     t.integer  "ial",                               default: 1
     t.string   "access_token"
     t.string   "scope"
+    t.string   "code_challenge"
   end
 
   add_index "identities", ["access_token"], name: "index_identities_on_access_token", unique: true, using: :btree

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -25,17 +25,19 @@ describe IdentityLinker do
       expect(identity_attributes).to include new_attributes
     end
 
-    it 'can take an optional nonce, session_uuid, ial, and scope to specify attributes' do
+    it 'can take an additional optional attributes' do
       session_uuid = SecureRandom.hex
       nonce = SecureRandom.hex
       ial = 3
       scope = 'openid profile email'
+      code_challenge = SecureRandom.hex
 
       IdentityLinker.new(user, 'test.host').link_identity(
         session_uuid: session_uuid,
         nonce: nonce,
         ial: ial,
-        scope: scope
+        scope: scope,
+        code_challenge: code_challenge
       )
       user.reload
 
@@ -44,6 +46,7 @@ describe IdentityLinker do
       expect(last_identity.session_uuid).to eq(session_uuid)
       expect(last_identity.ial).to eq(ial)
       expect(last_identity.scope).to eq(scope)
+      expect(last_identity.code_challenge).to eq(code_challenge)
     end
 
     it 'rejects bad attributes names' do


### PR DESCRIPTION
**Why**: Alternative to private_key_jwt for clients with OpenID Connect

PKCE boils down to having the client we generate a value (`code_verifier`) and then send its SHA256 (`code_challenge`) with our first step, and then the raw value `code_verifier` at the second step to be verified

