### PR TITLE
Use Devise's `stored_location_for` 

### DIFF
--- a/.reek
+++ b/.reek
@@ -34,6 +34,7 @@ NilCheck:
     - in_slo?
     - TotpSetupController#new
     - TotpSetupController#valid_code?
+    - TwoFactorAuthenticatable#apply_secure_headers_override
     - user_not_found?
     - SamlIdpLogoutConcern#name_id
     - User#password_reset_profile

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,8 +57,8 @@ class ApplicationController < ActionController::Base
     @_decorated_user ||= current_user.decorate
   end
 
-  def after_sign_in_path_for(_current_user = nil)
-    session[:user_return_to] || profile_path
+  def after_sign_in_path_for(user)
+    stored_location_for(user) || sp_session[:request_url] || profile_path
   end
 
   def render_401
@@ -109,5 +109,9 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def sp_session
+    session.fetch(:sp, {})
   end
 end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -28,6 +28,7 @@ module SamlIdpAuthConcern
                      return_url: current_sp_metadata[:return_to_sp_url],
                      name: current_sp_metadata[:friendly_name] ||
                            current_sp_metadata[:agency],
+                     request_url: request.original_url,
                      show_start_page: true }
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -20,10 +20,10 @@ module TwoFactorAuthenticatable
   private
 
   def apply_secure_headers_override
-    return unless after_sign_in_path_for.start_with?(openid_connect_authorize_path)
+    return unless stored_url_for_user&.start_with?(openid_connect_authorize_path)
 
     authorize_params = Rack::Utils.parse_nested_query(
-      URI(after_sign_in_path_for).query
+      URI(stored_url_for_user).query
     ).with_indifferent_access
 
     authorize_form = OpenidConnectAuthorizeForm.new(authorize_params)
@@ -34,6 +34,10 @@ module TwoFactorAuthenticatable
       form_action: ["'self'", authorize_form.allowed_form_action].compact,
       preserve_schemes: true
     )
+  end
+
+  def stored_url_for_user
+    session['user_return_to']
   end
 
   def authenticate_user
@@ -171,7 +175,7 @@ module TwoFactorAuthenticatable
     elsif after_otp_action_required?
       after_otp_action_path
     else
-      after_sign_in_path_for
+      after_sign_in_path_for(current_user)
     end
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -56,7 +56,7 @@ class SamlIdpController < ApplicationController
   end
 
   def delete_branded_experience
-    session.delete(:sp) if session[:sp]
-    session.delete(:user_return_to) if session[:user_return_to]
+    session.delete(:sp)
+    session.delete('user_return_to')
   end
 end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -18,7 +18,7 @@ module SignUp
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
         service_provider_attributes
       )
-      redirect_to after_sign_in_path_for
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     private
@@ -33,10 +33,6 @@ module SignUp
 
     def service_provider_attributes
       { loa3: sp_session[:loa3], service_provider_name: sp_session[:friendly_name] }
-    end
-
-    def sp_session
-      session[:sp]
     end
   end
 end

--- a/app/controllers/sign_up/recovery_codes_controller.rb
+++ b/app/controllers/sign_up/recovery_codes_controller.rb
@@ -27,7 +27,7 @@ module SignUp
 
     def confirm_has_not_already_viewed_recovery_code
       return if user_session[:first_time_recovery_code_view].present?
-      redirect_to after_sign_in_path_for
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     def next_step
@@ -36,7 +36,7 @@ module SignUp
       elsif current_user.password_reset_profile.present?
         reactivate_profile_path
       else
-        after_sign_in_path_for
+        after_sign_in_path_for(current_user)
       end
     end
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -37,7 +37,7 @@ module SignUp
 
     def require_no_authentication
       return unless current_user
-      redirect_to after_sign_in_path_for
+      redirect_to after_sign_in_path_for(current_user)
     end
 
     def permitted_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -49,7 +49,7 @@ module Users
 
     def check_user_needs_redirect
       if user_fully_authenticated?
-        redirect_to after_sign_in_path_for
+        redirect_to after_sign_in_path_for(current_user)
       elsif current_user
         sign_out
       end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -280,7 +280,7 @@ describe SamlIdpController do
     context 'service provider is valid' do
       before do
         @user = create(:user, :signed_up)
-        saml_get_auth(saml_settings)
+        @saml_request = saml_get_auth(saml_settings)
       end
 
       it 'stores SP metadata in session' do
