### PR TITLE
Fix rubocop warning

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -20,7 +20,6 @@ class OpenidConnectUserInfoPresenter
 
   private
 
-  # rubocop:disable Metrics/AbcSize
   def loa3_attributes
     phone = stringify_attr(loa3_data.phone)
 
@@ -33,7 +32,6 @@ class OpenidConnectUserInfoPresenter
       phone_verified: phone.present? ? true : nil,
     }
   end
-  # rubocop:enable Metrics/AbcSize
 
   def address
     return nil if loa3_data.address1.blank?


### PR DESCRIPTION
**Why**: rubocop reported it was an unnecessary disable

---

Unsure why this only warned and didn't cause a CI failure when I removed `middle_name` but  ¯\\\_(ツ)\_/¯