### PR TITLE
Remove basic account badge

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -91,14 +91,6 @@ UserDecorator = Struct.new(:user) do
     end
   end
 
-  def basic_account_partial
-    if identity_not_verified?
-      'profile/basic_account_badge'
-    else
-      'shared/null'
-    end
-  end
-
   private
 
   def masked_number(number)

--- a/app/views/profile/_basic_account_badge.html.slim
+++ b/app/views/profile/_basic_account_badge.html.slim
@@ -1,3 +1,0 @@
-.h6.border.rounded.p1.regular
-  = t('headings.profile.basic_account')
-  = tooltip(t('tooltips.verified_account'))

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -48,12 +48,8 @@ h1.hide = t('titles.profile')
       .clearfix.mxn1
         .sm-col.sm-col-5.px1 = t('.phone')
         .sm-col.sm-col-7.px1 = @decrypted_pii.phone
-.clearfix
-  h2.h3.my0.sm-col
-    = t('headings.profile.login_info')
-  .sm-col-right.left.sm-m0.mt1
-    = render partial: current_user.decorate.basic_account_partial
-
+h2.h3.my0
+  = t('headings.profile.login_info')
 .mt2.mb4
   .py-12p.border-top
     .clearfix.mxn1

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -15,7 +15,6 @@ en:
       forgot: Forgot your password?
     profile:
       account_history: Account history
-      basic_account: Basic Account
       login_info: Account information
       profile_info: Profile information
       two_factor: Two-factor authentication

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -15,7 +15,6 @@ es:
       forgot: ¿Olvidó su contraseña?
     profile:
       account_history: La historia de la cuenta
-      basic_account: Cuenta básica
       login_info: Información de la cuenta
       profile_info: Información del perfil
       two_factor: Autenticación de dos factores

--- a/config/locales/tooltips/en.yml
+++ b/config/locales/tooltips/en.yml
@@ -12,10 +12,6 @@ en:
     two_factor: >
       Two-factor authentication makes signing in more secure by requiring a
       mobile device as well as a password.
-    verified_account: >
-      For your security, some government agencies require customer accounts to
-      be verified using Personally Identifiable Information (PII) such as
-      Social Security Number and proof of address.
     authentication_app: An authentication application is a mobile security app
       that generates security codes even if you don't have an Internet connection
       or cellular service.

--- a/config/locales/tooltips/es.yml
+++ b/config/locales/tooltips/es.yml
@@ -5,5 +5,4 @@ es:
     profile_info: NOT TRANSLATED YET
     ssn: NOT TRANSLATED YET
     two_factor: NOT TRANSLATED YET
-    verified_account: NOT TRANSLATED YET
     authentication_app: NOT TRANSLATED YET

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -142,21 +142,5 @@ describe UserDecorator do
         it { expect(partial).to eq('profile/verified_account_badge') }
       end
     end
-
-    describe '#basic_account_partial' do
-      subject(:partial) { UserDecorator.new(user).basic_account_partial }
-
-      context 'with an unverified account' do
-        let(:user) { build(:user) }
-
-        it { expect(partial).to eq('profile/basic_account_badge') }
-      end
-
-      context 'with a verified account' do
-        let(:user) { create(:user, profiles: [verified_profile]) }
-
-        it { expect(partial).to eq('shared/null') }
-      end
-    end
   end
 end

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -6,15 +6,6 @@ feature 'User profile' do
       sign_in_live_with_2fa(profile.user)
     end
 
-    context 'LOA1 account' do
-      let(:profile) { create(:profile) }
-
-      it 'shows a "Basic Account" badge with a tooltip' do
-        expect(page).to have_content(t('headings.profile.basic_account'))
-        expect(page).to have_css("[aria-label='#{t('tooltips.verified_account')}']")
-      end
-    end
-
     context 'LOA3 account' do
       let(:profile) { create(:profile, :active, :verified, pii: { ssn: '111', dob: '1920-01-01' }) }
 


### PR DESCRIPTION
**Why**: Opt to instead show a "Verified" badge only. 