### PR TITLE
Add help text to initial change factor flow page

### DIFF
--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -1,13 +1,14 @@
 class ReauthnRequiredController < ApplicationController
   before_action :confirm_recently_authenticated
 
+  private
+
   def confirm_recently_authenticated
     @reauthn = reauthn?
     return unless user_signed_in?
     return if recently_authenticated?
-    store_location_for(:user, request.url)
-    user_session[:context] = 'reauthentication'
-    redirect_to user_password_confirm_url
+
+    prompt_for_current_password
   end
 
   def recently_authenticated?
@@ -15,5 +16,16 @@ class ReauthnRequiredController < ApplicationController
     authn_at = user_session[:authn_at]
     return false unless authn_at.present?
     authn_at > Time.zone.now - Figaro.env.reauthn_window.to_i
+  end
+
+  def prompt_for_current_password
+    store_location_for(:user, request.url)
+    user_session[:context] = 'reauthentication'
+    user_session[:factor_to_change] = factor_from_request_path(request.path)
+    redirect_to user_password_confirm_url
+  end
+
+  def factor_from_request_path(path)
+    path.split('/')[-1]
   end
 end

--- a/app/views/mfa_confirmation/new.html.slim
+++ b/app/views/mfa_confirmation/new.html.slim
@@ -1,6 +1,7 @@
 - title t('titles.passwords.confirm')
 
 h1.h3.my0 = t('headings.passwords.confirm')
+p.mt-tiny.mb0 = t('help_text.change_factor', factor: user_session[:factor_to_change])
 = simple_form_for(current_user,
                   url: reauthn_user_password_path,
                   html: { autocomplete: 'off', role: 'form', method: 'post' }) do |f|

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  help_text:
+    change_factor: >
+      Before you're able to edit your %{factor}, you will need to confirm your
+      password and receive a security code on your phone.

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -1,0 +1,5 @@
+---
+es:
+  help_text:
+    change_factor: >
+      NOT TRANSLATED YET

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -6,6 +6,9 @@ feature 'Changing authentication factor' do
 
     scenario 'editing password' do
       visit manage_password_path
+
+      expect(page).to have_content t('help_text.change_factor', factor: 'password')
+
       complete_2fa_confirmation
 
       expect(current_path).to eq manage_password_path
@@ -19,6 +22,9 @@ feature 'Changing authentication factor' do
       new_phone = '+1 (703) 555-0100'
 
       visit manage_phone_path
+
+      expect(page).to have_content t('help_text.change_factor', factor: 'phone')
+
       complete_2fa_confirmation
 
       update_phone_number
@@ -96,6 +102,8 @@ feature 'Changing authentication factor' do
 
     scenario 'editing email' do
       visit manage_email_path
+
+      expect(page).to have_content t('help_text.change_factor', factor: 'email')
       complete_2fa_confirmation
 
       expect(current_path).to eq manage_email_path


### PR DESCRIPTION
**Why**: For a better UX. When attempting to change your email, phone,
or password, and it's been more than `reauthn_window` seconds since you
last 2FA'd, you will be prompted to enter your current password, and
then the OTP sent to your phone. This PR adds help text to explain
why this is happening.