### PR TITLE
Remove unnecessary DB calls

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,4 +108,29 @@ class User < ActiveRecord::Base
   def decorate
     UserDecorator.new(self)
   end
+
+  # Devise automatically downcases and strips any attribute defined in
+  # config.case_insensitive_keys and config.strip_whitespace_keys via
+  # before_validation callbacks. Email is included by default, which means that
+  # every time the User model is saved, even if the email wasn't updated, a DB
+  # call will be made to downcase and strip the email.
+
+  # To avoid these unnecessary DB calls, we've set case_insensitive_keys and
+  # strip_whitespace_keys to empty arrays in config/initializers/devise.rb.
+  # In addition, we've overridden the downcase_keys and strip_whitespace
+  # methods below to do nothing.
+  #
+  # Note that we already downcase and strip emails, and only when necessary
+  # (i.e. when the email attribute is being created or updated, and when a user
+  # is entering an email address in a form). This is the proper way to handle
+  # this formatting, as opposed to via a model callback that performs this
+  # action regardless of whether or not it is needed. Search the codebase for
+  # ".downcase.strip" for examples.
+  def downcase_keys
+    # no-op
+  end
+
+  def strip_whitespace
+    # no-op
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,6 +4,7 @@ Devise.setup do |config|
   include Mailable
   require 'devise/orm/active_record'
   config.allow_unconfirmed_access_for = 0.days
+  config.case_insensitive_keys = []
   config.confirm_within = 24.hours
   config.expire_all_remember_me_on_sign_out = true
   config.mailer = 'CustomDeviseMailer'
@@ -16,6 +17,7 @@ Devise.setup do |config|
   config.sign_in_after_reset_password = false
   config.sign_out_via = :delete
   config.skip_session_storage = [:http_auth]
+  config.strip_whitespace_keys = []
   config.stretches = Rails.env.test? ? 1 : 12
   config.timeout_in = Figaro.env.session_timeout_in_minutes.to_i.minutes
 


### PR DESCRIPTION
**Why**: To make the app run faster.

**How**: Devise automatically includes `before_validation` callbacks
that downcase and strip whitespace from attributes defined in the
`config.case_insensitive_keys` and `config.strip_whitespace_keys`
arrays. The `email` attribute is included by default. This means that
every time the User model is saved, even if the email wasn't updated,
a DB call will be made to downcase and strip whitespace from the email.

This is unnecessary and can be avoided by making those config arrays
empty. Note that we already downcase and strip emails, and only when
necessary (i.e. when the email attribute is being created or updated,
and when a user is entering an email address in a form). This is the
proper way to handle this formatting, as opposed to via a model callback
that performs this action regardless of whether or not it is needed.

I noticed these unnecessary DB calls by running the app with
`rack_mini_profiler` set to `on`.