### PR TITLE
Enforce trailing comma for multi-line arrays / hashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -241,7 +241,7 @@ Style/TrailingCommaInLiteral:
   # hash, but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
   # non-empty array and hash literals.
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStyles:
     - comma
     - consistent_comma

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -12,7 +12,7 @@ module TwoFactorAuthenticatable
     authenticator: 'authenticator',
     sms: 'phone',
     voice: 'phone',
-    two_factor_authentication: 'otp'
+    two_factor_authentication: 'otp',
   }.freeze
 
   private
@@ -174,7 +174,7 @@ module TwoFactorAuthenticatable
       reenter_phone_number_path: reenter_phone_number_path,
       unconfirmed_phone: unconfirmed_phone?,
       recovery_code_unavailable: recovery_code_unavailable?,
-      totp_enabled: current_user.totp_enabled?
+      totp_enabled: current_user.totp_enabled?,
     }
   end
 
@@ -182,7 +182,7 @@ module TwoFactorAuthenticatable
     {
       delivery_method: delivery_method,
       user_email: current_user.email,
-      recovery_code_unavailable: recovery_code_unavailable?
+      recovery_code_unavailable: recovery_code_unavailable?,
     }
   end
 
@@ -191,7 +191,7 @@ module TwoFactorAuthenticatable
       reenter_phone_number_path: reenter_phone_number_path,
       phone_number: display_phone_to_deliver_to,
       unconfirmed_phone: unconfirmed_phone?,
-      recovery_code_unavailable: recovery_code_unavailable?
+      recovery_code_unavailable: recovery_code_unavailable?,
     }
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -51,7 +51,7 @@ class SamlIdpController < ApplicationController
       locals: {
         action_url: action_url,
         message: message,
-        type: type
+        type: type,
       },
       layout: false
     )

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -31,7 +31,7 @@ module TwoFactorAuthentication
       {
         context: context,
         method: params[:delivery_method],
-        confirmation_for_phone_change: confirmation_for_phone_change?
+        confirmation_for_phone_change: confirmation_for_phone_change?,
       }
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -71,7 +71,7 @@ module Users
       properties = {
         success: user_signed_in_and_not_locked_out?(user),
         user_id: user.uuid,
-        user_locked_out: user_locked_out?(user)
+        user_locked_out: user_locked_out?(user),
       }
 
       analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -20,7 +20,7 @@ module Verify
     def track_final_idv_event
       result = {
         success: true,
-        new_phone_added: idv_session.params['phone_confirmed_at'].present?
+        new_phone_added: idv_session.params['phone_confirmed_at'].present?,
       }
       analytics.track_event(Analytics::IDV_FINAL, result)
     end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -46,7 +46,7 @@ UserDecorator = Struct.new(:user) do
   def qrcode(otp_secret_key)
     options = {
       issuer: 'Login.gov',
-      otp_secret_key: otp_secret_key
+      otp_secret_key: otp_secret_key,
     }
     url = user.provisioning_uri(nil, options)
     qrcode = RQRCode::QRCode.new(url)

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -11,26 +11,26 @@ module Idv
         class: 'ccn',
         pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_CCN_LENGTH,
-        maxlength: FormFinanceValidator::VALID_CCN_LENGTH
+        maxlength: FormFinanceValidator::VALID_CCN_LENGTH,
       },
       mortgage: {
         class: 'mortgage',
         pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
-        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH,
       },
       home_equity_line: {
         class: 'home_equity_line',
         pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
-        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH,
       },
       auto_loan: {
         class: 'auto_loan',
         pattern: '[0-9]*',
         minlength: FormFinanceValidator::VALID_MINIMUM_LENGTH,
-        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH
-      }
+        maxlength: FormFinanceValidator::VALID_MAXIMUM_LENGTH,
+      },
     }.freeze
 
     attr_reader :idv_params, :finance_type, :blank, *FINANCE_TYPES
@@ -57,7 +57,7 @@ module Idv
 
     def self.ccn_inputs
       [
-        [:ccn, I18n.t('idv.form.ccn'), FINANCE_HTML_OPTIONS.fetch(:ccn, {})]
+        [:ccn, I18n.t('idv.form.ccn'), FINANCE_HTML_OPTIONS.fetch(:ccn, {})],
       ]
     end
 

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -101,7 +101,7 @@ module Idv
     def result
       {
         success: success,
-        errors: errors.messages
+        errors: errors.messages,
       }
     end
   end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -54,7 +54,7 @@ class OpenidConnectAuthorizeForm
       scope: scope.join(' '),
       state: state,
       code_challenge: code_challenge,
-      code_challenge_method: code_challenge_method
+      code_challenge_method: code_challenge_method,
     }.select { |_key, value| value.present? }
   end
 
@@ -67,7 +67,7 @@ class OpenidConnectAuthorizeForm
       success: valid?,
       redirect_uri: result_uri,
       client_id: client_id,
-      errors: errors.messages
+      errors: errors.messages,
     }
   end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -37,7 +37,7 @@ class OpenidConnectTokenForm
     {
       success: valid?,
       client_id: client_id,
-      errors: errors.messages
+      errors: errors.messages,
     }
   end
 
@@ -47,7 +47,7 @@ class OpenidConnectTokenForm
         access_token: identity.access_token,
         token_type: 'Bearer',
         expires_in: Pii::SessionStore.new(identity.session_uuid).ttl,
-        id_token: IdTokenBuilder.new(identity).id_token
+        id_token: IdTokenBuilder.new(identity).id_token,
       }
     else
       { error: errors.to_a.join(' ') }

--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -38,7 +38,7 @@ class OtpDeliverySelectionForm
       success: success,
       delivery_method: otp_method,
       resend: resend,
-      errors: errors.full_messages
+      errors: errors.full_messages,
     }
   end
 end

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -20,7 +20,7 @@ class OtpVerificationForm
 
   def result
     {
-      success: success
+      success: success,
     }
   end
 end

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -24,7 +24,7 @@ class PasswordForm
     {
       success: success,
       errors: errors.messages.values.flatten,
-      user_id: user.uuid
+      user_id: user.uuid,
     }
   end
 end

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -28,7 +28,7 @@ class PasswordResetEmailForm
       errors: errors.messages.values.flatten,
       user_id: user.uuid,
       role: user.role,
-      confirmed: user.confirmed?
+      confirmed: user.confirmed?,
     }
   end
 

--- a/app/forms/recovery_code_form.rb
+++ b/app/forms/recovery_code_form.rb
@@ -23,7 +23,7 @@ class RecoveryCodeForm
 
   def result
     {
-      success: success
+      success: success,
     }
   end
 end

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -42,7 +42,7 @@ class RegisterUserEmailForm
       success: success,
       errors: errors.messages.values.flatten,
       email_already_exists: email_taken?,
-      user_id: existing_user&.uuid
+      user_id: existing_user&.uuid,
     }
   end
 

--- a/app/forms/resend_email_confirmation_form.rb
+++ b/app/forms/resend_email_confirmation_form.rb
@@ -27,7 +27,7 @@ class ResendEmailConfirmationForm
       success: success,
       errors: errors.messages.values.flatten,
       user_id: user.uuid,
-      confirmed: user.confirmed?
+      confirmed: user.confirmed?,
     }
   end
 

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -37,7 +37,7 @@ class ResetPasswordForm
       errors: errors.messages.values.flatten,
       user_id: user.uuid,
       active_profile: user.active_profile.present?,
-      confirmed: user.confirmed?
+      confirmed: user.confirmed?,
     }
   end
 end

--- a/app/forms/totp_setup_form.rb
+++ b/app/forms/totp_setup_form.rb
@@ -21,7 +21,7 @@ class TotpSetupForm
 
   def result
     {
-      success: success
+      success: success,
     }
   end
 end

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -20,7 +20,7 @@ class TotpVerificationForm
 
   def result
     {
-      success: success
+      success: success,
     }
   end
 end

--- a/app/forms/two_factor_setup_form.rb
+++ b/app/forms/two_factor_setup_form.rb
@@ -37,7 +37,7 @@ class TwoFactorSetupForm
     {
       success: success,
       error: errors.messages.values.flatten.first,
-      otp_method: otp_method
+      otp_method: otp_method,
     }
   end
 end

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -54,7 +54,7 @@ class UpdateUserEmailForm
       success: success,
       errors: errors.messages.values.flatten,
       email_already_exists: email_taken?,
-      email_changed: email_changed?
+      email_changed: email_changed?,
     }
   end
 end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -23,7 +23,7 @@ class UpdateUserPasswordForm
   def result
     {
       success: success,
-      errors: errors.full_messages
+      errors: errors.full_messages,
     }
   end
 end

