### PR TITLE
OpenID Connect: pass back access_denied when user declines

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -38,7 +38,11 @@ module OpenidConnect
     def destroy
       analytics.track_event(Analytics::OPENID_CONNECT_DECLINE, client_id: @authorize_form.client_id)
 
-      render nothing: true # TODO: should we try to redirect back with an error?
+      if (redirect_uri = @authorize_form.decline_redirect_uri)
+        redirect_to redirect_uri
+      else
+        render :error
+      end
     end
 
     private

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -65,6 +65,14 @@ class OpenidConnectAuthorizeForm
     @_service_provider ||= ServiceProvider.from_issuer(client_id)
   end
 
+  def decline_redirect_uri
+    URIService.add_params(
+      validated_input_redirect_uri,
+      error: 'access_denied',
+      state: state
+    )
+  end
+
   private
 
   attr_reader :identity, :success

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -179,6 +179,25 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
         action
       end
+
+      it 'redirects back to the client app with a access_denied' do
+        action
+
+        redirect_uri = URI(response.location)
+        redirect_params = Rack::Utils.parse_nested_query(redirect_uri.query).with_indifferent_access
+
+        expect(redirect_params[:error]).to eq('access_denied')
+        expect(redirect_params[:state]).to eq(params[:state])
+      end
+
+      context 'with invalid params' do
+        before { params.delete(:redirect_uri) }
+
+        it 'renders the error page' do
+          action
+          expect(controller).to render_template('openid_connect/authorization/error')
+        end
+      end
     end
 
     context 'user is not signed in' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -291,4 +291,22 @@ RSpec.describe OpenidConnectAuthorizeForm do
       expect(form.client_id).to eq 'foobar'
     end
   end
+
+  describe '#decline_redirect_uri' do
+    subject(:decline_redirect_uri) { form.decline_redirect_uri }
+
+    it 'is an access_denied error' do
+      uri = URI(decline_redirect_uri)
+      redirect_params = Rack::Utils.parse_nested_query(uri.query).with_indifferent_access
+
+      expect(redirect_params[:error]).to eq('access_denied')
+      expect(redirect_params[:state]).to eq(state)
+    end
+
+    context 'with a bad redirect_uri' do
+      let(:redirect_uri) { 'http://wrong-redirect.com' }
+
+      it { expect(decline_redirect_uri).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Part of the spec