### PR TITLE
Split encrypted attribute concerns into 2 modules

### DIFF
--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -1,0 +1,80 @@
+module EncryptableAttribute
+  extend ActiveSupport::Concern
+
+  attr_accessor :attribute_user_access_key
+
+  class_methods do
+    # rubocop:disable MethodLength
+    def encrypted_attribute(name:, default:, setter: true)
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def #{name}
+          get_encrypted_attribute(name: :"#{name}", default: #{default} )
+        end
+
+        def stale_encrypted_#{name}?
+          return false unless self.public_send(:"#{name}").present?
+          encrypted_attributes[:"#{name}"].stale?
+        end
+      METHODS
+
+      return unless setter
+
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def #{name}=(attribute)
+          set_encrypted_attribute(name: :"#{name}", value: attribute, default: #{default} )
+        end
+      METHODS
+    end
+    # rubocop:enable MethodLength
+  end
+
+  private
+
+  def encrypted_attributes
+    @_encrypted_attributes ||= {}
+  end
+
+  def get_encrypted_attribute(name:, default:)
+    getter = encrypted_attribute_name(name)
+    encrypted_string = self[getter]
+    return default unless encrypted_string.present?
+    encrypted_attribute = encrypted_attributes[name]
+    return encrypted_attribute.decrypted if encrypted_attribute.present?
+    build_encrypted_attribute(name, encrypted_string).decrypted
+  end
+
+  def build_encrypted_attribute(name, encrypted_string)
+    encrypted_attribute = EncryptedAttribute.new(
+      encrypted_string,
+      cost: attribute_cost,
+      user_access_key: attribute_user_access_key
+    )
+    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
+    encrypted_attributes[name] = encrypted_attribute
+  end
+
+  def set_encrypted_attribute(name:, value:, default:)
+    setter = encrypted_attribute_name(name)
+    new_value = default
+    if value.present?
+      new_value = build_encrypted_attribute_from_plain(name, value).encrypted
+    end
+    self[setter] = new_value
+  end
+
+  def build_encrypted_attribute_from_plain(name, plain_value)
+    self.attribute_user_access_key ||= new_attribute_user_access_key
+    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
+      plain_value.downcase.strip,
+      attribute_user_access_key
+    )
+  end
+
+  def encrypted_attribute_name(name)
+    "encrypted_#{name}".to_sym
+  end
+
+  def new_attribute_user_access_key
+    EncryptedAttribute.new_user_access_key(cost: attribute_cost)
+  end
+end

--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -4,8 +4,14 @@ module EncryptableAttribute
   attr_accessor :attribute_user_access_key
 
   class_methods do
+    cattr_accessor :encryptable_attributes do
+      []
+    end
+
     # rubocop:disable MethodLength
     def encrypted_attribute(name:, default:, setter: true)
+      self.encryptable_attributes << name
+
       class_eval <<-METHODS, __FILE__, __LINE__ + 1
         def #{name}
           get_encrypted_attribute(name: :"#{name}", default: #{default.inspect})

--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -8,7 +8,7 @@ module EncryptableAttribute
     def encrypted_attribute(name:, default:, setter: true)
       class_eval <<-METHODS, __FILE__, __LINE__ + 1
         def #{name}
-          get_encrypted_attribute(name: :"#{name}", default: #{default} )
+          get_encrypted_attribute(name: :"#{name}", default: #{default.inspect})
         end
 
         def stale_encrypted_#{name}?
@@ -21,7 +21,7 @@ module EncryptableAttribute
 
       class_eval <<-METHODS, __FILE__, __LINE__ + 1
         def #{name}=(attribute)
-          set_encrypted_attribute(name: :"#{name}", value: attribute, default: #{default} )
+          set_encrypted_attribute(name: :"#{name}", value: attribute, default: #{default.inspect})
         end
       METHODS
     end

--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -1,10 +1,6 @@
 module UserEncryptedAttributeOverrides
   extend ActiveSupport::Concern
 
-  attr_accessor :attribute_user_access_key
-
-  ENCRYPTED_ATTRIBUTES = [:phone, :otp_secret_key].freeze
-
   # override some Devise methods to support our use of encrypted_email
 
   class_methods do
@@ -50,88 +46,9 @@ module UserEncryptedAttributeOverrides
     generate_confirmation_token
   end
 
-  def email
-    get_encrypted_attribute(name: :email, default: '')
-  end
-
+  # Override usual setter method in order to also set fingerprint
   def email=(email)
     set_encrypted_attribute(name: :email, value: email, default: '')
     self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''
-  end
-
-  def stale_encrypted_email?
-    return false unless email.present?
-    encrypted_attributes[:email].stale?
-  end
-
-  ENCRYPTED_ATTRIBUTES.each do |attribute|
-    class_eval <<-METHODS, __FILE__, __LINE__ + 1
-      def #{attribute}
-        get_encrypted_attribute(name: :"#{attribute}", default: nil)
-      end
-    METHODS
-  end
-
-  ENCRYPTED_ATTRIBUTES.each do |attribute|
-    class_eval <<-METHODS, __FILE__, __LINE__ + 1
-      def #{attribute}=(attribute)
-        set_encrypted_attribute(name: :"#{attribute}", value: attribute, default: nil)
-      end
-
-      def stale_encrypted_#{attribute}?
-        return false unless self.public_send(:"#{attribute}")
-        encrypted_attributes[:"#{attribute}"].stale?
-      end
-    METHODS
-  end
-
-  private
-
-  def encrypted_attributes
-    @_encrypted_attributes ||= {}
-  end
-
-  def get_encrypted_attribute(name:, default:)
-    getter = encrypted_attribute_name(name)
-    encrypted_string = self[getter]
-    return default unless encrypted_string.present?
-    encrypted_attribute = encrypted_attributes[name]
-    return encrypted_attribute.decrypted if encrypted_attribute.present?
-    build_encrypted_attribute(name, encrypted_string).decrypted
-  end
-
-  def build_encrypted_attribute(name, encrypted_string)
-    encrypted_attribute = EncryptedAttribute.new(
-      encrypted_string,
-      cost: attribute_cost,
-      user_access_key: attribute_user_access_key
-    )
-    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
-    encrypted_attributes[name] = encrypted_attribute
-  end
-
-  def set_encrypted_attribute(name:, value:, default:)
-    setter = encrypted_attribute_name(name)
-    new_value = default
-    if value.present?
-      new_value = build_encrypted_attribute_from_plain(name, value).encrypted
-    end
-    self[setter] = new_value
-  end
-
-  def build_encrypted_attribute_from_plain(name, plain_value)
-    self.attribute_user_access_key ||= new_attribute_user_access_key
-    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
-      plain_value.downcase.strip,
-      attribute_user_access_key
-    )
-  end
-
-  def encrypted_attribute_name(name)
-    "encrypted_#{name}".to_sym
-  end
-
-  def new_attribute_user_access_key
-    EncryptedAttribute.new_user_access_key(cost: attribute_cost)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,12 @@ class User < ActiveRecord::Base
     authentication_keys: [:email]
   )
 
+  include EncryptableAttribute
+
+  encrypted_attribute(name: :phone, default: :nil)
+  encrypted_attribute(name: :otp_secret_key, default: :nil)
+  encrypted_attribute(name: :email, default: "''", setter: false)
+
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides
   include UserEncryptedAttributeOverrides

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,9 +17,9 @@ class User < ActiveRecord::Base
 
   include EncryptableAttribute
 
-  encrypted_attribute(name: :phone, default: :nil)
-  encrypted_attribute(name: :otp_secret_key, default: :nil)
-  encrypted_attribute(name: :email, default: "''", setter: false)
+  encrypted_attribute(name: :phone, default: nil)
+  encrypted_attribute(name: :otp_secret_key, default: nil)
+  encrypted_attribute(name: :email, default: '', setter: false)
 
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -20,13 +20,11 @@ module KeyRotator
     end
 
     def encrypted_attributes
-      User.attribute_names.grep(/^encrypted_/).each_with_object({}) do |attribute, result|
-        next if attribute == 'encrypted_password'
-        plain_attribute_name = attribute.gsub(/^encrypted_/, '')
-        plain_attribute = user.public_send(plain_attribute_name)
+      User.encryptable_attributes.each_with_object({}) do |attribute, result|
+        plain_attribute = user.public_send(attribute)
         next unless plain_attribute
 
-        result[attribute] = EncryptedAttribute.new_from_decrypted(
+        result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(
           plain_attribute,
           uak
         ).encrypted

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -20,20 +20,12 @@ module KeyRotator
     end
 
     def encrypted_attributes
-      encrypted_email_attributes.merge!(other_encrypted_attributes)
-    end
-
-    def encrypted_email_attributes
-      email = EncryptedAttribute.new_from_decrypted(user.email, uak)
-      { encrypted_email: email.encrypted, attribute_cost: new_cost }
-    end
-
-    def other_encrypted_attributes
-      User::ENCRYPTED_ATTRIBUTES.each_with_object({}) do |attribute, result|
-        plain_attribute = user.public_send(attribute)
+      User.attribute_names.grep(/^encrypted_/).each_with_object({}) do |attribute, result|
+        plain_attribute_name = attribute.gsub(/^encrypted_/, '')
+        plain_attribute = user.public_send(plain_attribute_name)
         next unless plain_attribute
 
-        result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(
+        result[attribute] = EncryptedAttribute.new_from_decrypted(
           plain_attribute,
           uak
         ).encrypted

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -21,6 +21,7 @@ module KeyRotator
 
     def encrypted_attributes
       User.attribute_names.grep(/^encrypted_/).each_with_object({}) do |attribute, result|
+        next if attribute == 'encrypted_password'
         plain_attribute_name = attribute.gsub(/^encrypted_/, '')
         plain_attribute = user.public_send(plain_attribute_name)
         next unless plain_attribute


### PR DESCRIPTION
**Why**: Makes attribute declarations explicit, shorter files.