### PR TITLE
Add scope to return SSN in OpenID Connect

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -20,6 +20,7 @@ class OpenidConnectUserInfoPresenter
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def loa3_attributes
     phone = stringify_attr(loa3_data.phone)
 
@@ -27,11 +28,13 @@ class OpenidConnectUserInfoPresenter
       given_name: stringify_attr(loa3_data.first_name),
       family_name: stringify_attr(loa3_data.last_name),
       birthdate: stringify_attr(loa3_data.dob),
+      social_security_number: stringify_attr(loa3_data.ssn),
       address: address,
       phone: phone,
       phone_verified: phone.present? ? true : nil,
     }
   end
+  # rubocop:enable Metrics/AbcSize
 
   def address
     return nil if loa3_data.address1.blank?

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -5,6 +5,7 @@ class OpenidConnectAttributeScoper
     openid
     phone
     profile
+    social_security_number
   ).freeze
 
   ATTRIBUTE_SCOPE_MAP = {
@@ -16,6 +17,7 @@ class OpenidConnectAttributeScoper
     given_name: 'profile',
     family_name: 'profile',
     birthdate: 'profile',
+    social_security_number: 'social_security_number',
   }.with_indifferent_access.freeze
 
   SCOPE_ATTRIBUTE_MAP = ATTRIBUTE_SCOPE_MAP.group_by(&:last).map do |scope, attribute_scope|

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -6,12 +6,13 @@ en:
         allow_prompt: 'Review the information that %{name} has requested access to:'
         decline: Decline
         attributes:
-          email: Email address
           address: Mailing address
-          phone: Phone number
-          given_name: First name
-          family_name: Last name
           birthdate: Birthdate
+          email: Email address
+          family_name: Last name
+          given_name: First name
+          phone: Phone number
+          social_security_number: Social security number
       errors:
         bad_client_id: Bad client_id
         no_valid_acr_values: No acceptable acr_values found

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -6,12 +6,13 @@ es:
         allow_prompt: NOT TRANSLATED YET
         decline: NOT TRANSLATED YET
         attributes:
-          email: NOT TRANSLATED YET
           address: NOT TRANSLATED YET
-          phone: NOT TRANSLATED YET
-          given_name: NOT TRANSLATED YET
-          family_name: NOT TRANSLATED YET
           birthdate: NOT TRANSLATED YET
+          email: NOT TRANSLATED YET
+          family_name: NOT TRANSLATED YET
+          given_name: NOT TRANSLATED YET
+          phone: NOT TRANSLATED YET
+          social_security_number: NOT TRANSLATED YET
       errors:
         bad_client_id: NOT TRANSLATED YET
         no_valid_acr_values: NOT TRANSLATED YET

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   include Rails.application.routes.url_helpers
 
   let(:rails_session_id) { SecureRandom.uuid }
-  let(:scope) { 'openid email address phone profile' }
+  let(:scope) { 'openid email address phone profile social_security_number' }
   let(:identity) do
     build(:identity,
           rails_session_id: rails_session_id,
@@ -38,6 +38,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           state: 'DC',
           zipcode: '12345',
           phone: '+1 (555) 555-5555',
+          ssn: '666661234',
         }
       end
 
@@ -63,6 +64,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
                 region: 'DC',
                 postal_code: '12345'
               )
+              expect(user_info[:social_security_number]).to eq('666661234')
             end
           end
 
@@ -86,6 +88,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
               expect(user_info[:phone]).to eq('+1 (555) 555-5555')
               expect(user_info[:phone_verified]).to eq(true)
               expect(user_info[:address]).to eq(nil)
+              expect(user_info[:social_security_number]).to eq(nil)
             end
           end
         end

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe OpenidConnectAttributeScoper do
           region: 'DC',
           postal_code: '12345',
         },
+        social_security_number: '666661234',
       }
     end
 
@@ -92,6 +93,14 @@ RSpec.describe OpenidConnectAttributeScoper do
         expect(filtered[:given_name]).to be_present
         expect(filtered[:family_name]).to be_present
         expect(filtered[:birthdate]).to be_present
+      end
+    end
+
+    context 'with social_security_number scope' do
+      let(:scope) { 'openid social_security_number' }
+
+      it 'includes social_security_number' do
+        expect(filtered[:social_security_number]).to be_present
       end
     end
   end


### PR DESCRIPTION
**Why**: parity with SAML interface

