### PR TITLE
Improve modal accessibility

### DIFF
--- a/app/assets/javascripts/app/components/modal.js
+++ b/app/assets/javascripts/app/components/modal.js
@@ -1,4 +1,5 @@
 import 'classlist.js';
+import focusTrap from 'focus-trap';
 
 const STATES = {
   HIDE: 'hide',
@@ -9,6 +10,7 @@ class Modal {
   constructor(options) {
     this.el = document.querySelector(options.el);
     this.shown = false;
+    this.trap = focusTrap(this.el, { escapeDeactivates: false });
   }
 
   toggle() {
@@ -39,6 +41,7 @@ class Modal {
     this.shown = showing;
     el.classList[showing ? 'remove' : 'add']('display-none');
     document.body.classList[showing ? 'add' : 'remove']('modal-open');
+    this.trap[showing ? 'activate' : 'deactivate']();
   }
 
   _emitEvent(target = null, eventType) {

--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -1,16 +1,18 @@
 import 'classlist.js';
+import Modal from '../app/components/modal';
 
 function verifyModal() {
   const flash = document.querySelector('.alert');
-  const modal = document.getElementById('verification-modal');
-  const close = document.getElementById('js-close-modal');
+  const modalSelector = document.getElementById('verification-modal');
+  const modal = new Modal({ el: '#verification-modal' });
+  const modalDismiss = document.getElementById('js-close-modal');
 
   if (flash) flash.classList.add('display-none');
-  if (modal) modal.classList.remove('display-none');
+  if (modalSelector) modal.show();
 
-  if (close) {
-    close.addEventListener('click', function() {
-      modal.classList.add('display-none');
+  if (modalDismiss) {
+    modalDismiss.addEventListener('click', () => {
+      modal.hide();
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "classlist.js": "^1.1.20150312",
     "field-kit": "^2.1.0",
+    "focus-trap": "^2.3.0",
     "hint.css": "^2.3.2",
     "normalize.css": "^4.2.0",
     "zxcvbn": "^4.3.0"

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -71,6 +71,18 @@ shared_examples_for 'recovery code page' do
         expect(page).not_to have_xpath("//#{invisible_selector}[@id='recovery-code']")
       end
 
+      scenario 'focus is on first input and is trapped in modal' do
+        click_acknowledge_recovery_code
+
+        expect(page.evaluate_script('document.activeElement.name')).to eq 'recovery-0'
+
+        body_element = page.find('body')
+        body_element.send_keys [:shift, :tab]
+        expect(page.evaluate_script('document.activeElement.innerText')).to eq(
+          t('forms.buttons.back')
+        )
+      end
+
       context 'closing the modal', js: true do
         before do
           click_acknowledge_recovery_code

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -100,6 +100,12 @@ shared_examples_for 'recovery code page' do
             "//div[@id='recovery-code-reminder-alert'][@aria-hidden='false']"
           )
         end
+
+        scenario 'focus is returned to continue button' do
+          expect(page.evaluate_script('document.activeElement.value')).to eq(
+            t('forms.buttons.continue')
+          )
+        end
       end
       context 'submitting the confirmation form' do
         scenario 'does not submit when invalid' do


### PR DESCRIPTION
**Why**: Using the tab key, focus could be moved outside of the modal into the background.  This PR traps the focus inside the modal and automatically focuses the first interactive element.

![screen recording 2017-03-09 at 12 18 pm](https://cloud.githubusercontent.com/assets/1178494/23761986/b243ea7e-04c2-11e7-9b26-29411935f210.gif)
