### PR TITLE
Remove middle_name from OpenID Connect API

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -27,7 +27,6 @@ class OpenidConnectUserInfoPresenter
     {
       given_name: stringify_attr(loa3_data.first_name),
       family_name: stringify_attr(loa3_data.last_name),
-      middle_name: stringify_attr(loa3_data.middle_name),
       birthdate: stringify_attr(loa3_data.dob),
       address: address,
       phone: phone,

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -15,7 +15,6 @@ class OpenidConnectAttributeScoper
     phone_verified: 'phone',
     given_name: 'profile',
     family_name: 'profile',
-    middle_name: 'profile',
     birthdate: 'profile',
   }.with_indifferent_access.freeze
 

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       let(:pii) do
         {
           first_name: 'John',
-          middle_name: 'Jones',
           last_name: 'Smith',
           dob: '1970-01-01',
           address1: '123 Fake St',
@@ -53,7 +52,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           it 'returns loa3 attributes' do
             aggregate_failures do
               expect(user_info[:given_name]).to eq('John')
-              expect(user_info[:middle_name]).to eq('Jones')
               expect(user_info[:family_name]).to eq('Smith')
               expect(user_info[:birthdate]).to eq('1970-01-01')
               expect(user_info[:phone]).to eq('+1 (555) 555-5555')
@@ -84,7 +82,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:email_verified]).to eq(true)
               expect(user_info[:given_name]).to eq(nil)
               expect(user_info[:family_name]).to eq(nil)
-              expect(user_info[:middle_name]).to eq(nil)
               expect(user_info[:birthdate]).to eq(nil)
               expect(user_info[:phone]).to eq('+1 (555) 555-5555')
               expect(user_info[:phone_verified]).to eq(true)
@@ -101,7 +98,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           aggregate_failures do
             expect(user_info[:given_name]).to eq(nil)
             expect(user_info[:family_name]).to eq(nil)
-            expect(user_info[:middle_name]).to eq(nil)
             expect(user_info[:birthdate]).to eq(nil)
             expect(user_info[:phone]).to eq(nil)
             expect(user_info[:phone_verified]).to eq(nil)

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe OpenidConnectAttributeScoper do
         email_verified: true,
         given_name: 'John',
         family_name: 'Jones',
-        middle_name: 'Joe',
         birthdate: '1970-01-01',
         phone: '+1 (555) 555-5555',
         phone_verified: true,
@@ -72,7 +71,6 @@ RSpec.describe OpenidConnectAttributeScoper do
       it 'includes name attributes and birthdate' do
         expect(filtered[:given_name]).to be_present
         expect(filtered[:family_name]).to be_present
-        expect(filtered[:middle_name]).to be_present
         expect(filtered[:birthdate]).to be_present
       end
     end


### PR DESCRIPTION
**Why**: We don't collect it at all