### PR TITLE
Fix squashed accordion icon on mobile

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -32,28 +32,28 @@
   }
 
   .accordion-header-control[aria-expanded="false"] {
-    ~.minus-icon {
+    .minus-icon {
       display: none;
     }
 
-    ~.plus-icon {
+    .plus-icon {
       display: initial;
     }
   }
 
   .accordion-header-control[aria-expanded="true"] {
-    ~.minus-icon {
+    .minus-icon {
       display: initial;
     }
 
-    ~.plus-icon {
+    .plus-icon {
       display: none;
     }
   }
 
   .accordion-header-control {
     color: $blue;
-    margin-right: 20px;
+    padding-right: 30px;
 
     .accordion-content {
       max-height: 0;

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -20,24 +20,44 @@
     opacity: 1;
   }
 
-  .accordion-header-control {
-    background-position: right .25rem center;
-    background-repeat: no-repeat;
-    background-size: $h4;
-    color: $blue;
+  .accordion-header {
     cursor: pointer;
+    position: relative;
 
-    &[aria-expanded="true"] {
-      background-image: url(image-path('minus.svg'));
+    img {
+      position: absolute;
+      right: 1rem;
+      top: .8rem;
     }
+  }
+
+  .accordion-header-control[aria-expanded="false"] {
+    ~.minus-icon {
+      display: none;
+    }
+
+    ~.plus-icon {
+      display: initial;
+    }
+  }
+
+  .accordion-header-control[aria-expanded="true"] {
+    ~.minus-icon {
+      display: initial;
+    }
+
+    ~.plus-icon {
+      display: none;
+    }
+  }
+
+  .accordion-header-control {
+    color: $blue;
+    margin-right: 20px;
 
     .accordion-content {
       max-height: 0;
       transition: max-height .3s linear;
-    }
-
-    &[aria-expanded="false"] {
-      background-image: url(image-path('plus.svg'));
     }
   }
 

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -1,5 +1,5 @@
 .mb4.col-12.border.rounded-md.border-blue.fs-16p.accordion
-  .accordion-header.py1.pl2(
+  .accordion-header.py1.px2(
     class=('display-none' if options[:hide_header])
     role="heading"
   )
@@ -11,8 +11,8 @@
     )
       span.mb0.mr2
         = header_text
-    = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
-    = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
+      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
+      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
   .accordion-content.accordion-init.clearfix(
     id="#{target_id}"
     role="region"

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -3,13 +3,16 @@
     class=('display-none' if options[:hide_header])
     role="heading"
   )
-    p.accordion-header-control.mb0.mr2(
+    .accordion-header-control(
       aria-controls="#{target_id}"
       aria-expanded="true"
       role="button"
       tabindex="0"
     )
-      = header_text
+      span.mb0.mr2
+        = header_text
+    = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
+    = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
   .accordion-content.accordion-init.clearfix(
     id="#{target_id}"
     role="region"


### PR DESCRIPTION
**Why**: Currently the icons overlap the text which makes the intent
difficult to discern

Screenshot:
<img width="370" alt="screen shot 2017-04-03 at 9 16 23 pm" src="https://cloud.githubusercontent.com/assets/1421848/24637941/d37479c6-18b2-11e7-9954-75095c35929e.png">

I realize this pic doesn't have a screen size context, but it was captured with chrome's mobile device emulator enabled!

