### PR TITLE
Script to tag releases

### DIFF
--- a/bin/tag-release
+++ b/bin/tag-release
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+set -x
+
+TAG=$(date -u +"%Y-%m-%dT%H%M%S")
+
+git tag -s $TAG -m "$TAG release"
+git push origin $TAG


### PR DESCRIPTION
**Why**: Make it easy to create official releases.