### PR TITLE
Add server-side OTP and TOTP format validations

### DIFF
--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -14,7 +14,7 @@ class OtpVerificationForm
 
   def valid_direct_otp_code?
     code_length = Devise.direct_otp_length
-    return false unless code =~ /^\d{#{code_length}}$/
+    return false unless code =~ /\A\d{#{code_length}}\Z/
     user.authenticate_direct_otp(code)
   end
 end

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -13,8 +13,15 @@ class OtpVerificationForm
   attr_reader :code, :user
 
   def valid_direct_otp_code?
-    code_length = Devise.direct_otp_length
-    return false unless code =~ /\A\d{#{code_length}}\Z/
+    return false unless code =~ pattern_matching_otp_code_format
     user.authenticate_direct_otp(code)
+  end
+
+  def pattern_matching_otp_code_format
+    /\A\d{#{otp_code_length}}\Z/
+  end
+
+  def otp_code_length
+    Devise.direct_otp_length
   end
 end

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -13,6 +13,8 @@ class OtpVerificationForm
   attr_reader :code, :user
 
   def valid_direct_otp_code?
+    code_length = Devise.direct_otp_length
+    return false unless code =~ /^\d{#{code_length}}$/
     user.authenticate_direct_otp(code)
   end
 end

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -14,7 +14,7 @@ class TotpVerificationForm
 
   def valid_totp_code?
     code_length = Devise.otp_length
-    return false unless code =~ /^\d{#{code_length}}$/
+    return false unless code =~ /\A\d{#{code_length}}\Z/
     user.authenticate_totp(code)
   end
 

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -13,9 +13,16 @@ class TotpVerificationForm
   attr_reader :user, :code
 
   def valid_totp_code?
-    code_length = Devise.otp_length
-    return false unless code =~ /\A\d{#{code_length}}\Z/
+    return false unless code =~ pattern_matching_totp_code_format
     user.authenticate_totp(code)
+  end
+
+  def pattern_matching_totp_code_format
+    /\A\d{#{totp_code_length}}\Z/
+  end
+
+  def totp_code_length
+    Devise.otp_length
   end
 
   def extra_analytics_attributes

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -13,6 +13,8 @@ class TotpVerificationForm
   attr_reader :user, :code
 
   def valid_totp_code?
+    code_length = Devise.otp_length
+    return false unless code =~ /^\d{#{code_length}}$/
     user.authenticate_totp(code)
   end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -75,7 +75,6 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::MULTI_FACTOR_AUTH, properties)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
-        expect(subject.current_user).to receive(:authenticate_direct_otp).and_return(false)
 
         post :create, code: '12345', delivery_method: 'sms'
       end

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-describe TotpVerificationForm do
+describe OtpVerificationForm do
   describe '#submit' do
     context 'when the form is valid' do
       it 'returns FormResponse with success: true' do
         user = build_stubbed(:user)
         code = '123456'
-        form = TotpVerificationForm.new(user, code)
+        form = OtpVerificationForm.new(user, code)
         result = instance_double(FormResponse)
 
-        allow(user).to receive(:authenticate_totp).and_return(true)
+        allow(user).to receive(:authenticate_direct_otp).with(code).and_return(true)
 
         expect(FormResponse).to receive(:new).
-          with(success: true, errors: {}, extra: { multi_factor_auth_method: 'totp' }).
+          with(success: true, errors: {}).
           and_return(result)
         expect(form.submit).to eq result
       end
@@ -22,30 +22,28 @@ describe TotpVerificationForm do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
         code = '123456'
-        form = TotpVerificationForm.new(user, code)
+        form = OtpVerificationForm.new(user, code)
         result = instance_double(FormResponse)
 
-        allow(user).to receive(:authenticate_totp).and_return(false)
-
         expect(FormResponse).to receive(:new).
-          with(success: false, errors: {}, extra: { multi_factor_auth_method: 'totp' }).
+          with(success: false, errors: {}).
           and_return(result)
         expect(form.submit).to eq result
       end
     end
 
-    context 'when the code is not exactly Devise.otp_length digits' do
+    context 'when the code is not exactly Devise.direct_otp_length digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
         codes = %w(123abc 1234567 abcdef)
 
         codes.each do |code|
-          form = TotpVerificationForm.new(user, code)
+          form = OtpVerificationForm.new(user, code)
           result = instance_double(FormResponse)
-          allow(user).to receive(:authenticate_totp).with(code).and_return(true)
+          allow(user).to receive(:authenticate_direct_otp).with(code).and_return(true)
 
           expect(FormResponse).to receive(:new).
-            with(success: false, errors: {}, extra: { multi_factor_auth_method: 'totp' }).
+            with(success: false, errors: {}).
             and_return(result)
           expect(form.submit).to eq result
         end

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -32,12 +32,12 @@ describe OtpVerificationForm do
       end
     end
 
-    context 'when the code is not exactly Devise.direct_otp_length digits' do
+    context 'when the format of the code is not exactly 6 digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
-        codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
+        invalid_codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
 
-        codes.each do |code|
+        invalid_codes.each do |code|
           form = OtpVerificationForm.new(user, code)
           result = instance_double(FormResponse)
           allow(user).to receive(:authenticate_direct_otp).with(code).and_return(true)

--- a/spec/forms/otp_verification_form_spec.rb
+++ b/spec/forms/otp_verification_form_spec.rb
@@ -35,7 +35,7 @@ describe OtpVerificationForm do
     context 'when the code is not exactly Devise.direct_otp_length digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
-        codes = %w(123abc 1234567 abcdef)
+        codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
 
         codes.each do |code|
           form = OtpVerificationForm.new(user, code)

--- a/spec/forms/totp_verification_form_spec.rb
+++ b/spec/forms/totp_verification_form_spec.rb
@@ -34,12 +34,12 @@ describe TotpVerificationForm do
       end
     end
 
-    context 'when the code is not exactly 6 digits' do
+    context 'when the format of the code is not exactly 6 digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
-        codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
+        invalid_codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
 
-        codes.each do |code|
+        invalid_codes.each do |code|
           form = TotpVerificationForm.new(user, code)
           result = instance_double(FormResponse)
           allow(user).to receive(:authenticate_totp).with(code).and_return(true)

--- a/spec/forms/totp_verification_form_spec.rb
+++ b/spec/forms/totp_verification_form_spec.rb
@@ -37,7 +37,7 @@ describe TotpVerificationForm do
     context 'when the code is not exactly Devise.otp_length digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
-        codes = %w(123abc 1234567 abcdef)
+        codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)
 
         codes.each do |code|
           form = TotpVerificationForm.new(user, code)

--- a/spec/forms/totp_verification_form_spec.rb
+++ b/spec/forms/totp_verification_form_spec.rb
@@ -34,7 +34,7 @@ describe TotpVerificationForm do
       end
     end
 
-    context 'when the code is not exactly Devise.otp_length digits' do
+    context 'when the code is not exactly 6 digits' do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user)
         codes = %W(123abc 1234567 abcdef aaaaa\n123456\naaaaaaaaa)


### PR DESCRIPTION
**Why**: To minimize our attack surface and only accept allowed inputs,
which in this case is a string containing only numeric characters with
a length corresponding to the Devise.direct_otp_length and
Devise.otp_length settings, respectively.