### PR TITLE
Refactor Idv::ProfileForm

### DIFF
--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -40,8 +40,6 @@ module Idv
     def submit(params)
       initialize_params(params)
       profile.ssn_signature = ssn_signature
-      @success = valid?
-      result
     end
 
     private
@@ -96,13 +94,6 @@ module Idv
       Date.parse(dob.to_s)
     rescue
       nil
-    end
-
-    def result
-      {
-        success: success,
-        errors: errors.messages,
-      }
     end
   end
 end

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -2,6 +2,7 @@ module Idv
   class ProfileStep < Step
     def submit
       initialize_idv_session
+      submit_idv_form
 
       @success = complete?
 
@@ -36,6 +37,10 @@ module Idv
       idv_session.applicant_from_params
     end
 
+    def submit_idv_form
+      idv_form.submit(params)
+    end
+
     def complete?
       !attempts_exceeded? && form_valid? && vendor_validation_passed?
     end
@@ -49,7 +54,7 @@ module Idv
     end
 
     def form_valid?
-      form_validate(params)[:success] == true
+      @_form_valid ||= idv_form.valid?
     end
 
     def vendor_validator_class

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -34,27 +34,20 @@ describe Idv::ProfileForm do
         diff_user = create(:user)
         create(:profile, pii: { ssn: ssn }, user: diff_user)
 
-        result = {
-          success: false,
-          errors: { ssn: [t('idv.errors.duplicate_ssn')] },
-        }
+        subject.submit(profile_attrs.merge(ssn: ssn))
 
-        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
+        expect(subject.valid?).to eq false
         expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
       end
 
       it 'recognizes fingerprint regardless of HMAC key age' do
         diff_user = create(:user)
         create(:profile, pii: { ssn: ssn }, user: diff_user)
-
         rotate_hmac_key
 
-        result = {
-          success: false,
-          errors: { ssn: [t('idv.errors.duplicate_ssn')] },
-        }
+        subject.submit(profile_attrs.merge(ssn: ssn))
 
-        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
+        expect(subject.valid?).to eq false
         expect(subject.errors[:ssn]).to eq [t('idv.errors.duplicate_ssn')]
       end
     end
@@ -63,25 +56,18 @@ describe Idv::ProfileForm do
       it 'is valid' do
         create(:profile, pii: { ssn: ssn }, user: user)
 
-        result = {
-          success: true,
-          errors: {},
-        }
+        subject.submit(profile_attrs.merge(ssn: ssn))
 
-        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
+        expect(subject.valid?).to eq true
       end
 
       it 'recognizes fingerprint regardless of HMAC key age' do
         create(:profile, pii: { ssn: ssn }, user: user)
-
         rotate_hmac_key
 
-        result = {
-          success: true,
-          errors: {},
-        }
+        subject.submit(profile_attrs.merge(ssn: ssn))
 
-        expect(subject.submit(profile_attrs.merge(ssn: ssn))).to eq result
+        expect(subject.valid?).to eq true
       end
     end
   end
@@ -89,26 +75,18 @@ describe Idv::ProfileForm do
   describe 'dob validity' do
     context 'when dob is not parse-able' do
       it 'is invalid' do
-        result = {
-          success: false,
-          errors: { dob: [t('idv.errors.bad_dob')] },
-        }
+        subject.submit(profile_attrs.merge(dob: '00000000'))
 
-        expect(subject.submit(profile_attrs.merge(dob: '00000000'))).to eq result
+        expect(subject.valid?).to eq false
         expect(subject.errors[:dob]).to eq [t('idv.errors.bad_dob')]
       end
     end
 
     context 'when dob is in the future' do
       it 'is invalid' do
-        result = {
-          success: false,
-          errors: { dob: [t('idv.errors.bad_dob')] },
-        }
+        subject.submit(profile_attrs.merge(dob: (Time.zone.today + 1).strftime('%Y-%m-%d')))
 
-        expect(
-          subject.submit(profile_attrs.merge(dob: (Time.zone.today + 1).strftime('%Y-%m-%d')))
-        ).to eq result
+        expect(subject.valid?).to eq false
         expect(subject.errors[:dob]).to eq [t('idv.errors.bad_dob')]
       end
     end
@@ -116,21 +94,16 @@ describe Idv::ProfileForm do
 
   describe 'zipcode validity' do
     it 'accepts 9 numbers with optional `-` delimiting the 5th and 6th position' do
-      result = {
-        success: true,
-        errors: {},
-      }
-
       %w(12345 123454567 12345-1234).each do |valid_zip|
-        expect(
-          subject.submit(profile_attrs.merge(zipcode: valid_zip))
-        ).to eq result
+        subject.submit(profile_attrs.merge(zipcode: valid_zip))
+        expect(subject.valid?).to eq true
       end
     end
 
     it 'populates error for :zipcode when invalid' do
       %w(1234 123Ac-1234 1234B).each do |invalid_zip|
         subject.submit(profile_attrs.merge(zipcode: invalid_zip))
+        expect(subject.valid?).to eq false
         expect(subject.errors[:zipcode]).to eq [I18n.t('idv.errors.pattern_mismatch.zipcode')]
       end
     end
@@ -138,50 +111,18 @@ describe Idv::ProfileForm do
 
   describe 'ssn validity' do
     it 'accepts 9 numbers with optional `-` delimiters' do
-      result = {
-        success: true,
-        errors: {},
-      }
-
       %w(123411111 123-11-1123).each do |valid_ssn|
-        expect(
-          subject.submit(profile_attrs.merge(ssn: valid_ssn))
-        ).to eq result
+        subject.submit(profile_attrs.merge(ssn: valid_ssn))
+        expect(subject.valid?).to eq true
       end
     end
 
     it 'populates errors for :ssn when invalid' do
       %w(1234 123-1-1111 abc-11-1123).each do |invalid_ssn|
         subject.submit(profile_attrs.merge(ssn: invalid_ssn))
+        expect(subject.valid?).to eq false
         expect(subject.errors[:ssn]).to eq [I18n.t('idv.errors.pattern_mismatch.ssn')]
       end
-    end
-  end
-
-  describe '#submit' do
-    it 'returns true on success' do
-      result = {
-        success: true,
-        errors: {},
-      }
-
-      expect(subject.submit(profile_attrs)).to eq result
-    end
-
-    it 'returns false on failure' do
-      result = {
-        success: false,
-        errors: {
-          last_name: [t('errors.messages.missing_field')],
-          dob: [t('idv.errors.bad_dob')],
-          address1: [t('errors.messages.missing_field')],
-          city: [t('errors.messages.missing_field')],
-          state: [t('errors.messages.missing_field')],
-          zipcode: [t('errors.messages.missing_field')],
-        },
-      }
-
-      expect(subject.submit(ssn: ssn, first_name: 'Joe')).to eq result
     end
   end
 end


### PR DESCRIPTION
**Why**: To simplify it because it doesn't need to return a hash
or a FormResponse. The ProfileStep only needs to check the form's
validity by using the built-in `valid?` method.