### PR TITLE
Set SameSite=Lax for cookies

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -44,8 +44,13 @@ SecureHeaders::Configuration.default do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
+    # We need to set the SameSite setting to "Lax", not "Strict" due to a bug
+    # in Chrome that resets the session in the new browser tab that opens when
+    # the email confirmation link is clicked. Resetting the session means losing
+    # all the SP info we stored there, meaning during account creation, a user
+    # will be sent to the profile page instead of back to the SP.
     samesite: {
-      strict: true # mark all cookies as SameSite=Strict.
+      lax: true # mark all cookies as SameSite=Lax.
     },
   }
 


### PR DESCRIPTION
**Why**:
- There is a bug in Chrome that causes the session to be reset in the
following scenario:

  - Set cookies to use SameSite=Strict
  - Have Gmail open in a tab
  - In a different tab, visit sp.qa.login.gov and click Login.gov
  - Click "Get started" and enter your Gmail address
  - In the Gmail tab, click on the confirmation link in the email
  - In this new tab that was opened, complete the account setup

Result: You are redirected to the profile instead of `sign_up/completed`

We had originally set the setting to `Lax` due to this Chrome bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=619603
See https://github.com/18F/identity-idp/pull/189

Because that bug was closed in July 2016, we thought that it was safe
to go back to `Strict`, but it sounds like this might be a different
bug, or perhaps that original one hasn't really been fixed.

This bug only happens in Chrome, and seems to only happen when you click
the confirmation link from Gmail. If you copy and paste the link in a
new tab that you open manually, the redirect back to SP works fine.
Similarly, if you click the link from a non-Gmail email website, it
doesn't reset the session when it opens a new tab. I only tried
fastmail.com though.