### PR TITLE
Stop event from firing when printing

### DIFF
--- a/app/assets/javascripts/app/print-recovery-code.js
+++ b/app/assets/javascripts/app/print-recovery-code.js
@@ -1,7 +1,9 @@
 import isMobileUserAgent from './utils/mobile-user-agent';
 
-const openSystemPrintDialog = () =>
+const openSystemPrintDialog = (event) => {
+  event.preventDefault();
   window.print();
+};
 
 const enableRecoveryCodePrintButton = () => {
   const buttonNodes = document.querySelectorAll('[data-print]');

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -3,7 +3,8 @@
   footer,
   .btn,
   .btn-border,
-  .ico {
+  .ico,
+  .accordion {
     display: none;
   }
 }


### PR DESCRIPTION
**Why**: The default behavior of clicking an `a` tag causes the page to
scroll to the top