### PR TITLE
Preserve branded experience after session expires

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,11 +66,13 @@ class ApplicationController < ActionController::Base
   end
 
   def sp_from_sp_session
-    ServiceProvider.from_issuer(sp_session[:issuer])
+    sp = ServiceProvider.from_issuer(sp_session[:issuer])
+    sp if sp.is_a? ServiceProvider
   end
 
   def sp_from_params
-    ServiceProvider.from_issuer(params[:issuer])
+    sp = ServiceProvider.from_issuer(params[:issuer])
+    sp if sp.is_a? ServiceProvider
   end
 
   def decorated_user

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -5,15 +5,16 @@ feature 'LOA1 Single Sign On' do
 
   context 'First time registration' do
     it 'takes user to agency handoff page when sign up flow complete' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       saml_authn_request = auth_request.create(saml_settings)
-      user = create(:user, :with_phone)
 
       visit saml_authn_request
-      sign_in_and_require_viewing_recovery_code(user)
+      sign_up_and_2fa_loa1_user
 
-      click_acknowledge_recovery_code
       expect(current_path).to eq sign_up_completed_path
+
+      click_on t('forms.buttons.continue_to', sp: 'Your friendly Government Agency')
+
+      expect(current_url).to eq saml_authn_request
     end
 
     it 'takes user to the service provider, allows user to visit IDP' do

--- a/spec/features/session_timeout_spec.rb
+++ b/spec/features/session_timeout_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+feature 'Session Timeout' do
+  context 'when SP info no longer in session but issuer params exists' do
+    it 'preserves the branded experience' do
+      issuer = 'http://localhost:3000'
+      sp = ServiceProvider.from_issuer(issuer)
+      visit root_path(issuer: issuer)
+
+      expect(page).to have_link sp.friendly_name
+      expect(page).to have_css('img[src*=sp-logos]')
+    end
+  end
+
+  context 'when SP info is in session' do
+    it 'displays the branded experience' do
+      issuer = 'http://localhost:3000'
+      sp = ServiceProvider.from_issuer(issuer)
+      sp_session = { issuer: issuer }
+      page.set_rack_session(sp: sp_session)
+      visit root_path
+
+      expect(page).to have_link sp.friendly_name
+      expect(page).to have_css('img[src*=sp-logos]')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: If a user comes from a SP and stays idle on the sign in page,
the branded experience should remain after the session expires. Note
that this will not preserve the branded experience throughout the whole
flow, which is why we currently display a message that prompts the user
to start over from the SP.

Preserving the branded experience throughout without having to start
over is being worked on in a separate branch.

This PR fixes a bug I introduced when I refactored the branded
experience.