### PR TITLE
Add type=tel to numeric (t)otp inputs

### DIFF
--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -12,7 +12,7 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
     = text_field_tag(:code, '', value: @presenter.code_value, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-      autocomplete: 'off')
+      autocomplete: 'off', type: 'tel')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
 = render 'shared/fallback_links', presenter: @presenter

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -10,10 +10,9 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', required: true, autofocus: true,
-      pattern: '[0-9]*', class: 'col-12 field monospace mfa',
+      pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 = render 'shared/fallback_links', presenter: @presenter
 = render 'shared/cancel', link: reauthn? ? profile_path : destroy_user_session_path
-

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -1,6 +1,5 @@
 - title t('titles.totp_setup.new')
 
-
 h1.h3.my0 = t('headings.totp_setup.new')
 p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
 .mxn3.center.sm-left-align
@@ -8,7 +7,7 @@ p.mt-tiny.mb0 = t('forms.totp_setup.totp_info')
 = form_tag(authenticator_setup_path, method: :patch, role: 'form', class: 'mb1') do
   = label_tag 'code', t('forms.totp_setup.code'), class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = text_field_tag :code, '', required: true, pattern: '[0-9]*',
+    = text_field_tag :code, '', required: true, pattern: '[0-9]*', type: 'tel',
       class: 'block col-12 field monospace mfa', maxlength: Devise.otp_length
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 = render 'shared/cancel', link: profile_path


### PR DESCRIPTION
**Why**: This is the most reliable way to get a numeric keypad to
display on a mobile device when a user interacts with an input field.

Screenshot:

![reasonable-size-iphone](https://cloud.githubusercontent.com/assets/1421848/24455320/18bd49a4-145d-11e7-9493-24bad7c4befc.png)