--- a/app/helpers/accordion_helper.rb
+++ b/app/helpers/accordion_helper.rb
@@ -2,7 +2,7 @@ module AccordionHelper
   def accordion(target_id, header_text, &block)
     locals = {
       target_id: target_id,
-      header_text: header_text
+      header_text: header_text,
     }
 
     render(layout: 'shared/accordion', locals: locals, &block)

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -66,7 +66,7 @@ module FormHelper
       ['Washington', 'WA'],
       ['West Virginia', 'WV'],
       ['Wisconsin', 'WI'],
-      ['Wyoming', 'WY']
+      ['Wyoming', 'WY'],
     ]
   end
   # rubocop:enable MethodLength, WordArray

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -26,7 +26,7 @@ module SessionTimeoutWarningHelper
                warning: warning,
                start: start,
                frequency: frequency,
-               modal: modal
+               modal: modal,
              }
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,7 @@ class Event < ActiveRecord::Base
     phone_changed: 4,
     email_changed: 5,
     authenticator_enabled: 6,
-    authenticator_disabled: 7
+    authenticator_disabled: 7,
   }
 
   validates :event_type, presence: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,7 +9,7 @@ class Profile < ActiveRecord::Base
 
   enum deactivation_reason: {
     password_reset: 1,
-    encryption_error: 2
+    encryption_error: 2,
   }
 
   attr_reader :recovery_code

--- a/app/presenters/openid_connect_certs_presenter.rb
+++ b/app/presenters/openid_connect_certs_presenter.rb
@@ -1,7 +1,7 @@
 class OpenidConnectCertsPresenter
   def certs
     {
-      keys: keys.map { |key| JSON::JWK.new(key) }
+      keys: keys.map { |key| JSON::JWK.new(key) },
     }
   end
 

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -8,7 +8,7 @@ class OpenidConnectConfigurationPresenter
       grant_types_supported: %w(authorization_code),
       response_types_supported: %w(code),
       scopes_supported: OpenidConnectAttributeScoper::VALID_SCOPES,
-      subject_types_supported: %w(pairwise)
+      subject_types_supported: %w(pairwise),
     }.merge(url_configuration).merge(crypto_configuration)
   end
 
@@ -21,7 +21,7 @@ class OpenidConnectConfigurationPresenter
       jwks_uri: openid_connect_certs_url,
       service_documentation: 'https://pages.18f.gov/identity-dev-docs/',
       token_endpoint: openid_connect_token_url,
-      userinfo_endpoint: openid_connect_userinfo_url
+      userinfo_endpoint: openid_connect_userinfo_url,
     }
   end
 
@@ -29,7 +29,7 @@ class OpenidConnectConfigurationPresenter
     {
       id_token_signing_alg_values_supported: %w(RS256),
       token_endpoint_auth_methods_supported: %w(private_key_jwt),
-      token_endpoint_auth_signing_alg_values_supported: %w(RS256)
+      token_endpoint_auth_signing_alg_values_supported: %w(RS256),
     }
   end
 

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -12,7 +12,7 @@ class OpenidConnectUserInfoPresenter
       sub: identity.uuid,
       iss: root_url,
       email: identity.user.email,
-      email_verified: true
+      email_verified: true,
     }.merge(loa3_attributes)
 
     OpenidConnectAttributeScoper.new(identity.scope).filter(info)
@@ -30,7 +30,7 @@ class OpenidConnectUserInfoPresenter
       birthdate: loa3_data.dob,
       address: address,
       phone: phone,
-      phone_verified: phone ? true : nil
+      phone_verified: phone ? true : nil,
     }
   end
 
@@ -42,14 +42,14 @@ class OpenidConnectUserInfoPresenter
       street_address: street_address,
       locality: loa3_data.city,
       region: loa3_data.state,
-      postal_code: loa3_data.zipcode
+      postal_code: loa3_data.zipcode,
     }
   end
 
   def formatted_address
     [
       street_address,
-      "#{loa3_data.city}, #{loa3_data.state} #{loa3_data.zipcode}"
+      "#{loa3_data.city}, #{loa3_data.state} #{loa3_data.zipcode}",
     ].compact.join("\n")
   end
 

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -17,7 +17,7 @@ module TwoFactorAuthCode
       [
         otp_fallback_options,
         update_phone_link,
-        recovery_code_link
+        recovery_code_link,
       ].compact
     end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -7,7 +7,7 @@ class Analytics
   def track_event(event, attributes = {})
     analytics_hash = {
       event_properties: attributes.except(:user_id),
-      user_id: attributes[:user_id] || uuid
+      user_id: attributes[:user_id] || uuid,
     }
 
     ahoy.track(event, analytics_hash.merge!(request_attributes))
@@ -25,7 +25,7 @@ class Analytics
     {
       user_ip: request.remote_ip,
       user_agent: request.user_agent,
-      host: request.host
+      host: request.host,
     }
   end
 

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -10,7 +10,7 @@ class AttributeAsserter
     :zipcode,
     :dob,
     :ssn,
-    :phone
+    :phone,
   ].freeze
 
   URI_PATTERN = Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF
@@ -38,8 +38,8 @@ class AttributeAsserter
       uuid: {
         getter: uuid_getter_function,
         name_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT,
-        name_id_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
-      }
+        name_id_format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT,
+      },
     }
   end
 
@@ -67,7 +67,7 @@ class AttributeAsserter
     attrs[:email] = {
       getter: :email,
       name_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
-      name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS
+      name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
     }
   end
 

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -23,7 +23,7 @@ class EmailConfirmationTokenValidator
       success: success,
       error: [errors.full_messages, user.errors.full_messages].join,
       user_id: user.uuid,
-      existing_user: user.confirmed?
+      existing_user: user.confirmed?,
     }
   end
 

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -28,7 +28,7 @@ class IdTokenBuilder
     {
       exp: @custom_expiration || expires,
       iat: now,
-      nbf: now
+      nbf: now,
     }
   end
 

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -23,7 +23,7 @@ IdentityLinker = Struct.new(:user, :provider) do
     {
       last_authenticated_at: Time.current,
       session_uuid: session_uuid,
-      access_token: SecureRandom.urlsafe_base64
+      access_token: SecureRandom.urlsafe_base64,
     }
   end
 

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -42,7 +42,7 @@ module Idv
       {
         success: success,
         errors: errors,
-        vendor: { reasons: vendor_reasons }
+        vendor: { reasons: vendor_reasons },
       }
     end
   end

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -64,7 +64,7 @@ module Idv
     def extra_analytics_attributes
       {
         idv_attempts_exceeded: attempts_exceeded?,
-        vendor: { reasons: vendor_reasons }
+        vendor: { reasons: vendor_reasons },
       }
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -10,7 +10,7 @@ module Idv
       :recovery_code,
       :resolution,
       :step_attempts,
-      :vendor
+      :vendor,
     ].freeze
 
     def initialize(user_session, current_user)

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -16,7 +16,7 @@ class OpenidConnectAttributeScoper
     given_name: 'profile',
     family_name: 'profile',
     middle_name: 'profile',
-    birthdate: 'profile'
+    birthdate: 'profile',
   }.with_indifferent_access.freeze
 
   CLAIMS = ATTRIBUTE_SCOPE_MAP.keys

--- a/app/services/password_reset_token_validator.rb
+++ b/app/services/password_reset_token_validator.rb
@@ -23,7 +23,7 @@ class PasswordResetTokenValidator
     {
       success: success,
       error: errors.messages.values.flatten.first,
-      user_id: user&.uuid
+      user_id: user&.uuid,
     }
   end
 

--- a/app/services/pii/session_store.rb
+++ b/app/services/pii/session_store.rb
@@ -27,8 +27,8 @@ module Pii
     def put(pii, expiration = 5.minutes)
       session_data = {
         'warden.user.user.session' => {
-          decrypted_pii: pii.to_h.to_json
-        }
+          decrypted_pii: pii.to_h.to_json,
+        },
       }
 
       session_store.

--- a/app/services/recovery_code_generator.rb
+++ b/app/services/recovery_code_generator.rb
@@ -39,7 +39,7 @@ class RecoveryCodeGenerator
     key_maker.make(user_access_key)
     [
       user_access_key.encryption_key,
-      user_access_key.encrypted_password
+      user_access_key.encrypted_password,
     ].join(Pii::Encryptor::DELIMITER)
   end
 

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -23,7 +23,7 @@ class SamlRequestValidator
       authn_context: authn_context,
       errors: errors.messages.values.flatten,
       service_provider: service_provider.issuer,
