### PR TITLE
Pass User.uuid to Proofer::Applicant

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: 2b84e0ff1dc920b4a694dffbc43222acc25b3eff
+  revision: 1b8a94720efb66abe072030c185d5288f8172cc4
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -51,7 +51,7 @@ module Idv
 
     def applicant_from_params
       app_vars = params.select { |key, _value| Proofer::Applicant.method_defined?(key) }
-      Proofer::Applicant.new(app_vars)
+      Proofer::Applicant.new(app_vars.merge(uuid: current_user.uuid))
     end
 
     def profile

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -91,6 +91,14 @@ describe Verify::SessionsController do
         allow(@analytics).to receive(:track_event)
       end
 
+      context 'UUID' do
+        it 'assigned user UUID to applicant' do
+          post :create, profile: user_attrs
+
+          expect(subject.idv_session.applicant.uuid).to eq subject.current_user.uuid
+        end
+      end
+
       context 'existing SSN' do
         it 'redirects to custom error' do
           create(:profile, pii: { ssn: '666-66-1234' })


### PR DESCRIPTION
**Why**: Define our own "session id" for better vendor analytics.