### PR TITLE
Add validation to recovery code use

### DIFF
--- a/app/forms/recovery_code_form.rb
+++ b/app/forms/recovery_code_form.rb
@@ -21,6 +21,8 @@ class RecoveryCodeForm
   attr_reader :user, :success
 
   def valid_recovery_code?
+    word_regexp = /\w{#{RandomPhrase::WORD_LENGTH}}/
+    return false unless code =~ /\A#{word_regexp} #{word_regexp} #{word_regexp} #{word_regexp}\Z/
     recovery_code_generator = RecoveryCodeGenerator.new(user)
     recovery_code_generator.verify(code)
   end

--- a/app/views/partials/personal_key/_entry_fields.html.slim
+++ b/app/views/partials/personal_key/_entry_fields.html.slim
@@ -5,5 +5,9 @@
     - Figaro.env.recovery_code_length.to_i.times do
       .col.col-3.px1.sm-px2
         = f.input attribute_name, as: :array, label: false,
-          input_html: { 'aria-labelledby' => 'personal-key-label', autocapitalize: 'none',
-            autocomplete: 'off', required: true, spellcheck: 'false' }
+          input_html: { 'aria-labelledby' => 'personal-key-label',
+            autocapitalize: 'none',
+            autocomplete: 'off',
+            maxlength: RandomPhrase::WORD_LENGTH,
+            required: true,
+            spellcheck: 'false' }

--- a/spec/forms/recovery_code_form_spec.rb
+++ b/spec/forms/recovery_code_form_spec.rb
@@ -22,14 +22,11 @@ describe RecoveryCodeForm do
       it 'returns FormResponse with success: false' do
         user = build_stubbed(:user, :signed_up, recovery_code: 'code')
 
-        generator = instance_double(RecoveryCodeGenerator)
-        allow(RecoveryCodeGenerator).to receive(:new).with(user).
-          and_return(generator)
-        allow(generator).to receive(:verify).with('foo').and_return(false)
-
         form = RecoveryCodeForm.new(user, 'foo')
         result = instance_double(FormResponse)
         extra = { multi_factor_auth_method: 'recovery code' }
+
+        expect(RecoveryCodeGenerator).to_not receive(:new)
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: extra).and_return(result)


### PR DESCRIPTION
**Why**: We were lacking client or server side validation on a
recovery code when a user attempted to use it.