### PR TITLE
Add CSRF spec to /api/service_providers

### DIFF
--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -53,6 +53,22 @@ describe ServiceProviderController do
         expect(sp.valid?).to eq true
         expect(VALID_SERVICE_PROVIDERS).to include dashboard_sp_issuer
       end
+
+      context 'with CSRF protection enabled' do
+        before do
+          ActionController::Base.allow_forgery_protection = true
+        end
+
+        after do
+          ActionController::Base.allow_forgery_protection = false
+        end
+
+        it 'ignores invalid CSRF tokens' do
+          post :update
+
+          expect(response.status).to eq(200)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: More tests are a good thing.

Update for #1024