### PR TITLE
Ignore UncommunicativeParameterName in specs

### DIFF
--- a/.reek
+++ b/.reek
@@ -125,6 +125,9 @@ UtilityFunction:
     enabled: false
   TooManyStatements:
     enabled: false
+  UncommunicativeParameterName:
+    exclude:
+      - begin_sign_up_with_sp_and_loa
   UncommunicativeVariableName:
     exclude:
       - complete_idv_questions_fail


### PR DESCRIPTION
**Why**: We don't care about this particular offense.