### PR TITLE
Add attempts remaining to verification modals

### DIFF
--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -5,8 +5,9 @@ function verifyModal() {
 
   if (flash) {
     const name = flash.id.split('-').pop();
-    const heading = flash.querySelector('strong');
-    const content = flash.querySelector('span');
+    const heading = flash.querySelector('strong:first-of-type');
+    const content = flash.querySelector('span:first-of-type');
+    const attempts = flash.querySelector('span:last-of-type');
 
     if ((name === 'warning' || name === 'error') && (heading !== null && content !== null)) {
       const button = I18n.t(`idv.modal.button.${name}`);
@@ -20,9 +21,10 @@ function verifyModal() {
       el.innerHTML = `
         <div class="px2 py4 modal-inner">
           <div class="mx-auto p4 cntnr-xskinny border-box bg-white rounded-xxl modal-${name}">
-            <h2 class="my2 fs-20p sans-serif regular center">${heading.textContent}</h2>
+            <h2 class="my2 fs-20p sans-serif regular center">${heading.innerHTML}</h2>
             <hr class="mb3 bw4 rounded">
-            <p class="mb5">${content.textContent}</p>
+            <p>${content.innerHTML}</p>
+            <p class="mb5">${attempts.innerHTML}</p>
             <div class="center">
               <a href="#" id="js-close-modal" class="btn btn-wide px2 py1 rounded-lg border bw2">
                 ${button}

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -17,6 +17,10 @@ module IdvStepConcern
     idv_session.step_attempts[step_name] += 1
   end
 
+  def remaining_step_attempts
+    Idv::Attempter.idv_max_attempts - idv_session.step_attempts[step_name]
+  end
+
   def step_attempts_exceeded?
     idv_session.step_attempts[step_name] >= Idv::Attempter.idv_max_attempts
   end

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -58,7 +58,8 @@ module Verify
         accent: ActionController::Base.helpers.content_tag(
           :strong,
           t('idv.modal.finance.warning_accent')
-        )
+        ),
+        attempt: t('idv.modal.attempts', count: remaining_step_attempts)
       )
     end
 

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -53,14 +53,9 @@ module Verify
     end
 
     def show_warning
-      flash.now[:warning] = t(
-        'idv.modal.finance.warning_html',
-        accent: ActionController::Base.helpers.content_tag(
-          :strong,
-          t('idv.modal.finance.warning_accent')
-        ),
-        attempt: t('idv.modal.attempts', count: remaining_step_attempts)
-      )
+      presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
+
+      flash.now[:warning] = presenter.warning_message
     end
 
     def render_form

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -44,19 +44,14 @@ module Verify
       render :new
     end
 
-    def step_params
-      params.require(:idv_phone_form).permit(:phone)
+    def show_warning
+      presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
+
+      flash.now[:warning] = presenter.warning_message
     end
 
-    def show_warning
-      flash.now[:warning] = t(
-        'idv.modal.phone.warning_html',
-        accent: ActionController::Base.helpers.content_tag(
-          :strong,
-          t('idv.modal.phone.warning_accent')
-        ),
-        attempt: t('idv.modal.attempts', count: remaining_step_attempts)
-      )
+    def step_params
+      params.require(:idv_phone_form).permit(:phone)
     end
 
     def confirm_step_needed

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -54,7 +54,8 @@ module Verify
         accent: ActionController::Base.helpers.content_tag(
           :strong,
           t('idv.modal.phone.warning_accent')
-        )
+        ),
+        attempt: t('idv.modal.attempts', count: remaining_step_attempts)
       )
     end
 

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -55,13 +55,15 @@ module Verify
 
     def show_warning
       return unless step.form_valid_but_vendor_validation_failed?
+
+      helper = ActionController::Base.helpers
+
+      attempt = t('idv.modal.attempts', count: remaining_idv_attempts)
+      body = helper.content_tag(:span, t('idv.modal.sessions.body'))
+      heading = helper.content_tag(:strong, t('idv.modal.sessions.heading'))
+
       flash.now[:warning] = t(
-        'idv.modal.sessions.warning_html',
-        accent: ActionController::Base.helpers.content_tag(
-          :strong,
-          t('idv.modal.sessions.warning_accent')
-        ),
-        attempt: t('idv.modal.attempts', count: remaining_idv_attempts)
+        'idv.modal.warning_html', heading: heading, attempt: attempt, body: body
       )
     end
 

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -58,9 +58,15 @@ module Verify
       flash.now[:warning] = t(
         'idv.modal.sessions.warning_html',
         accent: ActionController::Base.helpers.content_tag(
-          :strong, t('idv.modal.sessions.warning_accent')
-        )
+          :strong,
+          t('idv.modal.sessions.warning_accent')
+        ),
+        attempt: t('idv.modal.attempts', count: remaining_idv_attempts)
       )
+    end
+
+    def remaining_idv_attempts
+      Idv::Attempter.idv_max_attempts - current_user.idv_attempts
     end
 
     def idv_profile_form

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -28,6 +28,10 @@ module Verify
 
     private
 
+    def step_name
+      :sessions
+    end
+
     def confirm_step_needed
       redirect_to verify_finance_path if idv_session.profile_confirmation == true
     end
@@ -55,16 +59,8 @@ module Verify
 
     def show_warning
       return unless step.form_valid_but_vendor_validation_failed?
-
-      helper = ActionController::Base.helpers
-
-      attempt = t('idv.modal.attempts', count: remaining_idv_attempts)
-      body = helper.content_tag(:span, t('idv.modal.sessions.body'))
-      heading = helper.content_tag(:strong, t('idv.modal.sessions.heading'))
-
-      flash.now[:warning] = t(
-        'idv.modal.warning_html', heading: heading, attempt: attempt, body: body
-      )
+      presenter = VerificationWarningPresenter.new(step_name, remaining_idv_attempts)
+      flash.now[:warning] = presenter.warning_message
     end
 
     def remaining_idv_attempts

--- a/app/presenters/verification_warning_presenter.rb
+++ b/app/presenters/verification_warning_presenter.rb
@@ -1,0 +1,26 @@
+class VerificationWarningPresenter
+  def initialize(name, remaining_step_attempts)
+    @name = name
+    @remaining_step_attempts = remaining_step_attempts
+  end
+
+  def warning_message
+    I18n.t('idv.modal.warning_html', heading: heading, attempt: attempt, body: body)
+  end
+
+  private
+
+  attr_reader :name, :remaining_step_attempts
+
+  def attempt
+    I18n.t('idv.modal.attempts', count: remaining_step_attempts)
+  end
+
+  def body
+    ActionController::Base.helpers.content_tag(:span, I18n.t("idv.modal.#{name}.body"))
+  end
+
+  def heading
+    ActionController::Base.helpers.content_tag(:strong, I18n.t("idv.modal.#{name}.heading"))
+  end
+end

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -132,21 +132,27 @@ en:
       sessions:
         no_pii: Do not use real personal information (demo purposes only)
     modal:
+      attempts:
+        one: 1 attempt
+        other: "%{count} attempts"
       button:
         warning: Try again
       finance:
         warning_accent: We could not find records matching your financial information.
         warning_html: >
-          %{accent} <span>Please check the information you entered.</span>
+          %{accent} <span>Please check the information you entered.</span> <span>
+          You have <strong>%{attempt} remaining.</strong></span>
       phone:
         warning_accent: We could not find records matching your phone information.
         warning_html: >
-          %{accent} <span>Please check the information you entered.</span>
+          %{accent} <span>Please check the information you entered.</span> <span>
+          You have <strong>%{attempt} remaining.</strong></span>
       sessions:
         warning_accent: We could not find records matching your personal information.
         warning_html: >
           %{accent} <span>Please check the information you entered. Common mistakes
-          are an incorrect Social Security Number, ZIP Code, or date of birth.</span>
+          are an incorrect Social Security Number, ZIP Code, or date of birth.</span> <span>
+          You have <strong>%{attempt} remaining.</strong></span>
     review:
       dob: Date of birth
       full_name: Full name

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -137,22 +137,19 @@ en:
         other: "%{count} attempts"
       button:
         warning: Try again
-      finance:
-        warning_accent: We could not find records matching your financial information.
-        warning_html: >
-          %{accent} <span>Please check the information you entered.</span> <span>
-          You have <strong>%{attempt} remaining.</strong></span>
+      financials:
+        heading: We could not find records matching your financial information.
+        body: Please check the information you entered.
       phone:
-        warning_accent: We could not find records matching your phone information.
-        warning_html: >
-          %{accent} <span>Please check the information you entered.</span> <span>
-          You have <strong>%{attempt} remaining.</strong></span>
+        heading: We could not find records matching your phone information.
+        body: Please check the information you entered.
       sessions:
-        warning_accent: We could not find records matching your personal information.
-        warning_html: >
-          %{accent} <span>Please check the information you entered. Common mistakes
-          are an incorrect Social Security Number, ZIP Code, or date of birth.</span> <span>
-          You have <strong>%{attempt} remaining.</strong></span>
+        heading: We could not find records matching your personal information.
+        body: >
+          Please check the information you entered. Common mistakes are an incorrect Social
+          Security Number, ZIP Code, or date of birth.
+      warning_html: >
+        %{heading} %{body} <span>You have <strong>%{attempt} remaining.</strong></span>
     review:
       dob: Date of birth
       full_name: Full name

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -104,15 +104,16 @@ es:
         other: NOT TRANSLATED YET
       button:
         warning: NOT TRANSLATED YET
-      finance:
-        warning_accent: NOT TRANSLATED YET
-        warning_html: NOT TRANSLATED YET
+      financials:
+        heading: NOT TRANSLATED YET
+        body: NOT TRANSLATED YET
       phone:
-        warning_accent: NOT TRANSLATED YET
-        warning_html: NOT TRANSLATED YET
+        heading: NOT TRANSLATED YET
+        body: NOT TRANSLATED YET
       sessions:
-        warning_accent: NOT TRANSLATED YET
-        warning_html: NOT TRANSLATED YET
+        heading: NOT TRANSLATED YET
+        body: NOT TRANSLATED YET
+      warning_html: NOT TRANSLATED YET
     review:
       dob: NOT TRANSLATED YET
       full_name: NOT TRANSLATED YET

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -99,6 +99,9 @@ es:
       sessions:
         no_pii: NOT TRANSLATED YET
     modal:
+      attempts:
+        one: NOT TRANSLATED YET
+        other: NOT TRANSLATED YET
       button:
         warning: NOT TRANSLATED YET
       finance:

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -109,14 +109,13 @@ describe Verify::FinanceController do
 
       context 'when CCN is not confirmed' do
         it 'renders #new with error' do
-          allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
-
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '00000000' }
 
-          expect(flash[:warning]).to match(
-            t('idv.modal.finance.warning_html',
-              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>",
-              attempt: t('idv.modal.attempts', count: 2))
+          expect(flash[:warning]).to eq(
+            t('idv.modal.warning_html',
+              heading: "<strong>#{t('idv.modal.financials.heading')}</strong>",
+              attempt: t('idv.modal.attempts', count: max_attempts - 1),
+              body: "<span>#{t('idv.modal.financials.body')}</span>")
           )
           expect(response).to render_template :new
         end

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -44,10 +44,7 @@ describe Verify::FinanceController do
           put :create, idv_finance_form: { foo: 'bar' }
 
           expect(response).to render_template :new
-          expect(flash[:warning]).to_not match(
-            t('idv.modal.finance.warning_html',
-              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>")
-          )
+          expect(flash[:warning]).to be_nil
           expect(subject.idv_session.params).to be_empty
         end
       end
@@ -57,10 +54,7 @@ describe Verify::FinanceController do
           put :create, idv_finance_form: { finance_type: 'foo', finance_account: '123' }
 
           expect(response).to render_template :new
-          expect(flash[:warning]).to_not match(
-            t('idv.modal.finance.warning_html',
-              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>")
-          )
+          expect(flash[:warning]).to be_nil
           expect(subject.idv_session.params).to be_empty
         end
       end
@@ -70,10 +64,7 @@ describe Verify::FinanceController do
           put :create, idv_finance_form: { finance_type: 'ccn', finance_account: 'abc' }
 
           expect(response).to render_template :new
-          expect(flash[:warning]).to_not match(
-            t('idv.modal.finance.warning_html',
-              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>")
-          )
+          expect(flash[:warning]).to be_nil
           expect(subject.idv_session.params).to be_empty
         end
       end
@@ -84,10 +75,7 @@ describe Verify::FinanceController do
             put :create, idv_finance_form: { finance_type: finance_type, finance_account: 'abc' }
 
             expect(response).to render_template :new
-            expect(flash[:warning]).to_not match(
-              t('idv.modal.finance.warning_html',
-                accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>")
-            )
+            expect(flash[:warning]).to be_nil
             expect(subject.idv_session.params).to be_empty
           end
         end
@@ -121,11 +109,14 @@ describe Verify::FinanceController do
 
       context 'when CCN is not confirmed' do
         it 'renders #new with error' do
+          allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
+
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '00000000' }
 
           expect(flash[:warning]).to match(
             t('idv.modal.finance.warning_html',
-              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>")
+              accent: "<strong>#{t('idv.modal.finance.warning_accent')}</strong>",
+              attempt: t('idv.modal.attempts', count: 2))
           )
           expect(response).to render_template :new
         end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -102,8 +102,6 @@ describe Verify::PhoneController do
         user = build(:user, phone: bad_phone, phone_confirmed_at: Time.zone.now)
         stub_subject(user)
 
-        allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
-
         put :create, idv_phone_form: { phone: bad_phone }
 
         result = {
@@ -113,10 +111,11 @@ describe Verify::PhoneController do
           }
         }
 
-        expect(flash[:warning]).to match(
-          t('idv.modal.phone.warning_html',
-            accent: "<strong>#{t('idv.modal.phone.warning_accent')}</strong>",
-            attempt: t('idv.modal.attempts', count: 2))
+        expect(flash[:warning]).to eq(
+          t('idv.modal.warning_html',
+            heading: "<strong>#{t('idv.modal.phone.heading')}</strong>",
+            attempt: t('idv.modal.attempts', count: max_attempts - 1),
+            body: "<span>#{t('idv.modal.phone.body')}</span>")
         )
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION, result

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -55,10 +55,7 @@ describe Verify::PhoneController do
         put :create, idv_phone_form: { phone: '703' }
 
         expect(response.body).to have_content invalid_phone_message
-        expect(flash[:warning]).to_not match(
-          t('idv.modal.phone.warning_html',
-            accent: "<strong>#{t('idv.modal.phone.warning_accent')}</strong>")
-        )
+        expect(flash[:warning]).to be_nil
         expect(subject.idv_session.params).to be_empty
       end
 
@@ -105,6 +102,8 @@ describe Verify::PhoneController do
         user = build(:user, phone: bad_phone, phone_confirmed_at: Time.zone.now)
         stub_subject(user)
 
+        allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
+
         put :create, idv_phone_form: { phone: bad_phone }
 
         result = {
@@ -116,7 +115,8 @@ describe Verify::PhoneController do
 
         expect(flash[:warning]).to match(
           t('idv.modal.phone.warning_html',
-            accent: "<strong>#{t('idv.modal.phone.warning_accent')}</strong>")
+            accent: "<strong>#{t('idv.modal.phone.warning_accent')}</strong>",
+            attempt: t('idv.modal.attempts', count: 2))
         )
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION, result

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -137,15 +137,16 @@ describe Verify::SessionsController do
           post :create, profile: partial_attrs
 
           expect(response).to render_template(:new)
-          expect(flash[:warning]).to_not match(
-            t('idv.modal.sessions.warning_html',
-              accent: "<strong>#{t('idv.modal.sessions.warning_accent')}</strong>")
-          )
+          expect(flash[:warning]).to be_nil
           expect(response.body).to match t('errors.messages.blank')
         end
       end
 
       context 'un-resolvable attributes' do
+        before do
+          allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
+        end
+
         let(:bad_attrs) { user_attrs.dup.merge(first_name: 'Bad') }
 
         it 're-renders form' do
@@ -153,7 +154,8 @@ describe Verify::SessionsController do
 
           expect(flash[:warning]).to match(
             t('idv.modal.sessions.warning_html',
-              accent: "<strong>#{t('idv.modal.sessions.warning_accent')}</strong>")
+              accent: "<strong>#{t('idv.modal.sessions.warning_accent')}</strong>",
+              attempt: t('idv.modal.attempts', count: 2))
           )
           expect(response).to render_template(:new)
         end

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -143,19 +143,16 @@ describe Verify::SessionsController do
       end
 
       context 'un-resolvable attributes' do
-        before do
-          allow(Idv::Attempter).to receive(:idv_max_attempts).and_return 3
-        end
-
         let(:bad_attrs) { user_attrs.dup.merge(first_name: 'Bad') }
 
         it 're-renders form' do
           post :create, profile: bad_attrs
 
-          expect(flash[:warning]).to match(
-            t('idv.modal.sessions.warning_html',
-              accent: "<strong>#{t('idv.modal.sessions.warning_accent')}</strong>",
-              attempt: t('idv.modal.attempts', count: 2))
+          expect(flash[:warning]).to eq(
+            t('idv.modal.warning_html',
+              heading: "<strong>#{t('idv.modal.sessions.heading')}</strong>",
+              attempt: t('idv.modal.attempts', count: max_attempts - 1),
+              body: "<span>#{t('idv.modal.sessions.body')}</span>")
           )
           expect(response).to render_template(:new)
         end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -144,7 +144,7 @@ feature 'IdV session' do
       expect(current_path).to eq verify_session_path
       expect(page).to have_css(
         '.modal-warning',
-        text: t('idv.modal.sessions.warning_accent')
+        text: t('idv.modal.sessions.heading')
       )
       click_link t('idv.modal.button.warning')
 
@@ -164,7 +164,7 @@ feature 'IdV session' do
       expect(current_path).to eq verify_finance_path
       expect(page).to have_css(
         '.modal-warning',
-        text: t('idv.modal.finance.warning_accent')
+        text: t('idv.modal.financials.heading')
       )
       click_link t('idv.modal.button.warning')
 
@@ -208,7 +208,7 @@ feature 'IdV session' do
       expect(current_path).to eq verify_phone_path
       expect(page).to have_css(
         '.modal-warning',
-        text: t('idv.modal.phone.warning_accent')
+        text: t('idv.modal.phone.heading')
       )
       click_link t('idv.modal.button.warning')
       expect(page).to have_selector("input[value='#{bad_phone_formatted}']")
@@ -237,7 +237,7 @@ feature 'IdV session' do
 
       expect(page).to have_css(
         '.alert-warning',
-        text: t('idv.modal.sessions.warning_accent')
+        text: t('idv.modal.sessions.heading')
       )
     end
 


### PR DESCRIPTION
**Why**: To let people know how many remaining attempts they have on a per step basis.

![screen shot 2017-02-06 at 5 44 48 pm](https://cloud.githubusercontent.com/assets/1178494/22669892/b0611718-ec94-11e6-9a69-53fbc6698e1d.png)
