### PR TITLE
Corrects email in use language

### DIFF
--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -15,7 +15,7 @@ en:
           address within %{confirmation_period} of receiving this message.
       footer: Please note that this link expires in %{confirmation_period}.
       header: >
-        %{intro} To confirm your email address, please click on the link below
+        %{intro} To confirm your email address, please click the link below
         or copy and paste the entire link into your browser.
       link_text: Confirm this email address
     contact_request:
@@ -23,7 +23,7 @@ en:
     email_change_notice:
       subject: Change your email address
     email_reuse_notice:
-      subject: Confirm your email address
+      subject: Email already in use
     help: >
       For more help, please visit the %{app} Help Center at %{link}.
     no_reply: Please do not reply to this message.

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -23,7 +23,7 @@ en:
     email_change_notice:
       subject: Change your email address
     email_reuse_notice:
-      subject: Email already in use
+      subject: Email address associated with an existing account
     help: >
       For more help, please visit the %{app} Help Center at %{link}.
     no_reply: Please do not reply to this message.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -34,9 +34,9 @@ en:
         If you did not request a new account or suspect an error, please visit
         the %{app} %{help_link} or %{contact_link}.
       intro: >
-        Your request to create a %{app} account using this email address cannot
-        be granted because this email address is already in use. If you requested this
-        change, please use the following link to log in to %{app}:
+        This email address is already in use, so we cannot create a new %{app} account with it. 
+        If you are not trying to sign in with this email address, you can ignore this message. 
+        Otherwise, you can use the following link to sign in to %{app}:
       link_text: Go to %{app}
       reset_password: >
         If you cannot remember your password, you can reset it at %{app}.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -34,9 +34,9 @@ en:
         If you did not request a new account or suspect an error, please visit
         the %{app} %{help_link} or %{contact_link}.
       intro: >
-        This email address is already in use, so we cannot create a new %{app} account with it. 
+        This email address is already associated with a %{app} account, so we cannot create a new account with it. 
         If you are not trying to sign in with this email address, you can ignore this message.
-        Otherwise, you can use the following link to sign in to %{app}:
+        To sign in with your existing account, follow the link below. 
       link_text: Go to %{app}
       reset_password: >
         If you cannot remember your password, you can reset it at %{app}.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -35,7 +35,7 @@ en:
         the %{app} %{help_link} or %{contact_link}.
       intro: >
         This email address is already in use, so we cannot create a new %{app} account with it. 
-        If you are not trying to sign in with this email address, you can ignore this message. 
+        If you are not trying to sign in with this email address, you can ignore this message.
         Otherwise, you can use the following link to sign in to %{app}:
       link_text: Go to %{app}
       reset_password: >


### PR DESCRIPTION
**Why** We had misleading copy in the email we sent when someone tries to create an account with an email address that's already in use.   