### PR TITLE
Update env var setting in `travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,5 @@ script:
 services:
   - redis-server
 env:
-  - COVERAGE=true
+  global:
+    - COVERAGE=true


### PR DESCRIPTION
**Why**: Adding additional env vars in the way we had it befofre would trigger a build
for each env var. Figured this out when setting env vars for dashboard!
See: https://docs.travis-ci.com/user/environment-variables/
> When you define multiple variables per line in the env array (matrix variables), one build is triggered per item.