### PR TITLE
Adds proxy object to manage FocusTrap activations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   'rules': {
     'func-names': 0,
     'space-before-function-paren': 0,
-    'prefer-arrow-callback': 0
+    'prefer-arrow-callback': 0,
+    'import/prefer-default-export': 'off'
   },
   'parserOptions': {
     'ecmaVersion': 6,

--- a/app/assets/javascripts/app/components/focus-trap-proxy.js
+++ b/app/assets/javascripts/app/components/focus-trap-proxy.js
@@ -1,0 +1,52 @@
+import focusTrap from 'focus-trap';
+
+function FocusTrapProxy() {
+  const NOOP = function() {};
+  const focusables = [];
+
+  return function trap(el, options) {
+    const safeOnDeactivate = options.onDeactivate || NOOP;
+
+    let ownTrap;
+    let lastActiveTrap = null;
+
+    options = Object.assign(options, {
+      onDeactivate() {
+        lastActiveTrap = this;
+
+        safeOnDeactivate();
+      }
+    });
+
+    ownTrap = new focusTrap(el, options)
+
+    focusables.push(ownTrap);
+
+    return {
+      activate() {
+        focusables.forEach(trap => trap.deactivate());
+
+        if (!lastActiveTrap) {
+          lastActiveTrap = ownTrap;
+        }
+
+        return ownTrap.activate();
+      },
+
+      deactivate(options = {}) {
+        lastActiveTrap && lastActiveTrap.activate();
+        lastActiveTrap = null;
+
+        const deactivatedTrap = ownTrap.deactivate(options);
+
+        return deactivatedTrap;
+      },
+
+      pause() {
+        ownTrap.pause();
+      }
+    };
+  };
+}
+
+export const focusTrapProxy = new FocusTrapProxy();

--- a/app/assets/javascripts/app/components/focus-trap-proxy.js
+++ b/app/assets/javascripts/app/components/focus-trap-proxy.js
@@ -1,24 +1,36 @@
-import focusTrap from 'focus-trap';
+/* eslint-disable */
+import FocusTrap from 'focus-trap';
+/* eslint-enable */
+
+function merge(target, ...sources) {
+  return sources.reduce((memo, source) => {
+    for (const prop in source) {
+      if (source.hasOwnProperty(prop)) {
+        memo[prop] = source[prop];
+      }
+    }
+
+    return memo;
+  }, target);
+}
 
 function FocusTrapProxy() {
   const NOOP = function() {};
   const focusables = [];
 
-  return function trap(el, options) {
+  return function makeTrap(el, options = {}) {
     const safeOnDeactivate = options.onDeactivate || NOOP;
-
-    let ownTrap;
     let lastActiveTrap = null;
 
-    options = Object.assign(options, {
+    const focusTrapOptions = merge({}, options, {
       onDeactivate() {
         lastActiveTrap = this;
 
         safeOnDeactivate();
-      }
+      },
     });
 
-    ownTrap = new focusTrap(el, options)
+    const ownTrap = new FocusTrap(el, focusTrapOptions);
 
     focusables.push(ownTrap);
 
@@ -33,20 +45,22 @@ function FocusTrapProxy() {
         return ownTrap.activate();
       },
 
-      deactivate(options = {}) {
+      deactivate(opts = {}) {
         lastActiveTrap && lastActiveTrap.activate();
         lastActiveTrap = null;
 
-        const deactivatedTrap = ownTrap.deactivate(options);
+        const deactivatedTrap = ownTrap.deactivate(opts);
 
         return deactivatedTrap;
       },
 
       pause() {
         ownTrap.pause();
-      }
+      },
     };
   };
 }
 
-export const focusTrapProxy = new FocusTrapProxy();
+const focusTrapProxy = new FocusTrapProxy();
+
+export default focusTrapProxy;

--- a/app/assets/javascripts/app/components/focus-trap-proxy.js
+++ b/app/assets/javascripts/app/components/focus-trap-proxy.js
@@ -2,17 +2,18 @@
 import FocusTrap from 'focus-trap';
 /* eslint-enable */
 
+/* eslint-disable no-param-reassign */
 function merge(target, ...sources) {
   return sources.reduce((memo, source) => {
-    for (const prop in source) {
-      if (source.hasOwnProperty(prop)) {
-        memo[prop] = source[prop];
-      }
-    }
+    Object.keys(source).forEach((key) => {
+      const prop = source[key];
+      memo[key] = prop;
+    });
 
     return memo;
   }, target);
 }
+/* eslint-disable no-param-reassign */
 
 function FocusTrapProxy() {
   const NOOP = function() {};
@@ -46,7 +47,7 @@ function FocusTrapProxy() {
       },
 
       deactivate(opts = {}) {
-        lastActiveTrap && lastActiveTrap.activate();
+        if (lastActiveTrap) lastActiveTrap.activate();
         lastActiveTrap = null;
 
         const deactivatedTrap = ownTrap.deactivate(opts);

--- a/app/assets/javascripts/app/components/index.js
+++ b/app/assets/javascripts/app/components/index.js
@@ -1,9 +1,11 @@
+import { focusTrapProxy } from './focus-trap-proxy';
 import Modal from './modal';
 import Accordion from './accordion';
 
 const LoginGov = window.LoginGov = (window.LoginGov || {});
+const trapModal = Modal(focusTrapProxy);
 
-LoginGov.Modal = Modal;
+LoginGov.Modal = trapModal;
 
 document.addEventListener('DOMContentLoaded', () => {
   const elements = document.querySelectorAll('.accordion');
@@ -15,3 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return accordion;
   });
 });
+
+export {
+  trapModal as Modal
+};

--- a/app/assets/javascripts/app/components/index.js
+++ b/app/assets/javascripts/app/components/index.js
@@ -1,9 +1,9 @@
-import { focusTrapProxy } from './focus-trap-proxy';
-import Modal from './modal';
+import focusTrapProxy from './focus-trap-proxy';
+import modal from './modal';
 import Accordion from './accordion';
 
 const LoginGov = window.LoginGov = (window.LoginGov || {});
-const trapModal = Modal(focusTrapProxy);
+const trapModal = modal(focusTrapProxy);
 
 LoginGov.Modal = trapModal;
 
@@ -19,5 +19,5 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 export {
-  trapModal as Modal
+  trapModal as Modal,
 };

--- a/app/assets/javascripts/app/components/modal.js
+++ b/app/assets/javascripts/app/components/modal.js
@@ -40,11 +40,7 @@ function Modal(focusTrap) {
       this.shown = showing;
       el.classList[showing ? 'remove' : 'add']('display-none');
       document.body.classList[showing ? 'add' : 'remove']('modal-open');
-      this.trap[showing ? 'activate' : 'deactivate']({
-        onDeactivate() {
-          console.log('deactivating', el)
-        }
-      });
+      this.trap[showing ? 'activate' : 'deactivate']();
     }
   }
 }

