### PR TITLE
Only redirect back to URIs we trust

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -141,11 +141,15 @@ class OpenidConnectAuthorizeForm
 
   def error_redirect_uri
     URIService.add_params(
-      redirect_uri_matches_sp_redirect_uri? ? redirect_uri : nil,
+      validated_input_redirect_uri,
       error: 'invalid_request',
       error_description: errors.full_messages.join(' '),
       state: state
     )
+  end
+
+  def validated_input_redirect_uri
+    redirect_uri if redirect_uri_matches_sp_redirect_uri?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -89,10 +89,14 @@ class OpenidConnectAuthorizeForm
   end
 
   def validate_redirect_uri_matches_sp_redirect_uri
-    return if redirect_uri.blank?
-    return unless service_provider.active?
-    return if redirect_uri.start_with?(sp_redirect_uri)
+    return if redirect_uri_matches_sp_redirect_uri?
     errors.add(:redirect_uri, t('openid_connect.authorization.errors.redirect_uri_no_match'))
+  end
+
+  def redirect_uri_matches_sp_redirect_uri?
+    redirect_uri.present? &&
+      service_provider.active? &&
+      redirect_uri.start_with?(sp_redirect_uri)
   end
 
   def validate_scope
@@ -137,7 +141,7 @@ class OpenidConnectAuthorizeForm
 
   def error_redirect_uri
     URIService.add_params(
-      redirect_uri,
+      redirect_uri_matches_sp_redirect_uri? ? redirect_uri : nil,
       error: 'invalid_request',
       error_description: errors.full_messages.join(' '),
       state: state

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -95,22 +95,35 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
 
     context 'with invalid params' do
-      let(:response_type) { nil }
+      context 'with a bad response_type' do
+        let(:response_type) { nil }
 
-      it 'is unsuccessful and has error messages' do
-        form_response = instance_double(FormResponse)
+        it 'is unsuccessful and has error messages' do
+          form_response = instance_double(FormResponse)
 
-        extra_attributes = {
-          client_id: client_id,
-          redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
-                        "Response+type+is+not+included+in+the+list&state=#{state}",
-        }
+          extra_attributes = {
+            client_id: client_id,
+            redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
+                          "Response+type+is+not+included+in+the+list&state=#{state}",
+          }
 
-        errors = { response_type: ['is not included in the list'] }
+          errors = { response_type: ['is not included in the list'] }
 
-        expect(FormResponse).to receive(:new).
-          with(success: false, errors: errors, extra: extra_attributes).and_return(form_response)
-        expect(result).to eq form_response
+          expect(FormResponse).to receive(:new).
+            with(success: false, errors: errors, extra: extra_attributes).and_return(form_response)
+          expect(result).to eq form_response
+        end
+      end
+    end
+
+    context 'with a bad redirect_uri' do
+      let(:redirect_uri) { 'https://wrongurl.com' }
+
+      it 'has errors and does not redirect to the bad redirect_uri' do
+        expect(result.errors[:redirect_uri]).
+          to include(t('openid_connect.authorization.errors.redirect_uri_no_match'))
+
+        expect(result.extra[:redirect_uri]).to be_nil
       end
     end
   end


### PR DESCRIPTION
**Why**: Security

---

Before: we detected that a bad redirect_uri was bad and generated errors, but we would redirect *to* that URI and send the errors

Now: We render an error page and do not redirect to a potentially bad place