### PR TITLE
Change personal key button (on profile) text to "Generate"

### DIFF
--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -17,4 +17,4 @@ en:
     items:
       recovery_code: Personal key
     links:
-      regenerate_recovery_code: Create
+      regenerate_recovery_code: Generate


### PR DESCRIPTION
**WHY**: Create was misleading, because a user already has a personal
key at this point

![screen shot 2017-03-30 at 10 20 54 am](https://cloud.githubusercontent.com/assets/601515/24517340/c21c215c-1532-11e7-8195-af86f14bfa52.png)
