### PR TITLE
Prompt user to verify profile with OTP

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -185,7 +185,7 @@ module TwoFactorAuthenticatable
   end
 
   def after_otp_action_required?
-    current_user.password_reset_profile.present? ||
+    decorated_user.password_reset_profile.present? ||
       @updating_existing_number ||
       decorated_user.should_acknowledge_personal_key?(session)
   end
@@ -196,7 +196,7 @@ module TwoFactorAuthenticatable
       sign_up_personal_key_path
     elsif @updating_existing_number
       profile_path
-    elsif current_user.password_reset_profile.present?
+    elsif decorated_user.password_reset_profile.present?
       reactivate_profile_path
     else
       profile_path

--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -33,7 +33,7 @@ module SignUp
     def next_step
       if session[:sp]
         sign_up_completed_path
-      elsif current_user.password_reset_profile.present?
+      elsif decorated_user.password_reset_profile.present?
         reactivate_profile_path
       else
         after_sign_in_path_for(current_user)

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -35,7 +35,7 @@ module TwoFactorAuthentication
     end
 
     def password_reset_profile
-      @_password_reset_profile ||= current_user.password_reset_profile
+      @_password_reset_profile ||= decorated_user.password_reset_profile
     end
 
     def pii

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -18,7 +18,7 @@ module Users
     private
 
     def next_step
-      if current_user.password_reset_profile.present?
+      if decorated_user.password_reset_profile.present?
         reactivate_profile_url
       else
         profile_url

--- a/app/controllers/users/verify_profile_controller.rb
+++ b/app/controllers/users/verify_profile_controller.rb
@@ -1,0 +1,42 @@
+module Users
+  class VerifyProfileController < ApplicationController
+    before_action :confirm_verification_needed
+
+    def index
+      @verify_profile_form = VerifyProfileForm.new(user: current_user)
+    end
+
+    def create
+      @verify_profile_form = build_verify_profile_form
+      if @verify_profile_form.submit
+        flash[:success] = t('profile.index.verification.success')
+        redirect_to profile_path
+      else
+        render :index
+      end
+    end
+
+    private
+
+    def build_verify_profile_form
+      VerifyProfileForm.new(
+        user: current_user,
+        otp: params_otp,
+        pii_attributes: decrypted_pii
+      )
+    end
+
+    def params_otp
+      params[:verify_profile_form].permit(:otp)[:otp]
+    end
+
+    def confirm_verification_needed
+      !current_user.active_profile.present? && decorated_user.pending_profile.present?
+    end
+
+    def decrypted_pii
+      cacher = Pii::Cacher.new(current_user, user_session)
+      cacher.fetch
+    end
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -51,6 +51,13 @@ UserDecorator = Struct.new(:user) do
     user.active_profile || pending_profile
   end
 
