### PR TITLE
Rename My account to Account settings

### DIFF
--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -4,7 +4,7 @@ en:
     footer_lite:
       gsa: U.S. General Services Administration
     nav_auth:
-      my_account: My account
+      my_account: Account settings
       welcome: Welcome
     usa_banner:
       official_site: An official website of the United States government


### PR DESCRIPTION
**Why**: To be consistent with style guide