### PR TITLE
Remove roman numerals from personal key lexicon

### DIFF
--- a/config/us-constitution.lexicon
+++ b/config/us-constitution.lexicon
@@ -484,12 +484,8 @@ honor
 hours
 house
 houses
-hu
 hundred
-i
 if
-ii
-iii
 illegal
 immediately
 imminent


### PR DESCRIPTION
**Why**: because they're weird and confusing