### PR TITLE
Allow confirming email in a different browser

### DIFF
--- a/.reek
+++ b/.reek
@@ -17,6 +17,9 @@ FeatureEnvy:
     - EncryptedSidekiqRedis#zrem
     - UserDecorator#should_acknowledge_recovery_code?
     - Pii::Attributes#[]=
+InstanceVariableAssumption:
+  exclude:
+    - User
 IrresponsibleModule:
   enabled: false
 ManualDispatch:
@@ -59,6 +62,7 @@ TooManyMethods:
     - ApplicationController
     - OpenidConnectAuthorizeForm
     - Idv::Session
+    - User
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sp_from_request_id
-    issuer = ServiceProviderRequest.find_by(uuid: params[:request_id]).issuer
+    issuer = ServiceProviderRequest.from_uuid(params[:request_id]).issuer
     sp = ServiceProvider.from_issuer(issuer)
     sp if sp.is_a? ServiceProvider
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,12 +57,12 @@ class ApplicationController < ActionController::Base
   def redirect_on_timeout
     return unless params[:timeout]
 
-    flash[:timeout] = decorated_session.timeout_flash_text
+    flash[:timeout] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
     redirect_to url_for(params.except(:timeout))
   end
 
   def current_sp
-    @current_sp ||= sp_from_sp_session || sp_from_params
+    @current_sp ||= sp_from_sp_session || sp_from_request_id
   end
 
   def sp_from_sp_session
@@ -70,8 +70,9 @@ class ApplicationController < ActionController::Base
     sp if sp.is_a? ServiceProvider
   end
 
-  def sp_from_params
-    sp = ServiceProvider.from_issuer(params[:issuer])
+  def sp_from_request_id
+    issuer = ServiceProviderRequest.find_by(uuid: params[:request_id]).issuer
+    sp = ServiceProvider.from_issuer(issuer)
     sp if sp.is_a? ServiceProvider
   end
 

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -1,0 +1,14 @@
+module FullyAuthenticatable
+  def confirm_two_factor_authenticated(id = nil)
+    return redirect_to sign_up_start_url(request_id: id) unless user_signed_in?
+
+    return prompt_to_set_up_2fa unless current_user.two_factor_enabled?
+
+    prompt_to_enter_otp
+  end
+
+  def delete_branded_experience
+    ServiceProviderRequest.find_by(uuid: sp_session[:request_id]).delete
+    session.delete(:sp)
+  end
+end

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -8,7 +8,7 @@ module FullyAuthenticatable
   end
 
   def delete_branded_experience
-    ServiceProviderRequest.find_by(uuid: sp_session[:request_id]).delete
+    ServiceProviderRequest.from_uuid(sp_session[:request_id]).delete
     session.delete(:sp)
   end
 end

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -1,11 +1,11 @@
 module UnconfirmedUserConcern
   def with_unconfirmed_user
-    token = params[:confirmation_token]
-    @user = User.find_or_initialize_with_error_by(:confirmation_token, token)
-    @user = User.confirm_by_token(token) if @user.confirmed?
+    @confirmation_token = params[:confirmation_token]
+    @user = User.find_or_initialize_with_error_by(:confirmation_token, @confirmation_token)
+    @user = User.confirm_by_token(@confirmation_token) if @user.confirmed?
     @password_form = PasswordForm.new(@user)
 
-    yield
+    yield if block_given?
   end
 
   def after_confirmation_path_for(user)

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -42,9 +42,7 @@ class SamlIdpController < ApplicationController
     needs_idv = identity_needs_verification?
     analytics.track_event(Analytics::SAML_AUTH, @result.to_h.merge(idv: needs_idv))
 
-    yield true if needs_idv
-
-    yield false
+    yield needs_idv
   end
 
   def store_location_and_redirect_to_verify_url

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -6,18 +6,16 @@ class SamlIdpController < ApplicationController
   include SamlIdp::Controller
   include SamlIdpAuthConcern
   include SamlIdpLogoutConcern
+  include FullyAuthenticatable
 
   skip_before_action :verify_authenticity_token
   skip_before_action :handle_two_factor_authentication, only: :logout
 
   def auth
-    link_identity_from_session_data
-
-    needs_idv = identity_needs_verification?
-    analytics.track_event(Analytics::SAML_AUTH, @result.to_h.merge(idv: needs_idv))
-
-    return redirect_to verify_url if needs_idv
-
+    return confirm_two_factor_authenticated(@request_id) unless user_fully_authenticated?
+    process_fully_authenticated_user do |needs_idv|
+      return store_location_and_redirect_to_verify_url if needs_idv
+    end
     delete_branded_experience
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
   end
@@ -38,6 +36,22 @@ class SamlIdpController < ApplicationController
 
   private
 
+  def process_fully_authenticated_user
+    link_identity_from_session_data
+
+    needs_idv = identity_needs_verification?
+    analytics.track_event(Analytics::SAML_AUTH, @result.to_h.merge(idv: needs_idv))
+
+    yield true if needs_idv
+
+    yield false
+  end
+
+  def store_location_and_redirect_to_verify_url
+    store_location_for(:user, request.original_url)
+    redirect_to verify_url
+  end
+
   def render_template_for(message, action_url, type)
     domain = SecureHeadersWhitelister.extract_domain(action_url)
     override_content_security_policy_directives(form_action: ["'self'", domain])
@@ -47,10 +61,5 @@ class SamlIdpController < ApplicationController
       locals: { action_url: action_url, message: message, type: type },
       layout: false
     )
-  end
-
-  def delete_branded_experience
-    session.delete(:sp)
-    session.delete('user_return_to')
   end
 end

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -47,7 +47,7 @@ module SignUp
     end
 
     def current_sp
