### PR TITLE
Return FormResponse in SamlRequestValidator

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -16,9 +16,9 @@ module SamlIdpAuthConcern
       authn_context: requested_authn_context
     )
 
-    return unless @result[:errors].present?
+    return if @result.success?
 
-    analytics.track_event(Analytics::SAML_AUTH, @result)
+    analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
     render nothing: true, status: :unauthorized
   end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -14,7 +14,7 @@ class SamlIdpController < ApplicationController
     link_identity_from_session_data
 
     needs_idv = identity_needs_verification?
-    analytics.track_event(Analytics::SAML_AUTH, @result.merge(idv: needs_idv))
+    analytics.track_event(Analytics::SAML_AUTH, @result.to_h.merge(idv: needs_idv))
 
     return redirect_to verify_url if needs_idv
 

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -8,34 +8,29 @@ class SamlRequestValidator
     self.service_provider = service_provider
     self.authn_context = authn_context
 
-    @success = valid?
-
-    result
+    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   private
 
   attr_accessor :service_provider, :authn_context
-  attr_reader :success
 
-  def result
+  def extra_analytics_attributes
     {
       authn_context: authn_context,
-      errors: errors.messages.values.flatten,
       service_provider: service_provider.issuer,
-      valid: success,
     }
   end
 
   def authorized_service_provider
     return if service_provider.active? # live? instead when dashboard approvals matter.
 
-    errors.add(:service_provider, 'Unauthorized Service Provider')
+    errors.add(:service_provider, :unauthorized_service_provider)
   end
 
   def authorized_authn_context
     return if Saml::Idp::Constants::VALID_AUTHN_CONTEXTS.include?(authn_context)
 
-    errors.add(:authn_context, 'Unauthorized authentication context')
+    errors.add(:authn_context, :unauthorized_authn_context)
   end
 end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -30,5 +30,7 @@ en:
       password_incorrect: Password is incorrect
       recovery_code_incorrect: Personal key is incorrect
       requires_phone: requires you to enter your phone number.
+      unauthorized_authn_context: Unauthorized authentication context
+      unauthorized_service_provider: Unauthorized Service Provider
       weak_password: Your password is not strong enough. %{feedback}
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -30,5 +30,7 @@ es:
       password_incorrect: La contraseña es incorrecta
       recovery_code_incorrect: El código de recuperación es incorrecto
       requires_phone: requiere que ingrese su número de teléfono.
+      unauthorized_authn_context: NOT TRANSLATED YET
+      unauthorized_service_provider: NOT TRANSLATED YET
       weak_password: Su contraseña no es suficientemente fuerte. %{feedback}
     not_authorized: No está autorizado para realizar esta acción.

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -198,10 +198,10 @@ describe SamlIdpController do
         expect(response.body).to be_empty
 
         analytics_hash = {
+          success: false,
+          errors: { authn_context: [t('errors.messages.unauthorized_authn_context')] },
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
-          errors: ['Unauthorized authentication context'],
           service_provider: 'http://localhost:3000',
-          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -220,11 +220,11 @@ describe SamlIdpController do
         expect(response.status).to eq(200)
 
         analytics_hash = {
+          success: true,
+          errors: {},
           authn_context: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-          errors: [],
           service_provider: 'http://localhost:3000',
           idv: false,
-          valid: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -244,10 +244,10 @@ describe SamlIdpController do
         expect(response.status).to eq(401)
 
         analytics_hash = {
+          success: false,
+          errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
           authn_context: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-          errors: ['Unauthorized Service Provider'],
           service_provider: 'invalid_provider',
-          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -267,10 +267,13 @@ describe SamlIdpController do
         expect(response.status).to eq(401)
 
         analytics_hash = {
+          success: false,
+          errors: {
+            service_provider: [t('errors.messages.unauthorized_service_provider')],
+            authn_context: [t('errors.messages.unauthorized_authn_context')],
+          },
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
-          errors: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
           service_provider: 'invalid_provider',
-          valid: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -743,10 +746,10 @@ describe SamlIdpController do
         allow(controller).to receive(:saml_request).and_return(FakeSamlRequest.new)
 
         analytics_hash = {
+          success: true,
+          errors: {},
           authn_context: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
-          errors: [],
           service_provider: 'http://localhost:3000',
-          valid: true,
           idv: true,
         }
 
@@ -765,10 +768,10 @@ describe SamlIdpController do
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
 
         analytics_hash = {
+          success: true,
+          errors: {},
           authn_context: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-          errors: [],
           service_provider: 'http://localhost:3000',
-          valid: true,
           idv: false,
         }
 

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe SamlRequestValidator do
+  describe '#call' do
+    context 'valid authentication context and service provider' do
+      it 'returns FormResponse with success: true' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        authn_context = Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+        allow(FormResponse).to receive(:new)
+        extra = {
+          authn_context: authn_context,
+          service_provider: sp.issuer,
+        }
+
+        SamlRequestValidator.new.call(service_provider: sp, authn_context: authn_context)
+
+        expect(FormResponse).to have_received(:new).
+          with(success: true, errors: {}, extra: extra)
+      end
+    end
+
+    context 'valid authentication context and invalid service provider' do
+      it 'returns FormResponse with success: false' do
+        sp = ServiceProvider.from_issuer('foo')
+        authn_context = Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+        allow(FormResponse).to receive(:new)
+        extra = {
+          authn_context: authn_context,
+          service_provider: sp.issuer,
+        }
+        errors = {
+          service_provider: [t('errors.messages.unauthorized_service_provider')],
+        }
+
+        SamlRequestValidator.new.call(service_provider: sp, authn_context: authn_context)
+
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'invalid authentication context and valid service provider' do
+      it 'returns FormResponse with success: false' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        authn_context = 'LOA11'
+        allow(FormResponse).to receive(:new)
+        extra = {
+          authn_context: authn_context,
+          service_provider: sp.issuer,
+        }
+        errors = {
+          authn_context: [t('errors.messages.unauthorized_authn_context')],
+        }
+
+        SamlRequestValidator.new.call(service_provider: sp, authn_context: authn_context)
+
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'invalid authentication context and invalid service provider' do
+      it 'returns FormResponse with success: false' do
+        sp = ServiceProvider.from_issuer('foo')
+        authn_context = 'LOA11'
+        allow(FormResponse).to receive(:new)
+        extra = {
+          authn_context: authn_context,
+          service_provider: sp.issuer,
+        }
+        errors = {
+          authn_context: [t('errors.messages.unauthorized_authn_context')],
+          service_provider: [t('errors.messages.unauthorized_service_provider')],
+        }
+
+        SamlRequestValidator.new.call(service_provider: sp, authn_context: authn_context)
+
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: For consistency with our other Service Objects that provide
analytics properties to controllers.