-      valid: success
+      valid: success,
     }
   end
 

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -7,7 +7,7 @@ module FormEmailValidator
     validates :email,
               email: {
                 mx: !ENV['RAILS_OFFLINE'],
-                ban_disposable_email: true
+                ban_disposable_email: true,
               }
   end
 

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -32,7 +32,7 @@ module FormPasswordValidator
 
   def i18n_variables
     {
-      feedback: zxcvbn_feedback
+      feedback: zxcvbn_feedback,
     }
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,7 +53,7 @@ namespace :deploy do
           branch: fetch(:branch),
           user: fetch(:local_user),
           sha: fetch(:current_revision),
-          timestamp: fetch(:release_timestamp)
+          timestamp: fetch(:release_timestamp),
         }
 
         execute :mkdir, '-p', 'public/api'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {
     host: Figaro.env.domain_name,
-    protocol: 'http'
+    protocol: 'http',
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {
     host: Figaro.env.domain_name,
-    protocol: 'https'
+    protocol: 'https',
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/devise_mailer_helpers.rb
+++ b/config/initializers/devise_mailer_helpers.rb
@@ -10,7 +10,7 @@ module Devise
           subject: subject_for(action),
           to: recipient,
           template_path: template_paths,
-          template_name: action
+          template_name: action,
         }.merge(opts)
 
         @email = headers[:to]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -9,7 +9,7 @@ Rails.application.config.filter_parameters += [
   :password,
   :phone,
   :profile,
-  :user
+  :user,
 ]
 # Configure redirect URLs to be filtered based on a matching string.
 Rails.application.config.filter_redirect << 'token'

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -27,7 +27,7 @@ SamlIdp.configure do |config|
   config.name_id.formats =
     {
       persistent: ->(principal) { principal.asserted_attributes[:uuid][:getter].call(principal) },
-      email_address: ->(principal) { principal.email }
+      email_address: ->(principal) { principal.email },
     }
 
   ## Technical contact ##

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -22,10 +22,10 @@ SecureHeaders::Configuration.default do |config|
       '*.newrelic.com',
       '*.nr-data.net',
       'dap.digitalgov.gov',
-      '*.google-analytics.com'
+      '*.google-analytics.com',
     ],
     style_src: ["'self'"],
-    base_uri: ["'self'"]
+    base_uri: ["'self'"],
   }
 
   if !Rails.env.production?
@@ -44,7 +44,7 @@ SecureHeaders::Configuration.default do |config|
     # is fixed in Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=619603
     samesite: {
       lax: true # mark all cookies as SameSite=Lax.
-    }
+    },
   }
 
   # Temporarily disabled until we configure pinning. See GitHub issue #1895.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,9 +6,9 @@ options = {
     driver: :hiredis,
     expire_after: Figaro.env.session_timeout_in_minutes.to_i.minutes,
     key_prefix: "#{Figaro.env.domain_name}:session:",
-    url: Figaro.env.redis_url
+    url: Figaro.env.redis_url,
   },
-  serializer: SessionEncryptor
+  serializer: SessionEncryptor,
 }
 
 Rails.application.config.session_store :redis_session_store, options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,11 @@ Rails.application.routes.draw do
 
   # Devise handles login itself. It's first in the chain to avoid a redirect loop during
   # authentication failure.
-  devise_for :users, skip: [:confirmations, :sessions, :registrations, :two_factor_authentication], controllers: {
-    passwords: 'users/reset_passwords'
-  }
+  devise_for(
+    :users,
+    skip: [:confirmations, :sessions, :registrations, :two_factor_authentication],
+    controllers: { passwords: 'users/reset_passwords' }
+  )
 
   # Additional device controller routes.
   devise_scope :user do

--- a/lib/service_provider.rb
+++ b/lib/service_provider.rb
@@ -17,7 +17,7 @@ class ServiceProvider
     {
       cert: ssl_cert,
       block_encryption: block_encryption,
-      key_transport: 'rsa-oaep-mgf1p'
+      key_transport: 'rsa-oaep-mgf1p',
     }
   end
 

--- a/spec/controllers/health/workers_controller_spec.rb
+++ b/spec/controllers/health/workers_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Health::WorkersController do
     let(:statuses) do
       [
         WorkerHealthChecker::Status.new('voice', 0.minutes.ago, true),
-        WorkerHealthChecker::Status.new('sms', 0.minutes.ago, true)
+        WorkerHealthChecker::Status.new('sms', 0.minutes.ago, true),
       ]
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Health::WorkersController do
       let(:statuses) do
         [
           WorkerHealthChecker::Status.new('voice', 0.minutes.ago, true),
-          WorkerHealthChecker::Status.new('sms', nil, false)
+          WorkerHealthChecker::Status.new('sms', nil, false),
         ]
       end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       response_type: 'code',
       scope: 'openid profile',
-      state:  SecureRandom.hex
+      state:  SecureRandom.hex,
     }
   end
 

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe OpenidConnect::TokenController do
         sub: client_id,
         aud: openid_connect_token_url,
         jti: SecureRandom.hex,
-        exp: 5.minutes.from_now.to_i
+        exp: 5.minutes.from_now.to_i,
       }
 
       client_private_key = OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read)

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -201,7 +201,7 @@ describe SamlIdpController do
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
           errors: ['Unauthorized authentication context'],
           service_provider: 'http://localhost:3000',
-          valid: false
+          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -223,7 +223,7 @@ describe SamlIdpController do
           authn_context: nil,
           errors: ['Unauthorized authentication context'],
           service_provider: 'http://localhost:3000',
-          valid: false
+          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -246,7 +246,7 @@ describe SamlIdpController do
           authn_context: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
           errors: ['Unauthorized Service Provider'],
           service_provider: 'invalid_provider',
-          valid: false
+          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -269,7 +269,7 @@ describe SamlIdpController do
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
           errors: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
           service_provider: 'invalid_provider',
-          valid: false
+          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -750,7 +750,7 @@ describe SamlIdpController do
           errors: [],
           service_provider: 'http://localhost:3000',
           valid: true,
-          idv: true
+          idv: true,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -772,7 +772,7 @@ describe SamlIdpController do
           errors: [],
           service_provider: 'http://localhost:3000',
           valid: true,
-          idv: false
+          idv: false,
         }
 
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -16,8 +16,8 @@ describe ServiceProviderController do
           assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
           block_encryption: 'aes256-cbc',
           cert: saml_test_sp_cert,
-          active: true
-        }
+          active: true,
+        },
       ]
     end
 

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -11,7 +11,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Confirmation token Please fill in this field.',
         user_id: nil,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -28,7 +28,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Confirmation token Please fill in this field.',
         user_id: nil,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -45,7 +45,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Confirmation token is invalid',
         user_id: nil,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -62,7 +62,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Confirmation token is invalid',
         user_id: nil,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -81,7 +81,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Email was already confirmed, please try signing in',
         user_id: user.uuid,
-        existing_user: true
+        existing_user: true,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -98,7 +98,7 @@ describe SignUp::EmailConfirmationsController do
         success: false,
         error: 'Confirmation token has expired',
         user_id: user.uuid,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -123,7 +123,7 @@ describe SignUp::EmailConfirmationsController do
         success: true,
         error: '',
         user_id: user.uuid,
-        existing_user: false
+        existing_user: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -148,7 +148,7 @@ describe SignUp::EmailConfirmationsController do
         success: true,
         error: '',
         user_id: user.uuid,
-        existing_user: true
+        existing_user: true,
       }
 
       expect(@analytics).to receive(:track_event).

--- a/spec/controllers/sign_up/email_resend_controller_spec.rb
+++ b/spec/controllers/sign_up/email_resend_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SignUp::EmailResendController do
           success: true,
           errors: [],
           user_id: user.uuid,
