### PR TITLE
Add verification_pending enum option to Profile

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -83,10 +83,11 @@ module Users
 
     def cache_active_profile
       cacher = Pii::Cacher.new(current_user, user_session)
+      profile = decorated_user.active_or_pending_profile
       begin
-        cacher.save(current_user.user_access_key)
+        cacher.save(current_user.user_access_key, profile)
       rescue Pii::EncryptionError => err
-        current_user.active_profile.deactivate(:encryption_error)
+        profile.deactivate(:encryption_error)
         analytics.track_event(Analytics::PROFILE_ENCRYPTION_INVALID, error: err.message)
       end
     end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -43,6 +43,14 @@ UserDecorator = Struct.new(:user) do
     user.active_identities.find_by(service_provider: service_provider.issuer)
   end
 
+  def pending_profile
+    user.profiles.verification_pending.order(created_at: :desc).first
+  end
+
+  def active_or_pending_profile
+    user.active_profile || pending_profile
+  end
+
   def qrcode(otp_secret_key)
     options = {
       issuer: 'Login.gov',

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -10,6 +10,7 @@ class Profile < ActiveRecord::Base
   enum deactivation_reason: {
     password_reset: 1,
     encryption_error: 2,
+    verification_pending: 3,
   }
 
   attr_reader :recovery_code

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -231,6 +231,19 @@ describe Users::SessionsController, devise: true do
         post :create, user: { email: user.email.upcase, password: user.password }
       end
 
+      it 'caches unverified PII pending confirmation' do
+        user = create(:user, :signed_up)
+        create(
+          :profile,
+          deactivation_reason: :verification_pending,
+          user: user, pii: { ssn: '1234' }
+        )
+
+        post :create, user: { email: user.email.upcase, password: user.password }
+
+        expect(controller.user_session[:decrypted_pii]).to match '1234'
+      end
+
       it 'caches PII in the user session' do
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -63,6 +63,15 @@ describe UserDecorator do
     end
   end
 
+  describe '#pending_profile' do
+    it 'returns Profile awaiting USPS confirmation' do
+      profile = create(:profile, deactivation_reason: :verification_pending)
+      user_decorator = UserDecorator.new(profile.user)
+
+      expect(user_decorator.pending_profile).to eq profile
+    end
+  end
+
   describe '#should_acknowledge_recovery_code?' do
     context 'user has no recovery code' do
       context 'service provider with loa1' do


### PR DESCRIPTION
**Why**: Delayed async verification will be possible with USPS
notification. Treat these as-yet-unverified Profiles like active
profiles at login time, in order to decrypt with user password
for checking the confirmation code.