### PR TITLE
Add UspsExporter

### DIFF
--- a/app/services/usps_exporter.rb
+++ b/app/services/usps_exporter.rb
@@ -1,0 +1,50 @@
+class UspsExporter
+  OTP_MAX_VALID_DAYS = 30
+
+  def initialize(csv_file_path)
+    @csv_file_path = csv_file_path
+  end
+
+  def run
+    CSV.open(csv_file_path, 'wb', col_sep: '|') do |csv|
+      make_csv(csv)
+    end
+    clear_entries
+  end
+
+  private
+
+  attr_reader :csv_file_path
+
+  def make_csv(csv)
+    entries.map(&:decrypted_entry).each do |entry|
+      csv << make_entry_row(entry)
+    end
+  end
+
+  def entries
+    @entries ||= UspsConfirmation.all
+  end
+
+  def clear_entries
+    UspsConfirmation.where(id: entries.map(&:id)).destroy_all
+  end
+
+  # rubocop:disable MethodLength, AbcSize
+  def make_entry_row(entry)
+    now = Time.zone.now
+    due = now + OTP_MAX_VALID_DAYS.days
+    [
+      "#{entry.first_name} #{entry.last_name}",
+      entry.address1,
+      entry.address2,
+      entry.city,
+      entry.state,
+      entry.zipcode,
+      entry.otp,
+      "#{now.strftime('%B %e')},#{now.year}",
+      "#{due.strftime('%B %e')},#{due.year}",
+    ]
+  end
+  # rubocop:enable MethodLength, AbcSize
+end

--- a/spec/services/usps_exporter_spec.rb
+++ b/spec/services/usps_exporter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe UspsExporter do
+  let(:export_file) { Tempfile.new('usps_export.psv') }
+  let(:usps_entry) do
+    UspsConfirmationEntry.new_from_hash(
+      first_name: 'Some',
+      last_name: 'One',
+      address1: '123 Any St',
+      city: 'Somewhere',
+      state: 'KS',
+      zipcode: '66666-1234',
+      otp: 123
+    )
+  end
+  let(:psv_file_contents) do
+    now = Time.zone.now
+    due = now + UspsExporter::OTP_MAX_VALID_DAYS.days
+    current_date = now.strftime('%B %e')
+    due_date = due.strftime('%B %e')
+    values = [
+      usps_entry.first_name + ' ' + usps_entry.last_name,
+      usps_entry.address1,
+      usps_entry.address2,
+      usps_entry.city,
+      usps_entry.state,
+      usps_entry.zipcode,
+      usps_entry.otp,
+      "#{current_date},#{now.year}",
+      "#{due_date},#{due.year}",
+    ]
+    values.join('|')
+  end
+
+  subject { described_class.new(export_file) }
+
+  describe '#run' do
+    before do
+      UspsConfirmation.create(entry: usps_entry.encrypted)
+    end
+
+    it 'creates file' do
+      subject.run
+
+      psv_contents = File.read(export_file)
+
+      expect(psv_contents).to eq("#{psv_file_contents}\n")
+    end
+
+    it 'clears entries after creating file' do
+      expect(UspsConfirmation.count).to eq 1
+
+      subject.run
+
+      expect(UspsConfirmation.count).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
**Why**: USPS confirmations must be exported to a file before they
can be transmitted to vendor via SFTP.