### PR TITLE
Refactor OpenidConnect::AuthorizationController

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -23,13 +23,13 @@ module OpenidConnect
 
     def create
       result = @authorize_form.submit(current_user, session.id)
-      analytics_attributes = result.to_h
+      analytics_attributes = result.to_h.except(:redirect_uri)
 
       analytics.track_event(
-        Analytics::OPENID_CONNECT_ALLOW, analytics_attributes.except(:redirect_uri)
+        Analytics::OPENID_CONNECT_ALLOW, analytics_attributes
       )
 
-      if (redirect_uri = analytics_attributes[:redirect_uri])
+      if (redirect_uri = result.extra[:redirect_uri])
         redirect_to redirect_uri
       else
         render :error

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -23,9 +23,13 @@ module OpenidConnect
 
     def create
       result = @authorize_form.submit(current_user, session.id)
-      analytics.track_event(Analytics::OPENID_CONNECT_ALLOW, result.except(:redirect_uri))
+      analytics_attributes = result.to_h
 
-      if (redirect_uri = result[:redirect_uri])
+      analytics.track_event(
+        Analytics::OPENID_CONNECT_ALLOW, analytics_attributes.except(:redirect_uri)
+      )
+
+      if (redirect_uri = analytics_attributes[:redirect_uri])
         redirect_to redirect_uri
       else
         render :error

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -44,18 +44,11 @@ class OpenidConnectAuthorizeForm
   end
 
   def submit(user, rails_session_id)
-    success = valid?
+    @success = valid?
 
     link_identity_to_client_id(user, rails_session_id) if success
 
-    result_uri = success ? success_redirect_uri : error_redirect_uri
-
-    {
-      success: success,
-      redirect_uri: result_uri,
-      client_id: client_id,
-      errors: errors.messages,
-    }
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   def loa3_requested?
@@ -72,7 +65,7 @@ class OpenidConnectAuthorizeForm
 
   private
 
-  attr_reader :identity
+  attr_reader :identity, :success
 
   def parse_to_values(param_value, possible_values)
     return [] if param_value.blank?
@@ -125,6 +118,17 @@ class OpenidConnectAuthorizeForm
     when Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
       3
     end
+  end
+
+  def extra_analytics_attributes
+    {
+      client_id: client_id,
+      redirect_uri: result_uri,
+    }
+  end
+
+  def result_uri
+    success ? success_redirect_uri : error_redirect_uri
   end
 
   def success_redirect_uri

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -5,7 +5,7 @@ class FormResponse
     @extra = extra
   end
 
-  attr_reader :errors
+  attr_reader :errors, :extra
 
   def success?
     @success
@@ -17,5 +17,5 @@ class FormResponse
 
   private
 
-  attr_reader :success, :extra
+  attr_reader :success
 end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -40,12 +40,24 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
     context 'with valid params' do
       it 'is successful' do
-        expect(result[:success]).to eq(true)
-        expect(result[:client_id]).to eq(client_id)
+        allow(FormResponse).to receive(:new)
+
+        form.submit(user, rails_session_id)
+
+        identity = user.identities.where(service_provider: client_id).first
+
+        extra_attributes = {
+          client_id: client_id,
+          redirect_uri: "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}",
+        }
+
+        expect(FormResponse).to have_received(:new).
+          with(success: true, errors: {}, extra: extra_attributes)
+        expect(form.client_id).to eq(client_id)
       end
 
       it 'links an identity for this client with the code as the session_uuid' do
-        redirect_uri = URI(result[:redirect_uri])
+        redirect_uri = URI(result.to_h[:redirect_uri])
         code = Rack::Utils.parse_nested_query(redirect_uri.query).with_indifferent_access[:code]
 
         identity = user.identities.where(service_provider: client_id).first
@@ -65,10 +77,20 @@ RSpec.describe OpenidConnectAuthorizeForm do
         let(:code_challenge_method) { 'S256' }
 
         it 'records the code_challenge on the identity' do
-          expect(result[:success]).to eq(true)
+          allow(FormResponse).to receive(:new)
+
+          form.submit(user, rails_session_id)
 
           identity = user.identities.where(service_provider: client_id).first
+
+          extra_attributes = {
+            client_id: client_id,
+            redirect_uri: "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}",
+          }
+
           expect(identity.code_challenge).to eq(code_challenge)
+          expect(FormResponse).to have_received(:new).
+            with(success: true, errors: {}, extra: extra_attributes)
         end
       end
     end
@@ -77,9 +99,20 @@ RSpec.describe OpenidConnectAuthorizeForm do
       let(:response_type) { nil }
 
       it 'is unsuccessful and has error messages' do
-        expect(result[:success]).to eq(false)
-        expect(result[:client_id]).to eq(client_id)
-        expect(result[:errors]).to be_present
+        form_response = instance_double(FormResponse)
+
+        extra_attributes = {
+          client_id: client_id,
+          redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
+                        "Response+type+is+not+included+in+the+list&state=#{state}",
+        }
+
+        errors = { response_type: ['is not included in the list'] }
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra_attributes).and_return(form_response)
+        expect(result).to eq form_response
+        expect(form.client_id).to eq(client_id)
       end
     end
   end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
         expect(FormResponse).to have_received(:new).
           with(success: true, errors: {}, extra: extra_attributes)
-        expect(form.client_id).to eq(client_id)
       end
 
       it 'links an identity for this client with the code as the session_uuid' do
@@ -112,7 +111,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra_attributes).and_return(form_response)
         expect(result).to eq form_response
-        expect(form.client_id).to eq(client_id)
       end
     end
   end
@@ -277,6 +275,14 @@ RSpec.describe OpenidConnectAuthorizeForm do
     context 'with a client_id with a non-http redirect_uri' do
       let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
       it { expect(allowed_form_action).to be_nil }
+    end
+  end
+
+  describe '#client_id' do
+    it 'returns the form client_id' do
+      form = OpenidConnectAuthorizeForm.new(client_id: 'foobar')
+
+      expect(form.client_id).to eq 'foobar'
     end
   end
 end

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -69,4 +69,13 @@ describe FormResponse do
       end
     end
   end
+
+  describe '#extra' do
+    it 'returns the extra hash' do
+      extra = { foo: 'bar' }
+      response = FormResponse.new(success: true, errors: {}, extra: extra)
+
+      expect(response.extra).to eq extra
+    end
+  end
 end


### PR DESCRIPTION
**Why**: To adhere to our pattern where the controller expects
the Form Object to return a FormResponse object whose errors
are a Hash.