### PR TITLE
User can visit IDP after logging in with SP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(user)
-    stored_location_for(user) || session[:saml_request_url] || profile_path
+    stored_location_for(user) || profile_path
   end
 
   def render_401

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -63,5 +63,6 @@ class SamlIdpController < ApplicationController
 
   def delete_branded_experience
     session.delete(:sp) if session[:sp]
+    session.delete(:user_return_to) if session[:user_return_to]
   end
 end

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -18,6 +18,7 @@ test:
     assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
     block_encryption: 'aes256-cbc'
     sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    friendly_name: 'Test SP'
     cert: 'saml_test_sp'
     logo: 'generic.svg'
     attribute_bundle:

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -18,6 +18,19 @@ feature 'LOA1 Single Sign On' do
 
       expect(current_url).to eq @saml_authn_request
     end
+
+    it 'takes user to agency handoff page when sign in flow complete' do
+      user = create(:user, :signed_up)
+      saml_authn_request = auth_request.create(saml_settings)
+
+      visit saml_authn_request
+      sign_in_live_with_2fa(user)
+
+      expect(current_url).to eq saml_authn_request
+
+      visit root_path
+      expect(current_path).to eq profile_path
+    end
   end
 
   def sign_in_and_require_viewing_recovery_code(user)

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -19,7 +19,7 @@ feature 'LOA1 Single Sign On' do
       expect(current_url).to eq @saml_authn_request
     end
 
-    it 'takes user to agency handoff page when sign in flow complete' do
+    it 'takes user to the service provider when complete, allows user to visit IDP' do
       user = create(:user, :signed_up)
       saml_authn_request = auth_request.create(saml_settings)
 

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -12,14 +12,10 @@ feature 'LOA1 Single Sign On' do
       sign_in_and_require_viewing_recovery_code(user)
 
       click_acknowledge_recovery_code
-
-      expect(page).to have_content t('titles.loa3_verified.false', app: APP_NAME)
-      click_on I18n.t('forms.buttons.continue_to', sp: 'Your friendly Government Agency')
-
-      expect(current_url).to eq @saml_authn_request
+      expect(current_path).to eq sign_up_completed_path
     end
 
-    it 'takes user to the service provider when complete, allows user to visit IDP' do
+    it 'takes user to the service provider, allows user to visit IDP' do
       user = create(:user, :signed_up)
       saml_authn_request = auth_request.create(saml_settings)
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -127,23 +127,6 @@ feature 'saml api' do
     end
   end
 
-  context 'visiting /test/saml' do
-    scenario 'it requires 2FA' do
-      sign_in_before_2fa(user)
-      visit '/test/saml'
-
-      expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
-    end
-
-    it 'adds acs_url domain names for current Rails env to CSP form_action' do
-      sign_in_and_2fa_user(user)
-      visit '/test/saml'
-
-      expect(page.response_headers['Content-Security-Policy']).
-        to include('form-action \'self\' localhost:3000 example.com')
-    end
-  end
-
   context 'dashboard' do
     let(:fake_dashboard_url) { 'http://dashboard.example.org' }
     let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }

--- a/spec/features/saml/test_sp_spec.rb
+++ b/spec/features/saml/test_sp_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'Test SP' do
+  let(:user) { create(:user, :signed_up) }
+
+  context 'visiting /test/saml' do
+    scenario 'it requires 2FA' do
+      sign_in_before_2fa(user)
+      visit test_saml_path
+
+      expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
+    end
+
+    scenario 'adds acs_url domain names for current Rails env to CSP form_action' do
+      sign_in_and_2fa_user(user)
+      visit '/test/saml'
+
+      expect(page.response_headers['Content-Security-Policy']).
+        to include('form-action \'self\' localhost:3000 example.com')
+    end
+  end
+
+  scenario 'allows user to visit IDP after login' do
+    test_sp_friendly_name_from_config = 'Test SP'
+    visit test_saml_path
+    sign_up_and_2fa_loa1_user
+    click_on I18n.t('forms.buttons.continue_to', sp: test_sp_friendly_name_from_config)
+
+    visit root_path
+
+    expect(current_path).to eq profile_path
+  end
+end

--- a/spec/features/saml/test_sp_spec.rb
+++ b/spec/features/saml/test_sp_spec.rb
@@ -4,13 +4,6 @@ feature 'Test SP' do
   let(:user) { create(:user, :signed_up) }
 
   context 'visiting /test/saml' do
-    scenario 'it requires 2FA' do
-      sign_in_before_2fa(user)
-      visit test_saml_path
-
-      expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
-    end
-
     scenario 'adds acs_url domain names for current Rails env to CSP form_action' do
       sign_in_and_2fa_user(user)
       visit '/test/saml'
@@ -18,16 +11,5 @@ feature 'Test SP' do
       expect(page.response_headers['Content-Security-Policy']).
         to include('form-action \'self\' localhost:3000 example.com')
     end
-  end
-
-  scenario 'allows user to visit IDP after login' do
-    test_sp_friendly_name_from_config = 'Test SP'
-    visit test_saml_path
-    sign_up_and_2fa_loa1_user
-    click_on I18n.t('forms.buttons.continue_to', sp: test_sp_friendly_name_from_config)
-
-    visit root_path
-
-    expect(current_path).to eq profile_path
   end
 end


### PR DESCRIPTION
**Why**: Session vars made it so that a user was always redirected to
the service provider after logging in, which is annoying.