### PR TITLE
Remove equifax_ssh_passphrase from RC

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -6,7 +6,7 @@ Figaro.require_keys(
   'domain_name',
   'enable_identity_verification',
   'enable_test_routes',
-  'equifax_ssh_passphrase',
+  #'equifax_ssh_passphrase',
   'hmac_fingerprinter_key',
   'idp_sso_target_url',
   'logins_per_ip_limit',


### PR DESCRIPTION
**Why**: Equifax features not yet needed in production.