### PR TITLE
Legacy encryption key support for when KMS is on

### DIFF
--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -1,6 +1,10 @@
 class EncryptedKeyMaker
   include Pii::Encodable
 
+  KEY_TYPE = {
+    KMS: 'KMSx',
+  }.freeze
+
   # Creates an encrypted encryption key.
   #
   # @param user_access_key [UserAccessKey]
@@ -34,7 +38,7 @@ class EncryptedKeyMaker
   private
 
   def unlock_key(user_access_key, encryption_key)
-    if FeatureManagement.use_kms?
+    if FeatureManagement.use_kms? && looks_like_kms?(user_access_key, encryption_key)
       unlock_kms(user_access_key, encryption_key)
     else
       unlock_local(user_access_key, encryption_key)
@@ -51,7 +55,7 @@ class EncryptedKeyMaker
       key_id: Figaro.env.aws_kms_key_id,
       plaintext: user_access_key.random_r
     ).ciphertext_blob
-    build_user_access_key(user_access_key, encrypted_key)
+    build_user_access_key(user_access_key, KEY_TYPE[:KMS] + encrypted_key)
   end
 
   def unlock_kms(user_access_key, encryption_key)
@@ -70,6 +74,10 @@ class EncryptedKeyMaker
       raise Pii::EncryptionError, 'invalid base64-encoded ciphertext'
     end
     user_access_key.unlock(encryptor.decrypt(ciphertext, Figaro.env.password_pepper))
+  end
+
+  def looks_like_kms?(user_access_key, encryption_key)
+    user_access_key.xor(decode(encryption_key)).start_with?(KEY_TYPE[:KMS])
   end
 
   def aws_client

--- a/spec/services/encrypted_key_maker_spec.rb
+++ b/spec/services/encrypted_key_maker_spec.rb
@@ -82,6 +82,15 @@ describe EncryptedKeyMaker do
 
         expect(subject.unlock(user_access_key, encryption_key)).to eq hash_E
       end
+
+      it 'recognizes locally-encrypted legacy keys' do
+        allow(FeatureManagement).to receive(:use_kms?).and_return(false)
+        subject.make(user_access_key)
+        encryption_key = user_access_key.encryption_key
+
+        allow(FeatureManagement).to receive(:use_kms?).and_return(true)
+        expect(subject.unlock(user_access_key, encryption_key)).to eq hash_E
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: Environments with existing encrypted accounts will
fail to decrypt properly when KMS is turned on. This change
prefixes the new KMS accounts with 'KMSx' flag so that
they are recognizable beyond respecting the feature flag.