-      @_current_sp ||= ServiceProviderRequest.find_by(uuid: params[:_request_id])
+      @_current_sp ||= ServiceProviderRequest.from_uuid(params[:_request_id])
     end
 
     def loa3_requested?

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -39,19 +39,19 @@ module SignUp
 
     def add_sp_details_to_session
       session[:sp] = {
-        issuer: current_sp.issuer,
+        issuer: sp_request.issuer,
         loa3: loa3_requested?,
-        request_url: current_sp.url,
-        request_id: current_sp.uuid,
+        request_url: sp_request.url,
+        request_id: sp_request.uuid,
       }
     end
 
-    def current_sp
-      @_current_sp ||= ServiceProviderRequest.from_uuid(params[:_request_id])
+    def sp_request
+      @_sp_request ||= ServiceProviderRequest.from_uuid(params[:_request_id])
     end
 
     def loa3_requested?
-      current_sp.loa == Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+      sp_request.loa == Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
     end
 
     def process_confirmed_user

--- a/app/controllers/sign_up/email_resend_controller.rb
+++ b/app/controllers/sign_up/email_resend_controller.rb
@@ -8,7 +8,7 @@ module SignUp
     end
 
     def create
-      @resend_email_confirmation_form = ResendEmailConfirmationForm.new(email_from_params)
+      @resend_email_confirmation_form = ResendEmailConfirmationForm.new(permitted_params)
       result = @resend_email_confirmation_form.submit
 
       analytics.track_event(Analytics::EMAIL_CONFIRMATION_RESEND, result.to_h)
@@ -22,14 +22,17 @@ module SignUp
 
     private
 
-    def email_from_params
-      params[:resend_email_confirmation_form][:email]
+    def permitted_params
+      params.require(:resend_email_confirmation_form).permit(:email, :request_id)
     end
 
     def handle_valid_email
-      User.send_confirmation_instructions(email: form_email)
       session[:email] = form_email
       redirect_to sign_up_verify_email_path
+    end
+
+    def request_id
+      permitted_params[:request_id]
     end
 
     def form_email

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -2,6 +2,10 @@ module SignUp
   class PasswordsController < ApplicationController
     include UnconfirmedUserConcern
 
+    def new
+      with_unconfirmed_user
+    end
+
     def create
       with_unconfirmed_user do
         result = @password_form.submit(permitted_params)

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -31,7 +31,7 @@ module SignUp
       if result.success?
         process_successful_creation
       else
-        render :new, locals: { request_id: saml_request_id }
+        render :new, locals: { request_id: sp_request_id }
       end
     end
 
@@ -58,7 +58,7 @@ module SignUp
       )
     end
 
-    def saml_request_id
+    def sp_request_id
       request_id = permitted_params.fetch(:request_id)
       return if request_id.empty?
 

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -62,7 +62,7 @@ module SignUp
       request_id = permitted_params.fetch(:request_id)
       return if request_id.empty?
 
-      ServiceProviderRequest.find_by(uuid: request_id).uuid
+      ServiceProviderRequest.from_uuid(request_id).uuid
     end
 
     def disable_account_creation

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -18,6 +18,7 @@ module SignUp
       @register_user_email_form = RegisterUserEmailForm.new
       session[:sign_up_init] = true
       analytics.track_event(Analytics::USER_REGISTRATION_ENTER_EMAIL_VISIT)
+      render :new, locals: { request_id: nil }
     end
 
     def create
@@ -30,7 +31,7 @@ module SignUp
       if result.success?
         process_successful_creation
       else
-        render :new
+        render :new, locals: { request_id: saml_request_id }
       end
     end
 
@@ -42,7 +43,7 @@ module SignUp
     end
 
     def permitted_params
-      params.require(:user).permit(:email)
+      params.require(:user).permit(:email, :request_id)
     end
 
     def process_successful_creation
@@ -52,7 +53,16 @@ module SignUp
       resend_confirmation = params[:user][:resend]
       session[:email] = user.email
 
-      redirect_to sign_up_verify_email_path(resend: resend_confirmation)
+      redirect_to sign_up_verify_email_path(
+        resend: resend_confirmation, request_id: permitted_params[:request_id]
+      )
+    end
+
+    def saml_request_id
+      request_id = permitted_params.fetch(:request_id)
+      return if request_id.empty?
+
+      ServiceProviderRequest.find_by(uuid: request_id).uuid
     end
 
     def disable_account_creation

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,10 +10,6 @@ module Users
     def new
       session.delete(:sign_up_init)
 
-      if session[:sp]&.delete(:show_start_page)
-        return redirect_to sign_up_start_path
-      end
-
       analytics.track_event(Analytics::SIGN_IN_PAGE_VISIT)
       super
     end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -39,15 +39,6 @@ class ServiceProviderSessionDecorator
     'shared/null'
   end
 
-  def timeout_flash_text
-    I18n.t(
-      'notices.session_cleared_with_sp',
-      link: view_context.link_to(sp_name, sp.return_to_sp_url),
-      minutes: Figaro.env.session_timeout_in_minutes,
-      sp: sp_name
-    )
-  end
-
   def sp_name
     sp.friendly_name || sp.agency
   end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -25,10 +25,6 @@ class SessionDecorator
 
   def logo_partial; end
 
-  def timeout_flash_text
-    I18n.t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
-  end
-
   def sp_name; end
 
   def sp_logo; end

--- a/app/forms/resend_email_confirmation_form.rb
+++ b/app/forms/resend_email_confirmation_form.rb
@@ -4,26 +4,40 @@ class ResendEmailConfirmationForm
 
   attr_reader :email
 
