### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -235,7 +235,7 @@ Style/TrailingCommaInArguments:
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -246,7 +246,7 @@ Style/TrailingCommaInLiteral:
   # If `consistent_comma`, the cop requires a comma after the last item of all
   # non-empty array and hash literals.
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,12 +15,14 @@ class Profile < ActiveRecord::Base
 
   attr_reader :recovery_code
 
+  # rubocop:disable Rails/SkipsModelValidations
   def activate
     transaction do
       Profile.where('user_id=?', user_id).update_all(active: false)
       update!(active: true, activated_at: Time.zone.now, deactivation_reason: nil)
     end
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def deactivate(reason)
     update!(active: false, deactivation_reason: reason)

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -15,7 +15,7 @@ class ServiceProvider < ActiveRecord::Base
     @ssl_cert ||= begin
       return if cert.blank?
 
-      cert_file = Rails.root.join("certs/sp/#{cert}.crt")
+      cert_file = Rails.root.join('certs', 'sp', "#{cert}.crt")
 
       return OpenSSL::X509::Certificate.new(cert) unless File.exist?(cert_file)
 

--- a/app/services/idv/vendor.rb
+++ b/app/services/idv/vendor.rb
@@ -4,7 +4,7 @@ module Idv
     # so make sure our load path includes whichever vendors we have defined.
     if Figaro.env.proofing_vendors
       Figaro.env.proofing_vendors.split(/\W+/).each do |vendor|
-        vendor_path = "#{Rails.root}/vendor/#{vendor}/lib"
+        vendor_path = Rails.root.join('vendor', vendor, 'lib')
         $LOAD_PATH.unshift vendor_path
       end
     end

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -6,9 +6,11 @@ module KeyRotator
       self.encryptor = Pii::PasswordEncryptor.new
     end
 
+    # rubocop:disable Rails/SkipsModelValidations
     def rotate
       user.update_columns(encrypted_attributes)
     end
+    # rubocop:enable Rails/SkipsModelValidations
 
     private
 

--- a/app/services/key_rotator/hmac_fingerprinter.rb
+++ b/app/services/key_rotator/hmac_fingerprinter.rb
@@ -12,6 +12,7 @@ module KeyRotator
 
     private
 
+    # rubocop:disable Rails/SkipsModelValidations
     def rotate_email_fingerprint(user)
       ee = EncryptedAttribute.new_from_decrypted(user.email)
       user.update_columns(email_fingerprint: ee.fingerprint)
@@ -21,5 +22,6 @@ module KeyRotator
       signature = Pii::Fingerprinter.fingerprint(pii_attributes.ssn.to_s)
       profile.update_columns(ssn_signature: signature)
     end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/app/services/request_key_manager.rb
+++ b/app/services/request_key_manager.rb
@@ -1,14 +1,14 @@
 class RequestKeyManager
   cattr_accessor :private_key do
     OpenSSL::PKey::RSA.new(
-      File.read(Rails.root.join('keys/saml.key.enc')),
+      File.read(Rails.root.join('keys', 'saml.key.enc')),
       Figaro.env.saml_passphrase
     )
   end
 
   cattr_accessor :equifax_ssh_key do
     OpenSSL::PKey::RSA.new(
-      File.read(Rails.root.join('keys/equifax_rsa')),
+      File.read(Rails.root.join('keys', 'equifax_rsa')),
       Figaro.env.equifax_ssh_passphrase
     )
   end

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -8,10 +8,12 @@ class SessionEncryptor
     build_user_access_key
   end
 
+  # rubocop:disable Security/MarshalLoad
   def self.load(value)
     decrypted = encryptor.decrypt(value, user_access_key)
     Marshal.load(::Base64.decode64(decrypted))
   end
+  # rubocop:enable Security/MarshalLoad
 
   def self.dump(value)
     plain = ::Base64.encode64(Marshal.dump(value))

--- a/app/services/worker_health_checker.rb
+++ b/app/services/worker_health_checker.rb
@@ -48,7 +48,7 @@ module WorkerHealthChecker
   end
 
   def sidekiq_queues
-    @_queues ||= YAML.load_file("#{Rails.root}/config/sidekiq.yml")[:queues]
+    @_queues ||= YAML.load_file(Rails.root.join('config', 'sidekiq.yml'))[:queues]
   end
 
   # Called on an interval to check background queue health and report errors to NewRelic

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ module Upaya
   class Application < Rails::Application
     config.active_job.queue_adapter = :sidekiq
     config.active_record.raise_in_transactional_callbacks = true
-    config.autoload_paths << Rails.root.join('app/mailers/concerns')
+    config.autoload_paths << Rails.root.join('app', 'mailers', 'concerns')
     config.time_zone = 'UTC'
     config.middleware.use Rack::Attack
     config.browserify_rails.force = true
