### PR TITLE
Set X-Frame-Options Response Headers to DENY

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,6 +1,6 @@
 SecureHeaders::Configuration.default do |config|
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
-  config.x_frame_options = 'SAMEORIGIN'
+  config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'


### PR DESCRIPTION
__Why__

* We currently had the X-Frame-Options set to SAME-ORIGIN. There's no reason to even support SAME-ORIGIN since our app does not use iframes. This can be set to DENY as per OWASP's anti-clickjacking recommendations:

https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet#Defending_with_X-Frame-Options_Response_Headers

__How__

* Set X-Frame-Options Response Headers to DENY