### PR TITLE
Update specs to not ref `t('devise.failure.unauthenticated')`

### DIFF
--- a/spec/features/saml/idp_initiated_slo_spec.rb
+++ b/spec/features/saml/idp_initiated_slo_spec.rb
@@ -74,7 +74,7 @@ feature 'IDP-initiated logout' do
       expect(logout_user.active_identities).to be_empty
 
       visit profile_path
-      expect(page).to have_content t('devise.failure.unauthenticated')
+      expect(current_path).to eq root_path
     end
 
     it 'references the correct SessionIndexes' do
@@ -86,7 +86,7 @@ feature 'IDP-initiated logout' do
       expect(request_xmldoc.asserted_session_index).to eq(@sp1_asserted_session_index)
       click_button t('forms.buttons.submit.default')
       visit profile_path
-      expect(page).to have_content t('devise.failure.unauthenticated')
+      expect(current_path).to eq root_path
     end
   end
 end

--- a/spec/features/saml/sp_initiated_slo_spec.rb
+++ b/spec/features/saml/sp_initiated_slo_spec.rb
@@ -23,7 +23,7 @@ feature 'SP-initiated logout' do
     it 'signs out the user from IdP' do
       visit profile_path
 
-      expect(page).to have_content t('devise.failure.unauthenticated')
+      expect(current_path).to eq root_path
     end
   end
 
@@ -46,7 +46,7 @@ feature 'SP-initiated logout' do
     it 'signs out the user from IdP' do
       visit profile_path
 
-      expect(page).to have_content t('devise.failure.unauthenticated')
+      expect(current_path).to eq root_path
     end
 
     it 'contains an issuer nodeset' do
@@ -168,8 +168,8 @@ feature 'SP-initiated logout' do
       click_button t('forms.buttons.submit.default') # LogoutResponse for originating SP: sp1
 
       visit profile_path
-      expect(page).to have_content t('devise.failure.unauthenticated')
 
+      expect(current_path).to eq root_path
       expect(user.active_identities.size).to eq(0)
     end
   end
@@ -207,8 +207,8 @@ feature 'SP-initiated logout' do
       click_button t('forms.buttons.submit.default') # LogoutResponse for originating SP: sp2
 
       visit profile_path
-      expect(page).to have_content t('devise.failure.unauthenticated')
 
+      expect(current_path).to eq root_path
       expect(user.active_identities.size).to eq(0)
 
       removed_keys = %w(logout_response logout_response_url)


### PR DESCRIPTION
**Why**: This is an empty string, so will be a false positive for any
view where we expect to see it.