### PR TITLE
Return FormResponse in FinancialsStep

### DIFF
--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -15,10 +15,10 @@ module Verify
 
     def create
       result = step.submit
-      analytics.track_event(Analytics::IDV_FINANCE_CONFIRMATION, result)
+      analytics.track_event(Analytics::IDV_FINANCE_CONFIRMATION, result.to_h)
       increment_step_attempts
 
-      if result[:success]
+      if result.success?
         redirect_to verify_address_url
       else
         render_failure

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -10,7 +10,7 @@ module Idv
         idv_session.financials_confirmation = false
       end
 
-      result
+      FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
     end
 
     def form_valid_but_vendor_validation_failed?
@@ -38,10 +38,8 @@ module Idv
       { finance_type => idv_form.idv_params[finance_type] }
     end
 
-    def result
+    def extra_analytics_attributes
       {
-        success: success,
-        errors: errors,
         vendor: { reasons: vendor_reasons },
       }
     end

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -19,43 +19,50 @@ describe Idv::FinancialsStep do
   end
 
   describe '#submit' do
-    it 'returns false for invalid params' do
+    it 'returns FormResponse with success: false for invalid params' do
       step = build_step(finance_type: :ccn, ccn: '1234')
+      extra = { vendor: { reasons: nil } }
+      errors = { ccn: [t('idv.errors.invalid_ccn')] }
 
-      result = {
-        success: false,
-        errors: { ccn: [t('idv.errors.invalid_ccn')] },
-        vendor: { reasons: nil },
-      }
+      response = instance_double(FormResponse)
+      allow(FormResponse).to receive(:new).and_return(response)
+      submission = step.submit
 
-      expect(step.submit).to eq result
+      expect(submission).to eq response
+      expect(FormResponse).to have_received(:new).
+        with(success: false, errors: errors, extra: extra)
       expect(idv_session.financials_confirmation).to eq false
     end
 
-    it 'returns true for mock-happy CCN' do
+    it 'returns FormResponse with success: true for mock-happy CCN' do
       step = build_step(finance_type: :ccn, ccn: '12345678')
+      extra = { vendor: { reasons: ['Good number'] } }
 
-      result = {
-        success: true,
-        errors: {},
-        vendor: { reasons: ['Good number'] },
-      }
+      response = instance_double(FormResponse)
+      allow(FormResponse).to receive(:new).and_return(response)
 
-      expect(step.submit).to eq result
+      submission = step.submit
+
+      expect(submission).to eq response
+      expect(FormResponse).to have_received(:new).
+        with(success: true, errors: {}, extra: extra)
       expect(idv_session.financials_confirmation).to eq true
       expect(idv_session.params).to eq idv_finance_form.idv_params
     end
 
-    it 'returns false for mock-sad CCN' do
+    it 'returns FormResponse with success: false for mock-sad CCN' do
       step = build_step(finance_type: :ccn, ccn: '00000000')
 
-      result = {
-        success: false,
-        errors: { ccn: ['The ccn could not be verified.'] },
-        vendor: { reasons: ['Bad number'] },
-      }
+      extra = { vendor: { reasons: ['Bad number'] } }
+      errors = { ccn: ['The ccn could not be verified.'] }
 
-      expect(step.submit).to eq result
+      response = instance_double(FormResponse)
+      allow(FormResponse).to receive(:new).and_return(response)
+      submission = step.submit
+
+      expect(submission).to eq response
+      expect(FormResponse).to have_received(:new).
+        with(success: false, errors: errors, extra: extra)
       expect(idv_session.financials_confirmation).to eq false
     end
   end


### PR DESCRIPTION
**Why**: To be consistent throughout the app.