### PR TITLE
Address verification mechanism selector page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ Metrics/ClassLength:
   Max: 100
   Exclude:
   - spec/**/*
+  - app/controllers/application_controller.rb
   - app/controllers/users/confirmations_controller.rb
   - app/controllers/devise/two_factor_authentication_controller.rb
 

--- a/app/controllers/verify/address_controller.rb
+++ b/app/controllers/verify/address_controller.rb
@@ -1,0 +1,15 @@
+module Verify
+  class AddressController < ApplicationController
+    include IdvStepConcern
+
+    before_action :confirm_step_needed
+
+    def index; end
+
+    private
+
+    def confirm_step_needed
+      redirect_to verify_review_path if idv_session.address_mechanism_chosen?
+    end
+  end
+end

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -28,7 +28,7 @@ module Verify
 
     def finish_proofing_success
       @recovery_code = recovery_code
-      idv_session.complete_profile
+      idv_session.complete_session
       idv_session.recovery_code = nil
       flash[:allow_confirmations_continue] = true
       flash.now[:success] = t('idv.messages.confirm')

--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -19,7 +19,7 @@ module Verify
       increment_step_attempts
 
       if result[:success]
-        redirect_to verify_phone_url
+        redirect_to verify_address_url
       else
         render_failure
         render_form
@@ -49,7 +49,7 @@ module Verify
     end
 
     def confirm_step_needed
-      redirect_to verify_phone_path if idv_session.financials_confirmation == true
+      redirect_to verify_address_path if idv_session.financials_confirmation == true
     end
 
     def render_form

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -11,7 +11,7 @@ module Verify
     def confirm_idv_steps_complete
       return redirect_to(verify_session_path) unless idv_profile_complete?
       return redirect_to(verify_finance_path) unless idv_finance_complete?
-      return redirect_to(verify_phone_path) unless idv_phone_complete?
+      return redirect_to(verify_address_path) unless idv_address_complete?
     end
 
     def confirm_current_password
@@ -49,8 +49,8 @@ module Verify
       idv_session.financials_confirmation == true
     end
 
-    def idv_phone_complete?
-      idv_session.phone_confirmation == true
+    def idv_address_complete?
+      idv_session.address_mechanism_chosen?
     end
 
     def init_profile
@@ -71,7 +71,8 @@ module Verify
     end
 
     def phone_confirmation_required?
-      idv_params[:phone] != current_user.phone
+      idv_params[:phone] != current_user.phone &&
+        idv_session.address_verification_mechanism == :phone
     end
 
     def valid_password?

--- a/app/controllers/verify/usps_controller.rb
+++ b/app/controllers/verify/usps_controller.rb
@@ -1,0 +1,22 @@
+module Verify
+  class UspsController < ApplicationController
+    include IdvStepConcern
+
+    before_action :confirm_step_needed
+
+    def index
+      @applicant = idv_session.resolution.vendor_resp.normalized_applicant
+    end
+
+    def create
+      idv_session.address_verification_mechanism = :usps
+      redirect_to verify_review_url
+    end
+
+    private
+
+    def confirm_step_needed
+      redirect_to verify_review_path if idv_session.address_mechanism_chosen?
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,7 +18,7 @@ class Profile < ActiveRecord::Base
   def activate
     transaction do
       Profile.where('user_id=?', user_id).update_all(active: false)
-      update!(active: true, activated_at: Time.zone.now)
+      update!(active: true, activated_at: Time.zone.now, deactivation_reason: nil)
     end
   end
 

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -34,6 +34,7 @@ module Idv
 
     def update_idv_session
       idv_session.phone_confirmation = true
+      idv_session.address_verification_mechanism = :phone
       idv_session.params = idv_form.idv_params
       idv_session.applicant.phone = idv_form.phone
     end

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -1,18 +1,19 @@
 module Idv
-  class ProfileFromApplicant
-    attr_reader :profile
+  class ProfileMaker
+    attr_reader :pii_attributes, :profile
 
