### PR TITLE
Allow dashboard to set approved status

### DIFF
--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,6 +1,5 @@
 class ServiceProviderUpdater
   PROTECTED_ATTRIBUTES = [
-    :approved,
     :created_at,
     :id,
     :native,

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -76,7 +76,7 @@ describe ServiceProviderUpdater do
         expect(sp.updated_at).to_not eq dashboard_service_providers.first[:updated_at]
         expect(sp.created_at).to_not eq dashboard_service_providers.first[:created_at]
         expect(sp.native).to eq false
-        expect(sp.approved).to eq false
+        expect(sp.approved).to eq true
       end
 
       it 'updates existing dashboard-provided Service Providers' do
@@ -94,7 +94,7 @@ describe ServiceProviderUpdater do
         expect(sp.updated_at).to_not eq dashboard_service_providers.first[:updated_at]
         expect(sp.created_at).to_not eq dashboard_service_providers.first[:created_at]
         expect(sp.native).to eq false
-        expect(sp.approved).to eq false
+        expect(sp.approved).to eq true
       end
 
       it 'removes inactive Service Providers' do


### PR DESCRIPTION
**Why**: I had mistakenly prevented it due to my misunderstanding of how
this works. The dashboard app is correctly only allowing admins to set
this attribute, so it's safe for the IdP to allow it through.