### PR TITLE
Centers the recovery code modal

### DIFF
--- a/app/assets/javascripts/misc/recovery-page-controller.js
+++ b/app/assets/javascripts/misc/recovery-page-controller.js
@@ -3,13 +3,14 @@ import Modal from '../app/components/modal';
 const modalSelector = '#personal-key-confirm';
 const modal = new Modal({ el: modalSelector });
 
+const recoveryCodeContainer = document.getElementById('recovery-code');
 const recoveryWords = [].slice.call(document.querySelectorAll('[data-recovery]'));
 const formEl = document.getElementById('confirm-key');
 const inputs = [].slice.call(formEl.elements).filter((el) => el.type === 'text');
 const modalTrigger = document.querySelector('[data-toggle="modal"]');
 const modalDismiss = document.querySelector('[data-dismiss="personal-key-confirm"]');
 
-const reminderEl = document.getElementById('recovery-code-reminder');
+const reminderEl = document.getElementById('recovery-code-reminder-alert');
 
 let isInvalidForm = false;
 
@@ -62,11 +63,19 @@ function handleSubmit(event) {
   }
 }
 
+function showReminderAlert() {
+  if (reminderEl.className.indexOf('invisible')) {
+    reminderEl.setAttribute('aria-hidden', false);
+    reminderEl.classList.remove('invisible');
+  }
+}
+
 function show(event) {
   event.preventDefault();
 
   modal.on('show', function() {
     inputs[0].focus();
+    recoveryCodeContainer.classList.add('invisible');
   });
 
   modal.show();
@@ -75,11 +84,8 @@ function show(event) {
 function hide() {
   modal.on('hide', function() {
     resetForm();
-
-    if (reminderEl.className.indexOf('hide')) {
-      reminderEl.setAttribute('aria-hidden', false);
-      reminderEl.classList.remove('hide');
-    }
+    recoveryCodeContainer.classList.remove('invisible');
+    showReminderAlert();
   });
 
   modal.hide();

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -18,24 +18,32 @@
   top: 0;
 }
 
+.modal-center {
+  display: table;
+  height: 100%;
+  width: 100%;
+}
+
+.modal-content {
+  display: table-cell;
+  vertical-align: middle;
+}
+
 // IE the backdrop
 .modal-cntnr {
-  background-color: rgba(91, 97, 106, .9);
+  background-color: rgba(91, 97, 106, .95);
   display: table;
   height: 100%;
   left: 0;
   position: fixed;
   top: 0;
   width: 100%;
-
-  .modal-inner {
-    display: table-cell;
-    vertical-align: top;
-   }
 }
 
 .modal-inner {
   display: block;
+  margin-left: auto;
+  margin-right: auto;
   position: relative;
 
   &.key-badge::before {

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -1,4 +1,4 @@
-.mb4.alert.alert-warning.hide(id='recovery-code-reminder' aria-hidden='true')
+.mb4.alert.alert-warning.hide(id='recovery-code-reminder-alert' aria-hidden='true')
   = t('users.recovery_code.reminder')
 
 h1.h3.my0 = t('headings.recovery_code')

--- a/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
+++ b/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
@@ -1,23 +1,26 @@
 #personal-key-confirm.hide
   .modal-cntnr
   .px2.py4.modal
-    .mx-auto.p5.cntnr-skinny.border-box.bg-white.rounded.relative.rounded-lg.modal-inner.key-badge
-      h3.mt0.mb2 = t('forms.recovery_code.title')
-      p.mb3 = t('forms.recovery_code.instructions')
+    .modal-center
+      .modal-content
+        .p5.cntnr-skinny.border-box.bg-white.rounded.rounded-lg.modal-inner.key-badge
+          h3.mt0.mb2 = t('forms.recovery_code.title')
+          p.mb3 = t('forms.recovery_code.instructions')
 
-      #recovery-code-alert.alert.alert-alert.hide(role='alert')
-        = t('users.recovery_code.confirmation_error')
+          #recovery-code-alert.alert.alert-alert.hide(role='alert')
+            = t('users.recovery_code.confirmation_error')
 
-      form(id='confirm-key' method='post' action="#{sign_up_recovery_code_path}")
-        - code.split(' ').each_with_index do |word, index|
-          .border.border-dashed.mb2
-            input(name="recovery-#{index}" type='text' class='col-12 field monospace'
+          form(id='confirm-key' method='post' action="#{sign_up_recovery_code_path}")
+            - code.split(' ').each_with_index do |word, index|
+              .border.border-dashed.mb2
+                input(
+                  name="recovery-#{index}" type='text' class='col-12 field monospace'
                   required=true pattern="#{word}"
                   aria-label="#{t('forms.recovery_code.confirmation_label', number: index + 1)}")
-        end
-        = hidden_field_tag :authenticity_token, form_authenticity_token
+            end
+            = hidden_field_tag :authenticity_token, form_authenticity_token
 
-        button(type='submit' class='btn btn-primary recovery-code-confirm')
-          = t('forms.buttons.continue')
-        button.ml2.btn.btn-outline.rounded-lg(data-dismiss='personal-key-confirm' type='button')
-          = t('forms.buttons.back')
+            button(type='submit' class='btn btn-primary recovery-code-confirm')
+              = t('forms.buttons.continue')
+            button.ml2.btn.btn-outline.rounded-lg(data-dismiss='personal-key-confirm' type='button')
+              = t('forms.buttons.back')

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -3,7 +3,7 @@ shared_examples_for 'recovery code page' do
 
   it 'hides confirmation importance reminder text by default' do
     expect(page).to have_xpath(
-      "//div[@id='recovery-code-reminder'][@aria-hidden='true']", visible: false
+      "//div[@id='recovery-code-reminder-alert'][@aria-hidden='true']", visible: false
     )
   end
 
@@ -49,6 +49,8 @@ shared_examples_for 'recovery code page' do
     end
 
     context 'with javascript enabled', js: true do
+      let(:invisible_selector) { generate_class_selector('invisible') }
+
       scenario 'content is hidden by default' do
         expect(page).to have_xpath("//#{accordion_selector}[@aria-expanded='false']")
         expect(page).not_to have_content(t('users.recovery_code.help_text'))
@@ -58,12 +60,13 @@ shared_examples_for 'recovery code page' do
         expect(page).to have_content(t('users.recovery_code.help_text'))
       end
 
-      scenario 'modal opens when continue is clicked', js: true do
+      scenario 'modal opens when continue is clicked' do
         expect(page).to have_xpath("//div[@id='personal-key-confirm'][@class='hide']")
 
         click_acknowledge_recovery_code
 
         expect(page).not_to have_xpath("//div[@id='personal-key-confirm'][@class='hide']")
+        expect(page).not_to have_xpath("//#{invisible_selector}[@id='recovery-code']")
       end
 
       context 'closing the modal', js: true do
@@ -78,7 +81,7 @@ shared_examples_for 'recovery code page' do
 
         scenario 'warning alert message appears' do
           expect(page).to have_xpath(
-            "//div[@id='recovery-code-reminder'][@aria-hidden='false']"
+            "//div[@id='recovery-code-reminder-alert'][@aria-hidden='false']"
           )
         end
       end


### PR DESCRIPTION
**Why**: Visual centering is more appealing and generally obscures the
recovery code the users are supposed to have written down

Screenshot:

![screen shot 2017-02-09 at 2 19 59 pm](https://cloud.githubusercontent.com/assets/1421848/22799184/e2453b98-eed2-11e6-9f46-4fa72f83656a.png)