-  def initialize(email = nil)
-    @email = email
+  def initialize(params = {})
+    @params = params
+    self.email = params[:email]
   end
 
   def submit
-    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
+    @success = valid?
+    send_confirmation_email_if_necessary
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+  end
+
+  def user
+    @_user ||= (email.presence && User.find_with_email(email)) || NonexistentUser.new
   end
 
   private
 
   attr_writer :email
+  attr_reader :params, :success
+
+  def send_confirmation_email_if_necessary
+    return unless valid? && user.persisted? && !user.confirmed?
+
+    user.send_custom_confirmation_instructions(request_id)
+  end
+
+  def request_id
+    params[:request_id]
+  end
 
   def extra_analytics_attributes
     {
       user_id: user.uuid,
       confirmed: user.confirmed?,
     }
-  end
-
-  def user
-    @_user ||= (email.presence && User.find_with_email(email)) || NonexistentUser.new
   end
 end

--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -19,6 +19,7 @@ class UpdateUserEmailForm
     if valid_form?
       @success = true
       UpdateUser.new(user: @user, attributes: { email: email }).call
+      @user.send_custom_confirmation_instructions
     else
       @success = process_errors
     end

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -14,8 +14,7 @@ module SessionTimeoutWarningHelper
   def timeout_refresh_url
     URIService.add_params(
       request.original_url,
-      timeout: true,
-      issuer: request.query_parameters[:issuer] || sp_session[:issuer]
+      timeout: true
     ).html_safe # rubocop:disable Rails/OutputSafety
   end
 

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -8,6 +8,7 @@ class CustomDeviseMailer < Devise::Mailer
     presenter = ConfirmationEmailPresenter.new(record, view_context)
     @first_sentence = presenter.first_sentence
     @confirmation_period = presenter.confirmation_period
+    @request_id = options[:request_id]
     super
   end
 end

--- a/app/models/nonexistent_user.rb
+++ b/app/models/nonexistent_user.rb
@@ -10,4 +10,8 @@ class NonexistentUser
   def confirmed?
     false
   end
+
+  def persisted?
+    false
+  end
 end

--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -1,0 +1,5 @@
+class ServiceProviderRequest < ActiveRecord::Base
+  def self.find_by(*args)
+    super || NullServiceProviderRequest.new
+  end
+end

--- a/app/models/service_provider_request.rb
+++ b/app/models/service_provider_request.rb
@@ -1,5 +1,5 @@
 class ServiceProviderRequest < ActiveRecord::Base
-  def self.find_by(*args)
-    super || NullServiceProviderRequest.new
+  def self.from_uuid(uuid)
+    find_by(uuid: uuid) || NullServiceProviderRequest.new
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,15 +134,16 @@ class User < ActiveRecord::Base
     # no-op
   end
 
-  # Override Devise because we want to include the SAML request id in the
-  # confirmation instructions email
+  # In order to pass in the SP request_id to the confirmation instructions
+  # email, we need to define `send_custom_confirmation_instructions` because
+  # Devise's `send_confirmation_instructions` does not include arguments.
+  # We also need to override the Devise method to do nothing because this method
+  # is called automatically when a user is created due to a Devise callback.
+  # If we didn't disable it, the user would receive two confirmation emails.
   def send_confirmation_instructions
     # no-op
   end
 
-  # This is basically Devise's send_confirmation_instructions method copied
-  # word for word, except that it adds the ability to pass in the request_id
-  # to the mailer.
   def send_custom_confirmation_instructions(id = nil)
     generate_confirmation_token! unless @raw_confirmation_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,9 @@ class User < ActiveRecord::Base
     # no-op
   end
 
+  # This is basically Devise's send_confirmation_instructions method copied
+  # word for word, except that it adds the ability to pass in the request_id
+  # to the mailer.
   def send_custom_confirmation_instructions(id = nil)
     generate_confirmation_token! unless @raw_confirmation_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,4 +133,17 @@ class User < ActiveRecord::Base
   def strip_whitespace
     # no-op
   end
+
+  # Override Devise because we want to include the SAML request id in the
+  # confirmation instructions email
+  def send_confirmation_instructions
+    # no-op
+  end
+
+  def send_custom_confirmation_instructions(id = nil)
+    generate_confirmation_token! unless @raw_confirmation_token
+
+    opts = pending_reconfirmation? ? { to: unconfirmed_email, request_id: id } : { request_id: id }
+    send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+  end
 end

--- a/app/services/null_service_provider_request.rb
+++ b/app/services/null_service_provider_request.rb
@@ -1,0 +1,7 @@
+class NullServiceProviderRequest
+  def uuid; end
+
+  def issuer; end
+
+  def delete; end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -11,13 +11,16 @@ table.button.expanded.large.radius
               td
                 center
                   = link_to t('mailer.confirmation_instructions.link_text'), \
-                    sign_up_create_email_confirmation_url(confirmation_token: @token), \
+                    sign_up_create_email_confirmation_url(_request_id: \
+                    @request_id, confirmation_token: @token), \
                     target: '_blank', \
                     class: 'float-center', align: 'center'
       td.expander
 
-p = link_to sign_up_create_email_confirmation_url(confirmation_token: @token), \
-    sign_up_create_email_confirmation_url(confirmation_token: @token), target: '_blank'
+p = link_to sign_up_create_email_confirmation_url(_request_id: @request_id, \
+    confirmation_token: @token), \
+    sign_up_create_email_confirmation_url(_request_id: @request_id, \
+    confirmation_token: @token), target: '_blank'
 
 table.spacer
   tbody

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -16,4 +16,5 @@ p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
   = render decorated_session.return_to_service_provider_partial
   .sm-col-right.mxn1
     = link_to t('links.passwords.forgot'), new_password_path(resource_name), class: 'px1'
