### PR TITLE
Fix registration endpoint in load testing script

### DIFF
--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -27,7 +27,7 @@ class UserBehavior(locust.TaskSet):
             'authenticity_token': authenticity_token(dom),
             'commit': 'Submit',
         }
-        resp = self.client.post('/sign_up/register', data=data, auth=auth)
+        resp = self.client.post('/sign_up/enter_email', data=data, auth=auth)
         resp.raise_for_status()
 
         # capture email confirmation link on resulting page


### PR DESCRIPTION
**Why**: The POST endpoint changed from `/sign_up/register` to
`/sign_up/enter_email`