### PR TITLE
Move helper text on "Enter OTP" page

### DIFF
--- a/app/views/shared/_fallback_links.html.slim
+++ b/app/views/shared/_fallback_links.html.slim
@@ -1,3 +1,3 @@
-.mt3.mb1
-  - presenter.fallback_links.each do |link|
-    p = link
+p.mt3#code-instructs = @presenter.help_text
+- presenter.fallback_links.each do |link|
+  p = link

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -1,7 +1,6 @@
 - title t('titles.enter_2fa_code')
 
 h1.h3.my0 = @presenter.header
-p.mt-tiny.mb0#code-instructs = @presenter.help_text
 
 = form_tag(:login_otp, method: :post, role: 'form', class: 'mt3 sm-mt4') do
   = hidden_field_tag(:reauthn, reauthn?)
@@ -15,6 +14,7 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
       autocomplete: 'off')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
+p.mt3.mb1#code-instructs = @presenter.help_text
 = render 'shared/fallback_links', presenter: @presenter
 
 - if confirmation_for_phone_change? || reauthn?

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -14,7 +14,6 @@ h1.h3.my0 = @presenter.header
       autocomplete: 'off')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top'
 
-p.mt3.mb1#code-instructs = @presenter.help_text
 = render 'shared/fallback_links', presenter: @presenter
 
 - if confirmation_for_phone_change? || reauthn?

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -13,7 +13,6 @@ h1.h3.my0 = @presenter.header
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
-p.mt3.mb1#code-instructs = @presenter.help_text
 = render 'shared/fallback_links', presenter: @presenter
 = render 'shared/cancel', link: reauthn? ? profile_path : destroy_user_session_path
 

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -1,7 +1,6 @@
 - title t('titles.enter_2fa_code')
 
 h1.h3.my0 = @presenter.header
-p.mt-tiny.mb0#code-instructs = @presenter.help_text
 
 = form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'mt3 sm-mt4') do
   - if reauthn?
@@ -14,6 +13,7 @@ p.mt-tiny.mb0#code-instructs = @presenter.help_text
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
+p.mt3.mb1#code-instructs = @presenter.help_text
 = render 'shared/fallback_links', presenter: @presenter
 = render 'shared/cancel', link: reauthn? ? profile_path : destroy_user_session_path
 


### PR DESCRIPTION
**WHY**: so that all instructional text is displayed together.

Before:

![screen shot 2017-03-29 at 5 20 41 pm](https://cloud.githubusercontent.com/assets/601515/24482165/2774964a-14a4-11e7-9e42-2470df7ef995.png)



![screen shot 2017-03-29 at 5 18 31 pm](https://cloud.githubusercontent.com/assets/601515/24482186/520ef274-14a4-11e7-8abf-8fddeb9c38a3.png)


After:


![screen shot 2017-03-29 at 5 20 22 pm](https://cloud.githubusercontent.com/assets/601515/24482175/35734f52-14a4-11e7-9f39-0b48243630b2.png)


![screen shot 2017-03-29 at 5 19 03 pm](https://cloud.githubusercontent.com/assets/601515/24482176/38c3634a-14a4-11e7-9490-6a6339671bb2.png)



