### PR TITLE
Remove create_branded_experience before_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :decorated_session, :decorated_user, :reauthn?, :user_fully_authenticated?
 
-  before_action :create_branded_experience
   prepend_before_action :session_expires_at
   before_action :set_locale
   before_action :disable_caching
@@ -134,13 +133,5 @@ class ApplicationController < ActionController::Base
 
   def sp_session
     session.fetch(:sp, {})
-  end
-
-  def create_branded_experience
-    return unless session[:sp]
-
-    @sp_logo = current_sp.logo
-    @sp_name = decorated_session.sp_name
-    @sp_return_url = current_sp.return_to_sp_url
   end
 end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,5 +1,5 @@
 class ServiceProviderSessionDecorator
-  attr_reader :sp_name
+  delegate :logo, to: :sp, prefix: true
 
   def initialize(sp:, view_context:)
     @sp = sp
@@ -46,6 +46,10 @@ class ServiceProviderSessionDecorator
       minutes: Figaro.env.session_timeout_in_minutes,
       sp: sp_name
     )
+  end
+
+  def sp_return_url
+    sp.return_to_sp_url
   end
 
   private

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -25,7 +25,9 @@ class SessionDecorator
     I18n.t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
   end
 
-  def sp_name
-    nil
-  end
+  def sp_name; end
+
+  def sp_logo; end
+
+  def sp_return_url; end
 end

--- a/app/views/devise/sessions/_return_to_service_provider.html.slim
+++ b/app/views/devise/sessions/_return_to_service_provider.html.slim
@@ -1,4 +1,4 @@
 .sm-col.py1.sm-p0
-  = link_to t('links.back_to_sp', sp: @sp_name),
-    @sp_return_url,
+  = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
+    decorated_session.sp_return_url,
     class: 'inline-block truncate align-bottom sm-maxw-190p'

--- a/app/views/openid_connect/authorization/index.html.slim
+++ b/app/views/openid_connect/authorization/index.html.slim
@@ -1,10 +1,10 @@
-- if @sp_logo
-  = image_tag(asset_url("sp-logos/#{@sp_logo}"), height: 50,
-    alt: @sp_name, class: 'align-middle')
+- if decorated_session.sp_logo
+  = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
+    alt: decorated_session.sp_name, class: 'align-middle')
 
-h3 = @sp_name
+h3 = decorated_session.sp_name
 
-p = t('openid_connect.authorization.index.allow_prompt', name: @sp_name)
+p = t('openid_connect.authorization.index.allow_prompt', name: decorated_session.sp_name)
 
 ul
   - @authorize_decorator.requested_attributes.each do |attribute|

--- a/app/views/shared/_nav_branded_logo.html.slim
+++ b/app/views/shared/_nav_branded_logo.html.slim
@@ -1,4 +1,4 @@
 .px2.inline-block
   span.absolute.top-0.bottom-0.border-right
-= image_tag(asset_url("sp-logos/#{@sp_logo}"), height: 50,
-  alt: @sp_name, class: 'align-middle')
+= image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
+  alt: decorated_session.sp_name, class: 'align-middle')

--- a/app/views/sign_up/completions/show.html.slim
+++ b/app/views/sign_up/completions/show.html.slim
@@ -6,5 +6,6 @@
                           width: 146, alt: '', class: 'mb1')
     h1.h3.mb3.my0 = t("titles.loa3_verified.#{session[:sp][:loa3]}", app: APP_NAME)
 
-    = button_to t('forms.buttons.continue_to', sp: @sp_name), sign_up_completed_path,
-      class: 'btn btn-wide px2 py1 rounded-lg border border-green bw2'
+    = button_to t('forms.buttons.continue_to', sp: decorated_session.sp_name), \
+                sign_up_completed_path, \
+                class: 'btn btn-wide px2 py1 rounded-lg border border-green bw2'

--- a/app/views/verify/_hardfail4.html.slim
+++ b/app/views/verify/_hardfail4.html.slim
@@ -1,1 +1,1 @@
-p.mb1 = t('idv.messages.hardfail4', sp: @sp_name)
+p.mb1 = t('idv.messages.hardfail4', sp: decorated_session.sp_name)

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -23,7 +23,7 @@ feature 'LOA3 Single Sign On' do
       click_acknowledge_recovery_code
 
       expect(page).to have_content t('titles.loa3_verified.true', app: APP_NAME)
-      click_on I18n.t('forms.buttons.continue_to', sp: @sp_name)
+      click_on I18n.t('forms.buttons.continue_to', sp: 'Test SP')
       expect(current_url).to eq saml_authn_request
 
       user_access_key = user.unlock_user_access_key(Features::SessionHelper::VALID_PASSWORD)

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -47,10 +47,8 @@ describe 'devise/sessions/new.html.slim' do
         return_to_sp_url: 'www.awesomeness.com'
       )
       view_context = ActionController::Base.new.view_context
-      decorated_session = DecoratedSession.new(sp: sp, view_context: view_context).call
-      allow(view).to receive(:decorated_session).and_return(decorated_session)
-      @sp_name = decorated_session.sp_name
-      @sp_return_url = sp.return_to_sp_url
+      @decorated_session = DecoratedSession.new(sp: sp, view_context: view_context).call
+      allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
 
     it 'displays a custom header' do
@@ -65,7 +63,7 @@ describe 'devise/sessions/new.html.slim' do
       render
 
       expect(rendered).to have_link(
-        t('links.back_to_sp', sp: 'Awesome Application!'), href: @sp_return_url
+        t('links.back_to_sp', sp: 'Awesome Application!'), href: @decorated_session.sp_return_url
       )
     end
   end

--- a/spec/views/shared/_nav_branded.html.slim_spec.rb
+++ b/spec/views/shared/_nav_branded.html.slim_spec.rb
@@ -12,8 +12,6 @@ describe 'shared/_nav_branded.html.slim' do
         sp: sp_with_logo, view_context: view_context
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
-      @sp_logo = sp_with_logo.logo
-      @sp_name = decorated_session.sp_name
       render
     end
 

--- a/spec/views/verify/fail.html.slim_spec.rb
+++ b/spec/views/verify/fail.html.slim_spec.rb
@@ -6,9 +6,8 @@ describe 'verify/fail.html.slim' do
   context 'when SP is present' do
     before do
       sp = build_stubbed(:service_provider, friendly_name: 'Awesome Application!')
-      decorated_session = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
-      @sp_name = decorated_session.sp_name
-      allow(view).to receive(:decorated_session).and_return(decorated_session)
+      @decorated_session = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+      allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
 
     it 'displays the hardfail4 partial' do
@@ -16,7 +15,7 @@ describe 'verify/fail.html.slim' do
 
       expect(view).to render_template(partial: 'verify/_hardfail4')
       expect(rendered).to have_content(
-        t('idv.messages.hardfail4', sp: @sp_name)
+        t('idv.messages.hardfail4', sp: @decorated_session.sp_name)
       )
     end
   end


### PR DESCRIPTION
**Why**: It's not needed. The same thing can be achieved with the
existing `decorated_session`.