### PR TITLE
Prevent accordion events from firing twice

### DIFF
--- a/app/assets/javascripts/misc/cancel-action-modal.js
+++ b/app/assets/javascripts/misc/cancel-action-modal.js
@@ -1,6 +1,4 @@
-import { Modal } from '../app/components/index';
-
-const modal = new Modal({ el: '#cancel-action-modal' });
+const modal = new window.LoginGov.Modal({ el: '#cancel-action-modal' });
 const modalTrigger = document.getElementById('auth-flow-cancel');
 const modalDismiss = document.getElementById('loa-continue');
 

--- a/app/assets/javascripts/misc/recovery-page-controller.js
+++ b/app/assets/javascripts/misc/recovery-page-controller.js
@@ -1,7 +1,5 @@
-import { Modal } from '../app/components/index';
-
 const modalSelector = '#personal-key-confirm';
-const modal = new Modal({ el: modalSelector });
+const modal = new window.LoginGov.Modal({ el: modalSelector });
 
 const recoveryCodeContainer = document.getElementById('recovery-code');
 const recoveryWords = [].slice.call(document.querySelectorAll('[data-recovery]'));

--- a/app/assets/javascripts/misc/verify-modal.js
+++ b/app/assets/javascripts/misc/verify-modal.js
@@ -1,10 +1,9 @@
 import 'classlist.js';
-import { Modal } from '../app/components/index';
 
 function verifyModal() {
   const flash = document.querySelector('.alert');
   const modalSelector = document.getElementById('verification-modal');
-  const modal = new Modal({ el: '#verification-modal' });
+  const modal = new window.LoginGov.Modal({ el: '#verification-modal' });
   const modalDismiss = document.getElementById('js-close-modal');
 
   if (flash) flash.classList.add('display-none');

--- a/spec/features/users/regenerate_recovery_code_spec.rb
+++ b/spec/features/users/regenerate_recovery_code_spec.rb
@@ -112,7 +112,7 @@ def expand_accordion
 end
 
 def expect_accordion_content_to_become_visible
-  expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='false']")
+  expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='true']")
   expect(page).to have_content(t('users.recovery_code.help_text'))
 end
 


### PR DESCRIPTION
**Why**: Using a `javascript_include_tag` to include a JS file with an
`import` statement ends up including all other code that the imported
file imports. This reduces the usefulness of using an import statement
with browserify, as that code should be shared, not compiled/included
multiple times. The simplest solution is to rely on the `Modal` class
ref stored on the window object.