### PR TITLE
Remove KMS ciphertext tag before deciphering

### DIFF
--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -59,7 +59,7 @@ class EncryptedKeyMaker
   end
 
   def unlock_kms(user_access_key, encryption_key)
-    ciphertext = user_access_key.xor(decode(encryption_key))
+    ciphertext = user_access_key.xor(decode(encryption_key)).sub(KEY_TYPE[:KMS], '')
     user_access_key.unlock(aws_client.decrypt(ciphertext_blob: ciphertext).plaintext)
   end
 

--- a/spec/services/encrypted_key_maker_spec.rb
+++ b/spec/services/encrypted_key_maker_spec.rb
@@ -91,6 +91,22 @@ describe EncryptedKeyMaker do
         allow(FeatureManagement).to receive(:use_kms?).and_return(true)
         expect(subject.unlock(user_access_key, encryption_key)).to eq hash_E
       end
+
+      it 'removes KMS ciphertext prefix before deciphering' do
+        prefix = EncryptedKeyMaker::KEY_TYPE[:KMS]
+        prefixed_ciphertext = prefix + ciphered_key
+        aws_client = Aws::KMS::Client.new(region: Figaro.env.aws_region)
+
+        expect(aws_client).to receive(:decrypt).
+          with(ciphertext_blob: ciphered_key).and_call_original
+        expect(subject).to receive(:aws_client).at_least(:twice).and_return(aws_client)
+        expect(user_access_key).to receive(:store_encrypted_key).
+          with(prefixed_ciphertext).and_call_original
+
+        subject.make(user_access_key)
+        encryption_key = user_access_key.encryption_key
+        subject.unlock(user_access_key, encryption_key)
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: We introduced encryption scheme tagging, but neglected
to remove the tag before decrypting.

This fix has been verified in QA actual KMS.