### PR TITLE
Extends sign_up_init session key to password page

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -22,6 +22,7 @@ module SignUp
     end
 
     def process_successful_password_creation
+      session.delete(:sign_up_init)
       @user.confirm
       UpdateUser.new(
         user: @user,

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -51,7 +51,6 @@ module SignUp
 
       resend_confirmation = params[:user][:resend]
       session[:email] = user.email
-      session.delete(:sign_up_init)
 
       redirect_to sign_up_verify_email_path(resend: resend_confirmation)
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,6 +8,8 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
 
     def new
+      session.delete(:sign_up_init)
+
       if session[:sp]&.delete(:show_start_page)
         return redirect_to sign_up_start_path
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
 
   def destroy_user
     user = current_user || User.find_by(confirmation_token: session[:user_confirmation_token])
+    session.delete(:user_confirmation_token)
     user && user.destroy!
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def destroy_user
     user = current_user || User.find_by(confirmation_token: session[:user_confirmation_token])
-    session.delete(:user_confirmation_token)
     user && user.destroy!
+    sign_out if user
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   end
 
   def user_signing_up?
-    !current_user || !current_user.two_factor_enabled?
+    sign_up_init? || current_user && !current_user.two_factor_enabled?
   end
 
   def session_with_trust?

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -9,4 +9,5 @@ p.mt-tiny.mb0#email-description
 
   = f.input :email, required: true, input_html: { 'aria-describedby': 'email-description' }
   = f.button :submit, t('forms.buttons.continue'), class: 'mt2'
+
 = render 'shared/cancel', link: new_user_session_path

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -23,6 +23,7 @@ describe SignUp::PasswordsController do
       expect(user.valid_password?('NewVal!dPassw0rd')).to eq true
       expect(user.confirmed?).to eq true
       expect(user.reset_requested_at).to be_nil
+      expect(subject.session[:sign_up_init]).to be_nil
     end
 
     it 'tracks an invalid password event' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -327,6 +327,14 @@ describe Users::SessionsController, devise: true do
 
         get :new
       end
+
+      it 'cleans up the sign_up_init key' do
+        subject.session[:sign_up_init] = true
+
+        get :new
+
+        expect(subject.session[:sign_up_init]).to be_nil
+      end
     end
   end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -43,13 +43,11 @@ feature 'Sign Up' do
 
       it 'allows the user to delete their account and returns them to the home page' do
         user = begin_sign_up_with_sp_and_loa(loa3: false)
-        click_on t('links.cancel')
 
+        click_on t('links.cancel')
         click_on t('sign_up.buttons.cancel')
 
         expect(page).to have_content t('sign_up.cancel.success')
-        expect(page).to have_content(t('headings.sign_in_with_sp',
-                                       sp: 'Your friendly Government Agency'))
         expect { User.find(user.id) }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe 'sign_up/passwords/new.html.slim' do
   before do
-    user = build_stubbed(:user, :signed_up)
-
+    user = build_stubbed(:user)
     allow(view).to receive(:current_user).and_return(nil)
+    allow(view).to receive(:session).and_return(sign_up_init: true)
+
     @password_form = PasswordForm.new(user)
 
     render

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'sign_up/registrations/new.html.slim' do
     @register_user_email_form = RegisterUserEmailForm.new
     allow(view).to receive(:controller_name).and_return('registrations')
     allow(view).to receive(:current_user).and_return(nil)
+    allow(view).to receive(:session).and_return(sign_up_init: true)
   end
 
   it 'has a localized title' do


### PR DESCRIPTION
**Why**: We don't currently have a way to account for a user who is
visiting the site and performing some action that is not signing up or
verifying their identity (like resetting a password). Previously the
lack of a `current_user` object was the sole check to determine if a
user was signing up. This caused the cancel partial to display incorrect text.

Screenshot:

<img width="621" alt="screen shot 2017-03-21 at 5 39 26 pm" src="https://cloud.githubusercontent.com/assets/1421848/24172102/5fe4ac2e-0e5d-11e7-880f-4e1e0aaa9049.png">