-    = link_to t('links.create_account'), sign_up_email_path, class: 'px1 border-left border-silver'
+    = link_to t('links.create_account'), sign_up_email_url(request_id: params[:request_id]), \
+      class: 'px1 border-left border-silver'

--- a/app/views/sign_up/email_resend/new.html.slim
+++ b/app/views/sign_up/email_resend/new.html.slim
@@ -6,4 +6,5 @@ h1.h3.my0 = t('headings.confirmations.new')
                   url: sign_up_create_email_resend_path,
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.input :email, required: true
+  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
   = f.button :submit, t('forms.buttons.resend_confirmation'), class: 'mt2 mb1'

--- a/app/views/sign_up/emails/show.html.slim
+++ b/app/views/sign_up/emails/show.html.slim
@@ -15,9 +15,11 @@
     html: { class: 'mb2' }) do |f|
     = f.input :email, as: :hidden, wrapper: false
     = f.input :resend, as: :hidden, wrapper: false
+    = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
     | #{t('notices.signed_up_but_unconfirmed.no_email_sent_explanation_start')}
     = f.button :submit, t('links.resend'), class: 'btn-link ml-tiny'
-  - link = link_to t('notices.use_diff_email.link'), sign_up_email_path
+  - link = link_to t('notices.use_diff_email.link'),
+           sign_up_email_path(request_id: params[:request_id])
   p = t('notices.use_diff_email.text_html', link: link)
   p = t('devise.registrations.close_window')
 

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -15,6 +15,7 @@ p.mb0
       input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
+  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -7,6 +7,7 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
     url: sign_up_register_path) do |f|
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
+  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
   p.mb-40p.mt1.italic
     = t('notices.terms_of_service.text_html',
         link: link_to( \

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -4,8 +4,9 @@
   h1.h3.mb2.blue.regular = decorated_session.registration_heading
   p.mb4 = t("devise.registrations.start.introduction.loa3_requested.#{loa3_requested?}")
   - ab_test(:demo) do |variant, _|
-    = link_to t(variant), sign_up_email_path, class: 'sm-col-10 col-12 btn btn-primary btn-wide mb1'
-  - auth_link = link_to t('links.sign_in'), new_user_session_path
+    = link_to t(variant), sign_up_email_path(request_id: params[:request_id]), \
+      class: 'sm-col-10 col-12 btn btn-primary btn-wide mb1'
+  - auth_link = link_to t('links.sign_in'), new_user_session_path(request_id: params[:request_id])
   p.mb0 == t('instructions.registration.already_have_account', link: auth_link)
 
 - if loa3_requested?
@@ -40,8 +41,5 @@
           p.mb2 = t('devise.registrations.start.bullet_5_html')
           p.mb3 = link_to \
             t('devise.registrations.start.learn_more'), MarketingSite.help_url, target: '_blank'
-  .center
-    - ab_test(:demo) do |variant, _|
-      = link_to t(variant), sign_up_email_path,
-        class: 'sm-col-10 col-12 btn btn-primary btn-wide mb1 js-toggle-button display-none'
+
   == javascript_include_tag 'misc/toggle-button'

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -35,9 +35,6 @@ en:
     session_cleared: >
       For your security, we refresh the page and clear out any information you typed into the
       form fields if you don't submit the form within %{minutes} minutes.
-    session_cleared_with_sp: >
-      For your security, your request from %{sp} expires after %{minutes} minutes if you don't
-      submit the form. Then you'll have to start again from %{link}.
     sign_in_consent:
       link: Security Consent & Privacy Act Statement.
       text: By signing in, you agree to %{app}’s %{link}

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -26,7 +26,6 @@ es:
         sign_out: NOT TRANSLATED YET
         message_html: NOT TRANSLATED YET
     session_cleared: NOT TRANSLATED YET
-    session_cleared_with_sp: NOT TRANSLATED YET
     sign_in_consent:
       link: NOT TRANSLATED YET
       text: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,13 +92,13 @@ Rails.application.routes.draw do
   get '/sign_up/email/confirm' => 'sign_up/email_confirmations#create',
       as: :sign_up_create_email_confirmation
   get '/sign_up/enter_email' => 'sign_up/registrations#new', as: :sign_up_email
+  post '/sign_up/enter_email' => 'sign_up/registrations#create', as: :sign_up_register
   get '/sign_up/enter_email/resend' => 'sign_up/email_resend#new', as: :sign_up_email_resend
   post '/sign_up/enter_email/resend' => 'sign_up/email_resend#create',
        as: :sign_up_create_email_resend
   get '/sign_up/enter_password' => 'sign_up/passwords#new'
   get '/sign_up/recovery_code' => 'sign_up/recovery_codes#show'
   post '/sign_up/recovery_code' => 'sign_up/recovery_codes#update'
-  post '/sign_up/register' => 'sign_up/registrations#create', as: :sign_up_register
   get '/sign_up/start' => 'sign_up/registrations#show', as: :sign_up_start
   get '/sign_up/verify_email' => 'sign_up/emails#show', as: :sign_up_verify_email
   get '/sign_up/completed' => 'sign_up/completions#show', as: :sign_up_completed

--- a/db/migrate/20170321170516_create_service_provider_requests.rb
+++ b/db/migrate/20170321170516_create_service_provider_requests.rb
@@ -1,0 +1,14 @@
+class CreateServiceProviderRequests < ActiveRecord::Migration
+  def change
+    create_table :service_provider_requests do |t|
+      t.string :issuer, null: false
+      t.string :loa, null: false
+      t.string :url, null: false
+      t.string :uuid, null: false
+
+      t.timestamps null: false
+
+      t.index :uuid
+    end
+  end
+end

--- a/db/migrate/20170321170516_create_service_provider_requests.rb
+++ b/db/migrate/20170321170516_create_service_provider_requests.rb
@@ -8,7 +8,7 @@ class CreateServiceProviderRequests < ActiveRecord::Migration
 
       t.timestamps null: false
 
-      t.index :uuid
+      t.index :uuid, unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20170321170516) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "service_provider_requests", ["uuid"], name: "index_service_provider_requests_on_uuid", using: :btree
+  add_index "service_provider_requests", ["uuid"], name: "index_service_provider_requests_on_uuid", unique: true, using: :btree
 
   create_table "service_providers", force: :cascade do |t|
     t.string   "issuer",                                                       null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306214524) do
