### PR TITLE
Improves small screen support for profile page

### DIFF
--- a/app/assets/stylesheets/components/_space-misc.scss
+++ b/app/assets/stylesheets/components/_space-misc.scss
@@ -16,9 +16,11 @@
 .mb-40p { margin-bottom: 40px; }
 
 .mtn1 { margin-top: -$space-1; }
+.mtn2 { margin-top: -$space-2; }
 .mtn3 { margin-top: -$space-3; }
 
 @media #{$breakpoint-sm} {
   .sm-mr-20p { margin-right: 20px; }
+  .sm-mtn2 { margin-top: -$space-2; }
   .sm-mtn3 { margin-top: -$space-3; }
 }

--- a/app/views/profile/_basic_account_badge.html.slim
+++ b/app/views/profile/_basic_account_badge.html.slim
@@ -1,3 +1,3 @@
-.h6.right.border.rounded.p1.regular
+.h6.border.rounded.p1.regular
   = t('headings.profile.basic_account')
   = tooltip(t('tooltips.verified_account'))

--- a/app/views/profile/_verified_account_badge.html.slim
+++ b/app/views/profile/_verified_account_badge.html.slim
@@ -1,1 +1,1 @@
-.h6.regular.right.border.rounded.p1.regular = t('headings.profile.verified_account')
+.h6.regular.border.rounded.p1 = t('headings.profile.verified_account')

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -14,12 +14,15 @@
 h1.hide = t('titles.profile')
 
 - if @decrypted_pii
-  h2.h3.my0.mr1.inline-block = t('headings.profile.profile_info')
-  = content_tag(:span, t('tooltips.profile_info'),
-    class: 'h5 blue sans-serif underline hint--top hint--no-animate',
-    tabindex: 0,
-    'aria-label': t('tooltips.profile_idv'))
-  = render partial: current_user.decorate.verified_account_partial
+  .clearfix
+    h2.h3.my0.mr1.sm-mr0.col.sm-col-8.lg-col-5 = t('headings.profile.profile_info')
+    .sm-col.sm-m0.sm-col-8.lg-col-5
+      = content_tag(:span, t('tooltips.profile_info'),
+        class: 'h5 blue sans-serif underline hint--top hint--no-animate',
+        tabindex: 0,
+        'aria-label': t('tooltips.profile_idv'))
+    .sm-col-right.left.mt2.sm-mtn3
+      = render partial: current_user.decorate.verified_account_partial
   .mt2.mb4
     .py-12p.border-top
       .clearfix.mxn1
@@ -45,10 +48,12 @@ h1.hide = t('titles.profile')
       .clearfix.mxn1
         .sm-col.sm-col-5.px1 = t('.phone')
         .sm-col.sm-col-7.px1 = @decrypted_pii.phone
+.clearfix
+  h2.h3.my0.sm-col
+    = t('headings.profile.login_info')
+  .sm-col-right.left.sm-m0.mt1
+    = render partial: current_user.decorate.basic_account_partial
 
-h2.h3.my0
-  = t('headings.profile.login_info')
-  = render partial: current_user.decorate.basic_account_partial
 .mt2.mb4
   .py-12p.border-top
     .clearfix.mxn1


### PR DESCRIPTION
**Why**: The verified and basic account badges were floating awkwardly
on small screen sizes

Screenshots:

Large screen:
<img width="843" alt="screen shot 2017-03-20 at 1 18 53 pm" src="https://cloud.githubusercontent.com/assets/1421848/24112433/e1180578-0d6f-11e7-8b62-a72ea3809136.png">


Medium Screen:
<img width="804" alt="screen shot 2017-03-20 at 1 19 01 pm" src="https://cloud.githubusercontent.com/assets/1421848/24112446/e6cef486-0d6f-11e7-80ec-fd8c18f4575e.png">


Small Screen:
<img width="370" alt="screen shot 2017-03-20 at 1 19 07 pm" src="https://cloud.githubusercontent.com/assets/1421848/24112450/ebdaf52e-0d6f-11e7-8ff6-cad8e999a86b.png">

Small screen, basic account: 
<img width="352" alt="screen shot 2017-03-21 at 8 45 37 am" src="https://cloud.githubusercontent.com/assets/1421848/24147913/d18be98c-0e12-11e7-887a-8259b8d73985.png">

