### PR TITLE
OIDC security

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -34,7 +34,11 @@ class OpenidConnectTokenForm
   end
 
   def submit
-    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
+    success = valid?
+
+    clear_authorization_code if success
+
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   def response
@@ -115,5 +119,9 @@ class OpenidConnectTokenForm
     {
       client_id: client_id,
     }
+  end
+
+  def clear_authorization_code
+    identity.update(session_uuid: nil)
   end
 end

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -30,7 +30,9 @@ class OpenidConnectTokenForm
       instance_variable_set(:"@#{key}", params[key])
     end
 
-    @identity = Identity.where(session_uuid: code).first
+    session_expiration = Figaro.env.session_timeout_in_minutes.to_i.minutes.ago
+    @identity = Identity.where(session_uuid: code).
+                where('updated_at >= ?', session_expiration).first
   end
 
   def submit

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -47,7 +47,7 @@ class OpenidConnectTokenForm
         access_token: identity.access_token,
         token_type: 'Bearer',
         expires_in: Pii::SessionStore.new(identity.rails_session_id).ttl,
-        id_token: IdTokenBuilder.new(identity).id_token,
+        id_token: IdTokenBuilder.new(identity: identity, code: code).id_token,
       }
     else
       { error: errors.to_a.join(' ') }

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe OpenidConnectTokenForm do
           expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
         end
       end
+
+      context 'code has expired' do
+        before { identity.update(updated_at: 1.day.ago) }
+
+        it 'is invalid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
+        end
+      end
     end
 
     context 'private_key_jwt' do

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -58,12 +58,23 @@ RSpec.describe OpenidConnectTokenForm do
       it { expect(valid?).to eq(false) }
     end
 
-    context 'with a bad code' do
-      before { user.identities.delete_all }
+    context 'code' do
+      context 'with a bad code' do
+        before { user.identities.delete_all }
 
-      it 'is invalid' do
-        expect(valid?).to eq(false)
-        expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
+        it 'is invalid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
+        end
+      end
+
+      context 'using the same code a second time' do
+        before { OpenidConnectTokenForm.new(params).submit }
+
+        it 'is invalid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
+        end
       end
     end
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -3,16 +3,23 @@ require 'rails_helper'
 RSpec.describe IdTokenBuilder do
   include Rails.application.routes.url_helpers
 
+  let(:code) { SecureRandom.hex }
+
   let(:identity) do
     build(:identity,
           nonce: SecureRandom.hex,
           uuid: SecureRandom.uuid,
           ial: 3,
+          # this is a known value from an example developer guide
+          # https://developer.pingidentity.com/en/resources/openid-connect-developers-guide.html
+          access_token: 'dNZX1hEZ9wBCzNL40Upu646bdzQA',
           user: build(:user))
   end
 
   let(:custom_expiration) { 5.minutes.from_now.to_i }
-  subject(:builder) { IdTokenBuilder.new(identity, custom_expiration: custom_expiration) }
+  subject(:builder) do
+    IdTokenBuilder.new(identity: identity, code: code, custom_expiration: custom_expiration)
+  end
 
   describe '#id_token' do
     subject(:id_token) { Timecop.freeze(now) { builder.id_token } }
@@ -69,6 +76,20 @@ RSpec.describe IdTokenBuilder do
 
     it 'sets the not-before to now' do
       expect(decoded_payload[:nbf]).to eq(now.to_i)
+    end
+
+    it 'sets the access token hash correctly' do
+      # this is a known value from an example developer guide
+      # https://developer.pingidentity.com/en/resources/openid-connect-developers-guide.html
+      expect(decoded_payload[:at_hash]).to eq('wfgvmE9VxjAudsl9lc6TqA')
+    end
+
+    it 'sets the code hash correctly' do
+      leftmost_128_bits = Digest::SHA256.digest(code).
+                          byteslice(0, IdTokenBuilder::NUM_BYTES_FIRST_128_BITS)
+      expected_hash = Base64.urlsafe_encode64(leftmost_128_bits, padding: false)
+
+      expect(decoded_payload[:c_hash]).to eq(expected_hash)
     end
 
     context 'including attributes allowed by the scope from the request' do


### PR DESCRIPTION
These things came up in our pentesting for OIDC

The weirdest part is definitely how to calculate the `c_hash` and the `at_hash`. Here is the language from the spec:

Source: http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken

> Access Token hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the `access_token` value, where the hash algorithm used is the hash algorithm used in the `alg` Header Parameter of the ID Token's JOSE Header. For instance, if the `alg` is RS256, hash the access_token value with SHA-256, then take the left-most 128 bits and base64url encode them. The `at_hash` value is a case sensitive string.