### PR TITLE
JS check on recovery code is case insensitive

### DIFF
--- a/app/assets/javascripts/misc/recovery-page-controller.js
+++ b/app/assets/javascripts/misc/recovery-page-controller.js
@@ -42,7 +42,7 @@ function handleSubmit(event) {
   const invalidMatches = inputs.reduce(function(accumulator, input, index) {
     const value = input.value;
 
-    if (value === recoveryWords[index].innerHTML.replace(/\s+/, '')) {
+    if (value.toUpperCase() === recoveryWords[index].innerHTML.replace(/\s+/, '').toUpperCase()) {
       return accumulator;
     }
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -162,7 +162,7 @@ module Features
       click_on button_text, class: 'recovery-code-continue'
 
       code_words.size.times do |index|
-        fill_in "recovery-#{index}", with: code_words[index]
+        fill_in "recovery-#{index}", with: code_words[index].downcase
       end
 
       click_on button_text, class: 'recovery-code-confirm'


### PR DESCRIPTION
**Why**: Users will eschew the shift key, but our codes are always
upper case.