### PR TITLE
Update marketing site URL

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -1,5 +1,5 @@
 class MarketingSite
-  BASE_URL = URI('https://login.gov').freeze
+  BASE_URL = URI('https://www.login.gov').freeze
 
   def self.base_url
     BASE_URL.to_s

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -3,25 +3,25 @@ require 'rails_helper'
 RSpec.describe MarketingSite do
   describe '.base_url' do
     it 'points to the base URL' do
-      expect(MarketingSite.base_url).to eq('https://login.gov')
+      expect(MarketingSite.base_url).to eq('https://www.login.gov')
     end
   end
 
   describe '.privacy_url' do
     it 'points to the privacy page' do
-      expect(MarketingSite.privacy_url).to eq('https://login.gov/policy')
+      expect(MarketingSite.privacy_url).to eq('https://www.login.gov/policy')
     end
   end
 
   describe '.contact_url' do
     it 'points to the contact page' do
-      expect(MarketingSite.contact_url).to eq('https://login.gov/contact')
+      expect(MarketingSite.contact_url).to eq('https://www.login.gov/contact')
     end
   end
 
   describe '.help_url' do
     it 'points to the help page' do
-      expect(MarketingSite.help_url).to eq('https://login.gov/help')
+      expect(MarketingSite.help_url).to eq('https://www.login.gov/help')
     end
   end
 end


### PR DESCRIPTION
**Why**: We're making www. the canonical domain for marketing