### PR TITLE
Removes redundant flash messages from otp pages

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -36,8 +36,6 @@ module Users
 
     def handle_valid_delivery_method(method)
       send_user_otp(method)
-      resent_message = t("notices.send_code.#{method}")
-      flash[:success] = resent_message if session[:code_sent].present?
       session[:code_sent] = 'true'
       redirect_to login_two_factor_path(delivery_method: method, reauthn: reauthn?)
     end

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -19,8 +19,6 @@ en:
     resend_confirmation_email:
       success: We have resent your confirmation email.
     send_code:
-      sms: We sent you a one-time passcode via text message.
-      voice: We will call you with your one-time passcode.
       recovery_code: You've got a new personal key.
     timeout_warning:
       signed_in:
@@ -36,8 +34,8 @@ en:
           For your security, in %{time_left_in_session} we will automatically
           cancel your sign in.
     session_cleared: >
-      For your security, we refresh the page and clear out any information you typed into the 
-      form fields if you don't submit the form within %{minutes} minutes. 
+      For your security, we refresh the page and clear out any information you typed into the
+      form fields if you don't submit the form within %{minutes} minutes.
     session_cleared_with_sp: >
       For your security, your request from %{sp} expires after %{minutes} minutes if you don't
       submit the form. Then you'll have to start again from %{link}.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -16,8 +16,6 @@ es:
     resend_confirmation_email:
       success: NOT TRANSLATED YET
     send_code:
-      sms: NOT TRANSLATED YET
-      voice: NOT TRANSLATED YET
       recovery_code: NOT TRANSLATED YET
     timeout_warning:
       signed_in:

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -147,23 +147,6 @@ describe Users::TwoFactorAuthenticationController do
 
         get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
       end
-
-      context 'first request' do
-        it 'does not notify the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
-
-          expect(flash[:success]).to eq nil
-        end
-      end
-
-      context 'multiple requests' do
-        it 'notifies the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
-          get :send_code, otp_delivery_selection_form: { otp_method: 'sms' }
-
-          expect(flash[:success]).to eq t('notices.send_code.sms')
-        end
-      end
     end
 
     context 'when selecting voice OTP delivery' do
@@ -204,23 +187,6 @@ describe Users::TwoFactorAuthenticationController do
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
 
         get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-      end
-
-      context 'first request' do
-        it 'does not notify the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-
-          expect(flash[:success]).to eq nil
-        end
-      end
-
-      context 'multiple requests' do
-        it 'notifies the user of OTP transmission via flash message' do
-          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-          get :send_code, otp_delivery_selection_form: { otp_method: 'voice' }
-
-          expect(flash[:success]).to eq t('notices.send_code.voice')
-        end
       end
     end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -87,9 +87,13 @@ feature 'Two Factor Authentication' do
     scenario 'user can resend one-time password (OTP)' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
+      old_code = find('input[@name="code"]').value
+
       click_link t('links.two_factor_authentication.resend_code.sms')
 
-      expect(page).to have_content(t('notices.send_code.sms'))
+      new_code = find('input[@name="code"]').value
+
+      expect(old_code).not_to eq(new_code)
     end
 
     scenario 'user can cancel OTP process' do


### PR DESCRIPTION
**Why**: The flash messages, which appeared on subsequent requests for
an OTP code, repeated information that was already present on the OTP
page.

**Old behavior**: With flash message

<img width="313" alt="screen shot 2017-03-20 at 2 03 14 pm" src="https://cloud.githubusercontent.com/assets/1598889/24175282/98d4f5e4-0e52-11e7-8dc3-1354dc444614.png">

**New behavior**: Page looks the same

<img width="630" alt="screen shot 2017-03-24 at 10 28 17 am" src="https://cloud.githubusercontent.com/assets/1421848/24298543/ad20e2e8-107c-11e7-93d9-62beddf3e8f8.png">


