### PR TITLE
Remove retry verification view

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -2,7 +2,7 @@ class VerifyController < ApplicationController
   include IdvSession
 
   before_action :confirm_two_factor_authenticated
-  before_action :confirm_idv_needed, only: [:cancel, :fail, :retry]
+  before_action :confirm_idv_needed, only: [:cancel, :fail]
 
   def index
     if active_profile?
@@ -10,10 +10,6 @@ class VerifyController < ApplicationController
     else
       analytics.track_event(Analytics::IDV_INTRO_VISIT)
     end
-  end
-
-  def retry
-    flash.now[:error] = I18n.t('idv.errors.fail')
   end
 
   def activated

--- a/app/views/verify/retry.html.slim
+++ b/app/views/verify/retry.html.slim
@@ -1,7 +1,0 @@
-- title t('idv.titles.fail')
-
-h1.h3.my0 = t('idv.titles.fail')
-
-p.mb1 = t('idv.messages.fail')
-
-= link_to t('idv.messages.review_and_continue'), verify_session_path, class: 'btn btn-primary'

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -16,7 +16,6 @@ en:
     errors:
       bad_dob: Your date of birth must be a valid date.
       duplicate_ssn: An account already exists with the information you provided.
-      fail: Sorry, we can’t verify your identity based on the information you submitted.
       finance_number_length: Number must be between %{minimum} and %{maximum} digits.
       hardfail: We were unable to verify your identity at this time.
       incorrect_password: The password you entered is not correct.
@@ -99,10 +98,6 @@ en:
         an account, but with a different email address.
       dupe_ssn2_html: Please %{link} with the email address you originally used.
       dupe_ssn2_link: sign out now and sign back in
-      fail: >
-        Please check that the personal and financial information you provided is
-        accurate. To learn more about the information we need from you and how it’s used
-        to verify your identity, please see our troubleshooting page.
       finance:
         disclaimer: By continuing, you agree to let %{app_name} compare the account
           information you provide with third-party sources in order to verify your
@@ -144,7 +139,6 @@ en:
         financial_info: Where is my financial account information?
         info_verified_html: We found records matching your %{phone_message}
         intro: Your verified information
-      review_and_continue: Review my info and try again
       sessions:
         pii: personal information
         success: We found records matching your %{pii_message}

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -11,7 +11,6 @@ es:
     errors:
       bad_dob: NOT TRANSLATED YET
       duplicate_ssn: NOT TRANSLATED YET
-      fail: NOT TRANSLATED YET
       finance_number_length: NOT TRANSLATED YET
       hardfail: NOT TRANSLATED YET
       incorrect_password: NOT TRANSLATED YET
@@ -78,7 +77,6 @@ es:
       dupe_ssn1: NOT TRANSLATED YET
       dupe_ssn2_html: NOT TRANSLATED YET
       dupe_ssn2_link: NOT TRANSLATED YET
-      fail: NOT TRANSLATED YET
       finance:
         disclaimer: NOT TRANSLATED YET
         hint: NOT TRANSLATED YET
@@ -105,7 +103,6 @@ es:
         financial_info: NOT TRANSLATED YET
         info_verified_html: NOT TRANSLATED YET
         intro: NOT TRANSLATED YET
-      review_and_continue: NOT TRANSLATED YET
       sessions:
         pii: NOT TRANSLATED YET
         success: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,6 @@ Rails.application.routes.draw do
   get '/verify/finance/other' => 'verify/finance_other#new'
   get '/verify/phone' => 'verify/phone#new'
   put '/verify/phone' => 'verify/phone#create'
-  get '/verify/retry' => 'verify#retry'
   get '/verify/review' => 'verify/review#new'
   put '/verify/review' => 'verify/review#create'
   get '/verify/session' => 'verify/sessions#new'

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -123,28 +123,4 @@ describe VerifyController do
       end
     end
   end
-
-  describe '#retry' do
-    context 'user has an active profile' do
-      it 'does not allow direct access and redirects to activated url' do
-        profile = create(:profile, :active, :verified)
-
-        stub_sign_in(profile.user)
-
-        get :retry
-
-        expect(response).to redirect_to verify_activated_url
-      end
-    end
-
-    context 'user does not have an active profile' do
-      it 'allows direct access' do
-        stub_sign_in
-
-        get :retry
-
-        expect(response).to render_template(:retry)
-      end
-    end
-  end
 end


### PR DESCRIPTION
**Why**: This appears to no longer be used, it was replaced by a modal and flash message on the actual form rather than redirecting to this page.