+ActiveRecord::Schema.define(version: 20170321170516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,17 @@ ActiveRecord::Schema.define(version: 20170306214524) do
   add_index "profiles", ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)", using: :btree
   add_index "profiles", ["user_id", "ssn_signature", "active"], name: "index_profiles_on_user_id_and_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
+
+  create_table "service_provider_requests", force: :cascade do |t|
+    t.string   "issuer",     null: false
+    t.string   "loa",        null: false
+    t.string   "url",        null: false
+    t.string   "uuid",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "service_provider_requests", ["uuid"], name: "index_service_provider_requests_on_uuid", using: :btree
 
   create_table "service_providers", force: :cascade do |t|
     t.string   "issuer",                                                       null: false

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
     end
 
     context 'user is not signed in' do
-      it 'redirects to login' do
+      it 'redirects to SP landing page with the request_id in the params' do
         action
         sp_request_id = ServiceProviderRequest.last.uuid
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -99,16 +99,21 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
     context 'user is not signed in' do
       it 'redirects to login' do
-        expect(action).to redirect_to(root_url)
+        action
+        sp_request_id = ServiceProviderRequest.last.uuid
+
+        expect(response).to redirect_to sign_up_start_url(request_id: sp_request_id)
       end
 
       it 'sets sp information in the session' do
         action
+        sp_request_id = ServiceProviderRequest.last.uuid
 
         expect(session[:sp]).to eq(
           loa3: false,
           issuer: 'urn:gov:gsa:openidconnect:test',
-          show_start_page: true
+          request_id: sp_request_id,
+          request_url: request.original_url
         )
       end
     end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -116,7 +116,7 @@ describe SignUp::RegistrationsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::USER_REGISTRATION_EMAIL, analytics_hash)
 
-      post :create, user: { email: 'invalid@' }
+      post :create, user: { email: 'invalid@', request_id: '' }
     end
   end
 

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -79,16 +79,6 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#timeout_flash_text' do
-    it 'returns the correct string' do
-      expect(subject.timeout_flash_text).
-        to eq t('notices.session_cleared_with_sp',
-                link: view_context.link_to(sp_name, sp.return_to_sp_url),
-                minutes: Figaro.env.session_timeout_in_minutes,
-                sp: sp_name)
-    end
-  end
-
   describe '#sp_name' do
     it 'returns the SP friendly name if present' do
       expect(subject.sp_name).to eq sp.friendly_name

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -55,14 +55,6 @@ RSpec.describe SessionDecorator do
     end
   end
 
-  describe '#timeout_flash_text' do
-    it 'returns the correct string' do
-      expect(subject.timeout_flash_text).to eq(
-        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
-      )
-    end
-  end
-
   describe '#sp_name' do
     it 'returns nil' do
       expect(subject.sp_name).to be_nil

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -15,7 +15,7 @@ feature 'Accessibility on pages that require authentication', :js do
       create(:user, :unconfirmed)
       confirm_last_user
 
-      expect(current_path).to eq(sign_up_create_email_confirmation_path)
+      expect(current_path).to eq(sign_up_enter_password_path)
       expect(page).to be_accessible
     end
 

--- a/spec/features/load_testing/email_sign_up_spec.rb
+++ b/spec/features/load_testing/email_sign_up_spec.rb
@@ -8,7 +8,7 @@ feature 'Email sign up' do
     sign_up_with(email)
     click_link('CONFIRM NOW')
 
-    expect(current_path).to eq sign_up_create_email_confirmation_path
+    expect(current_path).to eq sign_up_enter_password_path
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
   end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -113,7 +113,7 @@ feature 'OpenID Connect' do
       click_submit_default
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')
-      expect(ServiceProviderRequest.find_by(uuid: sp_request_id)).
+      expect(ServiceProviderRequest.from_uuid(sp_request_id)).
         to be_a NullServiceProviderRequest
       expect(page.get_rack_session.keys).to_not include('sp')
     end
@@ -190,7 +190,7 @@ feature 'OpenID Connect' do
       click_button t('openid_connect.authorization.index.allow')
       redirect_uri = URI(current_url)
       expect(redirect_uri.to_s).to start_with('gov.gsa.openidconnect.test://result')
-      expect(ServiceProviderRequest.find_by(uuid: sp_request_id)).
+      expect(ServiceProviderRequest.from_uuid(sp_request_id)).
         to be_a NullServiceProviderRequest
       expect(page.get_rack_session.keys).to_not include('sp')
     end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -165,7 +165,7 @@ feature 'OpenID Connect' do
       expect(id_token).to be_present
     end
 
