### PR TITLE
Do not include DAP on sign up email confirm page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,15 @@ module ApplicationHelper
     !current_user || !current_user.two_factor_enabled?
   end
 
+  def session_with_trust?
+    current_user || page_with_trust?
+  end
+
+  def page_with_trust?
+    current_page?(controller: 'sign_up/email_confirmations', action: 'create') ||
+      current_page?(controller: 'users/reset_passwords', action: 'edit')
+  end
+
   def loa3_requested?
     sp_session && sp_session[:loa3]
   end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -62,5 +62,5 @@ html lang="#{I18n.locale}" class='no-js'
     - if FeatureManagement.enable_i18n_mode?
       == javascript_include_tag 'misc/i18n-mode'
 
-    - if Figaro.env.participate_in_dap == 'true' && current_user.nil?
+    - if Figaro.env.participate_in_dap == 'true' && !session_with_trust?
       = render 'shared/dap_analytics'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,4 +20,39 @@ describe ApplicationHelper do
       expect(html).to have_xpath("//span[@aria-label='#{tooltip_text}']")
     end
   end
+
+  describe '#session_with_trust?' do
+    context 'no user present' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(helper.session_with_trust?).to eq false
+      end
+
+      context 'current path is email confirmation path' do
+        it 'returns true' do
+          allow(helper).to receive(:current_page?).with(
+            controller: 'sign_up/email_confirmations', action: 'create'
+          ).and_return(true)
+
+          expect(helper.session_with_trust?).to eq true
+        end
+      end
+
+      context 'current path is reset password path' do
+        it 'returns true' do
+          allow(helper).to receive(:current_page?).with(
+            controller: 'sign_up/email_confirmations', action: 'create'
+          ).and_return(true)
+          allow(helper).to receive(:current_page?).with(
+            controller: 'users/reset_passwords', action: 'edit'
+          ).and_return(true)
+
+          expect(helper.session_with_trust?).to eq true
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**WHY**: If someone can get to this page, it means they've established
some level of trust (the email address belongs to them) so we don't want
to collect analytics on this page.