### PR TITLE
Replace Marshal with JSON serializer

### DIFF
--- a/.reek
+++ b/.reek
@@ -49,6 +49,7 @@ TooManyMethods:
     - OpenidConnectAuthorizeForm
     - Idv::Session
     - User
+    - Idv::ProfileStep
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,11 @@ Rails/OutputSafety:
   Exclude:
   - lib/i18n_override.rb
 
+# temporarily disabled until the fix for https://github.com/bbatsov/rubocop/issues/4249
+# is available in a new release
+Rails/RelativeDateConstant:
+  Enabled: false
+
 Rails/TimeZone:
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -60,7 +60,7 @@ module Users
     end
 
     def expires_at
-      @_expires_at ||= (session[:session_expires_at] || (now - 1))
+      @_expires_at ||= (session[:session_expires_at]&.to_datetime || (now - 1))
     end
 
     def alive?

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -21,7 +21,6 @@ module Verify
 
     def new
       @idv_params = idv_params
-      idv_session.params.symbolize_keys!
       analytics.track_event(Analytics::IDV_REVIEW_VISIT)
 
       phone_of_record_msg = ActionController::Base.helpers.content_tag(
@@ -71,7 +70,7 @@ module Verify
 
     def phone_confirmation_required?
       idv_params[:phone] != current_user.phone &&
-        idv_session.address_verification_mechanism == :phone
+        idv_session.address_verification_mechanism == 'phone'
     end
 
     def valid_password?

--- a/app/controllers/verify/usps_controller.rb
+++ b/app/controllers/verify/usps_controller.rb
@@ -5,7 +5,7 @@ module Verify
     before_action :confirm_step_needed
 
     def index
-      @applicant = idv_session.resolution.vendor_resp.normalized_applicant
+      @applicant = idv_session.normalized_applicant_params
     end
 
     def create

--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -3,7 +3,7 @@ module Idv
     private
 
     def session_id
-      idv_session.resolution.session_id
+      idv_session.vendor_session_id
     end
 
     def try_submit

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -36,7 +36,6 @@ module Idv
       idv_session.phone_confirmation = true
       idv_session.address_verification_mechanism = :phone
       idv_session.params = idv_form.idv_params
-      idv_session.applicant.phone = idv_form.phone
     end
 
     def extra_analytics_attributes

--- a/app/services/idv/phone_validator.rb
+++ b/app/services/idv/phone_validator.rb
@@ -3,7 +3,7 @@ module Idv
     private
 
     def session_id
-      idv_session.resolution.session_id
+      idv_session.vendor_session_id
     end
 
     def try_submit

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -34,7 +34,7 @@ module Idv
     end
 
     def vendor_params
-      idv_session.applicant_from_params
+      idv_session.vendor_params
     end
 
     def submit_idv_form
@@ -63,7 +63,24 @@ module Idv
 
     def update_idv_session
       idv_session.profile_confirmation = success
-      idv_session.resolution = vendor_validator.result
+      idv_session.resolution = proofer_resolution
+      idv_session.vendor_session_id = proofer_resolution.session_id
+      idv_session.normalized_applicant_params = normalized_applicant_to_hash
+      idv_session.resolution_successful = proofer_resolution.success?
+    end
+
+    def proofer_resolution
+      @resolution ||= vendor_validator.result
+    end
+
+    def normalized_applicant
+      @normalized_applicant ||= proofer_resolution.vendor_resp.normalized_applicant
+    end
+
+    def normalized_applicant_to_hash
+      normalized_applicant.instance_variables.each_with_object({}) do |var, hash|
+        hash[var.to_s.delete('@')] = normalized_applicant.instance_variable_get(var)
+      end
     end
 
     def extra_analytics_attributes

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,4 +1,6 @@
 class SessionEncryptor
+  MARSHAL_SIGNATURE ||= 'BAh'.freeze
+
   def self.build_user_access_key
     key = Figaro.env.session_encryption_key
     UserAccessKey.new(password: key, salt: key)
@@ -8,15 +10,23 @@ class SessionEncryptor
     build_user_access_key
   end
 
-  # rubocop:disable Security/MarshalLoad
   def self.load(value)
     decrypted = encryptor.decrypt(value, user_access_key)
-    Marshal.load(::Base64.decode64(decrypted))
+
+    if decrypted.start_with?(MARSHAL_SIGNATURE)
+      Rails.logger.info 'Marshalled session found'
+      # rubocop:disable Security/MarshalLoad
+      Marshal.load(::Base64.decode64(decrypted)).tap do |decoded_value|
+        dump(decoded_value)
+      end
+      # rubocop:enable Security/MarshalLoad
+    else
+      JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
+    end
   end
-  # rubocop:enable Security/MarshalLoad
 
   def self.dump(value)
-    plain = ::Base64.encode64(Marshal.dump(value))
+    plain = JSON.generate(value, quirks_mode: true)
     encryptor.encrypt(plain, user_access_key)
   end
 

--- a/spec/controllers/verify/address_controller_spec.rb
+++ b/spec/controllers/verify/address_controller_spec.rb
@@ -17,7 +17,7 @@ describe Verify::AddressController do
     end
 
     it 'redirects if usps mechanism selected' do
-      subject.idv_session.address_verification_mechanism = :usps
+      subject.idv_session.address_verification_mechanism = 'usps'
 
       get :index
 

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -8,8 +8,10 @@ describe Verify::ConfirmationsController do
     stub_sign_in(user)
     idv_session = Idv::Session.new(subject.user_session, user)
     idv_session.vendor = :mock
-    idv_session.applicant = applicant
+    idv_session.applicant = idv_session.vendor_params
     idv_session.resolution = resolution
+    idv_session.normalized_applicant_params = { first_name: 'Somebody' }
+    idv_session.resolution_successful = resolution.success?
     user.unlock_user_access_key(password)
     profile_maker = Idv::ProfileMaker.new(
       applicant: applicant,
@@ -114,7 +116,7 @@ describe Verify::ConfirmationsController do
 
     context 'user picked USPS confirmation' do
       before do
-        subject.idv_session.address_verification_mechanism = :usps
+        subject.idv_session.address_verification_mechanism = 'usps'
       end
 
       it 'leaves profile deactivated' do

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -95,7 +95,7 @@ describe Verify::SessionsController do
         it 'assigned user UUID to applicant' do
           post :create, profile: user_attrs
 
-          expect(subject.idv_session.applicant.uuid).to eq subject.current_user.uuid
+          expect(subject.idv_session.applicant[:uuid]).to eq subject.current_user.uuid
         end
       end
 

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -10,7 +10,7 @@ describe Idv::FinancialsValidator do
     idvs
   end
 
-  let(:session_id) { idv_session.resolution.session_id }
+  let(:session_id) { idv_session.vendor_session_id }
 
   let(:params) do
     { ccn: '123-45-6789' }
@@ -26,7 +26,7 @@ describe Idv::FinancialsValidator do
       with(applicant: idv_session.applicant, vendor: :mock).
       and_return(agent)
     expect(agent).to receive(:submit_financials).
-      with(params, idv_session.resolution.session_id).and_return(confirmation)
+      with(params, idv_session.vendor_session_id).and_return(confirmation)
   end
 
   describe '#success?' do

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -47,7 +47,6 @@ describe Idv::PhoneStep do
       expect(step.submit).to eq result
       expect(idv_session.phone_confirmation).to eq true
       expect(idv_session.params).to eq idv_phone_form.idv_params
-      expect(idv_session.applicant.phone).to eq idv_phone_form.phone
     end
 
     it 'returns false for mock-sad phone' do

--- a/spec/services/idv/phone_validator_spec.rb
+++ b/spec/services/idv/phone_validator_spec.rb
@@ -10,7 +10,7 @@ describe Idv::PhoneValidator do
     idvs
   end
 
-  let(:session_id) { idv_session.resolution.session_id }
+  let(:session_id) { idv_session.vendor_session_id }
 
   let(:params) do
     { phone: '202-555-1212' }
@@ -26,7 +26,7 @@ describe Idv::PhoneValidator do
       with(applicant: idv_session.applicant, vendor: :mock).
       and_return(agent)
     expect(agent).to receive(:submit_phone).
-      with(params, idv_session.resolution.session_id).and_return(confirmation)
+      with(params, idv_session.vendor_session_id).and_return(confirmation)
   end
 
   describe '#success?' do

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -143,10 +143,7 @@ describe Idv::ProfileStep do
       step.submit
 
       expect(idv_session.params).to eq user_attrs
-      expect(idv_session.applicant).to be_a Proofer::Applicant
-      user_attrs.each do |key, value|
-        expect(idv_session.applicant.send(key)).to eq value
-      end
+      expect(idv_session.applicant).to eq user_attrs.merge(uuid: user.uuid)
     end
   end
 

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -5,7 +5,24 @@ describe SessionEncryptor do
     it 'decrypts encrypted session' do
       session = SessionEncryptor.dump(foo: 'bar')
 
-      expect(SessionEncryptor.load(session)).to eq(foo: 'bar')
+      expect(SessionEncryptor.load(session)).to eq('foo' => 'bar')
+    end
+
+    context 'value previously serialized with Marshal and Base64 encoded' do
+      it 'decrypts the session and then calls .dump' do
+        plain = ::Base64.encode64(Marshal.dump(foo: 'bar'))
+        user_access_key = SessionEncryptor.user_access_key
+        session = SessionEncryptor.encryptor.encrypt(plain, user_access_key)
+        decrypted = SessionEncryptor.encryptor.decrypt(session, user_access_key)
+        decoded_session = Marshal.load(::Base64.decode64(decrypted))
+
+        allow(Rails.logger).to receive(:info)
+        allow(SessionEncryptor).to receive(:dump)
+
+        expect(SessionEncryptor.load(session)).to eq(foo: 'bar')
+        expect(Rails.logger).to have_received(:info).with('Marshalled session found')
+        expect(SessionEncryptor).to have_received(:dump).with(decoded_session)
+      end
     end
   end
 


### PR DESCRIPTION
This PR switches our session serializer from Marshal to JSON. Marshal poses a security risk and was replaced as the default serializer in Rails back in 4.1

To make the failing tests pass, we need to convert the complex objects we store in the session during IdV, such as `Proofer::Applicant` into basic types, perhaps another hash of attributes.