### PR TITLE
Fix width of verification warning modals

### DIFF
--- a/app/views/shared/_modal_verification.slim
+++ b/app/views/shared/_modal_verification.slim
@@ -1,6 +1,6 @@
 #verification-modal.display-none
   = render layout: '/shared/modal_layout' do
-    .p4.cntnr-xskinny.border-box.bg-white.rounded-xxl(class="modal-#{view_model.error}")
+    .p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl(class="modal-#{view_model.error}")
       h2.my2.fs-20p.sans-serif.regular.center = t("idv.modal.#{view_model.step_name}.heading")
       hr.mb3.bw4.rounded
       .mb5


### PR DESCRIPTION
**Why**: Based on the visual designs, these should be the smallest width available.