-          confirmed: false
+          confirmed: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -43,7 +43,7 @@ RSpec.describe SignUp::EmailResendController do
           success: true,
           errors: [],
           user_id: 'nonexistent-uuid',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -63,7 +63,7 @@ RSpec.describe SignUp::EmailResendController do
           success: true,
           errors: [],
           user_id: user.uuid,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -14,7 +14,7 @@ describe SignUp::PasswordsController do
       analytics_hash = {
         success: true,
         errors: [],
-        user_id: user.uuid
+        user_id: user.uuid,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -40,7 +40,7 @@ describe SignUp::PasswordsController do
       analytics_hash = {
         success: false,
         errors: ['is too short (minimum is 8 characters)'],
-        user_id: user.uuid
+        user_id: user.uuid,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -55,7 +55,7 @@ describe SignUp::PasswordsController do
 
       analytics_hash = {
         success: true,
-        errors: []
+        errors: [],
       }
 
       expect(form).to receive(:submit).with(password: 'password').

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -58,7 +58,7 @@ describe SignUp::RegistrationsController, devise: true do
           success: true,
           errors: [],
           email_already_exists: false,
-          user_id: user.uuid
+          user_id: user.uuid,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -93,7 +93,7 @@ describe SignUp::RegistrationsController, devise: true do
         success: true,
         errors: [],
         email_already_exists: true,
-        user_id: existing_user.uuid
+        user_id: existing_user.uuid,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -110,7 +110,7 @@ describe SignUp::RegistrationsController, devise: true do
         success: false,
         errors: [t('valid_email.validations.email.invalid')],
         email_already_exists: false,
-        user_id: nil
+        user_id: nil,
       }
 
       expect(@analytics).to receive(:track_event).

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -37,7 +37,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       analytics_hash = {
         context: 'authentication',
         method: 'sms',
-        confirmation_for_phone_change: false
+        confirmation_for_phone_change: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -66,7 +66,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           success: false,
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms'
+          method: 'sms',
         }
 
         stub_analytics
@@ -100,7 +100,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           success: false,
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms'
+          method: 'sms',
         }
 
         stub_analytics
@@ -138,7 +138,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           success: true,
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms'
+          method: 'sms',
         }
 
         stub_analytics
@@ -222,7 +222,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               success: true,
               confirmation_for_phone_change: true,
               context: 'confirmation',
-              method: 'sms'
+              method: 'sms',
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -266,7 +266,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               success: false,
               confirmation_for_phone_change: true,
               context: 'confirmation',
-              method: 'sms'
+              method: 'sms',
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -300,7 +300,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               success: true,
               context: 'confirmation',
               method: 'sms',
-              confirmation_for_phone_change: false
+              confirmation_for_phone_change: false,
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -352,7 +352,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             success: true,
             confirmation_for_phone_change: false,
             context: 'idv',
-            method: 'sms'
+            method: 'sms',
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -417,7 +417,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             success: false,
             confirmation_for_phone_change: false,
             context: 'idv',
-            method: 'sms'
+            method: 'sms',
           }
 
           expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -71,7 +71,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
       it 'tracks the max attempts event' do
         properties = {
           success: false,
-          method: 'recovery code'
+          method: 'recovery code',
         }
 
         stub_analytics

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -20,7 +20,7 @@ describe Users::EmailsController do
           success: true,
           errors: [],
           email_already_exists: false,
-          email_changed: true
+          email_changed: true,
         }
 
         put :update, update_user_email_form: { email: new_email }
@@ -47,7 +47,7 @@ describe Users::EmailsController do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           email_already_exists: false,
-          email_changed: false
+          email_changed: false,
         }
 
         put :update, update_user_email_form: { email: '' }
@@ -70,7 +70,7 @@ describe Users::EmailsController do
           success: true,
           errors: [],
           email_already_exists: true,
-          email_changed: true
+          email_changed: true,
         }
 
         put :update, update_user_email_form: { email: second_user.email.upcase }
@@ -96,7 +96,7 @@ describe Users::EmailsController do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           email_already_exists: false,
-          email_changed: false
+          email_changed: false,
         }
 
         put :update, update_user_email_form: { email: 'foo' }
@@ -120,7 +120,7 @@ describe Users::EmailsController do
           success: true,
           errors: [],
           email_already_exists: false,
