### PR TITLE
Allow production env to disable sending emails

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -101,6 +101,7 @@ production:
   attribute_encryption_key_queue: '["old-key-one", "old-key-two"]'
   aws_kms_key_id: 'change-me'
   aws_region: 'change-me'
+  disable_email_sending: 'false'
   domain_name: 'example.com'
   enable_test_routes: 'false'
   equifax_avs_username: 'sekret'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,6 +19,7 @@ Rails.application.configure do
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_options = { from: Figaro.env.email_from }
+  config.action_mailer.delivery_method = :test if Figaro.env.disable_email_sending == 'true'
 
   # turn off IP spoofing protection since the network configuration in the production environment
   # creates false positive results.


### PR DESCRIPTION
**Why**: To prevent emails from being sent during load testing.
We don't require emails to be sent and parsed during load testing
thanks to the `enable_load_testing_mode` setting, which displays the
confirmation link directly on the web page.