### PR TITLE
Store identity.rails_session_id explicitly

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -46,7 +46,7 @@ class OpenidConnectTokenForm
       {
         access_token: identity.access_token,
         token_type: 'Bearer',
-        expires_in: Pii::SessionStore.new(identity.session_uuid).ttl,
+        expires_in: Pii::SessionStore.new(identity.rails_session_id).ttl,
         id_token: IdTokenBuilder.new(identity).id_token,
       }
     else

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -60,7 +60,7 @@ class OpenidConnectUserInfoPresenter
   def loa3_data
     @loa3_data ||= begin
       if loa3_session?
-        Pii::SessionStore.new(identity.session_uuid).load
+        Pii::SessionStore.new(identity.rails_session_id).load
       else
         Pii::Attributes.new_from_hash({})
       end

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -29,7 +29,7 @@ class AccessTokenVerifier
   def load_identity(access_token)
     identity = Identity.where(access_token: access_token).first
 
-    if identity && Pii::SessionStore.new(identity.session_uuid).ttl.positive?
+    if identity && Pii::SessionStore.new(identity.rails_session_id).ttl.positive?
       @identity = identity
     else
       errors.add(:access_token, t('openid_connect.user_info.errors.not_found'))

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -53,7 +53,7 @@ class IdTokenBuilder
   end
 
   def expires
-    ttl = Pii::SessionStore.new(identity.session_uuid).ttl
+    ttl = Pii::SessionStore.new(identity.rails_session_id).ttl
     Time.zone.now.to_i + ttl
   end
 end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -6,9 +6,10 @@ class IdentityLinker
     @provider = provider
   end
 
-  def link_identity(session_uuid: nil, **extra_attrs)
-    attributes = merged_attributes(session_uuid, extra_attrs)
+  def link_identity(**extra_attrs)
+    attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
+    identity
   end
 
   def already_linked?
@@ -25,20 +26,31 @@ class IdentityLinker
     user.identities.where(service_provider: provider)
   end
 
-  def merged_attributes(session_uuid, extra_attrs)
-    identity_attributes(session_uuid: session_uuid).merge(optional_attributes(extra_attrs))
+  def merged_attributes(extra_attrs)
+    identity_attributes.merge(optional_attributes(extra_attrs))
   end
 
-  def identity_attributes(session_uuid: nil)
-    session_uuid ||= SecureRandom.uuid
+  def identity_attributes
     {
       last_authenticated_at: Time.zone.now,
-      session_uuid: session_uuid,
+      session_uuid: SecureRandom.uuid,
       access_token: SecureRandom.urlsafe_base64,
     }
   end
 
-  def optional_attributes(nonce: nil, ial: nil, scope: nil, code_challenge: nil)
-    { nonce: nonce, ial: ial, scope: scope, code_challenge: code_challenge }
+  def optional_attributes(
+    code_challenge: nil,
+    ial: nil,
+    nonce: nil,
+    rails_session_id: nil,
+    scope: nil
+  )
+    {
+      code_challenge: code_challenge,
+      ial: ial,
+      nonce: nonce,
+      rails_session_id: rails_session_id,
+      scope: scope,
+    }
   end
 end

--- a/db/migrate/20170215160237_add_rails_session_id_to_identities.rb
+++ b/db/migrate/20170215160237_add_rails_session_id_to_identities.rb
@@ -1,0 +1,5 @@
+class AddRailsSessionIdToIdentities < ActiveRecord::Migration
+  def change
+    add_column :identities, :rails_session_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207192912) do
+ActiveRecord::Schema.define(version: 20170215160237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20170207192912) do
     t.string   "access_token"
     t.string   "scope"
     t.string   "code_challenge"
+    t.string   "rails_session_id"
   end
 
   add_index "identities", ["access_token"], name: "index_identities_on_access_token", unique: true, using: :btree

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OpenidConnect::TokenController do
 
     let(:user) { create(:user) }
     let(:grant_type) { 'authorization_code' }
