### PR TITLE
Move helper text

### DIFF
--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -15,7 +15,6 @@ p.mt-tiny.mb0
   .mb3
     fieldset.m0.p0.border-none
       legend.mb1.h4.serif.bold = t('devise.two_factor_authentication.otp_method.title')
-      p = t('devise.two_factor_authentication.otp_method.instruction')
       label.btn-border.col-12.sm-col-5.sm-mr2.mb2.sm-mb0
         .radio
           = radio_button_tag 'two_factor_setup_form[otp_method]', :sms, checked: true
@@ -26,6 +25,7 @@ p.mt-tiny.mb0
           = radio_button_tag 'two_factor_setup_form[otp_method]', :voice
           span.indicator
           = t('devise.two_factor_authentication.otp_method.voice')
+      p.mt1.mb0 = t('devise.two_factor_authentication.otp_method.instruction')
   = f.button :submit, t('forms.buttons.send_security_code')
 
 = render 'shared/cancel', link: destroy_user_session_path


### PR DESCRIPTION
**WHY**: So that the user action is front and center, and help text is secondary.

Before:

![screen shot 2017-03-29 at 5 01 40 pm](https://cloud.githubusercontent.com/assets/601515/24481748/671fd4d8-14a1-11e7-812c-1421d4b2d7cf.png)



After:

![screen shot 2017-03-29 at 5 00 00 pm](https://cloud.githubusercontent.com/assets/601515/24481742/565124ae-14a1-11e7-838c-bc7eef8e5e64.png)