-    def self.create(applicant:, user:, normalized_applicant:)
-      profile = Profile.new(user: user)
-      plain_pii = pii_from_applicant(applicant, normalized_applicant)
-      profile.encrypt_pii(user.user_access_key, plain_pii)
+    def initialize(applicant:, user:, normalized_applicant:)
+      @profile = Profile.new(user: user, deactivation_reason: :verification_pending)
+      @pii_attributes = pii_from_applicant(applicant, normalized_applicant)
+      profile.encrypt_pii(user.user_access_key, pii_attributes)
       profile.save!
-      profile
     end
+
+    private
 
     # rubocop:disable MethodLength, AbcSize
     # This method is single statement spread across many lines for readability
-    def self.pii_from_applicant(appl, norm_appl)
+    def pii_from_applicant(appl, norm_appl)
       Pii::Attributes.new_from_hash(
         first_name: Pii::Attribute.new(raw: appl.first_name, norm: norm_appl.first_name),
         middle_name: Pii::Attribute.new(raw: appl.middle_name, norm: norm_appl.middle_name),
@@ -24,10 +25,10 @@ module Idv
         zipcode: Pii::Attribute.new(raw: appl.zipcode, norm: norm_appl.zipcode),
         dob: Pii::Attribute.new(raw: appl.dob, norm: norm_appl.dob),
         ssn: Pii::Attribute.new(raw: appl.ssn, norm: norm_appl.ssn),
-        phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone)
+        phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone),
+        otp: SecureRandom.hex(5)
       )
     end
     # rubocop:enable MethodLength, AbcSize
-    private_class_method :pii_from_applicant
   end
 end

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -2,7 +2,7 @@ module Pii
   Attributes = Struct.new(
     :first_name, :middle_name, :last_name,
     :address1, :address2, :city, :state, :zipcode,
-    :ssn, :dob, :phone,
+    :ssn, :dob, :phone, :otp,
     :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
   ) do
     def self.new_from_hash(hash)

--- a/app/services/usps_confirmation_entry.rb
+++ b/app/services/usps_confirmation_entry.rb
@@ -2,9 +2,9 @@ UspsConfirmationEntry = Struct.new(
   :address1,
   :address2,
   :city,
-  :code,
   :first_name,
   :last_name,
+  :otp,
   :state,
   :zipcode
 ) do

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -1,0 +1,30 @@
+class UspsConfirmationMaker
+  def initialize(pii:)
+    @pii = pii
+  end
+
+  def perform
+    entry = UspsConfirmationEntry.new_from_hash(attributes)
+    UspsConfirmation.create!(entry: entry)
+  end
+
+  private
+
+  attr_reader :pii
+
+  # rubocop:disable AbcSize
+  # This method is single statement spread across many lines for readability
+  def attributes
+    {
+      address1: pii[:address1],
+      address2: pii[:address2],
+      city: pii[:city],
+      otp: pii[:otp],
+      first_name: pii[:first_name],
+      last_name: pii[:last_name],
+      state: pii[:state],
+      zipcode: pii[:zipcode],
+    }
+  end
+  # rubocop:enable AbcSize
+end

--- a/app/views/verify/address/index.html.slim
+++ b/app/views/verify/address/index.html.slim
@@ -1,0 +1,5 @@
+p Pick an address verification mechanism
+
+p =link_to 'Phone', verify_phone_path
+
+p =link_to 'USPS', verify_usps_path

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -19,5 +19,5 @@ p = t('idv.messages.phone.same_as_2fa')
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.input :phone, required: true, input_html: { class: 'phone' }
   = f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide'
-= render 'shared/cancel', link: verify_cancel_path
+= render 'shared/cancel', link: verify_address_path
 = render @view_model.modal_partial, view_model: @view_model

