### PR TITLE
Move `confirmation_for_phone_change` into presenter

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -223,6 +223,7 @@ module TwoFactorAuthenticatable
 
   def phone_view_data
     {
+      confirmation_for_phone_change: confirmation_for_phone_change?,
       phone_number: display_phone_to_deliver_to,
       code_value: direct_otp_code,
       otp_delivery_preference: two_factor_authentication_method,
@@ -235,6 +236,7 @@ module TwoFactorAuthenticatable
 
   def authenticator_view_data
     {
+      confirmation_for_phone_change: confirmation_for_phone_change?,
       two_factor_authentication_method: two_factor_authentication_method,
       user_email: current_user.email,
       personal_key_unavailable: personal_key_unavailable?,
@@ -266,6 +268,10 @@ module TwoFactorAuthenticatable
     else
       phone_setup_path
     end
+  end
+
+  def confirmation_for_phone_change?
+    confirmation_context? && current_user.phone.present?
   end
 
   def presenter_for_two_factor_authentication_method

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -4,8 +4,6 @@ module TwoFactorAuthentication
 
     skip_before_action :handle_two_factor_authentication
 
-    helper_method :confirmation_for_phone_change?
-
     def show
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH_ENTER_OTP_VISIT, analytics_properties)
 
@@ -36,10 +34,6 @@ module TwoFactorAuthentication
         method: params[:otp_delivery_preference],
         confirmation_for_phone_change: confirmation_for_phone_change?,
       }
-    end
-
-    def confirmation_for_phone_change?
-      confirmation_context? && current_user.phone.present?
     end
   end
 end

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -4,7 +4,7 @@ module TwoFactorAuthCode
     include ActionView::Helpers::TranslationHelper
     include Rails.application.routes.url_helpers
 
-    attr_reader :code_value
+    attr_reader :code_value, :confirmation_for_phone_change
 
     def initialize(data:, view:)
       data.each do |key, value|

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -16,7 +16,7 @@ h1.h3.my0 = @presenter.header
 
 = render 'shared/fallback_links', presenter: @presenter
 
-- if confirmation_for_phone_change? || reauthn?
+- if @presenter.confirmation_for_phone_change || reauthn?
   = render 'shared/cancel', link: profile_path
 - else
   = render 'shared/cancel', link: destroy_user_session_path

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -14,7 +14,6 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
   context 'user has a phone' do
     before do
       allow(view).to receive(:reauthn?).and_return(false)
-      allow(view).to receive(:confirmation_for_phone_change?).and_return(false)
       allow(view).to receive(:user_session).and_return({})
       allow(view).to receive(:current_user).and_return(User.new)
       controller.request.path_parameters[:otp_delivery_preference] =
@@ -103,14 +102,17 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
     end
 
     context 'user is changing phone number' do
-      before do
+      it 'provides a cancel link to return to profile' do
         user = build_stubbed(:user, :signed_up, personal_key: '1')
         allow(view).to receive(:current_user).and_return(user)
-        allow(view).to receive(:confirmation_for_phone_change?).and_return(true)
-        render
-      end
+        data = presenter_data.merge(confirmation_for_phone_change: true)
+        @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
+          data: data,
+          view: view
+        )
 
-      it 'provides a cancel link to return to profile' do
+        render
+
         expect(rendered).to have_link(
           t('links.cancel'),
           href: profile_path


### PR DESCRIPTION
**WHY**: Moving logic into models and out of controllers