@@ -22,7 +22,7 @@ module Upaya
       config.browserify_rails.commandline_options += ' -p [ proxyquireify/plugin ]'
       # Make sure Browserify is triggered when asked to serve javascript spec files
       config.browserify_rails.paths << lambda do |path|
-        path.start_with?(Rails.root.join('spec/javascripts').to_s)
+        path.start_with?(Rails.root.join('spec', 'javascripts').to_s)
       end
     end
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path
-Rails.application.config.assets.paths << "#{Rails.root}/node_modules"
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'lib', 'config_validator')
+require Rails.root.join('lib', 'config_validator.rb')
 
 Figaro.require_keys(
   'attribute_cost',

--- a/config/initializers/i18n_mode.rb
+++ b/config/initializers/i18n_mode.rb
@@ -1,5 +1,5 @@
 require 'feature_management'
 if FeatureManagement.enable_i18n_mode?
   # load libraries or overrides to be enabled with i18n_mode:
-  require File.join(Rails.root, 'lib', 'i18n_override.rb')
+  require Rails.root.join('lib', 'i18n_override.rb')
 end

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -4,7 +4,7 @@ SamlIdp.configure do |config|
   protocol = Rails.env.development? ? 'http://' : 'https://'
   api_base = protocol + Figaro.env.domain_name + '/api'
 
-  config.x509_certificate = File.read("#{Rails.root}/certs/saml.crt")
+  config.x509_certificate = File.read(Rails.root.join('certs', 'saml.crt'))
   config.secret_key = RequestKeyManager.private_key.to_pem
 
   config.algorithm = OpenSSL::Digest::SHA256

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -32,14 +32,14 @@ SecureHeaders::Configuration.default do |config|
     base_uri: ["'self'"],
   }
 
-  if !Rails.env.production?
-    config.csp = default_csp_config.merge(
-      script_src: ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
-      style_src: ["'self'", "'unsafe-inline'"]
-    )
-  else
-    config.csp = default_csp_config
-  end
+  config.csp = if !Rails.env.production?
+                 default_csp_config.merge(
+                   script_src: ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+                   style_src: ["'self'", "'unsafe-inline'"]
+                 )
+               else
+                 default_csp_config
+               end
 
   config.cookies = {
     secure: true, # mark all cookies as "Secure"

--- a/config/initializers/split.rb
+++ b/config/initializers/split.rb
@@ -1,5 +1,5 @@
 Split.configure do |config|
   config.db_failover = true
   config.enabled = !Rails.env.test?
-  config.experiments = YAML.load_file("#{Rails.root}/config/experiments.yml")
+  config.experiments = YAML.load_file(Rails.root.join('config', 'experiments.yml'))
 end

--- a/config/initializers/valid_email.rb
+++ b/config/initializers/valid_email.rb
@@ -1,3 +1,3 @@
-config = File.expand_path("#{Rails.root}/config/valid_email.yml", __FILE__)
+config = Rails.root.join('config', 'valid_email.yml')
 
 BanDisposableEmailValidator.config = YAML.load_file(config)['disposable_email_services']

--- a/config/initializers/zxcvbn_overrides.rb
+++ b/config/initializers/zxcvbn_overrides.rb
@@ -4,7 +4,7 @@ module Zxcvbn
   class Tester
     attr_accessor :data_path
     def initialize
-      @data_path = Rails.root.join('node_modules/zxcvbn/dist/zxcvbn.js')
+      @data_path = Rails.root.join('node_modules', 'zxcvbn', 'dist', 'zxcvbn.js')
       src = File.open(@data_path || DATA_PATH, 'r').read
       @context = ExecJS.compile(src)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,7 @@ AppSetting.find_or_create_by!(name: 'RegistrationsEnabled') do |setting|
 end
 
 # add config/service_providers.yml
-service_providers = YAML.load_file("#{Rails.root}/config/service_providers.yml").
+service_providers = YAML.load_file(Rails.root.join('config', 'service_providers.yml')).
                     fetch(Rails.env, {})
 
 service_providers.each do |issuer, config|

--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -74,7 +74,7 @@ class I18nLocaleTraverser
   end
 
   def traverse_file_for_key(file)
-    yml = YAML.load(File.open(file))[I18n.config.locale.to_s]
+    yml = YAML.safe_load(File.open(file))[I18n.config.locale.to_s]
 
     elements = @key.split('.')
 

--- a/spec/ab_testing/yaml_config_spec.rb
+++ b/spec/ab_testing/yaml_config_spec.rb
@@ -4,7 +4,7 @@ TESTS = ['demo'].freeze
 
 describe 'YAML config for A/B testing' do
   it 'includes the expected tests' do
-    config = YAML.load_file("#{Rails.root}/config/experiments.yml")
+    config = YAML.load_file(Rails.root.join('config', 'experiments.yml'))
 
     expect(config.keys).to eq TESTS
   end

--- a/spec/config/initializers/zxcvbn_overrides_spec.rb
+++ b/spec/config/initializers/zxcvbn_overrides_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Zxcvbn do
   describe '#src' do
     it 'defaults to library from npm' do
-      default = Rails.root.join('node_modules/zxcvbn/dist/zxcvbn.js')
+      default = Rails.root.join('node_modules', 'zxcvbn', 'dist', 'zxcvbn.js')
 
       data_path = Zxcvbn::Tester.new.data_path
 

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OpenidConnect::TokenController do
         exp: 5.minutes.from_now.to_i,
       }
 
