### PR TITLE
Updates footer link name

### DIFF
--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -12,7 +12,7 @@ en:
       auth_app_fallback_html: ' or %{link}.'
       fallback_to_sms_html: Send me a text message with the code instead
       fallback_to_voice_html: If you can't get text message right now, you can get a security code via %{link}
-    privacy_policy: Privacy Policy
+    privacy_policy: Privacy & security
     remove: Remove
     resend: Resend email
     sign_in: Sign in

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -12,7 +12,7 @@ en:
       auth_app_fallback_html: ' or %{link}.'
       fallback_to_sms_html: Send me a text message with the code instead
       fallback_to_voice_html: If you can't get text message right now, you can get a security code via %{link}
-    privacy_policy: Privacy & security
+    privacy_policy: Privacy and security
     remove: Remove
     resend: Resend email
     sign_in: Sign in

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -243,17 +243,17 @@ feature 'Two Factor Authentication' do
     it 'renders the requested pages' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
-      click_link 'Help'
+      click_link t('links.help')
 
       expect(current_url).to eq MarketingSite.help_url
 
       visit login_two_factor_path(otp_delivery_preference: 'sms')
-      click_link 'Contact'
+      click_link t('links.contact')
 
       expect(current_url).to eq MarketingSite.contact_url
 
       visit login_two_factor_path(otp_delivery_preference: 'sms')
-      click_link 'Privacy Policy'
+      click_link t('links.privacy_policy')
 
       expect(current_url).to eq MarketingSite.privacy_url
     end


### PR DESCRIPTION
**Why** Because the previous version was inaccurate; the linked page now contains security policy information along with privacy information.