-          email_changed: false
+          email_changed: false,
         }
 
         put :update, update_user_email_form: { email: user.email }

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -71,7 +71,7 @@ describe Users::PasswordsController do
         patch :update, update_user_password_form: params
 
         errors = [
-          "Password #{t('errors.messages.too_short.other', count: Devise.password_length.first)}"
+          "Password #{t('errors.messages.too_short.other', count: Devise.password_length.first)}",
         ]
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/users/reactivate_profile_controller_spec.rb
+++ b/spec/controllers/users/reactivate_profile_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Users::ReactivateProfileController do
         :create,
         reactivate_profile_form: {
           password: 'password',
-          recovery_code: 'recovery_code'
+          recovery_code: 'recovery_code',
         }
       )
     end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -12,7 +12,7 @@ describe Users::ResetPasswordsController, devise: true do
         analytics_hash = {
           success: false,
           error: 'invalid_token',
-          user_id: nil
+          user_id: nil,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -37,7 +37,7 @@ describe Users::ResetPasswordsController, devise: true do
         analytics_hash = {
           success: false,
           error: 'token_expired',
-          user_id: '123'
+          user_id: '123',
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -89,7 +89,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: ['is too short (minimum is 8 characters)', 'token_expired'],
           user_id: user.uuid,
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -122,7 +122,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: ['is too short (minimum is 8 characters)'],
           user_id: user.uuid,
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -162,7 +162,7 @@ describe Users::ResetPasswordsController, devise: true do
             errors: [],
             user_id: user.uuid,
             active_profile: false,
-            confirmed: true
+            confirmed: true,
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -202,7 +202,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: user.uuid,
           active_profile: true,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -241,7 +241,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: user.uuid,
           active_profile: false,
-          confirmed: false
+          confirmed: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -265,7 +265,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -290,7 +290,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: tech_user.uuid,
           role: 'tech',
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -315,7 +315,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: admin.uuid,
           role: 'admin',
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -340,7 +340,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: user.uuid,
           role: 'user',
-          confirmed: true
+          confirmed: true,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -364,7 +364,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [],
           user_id: user.uuid,
           role: 'user',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -392,7 +392,7 @@ describe Users::ResetPasswordsController, devise: true do
           errors: [t('valid_email.validations.email.invalid')],
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(form).to receive(:submit).and_return(analytics_hash)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -139,7 +139,7 @@ describe Users::SessionsController, devise: true do
       analytics_hash = {
         success: true,
         user_id: user.uuid,
-        user_locked_out: false
+        user_locked_out: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -155,7 +155,7 @@ describe Users::SessionsController, devise: true do
       analytics_hash = {
         success: false,
         user_id: user.uuid,
-        user_locked_out: false
+        user_locked_out: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -169,7 +169,7 @@ describe Users::SessionsController, devise: true do
       analytics_hash = {
         success: false,
         user_id: 'anonymous-uuid',
-        user_locked_out: false
+        user_locked_out: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -189,7 +189,7 @@ describe Users::SessionsController, devise: true do
       analytics_hash = {
         success: false,
         user_id: user.uuid,
-        user_locked_out: true
+        user_locked_out: true,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -249,7 +249,7 @@ describe Users::SessionsController, devise: true do
         analytics_hash = {
           success: true,
           user_id: user.uuid,
-          user_locked_out: false
+          user_locked_out: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -257,7 +257,7 @@ describe Users::SessionsController, devise: true do
 
         profile_encryption_error = {
           error: 'Unable to parse encrypted payload. ' \
-                 '#<TypeError: no implicit conversion of nil into String>'
+                 '#<TypeError: no implicit conversion of nil into String>',
         }
         expect(@analytics).to receive(:track_event).
           with(Analytics::PROFILE_ENCRYPTION_INVALID, profile_encryption_error)

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -69,7 +69,7 @@ describe Users::TotpSetupController, devise: true do
         expect(subject.current_user.totp_enabled?).to be(false)
 
         result = {
-          success: false
+          success: false,
         }
         expect(@analytics).to have_received(:track_event).with(Analytics::TOTP_SETUP, result)
       end
@@ -94,7 +94,7 @@ describe Users::TotpSetupController, devise: true do
         expect(subject.user_session[:new_totp_secret]).to be_nil
 
         result = {
-          success: true
+          success: true,
         }
         expect(@analytics).to have_received(:track_event).with(Analytics::TOTP_SETUP, result)
       end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -136,7 +136,7 @@ describe Users::TwoFactorAuthenticationController do
           delivery_method: 'sms',
           resend: nil,
           errors: [],
-          context: 'authentication'
+          context: 'authentication',
         }
 
         expect(@analytics).to receive(:track_event).
@@ -194,7 +194,7 @@ describe Users::TwoFactorAuthenticationController do
           delivery_method: 'voice',
           resend: nil,
           errors: [],
-          context: 'authentication'
+          context: 'authentication',
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -22,7 +22,7 @@ describe Users::TwoFactorAuthenticationSetupController do
       result = {
         success: false,
         error: t('errors.messages.improbable_phone'),
-        otp_method: 'sms'
+        otp_method: 'sms',
       }
 
       expect(@analytics).to receive(:track_event).
@@ -41,7 +41,7 @@ describe Users::TwoFactorAuthenticationSetupController do
         result = {
           success: true,
           error: nil,
-          otp_method: 'voice'
+          otp_method: 'voice',
         }
 
         expect(@analytics).to receive(:track_event).
@@ -72,7 +72,7 @@ describe Users::TwoFactorAuthenticationSetupController do
         result = {
           success: true,
           error: nil,
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(@analytics).to receive(:track_event).
@@ -102,7 +102,7 @@ describe Users::TwoFactorAuthenticationSetupController do
         result = {
           success: true,
           error: nil,
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -98,7 +98,7 @@ describe Verify::ConfirmationsController do
 
         result = {
           success: true,
-          new_phone_added: false
+          new_phone_added: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -115,7 +115,7 @@ describe Verify::ConfirmationsController do
 
         result = {
           success: true,
-          new_phone_added: true
+          new_phone_added: true,
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -164,7 +164,7 @@ describe Verify::FinanceController do
         result = {
           success: true,
           errors: {},
-          vendor: { reasons: ['Good number'] }
+          vendor: { reasons: ['Good number'] },
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -180,7 +180,7 @@ describe Verify::FinanceController do
         result = {
           success: false,
           errors: { ccn: ['The ccn could not be verified.'] },
-          vendor: { reasons: ['Bad number'] }
+          vendor: { reasons: ['Bad number'] },
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -197,7 +197,7 @@ describe Verify::FinanceController do
         result = {
           success: false,
           errors: { ccn: ['Credit card number should be only last 8 digits.'] },
-          vendor: { reasons: nil }
+          vendor: { reasons: nil },
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -70,8 +70,8 @@ describe Verify::PhoneController do
         result = {
           success: false,
           errors: {
-            phone: [invalid_phone_message]
-          }
+            phone: [invalid_phone_message],
+          },
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -110,8 +110,8 @@ describe Verify::PhoneController do
         result = {
           success: false,
           errors: {
-            phone: ['The phone number could not be verified.']
-          }
+            phone: ['The phone number could not be verified.'],
+          },
         }
 
         expect(flash[:warning]).to match(
@@ -134,7 +134,7 @@ describe Verify::PhoneController do
 
           expected_params = {
             phone: good_phone,
-            phone_confirmed_at: user.phone_confirmed_at
+            phone_confirmed_at: user.phone_confirmed_at,
           }
           expect(subject.idv_session.params).to eq expected_params
         end
@@ -150,7 +150,7 @@ describe Verify::PhoneController do
           expect(response).to redirect_to verify_review_path
 
           expected_params = {
-            phone: good_phone
+            phone: good_phone,
           }
           expect(subject.idv_session.params).to eq expected_params
         end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -21,7 +21,7 @@ describe Verify::ReviewController do
       state: 'KS',
       zipcode: '66044',
       phone: user.phone,
-      ccn: '12345678'
+      ccn: '12345678',
     }
   end
   let(:idv_session) do

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -13,7 +13,7 @@ describe Verify::SessionsController do
       address2: '',
       city: 'Somewhere',
       state: 'KS',
-      zipcode: '66044'
+      zipcode: '66044',
     }
   end
   let(:previous_address) do
@@ -22,7 +22,7 @@ describe Verify::SessionsController do
       prev_address2: '',
       prev_city: 'Elsewhere',
       prev_state: 'MO',
-      prev_zipcode: '66666'
+      prev_zipcode: '66666',
     }
   end
   let(:idv_session) { Idv::Session.new(subject.user_session, user) }
@@ -75,7 +75,7 @@ describe Verify::SessionsController do
           get :new
 
           result = {
-            request_path: verify_session_path
+            request_path: verify_session_path,
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -107,7 +107,7 @@ describe Verify::SessionsController do
             success: false,
             idv_attempts_exceeded: false,
             errors: { ssn: [t('idv.errors.duplicate_ssn')] },
-            vendor: { reasons: nil }
+            vendor: { reasons: nil },
           }
 
           expect(@analytics).to receive(:track_event).
@@ -165,9 +165,9 @@ describe Verify::SessionsController do
             success: false,
             idv_attempts_exceeded: false,
             errors: {
-              first_name: ['Unverified first name.']
+              first_name: ['Unverified first name.'],
             },
-            vendor: { reasons: ['The name was suspicious'] }
+            vendor: { reasons: ['The name was suspicious'] },
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -183,7 +183,7 @@ describe Verify::SessionsController do
             success: true,
             idv_attempts_exceeded: false,
             errors: {},
-            vendor: { reasons: ['Everything looks good'] }
+            vendor: { reasons: ['Everything looks good'] },
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -201,7 +201,7 @@ describe Verify::SessionsController do
           post :create, profile: user_attrs
 
           result = {
-            request_path: verify_session_path
+            request_path: verify_session_path,
           }
 
           expect(@analytics).to have_received(:track_event).

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -35,7 +35,7 @@ feature 'OpenID Connect' do
         sub: client_id,
         aud: openid_connect_token_url,
         jti: SecureRandom.hex,
-        exp: 5.minutes.from_now.to_i
+        exp: 5.minutes.from_now.to_i,
       }
 
       client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -26,7 +26,7 @@ feature 'LOA1 Single Sign On' do
       session = proxy.env['rack.session']
       session['warden.user.user.session'] = {
         'need_two_factor_authentication' => true,
-        first_time_recovery_code_view: true
+        first_time_recovery_code_view: true,
       }
       session[:saml_request_url] = @saml_authn_request
       session[:sp] = { loa3: false, name: 'Your friendly Government Agency' }

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -153,8 +153,8 @@ feature 'saml api' do
           issuer: dashboard_sp_issuer,
           acs_url: 'http://sp.example.org/saml/login',
           cert: saml_test_sp_cert,
-          active: true
-        }
+          active: true,
+        },
       ]
     end
 

--- a/spec/features/visitors/resend_email_confirmation_spec.rb
+++ b/spec/features/visitors/resend_email_confirmation_spec.rb
@@ -22,7 +22,7 @@ feature 'Visit requests confirmation instructions again during sign up' do
   scenario 'user enters email with invalid format' do
     invalid_addresses = [
       'user@domain-without-suffix',
-      'Buy Medz 0nl!ne http://pharma342.onlinestore.com'
+      'Buy Medz 0nl!ne http://pharma342.onlinestore.com',
     ]
     allow(ValidateEmail).to receive(:mx_valid?).and_return(false)
 
@@ -37,7 +37,7 @@ feature 'Visit requests confirmation instructions again during sign up' do
   scenario 'user enters email with invalid domain name' do
     invalid_addresses = [
       'foo@bar.com',
-      'foo@example.com'
+      'foo@example.com',
     ]
     allow(ValidateEmail).to receive(:mx_valid?).and_return(false)
 

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -18,7 +18,7 @@ feature 'Visitor signs up with email address' do
   scenario 'visitor cannot sign up with email with invalid domain name' do
     invalid_addresses = [
       'foo@bar.com',
-      'foo@example.com'
+      'foo@example.com',
     ]
     allow(ValidateEmail).to receive(:mx_valid?).and_return(false)
 

--- a/spec/forms/idv/finance_form_spec.rb
+++ b/spec/forms/idv/finance_form_spec.rb
@@ -29,7 +29,7 @@ describe Idv::FinanceForm do
       expect(subject.submit(ccn: '12345678', finance_type: :ccn)).to eq true
 
       expected_params = {
-        ccn: '12345678'
+        ccn: '12345678',
       }
 
       expect(subject.idv_params).to eq expected_params
@@ -85,7 +85,7 @@ describe Idv::FinanceForm do
           symbolized_type = type.to_sym
           params = {
             symbolized_type => long_value,
-            finance_type: symbolized_type
+            finance_type: symbolized_type,
           }
 
           expect(subject.submit(params)).to eq false

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -11,7 +11,7 @@ describe Idv::PhoneForm do
       subject.submit(phone: '703-555-1212')
 
       expected_params = {
-        phone: '+1 (703) 555-1212'
+        phone: '+1 (703) 555-1212',
       }
 
       expect(subject.idv_params).to eq expected_params
@@ -22,7 +22,7 @@ describe Idv::PhoneForm do
 
       expected_params = {
         phone: user.phone,
-        phone_confirmed_at: user.phone_confirmed_at
+        phone_confirmed_at: user.phone_confirmed_at,
       }
 
       expect(subject.idv_params).to eq expected_params

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -15,7 +15,7 @@ describe Idv::ProfileForm do
       address2: '',
       city: 'Somewhere',
       state: 'KS',
-      zipcode: '66044'
+      zipcode: '66044',
     }
   end
 
@@ -36,7 +36,7 @@ describe Idv::ProfileForm do
 
         result = {
           success: false,
-          errors: { ssn: [t('idv.errors.duplicate_ssn')] }
+          errors: { ssn: [t('idv.errors.duplicate_ssn')] },
         }
 
         expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
@@ -51,7 +51,7 @@ describe Idv::ProfileForm do
 
         result = {
           success: false,
-          errors: { ssn: [t('idv.errors.duplicate_ssn')] }
+          errors: { ssn: [t('idv.errors.duplicate_ssn')] },
         }
 
         expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
@@ -65,7 +65,7 @@ describe Idv::ProfileForm do
 
         result = {
           success: true,
-          errors: {}
+          errors: {},
         }
 
         expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
@@ -78,7 +78,7 @@ describe Idv::ProfileForm do
 
         result = {
           success: true,
-          errors: {}
+          errors: {},
         }
 
         expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
@@ -91,7 +91,7 @@ describe Idv::ProfileForm do
       it 'is invalid' do
         result = {
           success: false,
-          errors: { dob: [t('idv.errors.bad_dob')] }
+          errors: { dob: [t('idv.errors.bad_dob')] },
         }
 
         expect(subject.submit(profile_attrs.merge(dob: '00000000'))).to eq result
@@ -103,7 +103,7 @@ describe Idv::ProfileForm do
       it 'is invalid' do
         result = {
           success: false,
-          errors: { dob: [t('idv.errors.bad_dob')] }
+          errors: { dob: [t('idv.errors.bad_dob')] },
         }
 
         expect(
@@ -118,7 +118,7 @@ describe Idv::ProfileForm do
     it 'accepts 9 numbers with optional `-` delimiting the 5th and 6th position' do
       result = {
         success: true,
-        errors: {}
+        errors: {},
       }
 
       %w(12345 123454567 12345-1234).each do |valid_zip|
@@ -140,7 +140,7 @@ describe Idv::ProfileForm do
     it 'accepts 9 numbers with optional `-` delimiters' do
       result = {
         success: true,
-        errors: {}
+        errors: {},
       }
 
       %w(123411111 123-11-1123).each do |valid_ssn|
@@ -162,7 +162,7 @@ describe Idv::ProfileForm do
     it 'returns true on success' do
       result = {
         success: true,
-        errors: {}
+        errors: {},
       }
 
       expect(subject.submit(profile_attrs)).to eq result
@@ -177,8 +177,8 @@ describe Idv::ProfileForm do
           address1: [t('errors.messages.missing_field')],
           city: [t('errors.messages.missing_field')],
           state: [t('errors.messages.missing_field')],
-          zipcode: [t('errors.messages.missing_field')]
-        }
+          zipcode: [t('errors.messages.missing_field')],
+        },
       }
 
       expect(subject.submit(ssn: ssn, first_name: 'Joe')).to eq result

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
   let(:acr_values) do
     [
       Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+      Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
     ].join(' ')
   end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OpenidConnectTokenForm do
       client_assertion_type: client_assertion_type,
       code: code,
       code_verifier: code_verifier,
-      grant_type: grant_type
+      grant_type: grant_type,
     }
   end
 
@@ -30,7 +30,7 @@ RSpec.describe OpenidConnectTokenForm do
       sub: client_id,
       aud: openid_connect_token_url,
       jti: SecureRandom.hex,
-      exp: 5.minutes.from_now.to_i
+      exp: 5.minutes.from_now.to_i,
     }
   end
 

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -21,7 +21,7 @@ describe OtpDeliverySelectionForm do
           success: true,
           delivery_method: 'sms',
           resend: true,
-          errors: []
+          errors: [],
         }
 
         expect(result).to eq result_hash
