### PR TITLE
Send ASCII applicant attributes to vendor

### DIFF
--- a/.reek
+++ b/.reek
@@ -55,6 +55,7 @@ TooManyMethods:
     - Users::ConfirmationsController
     - ApplicationController
     - OpenidConnectAuthorizeForm
+    - Idv::Session
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -40,7 +40,7 @@ module Idv
 
     def cache_applicant_profile_id
       profile = Idv::ProfileFromApplicant.create(
-        applicant: applicant,
+        applicant: Proofer::Applicant.new(applicant_params),
         normalized_applicant: resolution.vendor_resp.normalized_applicant,
         user: current_user
       )
@@ -54,8 +54,7 @@ module Idv
     end
 
     def applicant_from_params
-      app_vars = params.select { |key, _value| Proofer::Applicant.method_defined?(key) }
-      Proofer::Applicant.new(app_vars.merge(uuid: current_user.uuid))
+      Proofer::Applicant.new(applicant_params_ascii.merge(uuid: current_user.uuid))
     end
 
     def profile
@@ -91,6 +90,14 @@ module Idv
 
     def session
       user_session[:idv]
+    end
+
+    def applicant_params
+      params.select { |key, _value| Proofer::Applicant.method_defined?(key) }
+    end
+
+    def applicant_params_ascii
+      Hash[applicant_params.map { |key, value| [key, value.to_ascii] }]
     end
   end
 end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -15,7 +15,7 @@ describe Verify::ReviewController do
   let(:norm_zipcode) { '66044-1234' }
   let(:user_attrs) do
     {
-      first_name: 'Some',
+      first_name: 'José',
       last_name: 'One',
       ssn: '666661234',
       dob: 'March 29, 1972',
@@ -33,13 +33,9 @@ describe Verify::ReviewController do
     idv_session.profile_confirmation = true
     idv_session.phone_confirmation = true
     idv_session.financials_confirmation = true
-    idv_session.resolution = Proofer::Resolution.new(
-      success: true,
-      vendor_resp: Proofer::Vendor::MockResponse.new(
-        normalized_applicant: Proofer::Applicant.new(user_attrs.merge(zipcode: norm_zipcode))
-      ),
-      session_id: 'some-session'
-    )
+    idv_session.params = user_attrs
+    vendor = Proofer::Vendor::Mock.new(applicant: idv_session.applicant_from_params)
+    idv_session.resolution = vendor.start
     idv_session
   end
 
@@ -217,6 +213,10 @@ describe Verify::ReviewController do
 
         expect(pii.zipcode.raw).to eq raw_zipcode
         expect(pii.zipcode.norm).to eq norm_zipcode
+
+        expect(idv_session.applicant.first_name).to eq 'Jose'
+        expect(pii.first_name.raw).to eq 'José'
+        expect(pii.first_name.norm).to eq 'JOSE'
       end
     end
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -48,7 +48,7 @@ feature 'IdV session' do
       click_acknowledge_recovery_code
 
       expect(current_url).to eq(profile_url)
-      expect(page).to have_content('Some One')
+      expect(page).to have_content('José One')
       expect(page).to have_content('123 Main St')
       expect(user.reload.active_profile).to be_a(Profile)
     end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -8,7 +8,7 @@ module IdvHelper
   end
 
   def fill_out_idv_form_ok
-    fill_in 'profile_first_name', with: 'Some'
+    fill_in 'profile_first_name', with: 'José'
     fill_in 'profile_last_name', with: 'One'
     fill_in 'profile_ssn', with: '666-66-1234'
     fill_in 'profile_dob', with: '01/02/1980'


### PR DESCRIPTION
**Why**: Vendors cannot handle more than 7-bit ASCII.
We preserve what the user tells us in full UTF-8.