### PR TITLE
Optimize find_first_by_auth_conditions

### DIFF
--- a/app/controllers/sign_up/email_resend_controller.rb
+++ b/app/controllers/sign_up/email_resend_controller.rb
@@ -8,7 +8,7 @@ module SignUp
     end
 
     def create
-      @resend_email_confirmation_form = ResendEmailConfirmationForm.new(downcased_email)
+      @resend_email_confirmation_form = ResendEmailConfirmationForm.new(email_from_params)
       result = @resend_email_confirmation_form.submit
 
       analytics.track_event(Analytics::EMAIL_CONFIRMATION_RESEND, result)
@@ -22,15 +22,19 @@ module SignUp
 
     private
 
-    def downcased_email
-      params[:resend_email_confirmation_form][:email].downcase
+    def email_from_params
+      params[:resend_email_confirmation_form][:email]
     end
 
     def handle_valid_email
-      User.send_confirmation_instructions(email: downcased_email)
-      session[:email] = downcased_email
+      User.send_confirmation_instructions(email: form_email)
+      session[:email] = form_email
       resend_confirmation = params[:resend_email_confirmation_form][:resend]
       redirect_to sign_up_verify_email_path(resend: resend_confirmation)
+    end
+
+    def form_email
+      @resend_email_confirmation_form.email
     end
   end
 end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -5,7 +5,7 @@ module Users
     end
 
     def create
-      @password_reset_email_form = PasswordResetEmailForm.new(downcased_email)
+      @password_reset_email_form = PasswordResetEmailForm.new(email)
       result = @password_reset_email_form.submit
 
       analytics.track_event(Analytics::PASSWORD_RESET_EMAIL, result)
@@ -49,10 +49,14 @@ module Users
 
     protected
 
-    def handle_valid_email
-      RequestPasswordReset.new(downcased_email).perform
+    def email
+      params[:password_reset_email_form][:email]
+    end
 
-      session[:email] = downcased_email
+    def handle_valid_email
+      RequestPasswordReset.new(email).perform
+
+      session[:email] = email
       resend_confirmation = params[:password_reset_email_form][:resend]
 
       redirect_to forgot_password_path(resend: resend_confirmation)
@@ -112,10 +116,6 @@ module Users
     def user_params
       params.require(:reset_password_form).
         permit(:password, :reset_password_token)
-    end
-
-    def downcased_email
-      params[:password_reset_email_form][:email].downcase
     end
   end
 end

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -20,6 +20,7 @@ class PasswordResetEmailForm
 
   private
 
+  attr_writer :email
   attr_reader :success
 
   def result

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -17,7 +17,7 @@ class RegisterUserEmailForm
   end
 
   def submit(params)
-    user.email = params[:email].downcase
+    user.email = params[:email]
 
     if valid_form?
       @success = true
@@ -31,6 +31,7 @@ class RegisterUserEmailForm
 
   private
 
+  attr_writer :email
   attr_reader :success
 
   def valid_form?

--- a/app/forms/resend_email_confirmation_form.rb
+++ b/app/forms/resend_email_confirmation_form.rb
@@ -20,6 +20,7 @@ class ResendEmailConfirmationForm
 
   private
 
+  attr_writer :email
   attr_reader :success
 
   def result

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -2,8 +2,7 @@ class UpdateUserEmailForm
   include ActiveModel::Model
   include FormEmailValidator
 
-  attr_accessor :email
-  attr_reader :user
+  attr_reader :email, :user
 
   def persisted?
     true
@@ -15,9 +14,7 @@ class UpdateUserEmailForm
   end
 
   def submit(params)
-    email = params[:email].downcase
-
-    self.email = email
+    self.email = params[:email]
 
     if valid_form?
       @success = true
@@ -39,6 +36,7 @@ class UpdateUserEmailForm
 
   private
 
+  attr_writer :email
   attr_reader :email_changed, :success
 
   def process_errors

--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -1,17 +1,17 @@
 module UserEncryptedAttributeOverrides
   extend ActiveSupport::Concern
 
-  # override some Devise methods to support our use of encrypted_email
-
   class_methods do
-    def find_first_by_auth_conditions(tainted_conditions, opts = {})
-      if tainted_conditions[:email].present?
-        opts[:email_fingerprint] = create_fingerprint(tainted_conditions.delete(:email))
-      end
-      to_adapter.find_first(devise_parameter_filter.filter(tainted_conditions).merge(opts))
+    # override this Devise method to support our use of encrypted_email
+    def find_first_by_auth_conditions(tainted_conditions, _opts = {})
+      email = tainted_conditions[:email]
+      return find_with_email(email) if email
+
+      find_by(tainted_conditions)
     end
 
     def find_with_email(email)
+      email = email.downcase.strip
       return nil if email.blank?
 
       email_fingerprint = create_fingerprint(email)
@@ -19,7 +19,7 @@ module UserEncryptedAttributeOverrides
     end
 
     def create_fingerprint(email)
-      Pii::Fingerprinter.fingerprint(email.downcase)
+      Pii::Fingerprinter.fingerprint(email)
     end
   end
 

--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -22,7 +22,7 @@ class EncryptedAttribute
   end
 
   def fingerprint
-    Pii::Fingerprinter.fingerprint(decrypted.downcase)
+    Pii::Fingerprinter.fingerprint(decrypted)
   end
 
   def stale?

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -47,7 +47,7 @@ module Pii
     end
 
     def stale_email_fingerprint?
-      Pii::Fingerprinter.stale?(user.email.downcase, user.email_fingerprint)
+      Pii::Fingerprinter.stale?(user.email, user.email_fingerprint)
     end
 
     def stale_attributes?

