### PR TITLE
Add native flag to ServiceProviders

### DIFF
--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -9,6 +9,10 @@ class NullServiceProvider
     false
   end
 
+  def native?
+    false
+  end
+
   def live?
     false
   end

--- a/db/migrate/20170222182714_add_native_to_service_provider.rb
+++ b/db/migrate/20170222182714_add_native_to_service_provider.rb
@@ -1,0 +1,5 @@
+class AddNativeToServiceProvider < ActiveRecord::Migration
+  def change
+    add_column :service_providers, :native, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170215175444) do
+ActiveRecord::Schema.define(version: 20170222182714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 20170215175444) do
     t.datetime "updated_at"
     t.boolean  "active",                                default: false,        null: false
     t.boolean  "approved",                              default: false,        null: false
+    t.boolean  "native",                                default: false,        null: false
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@ SERVICE_PROVIDERS.each do |issuer, config|
   ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
     sp.approved = VALID_SERVICE_PROVIDERS.include?(issuer)
     sp.active = true
+    sp.native = true
     sp.attributes = config
   end
 end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -34,6 +34,12 @@ describe ServiceProviderUpdater do
         cert: saml_test_sp_cert,
         active: false,
       },
+      {
+        issuer: 'http://localhost:3000',
+        agency: 'trying to override a test SP',
+        acs_url: 'http://nasty-override.example.org/saml/login',
+        active: true,
+      },
     ]
   end
 
@@ -78,6 +84,14 @@ describe ServiceProviderUpdater do
         sp = ServiceProvider.from_issuer(inactive_dashboard_sp_issuer)
 
         expect(sp).to be_a NullServiceProvider
+      end
+
+      it 'ignores attempts to alter native Service Providers' do
+        subject.run
+
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+
+        expect(sp.agency).to_not eq 'trying to override a test SP'
       end
     end
 


### PR DESCRIPTION
**Why**: Keep dashboard from altering native SPs that were
loaded from config/service_providers.yml