--- a/app/views/verify/usps/index.html.slim
+++ b/app/views/verify/usps/index.html.slim
@@ -1,0 +1,21 @@
+.my2.p3.py2.sm-px3.border.border-teal.rounded.rounded-xl.relative
+  = image_tag(asset_url('check-email.svg'), size: '48x48', alt: 'check email',\
+    class: 'absolute top-n24 left-0 right-0 mx-auto')
+  h1.sans-serif.h2
+    = t('idv.titles.verify_mail')
+  p
+    = t('idv.messages.usps.byline')
+  p.h4.bold
+    | #{@applicant.address1}<br>
+    - if @applicant.address2.present?
+      | #{@applicant.address2}<br>
+    | #{@applicant.city}, #{@applicant.state} #{@applicant.zipcode}
+
+  p.my0
+    = t('idv.messages.usps.success')
+
+= button_to t('forms.buttons.continue'), verify_usps_path, method: 'put',
+  class: 'btn btn-primary btn-wide'
+
+.mt2.pt1.border-top
+  = link_to t('idv.buttons.verify_by_phone'), verify_phone_path

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -5,6 +5,7 @@ en:
       continue: Continue identity verification
       cancel: Cancel and return to your profile
       help: Continue to Help Center
+      verify_by_phone: ‹ Verify by phone
     cancel:
       modal_header: Are you sure you want to cancel?
       warning_header: If you cancel now
@@ -143,6 +144,9 @@ en:
         pii: personal information
         success: We found records matching your %{pii_message}
         no_pii: Do not use real personal information (demo purposes only)
+      usps:
+        byline: We are mailing a letter with a comfirmation code to
+        success: It should arrive in 5 to 10 business days.
     modal:
       attempts:
         one: You have <strong>1 attempt remaining.</strong>
@@ -190,3 +194,4 @@ en:
       session:
         phone: What is your phone number?
         review: Encrypt your verified data by entering your password
+      verify_mail: Your letter is on its way

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -5,6 +5,7 @@ es:
       continue: NOT TRANSLATED YET
       cancel: NOT TRANSLATED YET
       help: NOT TRANSLATED YET
+      verify_by_phone: NOT TRANSLATED YET
     cancel:
       modal_header: NOT TRANSLATED YET
       warning_header: NOT TRANSLATED YET
@@ -107,6 +108,9 @@ es:
         pii: NOT TRANSLATED YET
         success: NOT TRANSLATED YET
         no_pii: NOT TRANSLATED YET
+      usps:
+        byline: NOT TRANSLATED YET
+        success: NOT TRANSLATED YET
     modal:
       attempts:
         one: NOT TRANSLATED YET
@@ -147,3 +151,4 @@ es:
       session:
         phone: NOT TRANSLATED YET
         review: NOT TRANSLATED YET
+      verify_mail: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
 
   get '/verify' => 'verify#index'
   get '/verify/activated' => 'verify#activated'
+  get '/verify/address' => 'verify/address#index'
   get '/verify/cancel' => 'verify#cancel'
   get '/verify/confirmations' => 'verify/confirmations#index'
   get '/verify/fail' => 'verify#fail'
@@ -128,6 +129,8 @@ Rails.application.routes.draw do
   put '/verify/session' => 'verify/sessions#create'
   delete '/verify/session' => 'verify/sessions#destroy'
   get '/verify/session/dupe' => 'verify/sessions#dupe'
+  get '/verify/usps' => 'verify/usps#index'
+  put '/verify/usps' => 'verify/usps#create'
 
   root to: 'users/sessions#new'
 

--- a/spec/controllers/verify/address_controller_spec.rb
+++ b/spec/controllers/verify/address_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Verify::AddressController do
+  let(:user) { build(:user) }
+
+  before do
+    stub_verify_steps_one_and_two(user)
+  end
+
+  describe '#index' do
+    it 'redirects if phone mechanism selected' do
+      subject.idv_session.phone_confirmation = true
+
+      get :index
+
+      expect(response).to redirect_to verify_review_path
+    end
+
+    it 'redirects if usps mechanism selected' do
+      subject.idv_session.address_verification_mechanism = :usps
+
+      get :index
+
+      expect(response).to redirect_to verify_review_path
+    end
+
+    it 'renders index if no mechanism selected' do
+      get :index
+
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -10,6 +10,14 @@ describe Verify::ConfirmationsController do
     idv_session.vendor = :mock
     idv_session.applicant = applicant
     idv_session.resolution = resolution
+    user.unlock_user_access_key(password)
+    profile_maker = Idv::ProfileMaker.new(
+      applicant: applicant,
+      user: user,
+      normalized_applicant: normalized_applicant
+    )
+    profile = profile_maker.profile
+    idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id
     idv_session.recovery_code = profile.recovery_code
     allow(subject).to receive(:idv_session).and_return(idv_session)