-      client_private_key = OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read)
+      client_private_key = OpenSSL::PKey::RSA.new(Rails.root.join('keys', 'saml_test_sp.key').read)
 
       JWT.encode(jwt_payload, client_private_key, 'RS256')
     end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -470,7 +470,7 @@ describe SamlIdpController do
           element = signature.at('//ds:X509Certificate',
                                  ds: Saml::XML::Namespaces::SIGNATURE)
 
-          crt = File.read("#{Rails.root}/certs/saml.crt")
+          crt = File.read(Rails.root.join('certs', 'saml.crt'))
           expect(element.text).to eq(crt.split("\n")[1...-1].join("\n").delete("\n"))
         end
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -216,7 +216,7 @@ feature 'OpenID Connect' do
   def client_private_key
     @client_private_key ||= begin
       OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys/saml_test_sp.key'))
+        File.read(Rails.root.join('keys', 'saml_test_sp.key'))
       )
     end
   end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe OpenidConnectTokenForm do
     }
   end
 
-  let(:client_private_key) { OpenSSL::PKey::RSA.new(Rails.root.join('keys/saml_test_sp.key').read) }
+  let(:client_private_key) do
+    OpenSSL::PKey::RSA.new(Rails.root.join('keys', 'saml_test_sp.key').read)
+  end
   let(:server_public_key) { RequestKeyManager.private_key.public_key }
 
   let(:user) { create(:user) }

--- a/spec/lib/i18n_override_spec.rb
+++ b/spec/lib/i18n_override_spec.rb
@@ -4,7 +4,7 @@ describe 'i18n override' do
   describe '.translate_with_markup' do
     it 'provides anchor tag to translated source' do
       allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(true)
-      require File.join(Rails.root, 'lib', 'i18n_override.rb')
+      require Rails.root.join('lib', 'i18n_override.rb')
 
       localized_str = I18n.translate_with_markup('shared.usa_banner.official_site')
 

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -68,7 +68,7 @@ describe ServiceProvider do
 
       it 'calls OpenSSL::X509::Certificate with the SP cert' do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')
-        cert = File.read("#{Rails.root}/certs/sp/saml_test_sp.crt")
+        cert = File.read(Rails.root.join('certs', 'sp', 'saml_test_sp.crt'))
 
         expect(OpenSSL::X509::Certificate).to receive(:new).with(cert)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,7 @@ ActiveRecord::Migration.maintain_test_schema!
 # run twice. It is recommended that you do not name files matching this glob to
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false

--- a/spec/services/worker_health_checker_spec.rb
+++ b/spec/services/worker_health_checker_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WorkerHealthChecker do
   end
 
   describe '#enqueue_dummy_jobs' do
-    let(:queues) { YAML.load_file("#{Rails.root}/config/sidekiq.yml")[:queues] }
+    let(:queues) { YAML.load_file(Rails.root.join('config', 'sidekiq.yml'))[:queues] }
 
     subject(:enqueue_dummy_jobs) { WorkerHealthChecker.enqueue_dummy_jobs }
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -49,11 +49,11 @@ module SamlAuthHelper
   end
 
   def saml_test_idp_cert
-    @saml_test_idp_cert ||= File.read("#{Rails.root}/certs/saml.crt")
+    @saml_test_idp_cert ||= File.read(Rails.root.join('certs', 'saml.crt'))
   end
 
   def saml_test_sp_cert
-    @saml_test_sp_cert ||= File.read("#{Rails.root}/certs/sp/saml_test_sp.crt")
+    @saml_test_sp_cert ||= File.read(Rails.root.join('certs', 'sp', 'saml_test_sp.crt'))
   end
 
   def auth_request
@@ -150,7 +150,7 @@ module SamlAuthHelper
   end
 
   def saml_test_key
-    @saml_test_key ||= File.read("#{Rails.root}/keys/saml_test_sp.key")
+    @saml_test_key ||= File.read(Rails.root.join('keys', 'saml_test_sp.key'))
   end
 
   # generates a SAML response and returns a parsed Nokogiri XML document


### PR DESCRIPTION
**Why**: The latest versions of Rubocop introduced some new cops:
- Rails/FilePath for file path joining
- Rails/SkipsModelValidations
- Security/MarshalLoad
- Security/YAMLLoad