### PR TITLE
Replace cancel account creation link on email signup screen with cancel link

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -26,7 +26,6 @@ module SignUp
     end
 
     def process_successful_password_creation
-      session.delete(:sign_up_init)
       @user.confirm
       UpdateUser.new(
         user: @user,

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -16,7 +16,6 @@ module SignUp
     def new
       ab_finished(:demo)
       @register_user_email_form = RegisterUserEmailForm.new
-      session[:sign_up_init] = true
       analytics.track_event(Analytics::USER_REGISTRATION_ENTER_EMAIL_VISIT)
       render :new, locals: { request_id: nil }
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,8 +8,6 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
 
     def new
-      session.delete(:sign_up_init)
-
       analytics.track_event(Analytics::SIGN_IN_PAGE_VISIT)
       super
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,12 +29,8 @@ module ApplicationHelper
     session.fetch(:sp, {})
   end
 
-  def sign_up_init?
-    session[:sign_up_init]
-  end
-
   def user_signing_up?
-    sign_up_init? || current_user && !current_user.two_factor_enabled?
+    params[:confirmation_token] || (current_user && !current_user.two_factor_enabled?)
   end
 
   def session_with_trust?
@@ -56,9 +52,7 @@ module ApplicationHelper
   end
 
   def sign_up_or_idv_no_js_link
-    if sign_up_init?
-      root_path
-    elsif user_signing_up?
+    if user_signing_up?
       destroy_user_path
     elsif user_verifying_identity?
       verify_session_path

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -2,12 +2,12 @@
 
 .mt2.pt1.border-top
   - if user_signing_up? || user_verifying_identity?
-    - method = sign_up_init? ? :get : :delete
+    - method = user_signing_up? ? :get : :delete
 
     = button_to cancel_link_text, cancel, method: method,
       class: 'btn btn-link', id: 'auth-flow-cancel'
     = render 'shared/cancel_action_modal',
       idv: user_verifying_identity?,
-      sign_up_init: sign_up_init?
+      user_signing_up: user_signing_up?
   - else
     = link_to cancel_link_text, cancel, class: 'h5'

--- a/app/views/shared/_cancel_action_modal.html.slim
+++ b/app/views/shared/_cancel_action_modal.html.slim
@@ -22,12 +22,13 @@
         - if idv
           = button_to t('idv.buttons.cancel'), verify_session_path, method: :delete,
             class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
-        - elsif sign_up_init
+        - elsif user_signing_up
+          = button_to t('sign_up.buttons.cancel'), destroy_user_path, method: :delete,
+            class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
+        - else
           .col-12
             = link_to cancel_link_text, '/', id: 'cancel-action-home',
               class: 'btn btn-outline blue border border-blue rounded-lg center block'
-        -else
-          = button_to t('sign_up.buttons.cancel'), destroy_user_path, method: :delete,
-            class: 'btn btn-outline blue border border-blue rounded-lg col-12 input-submit'
+
 
 == javascript_include_tag 'misc/cancel-action-modal'

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -17,4 +17,4 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
 
-= render 'shared/cancel', link: destroy_user_session_path
+= render 'shared/cancel', link: root_path

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -23,7 +23,6 @@ describe SignUp::PasswordsController do
       expect(user.valid_password?('NewVal!dPassw0rd')).to eq true
       expect(user.confirmed?).to eq true
       expect(user.reset_requested_at).to be_nil
-      expect(subject.session[:sign_up_init]).to be_nil
     end
 
     it 'tracks an invalid password event' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -327,14 +327,6 @@ describe Users::SessionsController, devise: true do
 
         get :new
       end
-
-      it 'cleans up the sign_up_init key' do
-        subject.session[:sign_up_init] = true
-
-        get :new
-
-        expect(subject.session[:sign_up_init]).to be_nil
-      end
     end
   end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -15,15 +15,10 @@ feature 'Sign Up' do
   context 'user cancels sign up on email screen' do
     before do
       visit sign_up_email_path
-      page.find('#auth-flow-cancel').click
+      click_on t('links.cancel')
     end
 
     it 'redirects user to the home page' do
-      expect(current_path).to eq(root_path)
-    end
-
-    it 'redirects to the homepage from the modal', js: true do
-      page.find('a', text: t('links.cancel_account_creation')).click
       expect(current_path).to eq(root_path)
     end
   end

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -4,7 +4,7 @@ describe 'sign_up/passwords/new.html.slim' do
   before do
     user = build_stubbed(:user)
     allow(view).to receive(:current_user).and_return(nil)
-    allow(view).to receive(:session).and_return(sign_up_init: true)
+    allow(view).to receive(:params).and_return(confirmation_token: 123)
 
     @password_form = PasswordForm.new(user)
 

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -31,8 +31,7 @@ describe 'sign_up/registrations/new.html.slim' do
 
   it 'includes a link to return to the home page' do
     render
-    link = t('links.cancel')
 
-    expect(rendered).to have_content(link)
+    expect(rendered).to have_link(t('links.cancel'), href: root_path)
   end
 end

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -5,7 +5,6 @@ describe 'sign_up/registrations/new.html.slim' do
     @register_user_email_form = RegisterUserEmailForm.new
     allow(view).to receive(:controller_name).and_return('registrations')
     allow(view).to receive(:current_user).and_return(nil)
-    allow(view).to receive(:session).and_return(sign_up_init: true)
     allow(view).to receive(:request_id).and_return(nil)
   end
 
@@ -30,10 +29,10 @@ describe 'sign_up/registrations/new.html.slim' do
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
 
-  it 'includes a form to cancel account creation' do
+  it 'includes a link to return to the home page' do
     render
-    link = t('links.cancel_account_creation')
+    link = t('links.cancel')
 
-    expect(rendered).to have_selector("input[value='#{link}']")
+    expect(rendered).to have_content(link)
   end
 end


### PR DESCRIPTION
**Why**: Although the user is technically canceling their account
creation, none of the actions in the modal make sense at this point,
since they haven't entered any information

![screen shot 2017-04-04 at 9 25 22 am](https://cloud.githubusercontent.com/assets/1421848/24659091/b617a094-1919-11e7-833d-31f957af53ca.png)