@@ -17,18 +25,21 @@ describe Verify::ConfirmationsController do
 
   let(:password) { 'sekrit phrase' }
   let(:user) { create(:user, :signed_up, password: password) }
-  let(:applicant) { Proofer::Applicant.new first_name: 'Some', last_name: 'One' }
+  let(:applicant) do
+    Proofer::Applicant.new(
+      first_name: 'Some',
+      last_name: 'One',
+      address1: '123 Any St',
+      address2: 'Ste 456',
+      city: 'Anywhere',
+      state: 'KS',
+      zipcode: '66666'
+    )
+  end
   let(:normalized_applicant) { Proofer::Applicant.new first_name: 'Somebody' }
   let(:agent) { Proofer::Agent.new vendor: :mock }
   let(:resolution) { agent.start applicant }
-  let(:profile) do
-    user.unlock_user_access_key(password)
-    Idv::ProfileFromApplicant.create(
-      applicant: applicant,
-      user: user,
-      normalized_applicant: normalized_applicant
-    )
-  end
+  let(:profile) { subject.idv_session.profile }
 
   describe 'before_actions' do
     it 'includes before_actions from AccountStateChecker' do
@@ -46,6 +57,10 @@ describe Verify::ConfirmationsController do
     end
 
     context 'user used 2FA phone as phone of record' do
+      before do
+        subject.idv_session.phone_confirmation = true
+      end
+
       it 'activates profile' do
         get :index
         profile.reload
@@ -85,6 +100,24 @@ describe Verify::ConfirmationsController do
           with(Analytics::IDV_FINAL, result)
 
         get :index
+      end
+    end
+
+    context 'user picked USPS confirmation' do
+      before do
+        subject.idv_session.address_verification_mechanism = :usps
+      end
+
+      it 'leaves profile deactivated' do
+        expect(UspsConfirmation.count).to eq 0
+
+        get :index
+        profile.reload
+
+        expect(profile).to_not be_active
+        expect(profile.verified_at).to be_nil
+        expect(profile.deactivation_reason).to eq 'verification_pending'
+        expect(UspsConfirmation.count).to eq 1
       end
     end
 

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -20,7 +20,7 @@ describe Verify::FinanceController do
 
       get :new
 
-      expect(response).to redirect_to verify_phone_path
+      expect(response).to redirect_to verify_address_path
     end
 
     it 'redirects to fail when step attempts are exceeded' do
@@ -100,7 +100,7 @@ describe Verify::FinanceController do
         it 'redirects to phone page' do
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '12345678' }
 
-          expect(response).to redirect_to verify_phone_url
+          expect(response).to redirect_to verify_address_url
 
           expected_params = { ccn: '12345678' }
           expect(subject.idv_session.params).to eq expected_params
@@ -128,7 +128,7 @@ describe Verify::FinanceController do
         it 'allows and does not affect attempt counter' do
           put :create, idv_finance_form: { finance_type: :ccn, ccn: '12345678' }
 
-          expect(response).to redirect_to verify_phone_path
+          expect(response).to redirect_to verify_address_path
           expect(subject.current_user.idv_attempts).to eq(max_attempts - 1)
           expect(subject.current_user.idv_attempted_at).to eq two_days_ago
         end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -20,7 +20,7 @@ describe Verify::PhoneController do
     let(:user) { build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now) }
 
     before do
-      stub_subject(user)
+      stub_verify_steps_one_and_two(user)
     end
 
     it 'redirects to review when step is complete' do
@@ -46,7 +46,7 @@ describe Verify::PhoneController do
 
       before do
         user = build(:user, phone: '+1 (415) 555-0130')
-        stub_subject(user)
+        stub_verify_steps_one_and_two(user)
         stub_analytics
         allow(@analytics).to receive(:track_event)
       end
@@ -88,7 +88,7 @@ describe Verify::PhoneController do
 
       it 'tracks event with valid phone' do
         user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
