### PR TITLE
Only run simplecov in CI env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
 services:
   - redis-server
 env:
-  - CI=true
+  - COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,5 @@ script:
   - bundle exec codeclimate-test-reporter
 services:
   - redis-server
+env:
+  - CI=true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-if ENV['CI']
+if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails' do
     add_filter '/config/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
-require 'simplecov'
-SimpleCov.start 'rails' do
-  add_filter '/config/'
-  add_filter '/lib/rspec/formatters/user_flow_formatter.rb'
+if ENV['CI']
+  require 'simplecov'
+  SimpleCov.start 'rails' do
+    add_filter '/config/'
+    add_filter '/lib/rspec/formatters/user_flow_formatter.rb'
+  end
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
**Why**:
* When running `rpsec spec/ --profile`, i18n-tasks was slowest file
* Ran 3 times, each time file took 35+ seconds to run
* Upon investigation, this appears to relate to Simplecov
* See https://github.com/glebm/i18n-tasks/issues/221
* Also https://github.com/colszowka/simplecov/issues/404
* Since there is no proposed solution at the moment (slowness appears to
  be coming from `Coverage`, which is part of the Ruby stdlib), the
  short term solution is to only run Simplecov on Travis, where required
* New timing for i18n-tasks: under 3 seconds!!!

Before:

```
Top 10 slowest example groups:
  I18n
    17.89 seconds average (35.78 seconds / 2 examples) ./spec/i18n_spec.rb:4
```
After:

```
Top 10 slowest example groups:
  I18n
    1.35 seconds average (2.71 seconds / 2 examples) ./spec/i18n_spec.rb:4
```