### PR TITLE
Use `application` layout as default layout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include UserSessionContext
 
-  FLASH_KEYS = ['alert', 'error', 'notice', 'success', 'warning'].freeze
+  FLASH_KEYS = %w[alert error notice success warning].freeze
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include UserSessionContext
 
+  FLASH_KEYS = ['alert', 'error', 'notice', 'success', 'warning'].freeze
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,6 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :disable_caching
 
-  layout 'card'
-
   def session_expires_at
     now = Time.zone.now
     session[:session_expires_at] = now + Devise.timeout_in
@@ -57,7 +55,7 @@ class ApplicationController < ActionController::Base
   def redirect_on_timeout
     return unless params[:timeout]
 
-    flash[:timeout] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+    flash[:notice] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
     redirect_to url_for(params.except(:timeout))
   end
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -10,7 +10,5 @@ class ProfileController < ApplicationController
       personal_key: flash[:personal_key],
       current_user: current_user
     )
-
-    flash.delete(:personal_key)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,9 +32,11 @@ module Users
     def timeout
       analytics.track_event(Analytics::SESSION_TIMED_OUT)
       sign_out
-      flash[:timeout] = t('session_timedout',
-                          app: APP_NAME,
-                          minutes: Figaro.env.session_timeout_in_minutes)
+      flash[:notice] = t(
+        'session_timedout',
+        app: APP_NAME,
+        minutes: Figaro.env.session_timeout_in_minutes
+      )
       redirect_to root_url
     end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -50,7 +50,10 @@ html lang="#{I18n.locale}" class='no-js'
         = yield(:nav)
       - else
         = render decorated_session.nav_partial
-      = content_for?(:content) ? yield(:content) : yield
+      .container.sm-pt4
+        div class="px2 py2 sm-py5 sm-px6 mx-auto sm-mb5 border-box card #{yield(:card_cls)}"
+          = render 'shared/flashes'
+          == yield
     = render 'shared/footer_lite'
 
     #session-timeout-cntnr

--- a/app/views/layouts/card.html.slim
+++ b/app/views/layouts/card.html.slim
@@ -1,7 +1,0 @@
-= content_for :content do
-  .container.sm-pt4
-    div class="px2 py2 sm-py5 sm-px6 mx-auto sm-mb5 border-box card #{yield(:card_cls)}"
-      = render 'shared/messages'
-      == yield
-
-= render template: 'layouts/application'

--- a/app/views/layouts/card_wide.html.slim
+++ b/app/views/layouts/card_wide.html.slim
@@ -1,3 +1,3 @@
 - card_cls 'card-wide'
 
-= render template: 'layouts/card'
+= render template: 'layouts/application'

--- a/app/views/shared/_flashes.html.slim
+++ b/app/views/shared/_flashes.html.slim
@@ -1,0 +1,4 @@
+- if flash.any?
+  - flash.to_hash.slice("alert", "error", "notice", "success", "warning").each do |type, message|
+      div class="alert alert-#{type}" role='alert'
+        = safe_join([message.html_safe])

--- a/app/views/shared/_flashes.html.slim
+++ b/app/views/shared/_flashes.html.slim
@@ -1,4 +1,4 @@
 - if flash.any?
-  - flash.to_hash.slice("alert", "error", "notice", "success", "warning").each do |type, message|
+  - flash.to_hash.slice(*ApplicationController::FLASH_KEYS).each do |type, message|
       div class="alert alert-#{type}" role='alert'
         = safe_join([message.html_safe])

--- a/app/views/shared/_messages.html.slim
+++ b/app/views/shared/_messages.html.slim
@@ -1,5 +1,0 @@
-- unless flash.empty?
-  - flash.each do |name, msg|
-    - if msg.present? && msg.is_a?(String)
-      div class="alert alert-#{name}" role='alert'
-        = safe_join([msg.html_safe])

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -112,9 +112,12 @@ describe Users::SessionsController, devise: true do
 
       get :timeout
 
-      expect(flash[:timeout]).to eq t('session_timedout',
-                                      app: APP_NAME,
-                                      minutes: Figaro.env.session_timeout_in_minutes)
+      expect(flash[:notice]).to eq t(
+        'session_timedout',
+        app: APP_NAME,
+        minutes: Figaro.env.session_timeout_in_minutes
+      )
+
       expect(subject.current_user).to be_nil
     end
 


### PR DESCRIPTION
**WHY**:
* This is more standard in Rails
* Before, we were using `card` everywhere, which also rendered
  `application`
* This also slightly refactors how we deal with rendering flash
  messages. We should only be showing standard flashes. Others are used
  to pass around boolean values but do not need to be rendered.