### PR TITLE
Move conditionals from views into view models

### DIFF
--- a/.reek
+++ b/.reek
@@ -93,6 +93,7 @@ UtilityFunction:
     - Remote#extract_trailing_options
     - Remote#host
     - Remote#parse_positional_arguments
+    - SessionsNew
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -28,6 +28,10 @@ module Verify
 
     private
 
+    def confirm_step_needed
+      redirect_to verify_finance_path if idv_session.profile_confirmation == true
+    end
+
     def step
       @_step ||= Idv::ProfileStep.new(
         idv_form: idv_profile_form,
@@ -43,22 +47,18 @@ module Verify
         flash[:error] = t('idv.errors.duplicate_ssn')
         redirect_to verify_session_dupe_path
       else
-        show_warning if step.form_valid_but_vendor_validation_failed?
+        show_warning
         @view_model = SessionsNew.new
         render :new
       end
     end
 
-    def confirm_step_needed
-      redirect_to verify_finance_path if idv_session.profile_confirmation == true
-    end
-
     def show_warning
+      return unless step.form_valid_but_vendor_validation_failed?
       flash.now[:warning] = t(
         'idv.modal.sessions.warning_html',
         accent: ActionController::Base.helpers.content_tag(
-          :strong,
-          t('idv.modal.sessions.warning_accent')
+          :strong, t('idv.modal.sessions.warning_accent')
         )
       )
     end

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -11,7 +11,7 @@ module Verify
     helper_method :step
 
     def new
-      @using_mock_vendor = idv_vendor.pick == :mock
+      @view_model = SessionsNew.new
       analytics.track_event(Analytics::IDV_BASIC_INFO_VISIT)
     end
 
@@ -44,6 +44,7 @@ module Verify
         redirect_to verify_session_dupe_path
       else
         show_warning if step.form_valid_but_vendor_validation_failed?
+        @view_model = SessionsNew.new
         render :new
       end
     end

--- a/app/view_models/sessions_new.rb
+++ b/app/view_models/sessions_new.rb
@@ -1,0 +1,19 @@
+class SessionsNew
+  def title
+    I18n.t('idv.titles.session.basic')
+  end
+
+  def mock_vendor_partial
+    if idv_vendor.pick == :mock
+      'verify/sessions/no_pii_warning'
+    else
+      'shared/null'
+    end
+  end
+
+  private
+
+  def idv_vendor
+    @_idv_vendor ||= Idv::Vendor.new
+  end
+end

--- a/app/views/verify/sessions/_no_pii_warning.html.slim
+++ b/app/views/verify/sessions/_no_pii_warning.html.slim
@@ -1,0 +1,1 @@
+.mt1.mb2.h6.caps.bold.red = t('idv.messages.sessions.no_pii')

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -1,7 +1,6 @@
-- title t('idv.titles.session.basic')
+- title @view_model.title
+= render @view_model.mock_vendor_partial
 
-- if @using_mock_vendor
-  .mt1.mb2.h6.caps.bold.red = t('idv.messages.sessions.no_pii')
 h1.h3.my0 = t('idv.titles.session.basic')
 = simple_form_for(idv_profile_form, url: verify_session_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/spec/view_models/sessions_new_spec.rb
+++ b/spec/view_models/sessions_new_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe SessionsNew do
+  describe '#mock_vendor_partial' do
+    context 'idv vendor is mock' do
+      it 'returns no pii warning partial' do
+        allow(Figaro.env).to receive(:proofing_vendors).and_return('mock')
+
+        partial = SessionsNew.new.mock_vendor_partial
+
+        expect(partial).to eq 'verify/sessions/no_pii_warning'
+      end
+    end
+
+    context 'idv vendor is not mock' do
+      it 'returns null partial' do
+        allow(Figaro.env).to receive(:proofing_vendors).and_return('other')
+
+        partial = SessionsNew.new.mock_vendor_partial
+
+        expect(partial).to eq 'shared/null'
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
 This is a small change that represents a direction we can head if we
want to have one instance var per view and remove all conditionals from
views. This is how micro-purchase cleaned up their views and controllers
quite a bit. See https://github.com/18F/micropurchase/tree/develop/app/view_models