### PR TITLE
Show "personal key"-specific copy on lockout page

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -44,12 +44,12 @@ module TwoFactorAuthenticatable
     authenticate_user!(force: true)
   end
 
-  def handle_second_factor_locked_user
+  def handle_second_factor_locked_user(type)
     analytics.track_event(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
     sign_out
 
-    render 'two_factor_authentication/shared/max_login_attempts_reached'
+    render 'two_factor_authentication/shared/max_login_attempts_reached', locals: { type: type }
   end
 
   def require_current_password
@@ -99,7 +99,7 @@ module TwoFactorAuthenticatable
     flash.now[:error] = t("devise.two_factor_authentication.invalid_#{type}")
 
     if decorated_user.blocked_from_entering_2fa_code?
-      handle_second_factor_locked_user
+      handle_second_factor_locked_user(type)
     else
       render_show_after_invalid
     end

--- a/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/recovery_code_verification_controller.rb
@@ -25,7 +25,7 @@ module TwoFactorAuthentication
         re_encrypt_profile_recovery_pii if password_reset_profile.present?
         handle_valid_otp
       else
-        handle_invalid_otp(type: 'recovery_code')
+        handle_invalid_otp(type: 'personal_key')
       end
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -51,7 +51,7 @@ module Users
     end
 
     def process_locked_out_user
-      render 'two_factor_authentication/shared/max_login_attempts_reached'
+      render 'two_factor_authentication/shared/max_login_attempts_reached', locals: { type: 'otp' }
       sign_out
     end
 

--- a/app/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb
+++ b/app/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb
@@ -5,7 +5,7 @@
   <%= t('titles.account_locked') %>
 </h1>
 <p>
-  <%= t('devise.two_factor_authentication.max_login_attempts_reached') %>
+<%= t("devise.two_factor_authentication.max_#{type}_login_attempts_reached") %>
 </p>
 <p>
   <%= t('devise.two_factor_authentication.please_try_again_html',

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -123,10 +123,13 @@ en:
       invalid_otp: >
         That security code is invalid. You can try entering it again or request a new
         one-time security code.
-      invalid_recovery_code: That personal key is invalid.
-      max_login_attempts_reached: >
+      invalid_personal_key: That personal key is invalid.
+      max_otp_login_attempts_reached: >
         Your account is temporarily locked because you have entered the one-time
         security code incorrectly too many times.
+      max_personal_key_login_attempts_reached: >
+        Your account is temporarily locked because you have entered the personal key
+        incorrectly too many times.
       otp_method:
         instruction: You can change your choice the next time you sign in
         sms: Text message (SMS)

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -106,8 +106,11 @@ es:
       invalid_otp:
         Esa contraseña no es válida. Puede intentar volver a ingresarlo o solicitar una nueva
         Código de acceso único.
-      invalid_recovery_code: Ese código de recuperación no es válido.
-      max_login_attempts_reached:
+      invalid_personal_key: Ese código de recuperación no es válido.
+      max_otp_login_attempts_reached:
+        Su cuenta ha sido bloqueada temporalmente porque ha ingresado el código de acceso único
+        de forma incorrecta demasiadas veces.
+      max_personal_key_login_attempts_reached:
         Su cuenta ha sido bloqueada temporalmente porque ha ingresado el código de acceso único
         de forma incorrecta demasiadas veces.
       otp_method:

--- a/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/recovery_code_verification_controller_spec.rb
@@ -74,7 +74,7 @@ describe TwoFactorAuthentication::RecoveryCodeVerificationController do
         post :create, payload
 
         expect(response).to render_template(:show)
-        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_recovery_code')
+        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_personal_key')
       end
 
       it 'tracks the max attempts event' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -149,7 +149,7 @@ feature 'Two Factor Authentication' do
         signin(user.email, user.password)
 
         expect(page).to have_content t('devise.two_factor_authentication.' \
-                                       'max_login_attempts_reached')
+                                       'max_otp_login_attempts_reached')
 
         visit profile_path
         expect(current_path).to eq root_path
@@ -194,25 +194,6 @@ feature 'Two Factor Authentication' do
       click_link t('links.cancel')
 
       expect(current_path).to eq root_path
-    end
-  end
-
-  describe 'signing in via recovery code' do
-    it 'displays new recovery code and redirects to profile after acknowledging' do
-      user = create(:user, :signed_up)
-      sign_in_before_2fa(user)
-
-      code = RecoveryCodeGenerator.new(user).create
-
-      click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
-
-      enter_recovery_code(code: code)
-
-      click_submit_default
-      click_acknowledge_recovery_code
-
-      expect(user.reload.recovery_code).to_not eq code
-      expect(current_path).to eq profile_path
     end
   end
 

--- a/spec/features/two_factor_authentication/sign_in_via_recovery_code_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_recovery_code_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+feature 'Signing in via recovery code' do
+  it 'displays new recovery code and redirects to profile after acknowledging' do
+    user = create(:user, :signed_up)
+    sign_in_before_2fa(user)
+
+    code = RecoveryCodeGenerator.new(user).create
+
+    click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
+
+    enter_recovery_code(code: code)
+
+    click_submit_default
+    click_acknowledge_recovery_code
+
+    expect(user.reload.recovery_code).to_not eq code
+    expect(current_path).to eq profile_path
+  end
+
+  context 'user enters incorrect recovery code' do
+    it 'locks user out when max login attempts has been reached' do
+      user = create(:user, :signed_up)
+      sign_in_before_2fa(user)
+      allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
+      code = RecoveryCodeGenerator.new(user).create
+      wrong_recovery_code = code.split(' ').reverse.join
+
+      click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
+      enter_recovery_code(code: wrong_recovery_code)
+      click_submit_default
+
+      expect(page).to have_content(
+        t('devise.two_factor_authentication.max_personal_key_login_attempts_reached')
+      )
+    end
+  end
+end

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+feature 'Password recovery via recovery code' do
+  include RecoveryCodeHelper
+
+  let(:user) { create(:user, :signed_up) }
+  let(:new_password) { 'some really awesome new password' }
+  let(:pii) { { ssn: '666-66-1234', dob: '1920-01-01' } }
+
+  scenario 'resets password and reactivates profile with recovery code', email: true do
+    recovery_code = recovery_code_from_pii(user, pii)
+
+    trigger_reset_password_and_click_email_link(user.email)
+
+    reset_password_and_sign_back_in(user, new_password)
+    click_submit_default
+    enter_correct_otp_code_for_user(user)
+
+    expect(current_path).to eq reactivate_profile_path
+
+    reactivate_profile(new_password, recovery_code)
+
+    expect(page).to have_content t('idv.messages.recovery_code')
+  end
+
+  scenario 'resets password, makes recovery code, attempts reactivate profile', email: true do
+    _recovery_code = recovery_code_from_pii(user, pii)
+
+    trigger_reset_password_and_click_email_link(user.email)
+
+    reset_password_and_sign_back_in(user, new_password)
+    click_submit_default
+    enter_correct_otp_code_for_user(user)
+
+    expect(current_path).to eq reactivate_profile_path
+
+    visit manage_recovery_code_path
+
+    new_recovery_code = scrape_recovery_code
+    click_acknowledge_recovery_code
+
+    expect(current_path).to eq reactivate_profile_path
+
+    reactivate_profile(new_password, new_recovery_code)
+
+    expect(page).to have_content t('errors.messages.recovery_code_incorrect')
+  end
+
+  scenario 'resets password, uses recovery code as 2fa', email: true do
+    recovery_code = recovery_code_from_pii(user, pii)
+
+    trigger_reset_password_and_click_email_link(user.email)
+
+    reset_password_and_sign_back_in(user, new_password)
+    click_submit_default
+
+    click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
+
+    enter_recovery_code(code: recovery_code)
+
+    click_submit_default
+
+    expect(current_path).to eq sign_up_recovery_code_path
+
+    new_recovery_code = scrape_recovery_code
+    click_acknowledge_recovery_code
+
+    expect(current_path).to eq reactivate_profile_path
+
+    reactivate_profile(new_password, new_recovery_code)
+
+    expect(page).to_not have_content t('errors.messages.recovery_code_incorrect')
+    expect(page).to have_content t('idv.messages.recovery_code')
+  end
+
+  def scrape_recovery_code
+    new_recovery_code_words = []
+    page.all(:css, '[data-recovery]').each do |node|
+      new_recovery_code_words << node.text
+    end
+    new_recovery_code_words.join(' ')
+  end
+
+  def reactivate_profile(password, recovery_code)
+    fill_in 'Password', with: password
+    enter_recovery_code(code: recovery_code)
+    click_button t('forms.reactivate_profile.submit')
+  end
+end

--- a/spec/features/users/regenerate_recovery_code_spec.rb
+++ b/spec/features/users/regenerate_recovery_code_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'View recovery code' do
   include XPathHelper
+  include RecoveryCodeHelper
 
   context 'during sign up' do
     scenario 'user refreshes recovery code page' do

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -1,43 +1,7 @@
 require 'rails_helper'
 
 feature 'Password Recovery' do
-  def reset_password_and_sign_back_in(user, password = 'a really long password')
-    fill_in t('forms.passwords.edit.labels.password'), with: password
-    click_button t('forms.passwords.edit.buttons.submit')
-    fill_in_credentials_and_submit(user.email, password)
-  end
-
-  def recovery_code_from_pii(user, pii)
-    profile = create(:profile, :active, :verified, user: user)
-    pii_attrs = Pii::Attributes.new_from_hash(pii)
-    user_access_key = user.unlock_user_access_key(user.password)
-    recovery_code = profile.encrypt_pii(user_access_key, pii_attrs)
-    profile.save!
-
-    recovery_code
-  end
-
-  def trigger_reset_password_and_click_email_link(email)
-    visit new_user_password_path
-    fill_in 'Email', with: email
-    click_button t('forms.buttons.continue')
-    open_last_email
-    click_email_link_matching(/reset_password_token/)
-  end
-
-  def scrape_recovery_code
-    new_recovery_code_words = []
-    page.all(:css, '[data-recovery]').each do |node|
-      new_recovery_code_words << node.text
-    end
-    new_recovery_code_words.join(' ')
-  end
-
-  def reactivate_profile(password, recovery_code)
-    fill_in 'Password', with: password
-    enter_recovery_code(code: recovery_code)
-    click_button t('forms.reactivate_profile.submit')
-  end
+  include RecoveryCodeHelper
 
   context 'user enters valid email in forgot password form', email: true do
     it 'redirects to forgot_password path and sends an email to the user' do
@@ -245,78 +209,6 @@ feature 'Password Recovery' do
 
         expect(page).to have_content 'is too short'
       end
-    end
-  end
-
-  context 'LOA3 user' do
-    let(:user) { create(:user, :signed_up) }
-    let(:new_password) { 'some really awesome new password' }
-    let(:pii) { { ssn: '666-66-1234', dob: '1920-01-01' } }
-
-    scenario 'resets password and reactivates profile with recovery code', email: true do
-      recovery_code = recovery_code_from_pii(user, pii)
-
-      trigger_reset_password_and_click_email_link(user.email)
-
-      reset_password_and_sign_back_in(user, new_password)
-      click_submit_default
-      enter_correct_otp_code_for_user(user)
-
-      expect(current_path).to eq reactivate_profile_path
-
-      reactivate_profile(new_password, recovery_code)
-
-      expect(page).to have_content t('idv.messages.recovery_code')
-    end
-
-    scenario 'resets password, makes recovery code, attempts reactivate profile', email: true do
-      _recovery_code = recovery_code_from_pii(user, pii)
-
-      trigger_reset_password_and_click_email_link(user.email)
-
-      reset_password_and_sign_back_in(user, new_password)
-      click_submit_default
-      enter_correct_otp_code_for_user(user)
-
-      expect(current_path).to eq reactivate_profile_path
-
-      visit manage_recovery_code_path
-
-      new_recovery_code = scrape_recovery_code
-      click_acknowledge_recovery_code
-
-      expect(current_path).to eq reactivate_profile_path
-
-      reactivate_profile(new_password, new_recovery_code)
-
-      expect(page).to have_content t('errors.messages.recovery_code_incorrect')
-    end
-
-    scenario 'resets password, uses recovery code as 2fa', email: true do
-      recovery_code = recovery_code_from_pii(user, pii)
-
-      trigger_reset_password_and_click_email_link(user.email)
-
-      reset_password_and_sign_back_in(user, new_password)
-      click_submit_default
-
-      click_link t('devise.two_factor_authentication.recovery_code_fallback.link')
-
-      enter_recovery_code(code: recovery_code)
-
-      click_submit_default
-
-      expect(current_path).to eq sign_up_recovery_code_path
-
-      new_recovery_code = scrape_recovery_code
-      click_acknowledge_recovery_code
-
-      expect(current_path).to eq reactivate_profile_path
-
-      reactivate_profile(new_password, new_recovery_code)
-
-      expect(page).to_not have_content t('errors.messages.recovery_code_incorrect')
-      expect(page).to have_content t('idv.messages.recovery_code')
     end
   end
 

--- a/spec/support/features/recovery_code_helper.rb
+++ b/spec/support/features/recovery_code_helper.rb
@@ -1,0 +1,25 @@
+module RecoveryCodeHelper
+  def reset_password_and_sign_back_in(user, password = 'a really long password')
+    fill_in t('forms.passwords.edit.labels.password'), with: password
+    click_button t('forms.passwords.edit.buttons.submit')
+    fill_in_credentials_and_submit(user.email, password)
+  end
+
+  def recovery_code_from_pii(user, pii)
+    profile = create(:profile, :active, :verified, user: user)
+    pii_attrs = Pii::Attributes.new_from_hash(pii)
+    user_access_key = user.unlock_user_access_key(user.password)
+    recovery_code = profile.encrypt_pii(user_access_key, pii_attrs)
+    profile.save!
+
+    recovery_code
+  end
+
+  def trigger_reset_password_and_click_email_link(email)
+    visit new_user_password_path
+    fill_in 'Email', with: email
+    click_button t('forms.buttons.continue')
+    open_last_email
+    click_email_link_matching(/reset_password_token/)
+  end
+end

--- a/spec/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb_spec.rb
@@ -5,13 +5,16 @@ describe 'two_factor_authentication/shared/max_login_attempts_reached.html.erb' 
     it 'includes localized error message with time remaining' do
       user_decorator = instance_double(UserDecorator)
       allow(view).to receive(:decorated_user).and_return(user_decorator)
+      allow(view).to receive(:type).and_return('otp')
       allow(user_decorator).to receive(:lockout_time_remaining_in_words).and_return('1000 years')
       allow(user_decorator).to receive(:lockout_time_remaining).and_return(10_000)
 
       render
 
       expect(rendered).to include(t('titles.account_locked'))
-      expect(rendered).to include(t('devise.two_factor_authentication.max_login_attempts_reached'))
+      expect(rendered).to include(
+        t('devise.two_factor_authentication.max_otp_login_attempts_reached')
+      )
       expect(rendered).to include('1000 years')
     end
   end


### PR DESCRIPTION
**WHY**: We render the same view template for lockout due to trying the
wrong OTP too many times or trying the wrong personal key too many
times. This PR uses key interpolation to customize the copy depending on
the situation.