### PR TITLE
Adds verified_account event

### DIFF
--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -36,9 +36,7 @@ module Verify
     end
 
     def create_account_verified_event
-      no_verified_event = current_user.events.account_verified.empty?
-
-      create_user_event(:account_verified) if no_verified_event
+      CreateVerifiedAccountEvent.new(current_user).call
     end
 
     def recovery_code

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -30,8 +30,17 @@ module Verify
       @recovery_code = recovery_code
       idv_session.complete_profile
       idv_session.recovery_code = nil
-      flash[:allow_confirmations_continue] = true
+      create_account_verified_event
       flash.now[:success] = t('idv.messages.confirm')
+      flash[:allow_confirmations_continue] = true
+    end
+
+    def create_account_verified_event
+      no_verified_event = current_user.events.find_by(
+        event_type: Event.event_types['account_verified']
+      ).empty?
+
+      create_user_event(:account_verified) if no_verified_event
     end
 
     def recovery_code

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -36,9 +36,7 @@ module Verify
     end
 
     def create_account_verified_event
-      no_verified_event = current_user.events.find_by(
-        event_type: Event.event_types['account_verified']
-      ).empty?
+      no_verified_event = current_user.events.account_verified.empty?
 
       create_user_event(:account_verified) if no_verified_event
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ActiveRecord::Base
     email_changed: 5,
     authenticator_enabled: 6,
     authenticator_disabled: 7,
+    account_verified: 8,
   }
 
   validates :event_type, presence: true

--- a/app/services/create_verified_account_event.rb
+++ b/app/services/create_verified_account_event.rb
@@ -1,0 +1,20 @@
+class CreateVerifiedAccountEvent
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    create_account_verified_event
+  end
+
+  private
+
+  def create_account_verified_event
+    return if user_account_verified?
+    Event.create(user: @user, event_type: :account_verified)
+  end
+
+  def user_account_verified?
+    @user.events.account_verified.present?
+  end
+end

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -2,6 +2,7 @@
 en:
   event_types:
     account_created: Account created
+    account_verified: Account verified
     authenticated_at: Signed in at %{service_provider}
     authenticator_disabled: Authenticator app disabled
     authenticator_enabled: Authenticator app enabled

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -2,6 +2,7 @@
 es:
   event_types:
     account_created: Cuenta creada
+    account_verified: NOT TRANSLATED YET
     authenticated_at: Se ha iniciado sesión en %{service_provider}
     authenticator_disabled: La aplicación de autenticador está inhabilitada
     authenticator_enabled: Aplicación de autenticador activada

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -91,7 +91,7 @@ describe Verify::ConfirmationsController do
         get :index
         user.reload
 
-        expect(user.events.where(event_type: 8).size).to be 1
+        expect(user.events.account_verified.size).to be 1
       end
     end
 

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -88,10 +88,11 @@ describe Verify::ConfirmationsController do
       end
 
       it 'creates an `account_verified` event once per confirmation' do
-        get :index
-        user.reload
+        event_creator = instance_double(CreateVerifiedAccountEvent)
+        expect(CreateVerifiedAccountEvent).to receive(:new).and_return(event_creator)
+        expect(event_creator).to receive(:call)
 
-        expect(user.events.account_verified.size).to be 1
+        get :index
       end
     end
 

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -86,6 +86,13 @@ describe Verify::ConfirmationsController do
 
         get :index
       end
+
+      it 'creates an `account_verified` event once per confirmation' do
+        get :index
+        user.reload
+
+        expect(user.events.where(event_type: 8).size).to be 1
+      end
     end
 
     context 'user confirmed a new phone' do

--- a/spec/services/create_account_verified_event_spec.rb
+++ b/spec/services/create_account_verified_event_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe CreateVerifiedAccountEvent do
+  let(:password) { 'password' }
+  let(:user) do
+    create(:user, :signed_up, password: password) do |user|
+      user.events.create(event_type: :account_verified)
+    end
+  end
+
+  let(:eventless_user) { create(:user, :signed_up, password: password) }
+
+  context '#call' do
+    it 'adds an `aacount_verified` event if the user does not have one' do
+      expect(eventless_user.events.account_verified.size).to be 0
+      CreateVerifiedAccountEvent.new(eventless_user).call
+      expect(eventless_user.events.account_verified.size).to be 1
+    end
+
+    it 'does not create duplicate events' do
+      CreateVerifiedAccountEvent.new(user).call
+      expect(user.events.account_verified.size).to be 1
+    end
+  end
+end

--- a/spec/services/create_account_verified_event_spec.rb
+++ b/spec/services/create_account_verified_event_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
 
 describe CreateVerifiedAccountEvent do
-  let(:password) { 'password' }
   let(:user) do
-    create(:user, :signed_up, password: password) do |user|
+    create(:user) do |user|
       user.events.create(event_type: :account_verified)
     end
   end
 
-  let(:eventless_user) { create(:user, :signed_up, password: password) }
+  let(:eventless_user) { create(:user) }
 
   context '#call' do
     it 'adds an `aacount_verified` event if the user does not have one' do


### PR DESCRIPTION
**Why**: So users can have a record of when their account was verified

Screenshot:

![screen shot 2017-03-10 at 3 25 27 pm](https://cloud.githubusercontent.com/assets/1421848/23811896/e96a3600-05a5-11e7-8e8f-b6d7ffe70de2.png)

