### PR TITLE
Remove VALID_SERVICE_PROVIDERS config

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -92,7 +92,6 @@ development:
   twilio_record_voice: 'true'
   use_dashboard_service_providers: 'true'
   use_kms: 'false'
-  valid_service_providers: '["https://rp1.serviceprovider.com/auth/saml/metadata", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails", "https://dashboard.login.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase", "urn:gov:gsa:openidconnect:development", "urn:gov:gsa:openidconnect:sp:sinatra"]'
   enable_i18n_mode: 'false'
   enable_load_testing_mode: 'false'
 
@@ -140,7 +139,6 @@ production:
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   twilio_record_voice: 'false'
   use_kms: 'false'
-  valid_service_providers: '["https://upaya-dev.18f.gov", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-demo", "https://dashboard.demo.login.gov", "https://dashboard.qa.login.gov", "https://dashboard.dev.login.gov", "urn:gov:gsa:saml:2.0.profiles:sp:sso:micropurchase-staging", "urn:gov:gsa:saml:2.0.profiles:sp:sso:micropurchase-production"]'
   enable_i18n_mode: 'false'
   enable_load_testing_mode: 'false'
 
@@ -183,6 +181,5 @@ test:
   twilio_accounts: '[{"sid":"sid1", "auth_token":"token1", "number":"9999999999"}, {"sid":"sid2", "auth_token":"token2", "number":"2222222222"}]'
   twilio_record_voice: 'true'
   use_kms: 'false'
-  valid_service_providers: '["http://localhost:3000", "https://rp1.serviceprovider.com/auth/saml/metadata", "https://rp2.serviceprovider.com/auth/saml/metadata", "http://test.host", "urn:gov:gsa:openidconnect:test", "urn:gov:gsa:openidconnect:sp:server"]'
   enable_i18n_mode: 'false'
   enable_load_testing_mode: 'false'

--- a/config/initializers/_service_providers.rb
+++ b/config/initializers/_service_providers.rb
@@ -1,8 +1,6 @@
 SERVICE_PROVIDERS = YAML.load_file("#{Rails.root}/config/service_providers.yml").
                     fetch(Rails.env, {})
 
-VALID_SERVICE_PROVIDERS = JSON.parse(Figaro.env.valid_service_providers).to_set
-
 # merge from dashboard
 require 'feature_management'
 if FeatureManagement.use_dashboard_service_providers?

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -33,8 +33,7 @@ Figaro.require_keys(
   'twilio_accounts',
   'twilio_record_voice',
   'use_kms',
-  'valid_authn_contexts',
-  'valid_service_providers'
+  'valid_authn_contexts'
 )
 
 ConfigValidator.new.validate

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ end
 # add config/service_providers.yml
 SERVICE_PROVIDERS.each do |issuer, config|
   ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
-    sp.approved = VALID_SERVICE_PROVIDERS.include?(issuer)
+    sp.approved = true
     sp.active = true
     sp.attributes = config
   end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -150,12 +150,10 @@ feature 'saml api' do
           body: dashboard_service_providers.to_json
         )
         SERVICE_PROVIDERS.delete dashboard_sp_issuer
-        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
       end
 
       after do
         SERVICE_PROVIDERS.delete dashboard_sp_issuer
-        VALID_SERVICE_PROVIDERS.delete dashboard_sp_issuer
       end
 
       it 'updates the service providers in the database' do


### PR DESCRIPTION
**Why**: All SPs listed in config/service_providers.yml are approved
by virtue of code review and PR merge. No need to specify it in code.
Approval is a future-feature of the dashboard only.