### PR TITLE
Add specs for ServiceProvider#live?

### DIFF
--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,9 +1,10 @@
 class ServiceProviderUpdater
   PROTECTED_ATTRIBUTES = [
-    :id,
+    :approved,
     :created_at,
-    :updated_at,
+    :id,
     :native,
+    :updated_at,
   ].to_set.freeze
 
   def run

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -94,4 +94,40 @@ describe ServiceProvider do
       end
     end
   end
+
+  describe '#live?' do
+    context 'when the service provider is not approved' do
+      it 'returns false' do
+        sp = create(:service_provider, issuer: 'foo')
+
+        expect(sp.live?).to be false
+      end
+    end
+
+    context 'when the service provider is approved but not active' do
+      it 'returns false' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        sp.update(active: false)
+
+        expect(sp.live?).to be false
+      end
+    end
+
+    context 'when the service provider is active and approved' do
+      it 'returns true' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+
+        expect(sp.live?).to be true
+      end
+    end
+
+    context 'when the service provider is active but not approved' do
+      it 'returns false' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        sp.update(approved: false)
+
+        expect(sp.live?).to be false
+      end
+    end
+  end
 end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -22,6 +22,7 @@ describe ServiceProviderUpdater do
         cert: saml_test_sp_cert,
         active: true,
         native: true,
+        approved: true,
       },
       {
         id: 'small number',
@@ -75,6 +76,7 @@ describe ServiceProviderUpdater do
         expect(sp.updated_at).to_not eq dashboard_service_providers.first[:updated_at]
         expect(sp.created_at).to_not eq dashboard_service_providers.first[:created_at]
         expect(sp.native).to eq false
+        expect(sp.approved).to eq false
       end
 
       it 'updates existing dashboard-provided Service Providers' do
@@ -92,6 +94,7 @@ describe ServiceProviderUpdater do
         expect(sp.updated_at).to_not eq dashboard_service_providers.first[:updated_at]
         expect(sp.created_at).to_not eq dashboard_service_providers.first[:created_at]
         expect(sp.native).to eq false
+        expect(sp.approved).to eq false
       end
 
       it 'removes inactive Service Providers' do


### PR DESCRIPTION
**Why**: To have complete code coverage.