-    let(:code) { SecureRandom.hex }
+    let(:code) { identity.session_uuid }
     let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
     let(:client_assertion) do
       jwt_payload = {
@@ -30,8 +30,8 @@ RSpec.describe OpenidConnect::TokenController do
       JWT.encode(jwt_payload, client_private_key, 'RS256')
     end
 
-    before do
-      IdentityLinker.new(user, client_id).link_identity(session_uuid: code, ial: 1)
+    let!(:identity) do
+      IdentityLinker.new(user, client_id).link_identity(rails_session_id: SecureRandom.hex, ial: 1)
     end
 
     context 'with valid params' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -44,13 +44,12 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(result[:client_id]).to eq(client_id)
       end
 
-      it 'links an identity for this client with the given session id as the code' do
+      it 'links an identity for this client with the code as the session_uuid' do
         redirect_uri = URI(result[:redirect_uri])
         code = Rack::Utils.parse_nested_query(redirect_uri.query).with_indifferent_access[:code]
-        expect(code).to eq(rails_session_id)
 
         identity = user.identities.where(service_provider: client_id).first
-        expect(identity.session_uuid).to eq(rails_session_id)
+        expect(identity.session_uuid).to eq(code)
         expect(identity.nonce).to eq(nonce)
       end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OpenidConnectTokenForm do
   end
 
   let(:grant_type) { 'authorization_code' }
-  let(:code) { SecureRandom.hex }
+  let(:code) { identity.session_uuid }
   let(:code_verifier) { nil }
   let(:client_assertion_type) { OpenidConnectTokenForm::CLIENT_ASSERTION_TYPE }
   let(:client_assertion) { JWT.encode(jwt_payload, client_private_key, 'RS256') }
@@ -39,11 +39,11 @@ RSpec.describe OpenidConnectTokenForm do
 
   let(:user) { create(:user) }
 
-  before do
+  let!(:identity) do
     IdentityLinker.new(user, client_id).
       link_identity(
         nonce: nonce,
-        session_uuid: code,
+        rails_session_id: SecureRandom.hex,
         ial: 1,
         code_challenge: code_challenge
       )
@@ -230,7 +230,7 @@ RSpec.describe OpenidConnectTokenForm do
 
     context 'with valid params' do
       before do
-        Pii::SessionStore.new(code).put({}, 5.minutes.to_i)
+        Pii::SessionStore.new(identity.rails_session_id).put({}, 5.minutes.to_i)
       end
 
       it 'has a properly-encoded id_token with an expiration that matches the expires_in' do

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe OpenidConnectUserInfoPresenter do
   include Rails.application.routes.url_helpers
 
-  let(:session_uuid) { SecureRandom.uuid }
+  let(:rails_session_id) { SecureRandom.uuid }
   let(:scope) { 'openid email address phone profile' }
   let(:identity) do
     build(:identity,
-          session_uuid: session_uuid,
+          rails_session_id: rails_session_id,
           user: build(:user),
           scope: scope)
   end
@@ -43,7 +43,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       end
 
       before do
-        Pii::SessionStore.new(session_uuid).put(pii, 5.minutes.to_i)
+        Pii::SessionStore.new(rails_session_id).put(pii, 5.minutes.to_i)
       end
 
       context 'when the identity has loa3 access' do

--- a/spec/services/access_token_verifier_spec.rb
+++ b/spec/services/access_token_verifier_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe AccessTokenVerifier do
       let(:access_token) { identity.access_token }
       before do
         identity.save!
-        Pii::SessionStore.new(identity.session_uuid).put({}, 1)
+        Pii::SessionStore.new(identity.rails_session_id).put({}, 1)
       end
 
       it 'is successful' do
@@ -59,7 +59,7 @@ RSpec.describe AccessTokenVerifier do
     context 'with a valid access_token' do
       before do
         identity.save!
-        Pii::SessionStore.new(identity.session_uuid).put({}, 1)
+        Pii::SessionStore.new(identity.rails_session_id).put({}, 1)
       end
       let(:access_token) { identity.access_token }
 
@@ -77,7 +77,7 @@ RSpec.describe AccessTokenVerifier do
     end
 
     context 'with an expired access_token' do
-      before { Pii::SessionStore.new(identity.session_uuid).destroy }
+      before { Pii::SessionStore.new(identity.rails_session_id).destroy }
 
       let(:access_token) { identity.access_token }
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe IdTokenBuilder do
       let(:custom_expiration) { nil }
       let(:expiration) { 100 }
 
-      before { Pii::SessionStore.new(identity.session_uuid).put(nil, expiration) }
+      before { Pii::SessionStore.new(identity.rails_session_id).put(nil, expiration) }
 
       it 'sets the expiration to the ttl of the session key in redis' do
         expect(decoded_payload[:exp]).to eq(now.to_i + expiration)

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -26,14 +26,14 @@ describe IdentityLinker do
     end
 
     it 'can take an additional optional attributes' do
-      session_uuid = SecureRandom.hex
+      rails_session_id = SecureRandom.hex
       nonce = SecureRandom.hex
       ial = 3
       scope = 'openid profile email'
       code_challenge = SecureRandom.hex
 
       IdentityLinker.new(user, 'test.host').link_identity(
-        session_uuid: session_uuid,
+        rails_session_id: rails_session_id,
         nonce: nonce,
         ial: ial,
         scope: scope,
@@ -43,7 +43,7 @@ describe IdentityLinker do
 
       last_identity = user.last_identity
       expect(last_identity.nonce).to eq(nonce)
-      expect(last_identity.session_uuid).to eq(session_uuid)
+      expect(last_identity.rails_session_id).to eq(rails_session_id)
       expect(last_identity.ial).to eq(ial)
       expect(last_identity.scope).to eq(scope)
       expect(last_identity.code_challenge).to eq(code_challenge)
@@ -57,6 +57,13 @@ describe IdentityLinker do
     it 'fails when given a nil provider' do
       linker = IdentityLinker.new(user, nil)
       expect { linker.link_identity }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'can link two different clients to the same rails_session_id' do
+      rails_session_id = SecureRandom.uuid
+
+      IdentityLinker.new(user, 'client1').link_identity(rails_session_id: rails_session_id)
+      IdentityLinker.new(user, 'client2').link_identity(rails_session_id: rails_session_id)
     end
   end
 


### PR DESCRIPTION
**Why**:
Co-opting identity.session_uuid with rails_session_id resulted in
duplicate key errors when trying to link multiple OIDC clients
with the same rails_session_id. Storing it into a separate column
is 1) more explicit and 2) not going to cause duplicate key errors.