-        stub_subject(user)
+        stub_verify_steps_one_and_two(user)
 
         put :create, idv_phone_form: { phone: good_phone }
 
@@ -101,7 +101,7 @@ describe Verify::PhoneController do
 
       it 'tracks event with invalid phone' do
         user = build(:user, phone: bad_phone, phone_confirmed_at: Time.zone.now)
-        stub_subject(user)
+        stub_verify_steps_one_and_two(user)
 
         put :create, idv_phone_form: { phone: bad_phone }
 
@@ -123,7 +123,7 @@ describe Verify::PhoneController do
       context 'when same as user phone' do
         it 'redirects to review page and sets phone_confirmed_at' do
           user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
-          stub_subject(user)
+          stub_verify_steps_one_and_two(user)
 
           put :create, idv_phone_form: { phone: good_phone }
 
@@ -140,7 +140,7 @@ describe Verify::PhoneController do
       context 'when different from user phone' do
         it 'redirects to review page and does not set phone_confirmed_at' do
           user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
-          stub_subject(user)
+          stub_verify_steps_one_and_two(user)
 
           put :create, idv_phone_form: { phone: good_phone }
 
@@ -158,7 +158,7 @@ describe Verify::PhoneController do
         let(:user) { build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now) }
 
         before do
-          stub_subject(user)
+          stub_verify_steps_one_and_two(user)
           user.idv_attempts = max_attempts - 1
           user.idv_attempted_at = two_days_ago
         end
@@ -172,18 +172,5 @@ describe Verify::PhoneController do
         end
       end
     end
-  end
-
-  def stub_subject(user)
-    user_session = {}
-    stub_sign_in(user)
-    idv_session = Idv::Session.new(user_session, user)
-    idv_session.resolution = Proofer::Resolution.new success: true, session_id: 'some-id'
-    idv_session.applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
-    idv_session.vendor = subject.idv_vendor.pick
-    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
-    allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
-    allow(subject).to receive(:idv_session).and_return(idv_session)
-    allow(subject).to receive(:user_session).and_return(user_session)
   end
 end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -69,15 +69,15 @@ describe Verify::ReviewController do
       allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
     end
 
-    context 'user has missed phone step' do
+    context 'user has missed address step' do
       before do
         idv_session.phone_confirmation = false
       end
 
-      it 'redirects to phone step' do
+      it 'redirects to address step' do
         get :show
 
-        expect(response).to redirect_to verify_phone_path
+        expect(response).to redirect_to verify_address_path
       end
     end
 
@@ -224,6 +224,7 @@ describe Verify::ReviewController do
       before do
         idv_session.params = user_attrs.merge(phone: '213-555-1000')
         idv_session.applicant = idv_session.applicant_from_params
+        idv_session.address_verification_mechanism = :phone
         stub_analytics
         allow(@analytics).to receive(:track_event)
       end

--- a/spec/controllers/verify/usps_controller_spec.rb
+++ b/spec/controllers/verify/usps_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+require 'proofer/vendor/mock'
+
+describe Verify::UspsController do
+  let(:user) { build(:user) }
+
+  describe 'before_actions' do
+    it 'includes authentication before_action' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+        :confirm_idv_session_started
+      )
+    end
+  end
+
+  describe '#index' do
+    before do
+      stub_verify_steps_one_and_two(user)
+    end
+
+    it 'renders confirmation page' do
+      get :index
+
+      expect(response).to be_ok
+    end
+  end
+
+  describe '#create' do
+    before do
+      stub_verify_steps_one_and_two(user)
+    end
+
+    it 'sets session to :usps and redirects' do
+      expect(subject.idv_session.address_verification_mechanism).to be_nil
+
+      put :create
+
+      expect(response).to redirect_to verify_review_path
+      expect(subject.idv_session.address_verification_mechanism).to eq :usps
+    end
+  end
+end

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -49,6 +49,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_out_idv_form_ok
       click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
+      click_idv_address_choose_phone
 
       expect(current_path).to eq verify_phone_path
       expect(page).to be_accessible
@@ -60,6 +61,7 @@ feature 'Accessibility on IDV pages', :js do
       fill_out_idv_form_ok
       click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
