### PR TITLE
Refactor sign up email confirmations

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -6,9 +6,9 @@ module SignUp
       with_unconfirmed_user do
         result = EmailConfirmationTokenValidator.new(@user).submit
 
-        analytics.track_event(Analytics::EMAIL_CONFIRMATION, result)
+        analytics.track_event(Analytics::EMAIL_CONFIRMATION, result.to_h)
 
-        if result[:success]
+        if result.success?
           process_successful_confirmation
         else
           process_unsuccessful_confirmation

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -3,6 +3,8 @@ class EmailConfirmationTokenValidator
 
   validate :token_not_expired
 
+  delegate :confirmation_token, to: :user
+
   def initialize(user)
     @user = user
   end
@@ -10,7 +12,7 @@ class EmailConfirmationTokenValidator
   def submit
     @success = valid? && user_valid?
 
-    result
+    FormResponse.new(success: success, errors: form_errors, extra: extra_analytics_attributes)
   end
 
   private
@@ -18,10 +20,12 @@ class EmailConfirmationTokenValidator
   attr_accessor :user
   attr_reader :success
 
-  def result
+  def form_errors
+    errors.messages.merge!(user.errors.messages)
+  end
+
+  def extra_analytics_attributes
     {
-      success: success,
-      error: [errors.full_messages, user.errors.full_messages].join,
       user_id: user.uuid,
       existing_user: user.confirmed?,
     }
@@ -32,6 +36,6 @@ class EmailConfirmationTokenValidator
   end
 
   def token_not_expired
-    errors.add(:confirmation_token, 'has expired') if user.confirmation_period_expired?
+    errors.add(:confirmation_token, :expired) if user.confirmation_period_expired?
   end
 end

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -9,7 +9,7 @@ describe SignUp::EmailConfirmationsController do
     it 'tracks nil email confirmation token' do
       analytics_hash = {
         success: false,
-        error: 'Confirmation token Please fill in this field.',
+        errors: { confirmation_token: [t('errors.messages.blank')] },
         user_id: nil,
         existing_user: false,
       }
@@ -26,7 +26,7 @@ describe SignUp::EmailConfirmationsController do
     it 'tracks blank email confirmation token' do
       analytics_hash = {
         success: false,
-        error: 'Confirmation token Please fill in this field.',
+        errors: { confirmation_token: [t('errors.messages.blank')] },
         user_id: nil,
         existing_user: false,
       }
@@ -43,7 +43,7 @@ describe SignUp::EmailConfirmationsController do
     it 'tracks confirmation token as a single-quoted empty string' do
       analytics_hash = {
         success: false,
-        error: 'Confirmation token is invalid',
+        errors: { confirmation_token: [t('errors.messages.invalid')] },
         user_id: nil,
         existing_user: false,
       }
@@ -60,7 +60,7 @@ describe SignUp::EmailConfirmationsController do
     it 'tracks confirmation token as a double-quoted empty string' do
       analytics_hash = {
         success: false,
-        error: 'Confirmation token is invalid',
+        errors: { confirmation_token: [t('errors.messages.invalid')] },
         user_id: nil,
         existing_user: false,
       }
@@ -79,7 +79,7 @@ describe SignUp::EmailConfirmationsController do
 
       analytics_hash = {
         success: false,
-        error: 'Email was already confirmed, please try signing in',
+        errors: { email: [t('errors.messages.already_confirmed')] },
         user_id: user.uuid,
         existing_user: true,
       }
@@ -99,7 +99,7 @@ describe SignUp::EmailConfirmationsController do
 
       analytics_hash = {
         success: false,
-        error: 'Confirmation token has expired',
+        errors: { confirmation_token: [t('errors.messages.expired')] },
         user_id: user.uuid,
         existing_user: false,
       }
@@ -123,7 +123,7 @@ describe SignUp::EmailConfirmationsController do
 
       analytics_hash = {
         success: true,
-        error: '',
+        errors: {},
         user_id: user.uuid,
         existing_user: false,
       }
@@ -149,7 +149,7 @@ describe SignUp::EmailConfirmationsController do
 
       analytics_hash = {
         success: true,
-        error: '',
+        errors: {},
         user_id: user.uuid,
         existing_user: true,
       }

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe EmailConfirmationTokenValidator do
+  describe '#submit' do
+    context 'confirmation token is invalid' do
+      it 'returns FormResponse with success: false' do
+        user = build_stubbed(:user, :unconfirmed)
+        user.errors.add(:confirmation_token, t('errors.messages.invalid'))
+
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
+
+        errors = { confirmation_token: [t('errors.messages.invalid')] }
+        extra = {
+          user_id: user.uuid,
+          existing_user: false,
+        }
+
+        validator = EmailConfirmationTokenValidator.new(user).submit
+
+        expect(validator).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'confirmation token has expired' do
+      it 'returns FormResponse with success: false' do
+        user = build_stubbed(:user, :unconfirmed)
+        allow(user).to receive(:confirmation_period_expired?).and_return(true)
+
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
+
+        errors = { confirmation_token: [t('errors.messages.expired')] }
+        extra = {
+          user_id: user.uuid,
+          existing_user: false,
+        }
+
+        validator = EmailConfirmationTokenValidator.new(user).submit
+
+        expect(validator).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'confirmation token has already been used' do
+      it 'returns FormResponse with success: false' do
+        user = build_stubbed(:user)
+        user.errors.add(:email, :already_confirmed)
+
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
+
+        errors = { email: [t('errors.messages.already_confirmed')] }
+        extra = {
+          user_id: user.uuid,
+          existing_user: true,
+        }
+
+        validator = EmailConfirmationTokenValidator.new(user).submit
+
+        expect(validator).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'confirmation token is valid' do
+      it 'returns FormResponse with success: true' do
+        user = build_stubbed(:user, :unconfirmed)
+
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
+
+        extra = {
+          user_id: user.uuid,
+          existing_user: false,
+        }
+
+        validator = EmailConfirmationTokenValidator.new(user).submit
+
+        expect(validator).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: true, errors: {}, extra: extra)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: For consistency with our pattern of returning FormResponse
to the controller.