### PR TITLE
Update mailer footer to link to Help page

### DIFF
--- a/app/views/layouts/user_mailer.html.slim
+++ b/app/views/layouts/user_mailer.html.slim
@@ -77,8 +77,8 @@ html xmlns="http://www.w3.org/1999/xhtml"
                                       tr
                                         th
                                           p == t('mailer.help',
-                                                link: link_to(MarketingSite.contact_url,
-                                                              MarketingSite.contact_url),
+                                                link: link_to(MarketingSite.help_url,
+                                                              MarketingSite.help_url),
                                                 app: link_to(APP_NAME,
                                                              Figaro.env.mailer_domain_name,
                                                              style: 'text-decoration: none;'))

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -25,8 +25,7 @@ en:
     email_reuse_notice:
       subject: Confirm your email address
     help: >
-      For more help, please contact the %{app} customer contact center via web
-      form at %{link}.
+      For more help, please visit the %{app} Help Center at %{link}.
     no_reply: Please do not reply to this message.
     privacy_policy: Privacy policy
     reset_password:

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -52,7 +52,7 @@ feature 'Password Recovery' do
 
       expect(last_email.subject).to eq t('devise.mailer.reset_password_instructions.' \
                                           'subject')
-      expect(last_email.html_part.body).to include MarketingSite.contact_url
+      expect(last_email.html_part.body).to include MarketingSite.help_url
       expect(last_email.html_part.body).to have_content(
         t(
           'mailer.reset_password.footer',

--- a/spec/views/layouts/user_mailer.html.slim_spec.rb
+++ b/spec/views/layouts/user_mailer.html.slim_spec.rb
@@ -28,9 +28,9 @@ describe 'layouts/user_mailer.html.slim' do
   it 'includes the support text and link' do
     expect(rendered).to have_content(t('mailer.no_reply'))
     expect(rendered).to have_content(
-      t('mailer.help', app: APP_NAME, link: MarketingSite.contact_url)
+      t('mailer.help', app: APP_NAME, link: MarketingSite.help_url)
     )
-    expect(rendered).to have_link(MarketingSite.contact_url, href: MarketingSite.contact_url)
+    expect(rendered).to have_link(MarketingSite.help_url, href: MarketingSite.help_url)
   end
 
   it 'includes link to About login.gov' do


### PR DESCRIPTION
**Why**: There is no longer a web form on the contact page.