+      click_idv_address_choose_phone
       fill_out_phone_form_ok
       click_button t('forms.buttons.continue')
 
@@ -71,10 +73,11 @@ feature 'Accessibility on IDV pages', :js do
       user = sign_in_and_2fa_user
       visit verify_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.continue')
+      click_idv_continue
       fill_out_and_submit_finance_form
+      click_idv_address_choose_phone
       fill_out_phone_form_ok(user.phone)
-      click_button t('forms.buttons.continue')
+      click_idv_continue
       fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
       click_submit_default
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -28,7 +28,7 @@ feature 'IdV session' do
       visit verify_session_path
 
       fill_out_idv_form_ok
-      click_button t('forms.buttons.continue')
+      click_idv_continue
 
       expect(page).to have_content(t('idv.form.ccn'))
       expect(page).to have_content(
@@ -37,9 +37,10 @@ feature 'IdV session' do
       )
 
       fill_out_financial_form_ok
-      click_button t('forms.buttons.continue')
+      click_idv_continue
+      click_idv_address_choose_phone
       fill_out_phone_form_ok(user.phone)
-      click_button t('forms.buttons.continue')
+      click_idv_continue
       fill_in :user_password, with: user_password
       click_button t('forms.buttons.submit.default')
 
@@ -184,6 +185,10 @@ feature 'IdV session' do
       fill_in :idv_finance_form_ccn, with: second_ccn_value
       click_idv_continue
 
+      # address mechanism choice
+      expect(current_path).to eq verify_address_path
+      click_idv_address_choose_phone
+
       # success advances to next step
       expect(current_path).to eq verify_phone_path
 
@@ -249,7 +254,7 @@ feature 'IdV session' do
       visit verify_session_path
 
       fill_out_idv_form_ok
-      click_button t('forms.buttons.continue')
+      click_idv_continue
 
       expect(page).to_not have_css('.js-finance-wrapper', text: t('idv.form.mortgage'))
 
@@ -268,7 +273,7 @@ feature 'IdV session' do
       _user = sign_in_and_2fa_user
       visit verify_session_path
       fill_out_idv_form_ok
-      click_button t('forms.buttons.continue')
+      click_idv_continue
       click_link t('idv.form.use_financial_account')
 
       select t('idv.form.mortgage'), from: 'idv_finance_form_finance_type'
@@ -291,7 +296,7 @@ feature 'IdV session' do
       visit verify_session_path
 
       fill_out_idv_form_ok
-      click_button 'Continue'
+      click_idv_continue
 
       find('#idv_finance_form_ccn').native.send_keys('abcd1234')
 
@@ -305,7 +310,7 @@ feature 'IdV session' do
         @user = sign_in_and_2fa_user
         visit verify_session_path
 
-        allow(SecureRandom).to receive(:hex).with(8).and_return(recovery_code)
+        allow(RandomPhrase).to receive(:to_s).and_return(recovery_code)
         complete_idv_profile_ok(@user)
       end
 
@@ -324,6 +329,21 @@ feature 'IdV session' do
 
         expect(page).to have_content(t('headings.recovery_code'))
       end
+    end
+
+    scenario 'pick USPS address verification' do
+      sign_in_and_2fa_user
+
+      visit verify_session_path
+
+      fill_out_idv_form_ok
+      click_idv_continue
+      fill_out_financial_form_ok
+      click_idv_continue
+      click_idv_address_choose_usps
+      click_idv_continue
+
+      expect(current_path).to eq verify_review_path
     end
   end
 

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -10,6 +10,7 @@ feature 'Verify phone' do
     click_idv_continue
     fill_out_financial_form_ok
     click_idv_continue
+    click_idv_address_choose_phone
 
     max_attempts_less_one.times do
       fill_out_phone_form_fail
@@ -61,9 +62,10 @@ feature 'Verify phone' do
 
   def complete_idv_profile_with_phone(phone)
     fill_out_idv_form_ok
-    click_button t('forms.buttons.continue')
+    click_idv_continue
     fill_out_financial_form_ok
-    click_button t('forms.buttons.continue')
+    click_idv_continue
+    click_idv_address_choose_phone
     fill_out_phone_form_ok(phone)
     click_button t('forms.buttons.continue')
     fill_in :user_password, with: user_password

