### PR TITLE
Refactor ResetPasswordsController

### DIFF
--- a/.reek
+++ b/.reek
@@ -25,7 +25,7 @@ NilCheck:
     - AdminConstraint#user_is_admin?
     - PasswordsController#edit
     - PasswordsController#mark_profile_inactive
-    - PasswordResetTokenValidator#result
+    - PasswordResetTokenValidator#submit
     - PhoneConfirmationFlow
     - RegisterUserEmailForm#result
     - slo_not_implemented_at_sp?

--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -13,20 +13,15 @@ class PasswordResetEmailForm
   end
 
   def submit
-    @success = valid?
-
-    result
+    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   private
 
   attr_writer :email
-  attr_reader :success
 
-  def result
+  def extra_analytics_attributes
     {
-      success: success,
-      errors: errors.messages.values.flatten,
       user_id: user.uuid,
       role: user.role,
       confirmed: user.confirmed?,

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -16,9 +16,7 @@ class ResetPasswordForm
 
     self.password = submitted_password
 
-    @success = valid?
-
-    result
+    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   private
@@ -31,10 +29,8 @@ class ResetPasswordForm
     errors.add(:reset_password_token, 'token_expired')
   end
 
-  def result
+  def extra_analytics_attributes
     {
-      success: success,
-      errors: errors.messages.values.flatten,
       user_id: user.uuid,
       active_profile: user.active_profile.present?,
       confirmed: user.confirmed?,

--- a/app/services/password_reset_token_validator.rb
+++ b/app/services/password_reset_token_validator.rb
@@ -9,23 +9,12 @@ class PasswordResetTokenValidator
   end
 
   def submit
-    @success = valid?
-
-    result
+    FormResponse.new(success: valid?, errors: errors.messages, extra: { user_id: user&.uuid })
   end
 
   private
 
   attr_accessor :user
-  attr_reader :success
-
-  def result
-    {
-      success: success,
-      error: errors.messages.values.flatten.first,
-      user_id: user&.uuid,
-    }
-  end
 
   def valid_token
     errors.add(:user, 'token_expired') unless user.reset_password_period_valid?

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -11,7 +11,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: false,
-          error: 'invalid_token',
+          errors: { user: ['invalid_token'] },
           user_id: nil,
         }
 
@@ -36,7 +36,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: false,
-          error: 'token_expired',
+          errors: { user: ['token_expired'] },
           user_id: '123',
         }
 
@@ -85,7 +85,10 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: false,
-          errors: ['is too short (minimum is 8 characters)', 'token_expired'],
+          errors: {
+            password: ['is too short (minimum is 8 characters)'],
+            reset_password_token: ['token_expired'],
+          },
           user_id: user.uuid,
           active_profile: false,
           confirmed: true,
@@ -118,7 +121,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: false,
-          errors: ['is too short (minimum is 8 characters)'],
+          errors: { password: ['is too short (minimum is 8 characters)'] },
           user_id: user.uuid,
           active_profile: false,
           confirmed: true,
