### PR TITLE
USPS confirmations

### DIFF
--- a/app/models/usps_confirmation.rb
+++ b/app/models/usps_confirmation.rb
@@ -1,0 +1,5 @@
+class UspsConfirmation < ActiveRecord::Base
+  def decrypted_entry
+    UspsConfirmationEntry.new_from_encrypted(entry)
+  end
+end

--- a/app/services/usps_confirmation_entry.rb
+++ b/app/services/usps_confirmation_entry.rb
@@ -1,0 +1,40 @@
+UspsConfirmationEntry = Struct.new(
+  :address1,
+  :address2,
+  :city,
+  :code,
+  :first_name,
+  :last_name,
+  :state,
+  :zipcode
+) do
+  def self.user_access_key
+    SessionEncryptor.user_access_key
+  end
+
+  def self.encryptor
+    Pii::PasswordEncryptor.new
+  end
+
+  def self.new_from_hash(hash)
+    attrs = new
+    hash.each { |key, val| attrs[key] = val }
+    attrs
+  end
+
+  def self.new_from_encrypted(encrypted)
+    decrypted = encryptor.decrypt(encrypted, user_access_key)
+    new_from_json(decrypted)
+  end
+
+  def self.new_from_json(pii_json)
+    return new unless pii_json.present?
+    pii = JSON.parse(pii_json, symbolize_names: true)
+    new_from_hash(pii)
+  end
+
+  def encrypted
+    klass = self.class
+    klass.encryptor.encrypt(to_json, klass.user_access_key)
+  end
+end

--- a/db/migrate/20170306214524_add_usps_confirmations.rb
+++ b/db/migrate/20170306214524_add_usps_confirmations.rb
@@ -1,0 +1,9 @@
+class AddUspsConfirmations < ActiveRecord::Migration
+  def change
+    create_table :usps_confirmations, force: :cascade do |t|
+      t.text     :entry, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170222182714) do
+ActiveRecord::Schema.define(version: 20170306214524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,6 +168,12 @@ ActiveRecord::Schema.define(version: 20170222182714) do
   add_index "users", ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", using: :btree
   add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
+
+  create_table "usps_confirmations", force: :cascade do |t|
+    t.text     "entry",      null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   add_foreign_key "events", "users"
 end

--- a/spec/models/usps_confirmation_spec.rb
+++ b/spec/models/usps_confirmation_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe UspsConfirmation do
+  describe '#decrypted_entry' do
+    it 'returns plain entry' do
+      usps_confirmation = subject
+      usps_confirmation.entry = UspsConfirmationEntry.new_from_hash(code: 123).encrypted
+
+      plain_entry = usps_confirmation.decrypted_entry
+
+      expect(plain_entry.code).to eq 123
+    end
+  end
+end

--- a/spec/services/usps_confirmation_entry_spec.rb
+++ b/spec/services/usps_confirmation_entry_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe UspsConfirmationEntry do
+  subject do
+    described_class.new_from_hash(
+      first_name: 'Some',
+      last_name: 'One',
+      code: 123
+    )
+  end
+
+  describe '#encrypted' do
+    it 'encrypts' do
+      encrypted_entry = subject.encrypted
+
+      expect(encrypted_entry).to_not match 'Some'
+    end
+  end
+
+  describe '#new_from_encrypted' do
+    it 'round-trips entry' do
+      encrypted_entry = subject.encrypted
+      plain_entry = described_class.new_from_encrypted(encrypted_entry)
+
+      expect(plain_entry).to eq subject
+    end
+  end
+end


### PR DESCRIPTION
**Why**: USPS confirmation requires separate storage than
Profile since the related PII must be symmetrically encrypted
w/o the user's password.