### PR TITLE
Catch Proofer agent exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: ef0ab14168a3d41491c3c1375b260778357edc34
+  revision: b2ba7fd3eedc933b2e508a3bf3c6b520be6fe3da
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -2,12 +2,14 @@ module Idv
   class FinancialsValidator < VendorValidator
     private
 
-    def result
-      @_result ||= idv_agent.submit_financials(vendor_params, session_id)
-    end
-
     def session_id
       idv_session.resolution.session_id
+    end
+
+    def try_submit
+      try_agent_action do
+        idv_agent.submit_financials(vendor_params, session_id)
+      end
     end
   end
 end

--- a/app/services/idv/phone_validator.rb
+++ b/app/services/idv/phone_validator.rb
@@ -2,12 +2,14 @@ module Idv
   class PhoneValidator < VendorValidator
     private
 
-    def result
-      @_result ||= idv_agent.submit_phone(vendor_params, session_id)
-    end
-
     def session_id
       idv_session.resolution.session_id
+    end
+
+    def try_submit
+      try_agent_action do
+        idv_agent.submit_phone(vendor_params, session_id)
+      end
     end
   end
 end

--- a/app/services/idv/profile_validator.rb
+++ b/app/services/idv/profile_validator.rb
@@ -1,7 +1,15 @@
 module Idv
   class ProfileValidator < VendorValidator
     def result
-      @_result ||= idv_agent.start(vendor_params)
+      @_result ||= try_start
+    end
+
+    private
+
+    def try_start
+      try_agent_action do
+        idv_agent.start(vendor_params)
+      end
     end
   end
 end

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -42,7 +42,10 @@ module Idv
     end
 
     def vendor_validator
-      vendor_validator_class.new(idv_session: idv_session, vendor_params: vendor_params)
+      @_vendor_validator ||= vendor_validator_class.new(
+        idv_session: idv_session,
+        vendor_params: vendor_params
+      )
     end
   end
 end

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -25,5 +25,27 @@ module Idv
         vendor: (idv_session.vendor || idv_vendor.pick)
       )
     end
+
+    def result
+      @_result ||= try_submit
+    end
+
+    def try_agent_action
+      yield
+    rescue => err
+      err_msg = err.to_s
+      NewRelic::Agent.notice_error(err)
+      agent_error_resolution(err_msg)
+    end
+
+    def agent_error_resolution(err_msg)
+      Proofer::Resolution.new(
+        success: false,
+        errors: { agent: [err_msg] },
+        vendor_resp: Proofer::Vendor::MockResponse.new(
+          reasons: [err_msg]
+        )
+      )
+    end
   end
 end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -53,6 +53,21 @@ feature 'IdV session' do
       expect(user.reload.active_profile).to be_a(Profile)
     end
 
+    scenario 'vendor agent throws exception' do
+      first_name_to_trigger_exception = 'Fail'
+
+      sign_in_and_2fa_user
+
+      visit verify_session_path
+
+      fill_out_idv_form_ok
+      fill_in 'profile_first_name', with: first_name_to_trigger_exception
+      click_idv_continue
+
+      expect(current_path).to eq verify_session_path
+      expect(page).to have_css('.modal-warning', text: t('idv.modal.sessions.heading'))
+    end
+
     scenario 'allows 3 attempts in 24 hours' do
       user = sign_in_and_2fa_user
 


### PR DESCRIPTION
**Why**: Proofer agent clients may throw exceptions for any number
of valid reasons. Instead of allowing those exceptions to propagate
up through the app, rescue them and log the exception messages.
This will allow us to surface upstream errors via our log alerting system.