### PR TITLE
Rescue AWS error when KMS on and password wrong

### DIFF
--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -61,6 +61,8 @@ class EncryptedKeyMaker
   def unlock_kms(user_access_key, encryption_key)
     ciphertext = user_access_key.xor(decode(encryption_key)).sub(KEY_TYPE[:KMS], '')
     user_access_key.unlock(aws_client.decrypt(ciphertext_blob: ciphertext).plaintext)
+  rescue Aws::KMS::Errors::InvalidCiphertextException
+    raise Pii::EncryptionError
   end
 
   def make_local(user_access_key)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -234,4 +234,16 @@ feature 'Sign in' do
       expect(user.encrypted_email).to eq encrypted_email
     end
   end
+
+  context 'KMS is on and user enters incorrect password' do
+    it 'redirects to root_path with user-friendly error message, not a 500 error' do
+      allow(FeatureManagement).to receive(:use_kms?).and_return(true)
+      stub_aws_kms_client_invalid_ciphertext
+
+      user = create(:user)
+      signin(user.email, 'invalid')
+      expect(current_path).to eq root_path
+      expect(page).to have_content t('devise.failure.invalid')
+    end
+  end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -10,6 +10,16 @@ module AwsKmsClientHelper
     [random_key, ciphered_key]
   end
 
+  def stub_aws_kms_client_invalid_ciphertext(ciphered_key = random_str)
+    aws_key_id = Figaro.env.aws_kms_key_id
+    Aws.config[:kms] = {
+      stub_responses: {
+        encrypt: { ciphertext_blob: ciphered_key, key_id: aws_key_id },
+        decrypt: 'InvalidCiphertextException',
+      },
+    }
+  end
+
   def random_str
     SecureRandom.random_bytes(32)
   end


### PR DESCRIPTION
**Why**: If a user signs in with a wrong password, the ciphertext blob
passed to the AWS KMS service will not match the blob that corresponds
to the correct password. AWS raises an error in this case, which causes
the user to see the 500 error page.

**How**: Rescue the AWS error and raise Pii::EncryptionError so that
`valid_password?` returns `false` and the user sees the regular
"Invalid email or password" flash message on the sign in page.

Note that the test is somewhat brittle because it assumes that AWS
will always handle this scenario by raising this exact error. If this
changes in the future, our test will still pass. We would either need
to keep up with all the changes to the API, or set up a KMS test
environment we can use to talk to the real API.