### PR TITLE
Refactor: separate controller actions for separate personal key views

### DIFF
--- a/app/controllers/users/recovery_codes_controller.rb
+++ b/app/controllers/users/recovery_codes_controller.rb
@@ -9,7 +9,20 @@ module Users
       analytics.track_event(Analytics::PROFILE_RECOVERY_CODE_CREATE)
 
       flash.now[:success] = t('notices.send_code.recovery_code') if params[:resend].present?
-      render '/sign_up/recovery_codes/show'
+    end
+
+    def update
+      redirect_to next_step
+    end
+
+    private
+
+    def next_step
+      if current_user.password_reset_profile.present?
+        reactivate_profile_path
+      else
+        profile_path
+      end
     end
   end
 end

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -6,13 +6,25 @@ module Verify
     before_action :confirm_idv_vendor_session_started
     before_action :confirm_profile_has_been_created
 
-    def index
+    def show
       track_final_idv_event
 
       finish_proofing_success
     end
 
+    def update
+      redirect_to next_step
+    end
+
     private
+
+    def next_step
+      if session[:sp]
+        sign_up_completed_path
+      else
+        after_sign_in_path_for(current_user)
+      end
+    end
 
     def confirm_profile_has_been_created
       redirect_to profile_path unless idv_session.profile.present?
@@ -27,7 +39,7 @@ module Verify
     end
 
     def finish_proofing_success
-      @recovery_code = recovery_code
+      @code = recovery_code
       idv_session.complete_session
       idv_session.recovery_code = nil
       create_account_verified_event

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -36,13 +36,13 @@ module TwoFactorAuthCode
 
     private
 
+    def recovery_code_tag
+      link_to(t("#{recovery_code_key}.link"), login_two_factor_recovery_code_path)
+    end
+
     def link_to(text, url, options = {})
       href = { href: url }
       content_tag(:a, text, options.merge(href))
-    end
-
-    def recovery_code_tag
-      link_to(t("#{recovery_code_key}.link"), login_two_factor_recovery_code_path)
     end
 
     def recovery_code_key

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -17,7 +17,7 @@ p.mt-tiny.mb0
 = accordion('recovery-code-info', t('users.recovery_code.help_text_header')) do
   = simple_format(t('users.recovery_code.help_text'))
 
-= button_to t('forms.buttons.continue'), sign_up_recovery_code_path,
+= button_to t('forms.buttons.continue'), update_path,
           class: 'btn btn-primary btn-wide mb1 recovery-code-continue',
           'data-toggle': 'modal'
 

--- a/app/views/sign_up/recovery_codes/show.html.slim
+++ b/app/views/sign_up/recovery_codes/show.html.slim
@@ -1,3 +1,3 @@
 - title t('titles.recovery_code')
 
-= render 'shared/personal_key', code: @code
+= render 'shared/personal_key', code: @code, update_path: sign_up_recovery_code_path

--- a/app/views/users/recovery_codes/show.html.slim
+++ b/app/views/users/recovery_codes/show.html.slim
@@ -1,0 +1,3 @@
+- title t('titles.recovery_code')
+
+= render 'shared/personal_key', code: @code, update_path: manage_recovery_code_path

--- a/app/views/verify/confirmations/index.html.slim
+++ b/app/views/verify/confirmations/index.html.slim
@@ -1,3 +1,0 @@
-- title t('idv.titles.complete')
-
-= render 'shared/personal_key', code: @recovery_code

--- a/app/views/verify/confirmations/show.html.slim
+++ b/app/views/verify/confirmations/show.html.slim
@@ -1,0 +1,3 @@
+- title t('titles.recovery_code')
+
+= render 'shared/personal_key', code: @code, update_path: verify_confirmations_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
   get '/manage/phone' => 'users/phones#edit'
   match '/manage/phone' => 'users/phones#update', via: [:patch, :put]
   get '/manage/recovery_code' => 'users/recovery_codes#show', as: :manage_recovery_code
+  post '/manage/recovery_code' => 'users/recovery_codes#update'
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   post '/openid_connect/authorize' => 'openid_connect/authorization#create',
@@ -111,7 +112,8 @@ Rails.application.routes.draw do
     get '/verify/activated' => 'verify#activated'
     get '/verify/address' => 'verify/address#index'
     get '/verify/cancel' => 'verify#cancel'
-    get '/verify/confirmations' => 'verify/confirmations#index'
+    get '/verify/confirmations' => 'verify/confirmations#show'
+    post '/verify/confirmations' => 'verify/confirmations#update'
     get '/verify/fail' => 'verify#fail'
     get '/verify/finance' => 'verify/finance#new'
     put '/verify/finance' => 'verify/finance#create'

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -62,7 +62,7 @@ describe Verify::ConfirmationsController do
       end
 
       it 'activates profile' do
-        get :index
+        get :show
         profile.reload
 
         expect(profile).to be_active
@@ -72,19 +72,19 @@ describe Verify::ConfirmationsController do
       it 'sets recovery code instance variable' do
         subject.idv_session.cache_applicant_profile_id
         code = subject.idv_session.recovery_code
-        get :index
+        get :show
 
-        expect(assigns(:recovery_code)).to eq(code)
+        expect(assigns(:code)).to eq(code)
       end
 
       it 'sets flash[:allow_confirmations_continue] to true' do
-        get :index
+        get :show
 
         expect(flash[:allow_confirmations_continue]).to eq true
       end
 
       it 'sets flash.now[:success]' do
-        get :index
+        get :show
         expect(flash[:success]).to eq t('idv.messages.confirm')
       end
 
@@ -99,7 +99,7 @@ describe Verify::ConfirmationsController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::IDV_FINAL, result)
 
-        get :index
+        get :show
       end
 
       it 'creates an `account_verified` event once per confirmation' do
@@ -107,7 +107,7 @@ describe Verify::ConfirmationsController do
         expect(CreateVerifiedAccountEvent).to receive(:new).and_return(event_creator)
         expect(event_creator).to receive(:call)
 
-        get :index
+        get :show
       end
     end
 
@@ -119,7 +119,7 @@ describe Verify::ConfirmationsController do
       it 'leaves profile deactivated' do
         expect(UspsConfirmation.count).to eq 0
 
-        get :index
+        get :show
         profile.reload
 
         expect(profile).to_not be_active
@@ -142,7 +142,7 @@ describe Verify::ConfirmationsController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::IDV_FINAL, result)
 
-        get :index
+        get :show
       end
     end
   end
@@ -151,7 +151,7 @@ describe Verify::ConfirmationsController do
     it 'redirects to /idv/sessions' do
       stub_sign_in(user)
 
-      get :index
+      get :show
 
       expect(response).to redirect_to(verify_session_path)
     end


### PR DESCRIPTION
**WHY**: We were showing the personal key modal in 3 separate places, but
redirecting users to a single controller action after all 3, which was
kind of confusing.