### PR TITLE
Minor load test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ requests, and the rate at which users are created, modify the `-c`,
 `-n`, and `-r` Locust parameters in `bin/load_test`. Run `locust --help` for
 more details.
 
+By default, the test will target the host running at `http://localhost:3000`.
+To change the target host, set the `TARGET_HOST` environment variable.
+For example:
+
+```
+TARGET_HOST=https://awesome.loadtesting.com make load_test type=create_account
+```
+
 [Locust.io]: http://locust.io/
 [laptop script]: https://github.com/18F/laptop
 

--- a/bin/load_test
+++ b/bin/load_test
@@ -34,13 +34,14 @@ brew_is_upgradable() {
 if [ $1 ]
 then
   test_to_run="$1"
+  target="${TARGET_HOST:-http://localhost:3000}"
 
   brew_install_or_upgrade 'libevent'
   source /usr/local/bin/virtualenvwrapper.sh
   mkvirtualenv locust && \
     workon locust &&  \
     pip install -r scripts/load_testing/requirements.txt && \
-    locust -f scripts/load_testing/$test_to_run.py -H http://localhost:3000 --no-web -c 3 -n 27 -r 1
+    locust -f scripts/load_testing/$test_to_run.py -H "$target" --no-web -c 3 -n 27 -r 1
   deactivate
 else
   echo "Usage: load_test [name_of_file]"

--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -27,12 +27,12 @@ class UserBehavior(locust.TaskSet):
             'authenticity_token': authenticity_token(dom),
             'commit': 'Submit',
         }
-        resp = self.client.post('/sign_up/register', data=data, auth=auth)
+        resp = self.client.post('/sign_up/enter_email', data=data, auth=auth)
         resp.raise_for_status()
 
         # capture email confirmation link on resulting page
         dom = pyquery.PyQuery(resp.content)
-        link = dom.find('#confirm-now')[0].attrib['href']
+        link = dom.find("a[href*='confirmation_token']")[0].attrib['href']
 
         # click email confirmation link and submit password
         resp = self.client.get(link, auth=auth)
@@ -51,12 +51,13 @@ class UserBehavior(locust.TaskSet):
         # visit phone setup page and submit phone number
         dom = pyquery.PyQuery(resp.content)
         data = {
+            '_method': 'patch',
             'two_factor_setup_form[phone]': '7035550001',
             'two_factor_setup_form[otp_method]': 'sms',
             'authenticity_token': authenticity_token(dom),
             'commit': 'Send passcode',
         }
-        resp = self.client.patch('/phone_setup', data=data, auth=auth)
+        resp = self.client.post('/phone_setup', data=data, auth=auth)
         resp.raise_for_status()
 
         # visit enter passcode page and submit pre-filled OTP


### PR DESCRIPTION
These are the fixes that I had to make as part of the work in https://github.com/18F/identity-private/issues/1697 for the April 7th  launch.  It gets the load test working for what is currently in the pt environment.

Some of these may be because the load testing script committed in https://github.com/18F/identity-idp/commit/59e34df07f4e4f531b97331a91f159c0a709fcb2 did not make it into the release branch, which means that the code in master that has that commit is a bit diverged from what is currently deployed.

Going forward, when we cut a release, whatever load test scripts were available for that version of code can be used.  This is a special case because this is our first load test.

I'm not sure if we want to merge this into master as is, since part of it isn't necessary to load test current master.  Just putting this up for the record.