### PR TITLE
Wait until password entry to set SP session data

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -31,27 +31,9 @@ module SignUp
       flash[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
       session[:user_confirmation_token] = @confirmation_token
       request_id = params.fetch(:_request_id, '')
-      add_sp_details_to_session unless request_id.empty?
       redirect_to sign_up_enter_password_url(
         request_id: request_id, confirmation_token: @confirmation_token
       )
-    end
-
-    def add_sp_details_to_session
-      session[:sp] = {
-        issuer: sp_request.issuer,
-        loa3: loa3_requested?,
-        request_url: sp_request.url,
-        request_id: sp_request.uuid,
-      }
-    end
-
-    def sp_request
-      @_sp_request ||= ServiceProviderRequest.from_uuid(params[:_request_id])
-    end
-
-    def loa3_requested?
-      sp_request.loa == Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
     end
 
     def process_confirmed_user

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -15,7 +15,7 @@ p.mb0
       input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
-  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
+  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -44,13 +44,8 @@ SecureHeaders::Configuration.default do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
-    # We need to set the SameSite setting to "Lax", not "Strict" due to a bug
-    # in Chrome that resets the session in the new browser tab that opens when
-    # the email confirmation link is clicked. Resetting the session means losing
-    # all the SP info we stored there, meaning during account creation, a user
-    # will be sent to the profile page instead of back to the SP.
     samesite: {
-      lax: true # mark all cookies as SameSite=Lax.
+      strict: true # mark all cookies as SameSite=Strict.
     },
   }
 

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'sign_up/passwords/new.html.slim' do
     user = build_stubbed(:user)
     allow(view).to receive(:current_user).and_return(nil)
     allow(view).to receive(:params).and_return(confirmation_token: 123)
+    allow(view).to receive(:request_id).and_return(nil)
 
     @password_form = PasswordForm.new(user)
 


### PR DESCRIPTION
**Why**: We've come across a reproducible scenario in Chrome where if
the SameSite cookie setting is `Strict`, clicking on the confirmation
email from a Gmail web page resets the IdP session after it gets set in
`SignUp::EmailConfirmationsController`. This means that after the user
finishes completing the account creation, they won't be redirected back
to the SP.

By making this change, it will hopefully allow us to revert back to the
more secure `Strict` setting because we had to change it to `Lax` to
get around this Chrome issue.