### PR TITLE
Recovery code controller preserves stored location

### DIFF
--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -35,6 +35,8 @@ module SignUp
         sign_up_completed_path
       elsif current_user.password_reset_profile.present?
         reactivate_profile_path
+      elsif (stored_location = stored_location_for(current_user))
+        stored_location
       else
         profile_path
       end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -125,6 +125,28 @@ feature 'OpenID Connect' do
       id_token = token_response[:id_token]
       expect(id_token).to be_present
     end
+
+    it 'continues to the authorization page on first-time signup' do
+      client_id = 'urn:gov:gsa:openidconnect:test'
+
+      visit openid_connect_authorize_path(
+        client_id: client_id,
+        response_type: 'code',
+        acr_values: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
+        scope: 'openid email',
+        redirect_uri: 'gov.gsa.openidconnect.test://result',
+        state: SecureRandom.hex,
+        prompt: 'select_account',
+        code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
+        code_challenge_method: 'S256'
+      )
+
+      sign_up_and_2fa_loa1_user
+
+      click_button t('openid_connect.authorization.index.allow')
+      redirect_uri = URI(current_url)
+      expect(redirect_uri.to_s).to start_with('gov.gsa.openidconnect.test://result')
+    end
   end
 
   def sp_public_key


### PR DESCRIPTION
**Why**:
So that OpenID connect clients can redirect to the authorization
page correctly after a first-time signup