### PR TITLE
Fix HTML5 validation of recovery code input

### DIFF
--- a/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
+++ b/app/views/sign_up/recovery_codes/_confirmation_modal.html.slim
@@ -13,11 +13,11 @@
             .col.col-3.px1.sm-px2
               input(
                 aria-label="#{t('forms.recovery_code.confirmation_label', number: index + 1)}"
-                autocapitalize='none'
+                maxlength="#{word.length}"
                 autocomplete='off'
                 class='col-12 border-dashed field monospace'
                 name="recovery-#{index}"
-                pattern="#{word}"
+                pattern="[#{word.upcase}#{word.downcase}]{#{word.length}}"
                 required=true
                 spellcheck='false'
                 type='text')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -151,6 +151,7 @@ module Features
     end
 
     def acknowledge_and_confirm_recovery_code
+      extra_characters_get_ignored = 'abc123qwerty'
       code_words = []
 
       page.all(:css, '[data-recovery]').map do |node|
@@ -162,7 +163,7 @@ module Features
       click_on button_text, class: 'recovery-code-continue'
 
       code_words.size.times do |index|
-        fill_in "recovery-#{index}", with: code_words[index].downcase
+        fill_in "recovery-#{index}", with: code_words[index].downcase + extra_characters_get_ignored
       end
 
       click_on button_text, class: 'recovery-code-confirm'


### PR DESCRIPTION
**Why**: Browser check was still enforcing case sensitivity and allowing
input strings of indefinite length.

**How**: Disallow input of strings longer than the target "word". Change
the match pattern to use both upper and lower case versions of the "word".