-    it 'continues to the branded authorization page on first-time signup' do
+    it 'continues to the branded authorization page on first-time signup', email: true do
       client_id = 'urn:gov:gsa:openidconnect:test'
 
       visit openid_connect_authorize_path(

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -167,32 +167,40 @@ feature 'OpenID Connect' do
 
     it 'continues to the branded authorization page on first-time signup', email: true do
       client_id = 'urn:gov:gsa:openidconnect:test'
+      email = 'test@test.com'
 
-      visit openid_connect_authorize_path(
-        client_id: client_id,
-        response_type: 'code',
-        acr_values: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
-        scope: 'openid email',
-        redirect_uri: 'gov.gsa.openidconnect.test://result',
-        state: SecureRandom.hex,
-        nonce: SecureRandom.hex,
-        prompt: 'select_account',
-        code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
-        code_challenge_method: 'S256'
-      )
+      perform_in_browser(:one) do
+        visit openid_connect_authorize_path(
+          client_id: client_id,
+          response_type: 'code',
+          acr_values: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
+          scope: 'openid email',
+          redirect_uri: 'gov.gsa.openidconnect.test://result',
+          state: SecureRandom.hex,
+          nonce: SecureRandom.hex,
+          prompt: 'select_account',
+          code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
+          code_challenge_method: 'S256'
+        )
 
-      expect(page).to have_content(t('headings.create_account_with_sp', sp: 'Example iOS App'))
+        expect(page).to have_content(t('headings.create_account_with_sp', sp: 'Example iOS App'))
+
+        sign_up_user_from_sp_without_confirming_email(email)
+      end
 
       sp_request_id = ServiceProviderRequest.last.uuid
-      sign_up_and_2fa_loa1_user_who_came_from_sp
 
-      click_button t('forms.buttons.continue_to', sp: 'Example iOS App')
-      click_button t('openid_connect.authorization.index.allow')
-      redirect_uri = URI(current_url)
-      expect(redirect_uri.to_s).to start_with('gov.gsa.openidconnect.test://result')
-      expect(ServiceProviderRequest.from_uuid(sp_request_id)).
-        to be_a NullServiceProviderRequest
-      expect(page.get_rack_session.keys).to_not include('sp')
+      perform_in_browser(:two) do
+        confirm_email_in_a_different_browser(email)
+
+        click_button t('forms.buttons.continue_to', sp: 'Example iOS App')
+        click_button t('openid_connect.authorization.index.allow')
+        redirect_uri = URI(current_url)
+        expect(redirect_uri.to_s).to start_with('gov.gsa.openidconnect.test://result')
+        expect(ServiceProviderRequest.from_uuid(sp_request_id)).
+          to be_a NullServiceProviderRequest
+        expect(page.get_rack_session.keys).to_not include('sp')
+      end
     end
   end
 

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -9,7 +9,8 @@ feature 'LOA1 Single Sign On' do
       authn_request = auth_request.create(saml_settings)
 
       perform_in_browser(:one) do
-        sign_up_user_from_sp_without_confirming_email(email: email, request: authn_request)
+        visit authn_request
+        sign_up_user_from_sp_without_confirming_email(email)
       end
 
       sp_request_id = ServiceProviderRequest.last.uuid

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -9,18 +9,14 @@ feature 'LOA3 Single Sign On' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
       xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+      email = 'test@test.com'
 
       visit saml_authn_request
       click_link t('experiments.demo.get_started')
-      email = 'test@example.com'
-      fill_in 'Email', with: email
-      click_button t('forms.buttons.submit.default')
-      open_email(email)
-      visit_in_email(t('mailer.confirmation_instructions.link_text'))
-      fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
-      click_button t('forms.buttons.submit.default')
-      fill_in 'Phone', with: '202-555-1212'
-      select_sms_delivery
+      submit_form_with_valid_email
+      click_confirmation_link_in_email(email)
+      submit_form_with_valid_password
+      set_up_2fa_with_valid_phone
       enter_2fa_code
 
       expect(current_path).to eq verify_path

--- a/spec/features/session_timeout_spec.rb
+++ b/spec/features/session_timeout_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 feature 'Session Timeout' do
-  context 'when SP info no longer in session but issuer params exists' do
+  context 'when SP info no longer in session but request_id params exists' do
     it 'preserves the branded experience' do
       issuer = 'http://localhost:3000'
+      sp_request = ServiceProviderRequest.create(issuer: issuer, url: 'foo', uuid: '123', loa: '1')
       sp = ServiceProvider.from_issuer(issuer)
-      visit root_path(issuer: issuer)
+
+      visit root_url(request_id: sp_request.uuid)
 
       expect(page).to have_link sp.friendly_name
       expect(page).to have_css('img[src*=sp-logos]')

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -35,7 +35,7 @@ describe RegisterUserEmailForm do
         user = instance_double(User, email: 'existing@test.com', confirmed?: false, uuid: '123')
         allow(User).to receive(:find_with_email).with(user.email).and_return(user)
 
-        expect(user).to receive(:send_confirmation_instructions)
+        expect(user).to receive(:send_custom_confirmation_instructions)
 
         extra = {
           email_already_exists: true,

--- a/spec/forms/resend_email_confirmation_form_spec.rb
+++ b/spec/forms/resend_email_confirmation_form_spec.rb
@@ -1,32 +1,35 @@
 require 'rails_helper'
 
 describe ResendEmailConfirmationForm do
-  subject { ResendEmailConfirmationForm.new(' Test@example.com ') }
+  let(:request_id) { SecureRandom.uuid }
+  let(:params) { { email: ' Test@example.com ', request_id: request_id } }
+  subject { ResendEmailConfirmationForm.new(params) }
 
   it_behaves_like 'email validation'
   it_behaves_like 'email normalization', ' Test@example.com '
 
   describe '#submit' do
-    context 'when email is valid and user exists' do
-      it 'returns hash with properties about the event and the user' do
-        user = build(:user, :signed_up)
-        subject = ResendEmailConfirmationForm.new(user.email)
+    context 'when email is valid, and user exists and is not confirmed' do
+      it 'returns FormResponse with success: true and sends confirmation email' do
+        user = create(:user, :unconfirmed)
+        subject = ResendEmailConfirmationForm.new(email: user.email, request_id: request_id)
 
         extra = {
           user_id: user.uuid,
-          confirmed: true,
+          confirmed: false,
         }
         result = instance_double(FormResponse)
 
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
+        expect(subject.user).to receive(:send_custom_confirmation_instructions).with(request_id)
         expect(subject.submit).to eq result
         expect(subject.email).to eq user.email
       end
     end
 
     context 'when email is valid and user does not exist' do
-      it 'returns hash with properties about the event and the nonexistent user' do
+      it 'returns FormResponse with success: true but does not send an email' do
         extra = {
           user_id: 'nonexistent-uuid',
           confirmed: false,
@@ -35,13 +38,14 @@ describe ResendEmailConfirmationForm do
 
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
+        expect(subject.user).to_not receive(:send_custom_confirmation_instructions)
         expect(subject.submit).to eq result
       end
     end
 
     context 'when email is invalid' do
-      it 'returns hash with properties about the event and the nonexistent user' do
-        subject = ResendEmailConfirmationForm.new('invalid')
+      it 'returns FormResponse with success: false and does not send an email' do
+        subject = ResendEmailConfirmationForm.new(email: 'invalid')
 
         extra = {
           user_id: 'nonexistent-uuid',
@@ -52,7 +56,27 @@ describe ResendEmailConfirmationForm do
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra).and_return(result)
+        expect(subject.user).to_not receive(:send_custom_confirmation_instructions)
         expect(subject.submit).to eq result
+      end
+    end
+
+    context 'when email is valid, and user exists and is already confirmed' do
+      it 'returns FormResponse with success: true and does not send an email' do
+        user = create(:user, :signed_up)
+        subject = ResendEmailConfirmationForm.new(email: user.email, request_id: request_id)
+
+        extra = {
+          user_id: user.uuid,
+          confirmed: true,
+        }
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
+        expect(subject.user).to_not receive(:send_custom_confirmation_instructions).with(request_id)
+        expect(subject.submit).to eq result
+        expect(subject.email).to eq user.email
       end
     end
   end

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -26,14 +26,14 @@ describe SessionTimeoutWarningHelper do
       )
     end
 
-    let(:query_parameters) { { issuer: 'http://localhost:3000' } }
+    let(:query_parameters) { { request_id: '123' } }
 
     context 'with no params in the request url' do
       let(:original_url) { 'http://test.host/foo/bar' }
 
-      it 'adds timeout=true and issuer=http%3A%2F%2Flocalhost%3A3000 params' do
+      it 'adds timeout=true params' do
         expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&timeout=true'
+          'http://test.host/foo/bar?timeout=true'
         )
       end
     end
@@ -43,42 +43,18 @@ describe SessionTimeoutWarningHelper do
 
       it 'adds timeout=true and preserves params' do
         expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&key=value&timeout=true'
+          'http://test.host/foo/bar?key=value&timeout=true'
         )
       end
     end
 