@@ -36,7 +36,7 @@ describe OtpDeliverySelectionForm do
           success: false,
           delivery_method: 'foo',
           resend: nil,
-          errors: subject.errors.full_messages
+          errors: subject.errors.full_messages,
         }
 
         expect(result).to eq result_hash

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -17,7 +17,7 @@ describe PasswordForm, type: :model do
         result = {
           success: true,
           errors: [],
-          user_id: user.uuid
+          user_id: user.uuid,
         }
 
         expect(form.submit(password: password)).to eq result
@@ -35,7 +35,7 @@ describe PasswordForm, type: :model do
         result_hash = {
           success: false,
           errors: ['is too short (minimum is 8 characters)'],
-          user_id: '123'
+          user_id: '123',
         }
 
         expect(form.submit(password: password)).to eq result_hash
@@ -58,7 +58,7 @@ describe PasswordForm, type: :model do
             ' This is similar to a commonly used password.' \
             ' Add another word or two.' \
             ' Uncommon words are better.'],
-          user_id: '123'
+          user_id: '123',
         }
 
         passwords.each do |password|

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -16,7 +16,7 @@ describe PasswordResetEmailForm do
           errors: [],
           user_id: user.uuid,
           role: user.role,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(subject.submit).to eq result
@@ -32,7 +32,7 @@ describe PasswordResetEmailForm do
           errors: [],
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(subject.submit).to eq result
@@ -48,7 +48,7 @@ describe PasswordResetEmailForm do
           errors: [t('valid_email.validations.email.invalid')],
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(subject.submit).to eq result

--- a/spec/forms/recovery_code_form_spec.rb
+++ b/spec/forms/recovery_code_form_spec.rb
@@ -10,7 +10,7 @@ describe RecoveryCodeForm do
         result = RecoveryCodeForm.new(user, raw_code).submit
 
         result_hash = {
-          success: true
+          success: true,
         }
 
         expect(result).to eq result_hash
@@ -30,7 +30,7 @@ describe RecoveryCodeForm do
         result = RecoveryCodeForm.new(user, 'foo').submit
 
         result_hash = {
-          success: false
+          success: false,
         }
 
         expect(result).to eq result_hash

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -14,7 +14,7 @@ describe RegisterUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: true,
-          user_id: existing_user.uuid
+          user_id: existing_user.uuid,
         }
 
         mailer = instance_double(ActionMailer::MessageDelivery)
@@ -39,7 +39,7 @@ describe RegisterUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: true,
-          user_id: '123'
+          user_id: '123',
         }
 
         expect(subject.submit(email: user.email)).to eq result
@@ -54,7 +54,7 @@ describe RegisterUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: false,
-          user_id: User.find_with_email('not_taken@gmail.com').uuid
+          user_id: User.find_with_email('not_taken@gmail.com').uuid,
         }
 
         expect(result).to eq result_hash
@@ -67,7 +67,7 @@ describe RegisterUserEmailForm do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           email_already_exists: false,
-          user_id: nil
+          user_id: nil,
         }
 
         expect(subject.submit(email: 'invalid_email')).to eq result

--- a/spec/forms/resend_email_confirmation_form_spec.rb
+++ b/spec/forms/resend_email_confirmation_form_spec.rb
@@ -15,7 +15,7 @@ describe ResendEmailConfirmationForm do
           success: true,
           errors: [],
           user_id: user.uuid,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(subject.submit).to eq result
@@ -30,7 +30,7 @@ describe ResendEmailConfirmationForm do
           success: true,
           errors: [],
           user_id: 'nonexistent-uuid',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(subject.submit).to eq result
@@ -45,7 +45,7 @@ describe ResendEmailConfirmationForm do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           user_id: 'nonexistent-uuid',
-          confirmed: false
+          confirmed: false,
         }
 
         expect(subject.submit).to eq result

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -20,7 +20,7 @@ describe ResetPasswordForm, type: :model do
           errors: ['token_expired'],
           user_id: '123',
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(form.submit(password: password)).to eq result
@@ -41,7 +41,7 @@ describe ResetPasswordForm, type: :model do
           errors: ['is too short (minimum is 8 characters)'],
           user_id: '123',
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(form.submit(password: password)).to eq result
@@ -62,7 +62,7 @@ describe ResetPasswordForm, type: :model do
           errors: [],
           user_id: '123',
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(form.submit(password: password)).to eq result
@@ -83,7 +83,7 @@ describe ResetPasswordForm, type: :model do
           errors: ['is too short (minimum is 8 characters)', 'token_expired'],
           user_id: '123',
           active_profile: false,
-          confirmed: true
+          confirmed: true,
         }
 
         expect(form.submit(password: password)).to eq result
@@ -110,7 +110,7 @@ describe ResetPasswordForm, type: :model do
               ' Uncommon words are better.'],
             user_id: nil,
             active_profile: false,
