### PR TITLE
Only use DAP when fully logged out

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -62,5 +62,5 @@ html lang="#{I18n.locale}" class='no-js'
     - if FeatureManagement.enable_i18n_mode?
       == javascript_include_tag 'misc/i18n-mode'
 
-    - if Figaro.env.participate_in_dap == 'true'
+    - if Figaro.env.participate_in_dap == 'true' && current_user.nil?
       = render 'shared/dap_analytics'

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -11,6 +11,14 @@ describe Users::SessionsController, devise: true do
 
       expect(response.body).to include('<form autocomplete="off"')
     end
+
+    it 'clears the session when user is not yet 2fa-ed' do
+      sign_in_before_2fa
+
+      get :new
+
+      expect(controller.current_user).to be nil
+    end
   end
 
   describe 'GET /active' do

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -58,19 +58,58 @@ describe 'layouts/application.html.slim' do
     end
   end
 
-  it 'displays the navbar component when user is fully authenticated' do
-    render
-    expect(rendered).to have_xpath('//nav[@class="bg-white"]')
+  context 'user is not authenticated' do
+    it 'displays the DAP analytics' do
+      allow(view).to receive(:current_user).and_return(nil)
+      allow(view).to receive(:user_fully_authenticated?).and_return(false)
+      allow(view).to receive(:decorated_session).and_return(
+        DecoratedSession.new(sp: nil, view_context: nil).call
+      )
+      allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
+
+      render
+
+      expect(view).to render_template(partial: 'shared/_dap_analytics')
+    end
   end
 
-  it 'displays only the logo when user is not fully authenticated' do
-    allow(view).to receive(:user_fully_authenticated?).and_return(false)
-    allow(view).to receive(:decorated_session).and_return(SessionDecorator.new)
-    render
+  context 'user is fully authenticated' do
+    it 'displays the navbar component' do
+      render
 
-    expect(rendered).to have_xpath('//nav[contains(@class, "bg-light-blue")]')
-    expect(rendered).to_not have_link(t('shared.nav_auth.my_account'), href: profile_path)
-    expect(rendered).to_not have_content(t('shared.nav_auth.welcome'))
-    expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+      expect(rendered).to have_xpath('//nav[@class="bg-white"]')
+    end
+
+    it 'does not render the DAP analytics' do
+      allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
+
+      render
+
+      expect(view).not_to render_template(partial: 'shared/_dap_analytics')
+    end
+  end
+
+  context 'user is not fully authenticated' do
+    before do
+      allow(view).to receive(:user_fully_authenticated?).and_return(false)
+      allow(view).to receive(:decorated_session).and_return(SessionDecorator.new)
+    end
+
+    it 'displays only the logo' do
+      render
+
+      expect(rendered).to have_xpath('//nav[contains(@class, "bg-light-blue")]')
+      expect(rendered).to_not have_link(t('shared.nav_auth.my_account'), href: profile_path)
+      expect(rendered).to_not have_content(t('shared.nav_auth.welcome'))
+      expect(rendered).to_not have_link(t('links.sign_out'), href: destroy_user_session_path)
+    end
+
+    it 'renders the DAP analytics' do
+      allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
+
+      render
+
+      expect(view).not_to render_template(partial: 'shared/_dap_analytics')
+    end
   end
 end


### PR DESCRIPTION
**Why**: The security and privacy risks of third parties are heightened
during logged-in sessions, since those services have a vantage point to
monitor, exfiltrate, or modify sensitive transactions. It also increases
the risk of logging URLs with sensitive data in the path or query
string, which could be seen by other government employees without a need
to know, or even shown publicly on analytics.usa.gov.

This PR includes DAP only on the root path (sign in form) and the first
page of the sign up process (email form).