-    context 'with timeout=true and issuer=http%3A%2F%2Flocalhost%3A3000 \
+    context 'with timeout=true and request_id=123 \
             in the query params already' do
-      let(:original_url) { 'http://test.host/foo/bar?timeout=true&issuer=http://localhost:3000' }
+      let(:original_url) { 'http://test.host/foo/bar?timeout=true&request_id=123' }
 
       it 'is the same' do
         expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=http%3A%2F%2Flocalhost%3A3000&timeout=true'
-        )
-      end
-    end
-
-    context 'when params[:issuer] is not present, but sp_session[:issuer] is' do
-      let(:query_parameters) { {} }
-      let(:original_url) { 'http://test.host/foo/bar' }
-
-      it 'reads issuer from sp_session' do
-        session[:sp] = { issuer: 'foo' }
-
-        expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=foo&timeout=true'
-        )
-      end
-    end
-
-    context 'when neither params[:issuer] nor sp_session[:issuer] are present' do
-      let(:query_parameters) { {} }
-      let(:original_url) { 'http://test.host/foo/bar' }
-
-      it 'sets issuer to nil' do
-        expect(helper.timeout_refresh_url).to eq(
-          'http://test.host/foo/bar?issuer=&timeout=true'
+          'http://test.host/foo/bar?request_id=123&timeout=true'
         )
       end
     end

--- a/spec/models/service_provider_request_spec.rb
+++ b/spec/models/service_provider_request_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe ServiceProviderRequest do
+  describe '.from_uuid' do
+    context 'when the record exists' do
+      it 'returns the record matching the uuid' do
+        sp_request = ServiceProviderRequest.create(
+          uuid: '123', issuer: 'foo', url: 'http://bar.com', loa: '1'
+        )
+
+        expect(ServiceProviderRequest.from_uuid('123')).to eq sp_request
+      end
+    end
+
+    context 'when the record does not exists' do
+      it 'returns an instance of NullServiceProviderRequest' do
+        expect(ServiceProviderRequest.from_uuid('123')).
+          to be_an_instance_of NullServiceProviderRequest
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,10 +11,10 @@ describe User do
     it { is_expected.to have_many(:events) }
   end
 
