### PR TITLE
Remove recovery code flash message from profile

### DIFF
--- a/app/controllers/users/recovery_codes_controller.rb
+++ b/app/controllers/users/recovery_codes_controller.rb
@@ -8,7 +8,7 @@ module Users
       @code = create_new_code
       analytics.track_event(Analytics::PROFILE_RECOVERY_CODE_CREATE)
 
-      flash[:success] = t('notices.send_code.recovery_code') if params[:resend].present?
+      flash.now[:success] = t('notices.send_code.recovery_code') if params[:resend].present?
       render '/sign_up/recovery_codes/show'
     end
   end

--- a/spec/controllers/users/recovery_codes_controller_spec.rb
+++ b/spec/controllers/users/recovery_codes_controller_spec.rb
@@ -29,7 +29,7 @@ describe Users::RecoveryCodesController do
         expect(flash[:sucess]).to be_nil
 
         get :show, resend: true
-        expect(flash[:success]).to eq t('notices.send_code.recovery_code')
+        expect(flash.now[:success]).to eq t('notices.send_code.recovery_code')
       end
     end
 


### PR DESCRIPTION
**Why**: This particular message should only be displayed on the personal key page.

**Removes this:**
![image](https://cloud.githubusercontent.com/assets/1178494/23567155/f0fb860e-0022-11e7-9c1f-3357ddb8096e.png)
