### PR TITLE
Fix typo in ivar name in spec

### DIFF
--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -135,7 +135,7 @@ feature 'OpenID Connect' do
   end
 
   def client_private_key
-    @client_public_key ||= begin
+    @client_private_key ||= begin
       OpenSSL::PKey::RSA.new(
         File.read(Rails.root.join('keys/saml_test_sp.key'))
       )


### PR DESCRIPTION
**Why**: it was misleading