### PR TITLE
Rename OpenID Connect API urls to be under /api

### DIFF
--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -11,5 +11,9 @@ module OpenidConnect
       render json: @token_form.response,
              status: (result[:success] ? :ok : :bad_request)
     end
+
+    def options
+      render nothing: true
+    end
   end
 end

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -18,10 +18,10 @@ class OpenidConnectConfigurationPresenter
     {
       authorization_endpoint: openid_connect_authorize_url,
       issuer: root_url,
-      jwks_uri: openid_connect_certs_url,
+      jwks_uri: api_openid_connect_certs_url,
       service_documentation: 'https://pages.18f.gov/identity-dev-docs/',
-      token_endpoint: openid_connect_token_url,
-      userinfo_endpoint: openid_connect_userinfo_url,
+      token_endpoint: api_openid_connect_token_url,
+      userinfo_endpoint: api_openid_connect_userinfo_url,
     }
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,14 @@ module Upaya
       allow do
         origins '*'
         resource '/.well-known/openid-configuration', headers: :any, methods: [:get]
+        resource '/api/openid_connect/certs', headers: :any, methods: [:get]
+        resource '/api/openid_connect/token',
+                 credentials: true,
+                 headers: :any,
+                 methods: [:post, :options]
+        resource '/api/openid_connect/userinfo', headers: :any, methods: [:get]
+
+        # legacy URLs
         resource '/openid_connect/certs', headers: :any, methods: [:get]
         resource '/openid_connect/token',
                  credentials: true,

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -21,6 +21,7 @@ en:
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
     token:
       errors:
+        invalid_aud: Invalid audience claim, expected %{url}
         invalid_authentication: Client must authenticate via PKCE or private_key_jwt, missing either code_challenge or client_assertion
         invalid_code: invalid code
         invalid_code_verifier: code_verifier did not match code_challenge

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -21,6 +21,7 @@ es:
         redirect_uri_no_match: NOT TRANSLATED YET
     token:
       errors:
+        invalid_aud: NOT TRANSLATED YET
         invalid_authentication: NOT TRANSLATED YET
         invalid_code: NOT TRANSLATED YET
         invalid_code_verifier: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
   get '/api/health/workers' => 'health/workers#index'
   get '/api/openid_connect/certs' => 'openid_connect/certs#index'
   post '/api/openid_connect/token' => 'openid_connect/token#create'
+  match '/api/openid_connect/token' => 'openid_connect/token#options', via: :options
   get '/api/openid_connect/userinfo' => 'openid_connect/user_info#show'
   get '/api/saml/metadata' => 'saml_idp#metadata'
   match '/api/saml/logout' => 'saml_idp#logout',
@@ -84,6 +85,7 @@ Rails.application.routes.draw do
 
   get '/openid_connect/certs' => 'openid_connect/certs#index', as: :old_openid_connect_certs
   post '/openid_connect/token' => 'openid_connect/token#create', as: :old_openid_connect_token
+  match '/openid_connect/token' => 'openid_connect/token#options', via: :options
   get '/openid_connect/userinfo' => 'openid_connect/user_info#show',
       as: :old_openid_connect_userinfo
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,9 @@ Rails.application.routes.draw do
   get '/.well-known/openid-configuration' => 'openid_connect/configuration#index',
       as: :openid_connect_configuration
   get '/api/health/workers' => 'health/workers#index'
+  get '/api/openid_connect/certs' => 'openid_connect/certs#index'
+  post '/api/openid_connect/token' => 'openid_connect/token#create'
+  get '/api/openid_connect/userinfo' => 'openid_connect/user_info#show'
   get '/api/saml/metadata' => 'saml_idp#metadata'
   match '/api/saml/logout' => 'saml_idp#logout',
         via: [:get, :post, :delete],
@@ -79,11 +82,10 @@ Rails.application.routes.draw do
   delete '/openid_connect/authorize' => 'openid_connect/authorization#destroy',
          as: :openid_connect_deny
 
-  get '/openid_connect/certs' => 'openid_connect/certs#index'
-
-  post '/openid_connect/token' => 'openid_connect/token#create'
-
-  get '/openid_connect/userinfo' => 'openid_connect/user_info#show'
+  get '/openid_connect/certs' => 'openid_connect/certs#index', as: :old_openid_connect_certs
+  post '/openid_connect/token' => 'openid_connect/token#create', as: :old_openid_connect_token
+  get '/openid_connect/userinfo' => 'openid_connect/user_info#show',
+      as: :old_openid_connect_userinfo
 
   get '/otp/send' => 'users/two_factor_authentication#send_code'
   get '/phone_setup' => 'users/two_factor_authentication_setup#index'

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OpenidConnect::TokenController do
       jwt_payload = {
         iss: client_id,
         sub: client_id,
-        aud: openid_connect_token_url,
+        aud: api_openid_connect_token_url,
         jti: SecureRandom.hex,
         exp: 5.minutes.from_now.to_i,
       }

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -77,4 +77,13 @@ RSpec.describe OpenidConnect::TokenController do
       end
     end
   end
+
+  describe '#options' do
+    it 'is empty so it can be used as a pre-flight request' do
+      process :options, 'OPTIONS'
+
+      expect(response).to be_ok
+      expect(response.body).to be_empty
+    end
+  end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -38,7 +38,7 @@ feature 'OpenID Connect' do
       jwt_payload = {
         iss: client_id,
         sub: client_id,
-        aud: openid_connect_token_url,
+        aud: api_openid_connect_token_url,
         jti: SecureRandom.hex,
         exp: 5.minutes.from_now.to_i,
       }
