### PR TITLE
Bugfix recovery code used as 2fa after pw reset

### DIFF
--- a/app/controllers/concerns/recovery_code_concern.rb
+++ b/app/controllers/concerns/recovery_code_concern.rb
@@ -3,7 +3,7 @@ module RecoveryCodeConcern
 
   def create_new_code
     if active_profile.present?
-      Pii::ReEncryptor.new(current_user, user_session).perform
+      Pii::ReEncryptor.new(user: current_user, user_session: user_session).perform
       active_profile.recovery_code
     else
       RecoveryCodeGenerator.new(current_user).create

--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -7,7 +7,7 @@ module SignUp
 
     def show
       user_session.delete(:first_time_recovery_code_view)
-      @code = create_new_code
+      @code = new_code
       analytics.track_event(Analytics::USER_REGISTRATION_RECOVERY_CODE_VISIT)
     end
 
@@ -16,6 +16,14 @@ module SignUp
     end
 
     private
+
+    def new_code
+      if session[:new_recovery_code].present?
+        session.delete(:new_recovery_code)
+      else
+        create_new_code
+      end
+    end
 
     def confirm_has_not_already_viewed_recovery_code
       return if user_session[:first_time_recovery_code_view].present?

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -10,11 +10,31 @@ module TwoFactorAuthentication
 
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'recovery code'))
 
+      handle_result(result)
+    end
+
+    private
+
+    def handle_result(result)
       if result[:success]
+        re_encrypt_profile_recovery_pii if password_reset_profile.present?
         handle_valid_otp
       else
         handle_invalid_otp(type: 'recovery_code')
       end
+    end
+
+    def re_encrypt_profile_recovery_pii
+      Pii::ReEncryptor.new(pii: pii, profile: password_reset_profile).perform
+      session[:new_recovery_code] = password_reset_profile.recovery_code
+    end
+
+    def password_reset_profile
+      @_password_reset_profile ||= current_user.password_reset_profile
+    end
+
+    def pii
+      @_pii ||= password_reset_profile.recover_pii(params[:code])
     end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -66,6 +66,8 @@ UserDecorator = Struct.new(:user) do
   end
 
   def should_acknowledge_recovery_code?(session)
+    return true if session[:new_recovery_code]
+
     sp_session = session[:sp]
 
     user.recovery_code.blank? &&

--- a/app/services/pii/re_encryptor.rb
+++ b/app/services/pii/re_encryptor.rb
@@ -1,8 +1,10 @@
 module Pii
   class ReEncryptor
-    def initialize(user, user_session)
+    def initialize(user: nil, user_session: nil, pii: nil, profile: nil)
       @user = user
       @user_session = user_session
+      @pii = pii
+      @profile = profile
     end
 
     def perform
@@ -15,7 +17,7 @@ module Pii
     attr_reader :user, :user_session
 
     def pii_attributes
-      cacher.fetch
+      @pii ||= cacher.fetch
     end
 
     def cacher
@@ -23,7 +25,7 @@ module Pii
     end
 
     def profile
-      user.active_profile
+      @profile ||= user.active_profile
     end
   end
 end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -7,6 +7,39 @@ feature 'Password Recovery' do
     fill_in_credentials_and_submit(user.email, password)
   end
 
+  def recovery_code_from_pii(user, pii)
+    profile = create(:profile, :active, :verified, user: user)
+    pii_attrs = Pii::Attributes.new_from_hash(pii)
+    user_access_key = user.unlock_user_access_key(user.password)
+    recovery_code = profile.encrypt_pii(user_access_key, pii_attrs)
+    profile.save!
+
+    recovery_code
+  end
+
+  def trigger_reset_password_and_click_email_link(email)
+    visit new_user_password_path
+    fill_in 'Email', with: email
+    click_button t('forms.buttons.continue')
+    open_last_email
+    click_email_link_matching(/reset_password_token/)
+  end
+
+  def scrape_recovery_code
+    new_recovery_code_words = []
+    page.all(:css, 'p[data-recovery]').each do |node|
+      new_recovery_code_words << node.text
+    end
+    new_recovery_code_words.join(' ')
+  end
+
+  def reactivate_profile(password, recovery_code)
+    click_link t('profile.index.reactivation.reactivate_button')
+    fill_in 'Password', with: password
+    fill_in 'Recovery code', with: recovery_code
+    click_button t('forms.reactivate_profile.submit')
+  end
+
   context 'user enters valid email in forgot password form', email: true do
     it 'redirects to forgot_password path and sends an email to the user' do
       user = create(:user, :signed_up)
@@ -40,11 +73,8 @@ feature 'Password Recovery' do
       user = create(:user, :unconfirmed)
       confirm_last_user
       reset_email
-      visit new_user_password_path
-      fill_in 'Email', with: user.email
-      click_button t('forms.buttons.continue')
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
+
+      trigger_reset_password_and_click_email_link(user.email)
 
       expect(current_path).to eq edit_user_password_path
 
@@ -79,11 +109,7 @@ feature 'Password Recovery' do
   context 'user has confirmed email and set a password, then resets password', email: true do
     before do
       @user = create(:user)
-      visit new_user_password_path
-      fill_in 'Email', with: @user.email
-      click_button t('forms.buttons.continue')
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
+      trigger_reset_password_and_click_email_link(@user.email)
     end
 
     it 'keeps user signed out after they successfully reset their password' do
@@ -121,11 +147,7 @@ feature 'Password Recovery' do
   context 'user with 2FA confirmation resets password', email: true do
     before do
       @user = create(:user, :signed_up)
