### PR TITLE
Disable reek Nil-check

### DIFF
--- a/.reek
+++ b/.reek
@@ -26,21 +26,7 @@ ManualDispatch:
   exclude:
     - EncryptedSidekiqRedis#respond_to_missing?
 NilCheck:
-  exclude:
-    - AdminConstraint#user_is_admin?
-    - PasswordsController#edit
-    - PasswordsController#mark_profile_inactive
-    - PasswordResetTokenValidator#submit
-    - PhoneConfirmationFlow
-    - slo_not_implemented_at_sp?
-    - SessionsController#new
-    - in_slo?
-    - TotpSetupController#new
-    - TotpSetupController#valid_code?
-    - TwoFactorAuthenticatable#apply_secure_headers_override
-    - user_not_found?
-    - SamlIdpLogoutConcern#name_id
-    - User#password_reset_profile
+  enabled: false
 LongParameterList:
   exclude:
     - IdentityLinker#optional_attributes

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -35,12 +35,11 @@ namespace :rotate do
   end
 
   def new_progress_bar(label, num)
-    unless ENV['PROGRESS'] == 'no'
-      ProgressBar.create(
-        title: label,
-        total: num,
-        format: '%t: |%B| %j%% [%a / %e]'
-      )
-    end
+    return if ENV['PROGRESS'] == 'no'
+    ProgressBar.create(
+      title: label,
+      total: num,
+      format: '%t: |%B| %j%% [%a / %e]'
+    )
   end
 end


### PR DESCRIPTION
**Why**: Maintaining a list of exceptions getting onerous. Just
permit it everywhere since the idiom foo&.bar? is recommended.