### PR TITLE
Disable autocomplete on 2FA code inputs

### DIFF
--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -11,7 +11,8 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag(:code, '', value: @presenter.code_value, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length)
+      'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
+      autocomplete: 'off')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 = render 'shared/fallback_links', presenter: @presenter

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -8,7 +8,7 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
     = label_tag 'code',
       t('simple_form.required.html') + t('forms.two_factor.recovery_code'),
       class: 'block bold'
-    = block_text_field_tag :code, '', required: true
+    = block_text_field_tag :code, '', required: true, autocomplete: 'off'
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -11,7 +11,7 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
+      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 = render 'shared/fallback_links', presenter: @presenter

--- a/spec/support/shared_examples_for_otp_forms.rb
+++ b/spec/support/shared_examples_for_otp_forms.rb
@@ -1,4 +1,10 @@
 shared_examples_for 'an otp form' do
+  it 'disables autocomplete' do
+    render
+
+    expect(rendered).to have_css('input[id=code][autocomplete=off]')
+  end
+
   describe 'tertiary form actions' do
     it 'allows the user to cancel out of the sign in process' do
       render


### PR DESCRIPTION
**Why**: So that browsers don't remember old 2FA codes

--

Thanks to @jgrevich for pointing this out

<img width="401" alt="login_gov_-_enter_the_secure_one-time_passcode 2" src="https://cloud.githubusercontent.com/assets/458784/23044287/8de19376-f46d-11e6-84b1-7e58aabd0769.png">


<img width="487" alt="login_gov_-_enter_the_secure_one-time_passcode" src="https://cloud.githubusercontent.com/assets/458784/23044290/8f7b84b2-f46d-11e6-9719-705b040be8c5.png">
