### PR TITLE
Refactor verification modals

### DIFF
--- a/.reek
+++ b/.reek
@@ -95,6 +95,8 @@ UtilityFunction:
     - Remote#host
     - Remote#parse_positional_arguments
     - SessionsNew
+    - FinanceNew
+    - PhoneNew
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -1,45 +1,17 @@
-const I18n = window.LoginGov.I18n;
+import 'classlist.js';
 
 function verifyModal() {
-  const flash = document.querySelector("[id^='js-modal']");
+  const flash = document.querySelector('.alert');
+  const modal = document.querySelector('.modal-cntnr');
+  const close = document.getElementById('js-close-modal');
 
-  if (flash) {
-    const name = flash.id.split('-').pop();
-    const heading = flash.querySelector('strong:first-of-type');
-    const content = flash.querySelector('span:first-of-type');
-    const attempts = flash.querySelector('span:last-of-type');
+  if (flash) flash.classList.add('hide');
+  if (modal) modal.classList.remove('hide');
 
-    if ((name === 'warning' || name === 'error') && (heading !== null && content !== null)) {
-      const button = I18n.t(`idv.modal.button.${name}`);
-
-      // Hide flash message
-      flash.classList.add('display-none');
-
-      // Add modal
-      const el = document.createElement('div');
-      el.classList.add('modal-cntnr');
-      el.innerHTML = `
-        <div class="px2 py4 modal-inner">
-          <div class="mx-auto p4 cntnr-xskinny border-box bg-white rounded-xxl modal-${name}">
-            <h2 class="my2 fs-20p sans-serif regular center">${heading.innerHTML}</h2>
-            <hr class="mb3 bw4 rounded">
-            <p>${content.innerHTML}</p>
-            <p class="mb5">${attempts.innerHTML}</p>
-            <div class="center">
-              <a href="#" id="js-close-modal" class="btn btn-wide px2 py1 rounded-lg border bw2">
-                ${button}
-              </a>
-            </div>
-          </div>
-        </div>`;
-      document.body.appendChild(el);
-
-      // Remove modal
-      const close = document.getElementById(`js-close-modal`);
-      close.addEventListener('click', function() {
-        el.parentNode.removeChild(el);
-      });
-    }
+  if (close) {
+    close.addEventListener('click', function() {
+      modal.classList.add('hide');
+    });
   }
 }
 

--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -5,12 +5,12 @@ function verifyModal() {
   const modal = document.querySelector('.modal-cntnr');
   const close = document.getElementById('js-close-modal');
 
-  if (flash) flash.classList.add('hide');
-  if (modal) modal.classList.remove('hide');
+  if (flash) flash.classList.add('display-none');
+  if (modal) modal.classList.remove('display-none');
 
   if (close) {
     close.addEventListener('click', function() {
-      modal.classList.add('hide');
+      modal.classList.add('display-none');
     });
   }
 }

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -17,6 +17,11 @@ module IdvStepConcern
     idv_session.step_attempts[step_name] += 1
   end
 
+  def show_vendor_warning
+    presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
+    flash.now[:warning] = presenter.warning_message
+  end
+
   def remaining_step_attempts
     Idv::Attempter.idv_max_attempts - idv_session.step_attempts[step_name]
   end

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -10,6 +10,7 @@ module Verify
     helper_method :step_name
 
     def new
+      @view_model = FinanceNew.new
       analytics.track_event(Analytics::IDV_FINANCE_CCN_VISIT)
     end
 
@@ -42,7 +43,13 @@ module Verify
     end
 
     def process_failure
-      show_warning if step.form_valid_but_vendor_validation_failed?
+      if step.form_valid_but_vendor_validation_failed?
+        show_vendor_warning
+        @view_model = FinanceNew.new(modal: 'warning')
+      else
+        @view_model = SessionsNew.new
+      end
+
       render_form
     end
 
@@ -52,13 +59,6 @@ module Verify
 
     def confirm_step_needed
       redirect_to verify_phone_path if idv_session.financials_confirmation == true
-    end
-
-    def show_warning
-      presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
-
-      flash.now[:warning] = presenter.warning_message
-      @modal = 'warning'
     end
 
     def render_form

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -6,6 +6,8 @@ module Verify
     before_action :confirm_step_allowed
 
     helper_method :idv_finance_form
+    helper_method :remaining_step_attempts
+    helper_method :step_name
 
     def new
       analytics.track_event(Analytics::IDV_FINANCE_CCN_VISIT)
@@ -56,6 +58,7 @@ module Verify
       presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
 
       flash.now[:warning] = presenter.warning_message
+      @modal = 'warning'
     end
 
     def render_form

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -47,7 +47,7 @@ module Verify
         show_vendor_warning
         @view_model = FinanceNew.new(modal: 'warning')
       else
-        @view_model = SessionsNew.new
+        @view_model = FinanceNew.new
       end
 
       render_form

--- a/app/controllers/verify/finance_other_controller.rb
+++ b/app/controllers/verify/finance_other_controller.rb
@@ -6,8 +6,11 @@ module Verify
     before_action :confirm_step_allowed
 
     helper_method :idv_finance_form
+    helper_method :remaining_step_attempts
+    helper_method :step_name
 
     def new
+      @view_model = FinanceNew.new
       analytics.track_event(Analytics::IDV_FINANCE_OTHER_VISIT)
     end
 

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -47,7 +47,7 @@ module Verify
         show_vendor_warning
         @view_model = PhoneNew.new(modal: 'warning')
       else
-        @view_model = SessionsNew.new
+        @view_model = PhoneNew.new
       end
 
       render :new

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -10,6 +10,7 @@ module Verify
     helper_method :step_name
 
     def new
+      @view_model = PhoneNew.new
       analytics.track_event(Analytics::IDV_PHONE_RECORD_VISIT)
     end
 
@@ -42,15 +43,14 @@ module Verify
     end
 
     def process_failure
-      show_warning if step.form_valid_but_vendor_validation_failed?
+      if step.form_valid_but_vendor_validation_failed?
+        show_vendor_warning
+        @view_model = PhoneNew.new(modal: 'warning')
+      else
+        @view_model = SessionsNew.new
+      end
+
       render :new
-    end
-
-    def show_warning
-      presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
-
-      flash.now[:warning] = presenter.warning_message
-      @modal = 'warning'
     end
 
     def step_params

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -6,6 +6,8 @@ module Verify
     before_action :confirm_step_allowed
 
     helper_method :idv_phone_form
+    helper_method :remaining_step_attempts
+    helper_method :step_name
 
     def new
       analytics.track_event(Analytics::IDV_PHONE_RECORD_VISIT)
@@ -48,6 +50,7 @@ module Verify
       presenter = VerificationWarningPresenter.new(step_name, remaining_step_attempts)
 
       flash.now[:warning] = presenter.warning_message
+      @modal = 'warning'
     end
 
     def step_params

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -53,17 +53,23 @@ module Verify
         flash[:error] = t('idv.errors.duplicate_ssn')
         redirect_to verify_session_dupe_path
       else
-        show_warning
-        @view_model = SessionsNew.new
+        process_vendor_error
         render :new
       end
     end
 
-    def show_warning
-      return unless step.form_valid_but_vendor_validation_failed?
+    def process_vendor_error
+      if step.form_valid_but_vendor_validation_failed?
+        show_vendor_warning
+        @view_model = SessionsNew.new(modal: 'warning')
+      else
+        @view_model = SessionsNew.new
+      end
+    end
+
+    def show_vendor_warning
       presenter = VerificationWarningPresenter.new(step_name, remaining_idv_attempts)
       flash.now[:warning] = presenter.warning_message
-      @modal = 'warning'
     end
 
     def remaining_idv_attempts

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -8,6 +8,8 @@ module Verify
     before_action :confirm_step_needed
 
     helper_method :idv_profile_form
+    helper_method :remaining_idv_attempts
+    helper_method :step_name
     helper_method :step
 
     def new
@@ -61,6 +63,7 @@ module Verify
       return unless step.form_valid_but_vendor_validation_failed?
       presenter = VerificationWarningPresenter.new(step_name, remaining_idv_attempts)
       flash.now[:warning] = presenter.warning_message
+      @modal = 'warning'
     end
 
     def remaining_idv_attempts

--- a/app/presenters/verification_warning_presenter.rb
+++ b/app/presenters/verification_warning_presenter.rb
@@ -5,22 +5,31 @@ class VerificationWarningPresenter
   end
 
   def warning_message
-    I18n.t('idv.modal.warning_html', heading: heading, attempt: attempt, body: body)
+    heading + warning + attempts
   end
 
   private
 
   attr_reader :name, :remaining_step_attempts
 
-  def attempt
-    I18n.t('idv.modal.attempts', count: remaining_step_attempts)
+  def helper
+    ActionController::Base.helpers
   end
 
-  def body
-    ActionController::Base.helpers.content_tag(:span, I18n.t("idv.modal.#{name}.body"))
+  def attempts
+    msg = I18n.t('idv.modal.attempts_html', attempt: I18n.t(
+      'idv.modal.attempts',
+      count: remaining_step_attempts
+    ))
+
+    helper.content_tag(:p, helper.safe_join([msg.html_safe]))
+  end
+
+  def warning
+    helper.content_tag(:p, I18n.t("idv.modal.#{name}.warning"))
   end
 
   def heading
-    ActionController::Base.helpers.content_tag(:strong, I18n.t("idv.modal.#{name}.heading"))
+    helper.content_tag(:p, I18n.t("idv.modal.#{name}.heading"), class: 'mb2 fs-20p')
   end
 end

--- a/app/view_models/finance_new.rb
+++ b/app/view_models/finance_new.rb
@@ -1,18 +1,10 @@
-class SessionsNew
+class FinanceNew
   def initialize(modal: nil)
     @modal = modal
   end
 
   def title
-    I18n.t('idv.titles.session.basic')
-  end
-
-  def mock_vendor_partial
-    if idv_vendor.pick == :mock
-      'verify/sessions/no_pii_warning'
-    else
-      'shared/null'
-    end
+    I18n.t('idv.titles.session.finance')
   end
 
   def modal_type
@@ -30,8 +22,4 @@ class SessionsNew
   private
 
   attr_reader :modal
-
-  def idv_vendor
-    @_idv_vendor ||= Idv::Vendor.new
-  end
 end

--- a/app/view_models/phone_new.rb
+++ b/app/view_models/phone_new.rb
@@ -1,18 +1,10 @@
-class SessionsNew
+class PhoneNew
   def initialize(modal: nil)
     @modal = modal
   end
 
   def title
-    I18n.t('idv.titles.session.basic')
-  end
-
-  def mock_vendor_partial
-    if idv_vendor.pick == :mock
-      'verify/sessions/no_pii_warning'
-    else
-      'shared/null'
-    end
+    I18n.t('idv.titles.phone')
   end
 
   def modal_type
@@ -30,8 +22,4 @@ class SessionsNew
   private
 
   attr_reader :modal
-
-  def idv_vendor
-    @_idv_vendor ||= Idv::Vendor.new
-  end
 end

--- a/app/views/shared/_messages.html.slim
+++ b/app/views/shared/_messages.html.slim
@@ -1,5 +1,5 @@
 - unless flash.empty?
   - flash.each do |name, msg|
     - if msg.present? && msg.is_a?(String)
-      div id="js-modal-#{name}" class="alert alert-#{name}" role='alert'
+      div class="alert alert-#{name}" role='alert'
         = safe_join([msg.html_safe])

--- a/app/views/shared/_modal_verification.slim
+++ b/app/views/shared/_modal_verification.slim
@@ -1,11 +1,12 @@
-.modal-cntnr.hide
+.modal-cntnr.display-none
   .px2.py4.modal-inner
     .mx-auto.p4.cntnr-xskinny.border-box.bg-white.rounded-xxl(class="modal-#{type}")
       h2.my2.fs-20p.sans-serif.regular.center = t("idv.modal.#{name}.heading")
       hr.mb3.bw4.rounded
       p = t("idv.modal.#{name}.#{type}")
-      - if type == 'warning'
-        p.mb5 = t('idv.modal.attempts_html', attempt: t('idv.modal.attempts', count: attempts))
+      p.mb5 = t('idv.modal.attempts_html', attempt: t('idv.modal.attempts', count: attempts))
       .center
         = link_to t("idv.modal.button.#{type}"), 'javascript:void(0)',
           id: 'js-close-modal', class: 'btn btn-wide px2 py1 rounded-lg border bw2'
+
+== javascript_include_tag 'misc/verify-modal'

--- a/app/views/shared/_modal_verification.slim
+++ b/app/views/shared/_modal_verification.slim
@@ -1,0 +1,11 @@
+.modal-cntnr.hide
+  .px2.py4.modal-inner
+    .mx-auto.p4.cntnr-xskinny.border-box.bg-white.rounded-xxl(class="modal-#{type}")
+      h2.my2.fs-20p.sans-serif.regular.center = t("idv.modal.#{name}.heading")
+      hr.mb3.bw4.rounded
+      p = t("idv.modal.#{name}.#{type}")
+      - if type == 'warning'
+        p.mb5 = t('idv.modal.attempts_html', attempt: t('idv.modal.attempts', count: attempts))
+      .center
+        = link_to t("idv.modal.button.#{type}"), 'javascript:void(0)',
+          id: 'js-close-modal', class: 'btn btn-wide px2 py1 rounded-lg border bw2'

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -27,4 +27,7 @@ p.mb3
 
 = render 'shared/cancel', link: verify_cancel_path
 
-== javascript_include_tag 'misc/verify-modal'
+- if @modal
+  = render 'shared/modal_verification',
+    attempts: remaining_step_attempts, name: step_name, type: @modal
+  == javascript_include_tag 'misc/verify-modal'

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -1,4 +1,4 @@
-- title t('idv.titles.session.finance')
+- title @view_model.title
 
 h1.h3.my0 = t('idv.titles.session.finance')
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_ccn')
@@ -27,7 +27,5 @@ p.mb3
 
 = render 'shared/cancel', link: verify_cancel_path
 
-- if @modal
-  = render 'shared/modal_verification',
-    attempts: remaining_step_attempts, name: step_name, type: @modal
-  == javascript_include_tag 'misc/verify-modal'
+= render @view_model.modal_partial, attempts: remaining_step_attempts, name: step_name,
+  type: @view_model.modal_type

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -1,4 +1,4 @@
-- title t('idv.titles.session.finance')
+- title @view_model.title
 
 h1.h3.my0 = t('idv.titles.session.finance')
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
@@ -37,7 +37,5 @@ p.mb3
 
 = render 'shared/cancel', link: verify_cancel_path
 
-- if @modal
-  = render 'shared/modal_verification',
-    attempts: remaining_step_attempts, name: step_name, type: @modal
-  == javascript_include_tag 'misc/verify-modal'
+= render @view_model.modal_partial, attempts: remaining_step_attempts, name: step_name,
+  type: @view_model.modal_type

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -37,4 +37,7 @@ p.mb3
 
 = render 'shared/cancel', link: verify_cancel_path
 
-== javascript_include_tag 'misc/verify-modal'
+- if @modal
+  = render 'shared/modal_verification',
+    attempts: remaining_step_attempts, name: step_name, type: @modal
+  == javascript_include_tag 'misc/verify-modal'

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -1,4 +1,4 @@
-- title t('idv.titles.phone')
+- title @view_model.title
 
 h1.h3.my0 = t('idv.titles.session.phone')
 p.mt-tiny.mb0 = t('idv.messages.phone.intro')
@@ -20,8 +20,5 @@ p = t('idv.messages.phone.same_as_2fa')
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
 = render 'shared/cancel', link: verify_cancel_path
 
-- if @modal
-  = render 'shared/modal_verification',
-    attempts: remaining_step_attempts, name: step_name, type: @modal
-  == javascript_include_tag 'misc/verify-modal'
-
+= render @view_model.modal_partial, attempts: remaining_step_attempts, name: step_name,
+  type: @view_model.modal_type

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -20,4 +20,8 @@ p = t('idv.messages.phone.same_as_2fa')
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
 = render 'shared/cancel', link: verify_cancel_path
 
-== javascript_include_tag 'misc/verify-modal'
+- if @modal
+  = render 'shared/modal_verification',
+    attempts: remaining_step_attempts, name: step_name, type: @modal
+  == javascript_include_tag 'misc/verify-modal'
+

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -58,7 +58,5 @@ h1.h3.my0 = t('idv.titles.session.basic')
     button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.continue')
 = render 'shared/cancel', link: verify_cancel_path
 
-- if @modal
-  = render 'shared/modal_verification',
-    attempts: remaining_idv_attempts, name: step_name, type: @modal
-  == javascript_include_tag 'misc/verify-modal'
+= render @view_model.modal_partial, attempts: remaining_idv_attempts, name: step_name,
+  type: @view_model.modal_type

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -58,4 +58,7 @@ h1.h3.my0 = t('idv.titles.session.basic')
     button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.continue')
 = render 'shared/cancel', link: verify_cancel_path
 
-== javascript_include_tag 'misc/verify-modal'
+- if @modal
+  = render 'shared/modal_verification',
+    attempts: remaining_idv_attempts, name: step_name, type: @modal
+  == javascript_include_tag 'misc/verify-modal'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -135,21 +135,20 @@ en:
       attempts:
         one: 1 attempt
         other: "%{count} attempts"
+      attempts_html: You have <strong>%{attempt} remaining.</strong>
       button:
         warning: Try again
       financials:
         heading: We could not find records matching your financial information.
-        body: Please check the information you entered.
+        warning: Please check the information you entered.
       phone:
         heading: We could not find records matching your phone information.
-        body: Please check the information you entered.
+        warning: Please check the information you entered.
       sessions:
         heading: We could not find records matching your personal information.
-        body: >
+        warning: >
           Please check the information you entered. Common mistakes are an incorrect Social
           Security Number, ZIP Code, or date of birth.
-      warning_html: >
-        %{heading} %{body} <span>You have <strong>%{attempt} remaining.</strong></span>
     review:
       dob: Date of birth
       full_name: Full name

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -102,18 +102,18 @@ es:
       attempts:
         one: NOT TRANSLATED YET
         other: NOT TRANSLATED YET
+      attempts_html: NOT TRANSLATED YET
       button:
         warning: NOT TRANSLATED YET
       financials:
         heading: NOT TRANSLATED YET
-        body: NOT TRANSLATED YET
+        warning: NOT TRANSLATED YET
       phone:
         heading: NOT TRANSLATED YET
-        body: NOT TRANSLATED YET
+        warning: NOT TRANSLATED YET
       sessions:
         heading: NOT TRANSLATED YET
-        body: NOT TRANSLATED YET
-      warning_html: NOT TRANSLATED YET
+        warning: NOT TRANSLATED YET
     review:
       dob: NOT TRANSLATED YET
       full_name: NOT TRANSLATED YET

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -111,7 +111,11 @@ describe Verify::FinanceController do
         it 'renders #new with error' do
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '00000000' }
 
