### PR TITLE
Small copy update for links to policy page

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -10,8 +10,8 @@ h1.h3.my0 = decorated_session.new_session_heading
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
   = f.button :submit, t('links.next'), class: 'btn-wide'
 
-- link = link_to t('notices.sign_in_consent.link'), MarketingSite.privacy_url, target: '_blank'
-p.my3 == t('notices.sign_in_consent.text', app: APP_NAME, link: link)
+p.my3
+  = link_to t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'
 
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -9,10 +9,7 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
             input_html: { 'aria-describedby' => 'email-description' }
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
   p.mb-40p.mt1.italic
-    = t('notices.terms_of_service.text_html',
-        link: link_to( \
-          t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'),
-        app: APP_NAME)
+    = link_to t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -35,9 +35,6 @@ en:
     session_cleared: >
       For your security, we refresh the page and clear out any information you typed into the
       form fields if you don't submit the form within %{minutes} minutes.
-    sign_in_consent:
-      link: Security Consent & Privacy Act Statement.
-      text: By signing in, you agree to %{app}’s %{link}
     signed_up_but_unconfirmed:
       first_paragraph_end: >
         with a link to confirm your email address. Follow the link to continue
@@ -45,9 +42,7 @@ en:
       first_paragraph_start: We sent an email to
       no_email_sent_explanation_start: Didn’t receive it?
     terms_of_service:
-      link: Security Consent & Privacy Act Statement
-      text_html: >
-        By continuing, you agree to %{app}’s %{link}.
+      link: Security Practices and Privacy Act Statement
     totp_configured: You enabled an authentication app.
     totp_disabled: You disabled your authentication app.
     use_diff_email:

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -26,16 +26,12 @@ es:
         sign_out: NOT TRANSLATED YET
         message_html: NOT TRANSLATED YET
     session_cleared: NOT TRANSLATED YET
-    sign_in_consent:
-      link: NOT TRANSLATED YET
-      text: NOT TRANSLATED YET
     signed_up_but_unconfirmed:
       first_paragraph_end: NOT TRANSLATED YET
       first_paragraph_start: NOT TRANSLATED YET
       no_email_sent_explanation_start: NOT TRANSLATED YET
     terms_of_service:
       link: NOT TRANSLATED YET
-      text_html: NOT TRANSLATED YET
     totp_configured: NOT TRANSLATED YET
     totp_disabled: NOT TRANSLATED YET
     use_diff_email:

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -34,7 +34,7 @@ describe 'devise/sessions/new.html.slim' do
     render
 
     expect(rendered).
-      to have_link(t('notices.sign_in_consent.link'), href: MarketingSite.privacy_url)
+      to have_link(t('notices.terms_of_service.link'), href: MarketingSite.privacy_url)
 
     expect(rendered).to have_selector("a[href='#{MarketingSite.privacy_url}'][target='_blank']")
   end


### PR DESCRIPTION
**WHY**: Per our privacy lawyer, we need to both change the link text (done) AND remove the "By continuing, you agree to/By signing in, you agree to" language.