### PR TITLE
Redirect to reactivate_profile_path after sign in

### DIFF
--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -33,6 +33,8 @@ module SignUp
     def next_step
       if session[:saml_request_url]
         sign_up_completed_path
+      elsif current_user.password_reset_profile.present?
+        reactivate_profile_path
       else
         profile_path
       end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -34,7 +34,6 @@ feature 'Password Recovery' do
   end
 
   def reactivate_profile(password, recovery_code)
-    click_link t('profile.index.reactivation.reactivate_button')
     fill_in 'Password', with: password
     fill_in 'Recovery code', with: recovery_code
     click_button t('forms.reactivate_profile.submit')
@@ -261,7 +260,7 @@ feature 'Password Recovery' do
       click_submit_default
       enter_correct_otp_code_for_user(user)
 
-      expect(page).to have_content t('profile.index.reactivation.instructions')
+      expect(current_path).to eq reactivate_profile_path
 
       reactivate_profile(new_password, recovery_code)
 
@@ -277,14 +276,14 @@ feature 'Password Recovery' do
       click_submit_default
       enter_correct_otp_code_for_user(user)
 
-      expect(page).to have_content t('profile.index.reactivation.instructions')
+      expect(current_path).to eq reactivate_profile_path
 
       visit manage_recovery_code_path
 
       new_recovery_code = scrape_recovery_code
       click_acknowledge_recovery_code
 
-      expect(page).to have_content t('profile.index.reactivation.instructions')
+      expect(current_path).to eq reactivate_profile_path
 
       reactivate_profile(new_password, new_recovery_code)
 
@@ -308,8 +307,7 @@ feature 'Password Recovery' do
       new_recovery_code = scrape_recovery_code
       click_acknowledge_recovery_code
 
-      expect(current_path).to eq profile_path
-      expect(page).to have_content t('profile.index.reactivation.instructions')
+      expect(current_path).to eq reactivate_profile_path
 
       reactivate_profile(new_password, new_recovery_code)
 


### PR DESCRIPTION
**Why**: LOA3 users who have reset their passwords should
be immediately prompted at sign in to reactivate their profile
with their personal key.