### PR TITLE
Remove unused method

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -76,9 +76,4 @@ class OpenidConnectUserInfoPresenter
   def loa3_session?
     identity.ial == 3
   end
-
-  def session_store
-    config = Rails.application.config
-    config.session_store.new({}, config.session_options)
-  end
 end


### PR DESCRIPTION
**Why**:
The functionality was refactored into Pii::SessionStore
in b936ecf1d2330d8270193f5029bda59b29f1796e

--


I was looking at our test coverage and found this method was not covered by tests, because we are not using it.