### PR TITLE
Return FormResponse in OpenidConnectTokenForm

### DIFF
--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -6,10 +6,10 @@ module OpenidConnect
       @token_form = OpenidConnectTokenForm.new(params)
 
       result = @token_form.submit
-      analytics.track_event(Analytics::OPENID_CONNECT_TOKEN, result)
+      analytics.track_event(Analytics::OPENID_CONNECT_TOKEN, result.to_h)
 
       render json: @token_form.response,
-             status: (result[:success] ? :ok : :bad_request)
+             status: (result.success? ? :ok : :bad_request)
     end
 
     def options

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -34,11 +34,7 @@ class OpenidConnectTokenForm
   end
 
   def submit
-    {
-      success: valid?,
-      client_id: client_id,
-      errors: errors.messages,
-    }
+    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   def response
@@ -113,5 +109,11 @@ class OpenidConnectTokenForm
     Base64.urlsafe_encode64(Base64.urlsafe_decode64(data.to_s), padding: false)
   rescue ArgumentError
     nil
+  end
+
+  def extra_analytics_attributes
+    {
+      client_id: client_id,
+    }
   end
 end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -239,29 +239,31 @@ RSpec.describe OpenidConnectTokenForm do
   end
 
   describe '#submit' do
-    subject(:result) { form.submit }
-
     context 'with valid params' do
-      it 'is valid and has no errors' do
-        expect(result[:success]).to eq(true)
-        expect(result[:errors]).to be_blank
-      end
+      it 'returns FormResponse with success: true' do
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
 
-      it 'has the client_id for tracking' do
-        expect(result[:client_id]).to eq(client_id)
+        submission = form.submit
+
+        expect(submission).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: true, errors: {}, extra: { client_id: client_id })
       end
     end
 
     context 'with invalid params' do
       let(:code) { nil }
 
-      it 'is invalid and has errors' do
-        expect(result[:success]).to eq(false)
-        expect(result[:errors]).to be_present
-      end
+      it 'returns FormResponse with success: false' do
+        response = instance_double(FormResponse)
+        allow(FormResponse).to receive(:new).and_return(response)
 
-      it 'has a nil client_id when there is insufficient data' do
-        expect(result).to include(client_id: nil)
+        submission = form.submit
+
+        expect(submission).to eq response
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: form.errors.messages, extra: { client_id: nil })
       end
     end
   end


### PR DESCRIPTION
**Why**: To adhere to our established convention.