### PR TITLE
Add specs for use of `update_columns`

### DIFF
--- a/spec/services/key_rotator/attribute_encryption_spec.rb
+++ b/spec/services/key_rotator/attribute_encryption_spec.rb
@@ -9,11 +9,21 @@ describe KeyRotator::AttributeEncryption do
       old_encrypted_phone = user.encrypted_phone
 
       rotate_attribute_encryption_key
-
       rotator.rotate
 
       expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(user.encrypted_phone).to_not eq old_encrypted_phone
+    end
+
+    it 'does not change the `updated_at` timestamp' do
+      user = create(:user)
+      old_updated_timestamp = user.updated_at
+
+      rotate_attribute_encryption_key
+      rotator = described_class.new(user)
+      rotator.rotate
+
+      expect(user.updated_at).to eq old_updated_timestamp
     end
   end
 end

--- a/spec/services/key_rotator/hmac_fingerprinter_spec.rb
+++ b/spec/services/key_rotator/hmac_fingerprinter_spec.rb
@@ -20,6 +20,20 @@ describe KeyRotator::HmacFingerprinter do
       expect(user.email_fingerprint).to_not eq old_email_fingerprint
     end
 
+    it 'does not change the `updated_at` timestamp' do
+      profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
+      user = profile.user
+      pii_attributes = profile.decrypt_pii(user.user_access_key)
+
+      old_updated_timestamp = user.updated_at
+
+      rotate_hmac_key
+      rotator = described_class.new
+      rotator.rotate(user: user, pii_attributes: pii_attributes)
+
+      expect(user.updated_at).to eq old_updated_timestamp
+    end
+
     it 'changes email fingerprint if no active profile' do
       rotator = described_class.new
       user = create(:user)


### PR DESCRIPTION
**Why**: We are using `update_columns` because it is faster and does not
change the `updated_at` timestamp on records. In this case, there is not
business rule for why we are doing this, but we want to preserve the
behvaior. So these tests are serving as documentation that using
`update_columns` was an intentional choice in these classes.