### PR TITLE
Set HTML5 input attributes for mobile

### DIFF
--- a/app/views/partials/personal_key/_entry_fields.html.slim
+++ b/app/views/partials/personal_key/_entry_fields.html.slim
@@ -5,5 +5,5 @@
     - Figaro.env.recovery_code_length.to_i.times do
       .col.col-3.px1.sm-px2
         = f.input attribute_name, as: :array, label: false,
-          input_html: { required: true, autocapitalize: 'none', autocomplete: 'off', \
-            spellcheck: 'false', 'aria-labelledby' => 'personal-key-label' }
+          input_html: { 'aria-labelledby' => 'personal-key-label', autocapitalize: 'none',
+            autocomplete: 'off', required: true, spellcheck: 'false' }

--- a/app/views/partials/personal_key/_entry_fields.html.slim
+++ b/app/views/partials/personal_key/_entry_fields.html.slim
@@ -5,4 +5,5 @@
     - Figaro.env.recovery_code_length.to_i.times do
       .col.col-3.px1.sm-px2
         = f.input attribute_name, as: :array, label: false,
-          input_html: { required: true, 'aria-labelledby': 'personal-key-label' }
+          input_html: { required: true, autocapitalize: 'none', autocomplete: 'off', \
+            spellcheck: 'false', 'aria-labelledby' => 'personal-key-label' }

--- a/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
+++ b/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
@@ -12,8 +12,14 @@
           - code.split(' ').each_with_index do |word, index|
             .col.col-3.px1.sm-px2
               input(
-                name="recovery-#{index}" type='text' class='col-12 border-dashed field monospace'
-                required=true pattern="#{word}"
+                name="recovery-#{index}"
+                type='text'
+                class='col-12 border-dashed field monospace'
+                required=true
+                pattern="#{word}"
+                autocapitalize='none'
+                autocomplete='off'
+                spellcheck='false'
                 aria-label="#{t('forms.recovery_code.confirmation_label', number: index + 1)}")
         = hidden_field_tag :authenticity_token, form_authenticity_token
 

--- a/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
+++ b/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
@@ -12,15 +12,15 @@
           - code.split(' ').each_with_index do |word, index|
             .col.col-3.px1.sm-px2
               input(
-                name="recovery-#{index}"
-                type='text'
-                class='col-12 border-dashed field monospace'
-                required=true
-                pattern="#{word}"
+                aria-label="#{t('forms.recovery_code.confirmation_label', number: index + 1)}"
                 autocapitalize='none'
                 autocomplete='off'
+                class='col-12 border-dashed field monospace'
+                name="recovery-#{index}"
+                pattern="#{word}"
+                required=true
                 spellcheck='false'
-                aria-label="#{t('forms.recovery_code.confirmation_label', number: index + 1)}")
+                type='text')
         = hidden_field_tag :authenticity_token, form_authenticity_token
 
         .clearfix.mxn2

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -177,6 +177,10 @@ module Features
       fields = page.all(selector)
 
       fields.zip(code_words) do |field, word|
+        expect(field[:autocapitalize]).to eq('none')
+        expect(field[:autocomplete]).to eq('off')
+        expect(field[:spellcheck]).to eq('false')
+
         field.set(word)
       end
     end


### PR DESCRIPTION
**Why**:
Disable autocorrect, autocapitalize, and spellcheck so things
like the iOS keyboard don't interfere with typing in things that
are not words

<img width="262" alt="screen_shot_2017-03-22_at_3_41_28_pm" src="https://cloud.githubusercontent.com/assets/458784/24218857/3aedf754-0f1b-11e7-8df7-d458f37730ca.png">


---

It turns out "spellcheck" is not actually supported yet on iOS, but it is in the MDN docs as a real attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input