-            confirmed: true
+            confirmed: true,
           }
 
           expect(form.submit(password: password)).

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -11,7 +11,7 @@ describe TotpSetupForm do
         form = TotpSetupForm.new(user, secret, code)
 
         result = {
-          success: true
+          success: true,
         }
 
         expect(form.submit).to eq result
@@ -23,7 +23,7 @@ describe TotpSetupForm do
         form = TotpSetupForm.new(user, secret, 'kode')
 
         result = {
-          success: false
+          success: false,
         }
 
         expect(form.submit).to eq result

--- a/spec/forms/two_factor_setup_form_spec.rb
+++ b/spec/forms/two_factor_setup_form_spec.rb
@@ -31,7 +31,7 @@ describe TwoFactorSetupForm, type: :model do
         result = {
           success: true,
           error: nil,
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(form.submit(phone: user.phone, otp_method: 'sms')).
@@ -44,7 +44,7 @@ describe TwoFactorSetupForm, type: :model do
         result = {
           success: true,
           error: nil,
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(subject.submit(phone: '+1 (703) 555-1212', otp_method: 'sms')).
@@ -60,7 +60,7 @@ describe TwoFactorSetupForm, type: :model do
         result = {
           success: true,
           error: nil,
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(form.submit(phone: valid_phone, otp_method: 'sms')).
@@ -73,7 +73,7 @@ describe TwoFactorSetupForm, type: :model do
         result = {
           success: false,
           error: t('errors.messages.improbable_phone'),
-          otp_method: 'sms'
+          otp_method: 'sms',
         }
 
         expect(subject.submit(phone: '', otp_method: 'sms')).

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -13,7 +13,7 @@ describe UpdateUserEmailForm do
         success: true,
         errors: [],
         email_already_exists: false,
-        email_changed: false
+        email_changed: false,
       }
 
       expect(result).to eq result_hash
@@ -41,7 +41,7 @@ describe UpdateUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: true,
-          email_changed: true
+          email_changed: true,
         }
 
         expect(result).to eq result_hash
@@ -62,7 +62,7 @@ describe UpdateUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: false,
-          email_changed: true
+          email_changed: true,
         }
 
         expect(user.unconfirmed_email).to eq 'new@example.com'
@@ -82,7 +82,7 @@ describe UpdateUserEmailForm do
           success: true,
           errors: [],
           email_already_exists: true,
-          email_changed: true
+          email_changed: true,
         }
 
         expect(result).to eq result_hash
@@ -98,7 +98,7 @@ describe UpdateUserEmailForm do
           success: false,
           errors: [t('valid_email.validations.email.invalid')],
           email_already_exists: false,
-          email_changed: false
+          email_changed: false,
         }
 
         expect(result).to eq result_hash

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -16,7 +16,7 @@ describe UpdateUserPasswordForm, type: :model do
 
         result_hash = {
           success: false,
-          errors: subject.errors.full_messages
+          errors: subject.errors.full_messages,
         }
 
         expect(result).to eq result_hash
@@ -33,7 +33,7 @@ describe UpdateUserPasswordForm, type: :model do
 
         result_hash = {
           success: true,
-          errors: []
+          errors: [],
         }
 
         expect(result).to eq result_hash

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -12,7 +12,7 @@ describe ConfigValidator do
         bad_key => 'yes',
         other_bad_key => 'no',
         noncandidate_key => 'yes',
-        good_key => 'foo'
+        good_key => 'foo',
       }
 
       expect { ConfigValidator.new.validate(env) }.to raise_error(

--- a/spec/lib/service_provider_spec.rb
+++ b/spec/lib/service_provider_spec.rb
@@ -22,7 +22,7 @@ describe ServiceProvider do
         service_provider = ServiceProvider.new('http://localhost:3000')
 
         fingerprint = {
-          fingerprint: '40808e52ef80f92e697149e058af95f898cefd9a54d0dc2416bd607c8f9891fa'
+          fingerprint: '40808e52ef80f92e697149e058af95f898cefd9a54d0dc2416bd607c8f9891fa',
         }
 
         yaml_attributes = ServiceProviderConfig.new(

--- a/spec/lib/sidekiq_logging_formatter_spec.rb
+++ b/spec/lib/sidekiq_logging_formatter_spec.rb
@@ -14,15 +14,15 @@ describe SidekiqLoggerFormatter do
             'job_id' => 'f1f1a7d1-b33a-4ce3-aa71-f3d74a1d99ae',
             'queue_name' => 'sms',
             'arguments' => ['sensitive pii'],
-            'locale' => 'en'
-          }
+            'locale' => 'en',
+          },
         ],
         'retry' => true,
         'jid' => '5187f014c38c66d0840633c2',
         'error_message' => 'hello world',
-        'error_class' => 'RuntimeError'
+        'error_class' => 'RuntimeError',
       },
-      'jobstr' => '{"args":"sensitive pii"}'
+      'jobstr' => '{"args":"sensitive pii"}',
     }
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -71,7 +71,7 @@ describe UserMailer, type: :mailer do
       'want_learn' => '1',
       'want_tell' => '0',
       'email_or_tel' => 'thomas jefferson',
-      'comments' => 'usa!'
+      'comments' => 'usa!',
     }
 
     let(:mail) { UserMailer.contact_request(details) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -240,7 +240,7 @@ describe User do
       before do
         user.profiles << [
           active_profile,
-          build(:profile, :verified, activated_at: 5.days.ago, pii: { first_name: 'Susan' })
+          build(:profile, :verified, activated_at: 5.days.ago, pii: { first_name: 'Susan' }),
         ]
       end
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           city: 'Washington',
           state: 'DC',
           zipcode: '12345',
-          phone: '+1 (555) 555-5555'
+          phone: '+1 (555) 555-5555',
         }
       end
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -22,7 +22,7 @@ describe 'throttling requests' do
       data = {
         count: 1,
         limit: Figaro.env.requests_per_ip_limit.to_i,
-        period: Figaro.env.requests_per_ip_period.to_i.seconds
+        period: Figaro.env.requests_per_ip_period.to_i.seconds,
       }
 
       expect(last_request.env['rack.attack.throttle_data']['req/ip']).to eq(data)
@@ -75,7 +75,7 @@ describe 'throttling requests' do
           discriminator: '1.2.3.4',
           event: 'throttle',
           type: 'req/ip',
-          user_ip: '1.2.3.4'
+          user_ip: '1.2.3.4',
         }
 
         expect(Rails.logger).to have_received(:warn).with(analytics_hash)
@@ -90,7 +90,7 @@ describe 'throttling requests' do
       data = {
         count: 1,
         limit: Figaro.env.logins_per_ip_limit.to_i,
-        period: Figaro.env.logins_per_ip_period.to_i.seconds
+        period: Figaro.env.logins_per_ip_period.to_i.seconds,
       }
 
       expect(last_request.env['rack.attack.throttle_data']['logins/ip/level_1']).to eq(data)
@@ -162,7 +162,7 @@ describe 'throttling requests' do
           discriminator: '1.2.3.4',
           event: 'throttle',
           type: 'logins/ip/level_1',
-          user_ip: '1.2.3.4'
+          user_ip: '1.2.3.4',
         }
 
         expect(Rails.logger).to have_received(:warn).with(analytics_hash)
@@ -208,7 +208,7 @@ describe 'throttling requests' do
         discriminator: user.uuid,
         event: 'throttle',
         type: 'OTP delivery',
-        user_ip: '1.2.3.4'
+        user_ip: '1.2.3.4',
       }
 
       expect(last_response.status).to eq(429)
@@ -235,7 +235,7 @@ describe 'throttling requests' do
         discriminator: second_user_with_same_number.uuid,
         event: 'throttle',
         type: 'OTP delivery',
-        user_ip: '1.2.3.5'
+        user_ip: '1.2.3.5',
       }
 
       expect(last_response.status).to eq(429)
@@ -267,7 +267,7 @@ describe 'throttling requests' do
         discriminator: user.uuid,
         event: 'throttle',
         type: 'OTP delivery',
-        user_ip: '1.2.3.4'
+        user_ip: '1.2.3.4',
       }
 
       expect(last_response.status).to eq(429)
@@ -299,7 +299,7 @@ describe 'throttling requests' do
         discriminator: user.uuid,
         event: 'throttle',
         type: 'OTP delivery',
-        user_ip: '1.2.3.4'
+        user_ip: '1.2.3.4',
       }
 
       expect(last_response.status).to eq(429)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -5,7 +5,7 @@ describe Analytics do
     {
       user_ip: FakeRequest.new.remote_ip,
       user_agent: FakeRequest.new.user_agent,
-      host: FakeRequest.new.host
+      host: FakeRequest.new.host,
     }
   end
 
