### PR TITLE
Check for SP logo file existence before rendering

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -7,7 +7,11 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_logo
-    sp.logo || DEFAULT_LOGO
+    if sp_logo_file_exist?
+      sp.logo
+    else
+      DEFAULT_LOGO
+    end
   end
 
   def return_to_service_provider_partial
@@ -48,4 +52,18 @@ class ServiceProviderSessionDecorator
   private
 
   attr_reader :sp, :view_context
+
+  def sp_logo_file_exist?
+    rails_app = Rails.application
+
+    if Rails.configuration.assets.compile
+      rails_app.precompiled_assets.include?(sp_logo_path)
+    else
+      rails_app.assets_manifest.assets[sp_logo_path].present?
+    end
+  end
+
+  def sp_logo_path
+    "sp-logos/#{sp.logo}"
+  end
 end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -73,12 +73,23 @@ RSpec.describe ServiceProviderSessionDecorator do
   describe '#sp_logo' do
     context 'service provider has a logo' do
       it 'returns the logo' do
-        sp_logo = 'real_logo.svg'
+        sp_logo = 'cbp.png'
         sp = build_stubbed(:service_provider, logo: sp_logo)
 
         subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
 
         expect(subject.sp_logo).to eq sp_logo
+      end
+
+      context 'sp logo refers to non-existent file' do
+        it 'returns the default logo' do
+          sp_logo = 'fake-logo.png'
+          sp = build_stubbed(:service_provider, logo: sp_logo)
+
+          subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+
+          expect(subject.sp_logo).to eq 'generic.svg'
+        end
       end
     end
 


### PR DESCRIPTION
**WHY**: We are going to start allowing agencies to tell us the name of
their logo. The process will still include adding the logo to the IDP
codebase separately. In the case that an agency enters in the wrong name
or sets up an SP logo before the image is deployed, we want to make sure
we don't return a broken image. This logic checks for whether the file
is there before rendering the image.

See
http://stackoverflow.com/questions/6782978/rails-3-1-determine-if-asset-exists/35319530#35319530
as ref for the "see if this asset exists" code.