### PR TITLE
Encrypt otp_secret_key

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -97,7 +97,7 @@ module TwoFactorAuthenticatable
   end
 
   def assign_phone
-    @updating_existing_number = old_phone
+    @updating_existing_number = old_phone.present?
 
     if @updating_existing_number && confirmation_context?
       phone_changed

--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -1,0 +1,104 @@
+module EncryptableAttribute
+  extend ActiveSupport::Concern
+
+  attr_accessor :attribute_user_access_key
+
+  module ClassMethods
+    cattr_accessor :encryptable_attributes do
+      []
+    end
+
+    private
+
+    def encrypted_attribute_getter(name)
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def #{name}
+          get_encrypted_attribute(name: :"#{name}")
+        end
+      METHODS
+    end
+
+    def encrypted_attribute_stale_predicate(name)
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def stale_encrypted_#{name}?
+          return false unless self.public_send(:"#{name}").present?
+          encrypted_attributes[:"#{name}"].stale?
+        end
+      METHODS
+    end
+
+    def encrypted_attribute_setter(name)
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def #{name}=(attribute)
+          set_encrypted_attribute(name: :"#{name}", value: attribute)
+        end
+      METHODS
+    end
+
+    def encrypted_attribute(name:)
+      encryptable_attributes << name
+
+      encrypted_attribute_getter(name)
+      encrypted_attribute_stale_predicate(name)
+      encrypted_attribute_setter(name)
+    end
+
+    def encrypted_attribute_without_setter(name:)
+      encryptable_attributes << name
+
+      encrypted_attribute_getter(name)
+      encrypted_attribute_stale_predicate(name)
+    end
+  end
+
+  private
+
+  def encrypted_attributes
+    @_encrypted_attributes ||= {}
+  end
+
+  def get_encrypted_attribute(name:)
+    getter = encrypted_attribute_name(name)
+    encrypted_string = self[getter]
+    return encrypted_string unless encrypted_string.present?
+    encrypted_attribute = encrypted_attributes[name]
+    return encrypted_attribute.decrypted if encrypted_attribute.present?
+    build_encrypted_attribute(name, encrypted_string).decrypted
+  end
+
+  def build_encrypted_attribute(name, encrypted_string)
+    encrypted_attribute = EncryptedAttribute.new(
+      encrypted_string,
+      cost: attribute_cost,
+      user_access_key: attribute_user_access_key
+    )
+    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
+    encrypted_attributes[name] = encrypted_attribute
+  end
+
+  def set_encrypted_attribute(name:, value:)
+    setter = encrypted_attribute_name(name)
+    new_value = if value.present?
+                  build_encrypted_attribute_from_plain(name, value).encrypted
+                else
+                  value
+                end
+    self[setter] = new_value
+  end
+
+  def build_encrypted_attribute_from_plain(name, plain_value)
+    self.attribute_user_access_key ||= new_attribute_user_access_key
+    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
+      plain_value.downcase.strip,
+      attribute_user_access_key
+    )
+  end
+
+  def encrypted_attribute_name(name)
+    "encrypted_#{name}".to_sym
+  end
+
+  def new_attribute_user_access_key
+    EncryptedAttribute.new_user_access_key(cost: attribute_cost)
+  end
+end

--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -1,8 +1,6 @@
 module UserEncryptedAttributeOverrides
   extend ActiveSupport::Concern
 
-  attr_accessor :attribute_user_access_key
-
   # override some Devise methods to support our use of encrypted_email
 
   class_methods do
@@ -14,6 +12,8 @@ module UserEncryptedAttributeOverrides
     end
 
     def find_with_email(email)
+      return nil if email.blank?
+
       email_fingerprint = create_fingerprint(email)
       find_by(email_fingerprint: email_fingerprint)
     end
@@ -48,80 +48,9 @@ module UserEncryptedAttributeOverrides
     generate_confirmation_token
   end
 
-  def email
-    get_encrypted_attribute(name: :email, default: '')
-  end
-
+  # Override usual setter method in order to also set fingerprint
   def email=(email)
-    set_encrypted_attribute(name: :email, value: email, default: '')
+    set_encrypted_attribute(name: :email, value: email)
     self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''