+  # This user's most recently activated profile that has also been deactivated
+  # due to a password reset, or nil if there is no such profile
+  def password_reset_profile
+    profile = user.profiles.order(activated_at: :desc).first
+    profile if profile&.password_reset?
+  end
+
   def qrcode(otp_secret_key)
     options = {
       issuer: 'Login.gov',

--- a/app/forms/reactivate_profile_form.rb
+++ b/app/forms/reactivate_profile_form.rb
@@ -30,7 +30,7 @@ class ReactivateProfileForm
   protected
 
   def password_reset_profile
-    @_password_reset_profile ||= user.password_reset_profile
+    @_password_reset_profile ||= user.decorate.password_reset_profile
   end
 
   def user_access_key

--- a/app/forms/verify_profile_form.rb
+++ b/app/forms/verify_profile_form.rb
@@ -1,0 +1,54 @@
+class VerifyProfileForm
+  include ActiveModel::Model
+
+  validates :otp, presence: true
+  validate :validate_otp
+  validate :validate_pending_profile
+
+  attr_accessor :otp, :pii_attributes
+  attr_reader :user
+
+  def initialize(user:, otp: nil, pii_attributes: nil)
+    @user = user
+    @otp = otp
+    @pii_attributes = pii_attributes
+  end
+
+  def submit
+    if valid?
+      activate_profile
+      true
+    else
+      clear_fields
+      false
+    end
+  end
+
+  protected
+
+  def pending_profile
+    @_pending_profile ||= user.decorate.pending_profile
+  end
+
+  def validate_pending_profile
+    errors.add :base, :no_pending_profile unless pending_profile
+  end
+
+  def validate_otp
+    return if valid_otp?
+    errors.add :otp, :otp_incorrect
+  end
+
+  def valid_otp?
+    ActiveSupport::SecurityUtils.secure_compare(otp, pii_attributes.otp.to_s)
+  end
+
+  # Reset sensitive fields so they don't get sent back to the browser
+  def clear_fields
+    self.otp = nil
+  end
+
+  def activate_profile
+    pending_profile.activate
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,13 +101,6 @@ class User < ActiveRecord::Base
     @_active_profile ||= profiles.verified.find(&:active?)
   end
 
-  # This user's most recently activated profile that has also been deactivated
-  # due to a password reset, or nil if there is no such profile
-  def password_reset_profile
-    profile = profiles.order(activated_at: :desc).first
-    profile if profile&.password_reset?
-  end
-
   # To send emails asynchronously via ActiveJob.
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/view_models/profile_index.rb
+++ b/app/view_models/profile_index.rb
@@ -20,8 +20,16 @@ class ProfileIndex
   end
 
   def password_reset_partial
-    if current_user.password_reset_profile.present?
+    if current_user.decorate.password_reset_profile.present?
       'profile/password_reset'
+    else
+      'shared/null'
+    end
+  end
+
+  def pending_profile_partial
+    if current_user.decorate.pending_profile.present?
+      'profile/pending_profile'
     else
       'shared/null'
     end
@@ -44,7 +52,7 @@ class ProfileIndex
   end
 
   def manage_personal_key_partial
-    if current_user.password_reset_profile.present?
+    if current_user.decorate.password_reset_profile.present?
       'shared/null'
     else
       'profile/manage_personal_key'

--- a/app/views/profile/_pending_profile.html.slim
+++ b/app/views/profile/_pending_profile.html.slim
@@ -1,0 +1,3 @@
+.mb4.alert.alert-warning
+  p = t('profile.index.verification.instructions')
+  p.mb0 = link_to t('profile.index.verification.reactivate_button'), verify_profile_path

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -8,6 +8,8 @@
 
 = render @view_model.password_reset_partial, view_model: @view_model
 
+= render @view_model.pending_profile_partial, view_model: @view_model
+
 h1.hide = t('titles.profile')
 
 = render @view_model.header_partial, view_model: @view_model

--- a/app/views/users/verify_profile/index.html.slim
+++ b/app/views/users/verify_profile/index.html.slim
@@ -1,0 +1,9 @@
+- title t('titles.verify_profile')
+
+h1.h3.my0 = t('forms.verify_profile.title')
+p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
+= simple_form_for(@verify_profile_form, url: verify_profile_path,
+  html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
+  = f.error :base
+  = f.input :otp, required: true, label: 'Secret code'
+  = f.button :submit, t('forms.verify_profile.submit'), class: 'mb1'

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -22,11 +22,13 @@ en:
       improbable_phone: Phone number is invalid. Please make sure you enter a 10-digit phone number.
       missing_field: Please fill in this field.
       no_password_reset_profile: No profile has been recently deactivated due to a password reset
+      no_pending_profile: No profile is waiting for verification
       not_found: not found
       not_locked: was not locked
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      otp_incorrect: Secret code is incorrect
       password_incorrect: Password is incorrect
       personal_key_incorrect: Personal key is incorrect
       requires_phone: requires you to enter your phone number.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -22,11 +22,13 @@ es:
       improbable_phone: El número de teléfono no es válido. Asegúrese de ingresar un número de teléfono de 10 dígitos.
       missing_field: Por favor, rellenar este campo.
       no_password_reset_profile: Ningún perfil ha sido desactivado recientemente por un restablecimiento de contraseña.
+      no_pending_profile: Ningún perfil está esperando verificación
       not_found: no encontrado
       not_locked: no estaba bloqueado
       not_saved:
         one: '1 error prohibió este %{resource} de ser guardado:'
         other: "%{count} errores prohibieron este %{resource} de ser guardado:"
+      otp_incorrect: El código secreto es incorrecto
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: El código de recuperación es incorrecto
       requires_phone: requiere que ingrese su número de teléfono.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -49,3 +49,7 @@ en:
       code: One-time security code
       personal_key: Personal key
       try_again: Use another phone number
+    verify_profile:
+      title: Verify your identity
+      submit: Submit
+      instructions: Enter your secret code

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -49,3 +49,7 @@ es:
       code: Código de acceso único
       personal_key: Código de recuperación
       try_again: Inténtalo de nuevo
+    verify_profile:
+      title: NOT TRANSLATED YET
+      submit: NOT TRANSLATED YET
+      instructions: NOT TRANSLATED YET

--- a/config/locales/profile/en.yml
+++ b/config/locales/profile/en.yml
@@ -14,6 +14,10 @@ en:
         instructions: For your security, you will need to verify your account information again.
         reactivate_button: Verify your identity
       ssn: Social Security Number
+      verification:
+        instructions: Your account requires a secret code to be verified.
+        reactivate_button: Enter the code you received via US mail
+        success: Your account has been verified.
     items:
       personal_key: Personal key
     links:

--- a/config/locales/profile/es.yml
+++ b/config/locales/profile/es.yml
@@ -14,6 +14,10 @@ es:
         instructions: NOT TRANSLATED YET
         reactivate_button: NOT TRANSLATED YET
       ssn: NOT TRANSLATED YET
+      verification:
+        instructions: NOT TRANSLATED YET
+        reactivate_button: NOT TRANSLATED YET
+        success: NOT TRANSLATED YET
     items:
       personal_key: NOT TRANSLATED YET
     links:

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -28,5 +28,6 @@ en:
       start: Set up two-factor authentication
     two_factor_setup: Two-factor authentication setup
     verify_email: Check your email
+    verify_profile: Activate your account
     visitors:
       index: Welcome

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -28,5 +28,6 @@ es:
       start: NOT TRANSLATED YET
     two_factor_setup: NOT TRANSLATED YET
     verify_email: NOT TRANSLATED YET
+    verify_profile: NOT TRANSLATED YET
     visitors:
       index: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,8 @@ Rails.application.routes.draw do
   get '/profile' => 'profile#index', as: :profile
   get '/profile/reactivate' => 'users/reactivate_profile#index', as: :reactivate_profile
   post '/profile/reactivate' => 'users/reactivate_profile#create'
+  get '/profile/verify' => 'users/verify_profile#index', as: :verify_profile
+  post '/profile/verify' => 'users/verify_profile#create'
 
   post '/sign_up/create_password' => 'sign_up/passwords#create', as: :sign_up_create_password
   get '/sign_up/email/confirm' => 'sign_up/email_confirmations#create',

--- a/spec/controllers/users/verify_profile_controller_spec.rb
+++ b/spec/controllers/users/verify_profile_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Users::VerifyProfileController do
+  include Features::LocalizationHelper
+
+  describe '#create' do
+    subject(:action) do
+      post(
+        :create,
+        verify_profile_form: {
+          otp: 'abc123',
+        }
+      )
+    end
+
+    before do
+      stub_sign_in
+
+      form = instance_double('VerifyProfileForm', submit: success)
+      expect(controller).to receive(:build_verify_profile_form).and_return(form)
+    end
+
+    context 'with a valid form' do
+      let(:success) { true }
+
+      it 'redirects to the profile page' do
+        action
+
+        expect(response).to redirect_to(profile_path)
+      end
+    end
+
+    context 'with an invalid form' do
+      let(:success) { false }
+
+      it 'renders the index page to show errors' do
+        action
+
+        expect(response).to render_template('users/verify_profile/index')
+      end
+    end
+  end
+end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -143,4 +143,34 @@ describe UserDecorator do
       end
     end
   end
+
+  describe '#password_reset_profile' do
+    let(:user) { create(:user) }
+    subject(:decorated_user) { UserDecorator.new(user) }
+
+    context 'with no profiles' do
+      it { expect(decorated_user.password_reset_profile).to be_nil }
+    end
+
+    context 'with an active profile' do
+      let(:active_profile) do
+        build(:profile, :active, :verified, activated_at: 1.day.ago, pii: { first_name: 'Jane' })
+      end
+
+      before do
+        user.profiles << [
+          active_profile,
+          build(:profile, :verified, activated_at: 5.days.ago, pii: { first_name: 'Susan' }),
+        ]
+      end
+
+      it { expect(decorated_user.password_reset_profile).to be_nil }
+
+      context 'when the active profile is deactivated due to password reset' do
+        before { active_profile.deactivate(:password_reset) }
+
+        it { expect(decorated_user.password_reset_profile).to eq(active_profile) }
+      end
+    end
+  end
 end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+feature 'verify profile with OTP' do
+  let(:user) { create(:user, :signed_up) }
+  let(:otp) { 'abc123' }
+
+  before do
+    create(
+      :profile,
+      deactivation_reason: :verification_pending,
+      pii: { otp: otp, ssn: '666-66-1234', dob: '1920-01-01' },
+      user: user
+    )
+  end
+
+  scenario 'received OTP via USPS' do
+    sign_in_live_with_2fa(user)
+
+    expect(current_path).to eq profile_path
+
+    click_on t('profile.index.verification.reactivate_button')
+
+    expect(current_path).to eq verify_profile_path
+
+    fill_in 'Secret code', with: otp
+    click_button t('forms.verify_profile.submit')
+
+    expect(current_path).to eq profile_path
+    expect(page).to_not have_content(t('profile.index.verification.reactivate_button'))
+  end
+
+  xscenario 'OTP has expired' do
+    # see https://github.com/18F/identity-private/issues/1108#issuecomment-293328267
+  end
+
+  scenario 'wrong OTP used' do
+    sign_in_live_with_2fa(user)
+
+    click_on t('profile.index.verification.reactivate_button')
+
+    fill_in 'Secret code', with: 'the wrong code'
+    click_button t('forms.verify_profile.submit')
+
+    expect(current_path).to eq verify_profile_path
+    expect(page).to have_content(t('errors.messages.otp_incorrect'))
+    expect(page.body).to_not match('the wrong code')
+  end
+end

--- a/spec/forms/verify_profile_form_spec.rb
+++ b/spec/forms/verify_profile_form_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe VerifyProfileForm do
+  subject(:form) do
+    VerifyProfileForm.new(user: user, otp: otp, pii_attributes: pii_attributes)
+  end
+
+  let(:user) { pending_profile.user }
+  let(:otp) { 'abc123' }
+  let(:pii_attributes) { Pii::Attributes.new_from_hash(otp: otp) }
+  let(:pending_profile) { create(:profile, deactivation_reason: :verification_pending) }
+
+  describe '#valid?' do
+    let(:valid_otp?) { true }
+
+    before do
+      allow(form).to receive(:valid_otp?).and_return(valid_otp?)
+    end
+
+    context 'when required attributes are not present' do
+      let(:otp) { nil }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:otp]).to eq [t('errors.messages.blank')]
+      end
+    end
+
+    context 'when there is no pending profile ' do
+      let(:pending_profile) { nil }
+      let(:user) { build_stubbed(:user) }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to eq [t('errors.messages.no_pending_profile')]
+      end
+    end
+
+    context 'when OTP does not match' do
+      let(:valid_otp?) { false }
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:otp]).to eq [t('errors.messages.otp_incorrect')]
+      end
+    end
+  end
+
+  describe '#submit' do
+    let(:valid_otp?) { true }
+
+    before do
+      allow(form).to receive(:valid_otp?).and_return(valid_otp?)
+    end
+
+    context 'correct OTP' do
+      it 'returns true' do
+        expect(subject.submit).to eq true
+      end
+
+      it 'activates the pending profile' do
+        expect(pending_profile).to_not be_active
+
+        subject.submit
+
+        expect(pending_profile.reload).to be_active
+      end
+    end
+
+    context 'incorrect OTP' do
+      let(:valid_otp?) { false }
+
+      it 'clears form' do
+        subject.submit
+
+        expect(subject.otp).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -225,35 +225,6 @@ describe User do
     end
   end
 
