### PR TITLE
Fixes IE 8 js bugs, malformed syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ brakeman:
 	bundle exec brakeman
 
 test: $(CONFIG)
-	RAILS_ENV=test bundle exec rspec && bundle exec teaspoon
+	bundle exec rspec && RAILS_ENV=test bundle exec teaspoon
 
 fast_test: $(CONFIG)
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ brakeman:
 	bundle exec brakeman
 
 test: $(CONFIG)
-	bundle exec rspec && bundle exec teaspoon
+	RAILS_ENV=test bundle exec rspec && bundle exec teaspoon
 
 fast_test: $(CONFIG)
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"

--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 window.LoginGov = window.LoginGov || {};
 
 <% keys = [

--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 window.LoginGov = window.LoginGov || {};
 
 <% keys = [

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,9 @@ html lang="#{I18n.locale}" class='no-js'
       = content_for?(:title) ? APP_NAME + ' - ' + yield(:title) : APP_NAME
 
     == stylesheet_link_tag 'application', media: 'all'
+    <!--[if IE 8]>
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.9/es5-shim.min.js'></script>
+    <![endif]-->
     == javascript_include_tag 'misc/i18n-strings'
     - unless controller_name == 'home'
       == javascript_include_tag 'application'
@@ -25,9 +28,10 @@ html lang="#{I18n.locale}" class='no-js'
     link rel='mask-icon' href='/safari-pinned-tab.svg' color='#e21c3d'
     meta name='theme-color' content='#ffffff'
 
-    <!--[if lt IE 10]>
+    <!--[if IE 9]>
       = stylesheet_link_tag 'ie9.css', media: 'all'
-    <!--[elseif lt IE 9]>
+    <![endif]-->
+    <!--[if lt IE 9]>
       <script src='https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js'></script>
       = stylesheet_link_tag 'ie8.css', media: 'all'
       <script src='https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js'></script>
@@ -49,14 +53,14 @@ html lang="#{I18n.locale}" class='no-js'
       = content_for?(:content) ? yield(:content) : yield
     = render 'shared/footer_lite'
 
-  #session-timeout-cntnr
-  - if current_user
-    = auto_session_timeout_js
-  - else
-    = auto_session_expired_js
+    #session-timeout-cntnr
+    - if current_user
+      = auto_session_timeout_js
+    - else
+      = auto_session_expired_js
 
-  - if FeatureManagement.enable_i18n_mode?
-    == javascript_include_tag 'misc/i18n-mode'
+    - if FeatureManagement.enable_i18n_mode?
+      == javascript_include_tag 'misc/i18n-mode'
 
-  - if Figaro.env.participate_in_dap == 'true'
-    = render 'shared/dap_analytics'
+    - if Figaro.env.participate_in_dap == 'true'
+      = render 'shared/dap_analytics'

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Upaya
 
     routes.default_url_options[:host] = Figaro.env.domain_name
 
-    unless Rails.env.production?
+    if Rails.env.test?
       config.browserify_rails.commandline_options += ' -p [ proxyquireify/plugin ]'
       # Make sure Browserify is triggered when asked to serve javascript spec files
       config.browserify_rails.paths << lambda do |path|


### PR DESCRIPTION
**Why**: we were serving pages with javascript errors and malformed
html, causing ie8 to complain

**How**: Fixed malformed IE specific html comment directives, adds es5
shim for ie8 only