### PR TITLE
Properly line up scissors on pkey page in Safari

### DIFF
--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -33,6 +33,11 @@
   }
 }
 
+.ico-scissors {
+  left: -5px;
+  top: -14px;
+}
+
 @media #{$breakpoint-sm} {
   .separator-text > div {
     &::after {

--- a/app/views/partials/personal_key/_key.slim
+++ b/app/views/partials/personal_key/_key.slim
@@ -1,7 +1,7 @@
 #recovery-code(class="col-12 border-box mt4 mb3 py2 px2 sm-px4 fs-20p sans-serif\
                       border border-dashed border-red rounded-xl relative clearfix")
   = image_tag asset_url('scissors.svg'), width: 24,
-    class: 'absolute', style: 'top:-14px;left:-5px'
+    class: 'absolute ico-scissors'
   p.bold.center.mt1
     = image_tag(asset_url('p-key.svg'), width: 36, class: 'align-middle mr1')
     = t('users.recovery_code.header')


### PR DESCRIPTION
**Why**: The icon appears to be getting set incorrectly because of a CSP
violation. It used an inline style, and safari seems to be more
stringent about that compared with other browsers.

Can be tested manually with the following steps:
1). Use any recent branch of identity-idp except for this one (as those branches will contain inline styles on the scissor icon).
2). Comment out line 38 of `config/initializers/secure_headers.rb`
3). (Re)Start your server.
4). Visit the personal key screen in Safari. You should see something like this:

<img width="577" alt="screen shot 2017-03-31 at 3 24 02 pm" src="https://cloud.githubusercontent.com/assets/1421848/24566097/1e0bbf7e-1626-11e7-9eb4-f36ee0d3ada9.png">

If you open the console, you'll also see a CSP violation for inline-styles

5). Check out this branch and visit the personal key screen in safari. You'll see the icon lined up nicely with the dotted border, as it appears in other browsers.

🎉 