### PR TITLE
Add a11y role to modals

### DIFF
--- a/app/views/shared/_modal_layout.slim
+++ b/app/views/shared/_modal_layout.slim
@@ -1,5 +1,5 @@
 .modal-backdrop
-.px2.py4.modal
+.px2.py4.modal role='dialog'
   .modal-center
     .modal-content
       = yield


### PR DESCRIPTION
**Why**: Without it, it's never announced that the user is entering into a modal, which would likely cause confusion.