### PR TITLE
Point email footer links to correct sites

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -1,6 +1,10 @@
 class MarketingSite
   BASE_URL = URI('https://login.gov').freeze
 
+  def self.base_url
+    BASE_URL.to_s
+  end
+
   def self.privacy_url
     URI.join(BASE_URL, '/policy').to_s
   end

--- a/app/views/layouts/user_mailer.html.slim
+++ b/app/views/layouts/user_mailer.html.slim
@@ -94,9 +94,11 @@ html xmlns="http://www.w3.org/1999/xhtml"
                                       tr
                                         th
                                           p.text-center
-                                            a href="#" = t('mailer.about', app: APP_NAME)
+                                            = link_to(t('mailer.about', app: APP_NAME),
+                                                      MarketingSite.base_url)
                                             ' &nbsp;&nbsp;|&nbsp;&nbsp;
-                                            a href="#" = t('mailer.privacy_policy')
+                                            = link_to(t('mailer.privacy_policy'),
+                                                      MarketingSite.privacy_url)
                                         th.expander
       /! prevent Gmail on iOS font size manipulation
       div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe MarketingSite do
+  describe '.base_url' do
+    it 'points to the base URL' do
+      expect(MarketingSite.base_url).to eq('https://login.gov')
+    end
+  end
+
   describe '.privacy_url' do
     it 'points to the privacy page' do
       expect(MarketingSite.privacy_url).to eq('https://login.gov/policy')

--- a/spec/views/layouts/user_mailer.html.slim_spec.rb
+++ b/spec/views/layouts/user_mailer.html.slim_spec.rb
@@ -33,11 +33,11 @@ describe 'layouts/user_mailer.html.slim' do
     expect(rendered).to have_link(MarketingSite.contact_url, href: MarketingSite.contact_url)
   end
 
-  it 'includes placeholder link to About login.gov' do
-    expect(rendered).to have_link("About #{APP_NAME}", href: '#')
+  it 'includes link to About login.gov' do
+    expect(rendered).to have_link(t('mailer.about', app: APP_NAME), href: MarketingSite.base_url)
   end
 
-  it 'includes placeholder link to the privacy policy' do
-    expect(rendered).to have_link('Privacy policy', href: '#')
+  it 'includes link to the privacy policy' do
+    expect(rendered).to have_link(t('mailer.privacy_policy'), href: MarketingSite.privacy_url)
   end
 end


### PR DESCRIPTION
**Why**: Up until now, we had placeholder links in the email footer
because we didn't have sites to point them to. Now that we do, we need
to update the links.

Note that the https://login.gov/policy link doesn't seem to be live yet.
I'm not sure if that's the wrong URL or if the page hasn't been
published yet.