### PR TITLE
One-line raise_error specs should stay on one line

### DIFF
--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -54,9 +54,7 @@ describe Users::PasswordsController do
         expect(flash[:recovery_code]).to be_present
         expect(profile.decrypt_pii(new_user_access_key)).to be_a Pii::Attributes
         expect(profile.decrypt_pii(new_user_access_key).ssn).to eq '1234'
-        expect do
-          profile.decrypt_pii(old_user_access_key)
-        end.to raise_error Pii::EncryptionError
+        expect { profile.decrypt_pii(old_user_access_key) }.to raise_error Pii::EncryptionError
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -79,9 +79,8 @@ describe Profile do
     it 'prevents create! via ActiveRecord uniqueness validation' do
       profile.active = true
       profile.save!
-      expect do
-        Profile.create!(user_id: user.id, active: true)
-      end.to raise_error(ActiveRecord::RecordInvalid)
+      expect { Profile.create!(user_id: user.id, active: true) }.
+        to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'prevents save! via psql unique partial index' do
@@ -100,9 +99,7 @@ describe Profile do
       pii_attrs = Pii::Attributes.new_from_hash(ssn: '1234')
       profile.encrypt_pii(user_access_key, pii_attrs)
       profile.save!
-      expect do
-        create(:profile, pii: { ssn: '1234' }, user: user)
-      end.to_not raise_error
+      expect { create(:profile, pii: { ssn: '1234' }, user: user) }.to_not raise_error
     end
 
     it 'prevents save! via ActiveRecord uniqueness validation' do

--- a/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
@@ -9,9 +9,7 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
     presenter = presenter_with
 
     %w(header help_text fallback_links).each do |m|
-      expect do
-        presenter.send(m.to_sym)
-      end.to raise_error(NotImplementedError)
+      expect { presenter.send(m.to_sym) }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/services/pii/cipher_spec.rb
+++ b/spec/services/pii/cipher_spec.rb
@@ -10,9 +10,7 @@ describe Pii::Cipher do
 
       expect(ciphertext).to_not match plaintext
       expect(ciphertext).to be_a String
-      expect do
-        JSON.parse(ciphertext)
-      end.to_not raise_error
+      expect { JSON.parse(ciphertext) }.to_not raise_error
     end
   end
 
@@ -27,9 +25,7 @@ describe Pii::Cipher do
       ciphertext = subject.encrypt(plaintext, cek)
       ciphertext += 'foo'
 
-      expect do
-        subject.decrypt(ciphertext, cek)
-      end.to raise_error Pii::EncryptionError
+      expect { subject.decrypt(ciphertext, cek) }.to raise_error Pii::EncryptionError
     end
   end
 

--- a/spec/services/pii/encryptor_spec.rb
+++ b/spec/services/pii/encryptor_spec.rb
@@ -23,9 +23,7 @@ describe Pii::Encryptor do
       encrypted = subject.encrypt(plaintext, aes_cek)
       diff_cek = aes_cek.tr('-', 'z')
 
-      expect do
-        subject.decrypt(encrypted, diff_cek)
-      end.to raise_error Pii::EncryptionError
+      expect { subject.decrypt(encrypted, diff_cek) }.to raise_error Pii::EncryptionError
     end
   end
 end

--- a/spec/services/pii/nist_encryption_spec.rb
+++ b/spec/services/pii/nist_encryption_spec.rb
@@ -39,9 +39,8 @@ describe 'NIST Encryption Model' do
       expect(hex_to_bin(user_access_key.z1).length).to eq 16
       expect(hex_to_bin(user_access_key.z2).length).to eq 16
 
-      expect do
-        SCrypt::Password.new(user_access_key.as_scrypt_hash)
-      end.to_not raise_error
+      expect { SCrypt::Password.new(user_access_key.as_scrypt_hash) }.
+        to_not raise_error
     end
   end
 
@@ -127,9 +126,7 @@ describe 'NIST Encryption Model' do
       # unroll encrypted_C to verify it was encrypted with hash_E
       cipher = Pii::Cipher.new
 
-      expect do
-        cipher.decrypt(encrypted_C, hash_E)
-      end.not_to raise_error
+      expect { cipher.decrypt(encrypted_C, hash_E) }.not_to raise_error
 
       deciphered = cipher.decrypt(encrypted_C, hash_E)
       deciphered_pii, deciphered_pii_fingerprint = open_envelope(deciphered)

--- a/spec/services/pii/password_encryptor_spec.rb
+++ b/spec/services/pii/password_encryptor_spec.rb
@@ -41,9 +41,8 @@ describe Pii::PasswordEncryptor do
       ciphertext = subject.encrypt(plaintext, user_access_key)
       different_user_access_key = UserAccessKey.new(password: 'different password', salt: salt)
 
-      expect do
-        subject.decrypt(ciphertext, different_user_access_key)
-      end.to raise_error Pii::EncryptionError
+      expect { subject.decrypt(ciphertext, different_user_access_key) }.
+        to raise_error Pii::EncryptionError
     end
   end
 end

--- a/spec/services/user_access_key_spec.rb
+++ b/spec/services/user_access_key_spec.rb
@@ -32,9 +32,7 @@ describe UserAccessKey do
 
   describe '#as_scrypt_hash' do
     it 'returns SCrypt compatible hash string' do
-      expect do
-        SCrypt::Password.new(subject.as_scrypt_hash)
-      end.to_not raise_error
+      expect { SCrypt::Password.new(subject.as_scrypt_hash) }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
**Why**: Consistent spec syntax.