### PR TITLE
Ab standard sign up cancel links

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -29,6 +29,7 @@ module SignUp
     def process_valid_confirmation_token
       @confirmation_token = params[:confirmation_token]
       flash.now[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
+      session[:user_confirmation_token] = params[:confirmation_token]
       render '/sign_up/passwords/new'
     end
 

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -29,7 +29,7 @@ module SignUp
     def process_valid_confirmation_token
       @confirmation_token = params[:confirmation_token]
       flash.now[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
-      session[:user_confirmation_token] = params[:confirmation_token]
+      session[:user_confirmation_token] = @confirmation_token
       render '/sign_up/passwords/new'
     end
 

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -14,6 +14,7 @@ module SignUp
     def new
       ab_finished(:demo)
       @register_user_email_form = RegisterUserEmailForm.new
+      session[:sign_up_init] = true
       analytics.track_event(Analytics::USER_REGISTRATION_ENTER_EMAIL_VISIT)
     end
 
@@ -48,6 +49,7 @@ module SignUp
 
       resend_confirmation = params[:user][:resend]
       session[:email] = user.email
+      session.delete(:sign_up_init)
 
       redirect_to sign_up_verify_email_path(resend: resend_confirmation)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,13 @@
 class UsersController < ApplicationController
   def destroy
-    destroy_user!
+    destroy_user
     flash[:success] = t('sign_up.cancel.success')
     redirect_to root_path
   end
 
   private
 
-  def destroy_user!
+  def destroy_user
     user = current_user || User.where(confirmation_token: session[:user_confirmation_token]).take
     user && user.destroy!
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,14 @@
 class UsersController < ApplicationController
   def destroy
-    current_user && curent_user.destroy!
-
+    destroy_user!
     flash[:success] = t('sign_up.cancel.success')
     redirect_to root_path
+  end
+
+  private
+
+  def destroy_user!
+    user = current_user || User.where(confirmation_token: session[:user_confirmation_token]).take
+    user && user.destroy!
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   private
 
   def destroy_user
-    user = current_user || User.where(confirmation_token: session[:user_confirmation_token]).take
+    user = current_user || User.find_by(confirmation_token: session[:user_confirmation_token])
     user && user.destroy!
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def destroy
-    return unless current_user.destroy!
+    current_user && curent_user.destroy!
 
     flash[:success] = t('sign_up.cancel.success')
     redirect_to root_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,10 @@ module ApplicationHelper
     session[:sp]
   end
 
+  def sign_up_init?
+    session[:sign_up_init]
+  end
+
   def user_signing_up?
     !current_user || !current_user.two_factor_enabled?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,4 +55,12 @@ module ApplicationHelper
       verify_session_path
     end
   end
+
+  def cancel_link_text
+    if user_signing_up?
+      t('links.cancel_account_creation')
+    else
+      t('links.cancel')
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,7 +53,9 @@ module ApplicationHelper
   end
 
   def sign_up_or_idv_no_js_link
-    if user_signing_up?
+    if sign_up_init?
+      root_path
+    elsif user_signing_up?
       destroy_user_path
     elsif user_verifying_identity?
       verify_session_path

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -4,6 +4,8 @@
   - if user_signing_up? || user_verifying_identity?
     = button_to cancel_link_text, cancel, method: :delete,
       class: 'btn btn-link', id: 'auth-flow-cancel'
-    = render 'shared/cancel_action_modal', idv: user_verifying_identity?
+    = render 'shared/cancel_action_modal',
+      idv: user_verifying_identity?,
+      sign_up_init: sign_up_init?
   - else
     = link_to cancel_link_text, cancel, class: 'h5'

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -2,7 +2,9 @@
 
 .mt2.pt1.border-top
   - if user_signing_up? || user_verifying_identity?
-    = button_to cancel_link_text, cancel, method: :delete,
+    - method = sign_up_init? ? :get : :delete
+
+    = button_to cancel_link_text, cancel, method: method,
       class: 'btn btn-link', id: 'auth-flow-cancel'
     = render 'shared/cancel_action_modal',
       idv: user_verifying_identity?,

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -2,8 +2,8 @@
 
 .mt2.pt1.border-top
   - if user_signing_up? || user_verifying_identity?
-    = button_to t('links.cancel'), cancel, method: :delete,
+    = button_to cancel_link_text, cancel, method: :delete,
       class: 'btn btn-link', id: 'auth-flow-cancel'
     = render 'shared/cancel_action_modal', idv: user_verifying_identity?
   - else
-    = link_to t('links.cancel'), cancel, class: 'h5'
+    = link_to cancel_link_text, cancel, class: 'h5'

--- a/app/views/shared/_cancel_action_modal.html.slim
+++ b/app/views/shared/_cancel_action_modal.html.slim
@@ -23,8 +23,9 @@
           = button_to t('idv.buttons.cancel'), verify_session_path, method: :delete,
             class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
         - elsif sign_up_init
-          = button_to cancel_link_text, destroy_user_session_path, method: :get,
-            class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
+          .col-12
+            = link_to cancel_link_text, '/', id: 'cancel-action-home',
+              class: 'btn btn-outline blue border border-blue rounded-lg center block'
         -else
           = button_to t('sign_up.buttons.cancel'), destroy_user_path, method: :delete,
             class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'

--- a/app/views/shared/_cancel_action_modal.html.slim
+++ b/app/views/shared/_cancel_action_modal.html.slim
@@ -22,7 +22,10 @@
         - if idv
           = button_to t('idv.buttons.cancel'), verify_session_path, method: :delete,
             class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
-        - else
+        - elsif sign_up_init
+          = button_to cancel_link_text, destroy_user_session_path, method: :get,
+            class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
+        -else
           = button_to t('sign_up.buttons.cancel'), destroy_user_path, method: :delete,
             class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
 

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -17,4 +17,6 @@ p.mb0
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'
 
+= render 'shared/cancel', link: destroy_user_session_path
+
 == javascript_include_tag 'misc/pw-strength'

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -7,11 +7,11 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
     url: sign_up_register_path) do |f|
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
-  .mt1.mb-tiny.bold = t('notices.terms_of_service.headline')
-  - link = link_to t('notices.terms_of_service.link'), privacy_path, target: '_blank'
-  p.mb-40p == t('notices.terms_of_service.text', link: link)
+  p.mb-40p.mt1.italic
+    = t('notices.terms_of_service.text_html',
+        link: link_to(t('notices.terms_of_service.link'), privacy_path, target: '_blank'))
+
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
-.clearfix.pt1.border-top
-  - auth_link = link_to t('links.sign_in'), new_user_session_path
-  .sm-col-right == t('instructions.registration.already_have_account', link: auth_link)
+
+= render 'shared/cancel', link: destroy_user_session_path

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -27,3 +27,5 @@ p.mt-tiny.mb0
           span.indicator
           = t('devise.two_factor_authentication.otp_method.voice')
   = f.button :submit, t('forms.buttons.send_passcode')
+
+= render 'shared/cancel', link: destroy_user_session_path

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -45,4 +45,4 @@ en:
     recovery_code_accent: Write it down or print it out.
     registration:
       already_have_account: Already have an account? %{link}
-      email: Pick an address to use for government communications.
+      email: Pick an address you want to use for government communications.

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -18,6 +18,7 @@ en:
     sign_in: Sign in
     sign_out: Sign out
     cancel: Cancel
+    cancel_account_creation: ‹ Cancel account creation
     two_factor_authentication:
       app: authentication app
       voice: phone call

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -18,6 +18,7 @@ es:
     sign_in: Iniciar sesión
     sign_out: Cerrar sesión
     cancel: Cancelar
+    cancel_account_creation: NOT TRANSLATED YET
     two_factor_authentication:
       app: NOT TRANSLATED YET
       voice: NOT TRANSLATED YET

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -46,12 +46,12 @@ en:
       first_paragraph_start: We sent an email to
       no_email_sent_explanation_start: Didn’t get an email?
     terms_of_service:
-      headline: By continuing, I agree to the terms of this service.
       link: Learn more ›
-      text: >
-        Providing information is voluntary. It is used to help you access
-        government services. login.gov uses industry-standard monitoring and security
-        practices to protect your data. %{link}
+      text_html: >
+        By continuing, I agree to the terms of this service. Providing
+        information is voluntary. It is used to help you access government services.
+        login.gov uses industry-standard monitoring and security practices to
+        protect your data. %{link}
     totp_configured: You enabled an authentication app.
     totp_disabled: You disabled your authentication app.
     use_diff_email:

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -37,9 +37,8 @@ es:
       first_paragraph_start: NOT TRANSLATED YET
       no_email_sent_explanation_start: NOT TRANSLATED YET
     terms_of_service:
-      headline: NOT TRANSLATED YET
       link: NOT TRANSLATED YET
-      text: NOT TRANSLATED YET
+      text_html: NOT TRANSLATED YET
     totp_configured: NOT TRANSLATED YET
     totp_disabled: NOT TRANSLATED YET
     use_diff_email:

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe UsersController do
   describe '#destroy' do
-    it 'redirects and displays the flash message even if no user is present' do
+    it 'redirects and displays the flash message if no user is present' do
       delete :destroy
 
       expect(response).to redirect_to(root_url)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -16,5 +16,14 @@ describe UsersController do
       expect(response).to redirect_to(root_url)
       expect(flash.now[:success]).to eq t('sign_up.cancel.success')
     end
+
+    it 'finds the proper user and removes their record without `current_user`' do
+      confirmation_token = '1'
+
+      create(:user, confirmation_token: confirmation_token)
+      subject.session[:user_confirmation_token] = confirmation_token
+
+      expect { delete :destroy }.to change(User, :count).by(-1)
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 describe UsersController do
   describe '#destroy' do
+    it 'redirects and displays the flash message even if no user is present' do
+      delete :destroy
+
+      expect(response).to redirect_to(root_url)
+      expect(flash.now[:success]).to eq t('sign_up.cancel.success')
+    end
+
     it 'destroys the current user and redirects to sign in page, with a helpful flash message' do
       sign_in_as_user
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -12,6 +12,22 @@ feature 'Sign Up' do
     end
   end
 
+  context 'user cancels sign up on email screen' do
+    before do
+      visit sign_up_email_path
+      page.find('#auth-flow-cancel').click
+    end
+
+    it 'redirects user to the home page' do
+      expect(current_path).to eq(root_path)
+    end
+
+    it 'redirects to the homepage from the modal', js: true do
+      page.find('a', text: t('links.cancel_account_creation')).click
+      expect(current_path).to eq(root_path)
+    end
+  end
+
   context 'with js', js: true do
     context 'sp loa1' do
       it 'allows the user to toggle the modal' do

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -3,6 +3,28 @@ require 'rails_helper'
 describe 'sign_up/passwords/new.html.slim' do
   before do
     user = build_stubbed(:user, :signed_up)
+
+    allow(view).to receive(:current_user).and_return(nil)
     @password_form = PasswordForm.new(user)
+
+    render
+  end
+
+  it 'renders the correct heading' do
+    expect(rendered).to have_content(t('forms.confirmation.show_hdr'))
+  end
+
+  it 'renders the proper help text' do
+    expect(rendered).to have_content(t('instructions.password.info.point_2'))
+    expect(rendered).to have_content(t('instructions.password.info.point_1'))
+    expect(rendered).to have_content(
+      t('instructions.password.info.lead', min_length: Devise.password_length.first)
+    )
+  end
+
+  it 'includes a form to cancel account creation' do
+    link = t('links.cancel_account_creation')
+
+    expect(rendered).to have_selector("input[value='#{link}']")
   end
 end

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -4,6 +4,7 @@ describe 'sign_up/registrations/new.html.slim' do
   before do
     @register_user_email_form = RegisterUserEmailForm.new
     allow(view).to receive(:controller_name).and_return('registrations')
+    allow(view).to receive(:current_user).and_return(nil)
   end
 
   it 'has a localized title' do
@@ -25,5 +26,12 @@ describe 'sign_up/registrations/new.html.slim' do
     render
 
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
+  end
+
+  it 'includes a form to cancel account creation' do
+    render
+    link = t('links.cancel_account_creation')
+
+    expect(rendered).to have_selector("input[value='#{link}']")
   end
 end

--- a/spec/views/two_factor_authentication_setup/index.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication_setup/index.html.slim_spec.rb
@@ -2,13 +2,16 @@ require 'rails_helper'
 
 describe 'users/two_factor_authentication_setup/index.html.slim' do
   before do
-    user = build_stubbed(:user, :signed_up)
+    user = build_stubbed(:user)
+
+    allow(view).to receive(:current_user).and_return(user)
+
     @two_factor_setup_form = TwoFactorSetupForm.new(user)
+
+    render
   end
 
   it 'sets form autocomplete to off' do
-    render
-
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
 end


### PR DESCRIPTION
Adds cancel links to each of the sign up pages that we'd like the user to be able to delete their account from.

<img width="588" alt="screen shot 2017-02-16 at 3 48 06 pm" src="https://cloud.githubusercontent.com/assets/1421848/23040450/5a088356-f45f-11e6-822e-b556d06a4b0b.png">


**NOTE**: The 'back' arrow is smaller than in the comps, but this should suffice until I get the svg image in there!
