### PR TITLE
Improve flash message when page is refreshed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,10 +47,28 @@ class ApplicationController < ActionController::Base
   private
 
   def redirect_on_timeout
-    request_params = request.query_parameters
-    return unless request_params[:timeout]
-    flash[:timeout] = t('notices.session_cleared')
-    redirect_to url_for(request_params.except(:timeout))
+    params = request.query_parameters
+    return unless params[:timeout]
+
+    params[:issuer].present? ? redirect_with_sp : redirect_without_sp
+  end
+
+  def sp_metadata
+    ServiceProvider.from_issuer(request.query_parameters[:issuer]).metadata
+  end
+
+  def redirect_with_sp
+    flash[:timeout] = t(
+      'notices.session_cleared_with_sp',
+      minutes: Figaro.env.session_timeout_in_minutes,
+      sp: sp_metadata[:friendly_name] || sp_metadata[:agency]
+    )
+    redirect_to url_for(request.query_parameters.except(:timeout))
+  end
+
+  def redirect_without_sp
+    flash[:timeout] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+    redirect_to url_for(request.query_parameters.except(:issuer, :timeout))
   end
 
   def decorated_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,11 +57,16 @@ class ApplicationController < ActionController::Base
     ServiceProvider.from_issuer(request.query_parameters[:issuer]).metadata
   end
 
