### PR TITLE
Add vendor-normalized values to Pii::Attributes

### DIFF
--- a/.reek
+++ b/.reek
@@ -14,6 +14,7 @@ FeatureEnvy:
     - mark_profile_inactive
     - EncryptedSidekiqRedis#zrem
     - UserDecorator#should_acknowledge_recovery_code?
+    - Pii::Attributes#[]=
 IrresponsibleModule:
   enabled: false
 ManualDispatch:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: 1b8a94720efb66abe072030c185d5288f8172cc4
+  revision: ef0ab14168a3d41491c3c1375b260778357edc34
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -54,7 +54,7 @@ module Verify
     end
 
     def init_profile
-      idv_session.cache_applicant_profile_id(idv_session.applicant)
+      idv_session.cache_applicant_profile_id
       idv_session.cache_encrypted_pii(current_user.user_access_key)
     end
 

--- a/app/services/idv/profile_from_applicant.rb
+++ b/app/services/idv/profile_from_applicant.rb
@@ -2,32 +2,32 @@ module Idv
   class ProfileFromApplicant
     attr_reader :profile
 
-    def self.create(applicant, user)
+    def self.create(applicant:, user:, normalized_applicant:)
       profile = Profile.new(user: user)
-      plain_pii = pii_from_applicant(applicant)
+      plain_pii = pii_from_applicant(applicant, normalized_applicant)
       profile.encrypt_pii(user.user_access_key, plain_pii)
       profile.save!
       profile
     end
 
-    # rubocop:disable MethodLength
+    # rubocop:disable MethodLength, AbcSize
     # This method is single statement spread across many lines for readability
-    def self.pii_from_applicant(applicant)
+    def self.pii_from_applicant(appl, norm_appl)
       Pii::Attributes.new_from_hash(
-        first_name: applicant.first_name,
-        middle_name: applicant.middle_name,
-        last_name: applicant.last_name,
-        address1: applicant.address1,
-        address2: applicant.address2,
-        city: applicant.city,
-        state: applicant.state,
-        zipcode: applicant.zipcode,
-        dob: applicant.dob,
-        ssn: applicant.ssn,
-        phone: applicant.phone
+        first_name: Pii::Attribute.new(raw: appl.first_name, norm: norm_appl.first_name),
+        middle_name: Pii::Attribute.new(raw: appl.middle_name, norm: norm_appl.middle_name),
+        last_name: Pii::Attribute.new(raw: appl.last_name, norm: norm_appl.last_name),
+        address1: Pii::Attribute.new(raw: appl.address1, norm: norm_appl.address1),
+        address2: Pii::Attribute.new(raw: appl.address2, norm: norm_appl.address2),
+        city: Pii::Attribute.new(raw: appl.city, norm: norm_appl.city),
+        state: Pii::Attribute.new(raw: appl.state, norm: norm_appl.state),
+        zipcode: Pii::Attribute.new(raw: appl.zipcode, norm: norm_appl.zipcode),
+        dob: Pii::Attribute.new(raw: appl.dob, norm: norm_appl.dob),
+        ssn: Pii::Attribute.new(raw: appl.ssn, norm: norm_appl.ssn),
+        phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone)
       )
     end
-    # rubocop:enable MethodLength
+    # rubocop:enable MethodLength, AbcSize
     private_class_method :pii_from_applicant
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -38,8 +38,12 @@ module Idv
       resolution.present? && applicant.present? && resolution.success?
     end
 
-    def cache_applicant_profile_id(applicant)
-      profile = Idv::ProfileFromApplicant.create(applicant, current_user)
+    def cache_applicant_profile_id
+      profile = Idv::ProfileFromApplicant.create(
+        applicant: applicant,
+        normalized_applicant: resolution.vendor_resp.normalized_applicant,
+        user: current_user
+      )
       self.profile_id = profile.id
       self.recovery_code = profile.recovery_code
     end

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -8,11 +8,16 @@ describe Verify::ConfirmationsController do
   let(:password) { 'sekrit phrase' }
   let(:user) { create(:user, :signed_up, password: password) }
   let(:applicant) { Proofer::Applicant.new first_name: 'Some', last_name: 'One' }
+  let(:normalized_applicant) { Proofer::Applicant.new first_name: 'Somebody' }
   let(:agent) { Proofer::Agent.new vendor: :mock }
   let(:resolution) { agent.start applicant }
   let(:profile) do
     user.unlock_user_access_key(password)
-    Idv::ProfileFromApplicant.create(applicant, user)
+    Idv::ProfileFromApplicant.create(
+      applicant: applicant,
+      user: user,
+      normalized_applicant: normalized_applicant
+    )
   end
 
   describe 'before_actions' do
@@ -59,7 +64,7 @@ describe Verify::ConfirmationsController do
       end
 
       it 'sets recovery code instance variable' do
-        subject.idv_session.cache_applicant_profile_id(applicant)
+        subject.idv_session.cache_applicant_profile_id
         code = subject.idv_session.recovery_code
         get :index
 

--- a/spec/services/idv/profile_from_applicant_spec.rb
+++ b/spec/services/idv/profile_from_applicant_spec.rb
@@ -4,9 +4,14 @@ describe Idv::ProfileFromApplicant do
   describe '#create' do
     it 'creates Profile with encrypted PII' do
       applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
+      normalized_applicant = Proofer::Applicant.new first_name: 'Somebody', last_name: 'Oneatatime'
       user = create(:user, :signed_up)
       user.unlock_user_access_key(user.password)
-      profile = described_class.create(applicant, user)
+      profile = described_class.create(
+        applicant: applicant,
+        user: user,
+        normalized_applicant: normalized_applicant
+      )
 
       expect(profile.id).to_not be_nil
       expect(profile.encrypted_pii).to_not be_nil


### PR DESCRIPTION
**Why**: Preserving what vendor tells us for later use.