### PR TITLE
Allow OTP codes to be prefilled on PT server

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,4 +1,6 @@
 class FeatureManagement
+  PT_DOMAIN_NAME = 'idp.pt.login.gov'.freeze
+
   def self.telephony_disabled?
     Figaro.env.telephony_disabled == 'true'
   end
@@ -15,7 +17,7 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_production?
-    Figaro.env.domain_name == 'idp.pt.login.gov' && telephony_disabled?
+    Figaro.env.domain_name == PT_DOMAIN_NAME && telephony_disabled?
   end
 
   def self.enable_i18n_mode?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -6,7 +6,16 @@ class FeatureManagement
   def self.prefill_otp_codes?
     # In development, when SMS is disabled we pre-fill the correct codes so that
     # developers can log in without needing to configure SMS delivery.
-    Rails.env.development? && FeatureManagement.telephony_disabled?
+    # We also allow this in production on a single server that is used for load testing.
+    development_and_telephony_disabled? || prefill_otp_codes_allowed_in_production?
+  end
+
+  def self.development_and_telephony_disabled?
+    Rails.env.development? && telephony_disabled?
+  end
+
+  def self.prefill_otp_codes_allowed_in_production?
+    Figaro.env.domain_name == 'idp.pt.login.gov' && telephony_disabled?
   end
 
   def self.enable_i18n_mode?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -18,6 +18,17 @@ describe 'FeatureManagement', type: :feature do
       end
     end
 
+    context 'when the server is idp.pt.login.gov' do
+      before { allow(FeatureManagement).to receive(:telephony_disabled?).and_return(true) }
+
+      it 'returns true in production mode' do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Figaro.env).to receive(:domain_name).and_return('idp.pt.login.gov')
+
+        expect(FeatureManagement.prefill_otp_codes?).to eq(true)
+      end
+    end
+
     context 'when SMS sending is enabled' do
       before { allow(FeatureManagement).to receive(:telephony_disabled?).and_return(false) }
 
@@ -29,6 +40,13 @@ describe 'FeatureManagement', type: :feature do
 
       it 'returns false in non-development mode' do
         allow(Rails.env).to receive(:development?).and_return(false)
+
+        expect(FeatureManagement.prefill_otp_codes?).to eq(false)
+      end
+
+      it 'returns false in production mode when server is pt' do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Figaro.env).to receive(:domain_name).and_return('idp.pt.login.gov')
 
         expect(FeatureManagement.prefill_otp_codes?).to eq(false)
       end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -23,7 +23,7 @@ describe 'FeatureManagement', type: :feature do
 
       it 'returns true in production mode' do
         allow(Rails.env).to receive(:production?).and_return(true)
-        allow(Figaro.env).to receive(:domain_name).and_return('idp.pt.login.gov')
+        allow(Figaro.env).to receive(:domain_name).and_return(FeatureManagement::PT_DOMAIN_NAME)
 
         expect(FeatureManagement.prefill_otp_codes?).to eq(true)
       end
@@ -46,7 +46,7 @@ describe 'FeatureManagement', type: :feature do
 
       it 'returns false in production mode when server is pt' do
         allow(Rails.env).to receive(:production?).and_return(true)
-        allow(Figaro.env).to receive(:domain_name).and_return('idp.pt.login.gov')
+        allow(Figaro.env).to receive(:domain_name).and_return(FeatureManagement::PT_DOMAIN_NAME)
 
         expect(FeatureManagement.prefill_otp_codes?).to eq(false)
       end


### PR DESCRIPTION
**Why**: To make load testing easier.