-          expect(flash[:warning]).to_not be_nil
+          expect(flash[:warning]).to match t('idv.modal.financials.heading')
+          expect(flash[:warning]).to match t(
+            'idv.modal.attempts_html',
+            attempt: t('idv.modal.attempts', count: max_attempts - 1)
+          )
           expect(response).to render_template :new
         end
       end

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -111,12 +111,7 @@ describe Verify::FinanceController do
         it 'renders #new with error' do
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '00000000' }
 
-          expect(flash[:warning]).to eq(
-            t('idv.modal.warning_html',
-              heading: "<strong>#{t('idv.modal.financials.heading')}</strong>",
-              attempt: t('idv.modal.attempts', count: max_attempts - 1),
-              body: "<span>#{t('idv.modal.financials.body')}</span>")
-          )
+          expect(flash[:warning]).to_not be_nil
           expect(response).to render_template :new
         end
       end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -111,7 +111,11 @@ describe Verify::PhoneController do
           },
         }
 
-        expect(flash[:warning]).to_not be_nil
+        expect(flash[:warning]).to match t('idv.modal.phone.heading')
+        expect(flash[:warning]).to match t(
+          'idv.modal.attempts_html',
+          attempt: t('idv.modal.attempts', count: max_attempts - 1)
+        )
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION, result
         )

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -111,12 +111,7 @@ describe Verify::PhoneController do
           },
         }
 