-  it 'should only send one email during creation' do
+  it 'does not send an email when #create is called' do
     expect do
       User.create(email: 'nobody@nobody.com')
-    end.to change(ActionMailer::Base.deliveries, :count).by(1)
+    end.to change(ActionMailer::Base.deliveries, :count).by(0)
   end
 
   describe 'password validations' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -214,9 +214,8 @@ module Features
       config.session_store.new({}, config.session_options)
     end
 
-    def sign_up_user_from_sp_without_confirming_email(email:, request:)
+    def sign_up_user_from_sp_without_confirming_email(email)
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      visit request
       sp_request_id = ServiceProviderRequest.last.uuid
 
       expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -257,6 +257,8 @@ module Features
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id, resend: true)
       expect(page).to have_css('img[src*=sp-logos]')
 
+      delete_sp_info_from_session_to_simulate_user_switching_browsers
+
       attempt_to_confirm_email_with_invalid_token(sp_request_id)
 
       expect(current_url).to eq sign_up_email_resend_url(request_id: sp_request_id)
@@ -319,6 +321,10 @@ module Features
 
     def click_link_to_resend_the_email
       click_button 'Resend email'
+    end
+
+    def delete_sp_info_from_session_to_simulate_user_switching_browsers
+      page.set_rack_session(sp: {})
     end
 
     def attempt_to_confirm_email_with_invalid_token(request_id)

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -26,7 +26,7 @@ describe 'devise/sessions/new.html.slim' do
 
     expect(rendered).
       to have_link(
-        t('links.create_account'), href: sign_up_email_path
+        t('links.create_account'), href: sign_up_email_url(request_id: nil)
       )
   end
 

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -6,6 +6,7 @@ describe 'sign_up/registrations/new.html.slim' do
     allow(view).to receive(:controller_name).and_return('registrations')
     allow(view).to receive(:current_user).and_return(nil)
     allow(view).to receive(:session).and_return(sign_up_init: true)
+    allow(view).to receive(:request_id).and_return(nil)
   end
 
   it 'has a localized title' do


### PR DESCRIPTION
**Why**: Some people might visit the site via a Service Provider (SP)
in one browser, but open the email confirmation link in a different
browser. This means that anything that was previously stored in the
session in the first browser won't be available in the second browser.
The consequence is that the user won't be redirected back to the SP
after they finish creating their account.

**How**:
- Add a new ServiceProviderRequest DB table

When a request is made from an SP, whether it's via SAML or OpenID
Connect, we create a new ServiceProviderRequest with the following
attributes: the full request URL, a random unique UUID (because it's
not guaranteed that separate requests will have a unique identifier
attached to them), the issuer, and LOA. We also store these same
attributes in the session to support the sign in scenario (as opposed
to account creation).

Then, we check to see if the user is fully authenticated, and if not,
we redirect them to the `/sign_up/start` page, and include the
request_id in the params, as well as in the links on that page that
point to the account creation and sign in pages. Note that I moved the
logic that determines whether or not the landing page should appear,
from the sessions controller to the SAML and OpenID Connect controllers,
since they are the ones that know where the user should go. This adheres
to the Tell, Don't Ask principle, and allows us to remove the
`show_start_page` key from the session.

When the user chooses to create an account, the form contains the
request_id in a hidden field so it can pass it on to the registrations
controller. To include the request_id in the confirmation email, I had
to create a new method based on the one Devise uses, but with the
ability to pass in the request_id. Since Devise automatically sends the
confirmation email when the user is created (via a callback), I had to
override the original method to do nothing.

By having the request_id in the email, that means that if the user
visits the confirmation URL in a different browser, we can go back to
storing the SP info in the session by looking up the
ServiceProviderRequest whose uuid matches the `_request_id` parameter
from the URL in the email. By going back to using the session from then
on, it frees us from having to keep passing in the request_id in URLs
and in forms. This is done in
`EmailConfirmationsController#process_valid_confirmation_token`.

Note that the request_id is prefixed with an underscore in the email to
make sure that the URL ends with the confirmation token. By default,
Rails sorts params in `link_to` helpers alphabetically, but we don't
want `request_id` to come last because if the user chooses to copy the
link instead of clicking it, and if they don't copy it correctly, the
app won't find the ServiceProviderRequest, whereas an invalid
confirmation token will display an error to the user.

Once the user finishes creating their account, when they click the
button to continue to the SP, the app makes the original SP request
again, calling the `before_action`s in the SAML and OpenId Connect
controllers a second time. However, we don't want to create a new
ServiceProviderRequest because we want to be able to delete the
original one after the user goes back to the SP. We don't want the
ServiceProviderRequests table to grow indefinitely. The only way
to know for sure whether or not a ServiceProviderRequest that matches
the request URL already exists is to query on its `url` field. The
problem is, given that we want to index that field since it will be
queried on every SP request, the url field value is too big for the
Postgres btree index. There are solutions to this problem (that I
haven't implemented before), but I didn't feel it was worth the
trouble when we can rely on the presence of `sp_session[:request_id]`
to determine whether or not a new ServiceProviderRequest should be
created or not. We also use the `sp_session[:request_id]` to determine
which ServiceProviderRequest to delete by find a matching uuid. Then,
we can safely delete the `:sp` Hash from the session.

By keeping track of the SP via the request_id, we can also remove the
session timeout code and flash message that dealt with the scenario
where a user makes a request from an SP, but then remains on the
sign in page for longer than 8 minutes. Note that all this does is
preserve the branded experience on the sign in page. Allowing the
SP info to be restored after sign in will be implemented in a
separate PR.

Note that this doesn't include the same fix for the scenario where a
user opens the password reset link in a different browser. That will be
in a separate PR.