### PR TITLE
Add confirm link to sign up flow when load testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ $ RAILS_ASSET_HOST=localhost:3000 rake spec:user_flows
 
 Then, visit http://localhost:3000/user_flows in your browser!
 
+### Load testing mode
+
+The sign up flow includes a step where the user receives an email with a
+tokenized link that enables them to confirm their account.
+
+If you would like to skip the email step, you can set the
+`Figaro.env.load_testing_mode` key to `true`. This will surface the tokenized
+confirmation link during the sign up flow so that checking email is not required
+to confirm an account's email address.
+
 ### Proofing vendors
 
 Some proofing vendor code is located in private Github repositories because of NDAs. You can still use it

--- a/app/views/sign_up/emails/show.html.slim
+++ b/app/views/sign_up/emails/show.html.slim
@@ -22,4 +22,6 @@
   p = t('devise.registrations.close_window')
 
   - if FeatureManagement.enable_load_testing_mode?
-    = link_to 'CONFIRM NOW', sign_up_create_email_confirmation_url(confirmation_token: User.find_with_email(email).confirmation_token)
+    = link_to 'CONFIRM NOW',
+      sign_up_create_email_confirmation_url(confirmation_token: \
+      User.find_with_email(email).confirmation_token)

--- a/app/views/sign_up/emails/show.html.slim
+++ b/app/views/sign_up/emails/show.html.slim
@@ -20,3 +20,6 @@
   - link = link_to t('notices.use_diff_email.link'), sign_up_email_path
   p = t('notices.use_diff_email.text_html', link: link)
   p = t('devise.registrations.close_window')
+
+  - if FeatureManagement.enable_load_testing_mode?
+    = link_to 'CONFIRM NOW', sign_up_create_email_confirmation_url(confirmation_token: User.find_with_email(email).confirmation_token)

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -94,6 +94,7 @@ development:
   use_kms: 'false'
   valid_service_providers: '["https://rp1.serviceprovider.com/auth/saml/metadata", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails", "https://dashboard.login.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase", "urn:gov:gsa:openidconnect:development", "urn:gov:gsa:openidconnect:sp:sinatra"]'
   enable_i18n_mode: 'false'
+  enable_load_testing_mode: 'false'
 
 production:
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -141,6 +142,7 @@ production:
   use_kms: 'false'
   valid_service_providers: '["https://upaya-dev.18f.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo", "https://dashboard.demo.login.gov", "https://dashboard.qa.login.gov", "https://dashboard.dev.login.gov", "urn:gov:gsa:saml:2.0.profiles:sp:sso:micropurchase-staging", "urn:gov:gsa:saml:2.0.profiles:sp:sso:micropurchase-production"]'
   enable_i18n_mode: 'false'
+  enable_load_testing_mode: 'false'
 
 test:
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
@@ -183,3 +185,4 @@ test:
   use_kms: 'false'
   valid_service_providers: '["http://localhost:3000", "https://rp1.serviceprovider.com/auth/saml/metadata", "https://rp2.serviceprovider.com/auth/saml/metadata", "http://test.host", "urn:gov:gsa:openidconnect:test", "urn:gov:gsa:openidconnect:sp:server"]'
   enable_i18n_mode: 'false'
+  enable_load_testing_mode: 'false'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -13,6 +13,10 @@ class FeatureManagement
     Figaro.env.enable_i18n_mode == 'true'
   end
 
+  def self.enable_load_testing_mode?
+    Figaro.env.enable_load_testing_mode == 'true'
+  end
+
   def self.password_strength_enabled?
     Figaro.env.password_strength_enabled == 'true'
   end

--- a/spec/features/load_testing/email_sign_up_spec.rb
+++ b/spec/features/load_testing/email_sign_up_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'Email sign up' do
+  scenario 'Load testing feature is on' do
+    allow(Figaro.env).to receive(:enable_load_testing_mode).and_return('true')
+    email = 'test@example.com'
+
+    sign_up_with(email)
+    click_link('CONFIRM NOW')
+
+    expect(current_path).to eq sign_up_create_email_confirmation_path
+    expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
+  end
+end


### PR DESCRIPTION
**Why**: When a script is going through the sign up flow to complete
load testing, the "check email" step will prevent the script from moving
forward. When load testing mode is turned on, the script can click a
link in the view to confirm the user's email address.

PR by @jessieay and @monfresh 