### PR TITLE
Allow assets to load on static pages

### DIFF
--- a/public/401.html
+++ b/public/401.html
@@ -3,7 +3,7 @@
 <head>
   <title>Unauthorized (401)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="css/static.css">
+  <link rel="stylesheet" href="/css/static.css">
 </head>
 <body>
   <div class="site-wrapper">
@@ -11,7 +11,7 @@
       <div class="cover-container">
         <div class="masthead clearfix">
           <div class="inner">
-            <img width="150" alt="login.gov" class="masthead-brand" src="images/logo-white.svg">
+            <img width="150" alt="login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>
         </div>
         <div class="inner cover">

--- a/public/422.html
+++ b/public/422.html
@@ -3,7 +3,7 @@
 <head>
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="css/static.css">
+  <link rel="stylesheet" href="/css/static.css">
 </head>
 <body>
   <div class="site-wrapper">
@@ -11,7 +11,7 @@
       <div class="cover-container">
         <div class="masthead clearfix">
           <div class="inner">
-            <img width="150" alt="login.gov" class="masthead-brand" src="images/logo-white.svg">
+            <img width="150" alt="login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>
         </div>
         <div class="inner cover">

--- a/public/429.html
+++ b/public/429.html
@@ -11,7 +11,7 @@
       <div class="cover-container">
         <div class="masthead clearfix">
           <div class="inner">
-            <img width="150" alt="login.gov" class="masthead-brand" src="images/logo-white.svg">
+            <img width="150" alt="login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>
         </div>
         <div class="inner cover">

--- a/public/500.html
+++ b/public/500.html
@@ -3,7 +3,7 @@
 <head>
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="css/static.css">
+  <link rel="stylesheet" href="/css/static.css">
 </head>
 <body>
   <div class="site-wrapper">
@@ -11,7 +11,7 @@
       <div class="cover-container">
         <div class="masthead clearfix">
           <div class="inner">
-            <img width="150" alt="login.gov" class="masthead-brand" src="images/logo-white.svg">
+            <img width="150" alt="login.gov" class="masthead-brand" src="/images/logo-white.svg">
           </div>
         </div>
         <div class="inner cover">


### PR DESCRIPTION
**Why**: To appear professional and not having broken images or missing
styles on our static pages.

**How**: Make sure to add a leading forward slash before the location of
CSS and image files so that the files are always fetched from the assets
root, as opposed to the root of the URL in the browser.