### PR TITLE
Pii::Attributes values now Pii::Attribute

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
     - 'app/decorators/user_decorator.rb'
     - 'app/services/omniauth_authorizer.rb'
     - 'app/services/single_logout_handler.rb'
+    - 'app/services/pii/attributes.rb'
     - 'config/environments/*.rb'
     - 'config/initializers/secure_headers.rb'
     - 'config/routes.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'simple_form'
 gem 'sinatra', require: false
 gem 'slim-rails'
 gem 'split', require: 'split/dashboard'
+gem 'stringex'
 gem 'twilio-ruby'
 gem 'two_factor_authentication', github: 'Houdini/two_factor_authentication', ref: '1d6abe3'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -568,6 +568,7 @@ GEM
     sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stringex (2.7.0)
     sysexits (1.2.0)
     systemu (2.6.5)
     teaspoon (1.1.5)
@@ -723,6 +724,7 @@ DEPENDENCIES
   slim-rails
   slim_lint
   split
+  stringex
   teaspoon-mocha
   test_after_commit
   thin

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -30,7 +30,7 @@ class OpenidConnectUserInfoPresenter
       birthdate: loa3_data.dob,
       address: address,
       phone: phone,
-      phone_verified: phone ? true : nil,
+      phone_verified: phone.present? ? true : nil,
     }
   end
 

--- a/app/services/pii/attribute.rb
+++ b/app/services/pii/attribute.rb
@@ -1,0 +1,17 @@
+module Pii
+  class Attribute
+    attr_accessor :raw, :norm
+
+    def initialize(raw: nil, norm: nil)
+      @raw = raw
+      @norm = norm
+    end
+
+    delegate :blank?, :present?, :to_s, :to_date, :==, :eql?, to: :raw
+    alias to_str to_s
+
+    def ascii
+      raw.to_ascii
+    end
+  end
+end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -38,7 +38,7 @@
     .py-12p.border-top
       .clearfix.mxn1
         .sm-col.sm-col-5.px1 = t('.ssn')
-        .sm-col.sm-col-7.px1 = "***-**-#{@decrypted_pii.ssn[-4..-1]}"
+        .sm-col.sm-col-7.px1 = "***-**-#{@decrypted_pii.ssn.raw[-4..-1]}"
     .py-12p.border-top.border-bottom
       .clearfix.mxn1
         .sm-col.sm-col-5.px1 = t('.phone')

--- a/spec/services/pii/attribute_spec.rb
+++ b/spec/services/pii/attribute_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Pii::Attribute do
+  let(:first_name_utf8) { 'José' }
+  let(:first_name_ascii) { 'Jose' }
+
+  subject { described_class.new(raw: first_name_utf8) }
+
+  describe '#ascii' do
+    it 'transliterates' do
+      expect(subject.ascii).to eq first_name_ascii
+    end
+  end
+
+  # rubocop:disable UnneededInterpolation
+  describe 'delegation' do
+    it 'delegates to raw' do
+      expect(subject.blank?).to eq false
+      expect(subject.present?).to eq true
+      expect(subject.to_s).to eq first_name_utf8
+      expect(subject.to_str).to eq first_name_utf8
+      expect("#{subject}").to eq first_name_utf8
+      expect(subject).to eq first_name_utf8
+    end
+  end
+  # rubocop:enable UnneededInterpolation
+end

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -9,6 +9,25 @@ describe Pii::Attributes do
 
       expect(pii.first_name).to eq 'Jane'
     end
+
+    it 'initializes from complex Hash' do
+      pii = described_class.new_from_hash(
+        first_name: { raw: 'José', norm: 'Jose' },
+        last_name: Pii::Attribute.new(raw: 'Foo')
+      )
+
+      expect(pii.first_name.to_s).to eq 'José'
+      expect(pii.first_name).to be_a Pii::Attribute
+      expect(pii.last_name).to be_a Pii::Attribute
+    end
+
+    it 'assigns to all members' do
+      pii = described_class.new_from_hash(first_name: 'Jane')
+
+      expect(pii.last_name).to be_a Pii::Attribute
+      expect(pii.last_name.raw).to eq nil
+      expect(pii.last_name).to eq nil
+    end
   end
 
   describe '#new_from_encrypted' do
@@ -26,7 +45,12 @@ describe Pii::Attributes do
       pii_json = { first_name: 'Jane' }.to_json
       pii_attrs = described_class.new_from_json(pii_json)
 
-      expect(pii_attrs.first_name).to eq 'Jane'
+      expect(pii_attrs.first_name.to_s).to eq 'Jane'
+    end
+
+    it 'returns all-nil object when passed blank JSON' do
+      expect(described_class.new_from_json(nil)).to be_a Pii::Attributes
+      expect(described_class.new_from_json('')).to be_a Pii::Attributes
     end
   end
 
@@ -35,6 +59,15 @@ describe Pii::Attributes do
       pii_attrs = described_class.new_from_hash(first_name: 'Jane')
 
       expect(pii_attrs.encrypted(user_access_key)).to_not match 'Jane'
+    end
+  end
+
+  describe '#==' do
+    it 'treats objects with same values as equal' do
+      pii_one = described_class.new_from_hash(first_name: 'Jane')
+      pii_two = described_class.new_from_hash(first_name: 'Jane')
+
+      expect(pii_one).to eq pii_two
     end
   end
 end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -20,7 +20,7 @@ describe Pii::Cacher do
       decrypted_pii_json = subject.save(user_access_key)
       decrypted_pii = JSON.parse(decrypted_pii_json, symbolize_names: true)
 
-      expect(decrypted_pii[:ssn]).to eq '1234'
+      expect(decrypted_pii[:ssn][:raw]).to eq '1234'
       expect(user_session[:decrypted_pii]).to eq decrypted_pii_json
     end
 
@@ -29,8 +29,8 @@ describe Pii::Cacher do
       decrypted_pii_json = subject.save(user_access_key, diff_profile)
       decrypted_pii = JSON.parse(decrypted_pii_json, symbolize_names: true)
 
-      expect(decrypted_pii[:ssn]).to_not eq '1234'
-      expect(decrypted_pii[:ssn]).to eq '5678'
+      expect(decrypted_pii[:ssn][:raw]).to_not eq '1234'
+      expect(decrypted_pii[:ssn][:raw]).to eq '5678'
       expect(user_session[:decrypted_pii]).to eq decrypted_pii_json
     end
 


### PR DESCRIPTION
**Why**: To allow storing of multiple String values
under a single attribute name, to capture normalized vendor
values and ASCII transliterations.