### PR TITLE
Call `render` before OTP partials

### DIFF
--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -3,7 +3,7 @@
 h1.h3.my0 = @presenter.header
 
 = form_tag(:login_otp, method: :post, role: 'form', class: 'mt3 sm-mt4') do
-  = @presenter.reauthn_hidden_field_partial
+  = render @presenter.reauthn_hidden_field_partial
   = label_tag 'code', \
     t('simple_form.required.html') + t('forms.two_factor.code'), \
     class: 'block bold'

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -3,7 +3,7 @@
 h1.h3.my0 = @presenter.header
 
 = form_tag(:login_two_factor_authenticator, method: :post, role: 'form', class: 'mt3 sm-mt4') do
-  = @presenter.reauthn_hidden_field_partial
+  = render @presenter.reauthn_hidden_field_partial
   = label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -99,6 +99,12 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
           href: profile_path
         )
       end
+
+      it 'renders the reauthn partial' do
+        expect(view).to render_template(
+          partial: 'two_factor_authentication/totp_verification/_reauthn'
+        )
+      end
     end
 
     context 'user is changing phone number' do

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -65,5 +65,11 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
         href: profile_path
       )
     end
+
+    it 'renders the reauthn partial' do
+      expect(view).to render_template(
+        partial: 'two_factor_authentication/totp_verification/_reauthn'
+      )
+    end
   end
 end


### PR DESCRIPTION
**WHY**: Otherwise, was rendering string value instead of view partial.

Before:
![screen shot 2017-04-11 at 2 55 42 pm](https://cloud.githubusercontent.com/assets/601515/24932918/97ea166a-1ec8-11e7-8321-6254f855fe27.png)


After:
![screen shot 2017-04-11 at 3 01 18 pm](https://cloud.githubusercontent.com/assets/601515/24932912/947cae16-1ec8-11e7-9a6f-42b3c83fc711.png)