-  def redirect_with_sp
+  def sp_name
+    sp_metadata[:friendly_name] || sp_metadata[:agency]
+  end
+
+  def redirect_with_sp # rubocop:disable Metrics/AbcSize
     flash[:timeout] = t(
       'notices.session_cleared_with_sp',
+      link: view_context.link_to(sp_name, sp_metadata[:return_to_sp_url]),
       minutes: Figaro.env.session_timeout_in_minutes,
-      sp: sp_metadata[:friendly_name] || sp_metadata[:agency]
+      sp: sp_name
     )
     redirect_to url_for(request.query_parameters.except(:timeout))
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::Base # rubocop:disable Metrics/ClassLength
   include BrandedExperience
   include UserSessionContext
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -25,6 +25,7 @@ module SamlIdpAuthConcern
   def add_sp_metadata_to_session
     session[:sp] = { loa3: loa3_requested?,
                      logo: current_sp_metadata[:logo],
+                     issuer: saml_request.service_provider.identifier,
                      return_url: current_sp_metadata[:return_to_sp_url],
                      name: current_sp_metadata[:friendly_name] ||
                            current_sp_metadata[:agency],

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -22,7 +22,7 @@ module SamlIdpAuthConcern
     render nothing: true, status: :unauthorized
   end
 
-  def add_sp_metadata_to_session
+  def add_sp_metadata_to_session # rubocop:disable Metrics/AbcSize
     session[:sp] = { loa3: loa3_requested?,
                      logo: current_sp_metadata[:logo],
                      issuer: saml_request.service_provider.identifier,

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -86,6 +86,7 @@ module OpenidConnect
       current_sp_metadata = @authorize_form.service_provider.metadata
       session[:sp] = { loa3: @authorize_form.loa3_requested?,
                        logo: current_sp_metadata[:logo],
+                       issuer: @authorize_form.client_id,
                        name: current_sp_metadata[:friendly_name] ||
                              current_sp_metadata[:agency],
                        show_start_page: true }

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -20,7 +20,7 @@ module SessionTimeoutWarningHelper
   end
 
   def sp_issuer
-    session[:sp][:issuer] if session[:sp].present?
+    sp_session[:issuer] if sp_session.present?
   end
 
   def auto_session_timeout_js

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -14,8 +14,13 @@ module SessionTimeoutWarningHelper
   def timeout_refresh_url
     URIService.add_params(
       request.original_url,
-      timeout: true
+      timeout: true,
+      issuer: request.query_parameters[:issuer] || sp_issuer
     ).html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def sp_issuer
+    session[:sp][:issuer] if session[:sp].present?
   end
 
   def auto_session_timeout_js

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,7 +1,5 @@
 - title t('titles.visitors.index')
 
-= session.inspect
-
 h1.h3.my0 = decorated_session.new_session_heading
 = simple_form_for(resource,
                   as: resource_name,

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,5 +1,7 @@
 - title t('titles.visitors.index')
 
+= session.inspect
+
 h1.h3.my0 = decorated_session.new_session_heading
 = simple_form_for(resource,
                   as: resource_name,

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -35,7 +35,12 @@ en:
         message_html: >
           For your security, in %{time_left_in_session} we will automatically
           cancel your sign in.
-    session_cleared: We cleared your information for your security.
+    session_cleared: >
+      For your security, we refresh the page and clear out any information you typed into the 
+      form fields if you don't submit the form within %{minutes} minutes. 
+    session_cleared_with_sp: >
+      For your security, your request from %{sp} expires after %{minutes} minutes if you don't
+      submit the form. Then you'll have to start again from %{sp}.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -40,7 +40,7 @@ en:
       form fields if you don't submit the form within %{minutes} minutes. 
     session_cleared_with_sp: >
       For your security, your request from %{sp} expires after %{minutes} minutes if you don't
-      submit the form. Then you'll have to start again from %{sp}.
+      submit the form. Then you'll have to start again from %{link}.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -29,6 +29,7 @@ es:
         sign_out: NOT TRANSLATED YET
         message_html: NOT TRANSLATED YET
     session_cleared: NOT TRANSLATED YET
+    session_cleared_with_sp: NOT TRANSLATED YET
     sign_in_consent:
       link: NOT TRANSLATED YET
       text: NOT TRANSLATED YET

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         expect(session[:sp]).to eq(
           loa3: false,
           logo: 'generic.svg',
+          issuer: 'urn:gov:gsa:openidconnect:test',
           name: 'Example iOS App',
           show_start_page: true
         )

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -287,6 +287,7 @@ describe SamlIdpController do
         expect(session[:sp]).to eq(
           loa3: false,
           logo: 'generic.svg',
+          issuer: 'http://localhost:3000',
           return_url: 'http://localhost:3000',
           name: 'Your friendly Government Agency',
           request_url: @saml_request.request.original_url,

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -115,7 +115,9 @@ feature 'Sign in' do
       visit sign_up_email_path(foo: 'bar')
       fill_in 'Email', with: 'test@example.com'
 
-      expect(page).to have_content(t('notices.session_cleared'))
+      expect(page).to have_content(
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+      )
       expect(page).to have_field('Email', with: '')
       expect(current_url).to match Regexp.escape(sign_up_email_path(foo: 'bar'))
     end
@@ -124,7 +126,9 @@ feature 'Sign in' do
       allow(Devise).to receive(:timeout_in).and_return(60)
 
       visit root_path
-      expect(page).to_not have_content(t('notices.session_cleared'))
+      expect(page).to_not have_content(
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+      )
     end
   end
 
@@ -159,7 +163,9 @@ feature 'Sign in' do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
 
-      expect(page).to have_content(t('notices.session_cleared'))
+      expect(page).to have_content(
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+      )
       expect(find_field('Email').value).to be_blank
       expect(find_field('Password').value).to be_blank
     end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -20,14 +20,14 @@ describe SessionTimeoutWarningHelper do
   end
 
   describe '#timeout_refresh_url' do
-    before { expect(helper).to receive(:request).and_return(double(original_url: original_url, query_parameters: query_parameters)) }
+    before { allow(helper).to receive(:request).and_return(double(original_url: original_url, query_parameters: query_parameters)) }
+    let(:query_parameters) { { issuer: 'ISSUER' } }
 
     context 'with no query in the request url' do
       let(:original_url) { 'http://test.host/foo/bar' }
-      let(:query_parameters) { 'foo' }
 
       it 'adds timeout=true and sp_name params' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true&sp_name=')
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?issuer=ISSUER&timeout=true')
       end
     end
 
@@ -36,16 +36,16 @@ describe SessionTimeoutWarningHelper do
 
       it 'adds timeout=true param' do
         expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?key=value&timeout=true&sp_name='
+          'http://test.host/foo/bar?issuer=ISSUER&key=value&timeout=true'
         )
       end
     end
 
-    context 'with timeout=true and sp_name= in the query params already' do
-      let(:original_url) { 'http://test.host/foo/bar?timeout=true&sp_name=' }
+    context 'with timeout=true and issuer=ISSUER in the query params already' do
+      let(:original_url) { 'http://test.host/foo/bar?timeout=true&issuer=ISSUER' }
 
       it 'is the same' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true&sp_name=')
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?issuer=ISSUER&timeout=true')
       end
     end
   end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -20,13 +20,14 @@ describe SessionTimeoutWarningHelper do
   end
 
   describe '#timeout_refresh_url' do
-    before { expect(helper).to receive(:request).and_return(double(original_url: original_url)) }
+    before { expect(helper).to receive(:request).and_return(double(original_url: original_url, query_parameters: query_parameters)) }
 
     context 'with no query in the request url' do
       let(:original_url) { 'http://test.host/foo/bar' }
+      let(:query_parameters) { 'foo' }
 
-      it 'adds timeout=true params' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true')
+      it 'adds timeout=true and sp_name params' do
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true&sp_name=')
       end
     end
 
@@ -34,15 +35,17 @@ describe SessionTimeoutWarningHelper do
       let(:original_url) { 'http://test.host/foo/bar?key=value' }
 
       it 'adds timeout=true param' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?key=value&timeout=true')
+        expect(helper.timeout_refresh_url).to eq(
+          'http://test.host/foo/bar?key=value&timeout=true&sp_name='
+        )
       end
     end
 
-    context 'with timeout=true in the query params already' do
-      let(:original_url) { 'http://test.host/foo/bar?timeout=true' }
+    context 'with timeout=true and sp_name= in the query params already' do
+      let(:original_url) { 'http://test.host/foo/bar?timeout=true&sp_name=' }
 
       it 'is the same' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true')
+        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?timeout=true&sp_name=')
       end
     end
   end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -20,14 +20,21 @@ describe SessionTimeoutWarningHelper do
   end
 
   describe '#timeout_refresh_url' do
-    before { allow(helper).to receive(:request).and_return(double(original_url: original_url, query_parameters: query_parameters)) }
-    let(:query_parameters) { { issuer: 'ISSUER' } }
+    before do
+      allow(helper).to receive(:request).and_return(
+        double(original_url: original_url, query_parameters: query_parameters)
+      )
+    end
+
+    let(:query_parameters) { { issuer: 'http://localhost:3000' } }
 
     context 'with no query in the request url' do
       let(:original_url) { 'http://test.host/foo/bar' }
 
       it 'adds timeout=true and sp_name params' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?issuer=ISSUER&timeout=true')
+        expect(helper.timeout_refresh_url).to eq(
+          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&timeout=true'
+        )
       end
     end
 
@@ -36,16 +43,18 @@ describe SessionTimeoutWarningHelper do
 
       it 'adds timeout=true param' do
         expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=ISSUER&key=value&timeout=true'
+          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&key=value&timeout=true'
         )
       end
     end
 
-    context 'with timeout=true and issuer=ISSUER in the query params already' do
-      let(:original_url) { 'http://test.host/foo/bar?timeout=true&issuer=ISSUER' }
+    context 'with timeout=true and issuer=http://localhost:3000 in the query params already' do
+      let(:original_url) { 'http://test.host/foo/bar?timeout=true&issuer=http://localhost:3000' }
 
       it 'is the same' do
-        expect(helper.timeout_refresh_url).to eq('http://test.host/foo/bar?issuer=ISSUER&timeout=true')
+        expect(helper.timeout_refresh_url).to eq(
+          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&timeout=true'
+        )
       end
     end
   end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -31,7 +31,7 @@ describe SessionTimeoutWarningHelper do
     context 'with no query in the request url' do
       let(:original_url) { 'http://test.host/foo/bar' }
 
-      it 'adds timeout=true and sp_name params' do
+      it 'adds timeout=true and issuer=http%3A%2F%2Flocalhost%3A3000 params' do
         expect(helper.timeout_refresh_url).to eq(
           'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&timeout=true'
         )
@@ -48,7 +48,8 @@ describe SessionTimeoutWarningHelper do
       end
     end
 
-    context 'with timeout=true and issuer=http://localhost:3000 in the query params already' do
+    context 'with timeout=true and issuer=http%3A%2F%2Flocalhost%3A3000 \
+            in the query params already' do
       let(:original_url) { 'http://test.host/foo/bar?timeout=true&issuer=http://localhost:3000' }
 
       it 'is the same' do


### PR DESCRIPTION
To give users more context on why we refresh the page and clear the form inputs.

**When accessing app directly:**
![screen shot 2017-03-01 at 7 01 14 pm](https://cloud.githubusercontent.com/assets/1178494/23487089/dc6e65de-feb1-11e6-8281-69e209d3a967.png)

**When accessing from service provider:**
![screen shot 2017-03-01 at 7 03 49 pm](https://cloud.githubusercontent.com/assets/1178494/23487091/dec02c8c-feb1-11e6-8b72-0303a22c4d8f.png)