-      visit new_user_password_path
-      fill_in 'Email', with: @user.email
-      click_button t('forms.buttons.continue')
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
+      trigger_reset_password_and_click_email_link(@user.email)
     end
 
     it 'redirects user to profile after signing back in' do
@@ -233,35 +255,23 @@ feature 'Password Recovery' do
     scenario 'resets password and reactivates profile with recovery code', email: true do
       recovery_code = recovery_code_from_pii(user, pii)
 
-      visit new_user_password_path
-      fill_in 'Email', with: user.email
-      click_button t('forms.buttons.continue')
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
+      trigger_reset_password_and_click_email_link(user.email)
 
       reset_password_and_sign_back_in(user, new_password)
       click_submit_default
       enter_correct_otp_code_for_user(user)
 
       expect(page).to have_content t('profile.index.reactivation.instructions')
-      click_link t('profile.index.reactivation.reactivate_button')
 
-      fill_in 'Password', with: new_password
-      fill_in 'Recovery code', with: recovery_code
-      click_button t('forms.reactivate_profile.submit')
+      reactivate_profile(new_password, recovery_code)
 
       expect(page).to have_content t('idv.messages.recovery_code')
     end
 
-    scenario 'resets password, makes recovery code, attempts reactivate profile',
-             email: true, js: true do
+    scenario 'resets password, makes recovery code, attempts reactivate profile', email: true do
       _recovery_code = recovery_code_from_pii(user, pii)
 
-      visit new_user_password_path
-      fill_in 'Email', with: user.email
-      click_button t('forms.buttons.continue')
-      open_last_email
-      click_email_link_matching(/reset_password_token/)
+      trigger_reset_password_and_click_email_link(user.email)
 
       reset_password_and_sign_back_in(user, new_password)
       click_submit_default
@@ -271,24 +281,40 @@ feature 'Password Recovery' do
 
       visit manage_recovery_code_path
 
-      new_recovery_code_words = []
-      page.all(:css, 'p[data-recovery]').each do |node|
-        new_recovery_code_words << node.text
-      end
-
-      new_recovery_code = new_recovery_code_words.join(' ')
-
-      acknowledge_and_confirm_recovery_code
+      new_recovery_code = scrape_recovery_code
+      click_acknowledge_recovery_code
 
       expect(page).to have_content t('profile.index.reactivation.instructions')
 
-      click_link t('profile.index.reactivation.reactivate_button')
-
-      fill_in 'Password', with: new_password
-      fill_in 'Recovery code', with: new_recovery_code
-      click_button t('forms.reactivate_profile.submit')
+      reactivate_profile(new_password, new_recovery_code)
 
       expect(page).to have_content t('errors.messages.recovery_code_incorrect')
+    end
+
+    scenario 'resets password, uses recovery code as 2fa', email: true do
+      recovery_code = recovery_code_from_pii(user, pii)
+
+      trigger_reset_password_and_click_email_link(user.email)
+
+      reset_password_and_sign_back_in(user, new_password)
+      click_submit_default
+
+      click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
+      fill_in 'code', with: recovery_code
+      click_submit_default
+
+      expect(current_path).to eq sign_up_recovery_code_path
+
+      new_recovery_code = scrape_recovery_code
+      click_acknowledge_recovery_code
+
+      expect(current_path).to eq profile_path
+      expect(page).to have_content t('profile.index.reactivation.instructions')
+
+      reactivate_profile(new_password, new_recovery_code)
+
+      expect(page).to_not have_content t('errors.messages.recovery_code_incorrect')
+      expect(page).to have_content t('idv.messages.recovery_code')
     end
   end
 
@@ -311,15 +337,5 @@ feature 'Password Recovery' do
     expect(page).to have_content t('devise.passwords.token_expired')
 
     expect(current_path).to eq new_user_password_path
-  end
-
-  def recovery_code_from_pii(user, pii)
-    profile = create(:profile, :active, :verified, user: user)
-    pii_attrs = Pii::Attributes.new_from_hash(pii)
-    user_access_key = user.unlock_user_access_key(user.password)
-    recovery_code = profile.encrypt_pii(user_access_key, pii_attrs)
-    profile.save!
-
-    recovery_code
   end
 end

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -4,7 +4,7 @@ describe Pii::ReEncryptor do
   describe '#perform' do
     it 're-encrypts PII using new code' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
-      user = create(:user, profiles: [profile])
+      user = profile.user
       user_session = {
         decrypted_pii: { ssn: '1234' }.to_json
       }
@@ -16,7 +16,18 @@ describe Pii::ReEncryptor do
         with(pii_attributes).and_call_original
       expect(user.active_profile).to receive(:save!).and_call_original
 
-      Pii::ReEncryptor.new(user, user_session).perform
+      Pii::ReEncryptor.new(user: user, user_session: user_session).perform
+    end
+
+    it 're-encrypts PII when supplied with raw PII and explicit profile' do
+      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
+      pii_attributes = Pii::Attributes.new_from_hash(ssn: '1234')
+
+      expect(profile).to receive(:encrypt_recovery_pii).
+        with(pii_attributes).and_call_original
+      expect(profile).to receive(:save!).and_call_original
+
+      Pii::ReEncryptor.new(profile: profile, pii: pii_attributes).perform
     end
   end
 end


### PR DESCRIPTION
**Why**: Because the recovery code does double-duty as both
2fa method and backup PII encryption key, if it gets used for 2fa
after a password reset, it cannot also be used to reactivate
the user's profile via backup PII encryption.

**How**: When the recovery code is used for 2fa method,
re-encrypt password_reset_profile immediately with a new
code so that the new code can be used to reactivate the profile
later.