### PR TITLE
Remove all `helper_method` usage from IDV controllers

### DIFF
--- a/app/controllers/verify/finance_controller.rb
+++ b/app/controllers/verify/finance_controller.rb
@@ -38,7 +38,7 @@ module Verify
       Verify::FinancialsNew.new(
         error: error,
         remaining_attempts: remaining_step_attempts,
-        idv_finance_form: idv_finance_form
+        idv_form: idv_finance_form
       )
     end
 

--- a/app/controllers/verify/finance_other_controller.rb
+++ b/app/controllers/verify/finance_other_controller.rb
@@ -23,7 +23,7 @@ module Verify
     def view_model
       Verify::FinancialsNew.new(
         remaining_attempts: remaining_step_attempts,
-        idv_finance_form: idv_finance_form
+        idv_form: idv_finance_form
       )
     end
 

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -6,10 +6,8 @@ module Verify
     before_action :confirm_step_needed
     before_action :confirm_step_allowed
 
-    helper_method :idv_phone_form
-
     def new
-      @view_model = Verify::PhoneNew.new(remaining_attempts: remaining_step_attempts)
+      @view_model = view_model
       analytics.track_event(Analytics::IDV_PHONE_RECORD_VISIT)
     end
 
@@ -41,7 +39,11 @@ module Verify
     end
 
     def view_model(error: nil)
-      Verify::PhoneNew.new(error: error, remaining_attempts: remaining_step_attempts)
+      Verify::PhoneNew.new(
+        error: error,
+        remaining_attempts: remaining_step_attempts,
+        idv_form: idv_phone_form
+      )
     end
 
     def step_params

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -6,8 +6,6 @@ module Verify
     before_action :confirm_idv_steps_complete
     before_action :confirm_current_password, only: [:create]
 
-    helper_method :idv_params
-
     def confirm_idv_steps_complete
       return redirect_to(verify_session_path) unless idv_profile_complete?
       return redirect_to(verify_finance_path) unless idv_finance_complete?
@@ -22,6 +20,7 @@ module Verify
     end
 
     def new
+      @idv_params = idv_params
       idv_session.params.symbolize_keys!
       analytics.track_event(Analytics::IDV_REVIEW_VISIT)
 

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -8,13 +8,10 @@ module Verify
     before_action :confirm_idv_needed
     before_action :confirm_step_needed, except: [:destroy]
 
-    helper_method :idv_profile_form
-    helper_method :step
-
     delegate :attempts_exceeded?, to: :step, prefix: true
 
     def new
-      @view_model = Verify::SessionsNew.new(remaining_attempts: remaining_idv_attempts)
+      @view_model = view_model
       analytics.track_event(Analytics::IDV_BASIC_INFO_VISIT)
     end
 
@@ -80,7 +77,11 @@ module Verify
     end
 
     def view_model(error: nil)
-      Verify::SessionsNew.new(error: error, remaining_attempts: remaining_idv_attempts)
+      Verify::SessionsNew.new(
+        error: error,
+        remaining_attempts: remaining_idv_attempts,
+        idv_form: idv_profile_form
+      )
     end
 
     def remaining_idv_attempts

--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -2,12 +2,13 @@ module Verify
   class Base
     include Rails.application.routes.url_helpers
 
-    def initialize(error: nil, remaining_attempts:)
+    def initialize(error: nil, remaining_attempts:, idv_form:)
       @error = error
       @remaining_attempts = remaining_attempts
+      @idv_form = idv_form
     end
 
-    attr_reader :error, :remaining_attempts
+    attr_reader :error, :remaining_attempts, :idv_form
 
     def mock_vendor_partial
       if idv_vendor.pick == :mock

--- a/app/view_models/verify/financials_new.rb
+++ b/app/view_models/verify/financials_new.rb
@@ -1,13 +1,5 @@
 module Verify
   class FinancialsNew < Verify::Base
-    def initialize(error: nil, remaining_attempts:, idv_finance_form:)
-      @error = error
-      @remaining_attempts = remaining_attempts
-      @idv_finance_form = idv_finance_form
-    end
-
-    attr_reader :idv_finance_form
-
     def step_name
       :financials
     end

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -6,7 +6,7 @@ p.mt-tiny.mb0
   = t('idv.messages.finance.intro_ccn_html',
       intro_help_link: link_to(t('idv.messages.finance.intro_ccn_help'), MarketingSite.help_url))
 