-  end
-
-  def stale_encrypted_email?
-    return false unless email.present?
-    encrypted_attributes[:email].stale?
-  end
-
-  def phone
-    get_encrypted_attribute(name: :phone, default: nil)
-  end
-
-  def phone=(phone)
-    set_encrypted_attribute(name: :phone, value: phone, default: nil)
-  end
-
-  def stale_encrypted_phone?
-    return false unless phone.present?
-    encrypted_attributes[:phone].stale?
-  end
-
-  private
-
-  def encrypted_attributes
-    @_encrypted_attributes ||= {}
-  end
-
-  def get_encrypted_attribute(name:, default:)
-    getter = encrypted_attribute_name(name)
-    encrypted_string = self[getter]
-    return default unless encrypted_string.present?
-    encrypted_attribute = encrypted_attributes[name]
-    return encrypted_attribute.decrypted if encrypted_attribute.present?
-    build_encrypted_attribute(name, encrypted_string).decrypted
-  end
-
-  def build_encrypted_attribute(name, encrypted_string)
-    encrypted_attribute = EncryptedAttribute.new(
-      encrypted_string,
-      cost: attribute_cost,
-      user_access_key: attribute_user_access_key
-    )
-    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
-    encrypted_attributes[name] = encrypted_attribute
-  end
-
-  def set_encrypted_attribute(name:, value:, default:)
-    setter = encrypted_attribute_name(name)
-    new_value = default
-    if value.present?
-      new_value = build_encrypted_attribute_from_plain(name, value).encrypted
-    end
-    self[setter] = new_value
-  end
-
-  def build_encrypted_attribute_from_plain(name, plain_value)
-    self.attribute_user_access_key ||= new_attribute_user_access_key
-    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
-      plain_value.downcase.strip,
-      attribute_user_access_key
-    )
-  end
-
-  def encrypted_attribute_name(name)
-    "encrypted_#{name}".to_sym
-  end
-
-  def new_attribute_user_access_key
-    EncryptedAttribute.new_user_access_key(cost: attribute_cost)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,12 @@ class User < ActiveRecord::Base
     authentication_keys: [:email]
   )
 
+  include EncryptableAttribute
+
+  encrypted_attribute(name: :phone)
+  encrypted_attribute(name: :otp_secret_key)
+  encrypted_attribute_without_setter(name: :email)
+
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides
   include UserEncryptedAttributeOverrides

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -1,33 +1,34 @@
 module KeyRotator
   class AttributeEncryption
-    def initialize
+    def initialize(user)
+      @user = user
       self.new_cost = Figaro.env.attribute_cost
       self.encryptor = Pii::PasswordEncryptor.new
     end
 
-    def rotate(user)
-      user.update_columns(build_rotated_columns(user))
+    def rotate
+      user.update_columns(encrypted_attributes)
     end
 
     private
 
     attr_accessor :encryptor, :new_cost
+    attr_reader :user
 
     def uak
       @_uak ||= EncryptedAttribute.new_user_access_key(cost: new_cost)
     end
 
