### PR TITLE
Recovery code entry screen mirrors confirmation

### DIFF
--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -6,7 +6,7 @@ module TwoFactorAuthentication
     skip_before_action :handle_two_factor_authentication
 
     def create
-      result = RecoveryCodeForm.new(current_user, params[:code]).submit
+      result = RecoveryCodeForm.new(current_user, personal_key).submit
 
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.merge(method: 'recovery code'))
 
@@ -34,7 +34,11 @@ module TwoFactorAuthentication
     end
 
     def pii
-      @_pii ||= password_reset_profile.recover_pii(params[:code])
+      @_pii ||= password_reset_profile.recover_pii(personal_key)
+    end
+
+    def personal_key
+      params[:code][:words].join(' ')
     end
   end
 end

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -7,7 +7,7 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
   label.block.bold#personal-key-label
     = t('simple_form.required.html') + t('forms.two_factor.recovery_code')
 
-  - ENV['recovery_code_length'].to_i.times do |_|
+  - Figaro.env.recovery_code_length.to_i.times do |_|
       .mb2
         = block_text_field_tag 'code[words][]', '', required: true, autocomplete: 'off',
           'aria-labelledby': 'personal-key-label'

--- a/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
+++ b/app/views/two_factor_authentication/recovery_code_verification/show.html.slim
@@ -4,11 +4,15 @@ h1.h3.my0 = t('devise.two_factor_authentication.recovery_code_header_text')
 p.mt-tiny.mb0 = t('devise.two_factor_authentication.recovery_code_prompt')
 
 = form_tag(:login_two_factor_recovery_code, method: :post, role: 'form', class: 'mt3 sm-mt4') do
-  .mb2
-    = label_tag 'code',
-      t('simple_form.required.html') + t('forms.two_factor.recovery_code'),
-      class: 'block bold'
-    = block_text_field_tag :code, '', required: true, autocomplete: 'off'
+  label.block.bold#personal-key-label
+    = t('simple_form.required.html') + t('forms.two_factor.recovery_code')
+
+  - ENV['recovery_code_length'].to_i.times do |_|
+      .mb2
+        = block_text_field_tag 'code[words][]', '', required: true, autocomplete: 'off',
+          'aria-labelledby': 'personal-key-label'
+  end
+
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary mt2'
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe TwoFactorAuthentication::RecoveryCodeVerificationController do
+  let(:code) { { words: ['foo'] } }
   describe '#show' do
     context 'when there is no session (signed out or locked out), and the user reloads the page' do
       it 'redirects to the home page' do
@@ -24,7 +25,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
       end
 
       it 'redirects to the profile' do
-        post :create, code: 'foo'
+        post :create, code: code
 
         expect(response).to redirect_to profile_path
       end
@@ -32,7 +33,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
       it 'calls handle_valid_otp' do
         expect(subject).to receive(:handle_valid_otp).and_call_original
 
-        post :create, code: 'foo'
+        post :create, code: code
       end
 
       it 'tracks the valid authentication event' do
@@ -42,7 +43,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::MULTI_FACTOR_AUTH, analytics_hash)
 
-        post :create, code: 'foo'
+        post :create, code: code
       end
     end
 
@@ -58,11 +59,11 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
       it 'calls handle_invalid_otp' do
         expect(subject).to receive(:handle_invalid_otp).and_call_original
 
-        post :create, code: 'foo'
+        post :create, code: code
       end
 
       it 're-renders the recovery code entry screen' do
-        post :create, code: 'foo'
+        post :create, code: code
 
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_recovery_code')
@@ -80,7 +81,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
           with(Analytics::MULTI_FACTOR_AUTH, properties)
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
-        3.times { post :create, code: 'foo' }
+        3.times { post :create, code: code }
       end
     end
   end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -183,9 +183,16 @@ feature 'Two Factor Authentication' do
       sign_in_before_2fa(user)
 
       code = RecoveryCodeGenerator.new(user).create
+      code_words = code.split(' ')
       click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
-      fill_in 'code', with: code
-      click_button t('forms.buttons.submit.default')
+
+      fields = page.all('input[type="text"]')
+
+      fields.size.times do |index|
+        fields[index].set(code_words[index])
+      end
+
+      click_submit_default
       click_acknowledge_recovery_code
 
       expect(user.reload.recovery_code).to_not eq code

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -292,6 +292,7 @@ feature 'Password Recovery' do
 
     scenario 'resets password, uses recovery code as 2fa', email: true do
       recovery_code = recovery_code_from_pii(user, pii)
+      code_words = recovery_code.split(' ')
 
       trigger_reset_password_and_click_email_link(user.email)
 
@@ -299,7 +300,13 @@ feature 'Password Recovery' do
       click_submit_default
 
       click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
-      fill_in 'code', with: recovery_code
+
+      fields = page.all('input[type="text"]')
+
+      fields.size.times do |index|
+        fields[index].set(code_words[index])
+      end
+
       click_submit_default
 
       expect(current_path).to eq sign_up_recovery_code_path

--- a/spec/support/shared_examples_for_otp_forms.rb
+++ b/spec/support/shared_examples_for_otp_forms.rb
@@ -2,7 +2,7 @@ shared_examples_for 'an otp form' do
   it 'disables autocomplete' do
     render
 
-    expect(rendered).to have_css('input[id=code][autocomplete=off]')
+    expect(rendered).to have_css('input[autocomplete=off]')
   end
 
   describe 'tertiary form actions' do


### PR DESCRIPTION
**Why**: It was confusing to present two different formats for entering
a recovery code to the end user