@@ -289,6 +289,7 @@ describe SamlIdpController do
           logo: 'generic.svg',
           return_url: 'http://localhost:3000',
           name: 'Your friendly Government Agency',
+          request_url: @saml_request.request.original_url,
           show_start_page: true
         )
       end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -7,7 +7,6 @@ describe SignUp::CompletionsController do
     context 'user signed in, sp info present' do
       before do
         stub_analytics
-        session[:user_return_to] = 'www.example.com'
         allow(@analytics).to receive(:track_event)
       end
 
@@ -61,12 +60,12 @@ describe SignUp::CompletionsController do
   describe '#update' do
     before do
       stub_analytics
-      session[:user_return_to] = 'www.example.com'
       allow(@analytics).to receive(:track_event)
     end
 
     context 'LOA1' do
       it 'tracks analytics' do
+        stub_sign_in
         subject.session[:sp] = { loa3: false, friendly_name: service_provider_name }
 
         patch :update

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -45,11 +45,7 @@ describe Verify::ConfirmationsController do
       stub_idv_session
     end
 
-    context 'original SAML Authn request missing' do
-      before do
-        subject.session[:user_return_to] = nil
-      end
-
+    context 'user used 2FA phone as phone of record' do
       it 'activates profile' do
         get :index
         profile.reload

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -6,9 +6,10 @@ feature 'LOA1 Single Sign On' do
   context 'First time registration' do
     it 'takes user to agency handoff page when sign up flow complete' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      @saml_authn_request = auth_request.create(saml_settings)
-
+      saml_authn_request = auth_request.create(saml_settings)
       user = create(:user, :with_phone)
+
+      visit saml_authn_request
       sign_in_and_require_viewing_recovery_code(user)
 
       click_acknowledge_recovery_code
@@ -49,8 +50,6 @@ feature 'LOA1 Single Sign On' do
         'need_two_factor_authentication' => true,
         first_time_recovery_code_view: true,
       }
-      session[:user_return_to] = @saml_authn_request
-      session[:sp] = { loa3: false, name: 'Your friendly Government Agency' }
     end
 
     visit profile_path

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -234,4 +234,17 @@ feature 'Two Factor Authentication' do
       expect(current_path).to eq root_path
     end
   end
+
+  describe 'signing in and visiting endpoint that requires user to be signed out' do
+    it 'does not result in infinite redirect loop after submitting OTP code' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      user = create(:user, :signed_up)
+      sign_in_user(user)
+
+      visit sign_up_email_path
+      click_submit_default
+
+      expect(current_path).to eq profile_path
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
- To prevent infinite redirect loops. For example, if you sign in
with email and password, then visit an endpoint that redirects to
`after_sign_in_path`, such as `sign_up/enter_email`, Devise will store
that  endpoint in  `session['user_return_to']`. After you enter your
OTP code,  `after_sign_in_path_for` is called, which will redirect to
`session['user_return_to']`, which is `sign_up/enter_email`, which in
turn sends you back to `session['user_return_to']`, ad infinitum.

  If you look at Devise's `stored_location_for(resource_or_scope)`, you
  will see that it uses `session.delete` when `is_navigational_format?`
  is `true`, which is the case in the scenario mentioned above. To
  avoid surprises and bugs like that, we should stick with Devise's
  `stored_location_for` instead of overriding it.

- Now that we are properly deleting the `user_return_to` key, we need
to reintroduce the storage of the original SAML request because in the
LOA3 scenario, when you create an account, `after_sign_in_path_for` is
called after you confirm your OTP, which will delete the SAML request
from `user_return_to` before redirecting the user to IdV. So, in order
to send the user back to the SP after IdV, we need to store the SAML
request elsewhere, like we used to before.

  The difference is that instead of having a separate
  `session[:saml_request_url]` that we have to worry about deleting after
  the user is sent to the SP (to allow them to visit the IdP directly
  after that), I added it as a new key to `session[:sp]` which is already
  being properly deleted in `delete_branded_experience`.

- Another bug uncovered by the proper deletion of `user_return_to` is
that `TwoFactorAuthenticatable#apply_secure_headers_override` was
calling `after_sign_in_path_for`, thereby deleting the stored location
in the scenario where a user was changing one of their factors and had
to go through the current password + 2FA flow.