### PR TITLE
Replace instances of `passcode` w/ `security code`

### DIFF
--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -15,7 +15,7 @@ class SmsOtpSenderJob < ActiveJob::Base
   def send_otp(twilio_service, code, phone)
     twilio_service.send_sms(
       to: phone,
-      body: "#{code} is your #{APP_NAME} one-time passcode."
+      body: "#{code} is your #{APP_NAME} one-time security code."
     )
   end
 end

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -26,6 +26,6 @@ p.mt-tiny.mb0
           = radio_button_tag 'two_factor_setup_form[otp_method]', :voice
           span.indicator
           = t('devise.two_factor_authentication.otp_method.voice')
-  = f.button :submit, t('forms.buttons.send_passcode')
+  = f.button :submit, t('forms.buttons.send_security_code')
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -92,7 +92,7 @@ en:
           Provide a <strong>financial account number</strong>, such as your  credit card number.
           This number will only be used to verify your identity.
         bullet_5_html: >
-          When you are finished with this process we’ll give you a personal key. <strong>Write 
+          When you are finished with this process we’ll give you a personal key. <strong>Write
           it down and store it in a safe place; it’s important.</strong> You’ll be asked for the
           personal key every time you make changes to your account.
         introduction:
@@ -115,31 +115,31 @@ en:
         confirm_with_sms: Confirm with text message
         confirm_with_voice: Confirm with voice call
       choose_delivery_confirmation: >
-        How would you like to receive your confirmation passcode for %{phone}?
+        How would you like to receive your confirmation security code for %{phone}?
       choose_otp_delivery_html: >
         We will send it to %{phone} immediately. Message and data rates may apply.
       contact_administrator: Please contact your system administrator.
-      header_text: Enter your passcode
+      header_text: Enter your security code
       invalid_otp: >
-        That passcode is invalid. You can try entering it again or request a new
-        one-time passcode.
+        That security code is invalid. You can try entering it again or request a new
+        one-time security code.
       invalid_recovery_code: That personal key is invalid.
       max_login_attempts_reached: >
         Your account is temporarily locked because you have entered the one-time
-        passcode incorrectly too many times.
+        security code incorrectly too many times.
       otp_method:
         instruction: You can change your choice the next time you sign in
         sms: Text message (SMS)
-        title: How would you like to receive your passcode?
+        title: How would you like to receive your security code?
         voice: Phone call
       otp_phone_label: Phone number
       otp_phone_label_info: Mobile or landline okay
       otp_setup_html: >
         <strong>Every time you log in,</strong> we will send you a one-time
-        passcode via text message or phone call. This helps safeguard your account.
+        security code via text message or phone call. This helps safeguard your account.
       otp_sms_disclaimer: Message and data rates may apply.
       please_confirm: >
-        Your phone number has been set. Confirm it by entering the passcode below.
+        Your phone number has been set. Confirm it by entering the security code below.
       please_try_again_html: Please try again in %{time_remaining}.
       recovery_code_fallback:
         link: Use a personal key instead
@@ -158,4 +158,4 @@ en:
       totp_info: Use any authenticator app to scan the QR code below.
       two_factor_setup: Add a phone number
       user:
-        new_otp_sent: We sent you a new one-time passcode.
+        new_otp_sent: We sent you a new one-time security code.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -9,7 +9,7 @@ en:
       edit: Edit
       enable: Enable
       resend_confirmation: Resend confirmation instructions
-      send_passcode: Send passcode
+      send_security_code: Send security code
       setup_totp: Set up authentication app
       submit:
         confirm_change: Confirm change
@@ -36,16 +36,16 @@ en:
       labels:
         email: Email address
     totp_setup:
-      code: One-time passcode
+      code: One-time security code
       totp_info: >
         To enable two-factor authentication, use the QR code provided to link
         this account to your authentication app.
       totp_intro: >
-        To receive a one-time passode, you may choose to use a two-factor
+        To receive a one-time security code, you may choose to use a two-factor
         authentication application to log into to your account. If so, you’ll need to
         link your login.gov account to the application you choose. Each time you sign in
         you’ll need to open the application and retrieve a code.
     two_factor:
-      code: One-time passcode
+      code: One-time security code
       recovery_code: Personal key
       try_again: Use another phone number

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -9,7 +9,7 @@ es:
       edit: Editar
       enable: Habilitar
       resend_confirmation: Reenviar instrucciones de confirmación
