### PR TITLE
Remove legacy OpenID Connect URLs

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -91,7 +91,6 @@ class OpenidConnectTokenForm
                                    algorithm: 'RS256', verify_iat: true,
                                    iss: client_id, verify_iss: true,
                                    sub: client_id, verify_sub: true)
-
     validate_aud_claim(payload)
   rescue JWT::DecodeError => err
     # TODO: i18n these JWT gem error messages
@@ -100,7 +99,7 @@ class OpenidConnectTokenForm
 
   def validate_aud_claim(payload)
     normalized_aud = payload['aud'].to_s.chomp('/')
-    return if [old_openid_connect_token_url, api_openid_connect_token_url].include?(normalized_aud)
+    return if api_openid_connect_token_url == normalized_aud
 
     errors.add(:client_assertion,
                t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url))

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,14 +36,6 @@ module Upaya
                  headers: :any,
                  methods: [:post, :options]
         resource '/api/openid_connect/userinfo', headers: :any, methods: [:get]
-
-        # legacy URLs
-        resource '/openid_connect/certs', headers: :any, methods: [:get]
-        resource '/openid_connect/token',
-                 credentials: true,
-                 headers: :any,
-                 methods: [:post, :options]
-        resource '/openid_connect/userinfo', headers: :any, methods: [:get]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,12 +83,6 @@ Rails.application.routes.draw do
   delete '/openid_connect/authorize' => 'openid_connect/authorization#destroy',
          as: :openid_connect_deny
 
-  get '/openid_connect/certs' => 'openid_connect/certs#index', as: :old_openid_connect_certs
-  post '/openid_connect/token' => 'openid_connect/token#create', as: :old_openid_connect_token
-  match '/openid_connect/token' => 'openid_connect/token#options', via: :options
-  get '/openid_connect/userinfo' => 'openid_connect/user_info#show',
-      as: :old_openid_connect_userinfo
-
   get '/otp/send' => 'users/two_factor_authentication#send_code'
   get '/phone_setup' => 'users/two_factor_authentication_setup#index'
   patch '/phone_setup' => 'users/two_factor_authentication_setup#set'

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -74,14 +74,6 @@ RSpec.describe OpenidConnectTokenForm do
           expect(form.errors).to be_blank
         end
 
-        context 'with the old audience url' do
-          before { jwt_payload[:aud] = 'http://www.example.com/openid_connect/token' }
-
-          it 'is valid' do
-            expect(valid?).to eq(true)
-          end
-        end
-
         context 'with a trailing slash in the audience url' do
           before { jwt_payload[:aud] = 'http://www.example.com/api/openid_connect/token/' }
 
@@ -111,6 +103,17 @@ RSpec.describe OpenidConnectTokenForm do
 
         context 'with a bad audience' do
           before { jwt_payload[:aud] = 'https://foobar.com' }
+
+          it 'is invalid' do
+            expect(valid?).to eq(false)
+            expect(form.errors[:client_assertion]).to include(
+              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url)
+            )
+          end
+        end
+
+        context 'with the old audience' do
+          before { jwt_payload[:aud] = 'http://www.example.com/openid_connect/token' }
 
           it 'is invalid' do
             expect(valid?).to eq(false)

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -22,16 +22,6 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
         expect(response['Access-Control-Allow-Methods']).to eq('GET')
       end
     end
-
-    it 'sets CORS headers for the legacy endpoint as well' do
-      get old_openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
-
-      aggregate_failures do
-        expect(response).to be_ok
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-        expect(response['Access-Control-Allow-Methods']).to eq('GET')
-      end
-    end
   end
 
   describe 'token endpoint' do
@@ -58,45 +48,11 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
       end
     end
-
-    it 'responds to POST requests with the right CORS headers for the old endpoint as well' do
-      post old_openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
-
-      aggregate_failures do
-        expect(response).to_not be_not_found
-        expect(response['Access-Control-Allow-Credentials']).to eq('true')
-        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-      end
-    end
-
-    it 'responds to OPTIONS requests with the right CORS headers for the old endpoint' do
-      reset!
-      integration_session.__send__ :process, 'OPTIONS', old_openid_connect_token_path, nil,
-                                   'HTTP_ORIGIN' => 'https://example.com'
-
-      aggregate_failures do
-        expect(response).to be_ok
-        expect(response['Access-Control-Allow-Credentials']).to eq('true')
-        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-      end
-    end
   end
 
   describe 'userinfo endpoint' do
     it 'sets CORS headers to allow all origins' do
       get api_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
-
-      aggregate_failures do
-        expect(response).to_not be_not_found
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-        expect(response['Access-Control-Allow-Methods']).to eq('GET')
-      end
-    end
-
-    it 'sets CORS headers to allow all origins' do
-      get old_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
 
       aggregate_failures do
         expect(response).to_not be_not_found


### PR DESCRIPTION
**DO NOT MERGE** until after March 6

**Why**: To use the new ones only