### PR TITLE
Disable DuplicateMethodCall in spec helper method

### DIFF
--- a/.reek
+++ b/.reek
@@ -106,6 +106,7 @@ UtilityFunction:
     exclude:
       - complete_2fa_confirmation
       - complete_idv_profile
+      - expect_current_address_in_profile
       - stub_subject
       - stub_idv_session
       - saml_settings


### PR DESCRIPTION
**Why**: We don't care about multiple calls to `expect(*)` in specs.