### PR TITLE
Prevent user from bypassing current password

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -4,9 +4,9 @@ module TwoFactorAuthenticatable
   included do
     before_action :authenticate_user
     before_action :handle_two_factor_authentication
+    before_action :require_current_password, if: :current_password_required?
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
-
     before_action :apply_secure_headers_override, only: :show
   end
 
@@ -50,6 +50,14 @@ module TwoFactorAuthenticatable
     sign_out
 
     render 'two_factor_authentication/shared/max_login_attempts_reached'
+  end
+
+  def require_current_password
+    redirect_to user_password_confirm_path
+  end
+
+  def current_password_required?
+    user_session[:current_password_required] == true
   end
 
   def check_already_authenticated

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -26,6 +26,7 @@ class MfaConfirmationController < ApplicationController
       redirect_to user_two_factor_authentication_path(reauthn: true)
     end
     session[:password_attempts] = 0
+    user_session[:current_password_required] = false
   end
 
   def handle_invalid_password

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -22,6 +22,7 @@ class ReauthnRequiredController < ApplicationController
     store_location_for(:user, request.url)
     user_session[:context] = 'reauthentication'
     user_session[:factor_to_change] = factor_from_request_path(request.path)
+    user_session[:current_password_required] = true
     redirect_to user_password_confirm_url
   end
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -6,7 +6,10 @@ describe Users::TwoFactorAuthenticationController do
       expect(subject).to have_actions(
         :before,
         :authenticate_user,
-        :check_already_authenticated
+        [:require_current_password, if: :current_password_required?],
+        :check_already_authenticated,
+        [:reset_attempt_count_if_user_no_longer_locked_out, only: :create],
+        [:apply_secure_headers_override, only: :show]
       )
     end
   end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -179,4 +179,18 @@ feature 'Changing authentication factor' do
   def submit_correct_otp
     click_submit_default
   end
+
+  describe 'attempting to bypass current password entry' do
+    it 'does not allow bypassing this step' do
+      sign_in_and_2fa_user
+      Timecop.travel(Figaro.env.reauthn_window.to_i + 1) do
+        visit manage_password_path
+        expect(current_path).to eq user_password_confirm_path
+
+        visit login_two_factor_path(delivery_method: 'sms')
+
+        expect(current_path).to eq user_password_confirm_path
+      end
+    end
+  end
 end

--- a/spec/support/matchers/have_actions.rb
+++ b/spec/support/matchers/have_actions.rb
@@ -32,6 +32,7 @@ RSpec::Matchers.define :have_actions do |kind, *names|
     actions = callbacks.each_with_object([]) do |f, result|
       result << f.filter unless action_has_only_option?(f) || action_has_except_option?(f)
       result << [f.filter, only: parsed_only_action(f)] if action_has_only_option?(f)
+      result << [f.filter, if: parsed_only_action(f)] if action_has_only_option?(f)
       result << [f.filter, except: parsed_except_action(f)] if action_has_except_option?(f)
     end
 
@@ -98,5 +99,15 @@ class StringOptionParser
 
   def single_action_passed_to_only_or_except_option_in_controller_callback
     @option.split('==')[1].strip.tr("'", '').to_sym
+  end
+end
+
+class SymbolOptionParser
+  def initialize(option)
+    @option = option
+  end
+
+  def parse
+    @option
   end
 end


### PR DESCRIPTION
**Why**: Both current password and 2FA are required before changing
a password. This fixes a security bug.