### PR TITLE
Clarify number in test as arbitrary

### DIFF
--- a/spec/services/random_phrase_spec.rb
+++ b/spec/services/random_phrase_spec.rb
@@ -23,7 +23,8 @@ describe RandomPhrase do
     end
 
     it 'does not contain the letters I L O U' do
-      100.times do
+      arbitrary_largish_number = 100
+      arbitrary_largish_number.times do
         phrase = RandomPhrase.new(num_words: 4)
 
         expect(phrase.to_s).to_not match(/[ILOU]/)


### PR DESCRIPTION
**Why**: Named variables are easier to grok.