-        expect(flash[:warning]).to eq(
-          t('idv.modal.warning_html',
-            heading: "<strong>#{t('idv.modal.phone.heading')}</strong>",
-            attempt: t('idv.modal.attempts', count: max_attempts - 1),
-            body: "<span>#{t('idv.modal.phone.body')}</span>")
-        )
+        expect(flash[:warning]).to_not be_nil
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION, result
         )

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -148,12 +148,7 @@ describe Verify::SessionsController do
         it 're-renders form' do
           post :create, profile: bad_attrs
 
-          expect(flash[:warning]).to eq(
-            t('idv.modal.warning_html',
-              heading: "<strong>#{t('idv.modal.sessions.heading')}</strong>",
-              attempt: t('idv.modal.attempts', count: max_attempts - 1),
-              body: "<span>#{t('idv.modal.sessions.body')}</span>")
-          )
+          expect(flash[:warning]).to_not be_nil
           expect(response).to render_template(:new)
         end
 

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -148,7 +148,11 @@ describe Verify::SessionsController do
         it 're-renders form' do
           post :create, profile: bad_attrs
 
-          expect(flash[:warning]).to_not be_nil
+          expect(flash[:warning]).to match t('idv.modal.sessions.heading')
+          expect(flash[:warning]).to match t(
+            'idv.modal.attempts_html',
+            attempt: t('idv.modal.attempts', count: max_attempts - 1)
+          )
           expect(response).to render_template(:new)
         end
 


### PR DESCRIPTION
**Why**: Originally I was using Javascript to transform the contents of a flash message into a modal window, but this refactor moves the modal view into a partial file instead.  This allows for more flexibility with the layout and styling of both the modal window, and fall back flash message.

I also intend to extend this for the hard fail modals when the max number of retries is reached (which should be much easier now that the view is in a partial).

**Modal:**
![screen shot 2017-02-09 at 4 08 40 pm](https://cloud.githubusercontent.com/assets/1178494/22803240/240b7286-eee2-11e6-88d6-0df09669a719.png)

**Fallback flash message:**
![screen shot 2017-02-09 at 4 09 17 pm](https://cloud.githubusercontent.com/assets/1178494/22803252/2cf50ac4-eee2-11e6-8b1b-319d07e42e06.png)
