### PR TITLE
Enable analytics logs during load testing

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -5,5 +5,9 @@ Ahoy.visit_duration = 30.minutes
 
 module Ahoy
   class Store < Ahoy::Stores::LogStore
+    def exclude?
+      return if FeatureManagement.enable_load_testing_mode?
+      super
+    end
   end
 end


### PR DESCRIPTION
**Why**: Ahoy excludes bots by default, and it detects Locust as a bot.
Luckily, Ahoy makes it easy to customize what gets excluded by
overriding the `exclude?` method. In this case, we're telling Ahoy to
allow everything during load testing. Otherwise, use the default
settings.

This allows us to better simulate server load.