### PR TITLE
Use ruby native .rjust method

### DIFF
--- a/app/services/user_access_key.rb
+++ b/app/services/user_access_key.rb
@@ -74,14 +74,8 @@ class UserAccessKey
 
   attr_accessor :made, :unlocked
 
-  def z1_with_padding(len)
-    cur_len = z1.length
-    str = z1.dup
-    while cur_len < len
-      str = '0' + str
-      cur_len += 1
-    end
-    str
+  def z1_with_padding(length)
+    z1.dup.rjust(length, '0')
   end
 
   def build(password, pw_salt)


### PR DESCRIPTION
**Why**: Small refactor to use the built-in Ruby method instead
of doing it the long way, manually.

h/t @zachmargolis 