--- a/app/assets/javascripts/app/components/modal.js
+++ b/app/assets/javascripts/app/components/modal.js
@@ -1,5 +1,4 @@
 import 'classlist.js';
-import focusTrap from 'focus-trap';
 import Events from '../utils/events';
 
 const STATES = {
@@ -7,41 +6,48 @@ const STATES = {
   SHOW: 'show',
 };
 
-class Modal extends Events {
-  constructor(options) {
-    super();
+function Modal(focusTrap) {
+  return class Modal extends Events {
+    constructor(options) {
+      super();
 
-    this.el = document.querySelector(options.el);
-    this.shown = false;
-    this.trap = focusTrap(this.el, { escapeDeactivates: false });
-  }
+      this.el = document.querySelector(options.el);
+      this.shown = false;
+      this.trap = focusTrap(this.el, { escapeDeactivates: false });
+    }
 
-  toggle() {
-    if (this.shown) {
-      this.hide();
-    } else {
-      this.show();
+    toggle() {
+      if (this.shown) {
+        this.hide();
+      } else {
+        this.show();
+      }
+    }
+
+    show(target) {
+      this._setElementVisibility(target, true);
+      this.emit(STATES.SHOW);
+    }
+
+    hide(target) {
+      this._setElementVisibility(target, false);
+      this.emit(STATES.HIDE);
+    }
+
+    _setElementVisibility(target = null, showing) {
+      const el = target || this.el;
+
+      this.shown = showing;
+      el.classList[showing ? 'remove' : 'add']('display-none');
+      document.body.classList[showing ? 'add' : 'remove']('modal-open');
+      this.trap[showing ? 'activate' : 'deactivate']({
+        onDeactivate() {
+          console.log('deactivating', el)
+        }
+      });
     }
   }
-
-  show(target) {
-    this._setElementVisibility(target, true);
-    this.emit(STATES.SHOW);
-  }
-
-  hide(target) {
-    this._setElementVisibility(target, false);
-    this.emit(STATES.HIDE);
-  }
-
-  _setElementVisibility(target = null, showing) {
-    const el = target || this.el;
-
-    this.shown = showing;
-    el.classList[showing ? 'remove' : 'add']('display-none');
-    document.body.classList[showing ? 'add' : 'remove']('modal-open');
-    this.trap[showing ? 'activate' : 'deactivate']();
-  }
 }
+
 
 export default Modal;

--- a/app/assets/javascripts/app/components/modal.js
+++ b/app/assets/javascripts/app/components/modal.js
@@ -6,8 +6,8 @@ const STATES = {
   SHOW: 'show',
 };
 
-function Modal(focusTrap) {
-  return class Modal extends Events {
+function modal(focusTrap) {
+  return class extends Events {
     constructor(options) {
       super();
 
@@ -42,8 +42,8 @@ function Modal(focusTrap) {
       document.body.classList[showing ? 'add' : 'remove']('modal-open');
       this.trap[showing ? 'activate' : 'deactivate']();
     }
-  }
+  };
 }
 
 
-export default Modal;
+export default modal;

--- a/app/assets/javascripts/misc/cancel-action-modal.js
+++ b/app/assets/javascripts/misc/cancel-action-modal.js
@@ -1,4 +1,4 @@
-import Modal from '../app/components/modal';
+import { Modal } from '../app/components/index';
 
 const modal = new Modal({ el: '#cancel-action-modal' });
 const modalTrigger = document.getElementById('auth-flow-cancel');

--- a/app/assets/javascripts/misc/recovery-page-controller.js
+++ b/app/assets/javascripts/misc/recovery-page-controller.js
@@ -1,4 +1,4 @@
-import Modal from '../app/components/modal';
+import { Modal } from '../app/components/index';
 
 const modalSelector = '#personal-key-confirm';
 const modal = new Modal({ el: modalSelector });

--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -1,5 +1,5 @@
 import 'classlist.js';
-import Modal from '../app/components/modal';
+import { Modal } from '../app/components/index';
 
 function verifyModal() {
   const flash = document.querySelector('.alert');

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -30,12 +30,12 @@ function success(data) {
       time_cutoff = new Date().getTime() + warning,
       show_warning = time_timeout < time_cutoff;
 
-  if (show_warning & !modal.shown) {
+  if (show_warning && !modal.shown) {
     modal.show();
     window.LoginGov.countdownTimer(document.getElementById('countdown'), warning);
   }
 
-  if (!show_warning & el) modal.hide();
+  if (!show_warning && modal.shown) modal.hide();
   if (!data.live) {
     window.LoginGov.autoLogout();
   }

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -2,6 +2,10 @@ var frequency = <%= frequency %> * 1000;
 var warning = <%= warning %> * 1000;
 var start = <%= start %> * 1000;
 var warning_info = "<%= j render('session_timeout/warning', locals: { modal: modal }) %>";
+var warningEl = document.getElementById('session-timeout-cntnr');
+warningEl.insertAdjacentHTML('afterbegin', warning_info);
+
+var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
 
 function ping() {
   var request = new XMLHttpRequest();
@@ -26,12 +30,12 @@ function success(data) {
       time_cutoff = new Date().getTime() + warning,
       show_warning = time_timeout < time_cutoff;
 
-  if (show_warning & !el) {
-    cntnr.insertAdjacentHTML('afterbegin', warning_info);
+  if (show_warning & !modal.shown) {
+    modal.show();
     window.LoginGov.countdownTimer(document.getElementById('countdown'), warning);
   }
 
-  if (!show_warning & el) el.remove();
+  if (!show_warning & el) modal.hide();
   if (!data.live) {
     window.LoginGov.autoLogout();
   }

--- a/app/views/session_timeout/_warning.html.slim
+++ b/app/views/session_timeout/_warning.html.slim
@@ -1,4 +1,4 @@
-#session-timeout-msg
+#session-timeout-msg.display-none
   = render layout: '/shared/modal_layout' do
     .p4.cntnr-skinny.border-box.bg-white.rounded.relative
       = image_tag(asset_url('clock.svg'), class: 'modal-ico')

--- a/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
+++ b/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
@@ -7,7 +7,7 @@
       #recovery-code-alert.alert.alert-alert.display-none(role='alert')
         = t('users.recovery_code.confirmation_error')
 
-      form(id='confirm-key' method='post' action="#{sign_up_recovery_code_path}")
+      form(id='confirm-key' method='post' action="#{sign_up_recovery_code_path}" name="key-confirm")
         .clearfix.mxn1.sm-mxn2.mb4.separator-inputs
           - code.split(' ').each_with_index do |word, index|
             .col.col-3.px1.sm-px2
@@ -28,5 +28,8 @@
             button(type='submit' class='col-12 btn btn-primary recovery-code-confirm')
               = t('forms.buttons.continue')
           .col.col-12.sm-col-6.px2
-            button.col-12.btn.btn-outline.blue.rounded-lg(data-dismiss='personal-key-confirm')
+            button.col-12.btn.btn-outline.blue.rounded-lg(
+              type="button"
+              data-dismiss="personal-key-confirm"
+            )
               = t('forms.buttons.back')

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -89,7 +89,7 @@ development:
   scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   secret_key_base: 'development_secret_key_base'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
-  session_timeout_in_minutes: '15'
+  session_timeout_in_minutes: '1'
   telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   twilio_record_voice: 'true'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -89,7 +89,7 @@ development:
   scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   secret_key_base: 'development_secret_key_base'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
-  session_timeout_in_minutes: '1'
+  session_timeout_in_minutes: '15'
   telephony_disabled: 'true'
   twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
   twilio_record_voice: 'true'

--- a/spec/javascripts/app/components/focus-trap-proxy_spec.js
+++ b/spec/javascripts/app/components/focus-trap-proxy_spec.js
@@ -1,4 +1,7 @@
+/* eslint-disable */
 const proxyquire = require('proxyquireify')(require);
+/* eslint-enable */
+
 const stub = sinon.stub;
 const focusTrapStub = stub();
 

--- a/spec/javascripts/app/components/focus-trap-proxy_spec.js
+++ b/spec/javascripts/app/components/focus-trap-proxy_spec.js
@@ -10,15 +10,19 @@ const focusTrapAPI = {
   deactivate: stub(),
 };
 
-focusTrapStub.returns(focusTrapAPI);
-
 describe('focusTrap', () => {
   let proxy;
 
   beforeEach(function() {
     proxy = proxyquire('app/components/focus-trap-proxy', {
       'focus-trap': focusTrapStub,
-    }).focusTrapProxy;
+    }).default;
+
+    Object.keys(focusTrapAPI).forEach((methodName) => {
+      focusTrapAPI[methodName].reset();
+    });
+
+    focusTrapStub.returns(focusTrapAPI);
   });
 
   it('calls the underlying focusTrap object', () => {
@@ -50,7 +54,7 @@ describe('focusTrap', () => {
       trapB.activate();
       trapB.deactivate();
 
-      expect(focusTrapAPI.activate.calledThrice).to.be.true();
+      expect(focusTrapAPI.activate.callCount).to.be.equal(3);
       expect(focusTrapAPI.deactivate.callCount).to.equal(5);
     });
   });

--- a/spec/javascripts/app/components/focus-trap-proxy_spec.js
+++ b/spec/javascripts/app/components/focus-trap-proxy_spec.js
@@ -1,0 +1,54 @@
+const proxyquire = require('proxyquireify')(require);
+const stub = sinon.stub;
+const focusTrapStub = stub();
+
+const focusTrapAPI = {
+  activate: stub(),
+  deactivate: stub(),
+};
+
+focusTrapStub.returns(focusTrapAPI);
+
+describe('focusTrap', () => {
+  let proxy;
+
+  beforeEach(function() {
+    proxy = proxyquire('app/components/focus-trap-proxy', {
+      'focus-trap': focusTrapStub,
+    }).focusTrapProxy;
+  });
+
+  it('calls the underlying focusTrap object', () => {
+    proxy('', {});
+    expect(focusTrapStub.calledOnce).to.be.true();
+  });
+
+  context('#activate', () => {
+    it('deactivates all registered traps when activate is called', () => {
+      const trapA = proxy('', {});
+
+      // define a couple more traps
+      proxy('', {});
+      proxy('', {});
+
+      trapA.activate();
+
+      expect(focusTrapAPI.activate.calledOnce).to.be.true();
+      expect(focusTrapAPI.deactivate.callCount).to.equal(3);
+    });
+  });
+
+  context('#deactivate', () => {
+    it('proxies to `deactivate` and reactivates the last active trap', () => {
+      const trapA = proxy('', {});
+      const trapB = proxy('', {});
+
+      trapA.activate();
+      trapB.activate();
+      trapB.deactivate();
+
+      expect(focusTrapAPI.activate.calledThrice).to.be.true();
+      expect(focusTrapAPI.deactivate.callCount).to.equal(5);
+    });
+  });
+});

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -96,7 +96,9 @@ shared_examples_for 'recovery code page' do
 
         it 'does not interfere with the session timeout modal' do
           click_acknowledge_recovery_code
+          find('a', text: t('notices.timeout_warning.signed_in.sign_out'))
           click_on t('notices.timeout_warning.signed_in.sign_out')
+
           expect(current_path).to eq(root_path)
         end
       end

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -1,5 +1,6 @@
 shared_examples_for 'recovery code page' do
   include XPathHelper
+  include SessionTimeoutWarningHelper
 
   it 'hides confirmation importance reminder text by default' do
     expect(page).to have_xpath(
@@ -56,7 +57,7 @@ shared_examples_for 'recovery code page' do
         expect(page).not_to have_content(t('users.recovery_code.help_text'))
 
         page.find('.accordion-header-control').click
-        expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='true']")
+        expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='false']")
         expect(page).to have_content(t('users.recovery_code.help_text'))
       end
 
@@ -81,6 +82,23 @@ shared_examples_for 'recovery code page' do
         expect(page.evaluate_script('document.activeElement.innerText')).to eq(
           t('forms.buttons.back')
         )
+      end
+
+      context 'when the session times out and the modal is visible' do
+        before do
+          allow(Figaro.env).to receive(:session_check_frequency).and_return('1')
+          allow(Figaro.env).to receive(:session_check_delay).and_return('2')
+          allow(Figaro.env).to receive(:session_timeout_warning_seconds).
+            and_return(Devise.timeout_in.to_s)
+          sign_in_and_2fa_user
+          visit manage_recovery_code_path
+        end
+
+        it 'does not interfere with the session timeout modal' do
+          click_acknowledge_recovery_code
+          click_on t('notices.timeout_warning.signed_in.sign_out')
+          expect(current_path).to eq(root_path)
+        end
       end
 
       context 'closing the modal', js: true do


### PR DESCRIPTION
Fixes issue with open modals not yielding focus to the session timeout modal.

To manually test:

1. Log in to an existing account
2. On profile page, click to create a new personal key
3. Click continue on personal key page
4. Do not fill the form in the modal, instead wait for the session timeout modal
5. Click the "Keep me signed in" button

The timeout modal should redirect you back to the current page. Currently, clicking on the session timeout modal buttons with another active modal produces no effect.

The **Why** section didn't make it over from my original commit, and also assumed knowledge of the focus trap library. Here is a more explicit one:

To make our modals a11y compliant, we need a way to trap focus within them. This prevents users from being able to tab outside of the modal and end up in a state we didn't account for (e.g. interacting with a button underneath the modal). To achieve this, we used a library called [focus-trap](https://github.com/davidtheclark/focus-trap). This library ensures that focus can't leave the root element that an instance of a `FocusTrap` object is instantiated with.

The problem occurs when the session timeout modal appears over a modal which has been focus trapped. When the second modal appears, focus-trap has no knowledge of the event. Furthermore, only one element can have focus at a time, which means the session timeout modal will never get focus if a user attempts to interact with it. Since focus-trap maintains no references to other nodes which might have a focus trap defined, and because it doesn't expose the underlying focused element to a developer, it becomes necessary to have an intermediate object.

This object, the `FocusTrapProxy`, intercepts calls to focus-trap (using the same API as focus-trap) and has some internal state to manage the last focused element. This ensures that once an overlying modal (or any focused element) is closed, the element the user was interacting with prior to the modal opening becomes refocused.

**Caveat**: In this specific instance, the session timeout modal actually redirects the user, so we don't need to worry about restoring focus to the previous element. However, this functionality was very easy to add, and should we ever have instances of secondary actions appearing and being resolved without a page refresh, we can be reasonably confident that focusing will behave correctly.