### PR TITLE
Show mock vendor partial on all verify pages

### DIFF
--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -55,6 +55,10 @@ module Verify
     end
 
     def flash_message
+      flash_heading = html_paragraph(
+        text: I18n.t("idv.modal.#{step_name}.heading"), css_class: 'mb2 fs-20p'
+      )
+      flash_body = html_paragraph(text: I18n.t("idv.modal.#{step_name}.#{error}"))
       flash_heading + flash_body + attempts
     end
 
@@ -70,14 +74,6 @@ module Verify
 
     def button_css_classes
       'btn btn-wide px2 py1 rounded-lg border bw2'
-    end
-
-    def flash_heading
-      html_paragraph(text: I18n.t("idv.modal.#{step_name}.heading"), css_class: 'mb2 fs-20p')
-    end
-
-    def flash_body
-      html_paragraph(text: I18n.t("idv.modal.#{step_name}.#{error}"))
     end
 
     def attempts

--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -9,6 +9,14 @@ module Verify
 
     attr_reader :error, :remaining_attempts
 
+    def mock_vendor_partial
+      if idv_vendor.pick == :mock
+        'verify/sessions/no_pii_warning'
+      else
+        'shared/null'
+      end
+    end
+
     def title
       I18n.t("idv.titles.#{step_name}")
     end
@@ -52,21 +60,8 @@ module Verify
 
     private
 
-    def attempts
-      if error == 'warning'
-        html_paragraph(text: I18n.t('idv.modal.attempts', count: remaining_attempts))
-      else
-        ''
-      end
-    end
-
-    def html_paragraph(text:, css_class: '')
-      html = helper.safe_join([text.html_safe])
-      helper.content_tag(:p, html, class: css_class)
-    end
-
-    def helper
-      ActionController::Base.helpers
+    def idv_vendor
+      @_idv_vendor ||= Idv::Vendor.new
     end
 
     def button_link_text
@@ -83,6 +78,23 @@ module Verify
 
     def flash_body
       html_paragraph(text: I18n.t("idv.modal.#{step_name}.#{error}"))
+    end
+
+    def attempts
+      if error == 'warning'
+        html_paragraph(text: I18n.t('idv.modal.attempts', count: remaining_attempts))
+      else
+        ''
+      end
+    end
+
+    def html_paragraph(text:, css_class: '')
+      html = helper.safe_join([text.html_safe])
+      helper.content_tag(:p, html, class: css_class)
+    end
+
+    def helper
+      ActionController::Base.helpers
     end
   end
 end

--- a/app/view_models/verify/sessions_new.rb
+++ b/app/view_models/verify/sessions_new.rb
@@ -1,21 +1,7 @@
 module Verify
   class SessionsNew < Verify::Base
-    def mock_vendor_partial
-      if idv_vendor.pick == :mock
-        'verify/sessions/no_pii_warning'
-      else
-        'shared/null'
-      end
-    end
-
     def step_name
       :sessions
-    end
-
-    private
-
-    def idv_vendor
-      @_idv_vendor ||= Idv::Vendor.new
     end
   end
 end

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -1,6 +1,7 @@
 - title @view_model.title
+= render @view_model.mock_vendor_partial
 
-h1.h3.my0 = t('idv.titles.financials')
+h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0
   = t('idv.messages.finance.intro_ccn_html',
       intro_help_link: link_to(t('idv.messages.finance.intro_ccn_help'), help_path))

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -1,6 +1,7 @@
 - title @view_model.title
+= render @view_model.mock_vendor_partial
 
-h1.h3.my0 = t('idv.titles.financials')
+h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
 = simple_form_for(idv_finance_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -1,4 +1,5 @@
 - title @view_model.title
+= render @view_model.mock_vendor_partial
 
 h1.h3.my0 = t('idv.titles.session.phone')
 p.mt-tiny.mb0 = t('idv.messages.phone.intro')

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -1,7 +1,7 @@
 - title @view_model.title
 = render @view_model.mock_vendor_partial
 
-h1.h3.my0 = t('idv.titles.sessions')
+h1.h3.my0 = @view_model.title
 = simple_form_for(idv_profile_form, url: verify_session_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification

--- a/spec/view_models/verify/base_spec.rb
+++ b/spec/view_models/verify/base_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe Verify::SessionsNew do
+RSpec.describe Verify::Base do
   describe '#mock_vendor_partial' do
     context 'idv vendor is mock' do
       it 'returns no pii warning partial' do
         allow(Figaro.env).to receive(:proofing_vendors).and_return('mock')
 
-        partial = Verify::SessionsNew.new(remaining_attempts: 1).mock_vendor_partial
+        partial = Verify::Base.new(remaining_attempts: 1).mock_vendor_partial
 
         expect(partial).to eq 'verify/sessions/no_pii_warning'
       end
@@ -16,7 +16,7 @@ RSpec.describe Verify::SessionsNew do
       it 'returns null partial' do
         allow(Figaro.env).to receive(:proofing_vendors).and_return('other')
 
-        partial = Verify::SessionsNew.new(remaining_attempts: 1).mock_vendor_partial
+        partial = Verify::Base.new(remaining_attempts: 1).mock_vendor_partial
 
         expect(partial).to eq 'shared/null'
       end


### PR DESCRIPTION
**Why**: Should tell people not to use real data on all pages when
in mock mode, right?

This red text is what is being added (currently just on first verify page)

![screen shot 2017-02-15 at 4 45 04 pm](https://cloud.githubusercontent.com/assets/601515/23002235/81b9d6d2-f39e-11e6-9d8b-8fa4136c7e39.png)
