### PR TITLE
Allow signing in to SP after session timeout

### DIFF
--- a/.reek
+++ b/.reek
@@ -95,22 +95,7 @@ UtilityFunction:
     exclude:
       - complete_idv_session
   DuplicateMethodCall:
-    exclude:
-      - complete_2fa_confirmation
-      - complete_idv_profile
-      - expect_current_address_in_profile
-      - stub_subject
-      - stub_idv_session
-      - saml_settings
-      - sign_up_and_2fa
-      - raw_xml_response
-      - rotate_attribute_encryption_key
-      - rotate_attribute_encryption_key_with_invalid_queue
-      - rotate_hmac_key
-      - sign_in_user
-      - stub_auth
-      - stub_sign_in
-      - stub_verify_steps_one_and_two
+    enabled: false
   FeatureEnvy:
     enabled: false
   NestedIterators:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,10 +47,6 @@ class ApplicationController < ActionController::Base
     @_decorated_session ||= DecoratedSession.new(sp: current_sp, view_context: view_context).call
   end
 
-  def signed_in_path
-    user_fully_authenticated? ? profile_path : user_two_factor_authentication_path
-  end
-
   private
 
   def disable_caching
@@ -86,6 +82,10 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(user)
     stored_location_for(user) || sp_session[:request_url] || signed_in_path
+  end
+
+  def signed_in_path
+    user_fully_authenticated? ? profile_path : user_two_factor_authentication_path
   end
 
   def render_401

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,10 @@ class ApplicationController < ActionController::Base
     @_decorated_session ||= DecoratedSession.new(sp: current_sp, view_context: view_context).call
   end
 
+  def signed_in_path
+    user_fully_authenticated? ? profile_path : user_two_factor_authentication_path
+  end
+
   private
 
   def disable_caching
@@ -81,7 +85,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(user)
-    stored_location_for(user) || sp_session[:request_url] || profile_path
+    stored_location_for(user) || sp_session[:request_url] || signed_in_path
   end
 
   def render_401

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -18,7 +18,7 @@ module SignUp
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
         service_provider_attributes
       )
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to sp_session[:request_url]
     end
 
     private

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -1,0 +1,27 @@
+class StoreSpMetadataInSession
+  def initialize(session:, request_id:)
+    @session = session
+    @request_id = request_id
+  end
+
+  def call
+    session[:sp] = {
+      issuer: sp_request.issuer,
+      loa3: loa3_requested?,
+      request_url: sp_request.url,
+      request_id: sp_request.uuid,
+    }
+  end
+
+  private
+
+  attr_reader :session, :request_id
+
+  def sp_request
+    @sp_request ||= ServiceProviderRequest.find_by(uuid: request_id)
+  end
+
+  def loa3_requested?
+    sp_request.loa == Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+  end
+end

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -7,6 +7,7 @@ h1.h3.my0 = decorated_session.new_session_heading
                   html: { autocomplete: 'off', role: 'form' }) do |f|
   = f.input :email, required: true, input_html: { class: 'mb4' }
   = f.input :password, required: true
+  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
   = f.button :submit, t('links.next'), class: 'btn-wide'
 
 - link = link_to t('notices.sign_in_consent.link'), MarketingSite.privacy_url, target: '_blank'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -138,22 +138,4 @@ describe ApplicationController do
       end
     end
   end
-
-  describe '#signed_in_path' do
-    context 'user is not fully authenticated' do
-      it 'redirects to user_two_factor_authentication_path' do
-        allow(subject).to receive(:user_fully_authenticated?).and_return(false)
-
-        expect(subject.signed_in_path).to eq user_two_factor_authentication_path
-      end
-    end
-
-    context 'user is fully authenticated' do
-      it 'redirects to profile_path' do
-        allow(subject).to receive(:user_fully_authenticated?).and_return(true)
-
-        expect(subject.signed_in_path).to eq profile_path
-      end
-    end
-  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -138,4 +138,22 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#signed_in_path' do
+    context 'user is not fully authenticated' do
+      it 'redirects to user_two_factor_authentication_path' do
+        allow(subject).to receive(:user_fully_authenticated?).and_return(false)
+
+        expect(subject.signed_in_path).to eq user_two_factor_authentication_path
+      end
+    end
+
+    context 'user is fully authenticated' do
+      it 'redirects to profile_path' do
+        allow(subject).to receive(:user_fully_authenticated?).and_return(true)
+
+        expect(subject.signed_in_path).to eq profile_path
+      end
+    end
+  end
 end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -63,7 +63,10 @@ describe SignUp::CompletionsController do
     context 'LOA1' do
       it 'tracks analytics' do
         stub_sign_in
-        subject.session[:sp] = { loa3: false }
+        subject.session[:sp] = {
+          loa3: false,
+          request_url: 'http://example.com',
+        }
 
         patch :update
 
@@ -78,7 +81,10 @@ describe SignUp::CompletionsController do
       it 'tracks analytics' do
         user = create(:user, profiles: [create(:profile, :verified, :active)])
         stub_sign_in(user)
-        subject.session[:sp] = { loa3: true }
+        subject.session[:sp] = {
+          loa3: true,
+          request_url: 'http://example.com',
+        }
 
         patch :update
 

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -74,6 +74,22 @@ feature 'LOA1 Single Sign On' do
 
       expect(current_path).to eq sign_up_completed_path
     end
+
+    it 'after session timeout, signing in takes user back to SP' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+
+      user = create(:user, :signed_up)
+      saml_authn_request = auth_request.create(saml_settings)
+
+      visit saml_authn_request
+      sp_request_id = ServiceProviderRequest.last.uuid
+      page.set_rack_session(sp: {})
+      visit new_user_session_url(request_id: sp_request_id)
+      fill_in_credentials_and_submit(user.email, user.password)
+      click_submit_default
+
+      expect(current_url).to eq saml_authn_request
+    end
   end
 
   context 'fully signed up user is signed in with email and password only' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -25,6 +25,7 @@ module ControllerHelper
     sign_in_as_user(user)
     controller.current_user.send_new_otp
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
+    allow(controller).to receive(:signed_in_path).and_return(profile_path)
   end
 
   def stub_sign_in(user = build(:user, password: VALID_PASSWORD))
@@ -42,6 +43,7 @@ module ControllerHelper
     allow(request.env['warden']).to receive(:session).and_return(user: {})
     allow(controller).to receive(:current_user).and_return(user)
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
+    allow(controller).to receive(:signed_in_path).and_return(profile_path)
   end
 
   def stub_verify_steps_one_and_two(user)


### PR DESCRIPTION
**Why**: We rely on the original SP request URL to be available in the
session in order to complete the authentication flow and redirect the
user back to the SP. If a user comes from an SP, but sits on the sign
in page long enough for the session to time out, the request URL will
be deleted from the session, and after they sign back in, they will end
up on the profile page instead of going back to the SP.

**How**:
- Take advantage of the `request_id` param to restore the SP info
in the session after the user signs in, the same way we do when a user
confirms their email in a different browser
- Create a `signed_in_path` method that only redirects to the profile
path if the user is fully authenticated. Otherwise, it redirects to
user_two_factor_authentication_path. Use this new method in
`after_sign_in_path_for`. Why? Because any controller that includes a
`before_action` that gets executed will set the stored location for the
user to that controller. This means that if we redirect to the
profile_path while there is no stored location (which will be the case
if the session times out) and the user isn't yet fully authenticated, it
will call the `confirm_two_factor_authenticated` `before_action`, and
the stored location will now be the profile page. So, after the user
enters their OTP, they will be sent to the profile page instead of back
to SamlIdpController#auth to complete the auth flow back to the SP.