### PR TITLE
Use SameSite=Strict for cookies

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -44,10 +44,8 @@ SecureHeaders::Configuration.default do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
-    # We need to set the SameSite setting to "Lax", not "Strict" until this bug
-    # is fixed in Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=619603
     samesite: {
-      lax: true # mark all cookies as SameSite=Lax.
+      strict: true # mark all cookies as SameSite=Strict.
     },
   }
 


### PR DESCRIPTION
**Why**: That's the recommended setting. We had set it to `Lax` at one
point due to a Chrome bug — which has since been fixed — that broke
SAML authentication because of our reliance on the session to store the
SAML request URL.

In general, we know that relying on the session for this is not ideal,
and we are working on solving that problem.