@@ -158,7 +161,7 @@ describe Users::ResetPasswordsController, devise: true do
 
           analytics_hash = {
             success: true,
-            errors: [],
+            errors: {},
             user_id: user.uuid,
             active_profile: false,
             confirmed: true,
@@ -197,7 +200,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           active_profile: true,
           confirmed: true,
@@ -236,7 +239,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           active_profile: false,
           confirmed: false,
@@ -260,7 +263,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
@@ -285,7 +288,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: tech_user.uuid,
           role: 'tech',
           confirmed: true,
@@ -310,7 +313,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: admin.uuid,
           role: 'admin',
           confirmed: true,
@@ -334,7 +337,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           role: 'user',
           confirmed: true,
@@ -358,7 +361,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         analytics_hash = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           role: 'user',
           confirmed: false,
@@ -379,20 +382,15 @@ describe Users::ResetPasswordsController, devise: true do
 
     context 'email is invalid' do
       it 'displays an error and tracks event' do
-        form = instance_double(PasswordResetEmailForm)
-        expect(PasswordResetEmailForm).to receive(:new).with('foo').and_return(form)
-
         stub_analytics
 
         analytics_hash = {
           success: false,
-          errors: [t('valid_email.validations.email.invalid')],
+          errors: { email: [t('valid_email.validations.email.invalid')] },
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
         }
-
-        expect(form).to receive(:submit).and_return(analytics_hash)
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -12,14 +12,16 @@ describe PasswordResetEmailForm do
         user = build(:user, :signed_up, email: 'test1@test.com')
         subject = PasswordResetEmailForm.new('Test1@test.com')
 
-        result = {
-          success: true,
-          errors: [],
+        extra = {
           user_id: user.uuid,
           role: user.role,
           confirmed: true,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
         expect(subject.submit).to eq result
         expect(subject).to respond_to(:resend)
       end
@@ -27,14 +29,16 @@ describe PasswordResetEmailForm do
 
     context 'when email is valid and user does not exist' do
       it 'returns hash with properties about the event and the nonexistent user' do
-        result = {
-          success: true,
-          errors: [],
+        extra = {
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
         expect(subject.submit).to eq result
       end
     end
@@ -43,14 +47,18 @@ describe PasswordResetEmailForm do
       it 'returns hash with properties about the event and the nonexistent user' do
         subject = PasswordResetEmailForm.new('invalid')
 
-        result = {
-          success: false,
-          errors: [t('valid_email.validations.email.invalid')],
+        errors = { email: [t('valid_email.validations.email.invalid')] }
+
+        extra = {
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
         expect(subject.submit).to eq result
       end
     end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -15,14 +15,18 @@ describe ResetPasswordForm, type: :model do
 
         password = 'valid password'
 
-        result = {
-          success: false,
-          errors: ['token_expired'],
+        errors = { reset_password_token: ['token_expired'] }
+
+        extra = {
           user_id: '123',
           active_profile: false,
           confirmed: true,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
       end
     end
@@ -36,14 +40,18 @@ describe ResetPasswordForm, type: :model do
 
         password = 'invalid'
 
-        result = {
-          success: false,
-          errors: ['is too short (minimum is 8 characters)'],
+        errors = { password: ['is too short (minimum is 8 characters)'] }
+
+        extra = {
           user_id: '123',
           active_profile: false,
           confirmed: true,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
       end
     end
@@ -57,14 +65,16 @@ describe ResetPasswordForm, type: :model do
 
         password = 'valid password'
 
-        result = {
-          success: true,
-          errors: [],
+        extra = {
           user_id: '123',
           active_profile: false,
           confirmed: true,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
       end
     end
@@ -78,14 +88,21 @@ describe ResetPasswordForm, type: :model do
 
         password = 'short'
 
-        result = {
-          success: false,
-          errors: ['is too short (minimum is 8 characters)', 'token_expired'],
+        errors = {
+          password: ['is too short (minimum is 8 characters)'],
+          reset_password_token: ['token_expired'],
+        }
+
+        extra = {
           user_id: '123',
           active_profile: false,
           confirmed: true,
         }
 
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
       end
     end
@@ -102,17 +119,22 @@ describe ResetPasswordForm, type: :model do
         passwords = ['custom!@', 'benevolent', 'custom benevolent comcast']
 
         passwords.each do |password|
-          result = {
-            success: false,
-            errors: ['Your password is not strong enough.' \
+          errors = {
+            password: ['Your password is not strong enough.' \
               ' This is similar to a commonly used password.' \
               ' Add another word or two.' \
               ' Uncommon words are better.'],
+          }
+
+          extra = {
             user_id: nil,
             active_profile: false,
             confirmed: true,
           }
 
+          result = instance_double(FormResponse)
+          expect(FormResponse).to receive(:new).
+            with(success: false, errors: errors, extra: extra).and_return(result)
           expect(form.submit(password: password)).
             to eq result
         end


### PR DESCRIPTION
**Why**: To adhere to our pattern where the controller expects
the Form Object to return a FormResponse object whose errors
are a Hash.