### PR TITLE
Update user flows tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ We have an automated tool for generating user flows using real views generated f
 The local instance of the application must be running in order to serve up the assets (eg. `make run`). Then, you can specify where the assets are hosted from and generate the views with:
 
 ```
-$ RAILS_ASSET_HOST=localhost:3000 rake spec:user_flows
+$ rake spec:user_flows
 ```
 
 Then, visit http://localhost:3000/user_flows in your browser!

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,6 +19,8 @@ Rails.application.configure do
 
   if ENV.key?('RAILS_ASSET_HOST')
     config.action_controller.asset_host = ENV['RAILS_ASSET_HOST']
+  else
+    config.action_controller.asset_host = '//'
   end
 
   config.assets.debug = true

--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -109,12 +109,7 @@ feature 'SP-initiated authentication with login.gov', devise: true, user_flow: t
           screenshot_and_save_page
         end
 
-        context 'with SMS OTP selected' do
-          before do
-            choose t('devise.two_factor_authentication.otp_method.sms')
-            click_button t('forms.buttons.submit.default')
-          end
-
+        context 'with SMS OTP selected (default)' do
           it 'prompts for OTP verification' do
             screenshot_and_save_page
           end


### PR DESCRIPTION
The user flows had broken a bit
1. the HTML was pointing at assets at www.example.com instead of relative to the current host
2. the change in OTP flow "broke" two specs