-= simple_form_for(@view_model.idv_finance_form, url: verify_finance_path,
+= simple_form_for(@view_model.idv_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   = hidden_field_tag 'idv_finance_form[finance_type]', :ccn
 

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -3,7 +3,7 @@
 
 h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
-= simple_form_for(@view_model.idv_finance_form, url: verify_finance_path,
+= simple_form_for(@view_model.idv_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
   .select-alt.mb2
     = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -16,7 +16,7 @@ p.mt-tiny.mb2 = t('idv.messages.phone.intro')
 em
   = t('idv.messages.phone.same_as_2fa')
 
-= simple_form_for(idv_phone_form, url: verify_phone_path,
+= simple_form_for(@view_model.idv_form, url: verify_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form', class: 'mt2' }) do |f|
   = f.label :phone, label: t('idv.form.phone'), class: 'bold'
   span.ml1

--- a/app/views/verify/review/new.html.slim
+++ b/app/views/verify/review/new.html.slim
@@ -12,23 +12,23 @@ h1.h3.my0 = t('idv.titles.session.review')
     .pl5
       .h6 = t('idv.review.full_name')
       .h4.bold.ico-absolute.ico-absolute-success
-        = "#{idv_params[:first_name]} #{idv_params[:last_name]}"
+        = "#{@idv_params[:first_name]} #{@idv_params[:last_name]}"
 
       .mt3.h6 = t('idv.review.mailing_address')
       .h4.bold.ico-absolute.ico-absolute-success
-        | #{idv_params[:address1]}<br>
-        - if idv_params[:address2].present?
-          | #{idv_params[:address2]}<br>
-        | #{idv_params[:city]}, #{idv_params[:state]} #{idv_params[:zipcode]}
+        | #{@idv_params[:address1]}<br>
+        - if @idv_params[:address2].present?
+          | #{@idv_params[:address2]}<br>
+        | #{@idv_params[:city]}, #{@idv_params[:state]} #{@idv_params[:zipcode]}
 
       .mt3.h6 = t('idv.review.dob')
-      .h4.bold.ico-absolute.ico-absolute-success #{idv_params[:dob].to_date.to_formatted_s(:long)}
+      .h4.bold.ico-absolute.ico-absolute-success #{@idv_params[:dob].to_date.to_formatted_s(:long)}
 
       .mt3.h6 = t('idv.review.ssn')
-      .h4.bold.ico-absolute.ico-absolute-success #{idv_params[:ssn]}
+      .h4.bold.ico-absolute.ico-absolute-success #{@idv_params[:ssn]}
 
       .h6.mt3 = t('idv.messages.phone.phone_of_record').capitalize
-      .h4.bold.ico-absolute.ico-absolute-success #{idv_params[:phone]}
+      .h4.bold.ico-absolute.ico-absolute-success #{@idv_params[:phone]}
 
       .mt3.mb3
         = link_to t('idv.messages.review.financial_info'), MarketingSite.help_url

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -49,7 +49,9 @@ h1.h3.my0 = @view_model.title
       label: t('idv.form.dob'), required: true,
       hint: t('idv.form.dob_hint'), hint_html: { id: 'dob-instructs', class: 'mb1' },
       pattern: '(0[1-9]|1[012])/(0[1-9]|1[0-9]|2[0-9]|3[01])/[0-9]{4}',
-      input_html: { class: 'dob', value: @view_model.idv_form.dob, 'aria-describedby': 'dob-instructs' }
+      input_html: { class: 'dob',
+        value: @view_model.idv_form.dob,
+        'aria-describedby': 'dob-instructs' }
     / using :tel for mobile numeric keypad
     = f.input :ssn, as: :tel,
       label: t('idv.form.ssn_label_html', tooltip: tooltip(t('tooltips.ssn'))),

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -2,7 +2,7 @@
 = render @view_model.mock_vendor_partial
 
 h1.h3.my0 = @view_model.title
-= simple_form_for(idv_profile_form, url: verify_session_path,
+= simple_form_for(@view_model.idv_form, url: verify_session_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification
   fieldset.mb3.ml0.p0.border-none
@@ -23,7 +23,7 @@ h1.h3.my0 = @view_model.title
         = f.input :zipcode, as: :tel,
           label: t('idv.form.zipcode'), required: true,
           pattern: '(\d{5}([\-]\d{4})?)',
-          input_html: { class: 'zipcode', value: idv_profile_form.zipcode }
+          input_html: { class: 'zipcode', value: @view_model.idv_form.zipcode }
     .mb-tiny = t('idv.form.previous_address_html')
     = accordion('previous-address', t('idv.form.previous_address_add'),
       hide_header: true, hide_close_link: true) do
@@ -41,7 +41,7 @@ h1.h3.my0 = @view_model.title
             = f.input :prev_zipcode, as: :tel,
               label: t('idv.form.zipcode'),
               pattern: '(\d{5}([\-]\d{4})?)',
-              input_html: { class: 'zipcode', value: idv_profile_form.prev_zipcode }
+              input_html: { class: 'zipcode', value: @view_model.idv_form.prev_zipcode }
   fieldset.m0.p0.border-none
     legend.col-12.mb3.pb-tiny.border-bottom.border-teal = t('idv.form.personal_details')
     / using :tel for mobile numeric keypad
@@ -49,13 +49,13 @@ h1.h3.my0 = @view_model.title
       label: t('idv.form.dob'), required: true,
       hint: t('idv.form.dob_hint'), hint_html: { id: 'dob-instructs', class: 'mb1' },
       pattern: '(0[1-9]|1[012])/(0[1-9]|1[0-9]|2[0-9]|3[01])/[0-9]{4}',
-      input_html: { class: 'dob', value: idv_profile_form.dob, 'aria-describedby': 'dob-instructs' }
+      input_html: { class: 'dob', value: @view_model.idv_form.dob, 'aria-describedby': 'dob-instructs' }
     / using :tel for mobile numeric keypad
     = f.input :ssn, as: :tel,
       label: t('idv.form.ssn_label_html', tooltip: tooltip(t('tooltips.ssn'))),
       required: true,
       pattern: '^\d{3}-?\d{2}-?\d{4}$',
-      input_html: { class: 'ssn', value: idv_profile_form.ssn }
+      input_html: { class: 'ssn', value: @view_model.idv_form.ssn }
   .mt3
     button type='submit' class='btn btn-primary btn-wide' = t('forms.buttons.continue')
 = render 'shared/cancel', link: verify_cancel_path

--- a/spec/view_models/verify/base_spec.rb
+++ b/spec/view_models/verify/base_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Verify::Base do
       it 'returns no pii warning partial' do
         allow(Figaro.env).to receive(:proofing_vendors).and_return('mock')
 
-        partial = Verify::Base.new(remaining_attempts: 1).mock_vendor_partial
+        partial = Verify::Base.new(remaining_attempts: 1, idv_form: nil).mock_vendor_partial
 
         expect(partial).to eq 'verify/sessions/no_pii_warning'
       end
@@ -16,7 +16,7 @@ RSpec.describe Verify::Base do
       it 'returns null partial' do
         allow(Figaro.env).to receive(:proofing_vendors).and_return('other')
 
-        partial = Verify::Base.new(remaining_attempts: 1).mock_vendor_partial
+        partial = Verify::Base.new(remaining_attempts: 1, idv_form: nil).mock_vendor_partial
 
         expect(partial).to eq 'shared/null'
       end

--- a/spec/views/verify/review/new.html.slim_spec.rb
+++ b/spec/views/verify/review/new.html.slim_spec.rb
@@ -17,7 +17,7 @@ describe 'verify/review/new.html.slim' do
         city: 'Somewhere',
         state: 'MO',
         zipcode: '12345',
-        phone: '+1 (213) 555-0000'
+        phone: '+1 (213) 555-0000',
       }
 
       render

--- a/spec/views/verify/review/new.html.slim_spec.rb
+++ b/spec/views/verify/review/new.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'verify/review/new.html.slim' do
     before do
       user = build_stubbed(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:idv_params).and_return(
+      @idv_params = {
         first_name: 'Some',
         last_name: 'One',
         ssn: '666-66-1234',
@@ -18,7 +18,7 @@ describe 'verify/review/new.html.slim' do
         state: 'MO',
         zipcode: '12345',
         phone: '+1 (213) 555-0000'
-      )
+      }
 
       render
     end


### PR DESCRIPTION
**WHY**: Better to include in view model (refactor)