### PR TITLE
Add js validation to phone field during IDV

### DIFF
--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -16,7 +16,7 @@ p = t('idv.messages.phone.same_as_2fa')
 
 = simple_form_for(idv_phone_form, url: verify_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
-  = f.input :phone, required: true
+  = f.input :phone, required: true, input_html: { class: 'phone' }
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
 = render 'shared/cancel', link: verify_cancel_path
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 feature 'IdV session' do
   include IdvHelper
 
-  let(:user_password) { Features::SessionHelper::VALID_PASSWORD }
-
   context 'landing page' do
     before do
       sign_in_and_2fa_user
@@ -275,27 +273,6 @@ feature 'IdV session' do
       expect(find('#idv_finance_form_ccn').value).to eq '1234'
     end
 
-    context 'Idv phone and user phone are different' do
-      it 'prompts to confirm phone' do
-        user = create(
-          :user, :signed_up,
-          phone: '+1 (416) 555-0190',
-          password: Features::SessionHelper::VALID_PASSWORD
-        )
-        sign_in_and_2fa_user(user)
-        visit verify_session_path
-
-        complete_idv_profile_with_phone('555-555-0000')
-
-        expect(page).to have_link t('forms.two_factor.try_again'), href: verify_phone_path
-
-        enter_correct_otp_code_for_user(user)
-        click_acknowledge_recovery_code
-
-        expect(current_path).to eq profile_path
-      end
-    end
-
     context 'recovery codes information and actions' do
       before do
         recovery_code = 'a1b2c3d4e5f6g7h8'
@@ -318,18 +295,5 @@ feature 'IdV session' do
   def complete_idv_profile_fail
     fill_out_idv_form_fail
     click_button 'Continue'
-  end
-
-  def complete_idv_profile_with_phone(phone)
-    fill_out_idv_form_ok
-    click_button t('forms.buttons.continue')
-    fill_out_financial_form_ok
-    click_button t('forms.buttons.continue')
-    fill_out_phone_form_ok(phone)
-    click_button t('forms.buttons.continue')
-    fill_in :user_password, with: user_password
-    click_submit_default
-    # choose default SMS delivery method for confirming this new number
-    click_submit_default
   end
 end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -4,7 +4,6 @@ feature 'IdV session' do
   include IdvHelper
 
   let(:user_password) { Features::SessionHelper::VALID_PASSWORD }
-  let(:max_attempts_less_one) { Idv::Attempter.idv_max_attempts - 1 }
 
   context 'landing page' do
     before do
@@ -96,26 +95,6 @@ feature 'IdV session' do
       end
 
       fill_out_financial_form_fail
-      click_idv_continue
-      expect(current_path).to eq verify_fail_path
-    end
-
-    scenario 'phone step redirects to fail after max attempts' do
-      sign_in_and_2fa_user
-      visit verify_session_path
-      fill_out_idv_form_ok
-      click_idv_continue
-      fill_out_financial_form_ok
-      click_idv_continue
-
-      max_attempts_less_one.times do
-        fill_out_phone_form_fail
-        click_idv_continue
-
-        expect(current_path).to eq verify_phone_path
-      end
-
-      fill_out_phone_form_fail
       click_idv_continue
       expect(current_path).to eq verify_fail_path
     end

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+feature 'Verify phone' do
+  include IdvHelper
+
+  scenario 'phone step redirects to fail after max attempts' do
+    sign_in_and_2fa_user
+    visit verify_session_path
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+
+    max_attempts_less_one.times do
+      fill_out_phone_form_fail
+      click_idv_continue
+
+      expect(current_path).to eq verify_phone_path
+    end
+
+    fill_out_phone_form_fail
+    click_idv_continue
+    expect(current_path).to eq verify_fail_path
+  end
+
+  scenario 'enter invalid phone number', :js do
+    sign_in_and_2fa_user
+    visit verify_session_path
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+
+    visit verify_phone_path
+    submit_form_with_invalid_phone
+
+    expect(page).to have_content t('errors.messages.improbable_phone')
+  end
+
+  def submit_form_with_invalid_phone
+    fill_in 'Phone', with: 'five one zero five five five four three two one'
+    click_idv_continue
+  end
+end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -1,4 +1,8 @@
 module IdvHelper
+  def max_attempts_less_one
+    Idv::Attempter.idv_max_attempts - 1
+  end
+
   def fill_out_idv_form_ok
     fill_in 'profile_first_name', with: 'Some'
     fill_in 'profile_last_name', with: 'One'

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -3,6 +3,10 @@ module IdvHelper
     Idv::Attempter.idv_max_attempts - 1
   end
 
+  def user_password
+    Features::SessionHelper::VALID_PASSWORD
+  end
+
   def fill_out_idv_form_ok
     fill_in 'profile_first_name', with: 'Some'
     fill_in 'profile_last_name', with: 'One'


### PR DESCRIPTION
**Why**: We have this one 2fa setup form and profile edit form for
phone, but not on this form.

NOTE that spec updates do not test this new behavior. As far as I can
tell, it's not easy / possible to test this js validation and we do not
test it for the existing two phone forms.

Before:

![screen shot 2017-02-07 at 5 40 38 pm](https://cloud.githubusercontent.com/assets/601515/22720134/f0e4930e-ed5d-11e6-8532-c046b1ff68a3.png)


After:

![screen shot 2017-02-07 at 5 41 29 pm](https://cloud.githubusercontent.com/assets/601515/22720139/f5772fda-ed5d-11e6-9e6d-436a357df520.png)
