### PR TITLE
Use generic.svg logo when SP does not have a logo

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,9 +1,13 @@
 class ServiceProviderSessionDecorator
-  delegate :logo, to: :sp, prefix: true
+  DEFAULT_LOGO = 'generic.svg'.freeze
 
   def initialize(sp:, view_context:)
     @sp = sp
     @view_context = view_context
+  end
+
+  def sp_logo
+    sp.logo || DEFAULT_LOGO
   end
 
   def return_to_service_provider_partial
@@ -31,12 +35,6 @@ class ServiceProviderSessionDecorator
 
   def idv_hardfail4_partial
     'verify/hardfail4'
-  end
-
-  def logo_partial
-    return 'shared/nav_branded_logo' if sp.logo
-
-    'shared/null'
   end
 
   def sp_name

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -23,8 +23,6 @@ class SessionDecorator
     'shared/null'
   end
 
-  def logo_partial; end
-
   def sp_name; end
 
   def sp_logo; end

--- a/app/views/openid_connect/authorization/index.html.slim
+++ b/app/views/openid_connect/authorization/index.html.slim
@@ -1,6 +1,5 @@
-- if decorated_session.sp_logo
-  = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
-    alt: decorated_session.sp_name, class: 'align-middle')
+= image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
+  alt: decorated_session.sp_name, class: 'align-middle')
 
 h3 = decorated_session.sp_name
 

--- a/app/views/shared/_nav_branded.html.slim
+++ b/app/views/shared/_nav_branded.html.slim
@@ -2,4 +2,7 @@ nav.py2.sm-pt3.sm-pb0.bg-light-blue.center
   .my1.sm-mb0.relative
     = image_tag(asset_url('logo.svg'), width: 124,
       alt: APP_NAME, class: 'align-middle')
-    = render decorated_session.logo_partial
+    .px2.inline-block
+      span.absolute.top-0.bottom-0.border-right
+    = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
+      alt: decorated_session.sp_name, class: 'align-middle')

--- a/app/views/shared/_nav_branded_logo.html.slim
+++ b/app/views/shared/_nav_branded_logo.html.slim
@@ -1,4 +1,0 @@
-.px2.inline-block
-  span.absolute.top-0.bottom-0.border-right
-= image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
-  alt: decorated_session.sp_name, class: 'align-middle')

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ServiceProviderSessionDecorator do
 
         subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
 
-        expect(subject.sp_logo).to eq ServiceProviderSessionDecorator::DEFAULT_LOGO
+        expect(subject.sp_logo).to eq 'generic.svg'
       end
     end
   end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -56,29 +56,6 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#logo_partial' do
-    context 'logo present' do
-      it 'returns branded logo partial' do
-        sp_with_logo = build_stubbed(:service_provider, logo: 'foo')
-        decorator = ServiceProviderSessionDecorator.new(
-          sp: sp_with_logo, view_context: view_context
-        )
-
-        expect(decorator.logo_partial).to eq 'shared/nav_branded_logo'
-      end
-    end
-
-    context 'logo not present' do
-      it 'is null' do
-        decorator = ServiceProviderSessionDecorator.new(
-          sp: sp, view_context: view_context
-        )
-
-        expect(decorator.logo_partial).to eq 'shared/null'
-      end
-    end
-  end
-
   describe '#sp_name' do
     it 'returns the SP friendly name if present' do
       expect(subject.sp_name).to eq sp.friendly_name
@@ -90,6 +67,29 @@ RSpec.describe ServiceProviderSessionDecorator do
       subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
       expect(subject.sp_name).to eq sp.agency
       expect(subject.sp_name).to_not be_nil
+    end
+  end
+
+  describe '#sp_logo' do
+    context 'service provider has a logo' do
+      it 'returns the logo' do
+        sp_logo = 'real_logo.svg'
+        sp = build_stubbed(:service_provider, logo: sp_logo)
+
+        subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+
+        expect(subject.sp_logo).to eq sp_logo
+      end
+    end
+
+    context 'service provider does not have a logo' do
+      it 'returns the default logo' do
+        sp = build_stubbed(:service_provider, logo: nil)
+
+        subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+
+        expect(subject.sp_logo).to eq ServiceProviderSessionDecorator::DEFAULT_LOGO
+      end
     end
   end
 end

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe SessionDecorator do
     end
   end
 
-  describe '#logo_partial' do
+  describe '#sp_logo' do
     it 'returns nil' do
-      expect(subject.logo_partial).to be_nil
+      expect(subject.sp_logo).to be_nil
     end
   end
 

--- a/spec/views/openid_connect/authorization/index.html.slim_spec.rb
+++ b/spec/views/openid_connect/authorization/index.html.slim_spec.rb
@@ -34,7 +34,7 @@ describe 'openid_connect/authorization/index.html.slim' do
   end
 
   context 'when the service provider does not have a logo' do
-    it 'does not render the logo' do
+    it 'renders the default logo' do
       sp_without_logo = build_stubbed(:service_provider)
       decorated_session = ServiceProviderSessionDecorator.new(
         sp: sp_without_logo, view_context: view_context
@@ -42,7 +42,7 @@ describe 'openid_connect/authorization/index.html.slim' do
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render
 
-      expect(rendered).to_not have_css('img')
+      expect(rendered).to have_css('img[src*=sp-logos]')
     end
   end
 end

--- a/spec/views/shared/_nav_branded.html.slim_spec.rb
+++ b/spec/views/shared/_nav_branded.html.slim_spec.rb
@@ -22,7 +22,7 @@ describe 'shared/_nav_branded.html.slim' do
 
   context 'without a SP-logo configured' do
     before do
-      sp_without_logo = build_stubbed(:service_provider)
+      sp_without_logo = build_stubbed(:service_provider, friendly_name: 'No logo no problem')
       decorated_session = ServiceProviderSessionDecorator.new(
         sp: sp_without_logo, view_context: view_context
       )
@@ -30,8 +30,8 @@ describe 'shared/_nav_branded.html.slim' do
       render
     end
 
-    it 'does not display the SP logo' do
-      expect(rendered).to_not have_css("img[alt*='Best SP ever']")
+    it 'displayes the generic  SP logo' do
+      expect(rendered).to have_css("img[alt*='No logo no problem']")
     end
   end
 end


### PR DESCRIPTION
**Why**: Agencies want to see what things will look like with a logo. So
even if they don't have one set up yet, this will enable them to see the
branded layout.