### PR TITLE
Do not show DAP on "enter email" page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,7 +42,7 @@ module ApplicationHelper
   end
 
   def page_with_trust?
-    current_page?(controller: 'sign_up/email_confirmations', action: 'create') ||
+    current_page?(controller: 'sign_up/passwords', action: 'new') ||
       current_page?(controller: 'users/reset_passwords', action: 'edit')
   end
 

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 feature 'Email confirmation during sign up' do
   scenario 'confirms valid email and sets valid password' do
+    allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
     reset_email
     email = 'test@example.com'
     sign_up_with(email)
     open_email(email)
     visit_in_email(t('mailer.confirmation_instructions.link_text'))
 
+    expect(page.html).not_to include(t('notices.dap_html'))
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
     expect(page).to have_title t('titles.confirmations.show')
     expect(page).to have_content t('forms.confirmation.show_hdr')
@@ -65,11 +67,13 @@ feature 'Email confirmation during sign up' do
 
   context 'confirmed user is signed out and tries to confirm again' do
     it 'redirects to sign in page with message that user is already confirmed' do
+      allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
       sign_up_and_set_password
 
       visit destroy_user_session_url
       visit sign_up_create_email_confirmation_url(confirmation_token: @raw_confirmation_token)
 
+      expect(page.html).to include(t('notices.dap_html'))
       expect(page).to have_content(
         t('devise.confirmations.already_confirmed', action: 'Please sign in.')
       )

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -41,6 +41,7 @@ feature 'Password Recovery' do
 
   context 'user enters valid email in forgot password form', email: true do
     it 'redirects to forgot_password path and sends an email to the user' do
+      allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
       user = create(:user, :signed_up)
 
       visit root_path
@@ -63,6 +64,7 @@ feature 'Password Recovery' do
       open_last_email
       click_email_link_matching(/reset_password_token/)
 
+      expect(page.html).not_to include(t('notices.dap_html'))
       expect(current_path).to eq edit_user_password_path
     end
   end
@@ -110,6 +112,7 @@ feature 'Password Recovery' do
       @user = create(:user)
       trigger_reset_password_and_click_email_link(@user.email)
     end
+
 
     it 'keeps user signed out after they successfully reset their password' do
       fill_in 'New password', with: 'NewVal!dPassw0rd'

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -113,7 +113,6 @@ feature 'Password Recovery' do
       trigger_reset_password_and_click_email_link(@user.email)
     end
 
-
     it 'keeps user signed out after they successfully reset their password' do
       fill_in 'New password', with: 'NewVal!dPassw0rd'
       click_button t('forms.passwords.edit.buttons.submit')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,7 +34,7 @@ describe ApplicationHelper do
       context 'current path is email confirmation path' do
         it 'returns true' do
           allow(helper).to receive(:current_page?).with(
-            controller: 'sign_up/email_confirmations', action: 'create'
+            controller: 'sign_up/passwords', action: 'new'
           ).and_return(true)
 
           expect(helper.session_with_trust?).to eq true
@@ -44,7 +44,7 @@ describe ApplicationHelper do
       context 'current path is reset password path' do
         it 'returns true' do
           allow(helper).to receive(:current_page?).with(
-            controller: 'sign_up/email_confirmations', action: 'create'
+            controller: 'sign_up/passwords', action: 'new'
           ).and_return(true)
           allow(helper).to receive(:current_page?).with(
             controller: 'users/reset_passwords', action: 'edit'


### PR DESCRIPTION
**Why**: Before, we were excluding from POST controller action, which
actually does not render a view. Instead, it redirects to various views
depending on whether the confirmation token is valid or not. If it is
invalid, we don't care about whether we show DAP or not because the
session does not have trusted info. If the user is already confirmed,
they will be logged in so DAP will not be included. So what we really
care about is just the case when a user has a valid confirmation token.
In that case, the user is redirected to `sign_up_enter_password_url`
(see `process_valid_confirmation_token` method). Now, we are excluding
DAP from that page.

QA'd locally to make sure.