### PR TITLE
Fix recovery code bug on IdV confirmation

### DIFF
--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -4,6 +4,7 @@ module Verify
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_vendor_session_started
+    before_action :confirm_profile_has_been_created
 
     def index
       track_final_idv_event
@@ -12,6 +13,10 @@ module Verify
     end
 
     private
+
+    def confirm_profile_has_been_created
+      redirect_to profile_path unless idv_session.profile.present?
+    end
 
     def track_final_idv_event
       result = {
@@ -22,11 +27,19 @@ module Verify
     end
 
     def finish_proofing_success
-      @recovery_code = idv_session.recovery_code
-      idv_attempter.reset
+      @recovery_code = recovery_code
       idv_session.complete_profile
-      idv_session.clear
+      idv_session.recovery_code = nil
       flash[:allow_confirmations_continue] = true
+    end
+
+    def recovery_code
+      idv_session.recovery_code || generate_recovery_code
+    end
+
+    def generate_recovery_code
+      cacher = Pii::Cacher.new(current_user, user_session)
+      idv_session.profile.encrypt_recovery_pii(cacher.fetch)
     end
   end
 end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -18,6 +18,8 @@ class VerifyController < ApplicationController
 
   def activated
     redirect_to verify_url unless active_profile?
+    idv_attempter.reset
+    idv_session.clear
   end
 
   def fail

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -70,7 +70,7 @@ module Idv
       profile.verified_at = Time.zone.now
       profile.vendor = vendor
       profile.activate
-      move_pii_to_user_session
+      move_pii_to_user_session if session[:decrypted_pii].present?
     end
 
     def alive?

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -33,6 +33,20 @@ describe VerifyController do
         get :activated
 
         expect(response).to render_template(:activated)
+        expect(subject.idv_session.alive?).to eq false
+      end
+
+      it 'resets IdV attempts' do
+        profile = create(:profile, :active, :verified)
+
+        stub_sign_in(profile.user)
+
+        attempter = instance_double(Idv::Attempter, reset: false)
+        allow(Idv::Attempter).to receive(:new).with(profile.user).and_return(attempter)
+
+        expect(attempter).to receive(:reset)
+
+        get :activated
       end
     end
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -313,6 +313,16 @@ feature 'IdV session' do
       end
 
       it_behaves_like 'recovery code page'
+
+      scenario 'reload recovery code page' do
+        visit current_path
+
+        expect(page).to have_content(t('headings.recovery_code'))
+
+        visit current_path
+
+        expect(page).to have_content(t('headings.recovery_code'))
+      end
     end
   end
 

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -73,14 +73,4 @@ module IdvHelper
     fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
     click_submit_default
   end
-
-  def stub_idv_session
-    stub_sign_in(user)
-    idv_session = Idv::Session.new(subject.user_session, user)
-    idv_session.vendor = :mock
-    idv_session.applicant = applicant
-    idv_session.resolution = resolution
-    idv_session.profile_id = profile.id
-    allow(subject).to receive(:idv_session).and_return(idv_session)
-  end
 end


### PR DESCRIPTION
**Why**: Page reload on personal key (recovery code) confirmation
was failing because the IdV session was cleared immediately after
display.