--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -2,6 +2,10 @@ module FormEmailValidator
   extend ActiveSupport::Concern
 
   included do
+    include ActiveModel::Validations::Callbacks
+
+    before_validation :downcase_and_strip
+
     validate :email_is_unique
 
     validates :email,
@@ -16,6 +20,10 @@ module FormEmailValidator
   end
 
   private
+
+  def downcase_and_strip
+    self.email = email.downcase.strip
+  end
 
   def email_is_unique
     return if persisted? && email == @user.email

--- a/spec/controllers/sign_up/email_resend_controller_spec.rb
+++ b/spec/controllers/sign_up/email_resend_controller_spec.rb
@@ -85,5 +85,16 @@ RSpec.describe SignUp::EmailResendController do
         expect(response).to render_template(:new)
       end
     end
+
+    context 'email is capitalized and/or contains spaces' do
+      it 'sends an email' do
+        create(:user, :unconfirmed, email: 'test@example.com')
+
+        user_params = { resend_email_confirmation_form: { email: 'TEST@example.com ' } }
+
+        expect { post :create, user_params }.
+          to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
   end
 end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -85,7 +85,7 @@ describe SignUp::RegistrationsController, devise: true do
     end
 
     it 'tracks successful user registration with existing email' do
-      existing_user = create(:user)
+      existing_user = create(:user, email: 'test@example.com')
 
       stub_analytics
 
@@ -100,7 +100,7 @@ describe SignUp::RegistrationsController, devise: true do
         with(Analytics::USER_REGISTRATION_EMAIL, analytics_hash)
       expect(subject).to_not receive(:create_user_event)
 
-      post :create, user: { email: existing_user.email }
+      post :create, user: { email: 'TEST@example.com ' }
     end
 
     it 'tracks unsuccessful user registration' do

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -330,8 +330,7 @@ describe Users::ResetPasswordsController, devise: true do
       it 'sends password reset email to user and tracks event' do
         stub_analytics
 
-        user = build(:user, :signed_up, role: :user)
-        allow(User).to receive(:find_with_email).with(user.email).and_return(user)
+        user = build(:user, :signed_up, role: :user, email: 'test@example.com')
 
         analytics_hash = {
           success: true,
@@ -344,7 +343,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: user.email } }.
+        expect { put :create, password_reset_email_form: { email: 'Test@example.com' } }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(response).to redirect_to forgot_password_path

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 describe PasswordResetEmailForm do
-  subject { PasswordResetEmailForm.new('test@example.com') }
+  subject { PasswordResetEmailForm.new(' Test@example.com ') }
 
   it_behaves_like 'email validation'
+  it_behaves_like 'email normalization', ' Test@example.com '
 
   describe '#submit' do
     context 'when email is valid and user exists' do
       it 'returns hash with properties about the event and the user' do
-        user = build(:user, :signed_up)
-        subject = PasswordResetEmailForm.new(user.email)
+        user = build(:user, :signed_up, email: 'test1@test.com')
+        subject = PasswordResetEmailForm.new('Test1@test.com')
 
         result = {
           success: true,
@@ -20,7 +21,6 @@ describe PasswordResetEmailForm do
         }
 
         expect(subject.submit).to eq result
-        expect(subject.email).to eq user.email
         expect(subject).to respond_to(:resend)
       end
     end

--- a/spec/forms/resend_email_confirmation_form_spec.rb
+++ b/spec/forms/resend_email_confirmation_form_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 describe ResendEmailConfirmationForm do
-  subject { ResendEmailConfirmationForm.new('test@example.com') }
+  subject { ResendEmailConfirmationForm.new(' Test@example.com ') }
 
   it_behaves_like 'email validation'
+  it_behaves_like 'email normalization', ' Test@example.com '
 
   describe '#submit' do
     context 'when email is valid and user exists' do

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 describe UpdateUserEmailForm do
-  subject { UpdateUserEmailForm.new(User.new(email: 'old@example.com')) }
+  subject { UpdateUserEmailForm.new(User.new(email: ' OLD@example.com ')) }
 
   it_behaves_like 'email validation'
+  it_behaves_like 'email normalization', ' OLD@example.com '
 
   describe '#email_changed?' do
     it 'is false when the submitted email is the same as the current email' do
-      result = subject.submit(email: 'OLD@example.com')
+      result = subject.submit(email: 'OLD@example.com ')
 
       result_hash = {
         success: true,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -276,4 +276,12 @@ describe User do
       expect(user.otp_secret_key).to eq 'abc123'
     end
   end
+
+  describe '.find_with_email' do
+    it 'strips whitespace and downcases email before looking it up' do
+      user = create(:user, email: 'test1@test.com')
+
+      expect(User.find_with_email(' Test1@test.com ')).to eq user
+    end
+  end
 end

--- a/spec/support/shared_examples_for_email_normalization.rb
+++ b/spec/support/shared_examples_for_email_normalization.rb
@@ -1,0 +1,9 @@
+shared_examples 'email normalization' do |email|
+  it 'downcases and strips the email before validation' do
+    old_email = email
+
+    subject.valid?
+
+    expect(subject.email).to eq old_email.downcase.strip
+  end
+end


### PR DESCRIPTION
**Why**: It was calling `Pii::Fingerprinter.fingerprint` twice
when it only needs to call it once.

**How**:
- Rewrite the method so that it calls the appropriate finder without
going through the extra steps Devise goes through (such as logic that
only applies to MongoDB).
- Ensure emails get downcased and stripped in `find_with_email` so that
we don't have to remember to do it before making any calls to
`find_with_email`
- In the cases where `find_with_email` does not get called, make sure
emails are downcased and stripped at the appropriate endpoints