### PR TITLE
Return timestamp in Profile events list

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -4,6 +4,6 @@ EventDecorator = Struct.new(:event) do
   end
 
   def happened_at
-    event.created_at
+    EasternTimePresenter.new(event.created_at).to_s
   end
 end

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -4,6 +4,6 @@ IdentityDecorator = Struct.new(:identity) do
   end
 
   def happened_at
-    identity.last_authenticated_at
+    EasternTimePresenter.new(identity.last_authenticated_at).to_s
   end
 end

--- a/app/presenters/eastern_time_presenter.rb
+++ b/app/presenters/eastern_time_presenter.rb
@@ -6,7 +6,7 @@ class EasternTimePresenter
   def to_s
     I18n.t(
       'event_types.eastern_timestamp',
-       timestamp: I18n.l(eastern_timestamp, format: :event_timestamp)
+      timestamp: I18n.l(eastern_timestamp, format: :event_timestamp)
     )
   end
 

--- a/app/presenters/eastern_time_presenter.rb
+++ b/app/presenters/eastern_time_presenter.rb
@@ -5,9 +5,8 @@ class EasternTimePresenter
 
   def to_s
     I18n.t(
-      'event_types.timestamp',
-      date: eastern_timestamp.strftime('%B %e, %Y'),
-      time: eastern_timestamp.strftime('%-l:%M %p')
+      'event_types.eastern_timestamp',
+       timestamp: I18n.l(eastern_timestamp, format: :event_timestamp)
     )
   end
 

--- a/app/presenters/eastern_time_presenter.rb
+++ b/app/presenters/eastern_time_presenter.rb
@@ -1,0 +1,21 @@
+class EasternTimePresenter
+  def initialize(timestamp)
+    @timestamp = timestamp
+  end
+
+  def to_s
+    I18n.t(
+      'event_types.timestamp',
+      date: eastern_timestamp.strftime('%B %e, %Y'),
+      time: eastern_timestamp.strftime('%-l:%M %p')
+    )
+  end
+
+  private
+
+  attr_reader :timestamp
+
+  def eastern_timestamp
+    timestamp.in_time_zone('Eastern Time (US & Canada)')
+  end
+end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -58,4 +58,4 @@ h2.h3.my0 = t('headings.profile.account_history')
         .sm-col.sm-col-6.px1
           .truncate = event.pretty_event_type
         .sm-col.sm-col-6.px1.sm-right-align
-          = event.happened_at.to_date.to_formatted_s(:long)
+          = event.happened_at

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -105,6 +105,7 @@ ignore_unused:
   - 'links.phone_confirmation.fallback_to_{sms,authenticator,voice}_html'
   - 'links.two_factor_authentication.resend_code.{sms,voice}_html'
   - 'links.two_factor_authentication.{sms,voice}_html'
+  - 'time.*'
   - 'tooltips.authentication_app'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -9,4 +9,4 @@ en:
     email_changed: Email address changed
     phone_changed: Phone number changed
     phone_confirmed: Phone confirmed
-    timestamp: '%{date} at %{time} (Eastern)'
+    eastern_timestamp: '%{timestamp} (Eastern)'

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -9,3 +9,4 @@ en:
     email_changed: Email address changed
     phone_changed: Phone number changed
     phone_confirmed: Phone confirmed
+    timestamp: '%{date} at %{time} (Eastern)'

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -9,3 +9,4 @@ es:
     email_changed: Dirección de correo electrónico cambiada
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado
+    timestamp: '%{date} a las %{time} (zona horaria del Este)'

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -9,4 +9,4 @@ es:
     email_changed: Dirección de correo electrónico cambiada
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado
-    timestamp: '%{date} a las %{time} (zona horaria del Este)'
+    timestamp: '%{timestamp} (zona horaria del Este)'

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -9,4 +9,4 @@ es:
     email_changed: Dirección de correo electrónico cambiada
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado
-    timestamp: '%{timestamp} (zona horaria del Este)'
+    eastern_timestamp: '%{timestamp} (zona horaria del Este)'

--- a/config/locales/time/en.yml
+++ b/config/locales/time/en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  time:
+    formats:
+      event_timestamp: "%B %e, %Y at %-l:%M %p"

--- a/config/locales/time/es.yml
+++ b/config/locales/time/es.yml
@@ -1,0 +1,5 @@
+---
+es:
+  time:
+    formats:
+      event_timestamp: "%B %e, %Y a las %-l:%M %p"

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -9,13 +9,4 @@ describe EventDecorator do
       expect(decorator.pretty_event_type).to eq t('event_types.email_changed')
     end
   end
-
-  describe '#happened_at' do
-    it 'returns created_at' do
-      event = build_stubbed(:event, event_type: :email_changed)
-      decorator = EventDecorator.new(event)
-
-      expect(decorator.happened_at).to eq event.created_at
-    end
-  end
 end

--- a/spec/decorators/identity_decorator_spec.rb
+++ b/spec/decorators/identity_decorator_spec.rb
@@ -13,10 +13,4 @@ describe IdentityDecorator do
       )
     end
   end
-
-  describe '#happened_at' do
-    it 'returns last_authenticated_at' do
-      expect(subject.happened_at).to eq identity.last_authenticated_at
-    end
-  end
 end

--- a/spec/presenters/eastern_time_presenter_spec.rb
+++ b/spec/presenters/eastern_time_presenter_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe EasternTimePresenter do
+  describe '#to_s' do
+    it 'returns the formatted timestamp in a string' do
+      str = "2017-04-12 18:19:18 UTC"
+      timestamp = DateTime.parse(str)
+
+      expect(EasternTimePresenter.new(timestamp).to_s).to eq(
+        'April 12, 2017 at 2:19 PM (Eastern)'
+      )
+    end
+  end
+end

--- a/spec/presenters/eastern_time_presenter_spec.rb
+++ b/spec/presenters/eastern_time_presenter_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe EasternTimePresenter do
   describe '#to_s' do
     it 'returns the formatted timestamp in a string' do
-      str = "2017-04-12 18:19:18 UTC"
-      timestamp = DateTime.parse(str)
+      str = '2017-04-12 18:19:18 UTC'
+      timestamp = Time.zone.parse(str)
 
       expect(EasternTimePresenter.new(timestamp).to_s).to eq(
         'April 12, 2017 at 2:19 PM (Eastern)'


### PR DESCRIPTION
**WHY**: Users should be able to see the time AND date for events in their account history.

![screen shot 2017-04-12 at 11 33 35 am](https://cloud.githubusercontent.com/assets/601515/24973741/c2e5fb8e-1f74-11e7-9457-8bd1f385e45b.png)
