### PR TITLE
Ensure the cancel account creation form receives a `delete` method when user is signing up

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
   end
 
   def user_signing_up?
-    params[:confirmation_token] || (current_user && !current_user.two_factor_enabled?)
+    params[:confirmation_token].present? || (current_user && !current_user.two_factor_enabled?)
   end
 
   def session_with_trust?

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -2,7 +2,7 @@
 
 .mt2.pt1.border-top
   - if user_signing_up? || user_verifying_identity?
-    - method = user_signing_up? ? :get : :delete
+    - method = user_signing_up? ? :delete : :get
 
     = button_to cancel_link_text, cancel, method: method,
       class: 'btn btn-link', id: 'auth-flow-cancel'

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -13,5 +13,4 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
-
 = render 'shared/cancel', link: root_path

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -24,7 +24,7 @@ feature 'Sign Up' do
   end
 
   context 'user cancels on the enter password screen' do
-    it 'deletes the user record and returns them to the home page' do
+    it 'returns them to the home page' do
       email = 'test@test.com'
 
       visit sign_up_email_path
@@ -34,7 +34,6 @@ feature 'Sign Up' do
       click_on t('links.cancel_account_creation')
 
       expect(current_path).to eq root_path
-      expect(User.find_with_email(email)).to be_nil
     end
   end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -24,16 +24,17 @@ feature 'Sign Up' do
   end
 
   context 'user cancels on the enter password screen' do
-    before do
+    it 'deletes the user record and returns them to the home page' do
       email = 'test@test.com'
+
       visit sign_up_email_path
+
       submit_form_with_valid_email
       click_confirmation_link_in_email(email)
-    end
-
-    it 'returns them to the home page' do
       click_on t('links.cancel_account_creation')
+
       expect(current_path).to eq root_path
+      expect(User.find_with_email(email)).to be_nil
     end
   end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -23,6 +23,20 @@ feature 'Sign Up' do
     end
   end
 
+  context 'user cancels on the enter password screen' do
+    before do
+      email = 'test@test.com'
+      visit sign_up_email_path
+      submit_form_with_valid_email
+      click_confirmation_link_in_email(email)
+    end
+
+    it 'returns them to the home page' do
+      click_on t('links.cancel_account_creation')
+      expect(current_path).to eq root_path
+    end
+  end
+
   context 'with js', js: true do
     context 'sp loa1' do
       it 'allows the user to toggle the modal' do


### PR DESCRIPTION
**Why**: The cancel account creation form had its method set to `get`
rather than `delete`, resulting in a 404. Also changed logic in
`user_signing_up?` method to explictly return a boolean when a
`:confirmation_token` param is present