### PR TITLE
SAML Authn defaults to LOA1 if not specified

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -30,7 +30,11 @@ module SamlIdpAuthConcern
   end
 
   def requested_authn_context
-    @requested_authn_context ||= saml_request.requested_authn_context
+    @requested_authn_context ||= saml_request.requested_authn_context || default_authn_context
+  end
+
+  def default_authn_context
+    Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
   end
 
   def link_identity_from_session_data

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -210,24 +210,14 @@ describe SamlIdpController do
     end
 
     context 'authn_context is missing' do
-      it 'renders nothing with a 401 error' do
+      it 'defaults to LOA1' do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
         saml_get_auth(missing_authn_context_saml_settings)
 
-        expect(response.status).to eq(401)
-        expect(response.body).to be_empty
-
-        analytics_hash = {
-          authn_context: nil,
-          errors: ['Unauthorized authentication context'],
-          service_provider: 'http://localhost:3000',
-          valid: false,
-        }
-
-        expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
+        expect(response.status).to eq(302)
+        expect(@analytics).to_not have_received(:track_event)
       end
     end
 


### PR DESCRIPTION
**Why**: There is no LOA0 and some SPs are using
off-the-shelf integrations that do not allow for customization.