-  describe '#password_reset_profile' do
-    let(:user) { create(:user) }
-
-    context 'with no profiles' do
-      it { expect(user.password_reset_profile).to be_nil }
-    end
-
-    context 'with an active profile' do
-      let(:active_profile) do
-        build(:profile, :active, :verified, activated_at: 1.day.ago, pii: { first_name: 'Jane' })
-      end
-
-      before do
-        user.profiles << [
-          active_profile,
-          build(:profile, :verified, activated_at: 5.days.ago, pii: { first_name: 'Susan' }),
-        ]
-      end
-
-      it { expect(user.password_reset_profile).to be_nil }
-
-      context 'when the active profile is deactivated due to password reset' do
-        before { active_profile.deactivate(:password_reset) }
-
-        it { expect(user.password_reset_profile).to eq(active_profile) }
-      end
-    end
-  end
-
   describe 'encrypted attributes' do
     context 'input is MixEd CaSe with whitespace' do
       it 'normalizes email' do

--- a/spec/views/profile/index.html.slim_spec.rb
+++ b/spec/views/profile/index.html.slim_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 describe 'profile/index.html.slim' do
   let(:user) { build_stubbed(:user, :signed_up) }
+  let(:decorated_user) { user.decorate }
 
   before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(user).to receive(:decorate).and_return(decorated_user)
     assign(:view_model, ProfileIndex.new(decrypted_pii: nil, personal_key: nil, current_user: user))
   end
 
