### PR TITLE
Return FormResponse in ResendEmailConfirmationForm

### DIFF
--- a/app/controllers/sign_up/email_resend_controller.rb
+++ b/app/controllers/sign_up/email_resend_controller.rb
@@ -11,9 +11,9 @@ module SignUp
       @resend_email_confirmation_form = ResendEmailConfirmationForm.new(email_from_params)
       result = @resend_email_confirmation_form.submit
 
-      analytics.track_event(Analytics::EMAIL_CONFIRMATION_RESEND, result)
+      analytics.track_event(Analytics::EMAIL_CONFIRMATION_RESEND, result.to_h)
 
-      if result[:success]
+      if result.success?
         handle_valid_email
       else
         render :new

--- a/app/forms/resend_email_confirmation_form.rb
+++ b/app/forms/resend_email_confirmation_form.rb
@@ -9,20 +9,15 @@ class ResendEmailConfirmationForm
   end
 
   def submit
-    @success = valid?
-
-    result
+    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   private
 
   attr_writer :email
-  attr_reader :success
 
-  def result
+  def extra_analytics_attributes
     {
-      success: success,
-      errors: errors.messages.values.flatten,
       user_id: user.uuid,
       confirmed: user.confirmed?,
     }

--- a/spec/controllers/sign_up/email_resend_controller_spec.rb
+++ b/spec/controllers/sign_up/email_resend_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SignUp::EmailResendController do
         stub_analytics
         result = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           confirmed: false,
         }
@@ -41,7 +41,7 @@ RSpec.describe SignUp::EmailResendController do
         stub_analytics
         result = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: 'nonexistent-uuid',
           confirmed: false,
         }
@@ -61,7 +61,7 @@ RSpec.describe SignUp::EmailResendController do
         stub_analytics
         result = {
           success: true,
-          errors: [],
+          errors: {},
           user_id: user.uuid,
           confirmed: true,
         }

--- a/spec/forms/resend_email_confirmation_form_spec.rb
+++ b/spec/forms/resend_email_confirmation_form_spec.rb
@@ -12,13 +12,14 @@ describe ResendEmailConfirmationForm do
         user = build(:user, :signed_up)
         subject = ResendEmailConfirmationForm.new(user.email)
 
-        result = {
-          success: true,
-          errors: [],
+        extra = {
           user_id: user.uuid,
           confirmed: true,
         }
+        result = instance_double(FormResponse)
 
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
         expect(subject.submit).to eq result
         expect(subject.email).to eq user.email
       end
@@ -26,13 +27,14 @@ describe ResendEmailConfirmationForm do
 
     context 'when email is valid and user does not exist' do
       it 'returns hash with properties about the event and the nonexistent user' do
-        result = {
-          success: true,
-          errors: [],
+        extra = {
           user_id: 'nonexistent-uuid',
           confirmed: false,
         }
+        result = instance_double(FormResponse)
 
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
         expect(subject.submit).to eq result
       end
     end
@@ -41,13 +43,15 @@ describe ResendEmailConfirmationForm do
       it 'returns hash with properties about the event and the nonexistent user' do
         subject = ResendEmailConfirmationForm.new('invalid')
 
-        result = {
-          success: false,
-          errors: [t('valid_email.validations.email.invalid')],
+        extra = {
           user_id: 'nonexistent-uuid',
           confirmed: false,
         }
+        errors = { email: [t('valid_email.validations.email.invalid')] }
+        result = instance_double(FormResponse)
 
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
         expect(subject.submit).to eq result
       end
     end


### PR DESCRIPTION
**Why**: For consistency with other Form Objects