### PR TITLE
Remove unused paths and specs from rack attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -89,7 +89,6 @@ module Rack
       # `filter` returns truthy value if request fails, or if it's to a
       # previously banned phone_number so the request is blocked
       phone_number = req.env['warden'].user&.phone
-      paths = %w(/otp/send /phone_confirmation/send /idv/phone_confirmation/send)
 
       Allow2Ban.filter(
         "otp-#{phone_number}",
@@ -98,7 +97,7 @@ module Rack
         bantime: Figaro.env.otp_delivery_blocklist_bantime.to_i.minutes
       ) do
         # The count for the phone_number is incremented if the return value is truthy
-        req.get? && paths.include?(req.path)
+        req.get? && req.path == '/otp/send'
       end
     end
 


### PR DESCRIPTION
**Why**: In https://github.com/18F/identity-idp/pull/584, I had removed
the `/phone_confirmation/send` and `/idv/phone_confirmation/send`
endpoints, but I forgot to clean them out of rack attack.

This is not causing any issues since the `/otp/send` path is still
used. I also added an additional spec to make sure that the `/otp/send`
path exists in case its gets removed.