### PR TITLE
Have Modal class extends Events class

### DIFF
--- a/app/assets/javascripts/app/components/modal.js
+++ b/app/assets/javascripts/app/components/modal.js
@@ -1,13 +1,16 @@
 import 'classlist.js';
 import focusTrap from 'focus-trap';
+import Events from '../utils/events';
 
 const STATES = {
   HIDE: 'hide',
   SHOW: 'show',
 };
 
-class Modal {
+class Modal extends Events {
   constructor(options) {
+    super();
+
     this.el = document.querySelector(options.el);
     this.shown = false;
     this.trap = focusTrap(this.el, { escapeDeactivates: false });
@@ -23,16 +26,12 @@ class Modal {
 
   show(target) {
     this._setElementVisibility(target, true);
-    this._emitEvent(target, STATES.SHOW);
+    this.emit(STATES.SHOW);
   }
 
   hide(target) {
     this._setElementVisibility(target, false);
-    this._emitEvent(target, STATES.HIDE);
-  }
-
-  on(event, callback) {
-    this.el.addEventListener(event, callback);
+    this.emit(STATES.HIDE);
   }
 
   _setElementVisibility(target = null, showing) {
@@ -42,11 +41,6 @@ class Modal {
     el.classList[showing ? 'remove' : 'add']('display-none');
     document.body.classList[showing ? 'add' : 'remove']('modal-open');
     this.trap[showing ? 'activate' : 'deactivate']();
-  }
-
-  _emitEvent(target = null, eventType) {
-    const emittable = new Event(eventType);
-    (target || this.el).dispatchEvent(emittable);
   }
 }
 


### PR DESCRIPTION
**Why**: Event emitting is a discrete piece of functiontality that
doesn't need to be defined on an unrelated class