### PR TITLE
Remove references to `session[:saml_request_url]`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,8 +57,8 @@ class ApplicationController < ActionController::Base
     @_decorated_user ||= current_user.decorate
   end
 
-  def after_sign_in_path_for(user)
-    stored_location_for(user) || profile_path
+  def after_sign_in_path_for(_current_user = nil)
+    session[:user_return_to] || profile_path
   end
 
   def render_401

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -4,7 +4,7 @@ module SamlIdpAuthConcern
   included do
     before_action :validate_saml_request, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
-    before_action :store_saml_request_attributes_in_session, only: :auth
+    before_action :add_sp_metadata_to_session, only: :auth
     before_action :confirm_two_factor_authenticated, only: :auth
   end
 
@@ -20,12 +20,6 @@ module SamlIdpAuthConcern
 
     analytics.track_event(Analytics::SAML_AUTH, @result)
     render nothing: true, status: :unauthorized
-  end
-
-  # stores original SAMLRequest in session to continue SAML Authn flow
-  def store_saml_request_attributes_in_session
-    add_sp_metadata_to_session
-    session[:saml_request_url] = request.original_url
   end
 
   def add_sp_metadata_to_session

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -152,7 +152,7 @@ module TwoFactorAuthenticatable
     elsif after_otp_action_required?
       after_otp_action_path
     else
-      after_sign_in_path_for(current_user)
+      after_sign_in_path_for
     end
   end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -18,7 +18,7 @@ module SignUp
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
         service_provider_attributes
       )
-      redirect_to session[:saml_request_url]
+      redirect_to after_sign_in_path_for
     end
 
     private

--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -27,18 +27,16 @@ module SignUp
 
     def confirm_has_not_already_viewed_recovery_code
       return if user_session[:first_time_recovery_code_view].present?
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to after_sign_in_path_for
     end
 
     def next_step
-      if session[:saml_request_url]
+      if session[:sp]
         sign_up_completed_path
       elsif current_user.password_reset_profile.present?
         reactivate_profile_path
-      elsif (stored_location = stored_location_for(current_user))
-        stored_location
       else
-        profile_path
+        after_sign_in_path_for
       end
     end
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -35,7 +35,7 @@ module SignUp
 
     def require_no_authentication
       return unless current_user
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to after_sign_in_path_for
     end
 
     def permitted_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -45,7 +45,7 @@ module Users
 
     def check_user_needs_redirect
       if user_fully_authenticated?
-        redirect_to after_sign_in_path_for(current_user)
+        redirect_to after_sign_in_path_for
       elsif current_user
         sign_out
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -344,10 +344,6 @@ describe SamlIdpController do
         generate_saml_response(user)
       end
 
-      it 'stores the SAML Request original_url in the session' do
-        expect(session[:saml_request_url]).to eq(request.original_url)
-      end
-
       it 'calls IdentityLinker' do
         user = create(:user, :signed_up)
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -786,7 +786,7 @@ describe SamlIdpController do
         [:apply_secure_headers_override, only: [:auth, :logout]],
         [:validate_saml_request, only: :auth],
         [:validate_service_provider_and_authn_context, only: :auth],
-        [:store_saml_request_attributes_in_session, only: :auth],
+        [:add_sp_metadata_to_session, only: :auth],
         [:confirm_two_factor_authenticated, only: :auth]
       )
     end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -7,7 +7,7 @@ describe SignUp::CompletionsController do
     context 'user signed in, sp info present' do
       before do
         stub_analytics
-        session[:saml_request_url] = 'www.example.com'
+        session[:user_return_to] = 'www.example.com'
         allow(@analytics).to receive(:track_event)
       end
 
@@ -61,7 +61,7 @@ describe SignUp::CompletionsController do
   describe '#update' do
     before do
       stub_analytics
-      session[:saml_request_url] = 'www.example.com'
+      session[:user_return_to] = 'www.example.com'
       allow(@analytics).to receive(:track_event)
     end
 

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -32,7 +32,7 @@ describe Verify::ConfirmationsController do
 
     context 'original SAML Authn request missing' do
       before do
-        subject.session[:saml_request_url] = nil
+        subject.session[:user_return_to] = nil
       end
 
       it 'cleans up PII from session' do

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -37,7 +37,7 @@ feature 'LOA1 Single Sign On' do
         'need_two_factor_authentication' => true,
         first_time_recovery_code_view: true,
       }
-      session[:saml_request_url] = @saml_authn_request
+      session[:user_return_to] = @saml_authn_request
       session[:sp] = { loa3: false, name: 'Your friendly Government Agency' }
     end
     visit profile_path


### PR DESCRIPTION
**Why**:
* Previously, we were using this as an option in the
`after_sign_in_path` method, but that was removed at https://github.com/18F/identity-idp/pull/1075
* We didn't need that logic because Devise itself saves `session[:user_return_to]` for us and
that saves the `saml_request_url`
* Needed to keep method name of `after_sign_in_path_for` because we are
 still calling `super` to a devise controller, which then calls
`after_sign_in_path_for` -- we must override that method to get our
desired behavior. Original method def here: https://github.com/plataformatec/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/controllers/helpers.rb#L213
* Next step on this would be to try and move away from our `super` calls
to Devise, since those are creating a lot of confusion with when and how
session vars are being saved.