### PR TITLE
OpenID Connect: stricter requirements around nonce and state

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -18,16 +18,18 @@ class OpenidConnectAuthorizeForm
 
   attr_reader(*ATTRS)
 
-  validates_presence_of :acr_values,
-                        :client_id,
-                        :prompt,
-                        :redirect_uri,
-                        :scope,
-                        :state
+  RANDOM_VALUE_MINIMUM_LENGTH = 32
 
-  validates_inclusion_of :response_type, in: %w(code)
-  validates_inclusion_of :prompt, in: %w(select_account)
-  validates_inclusion_of :code_challenge_method, in: %w(S256), if: :code_challenge
+  validates :acr_values, presence: true
+  validates :client_id, presence: true
+  validates :redirect_uri, presence: true
+  validates :scope, presence: true
+  validates :state, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
+  validates :nonce, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
+
+  validates :response_type, inclusion: { in: %w(code) }
+  validates :prompt, presence: true, inclusion: { in: %w(select_account) }
+  validates :code_challenge_method, inclusion: { in: %w(S256) }, if: :code_challenge
 
   validate :validate_acr_values
   validate :validate_client_id

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
                  success: false,
                  client_id: client_id,
-                 errors: { state: ['Please fill in this field.'] })
+                 errors: {
+                   state: ['Please fill in this field.', 'is too short (minimum is 32 characters)'],
+                 })
 
           action
         end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -99,6 +99,7 @@ feature 'OpenID Connect' do
         scope: 'openid email',
         redirect_uri: 'http://localhost:7654/auth/result',
         state: SecureRandom.hex,
+        nonce: SecureRandom.hex,
         prompt: 'select_account'
       )
 
@@ -170,6 +171,7 @@ feature 'OpenID Connect' do
         scope: 'openid email',
         redirect_uri: 'gov.gsa.openidconnect.test://result',
         state: SecureRandom.hex,
+        nonce: SecureRandom.hex,
         prompt: 'select_account',
         code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
         code_challenge_method: 'S256'

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -157,9 +157,16 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
-    context 'without the optional nonce' do
-      let(:nonce) { nil }
-      it { expect(valid?).to eq(true) }
+    context 'nonce' do
+      context 'without a nonce' do
+        let(:nonce) { nil }
+        it { expect(valid?).to eq(false) }
+      end
+
+      context 'with a nonce that is shorter than RANDOM_VALUE_MINIMUM_LENGTH characters' do
+        let(:nonce) { '1' * (OpenidConnectAuthorizeForm::RANDOM_VALUE_MINIMUM_LENGTH - 1) }
+        it { expect(valid?).to eq(false) }
+      end
     end
 
     context 'when prompt is not select_account' do
@@ -211,9 +218,16 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it { expect(valid?).to eq(false) }
     end
 
-    context 'without a state' do
-      let(:state) { nil }
-      it { expect(valid?).to eq(false) }
+    context 'state' do
+      context 'without a state' do
+        let(:state) { nil }
+        it { expect(valid?).to eq(false) }
+      end
+
+      context 'with a state that is shorter than RANDOM_VALUE_MINIMUM_LENGTH characters' do
+        let(:state) { '1' * (OpenidConnectAuthorizeForm::RANDOM_VALUE_MINIMUM_LENGTH - 1) }
+        it { expect(valid?).to eq(false) }
+      end
     end
 
     context 'PKCE' do


### PR DESCRIPTION
**Why**:
For added security
- make nonce required, add minumum length to it
- add minimum length to state param as well