### PR TITLE
Removes flash message from personal key screen

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -123,8 +123,6 @@ module TwoFactorAuthenticatable
 
   def handle_valid_otp_for_confirmation_context
     assign_phone
-
-    flash[:success] = t('notices.phone_confirmation_successful')
   end
 
   def handle_valid_otp_for_authentication_context

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -15,7 +15,6 @@ en:
       no_email_sent_explanation_start: Didn’t receive an email?
       resend_email_success: We have resent your password reset email.
     password_changed: You changed your password.
-    phone_confirmation_successful: You confirmed your phone number. Now your account is more secure!
     resend_confirmation_email:
       success: We have resent your confirmation email.
     send_code:

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -12,7 +12,6 @@ es:
       no_email_sent_explanation_start: NOT TRANSLATED YET
       resend_email_success: NOT TRANSLATED YET
     password_changed: NOT TRANSLATED YET
-    phone_confirmation_successful: NOT TRANSLATED YET
     resend_confirmation_email:
       success: NOT TRANSLATED YET
     send_code:

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -384,10 +384,6 @@ describe TwoFactorAuthentication::OtpVerificationController do
           expect(response).to redirect_to(verify_confirmations_path)
         end
 
-        it 'displays success flash notice' do
-          expect(flash[:success]).to eq t('notices.phone_confirmation_successful')
-        end
-
         it 'does not call UserMailer' do
           expect(UserMailer).to_not have_received(:phone_changed)
         end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -42,7 +42,6 @@ feature 'Changing authentication factor' do
 
       submit_correct_otp
 
-      expect(page).to have_content t('notices.phone_confirmation_successful')
       expect(current_path).to eq profile_path
       expect(UserMailer).to have_received(:phone_changed).with(user)
       expect(mailer).to have_received(:deliver_later)


### PR DESCRIPTION
**Why**: The success message referred to validating your phone number,
which is nice but not necessary. It also caused content the user needs
to interact with to be pushed down farther

Old screen:

<img width="387" alt="screen shot 2017-03-20 at 6 46 15 pm" src="https://cloud.githubusercontent.com/assets/1598889/24160998/7cd98666-0e20-11e7-91aa-40a2bb20395c.png">


New screen:

<img width="650" alt="screen shot 2017-03-24 at 2 59 59 pm" src="https://cloud.githubusercontent.com/assets/1421848/24309577/c3d5fd36-10a2-11e7-81b1-073e57661b63.png">
