### PR TITLE
Allow users to "manage" recovery code during sp-login

### DIFF
--- a/app/controllers/concerns/user_session_context.rb
+++ b/app/controllers/concerns/user_session_context.rb
@@ -5,7 +5,6 @@ module UserSessionContext
     user_session[:context] || DEFAULT_CONTEXT
   end
 
-  # TODO: Figure out better names for this and the method below
   def initial_authentication_context?
     context == DEFAULT_CONTEXT
   end

--- a/app/controllers/users/recovery_codes_controller.rb
+++ b/app/controllers/users/recovery_codes_controller.rb
@@ -9,7 +9,20 @@ module Users
       analytics.track_event(Analytics::PROFILE_RECOVERY_CODE_CREATE)
 
       flash.now[:success] = t('notices.send_code.recovery_code') if params[:resend].present?
-      render '/sign_up/recovery_codes/show'
+    end
+
+    def update
+      redirect_to next_step
+    end
+
+    private
+
+    def next_step
+      if current_user.password_reset_profile.present?
+        reactivate_profile_path
+      else
+        profile_path
+      end
     end
   end
 end

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -6,13 +6,25 @@ module Verify
     before_action :confirm_idv_vendor_session_started
     before_action :confirm_profile_has_been_created
 
-    def index
+    def show
       track_final_idv_event
 
       finish_proofing_success
     end
 
+    def update
+      redirect_to next_step
+    end
+
     private
+
+    def next_step
+      if session[:sp]
+        sign_up_completed_path
+      else
+        after_sign_in_path_for(current_user)
+      end
+    end
 
     def confirm_profile_has_been_created
       redirect_to profile_path unless idv_session.profile.present?

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -20,7 +20,7 @@ p.mt-tiny.mb0
 = accordion('recovery-code-info', t('users.recovery_code.help_text_header')) do
   = simple_format(t('users.recovery_code.help_text'))
 
-= button_to t('forms.buttons.continue'), sign_up_recovery_code_path,
+= button_to t('forms.buttons.continue'), update_path,
           class: 'btn btn-primary btn-wide mb1 recovery-code-continue',
           'data-toggle': 'modal'
 

--- a/app/views/sign_up/recovery_codes/show.html.slim
+++ b/app/views/sign_up/recovery_codes/show.html.slim
@@ -1,3 +1,3 @@
 - title t('titles.recovery_code')
 
-= render 'shared/personal_key', code: @code
+= render 'shared/personal_key', code: @code, update_path: sign_up_recovery_code_path

--- a/app/views/users/recovery_codes/show.html.slim
+++ b/app/views/users/recovery_codes/show.html.slim
@@ -1,0 +1,3 @@
+- title t('titles.recovery_code')
+
+= render 'shared/personal_key', code: @code, update_path: manage_recovery_code_path

--- a/app/views/verify/confirmations/index.html.slim
+++ b/app/views/verify/confirmations/index.html.slim
@@ -1,3 +1,0 @@
-- title t('idv.titles.complete')
-
-= render 'shared/personal_key', code: @recovery_code

--- a/app/views/verify/confirmations/show.html.slim
+++ b/app/views/verify/confirmations/show.html.slim
@@ -1,0 +1,3 @@
+- title t('idv.titles.complete')
+
+= render 'shared/personal_key', code: @recovery_code, update_path: verify_confirmations_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   get '/manage/phone' => 'users/phones#edit'
   match '/manage/phone' => 'users/phones#update', via: [:patch, :put]
   get '/manage/recovery_code' => 'users/recovery_codes#show', as: :manage_recovery_code
+  post '/manage/recovery_code' => 'users/recovery_codes#update'
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   post '/openid_connect/authorize' => 'openid_connect/authorization#create',
@@ -115,7 +116,8 @@ Rails.application.routes.draw do
   get '/verify' => 'verify#index'
   get '/verify/activated' => 'verify#activated'
   get '/verify/cancel' => 'verify#cancel'
-  get '/verify/confirmations' => 'verify/confirmations#index'
+  get '/verify/confirmations' => 'verify/confirmations#show'
+  post '/verify/confirmations' => 'verify/confirmations#update'
   get '/verify/fail' => 'verify#fail'
   get '/verify/finance' => 'verify/finance#new'
   put '/verify/finance' => 'verify/finance#create'

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -47,7 +47,7 @@ describe Verify::ConfirmationsController do
 
     context 'user used 2FA phone as phone of record' do
       it 'activates profile' do
-        get :index
+        get :show
         profile.reload
 
         expect(profile).to be_active
@@ -57,19 +57,19 @@ describe Verify::ConfirmationsController do
       it 'sets recovery code instance variable' do
         subject.idv_session.cache_applicant_profile_id
         code = subject.idv_session.recovery_code
-        get :index
+        get :show
 
         expect(assigns(:recovery_code)).to eq(code)
       end
 
       it 'sets flash[:allow_confirmations_continue] to true' do
-        get :index
+        get :show
 
         expect(flash[:allow_confirmations_continue]).to eq true
       end
 
       it 'sets flash.now[:success]' do
-        get :index
+        get :show
         expect(flash[:success]).to eq t('idv.messages.confirm')
       end
 
@@ -84,7 +84,7 @@ describe Verify::ConfirmationsController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::IDV_FINAL, result)
 
-        get :index
+        get :show
       end
     end
 
@@ -101,7 +101,7 @@ describe Verify::ConfirmationsController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::IDV_FINAL, result)
 
-        get :index
+        get :show
       end
     end
   end
@@ -110,7 +110,7 @@ describe Verify::ConfirmationsController do
     it 'redirects to /idv/sessions' do
       stub_sign_in(user)
 
-      get :index
+      get :show
 
       expect(response).to redirect_to(verify_session_path)
     end

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -40,6 +40,25 @@ feature 'LOA1 Single Sign On' do
       )
       expect(page).to_not have_css('.accordion-header')
     end
+
+    it 'allows user to view recovery code via profile' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      saml_authn_request = auth_request.create(saml_settings)
+      user = create(:user, :with_phone)
+      code = RecoveryCodeGenerator.new(user).create
+
+      visit saml_authn_request
+      sign_in_and_require_viewing_recovery_code(user)
+      click_on(t('shared.nav_auth.my_account'))
+      click_on(t('profile.links.regenerate_recovery_code'))
+
+      expect(current_path).to eq manage_recovery_code_path
+
+      click_acknowledge_recovery_code
+      enter_recovery_code(code: code)
+
+      expect(current_path).to eq profile_path
+    end
   end
 
   def sign_in_and_require_viewing_recovery_code(user)


### PR DESCRIPTION
**Why**: Before, we were using shared controller logic that assumed any
sp-initiated login would want to finish login after viewing a recovery
code. But if someone goes through the whole process before the recovery
code step and then clicks to view their account details, they should be
able to view their recovery code via their profile without being
redirected to the SP afterward.

See: https://github.com/18F/identity-idp/pull/1097#discussion_r100928413