-      send_passcode: Enviar contraseña
+      send_security_code: Enviar contraseña
       setup_totp: Configurar la aplicación de autenticación
       submit:
         confirm_change: Confirm change

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -3,8 +3,8 @@ en:
   jobs:
     voice_otp_sender_job:
       message_final: >
-        Hello! Your login.gov one time passcode is, %{code}, again, your
-        passcode is, %{code}, goodbye!
+        Hello! Your login.gov one time security code is, %{code}, again, your
+        security code is, %{code}, goodbye!
       message_repeat: >
-        Hello! Your login.gov one time passcode is, %{code}, again, your
-        passcode is, %{code}. Press 1 to repeat your code.
+        Hello! Your login.gov one time security code is, %{code}, again, your
+        security code is, %{code}. Press 1 to repeat your code.

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -11,7 +11,7 @@ en:
     phone_confirmation:
       auth_app_fallback_html: ' or %{link}.'
       fallback_to_sms_html: Send me a text message with the code instead
-      fallback_to_voice_html: If you can't get text message right now, you can get a passcode via %{link}
+      fallback_to_voice_html: If you can't get text message right now, you can get a security code via %{link}
     privacy_policy: Privacy Policy
     remove: Remove
     resend: Resend email
@@ -21,9 +21,9 @@ en:
     cancel_account_creation: ‹ Cancel account creation
     cancel_idv: ‹ Cancel account verification
     two_factor_authentication:
-      app: get a passcode via authentication app
-      voice: get a passcode via phone call
-      sms: get a passcode via text message
+      app: get a security code via authentication app
+      voice: get a security code via phone call
+      sms: get a security code via text message
       resend_code:
         sms: Get another text message
         voice: Get another phone call

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -9,7 +9,7 @@ en:
       email: Edit your email address
       password: Edit your password
       phone: Edit your phone number
-    enter_2fa_code: Enter the secure one-time passcode
+    enter_2fa_code: Enter the secure one-time security code
     loa3_verified:
       'true': You have verified your identity with %{app}
       'false': You have created your account with %{app}
@@ -24,7 +24,7 @@ en:
       new: Sign up for a account
       start: Get started
     totp_setup:
-      new: Enter the secure one-time passcode
+      new: Enter the secure one-time security code
       start: Set up two-factor authentication
     two_factor_setup: Two-factor authentication setup
     verify_email: Check your email

--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -54,12 +54,12 @@ class UserBehavior(locust.TaskSet):
             'two_factor_setup_form[phone]': '7035550001',
             'two_factor_setup_form[otp_method]': 'sms',
             'authenticity_token': authenticity_token(dom),
-            'commit': 'Send passcode',
+            'commit': 'Send security code',
         }
         resp = self.client.patch('/phone_setup', data=data, auth=auth)
         resp.raise_for_status()
 
