### PR TITLE
Updates cancel idv link text for loa3 sessions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,6 +71,8 @@ module ApplicationHelper
   def cancel_link_text
     if user_signing_up?
       t('links.cancel_account_creation')
+    elsif user_verifying_identity?
+      t('links.cancel_idv')
     else
       t('links.cancel')
     end

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -19,6 +19,7 @@ en:
     sign_out: Sign out
     cancel: Cancel
     cancel_account_creation: ‹ Cancel account creation
+    cancel_idv: ‹ Cancel account verification
     two_factor_authentication:
       app: authentication app
       voice: phone call

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -19,6 +19,7 @@ es:
     sign_out: Cerrar sesión
     cancel: Cancelar
     cancel_account_creation: NOT TRANSLATED YET
+    cancel_idv: NOT TRANSLATED YET
     two_factor_authentication:
       app: NOT TRANSLATED YET
       voice: NOT TRANSLATED YET


### PR DESCRIPTION
**Why**: To match our latest designs, and consistency is good