### PR TITLE
[Issue #1519] Disables caching 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
 
   prepend_before_action :session_expires_at
   before_action :set_locale
+  before_action :disable_caching
 
   layout 'card'
 
@@ -45,6 +46,11 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   private
+
+  def disable_caching
+    response.headers['Cache-Control'] = 'no-store'
+    response.headers['Pragma'] = 'no-cache'
+  end
 
   def redirect_on_timeout
     params = request.query_parameters

--- a/app/controllers/openid_connect/certs_controller.rb
+++ b/app/controllers/openid_connect/certs_controller.rb
@@ -1,5 +1,7 @@
 module OpenidConnect
   class CertsController < ApplicationController
+    skip_before_action :disable_caching
+
     def index
       expires_in 1.week, public: true
 

--- a/app/controllers/openid_connect/configuration_controller.rb
+++ b/app/controllers/openid_connect/configuration_controller.rb
@@ -1,5 +1,7 @@
 module OpenidConnect
   class ConfigurationController < ApplicationController
+    skip_before_action :disable_caching
+
     def index
       expires_in 1.week, public: true
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   before_action :skip_session_expiration
+  skip_before_action :disable_caching
 
   def page_not_found
     render layout: false, status: 404

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -9,8 +9,6 @@ class SamlIdpController < ApplicationController
 
   skip_before_action :verify_authenticity_token
 
-  before_action :disable_caching
-
   def auth
     link_identity_from_session_data
 
@@ -38,11 +36,6 @@ class SamlIdpController < ApplicationController
   end
 
   private
-
-  def disable_caching
-    expires_now
-    response.headers['Pragma'] = 'no-cache'
-  end
 
   def render_template_for(message, action_url, type)
     domain = SecureHeadersWhitelister.extract_domain(action_url)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,21 @@
 require 'rails_helper'
 
 describe ApplicationController do
+  describe '#disable_caching' do
+    controller do
+      def index
+        render text: 'Hello'
+      end
+    end
+
+    it 'sets headers to disable cache' do
+      get :index
+
+      expect(response.headers['Cache-Control']).to eq 'no-store'
+      expect(response.headers['Pragma']).to eq 'no-cache'
+    end
+  end
+
   describe 'handling InvalidAuthenticityToken exceptions' do
     controller do
       def index

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -24,4 +24,21 @@ describe PagesController do
       expect(response).to render_template(layout: false)
     end
   end
+
+  describe 'content expiry' do
+    controller do
+      def index
+        render text: 'Hello'
+      end
+    end
+
+    it 'does not set headers to disable cache' do
+      routes.draw { get 'foo' => 'pages#page_not_found' }
+
+      get :page_not_found
+
+      expect(response.headers['Cache-Control']).to_not eq 'no-store'
+      expect(response.headers['Pragma']).to_not eq 'no-cache'
+    end
+  end
 end


### PR DESCRIPTION
### Why
Applications should return caching directives instructing
browsers not to store local copies of any sensitive data

### How
Sets headers as requested: no-cache and no-store for all dynamic
site content.