@@ -46,7 +46,7 @@ feature 'OpenID Connect' do
       client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
       client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
-      page.driver.post openid_connect_token_path,
+      page.driver.post api_openid_connect_token_path,
                        grant_type: 'authorization_code',
                        code: code,
                        client_assertion_type: client_assertion_type,
@@ -75,7 +75,7 @@ feature 'OpenID Connect' do
       access_token = token_response[:access_token]
       expect(access_token).to be_present
 
-      page.driver.get openid_connect_userinfo_path,
+      page.driver.get api_openid_connect_userinfo_path,
                       {},
                       'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
 
@@ -148,7 +148,7 @@ feature 'OpenID Connect' do
       code = redirect_params[:code]
       expect(code).to be_present
 
-      page.driver.post openid_connect_token_path,
+      page.driver.post api_openid_connect_token_path,
                        grant_type: 'authorization_code',
                        code: code,
                        code_verifier: code_verifier
@@ -184,7 +184,7 @@ feature 'OpenID Connect' do
   end
 
   def sp_public_key
-    page.driver.get openid_connect_certs_path
+    page.driver.get api_openid_connect_certs_path
 
     expect(page.status_code).to eq(200)
     certs_response = JSON.parse(page.body).with_indifferent_access

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe OpenidConnectConfigurationPresenter do
       aggregate_failures do
         expect(configuration[:issuer]).to eq(root_url)
         expect(configuration[:authorization_endpoint]).to eq(openid_connect_authorize_url)
-        expect(configuration[:token_endpoint]).to eq(openid_connect_token_url)
-        expect(configuration[:userinfo_endpoint]).to eq(openid_connect_userinfo_url)
-        expect(configuration[:jwks_uri]).to eq(openid_connect_certs_url)
+        expect(configuration[:token_endpoint]).to eq(api_openid_connect_token_url)
+        expect(configuration[:userinfo_endpoint]).to eq(api_openid_connect_userinfo_url)
+        expect(configuration[:jwks_uri]).to eq(api_openid_connect_certs_url)
         expect(configuration[:service_documentation]).to eq('https://pages.18f.gov/identity-dev-docs/')
         expect(configuration[:response_types_supported]).to eq(%w(code))
         expect(configuration[:grant_types_supported]).to eq(%w(authorization_code))

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'certs endpoint' do
     it 'sets CORS headers to allow all origins' do
-      get openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      get api_openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
@@ -25,7 +25,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'token endpoint' do
     it 'responds to OPTIONS requests with the right CORS headers' do
-      post openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      post api_openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
         expect(response['Access-Control-Allow-Credentials']).to eq('true')
@@ -36,7 +36,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
     it 'responds to POST requests with the right CORS headers' do
       reset!
-      integration_session.__send__ :process, 'OPTIONS', openid_connect_token_path, nil,
+      integration_session.__send__ :process, 'OPTIONS', api_openid_connect_token_path, nil,
                                    'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
@@ -49,7 +49,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'userinfo endpoint' do
     it 'sets CORS headers to allow all origins' do
-      get openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      get api_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
       get api_openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
+        expect(response).to be_ok
+        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        expect(response['Access-Control-Allow-Methods']).to eq('GET')
+      end
+    end
+
+    it 'sets CORS headers for the legacy endpoint as well' do
+      get old_openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+
+      aggregate_failures do
+        expect(response).to be_ok
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
         expect(response['Access-Control-Allow-Methods']).to eq('GET')
       end
@@ -24,22 +35,48 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   end
 
   describe 'token endpoint' do
-    it 'responds to OPTIONS requests with the right CORS headers' do
+    it 'responds to POST requests with the right CORS headers' do
       post api_openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
+        expect(response).to_not be_not_found
         expect(response['Access-Control-Allow-Credentials']).to eq('true')
         expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
       end
     end
 
-    it 'responds to POST requests with the right CORS headers' do
+    it 'responds to OPTIONS requests with the right CORS headers' do
       reset!
       integration_session.__send__ :process, 'OPTIONS', api_openid_connect_token_path, nil,
                                    'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
+        expect(response).to be_ok
+        expect(response['Access-Control-Allow-Credentials']).to eq('true')
+        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
+        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+      end
+    end
+
+    it 'responds to POST requests with the right CORS headers for the old endpoint as well' do
+      post old_openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+
+      aggregate_failures do
+        expect(response).to_not be_not_found
+        expect(response['Access-Control-Allow-Credentials']).to eq('true')
+        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
+        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+      end
+    end
+
+    it 'responds to OPTIONS requests with the right CORS headers for the old endpoint' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', old_openid_connect_token_path, nil,
+                                   'HTTP_ORIGIN' => 'https://example.com'
+
+      aggregate_failures do
+        expect(response).to be_ok
         expect(response['Access-Control-Allow-Credentials']).to eq('true')
         expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
@@ -52,6 +89,17 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
       get api_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
+        expect(response).to_not be_not_found
+        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        expect(response['Access-Control-Allow-Methods']).to eq('GET')
+      end
+    end
+
+    it 'sets CORS headers to allow all origins' do
+      get old_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+
+      aggregate_failures do
+        expect(response).to_not be_not_found
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
         expect(response['Access-Control-Allow-Methods']).to eq('GET')
       end


### PR DESCRIPTION
**Why**: For consistency with other API urls, like /api/saml

---

This is a proposal in the form of a PR, that we move the canonical API URLs for OpenID connect under the `/api` namespace.

Clients that use auto-discovery will not have to change, and if we merged this, I would follow up with the developers we know about and ask them to migrate their clients. Then, we could consider removing the old URLs completely.