### PR TITLE
Prevent pkey modal from jumping on focus in iOS

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -9,7 +9,11 @@
 }
 
 .modal-open {
+  left: 0;
   overflow: hidden;
+  position: fixed;
+  right: 0;
+  width: 100%;
 
   .modal {
     overflow-x: hidden;
@@ -23,6 +27,7 @@
   left: 0;
   outline: 0;
   overflow: hidden;
+  -webkit-overflow-scrolling: auto;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
**Why**: Mobile safari has issues with handling elements that have
`position: fixed` set while receiving a scroll event.

**How**: Adding `-webkit-overflow-scrolling: auto` prevents `input`
field cursor from remaining in the original fixed position until the
scroll event completes, and prevents the modal from jumping each
time an input is focused.  Adding `position: fixed`
to the `body` element when the modal is open prevents the user from
being able to scroll the content underneath the modal.

**NOTE** There will always be some jumping on first focus, as the default behavior of iOS safari is to attempt to scroll to an input element.

Gif xposted from issue:
![iosstuff](https://cloud.githubusercontent.com/assets/1421848/24613053/1c48b8be-1855-11e7-8b8e-41a34debed99.gif)