### PR TITLE
Simplify legalese on "Enter Email Address" screen

### DIFF
--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -47,10 +47,7 @@ en:
     terms_of_service:
       link: Security Consent & Privacy Act Statement
       text_html: >
-        By continuing, I agree to %{app}’s %{link}. Providing
-        information is voluntary. It is used to help you access government services.
-        login.gov uses industry-standard monitoring and security practices to
-        protect your data.
+        By continuing, you agree to %{app}’s %{link}.
     totp_configured: You enabled an authentication app.
     totp_disabled: You disabled your authentication app.
     use_diff_email:


### PR DESCRIPTION

**Why**: To reduce friction, we simply inform the user that they are
agreeing to our privacy policy, and provide a link to said policy.

**Screenshot**:
![screen shot 2017-03-30 at 1 44 33 pm](https://cloud.githubusercontent.com/assets/1421848/24518180/0e4b4bcc-154f-11e7-866d-8123740f7b52.png)