### PR TITLE
Load queues from Sidekiq config, not Redis

### DIFF
--- a/app/services/worker_health_checker.rb
+++ b/app/services/worker_health_checker.rb
@@ -39,12 +39,16 @@ module WorkerHealthChecker
     end
   end
 
-  # called on an interval to enqueues a dummy job in each queue
+  # called on an interval to enqueue a dummy job in each queue
   # @see deploy/schedule.rb
-  def enqueue_dummy_jobs
-    Sidekiq::Queue.all.each do |queue|
-      DummyJob.set(queue: queue.name).perform_later
+  def enqueue_dummy_jobs(queues = sidekiq_queues)
+    queues.each do |queue|
+      DummyJob.set(queue: queue).perform_later
     end
+  end
+
+  def sidekiq_queues
+    @_queues ||= YAML.load_file("#{Rails.root}/config/sidekiq.yml")[:queues]
   end
 
   # Called on an interval to check background queue health and report errors to NewRelic

--- a/spec/services/worker_health_checker_spec.rb
+++ b/spec/services/worker_health_checker_spec.rb
@@ -21,23 +21,20 @@ RSpec.describe WorkerHealthChecker do
   end
 
   describe '#enqueue_dummy_jobs' do
-    let(:queue1) { 'queue1' }
-    let(:queue2) { 'queue2' }
-
-    before do
-      create_sidekiq_queues(queue1, queue2)
-    end
+    let(:queues) { YAML.load_file("#{Rails.root}/config/sidekiq.yml")[:queues] }
 
     subject(:enqueue_dummy_jobs) { WorkerHealthChecker.enqueue_dummy_jobs }
 
-    it 'queues a dummy job per queue that update health per job' do
-      expect(WorkerHealthChecker.status(queue1).healthy?).to eq(false)
-      expect(WorkerHealthChecker.status(queue2).healthy?).to eq(false)
+    it 'queues a dummy job per queue that updates health per job' do
+      queues.each do |queue|
+        expect(WorkerHealthChecker.status(queue).healthy?).to eq(false)
+      end
 
       enqueue_dummy_jobs
 
-      expect(WorkerHealthChecker.status(queue1).healthy?).to eq(true)
-      expect(WorkerHealthChecker.status(queue2).healthy?).to eq(true)
+      queues.each do |queue|
+        expect(WorkerHealthChecker.status(queue).healthy?).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
**Why**: The purpose of our Sidekiq Worker Health check is to
test each known queue and trigger a Dummy backround job that uses
that queue so Sidekiq can pick it up.

Before, we were only iterating through queues that were already sent
to Sidekiq, which at any given time might only be a subset of the total
queues we have defined.

**How**: Fetch the list of queues from our Sidekiq config, which is
where we define all queues that Sidekiq should use.