### PR TITLE
Set CSP correctly after entering wrong 2FA code

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -7,7 +7,7 @@ module TwoFactorAuthenticatable
     before_action :require_current_password, if: :current_password_required?
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
-    before_action :apply_secure_headers_override, only: :show
+    before_action :apply_secure_headers_override, only: [:show, :create]
   end
 
   DELIVERY_METHOD_MAP = {

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -9,7 +9,7 @@ describe Users::TwoFactorAuthenticationController do
         [:require_current_password, if: :current_password_required?],
         :check_already_authenticated,
         [:reset_attempt_count_if_user_no_longer_locked_out, only: :create],
-        [:apply_secure_headers_override, only: :show]
+        [:apply_secure_headers_override, only: [:show, :create]]
       )
     end
   end


### PR DESCRIPTION
**Why**: Bug that prevented redirecting back to client apps