@@ -52,8 +54,7 @@ describe 'profile/index.html.slim' do
 
   context 'when the user does not have password_reset_profile' do
     before do
-      allow(view).to receive(:current_user).and_return(user)
-      allow(user).to receive(:password_reset_profile).and_return(false)
+      allow(decorated_user).to receive(:password_reset_profile).and_return(false)
     end
 
     it 'contains a personal key section' do
@@ -67,8 +68,7 @@ describe 'profile/index.html.slim' do
 
   context 'when current user has password_reset_profile' do
     before do
-      allow(view).to receive(:current_user).and_return(user)
-      allow(user).to receive(:password_reset_profile).and_return(true)
+      allow(decorated_user).to receive(:password_reset_profile).and_return(true)
     end
 
     it 'lacks a personal key section' do
@@ -78,6 +78,33 @@ describe 'profile/index.html.slim' do
       expect(rendered).to_not have_link(
         t('profile.links.regenerate_personal_key'), href: manage_personal_key_path
       )
+    end
+  end
+
+  context 'when the user does not have pending_profile' do
+    before do
+      allow(decorated_user).to receive(:pending_profile).and_return(false)
+    end
+
+    it 'lacks a pending profile section' do
+      render
+
+      expect(rendered).to_not have_link(
+        t('profile.index.verification.reactivate_button'), href: verify_profile_path
+      )
+    end
+  end
+
+  context 'when current user has pending_profile' do
+    before do
+      allow(decorated_user).to receive(:pending_profile).and_return(true)
+    end
+
+    it 'contains a link to activate profile' do
+      render
+
+      expect(rendered).
+        to have_link(t('profile.index.verification.reactivate_button'), href: verify_profile_path)
     end
   end
 


### PR DESCRIPTION
**Why**: A profile can be pending verification if the OTP
is delivered via USPS.

**How**: Keeping User model extensions in the UserDecorator. Add
button to /profile for verifying a profile.