### PR TITLE
Remove reminder flash on personal key page

### DIFF
--- a/app/assets/javascripts/misc/recovery-page-controller.js
+++ b/app/assets/javascripts/misc/recovery-page-controller.js
@@ -10,8 +10,6 @@ const inputs = [].slice.call(formEl.elements).filter((el) => el.type === 'text')
 const modalTrigger = document.querySelector('[data-toggle="modal"]');
 const modalDismiss = document.querySelector('[data-dismiss="personal-key-confirm"]');
 
-const reminderEl = document.getElementById('recovery-code-reminder-alert');
-
 let isInvalidForm = false;
 
 // The following methods are strictly fallbacks for IE < 11. There is limited
@@ -63,13 +61,6 @@ function handleSubmit(event) {
   }
 }
 
-function showReminderAlert() {
-  if (reminderEl.className.indexOf('display-none')) {
-    reminderEl.setAttribute('aria-hidden', false);
-    reminderEl.classList.remove('display-none');
-  }
-}
-
 function show(event) {
   event.preventDefault();
 
@@ -85,7 +76,6 @@ function hide() {
   modal.on('hide', function() {
     resetForm();
     recoveryCodeContainer.classList.remove('invisible');
-    showReminderAlert();
   });
 
   modal.hide();

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -1,6 +1,3 @@
-.mb4.alert.alert-warning.display-none(id='recovery-code-reminder-alert' aria-hidden='true')
-  = t('users.recovery_code.reminder')
-
 h1.h3.my0 = t('headings.recovery_code')
 
 p.mt-tiny.mb0

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -12,9 +12,6 @@ en:
       get_another: Get another key
       print: Print this page
       help_text_header: Why do I need to store my new key on paper?
-      reminder: We've noticed you've come back to this page. You need to confirm
-        that you've saved your personal key on the next page, so please write it
-        down or print it out.
       help_text: |
         To protect your account, you need a password and access to your telephone or authentication application at sign-in. If you can’t use your phone or app, you can sign in with your personal key instead.
 

--- a/config/locales/users/es.yml
+++ b/config/locales/users/es.yml
@@ -14,4 +14,3 @@ es:
       help_text: NOT TRANSLATED YET
       close: NOT TRANSLATED YET
       confirmation_error: NOT TRANSLATED YET
-      reminder: NOT TRANSLATED YET

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -140,9 +140,6 @@ def expect_to_be_back_on_manage_recovery_code_page_with_continue_button_in_focus
   expect(page).to have_xpath(
     "//div[@id='personal-key-confirm'][@class='display-none']", visible: false
   )
-  expect(page).to have_xpath(
-    "//div[@id='recovery-code-reminder-alert'][@aria-hidden='false']"
-  )
   expect(page.evaluate_script('document.activeElement.value')).to eq(
     t('forms.buttons.continue')
   )

--- a/spec/support/shared_examples_for_recovery_codes.rb
+++ b/spec/support/shared_examples_for_recovery_codes.rb
@@ -1,16 +1,6 @@
 shared_examples_for 'recovery code page' do
   include XPathHelper
 
-  it 'hides confirmation importance reminder text by default' do
-    expect(page).to have_xpath(
-      "//div[@id='recovery-code-reminder-alert'][@aria-hidden='true']", visible: false
-    )
-  end
-
-  it 'contains correct confirmation importance reminder text' do
-    expect(page).to have_content(t('users.recovery_code.reminder'))
-  end
-
   context 'regenerating recovery code with `Get another code` button' do
     scenario 'displays a flash message and a new code' do
       old_code = @user.reload.recovery_code


### PR DESCRIPTION
**WHY**: The user has clicked "Back" specifically because they either
did not save their key or have written it incorrectly. No need to remind
them again.