### PR TITLE
Fix CSP form-action for native apps

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -31,7 +31,7 @@ module TwoFactorAuthenticatable
     return unless authorize_form.valid?
 
     override_content_security_policy_directives(
-      form_action: ["'self'", authorize_form.allowed_form_action].compact,
+      form_action: ["'self'", authorize_form.sp_redirect_uri].compact,
       preserve_schemes: true
     )
   end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -49,7 +49,7 @@ module OpenidConnect
 
     def apply_secure_headers_override
       override_content_security_policy_directives(
-        form_action: ["'self'", @authorize_form.allowed_form_action].compact,
+        form_action: ["'self'", @authorize_form.sp_redirect_uri].compact,
         preserve_schemes: true
       )
     end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -55,8 +55,8 @@ class OpenidConnectAuthorizeForm
     ial == 3
   end
 
-  def allowed_form_action
-    sp_redirect_uri if sp_redirect_uri =~ %r{https?://}
+  def sp_redirect_uri
+    service_provider.redirect_uri
   end
 
   def service_provider
@@ -142,10 +142,6 @@ class OpenidConnectAuthorizeForm
       error_description: errors.full_messages.join(' '),
       state: state
     )
-  end
-
-  def sp_redirect_uri
-    service_provider.redirect_uri
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -257,27 +257,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
-  describe '#allowed_form_action' do
-    subject(:allowed_form_action) { form.allowed_form_action }
-
-    context 'with a bad client_id' do
-      let(:client_id) { 'foobar' }
-      it { expect(allowed_form_action).to be_nil }
-    end
-
-    context 'with a client_id with an http redirect_uri' do
-      let(:client_id) { 'urn:gov:gsa:openidconnect:sp:server' }
-      it 'is the domain and port and scheme' do
-        expect(allowed_form_action).to eq('http://localhost:7654/')
-      end
-    end
-
-    context 'with a client_id with a non-http redirect_uri' do
-      let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
-      it { expect(allowed_form_action).to be_nil }
-    end
-  end
-
   describe '#client_id' do
     it 'returns the form client_id' do
       form = OpenidConnectAuthorizeForm.new(client_id: 'foobar')


### PR DESCRIPTION
**Why**:
The old code didn't allow redirecting into native apps because the
URLs didn't start with http, so it didn't allow any other form-action
sources. Now it allows them just like web apps