-        # visit enter passcode page and submit pre-filled OTP
+        # visit enter security code page and submit pre-filled OTP
         dom = pyquery.PyQuery(resp.content)
         otp_code = dom.find('input[name="code"]')[0].attrib['value']
         data = {

--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -70,7 +70,7 @@ feature 'SP-initiated authentication with login.gov', devise: true, user_flow: t
                 context 'with SMS delivery' do
                   before do
                     choose t('devise.two_factor_authentication.otp_method.sms')
-                    click_button t('forms.buttons.send_passcode')
+                    click_send_security_code
                   end
 
                   it 'prompts for OTP' do
@@ -81,7 +81,7 @@ feature 'SP-initiated authentication with login.gov', devise: true, user_flow: t
                 context 'with Voice delivery' do
                   before do
                     choose t('devise.two_factor_authentication.otp_method.voice')
-                    click_button t('forms.buttons.send_passcode')
+                    click_send_security_code
                   end
 
                   it 'prompts for OTP' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -34,7 +34,7 @@ feature 'saml api' do
 
       it 'prompts the user to confirm phone after setting up 2FA' do
         fill_in 'Phone', with: '202-555-1212'
-        click_button t('forms.buttons.send_passcode')
+        click_send_security_code
 
         expect(current_path).to eq login_two_factor_path(delivery_method: 'sms')
       end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -13,7 +13,7 @@ feature 'Two Factor Authentication' do
       expect(page).
         to have_content t('devise.two_factor_authentication.two_factor_setup')
 
-      send_passcode_without_entering_phone_number
+      send_security_code_without_entering_phone_number
 
       expect(current_path).to eq phone_setup_path
 
@@ -38,24 +38,24 @@ feature 'Two Factor Authentication' do
     visit profile_path
   end
 
-  def send_passcode_without_entering_phone_number
-    click_button t('forms.buttons.send_passcode')
+  def send_security_code_without_entering_phone_number
+    click_send_security_code
   end
 
   def submit_2fa_setup_form_with_empty_string_phone
     fill_in 'Phone', with: ''
-    click_button t('forms.buttons.send_passcode')
+    click_send_security_code
   end
 
   def submit_2fa_setup_form_with_invalid_phone
     fill_in 'Phone', with: 'five one zero five five five four three two one'
-    click_button t('forms.buttons.send_passcode')
+    click_send_security_code
   end
 
   def submit_2fa_setup_form_with_valid_phone_and_choose_phone_call_delivery
     fill_in 'Phone', with: '555-555-1212'
     choose 'Phone call'
-    click_button t('forms.buttons.send_passcode')
+    click_send_security_code
   end
 
   describe 'When the user has already set up 2FA' do

--- a/spec/features/users/recovery_code_spec.rb
+++ b/spec/features/users/recovery_code_spec.rb
@@ -94,8 +94,8 @@ def sign_up_and_view_recovery_code
   allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
   sign_up_and_set_password
   fill_in 'Phone', with: '202-555-1212'
-  click_button t('forms.buttons.send_passcode')
-  click_button t('forms.buttons.submit.default')
+  click_send_security_code
+  click_submit_default
 end
 
 def expect_accordion_content_to_be_hidden_by_default

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -7,7 +7,7 @@ feature 'Phone confirmation during sign up' do
       allow(SmsOtpSenderJob).to receive(:perform_later)
       @user = sign_in_before_2fa
       fill_in 'Phone', with: '555-555-5555'
-      click_button t('forms.buttons.send_passcode')
+      click_send_security_code
 
       expect(SmsOtpSenderJob).to have_received(:perform_later).with(
         code: @user.reload.direct_otp,
@@ -59,7 +59,7 @@ feature 'Phone confirmation during sign up' do
       @existing_user = create(:user, :signed_up)
       @user = sign_in_before_2fa
       fill_in 'Phone', with: @existing_user.phone
-      click_button t('forms.buttons.send_passcode')
+      click_send_security_code
     end
 
     it 'pretends the phone is valid and prompts to confirm the number' do
@@ -73,7 +73,7 @@ feature 'Phone confirmation during sign up' do
 
     it 'does not confirm the new number with an invalid code' do
       fill_in 'code', with: 'foobar'
-      click_button t('forms.buttons.submit.default')
+      click_submit_default
 
       expect(@user.reload.phone_confirmed_at).to be_nil
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -20,7 +20,7 @@ describe SmsOtpSenderJob do
 
       expect(msg.from).to match(/(\+19999999999|\+12222222222)/)
       expect(msg.to).to eq('555-5555')
-      expect(msg.body).to include('one-time passcode')
+      expect(msg.body).to include('one-time security code')
       expect(msg.body).to include('1234')
     end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -12,7 +12,7 @@ module Features
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = sign_up_and_set_password
       fill_in 'Phone', with: '202-555-1212'
-      select_sms_delivery
+      click_send_security_code
       enter_2fa_code
       click_acknowledge_recovery_code
       user
@@ -47,7 +47,7 @@ module Features
 
       visit profile_path
       fill_in 'Phone', with: '202-555-1212'
-      select_sms_delivery
+      click_send_security_code
       user
     end
 
@@ -110,8 +110,8 @@ module Features
       )
     end
 
-    def select_sms_delivery
-      click_button t('forms.buttons.send_passcode')
+    def click_send_security_code
+      click_button t('forms.buttons.send_security_code')
     end
 
     def enter_2fa_code
@@ -350,7 +350,7 @@ module Features
 
     def set_up_2fa_with_valid_phone
       fill_in 'Phone', with: '202-555-1212'
-      select_sms_delivery
+      click_send_security_code
     end
   end
 end


### PR DESCRIPTION
**Why**: Security code is our new way of referring to one-time login
codes, and should be standardized across the app

I also went ahead and renamed the helper method that clicked on the `send_passcode` button, and updated specs that previous called `click_on #{button_name}` to use the helper method instead.