### PR TITLE
Prevent TOTP-enabled users from viewing TOTP setup

### DIFF
--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -3,6 +3,8 @@ module Users
     before_action :confirm_two_factor_authenticated
 
     def new
+      return redirect_to profile_path if current_user.totp_enabled?
+
       user_session[:new_totp_secret] = current_user.generate_totp_secret if new_totp_secret.nil?
 
       @qrcode = decorated_user.qrcode(new_totp_secret)


### PR DESCRIPTION
**Why**: To avoid any potential confusion, we should disallow
TOTP-enabled users from accessing the TOTP setup page. Note that this
is an edge case since there is no direct link the TOTP setup page from
the app once they've enabled it, but they could potentially bookmark
the URL and visit it later. If they do, we redirect them to the profile
page.