--- a/spec/features/idv/previous_address_spec.rb
+++ b/spec/features/idv/previous_address_spec.rb
@@ -37,7 +37,7 @@ feature 'IdV with previous address filled in' do
 
     fill_out_financial_form_ok
     click_idv_continue
-
+    click_idv_address_choose_phone
     fill_out_phone_form_ok(user.phone)
     click_idv_continue
 

--- a/spec/models/usps_confirmation_spec.rb
+++ b/spec/models/usps_confirmation_spec.rb
@@ -4,11 +4,11 @@ describe UspsConfirmation do
   describe '#decrypted_entry' do
     it 'returns plain entry' do
       usps_confirmation = subject
-      usps_confirmation.entry = UspsConfirmationEntry.new_from_hash(code: 123).encrypted
+      usps_confirmation.entry = UspsConfirmationEntry.new_from_hash(otp: 123).encrypted
 
       plain_entry = usps_confirmation.decrypted_entry
 
-      expect(plain_entry.code).to eq 123
+      expect(plain_entry.otp).to eq 123
     end
   end
 end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -1,21 +1,30 @@
 require 'rails_helper'
 
-describe Idv::ProfileFromApplicant do
-  describe '#create' do
+describe Idv::ProfileMaker do
+  describe '#new' do
     it 'creates Profile with encrypted PII' do
       applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
       normalized_applicant = Proofer::Applicant.new first_name: 'Somebody', last_name: 'Oneatatime'
       user = create(:user, :signed_up)
       user.unlock_user_access_key(user.password)
-      profile = described_class.create(
+
+      profile_maker = described_class.new(
         applicant: applicant,
         user: user,
         normalized_applicant: normalized_applicant
       )
 
+      profile = profile_maker.profile
+      pii = profile_maker.pii_attributes
+
+      expect(profile).to be_a Profile
       expect(profile.id).to_not be_nil
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match 'Some'
+
+      expect(pii).to be_a Pii::Attributes
+      expect(pii.first_name.raw).to eq 'Some'
+      expect(pii.first_name.norm).to eq 'Somebody'
     end
   end
 end

--- a/spec/services/usps_confirmation_entry_spec.rb
+++ b/spec/services/usps_confirmation_entry_spec.rb
@@ -5,7 +5,7 @@ describe UspsConfirmationEntry do
     described_class.new_from_hash(
       first_name: 'Some',
       last_name: 'One',
-      code: 123
+      otp: 123
     )
   end
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -43,6 +43,25 @@ module ControllerHelper
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
   end
+
+  def stub_verify_steps_one_and_two(user)
+    user_session = {}
+    stub_sign_in(user)
+    idv_session = Idv::Session.new(user_session, user)
+    idv_session.resolution = Proofer::Resolution.new(
+      success: true,
+      session_id: 'some-id',
+      vendor_resp: Proofer::Vendor::MockResponse.new(
+        normalized_applicant: Proofer::Applicant.new(first_name: 'Somebody')
+      )
+    )
+    idv_session.applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
+    idv_session.vendor = subject.idv_vendor.pick
+    allow(subject).to receive(:confirm_idv_session_started).and_return(true)
+    allow(subject).to receive(:confirm_idv_attempts_allowed).and_return(true)
+    allow(subject).to receive(:idv_session).and_return(idv_session)
+    allow(subject).to receive(:user_session).and_return(user_session)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -63,11 +63,20 @@ module IdvHelper
     click_button t('forms.buttons.continue')
   end
 
+  def click_idv_address_choose_phone
+    click_link 'Phone'
+  end
+
+  def click_idv_address_choose_usps
+    click_link 'USPS'
+  end
+
   def complete_idv_profile_ok(user)
     fill_out_idv_form_ok
     click_idv_continue
     fill_out_financial_form_ok
     click_idv_continue
+    click_idv_address_choose_phone
     fill_out_phone_form_ok(user.phone)
     click_idv_continue
     fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD


### PR DESCRIPTION
**Why**: User should be able to select USPS or phone mechanism for verifying receipt of the OTP.