@@ -21,7 +21,7 @@ describe Analytics do
 
       analytics_hash = {
         event_properties: {},
-        user_id: user.uuid
+        user_id: user.uuid,
       }
 
       expect(ahoy).to receive(:track).
@@ -38,7 +38,7 @@ describe Analytics do
 
       analytics_hash = {
         event_properties: {},
-        user_id: tracked_user.uuid
+        user_id: tracked_user.uuid,
       }
 
       expect(ahoy).to receive(:track).

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -46,7 +46,7 @@ describe FormResponse do
         response = FormResponse.new(success: true, errors: errors)
         response_hash = {
           success: true,
-          errors: errors
+          errors: errors,
         }
 
         expect(response.to_h).to eq response_hash
@@ -62,7 +62,7 @@ describe FormResponse do
           success: true,
           errors: errors,
           user_id: 1,
-          context: 'confirmation'
+          context: 'confirmation',
         }
 
         expect(response.to_h).to eq response_hash

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -13,7 +13,7 @@ describe IdentityLinker do
       new_attributes = {
         service_provider: 'test.host',
         user_id: user.id,
-        uuid: last_identity.uuid
+        uuid: last_identity.uuid,
       }
 
       identity_attributes = last_identity.attributes.symbolize_keys.

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -25,7 +25,7 @@ describe Idv::FinancialsStep do
       result = {
         success: false,
         errors: { ccn: [t('idv.errors.invalid_ccn')] },
-        vendor: { reasons: nil }
+        vendor: { reasons: nil },
       }
 
       expect(step.submit).to eq result
@@ -38,7 +38,7 @@ describe Idv::FinancialsStep do
       result = {
         success: true,
         errors: {},
-        vendor: { reasons: ['Good number'] }
+        vendor: { reasons: ['Good number'] },
       }
 
       expect(step.submit).to eq result
@@ -52,7 +52,7 @@ describe Idv::FinancialsStep do
       result = {
         success: false,
         errors: { ccn: ['The ccn could not be verified.'] },
-        vendor: { reasons: ['Bad number'] }
+        vendor: { reasons: ['Bad number'] },
       }
 
       expect(step.submit).to eq result

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -14,7 +14,7 @@ describe Idv::ProfileStep do
       address2: '',
       city: 'Somewhere',
       state: 'KS',
-      zipcode: '66044'
+      zipcode: '66044',
     }
   end
 
@@ -33,7 +33,7 @@ describe Idv::ProfileStep do
       result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: ['Everything looks good'] }
+        vendor: { reasons: ['Everything looks good'] },
       }
 
       expect(FormResponse).to receive(:new).
@@ -49,7 +49,7 @@ describe Idv::ProfileStep do
       errors = { ssn: ['Unverified SSN.'] }
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: ['The SSN was suspicious'] }
+        vendor: { reasons: ['The SSN was suspicious'] },
       }
 
       result = instance_double(FormResponse)
@@ -66,7 +66,7 @@ describe Idv::ProfileStep do
       errors = { ssn: [t('idv.errors.pattern_mismatch.ssn')] }
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: nil }
+        vendor: { reasons: nil },
       }
 
       result = instance_double(FormResponse)
@@ -85,7 +85,7 @@ describe Idv::ProfileStep do
       result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: ['The name was suspicious'] }
+        vendor: { reasons: ['The name was suspicious'] },
       }
 
       expect(FormResponse).to receive(:new).
@@ -102,7 +102,7 @@ describe Idv::ProfileStep do
       result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: ['The ZIP code was suspicious'] }
+        vendor: { reasons: ['The ZIP code was suspicious'] },
       }
 
       expect(FormResponse).to receive(:new).
@@ -119,7 +119,7 @@ describe Idv::ProfileStep do
       result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
-        vendor: { reasons: ['The ZIP code was suspicious'] }
+        vendor: { reasons: ['The ZIP code was suspicious'] },
       }
 
       expect(FormResponse).to receive(:new).

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe OpenidConnectAttributeScoper do
           street_address: '123 Fake St',
           locality: 'Washington',
           region: 'DC',
-          postal_code: '12345'
-        }
+          postal_code: '12345',
+        },
       }
     end
 

--- a/spec/services/pii/re_encryptor_spec.rb
+++ b/spec/services/pii/re_encryptor_spec.rb
@@ -6,7 +6,7 @@ describe Pii::ReEncryptor do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
       user_session = {
-        decrypted_pii: { ssn: '1234' }.to_json
+        decrypted_pii: { ssn: '1234' }.to_json,
       }
 
       pii_attributes = Pii::Attributes.new

--- a/spec/services/service_provider_config_spec.rb
+++ b/spec/services/service_provider_config_spec.rb
@@ -9,7 +9,7 @@ describe ServiceProviderConfig do
         acs_url: 'http://test.host/test/saml/decode_assertion',
         block_encryption: 'aes256-cbc',
         metadata_url: 'http://test.host/test/saml/metadata',
-        sp_initiated_login_url: 'http://test.host/test/saml'
+        sp_initiated_login_url: 'http://test.host/test/saml',
       }
 
       expect(config.sp_attributes).to eq yaml_hash

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -17,7 +17,7 @@ describe ServiceProviderUpdater do
         assertion_consumer_logout_service_url: 'http://sp.example.org/saml/logout',
         block_encryption: 'aes256-cbc',
         cert: saml_test_sp_cert,
-        active: true
+        active: true,
       },
       {
         issuer: inactive_dashboard_sp_issuer,
@@ -28,8 +28,8 @@ describe ServiceProviderUpdater do
         assertion_consumer_logout_service_url: 'http://oldsp.example.org/saml/logout',
         block_encryption: 'aes256-cbc',
         cert: saml_test_sp_cert,
-        active: false
-      }
+        active: false,
+      },
     ]
   end
 

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -4,8 +4,8 @@ module AwsKmsClientHelper
     Aws.config[:kms] = {
       stub_responses: {
         encrypt: { ciphertext_blob: ciphered_key, key_id: aws_key_id },
-        decrypt: { plaintext: random_key, key_id: aws_key_id }
-      }
+        decrypt: { plaintext: random_key, key_id: aws_key_id },
+      },
     }
     [random_key, ciphered_key]
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -112,7 +112,7 @@ module SamlAuthHelper
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone"
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
     ]
     settings
   end
@@ -122,7 +122,7 @@ module SamlAuthHelper
     settings.authn_context = [
       settings.authn_context,
       "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone"
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
     ]
     settings
   end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -111,7 +111,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         resend_path = otp_send_path(otp_delivery_selection_form: {
                                       otp_method: delivery_method,
-                                      resend: true
+                                      resend: true,
                                     })
 
         expect(rendered).to have_link(
@@ -122,7 +122,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       it 'has a fallback link to send confirmation with voice' do
         expected_fallback_path = otp_send_path(otp_delivery_selection_form: {
-                                                 otp_method: 'voice'
+                                                 otp_method: 'voice',
                                                })
         expected_link = link_to(t('links.two_factor_authentication.voice'),
                                 expected_fallback_path)
@@ -136,7 +136,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       it 'does not have a fallback link to send confirmation via SMS' do
         unexpected_fallback_path = otp_send_path(otp_delivery_selection_form: {
-                                                   otp_method: delivery_method
+                                                   otp_method: delivery_method,
                                                  })
         unexpected_link = link_to(
           t("links.two_factor_authentication.#{delivery_method}"),
@@ -165,7 +165,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         resend_path = otp_send_path(otp_delivery_selection_form: {
                                       otp_method: delivery_method,
-                                      resend: true
+                                      resend: true,
                                     })
 
         expect(rendered).to have_link(
@@ -176,7 +176,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       it 'has a fallback link to send confirmation as SMS' do
         expected_fallback_path = otp_send_path(otp_delivery_selection_form: {
-                                                 otp_method: 'sms'
+                                                 otp_method: 'sms',
                                                })
         expected_link = link_to(t('links.two_factor_authentication.sms'),
                                 expected_fallback_path)
@@ -190,7 +190,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       it 'does not have a fallback link to send a confirmation as SMS' do
         unexpected_fallback_path = otp_send_path(otp_delivery_selection_form: {
-                                                   otp_method: delivery_method
+                                                   otp_method: delivery_method,
                                                  })
         unexpected_link = link_to(
           t("links.two_factor_authentication.#{delivery_method}"),


### PR DESCRIPTION
**Why**: Makes diffs easier to read and is consistent with the enforced
style in our js!