### PR TITLE
Update personal key spec description

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature 'Signing in via personal key' do
-  it 'displays new personal key and redirects to profile after acknowledging' do
+feature 'Signing in via one-time use personal key' do
+  it 'destroys old key, displays new one, and redirects to profile after acknowledging' do
     user = create(:user, :signed_up)
     sign_in_before_2fa(user)
 


### PR DESCRIPTION
**Why**: I had forgotten that the personal key was one-time use, so I
wasn't sure why a new one was being generated after signing in with
the old one.

This PR updates the spec description to specify that the personal key
is one-time use only.