-    def build_rotated_columns(user)
-      email = EncryptedAttribute.new_from_decrypted(user.email, uak)
-      to_update = { encrypted_email: email.encrypted, attribute_cost: new_cost }
-      plain_phone = user.phone
-      if plain_phone.present?
-        to_update[:encrypted_phone] = EncryptedAttribute.new_from_decrypted(
-          plain_phone,
+    def encrypted_attributes
+      User.encryptable_attributes.each_with_object({}) do |attribute, result|
+        plain_attribute = user.public_send(attribute)
+        next unless plain_attribute
+
+        result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(
+          plain_attribute,
           uak
         ).encrypted
       end
-      to_update
     end
   end
 end

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -39,7 +39,7 @@ module Pii
     end
 
     def rotate_encrypted_attributes
-      KeyRotator::AttributeEncryption.new.rotate(user)
+      KeyRotator::AttributeEncryption.new(user).rotate
     end
 
     def stale_fingerprints?(profile)
@@ -51,7 +51,8 @@ module Pii
     end
 
     def stale_attributes?
-      user.stale_encrypted_phone? || user.stale_encrypted_email?
+      user.stale_encrypted_phone? || user.stale_encrypted_email? ||
+        user.stale_encrypted_otp_secret_key?
     end
 
     def stale_ssn_signature?(profile)

--- a/db/migrate/20170207192356_remove_unused_encrypted_otp_secret_columns.rb
+++ b/db/migrate/20170207192356_remove_unused_encrypted_otp_secret_columns.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedEncryptedOtpSecretColumns < ActiveRecord::Migration
+  def change
+    remove_column :users, :encrypted_otp_secret_key_iv, :string
+    remove_column :users, :encrypted_otp_secret_key_salt, :string
+  end
+end

--- a/db/migrate/20170207192911_update_encrypted_otp_secret_key_length.rb
+++ b/db/migrate/20170207192911_update_encrypted_otp_secret_key_length.rb
@@ -1,0 +1,5 @@
+class UpdateEncryptedOtpSecretKeyLength < ActiveRecord::Migration
+  def change
+    change_column :users, :encrypted_otp_secret_key, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203150129) do
+ActiveRecord::Schema.define(version: 20170207192912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,39 +88,37 @@ ActiveRecord::Schema.define(version: 20170203150129) do
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "encrypted_password",            limit: 255, default: ""
-    t.string   "reset_password_token",          limit: 255
+    t.string   "encrypted_password",           limit: 255, default: ""
+    t.string   "reset_password_token",         limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                             default: 0,  null: false
+    t.integer  "sign_in_count",                            default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",            limit: 255
-    t.string   "last_sign_in_ip",               limit: 255
+    t.string   "current_sign_in_ip",           limit: 255
+    t.string   "last_sign_in_ip",              limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "confirmation_token",            limit: 255
+    t.string   "confirmation_token",           limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email",             limit: 255
+    t.string   "unconfirmed_email",            limit: 255
     t.integer  "role"
-    t.string   "otp_secret_key",                limit: 255
-    t.integer  "second_factor_attempts_count",              default: 0
-    t.string   "phone_plain",                   limit: 255
-    t.string   "uuid",                          limit: 255,              null: false
+    t.string   "otp_secret_key",               limit: 255
+    t.integer  "second_factor_attempts_count",             default: 0
+    t.string   "phone_plain",                  limit: 255
+    t.string   "uuid",                         limit: 255,              null: false
     t.datetime "reset_requested_at"
     t.datetime "second_factor_locked_at"
     t.datetime "locked_at"
-    t.integer  "failed_attempts",                           default: 0
-    t.string   "unlock_token",                  limit: 255
+    t.integer  "failed_attempts",                          default: 0
+    t.string   "unlock_token",                 limit: 255
     t.datetime "phone_confirmed_at"
-    t.string   "encrypted_otp_secret_key",      limit: 255
-    t.string   "encrypted_otp_secret_key_iv",   limit: 255
-    t.string   "encrypted_otp_secret_key_salt", limit: 255
+    t.text     "encrypted_otp_secret_key"
     t.string   "direct_otp"
     t.datetime "direct_otp_sent_at"
     t.datetime "idv_attempted_at"
-    t.integer  "idv_attempts",                              default: 0
+    t.integer  "idv_attempts",                             default: 0
     t.string   "recovery_code"
     t.string   "password_salt"
     t.string   "encryption_key"
@@ -128,11 +126,11 @@ ActiveRecord::Schema.define(version: 20170203150129) do
     t.string   "recovery_salt"
     t.string   "password_cost"
     t.string   "recovery_cost"
-    t.string   "email_fingerprint",                         default: "", null: false
-    t.text     "encrypted_email",                           default: "", null: false
+    t.string   "email_fingerprint",                        default: "", null: false
+    t.text     "encrypted_email",                          default: "", null: false
     t.string   "attribute_cost"
     t.text     "encrypted_phone"
-    t.integer  "otp_delivery_preference",                   default: 0,  null: false
+    t.integer  "otp_delivery_preference",                  default: 0,  null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -6,14 +6,14 @@ namespace :rotate do
   #
   desc 'attribute encryption key'
   task attribute_encryption_key: :environment do
-    rotator = KeyRotator::AttributeEncryption.new
     num_users = User.count
     progress = new_progress_bar('Users', num_users)
 
     User.find_in_batches.with_index do |users, batch|
       User.transaction do
         users.each do |user|
-          rotator.rotate(user)
+          rotator = KeyRotator::AttributeEncryption.new(user)
+          rotator.rotate
           progress.increment
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -268,5 +268,12 @@ describe User do
         expect(user.phone).to eq '555 555 5555'
       end
     end
+
+    it 'decrypts phone and otp_secret_key' do
+      user = create(:user, phone: '+1 (202) 555-1212', otp_secret_key: 'abc123')
+
+      expect(user.phone).to eq '+1 (202) 555-1212'
+      expect(user.otp_secret_key).to eq 'abc123'
+    end
   end
 end

--- a/spec/services/key_rotator/attribute_encryption_spec.rb
+++ b/spec/services/key_rotator/attribute_encryption_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 describe KeyRotator::AttributeEncryption do
   describe '#rotate' do
     it 're-encrypts email and phone' do
-      rotator = described_class.new
       user = create(:user, phone: '213-555-5555')
+      rotator = described_class.new(user)
       old_encrypted_email = user.encrypted_email
       old_encrypted_phone = user.encrypted_phone
 
       rotate_attribute_encryption_key
 
-      rotator.rotate(user)
+      rotator.rotate
 
       expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(user.encrypted_phone).to_not eq old_encrypted_phone

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Pii::Cacher do
   let(:password) { 'salty peanuts are best' }
   let(:user_access_key) { user.unlock_user_access_key(password) }
-  let(:user) { create(:user, password: password) }
+  let(:user) { create(:user, :with_phone, password: password, otp_secret_key: 'abc123') }
   let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
   let(:diff_profile) { build(:profile, :verified, user: user, pii: { ssn: '5678' }) }
   let(:user_session) { {} }
@@ -38,6 +38,8 @@ describe Pii::Cacher do
       old_ssn_signature = profile.ssn_signature
       old_email_fingerprint = user.email_fingerprint
       old_encrypted_email = user.encrypted_email
+      old_encrypted_phone = user.encrypted_phone
+      old_encrypted_otp_secret_key = user.encrypted_otp_secret_key
 
       rotate_all_keys
 
@@ -47,6 +49,17 @@ describe Pii::Cacher do
       expect(user.email_fingerprint).to_not eq old_email_fingerprint
       expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(profile.ssn_signature).to_not eq old_ssn_signature
+      expect(user.encrypted_phone).to_not eq old_encrypted_phone
+      expect(user.encrypted_otp_secret_key).to_not eq old_encrypted_otp_secret_key
+    end
+
+    it 'does not attempt to rotate nil attributes' do
+      user = create(:user, password: password)
+      user_access_key = user.unlock_user_access_key(password)
+      cacher = described_class.new(user, user_session)
+      rotate_all_keys
+
+      expect { cacher.save(user_access_key) }.to_not raise_error
     end
   end
 

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'two_factor_authentication/totp_verification/show.html.slim' do
-  let(:user) { build_stubbed(:user, :signed_up, otp_secret_key: 123) }
+  let(:user) { build_stubbed(:user, :signed_up, otp_secret_key: '6pcrpu334cx7zyf7') }
   let(:presenter_data) do
     attributes_for(:generic_otp_presenter).merge(
       delivery_method: 'authenticator',


### PR DESCRIPTION
**Why**: The `otp_secret_key` is what is used to generate the codes for
authenticator apps. If someone got a hold of our DB, they would be able
to get the 6-digit TOTP code for any user who had enabled an
authenticator app.

**How**:
- Use our current encryption scheme to populate the
`encrypted_otp_secret_key` column and override the reader and writer
methods for `otp_secret_key` so that the value is read from the
encrypted column
- Change the `encrypted_otp_secret_key` column type from string to text
because the encrypted value is more than 255 characters
- Remove unused `encrypted_otp_secret_key_*` columns. They came from the
`two_factor_authentication` gem, but we're not using the gem's
encryption.

Once these migrations and code have been pushed to all servers,
we'll remove the `otp_secret_key` column.