### PR TITLE
Refactor personal key JS specs

### DIFF
--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -1,6 +1,5 @@
 shared_examples_for 'recovery code page' do
   include XPathHelper
-  include SessionTimeoutWarningHelper
 
   it 'hides confirmation importance reminder text by default' do
     expect(page).to have_xpath(
@@ -46,98 +45,6 @@ shared_examples_for 'recovery code page' do
 
       it 'displays the modal instructions' do
         expect(page).to have_content t('forms.recovery_code.instructions')
-      end
-    end
-
-    context 'with javascript enabled', js: true do
-      let(:invisible_selector) { generate_class_selector('invisible') }
-
-      scenario 'content is hidden by default' do
-        expect(page).to have_xpath("//#{accordion_control_selector}")
-        expect(page).not_to have_content(t('users.recovery_code.help_text'))
-
-        page.find('.accordion-header-control').click
-        expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='false']")
-        expect(page).to have_content(t('users.recovery_code.help_text'))
-      end
-
-      scenario 'modal opens when continue is clicked' do
-        expect(page).to have_xpath(
-          "//div[@id='personal-key-confirm'][@class='display-none']", visible: false
-        )
-
-        click_acknowledge_recovery_code
-
-        expect(page).not_to have_xpath("//div[@id='personal-key-confirm'][@class='display-none']")
-        expect(page).not_to have_xpath("//#{invisible_selector}[@id='recovery-code']")
-      end
-
-      scenario 'focus is on first input and is trapped in modal' do
-        click_acknowledge_recovery_code
-
-        expect(page.evaluate_script('document.activeElement.name')).to eq 'recovery-0'
-
-        body_element = page.find('body')
-        body_element.send_keys [:shift, :tab]
-        expect(page.evaluate_script('document.activeElement.innerText')).to eq(
-          t('forms.buttons.back')
-        )
-      end
-
-      context 'when the session times out and the modal is visible' do
-        before do
-          allow(Figaro.env).to receive(:session_check_frequency).and_return('1')
-          allow(Figaro.env).to receive(:session_check_delay).and_return('2')
-          allow(Figaro.env).to receive(:session_timeout_warning_seconds).
-            and_return(Devise.timeout_in.to_s)
-          sign_in_and_2fa_user
-          visit manage_recovery_code_path
-        end
-
-        it 'does not interfere with the session timeout modal' do
-          click_acknowledge_recovery_code
-          find('a', text: t('notices.timeout_warning.signed_in.sign_out'))
-          click_on t('notices.timeout_warning.signed_in.sign_out')
-
-          expect(current_path).to eq(root_path)
-        end
-      end
-
-      context 'closing the modal', js: true do
-        before do
-          click_acknowledge_recovery_code
-          click_on t('forms.buttons.back')
-        end
-
-        scenario 'modal closes when back button within modal is clicked' do
-          expect(page).to have_xpath(
-            "//div[@id='personal-key-confirm'][@class='display-none']", visible: false
-          )
-        end
-
-        scenario 'warning alert message appears' do
-          expect(page).to have_xpath(
-            "//div[@id='recovery-code-reminder-alert'][@aria-hidden='false']"
-          )
-        end
-
-        scenario 'focus is returned to continue button' do
-          expect(page.evaluate_script('document.activeElement.value')).to eq(
-            t('forms.buttons.continue')
-          )
-        end
-      end
-      context 'submitting the confirmation form' do
-        scenario 'does not submit when invalid' do
-          click_acknowledge_recovery_code
-          click_on t('forms.buttons.continue'), class: 'recovery-code-confirm'
-          expect(current_path).not_to eq profile_path
-        end
-
-        scenario 'submits when valid' do
-          acknowledge_and_confirm_recovery_code
-          expect(page).to have_current_path profile_path
-        end
       end
     end
   end


### PR DESCRIPTION
**Why**:
- The JS-enabled specs were being called in two places because
they were included in a shared example. There's no benefit to running
these slow tests twice.
- The session timeout modal spec was failing intermittently due to being
nested inside a context that included a before block that already signed
in the user, and the test itself was trying to sign in the user as well.

**How**:
- Move the JS specs from `shared_examples_for_recovery_codes.rb` to
`users/recovery_code_spec.rb`.
- Merge all the specs into one big spec to speed up the test, and define
methods that describe the actions and expectations for readability.