### PR TITLE
Fix eslint issue: Add `app` to project's dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,10 +21,22 @@
     'space-before-function-paren': 0,
     'prefer-arrow-callback': 0,
     'import/prefer-default-export': 'off',
-    'import/extensions': ['off', 'never']
+    'import/extensions': ['off', 'never'],
   },
   'parserOptions': {
     'ecmaVersion': 6,
     'sourceType': 'module'
+  },
+  'settings': {
+    'import/core-modules': [
+      'app/components/index',
+      'app/utils/index',
+      'app/pw-toggle',
+      'app/form-validation',
+      'app/form-field-format',
+      'app/idv-finance-helper',
+      'app/radio-btn',
+      'app/print-personal-key',
+    ],
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	@echo "--- fasterer ---"
 	bundle exec fasterer
 	@echo "--- eslint ---"
-	eslint app
+	node_modules/.bin/eslint app
 
 lintfix:
 	@echo "--- rubocop fix ---"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ setup $(CONFIG): config/application.yml.example
 
 check: lint test
 
-lint: $(CONFIG)
+lint:
 	@echo "--- rubocop ---"
 	bundle exec rubocop -R
 	@echo "--- slim-lint ---"
@@ -23,8 +23,10 @@ lint: $(CONFIG)
 	bundle exec reek
 	@echo "--- fasterer ---"
 	bundle exec fasterer
+	@echo "--- eslint ---"
+	eslint app
 
-lintfix: $(CONFIG)
+lintfix:
 	@echo "--- rubocop fix ---"
 	bundle exec rubocop -R -a
 	@echo "--- reek fix ---"

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ make brakeman
 Run eslint
 
 ```
-$ npm install --save-dev eslint-config-airbnb eslint@^3.15.0 eslint-plugin-jsx-a11y@^3.0.2 eslint-plugin-react@^6.9.0
+$ npm install --save-dev eslint-config-airbnb eslint@^3.15.0
 $ eslint app
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ make brakeman
 Run eslint
 
 ```
-$ npm install --save-dev eslint-config-airbnb eslint@^3.15.0
+$ npm install eslint-config-airbnb eslint@^3.15.0
 $ eslint app
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ Run security scanner
 $ make brakeman
 ```
 
+Run eslint
+
+```
+$ npm install --save-dev eslint-config-airbnb eslint@^3.15.0 eslint-plugin-jsx-a11y@^3.0.2 eslint-plugin-react@^6.9.0
+$ eslint app
+```
+
 #### User flows
 
 We have an automated tool for generating user flows using real views generated from the application. These specs are excluded from our typical spec run because of the overhead of generating screenshots for each view.

--- a/README.md
+++ b/README.md
@@ -167,13 +167,6 @@ Run security scanner
 $ make brakeman
 ```
 
-Run eslint
-
-```
-$ npm install eslint-config-airbnb eslint@^3.15.0
-$ eslint app
-```
-
 #### User flows
 
 We have an automated tool for generating user flows using real views generated from the application. These specs are excluded from our typical spec run because of the overhead of generating screenshots for each view.

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "dirty-chai": "^1.2.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
-    "eslint-plugin-jsx-a11y": "^3.0.2",
-    "eslint-plugin-react": "^6.10.3",
     "proxyquireify": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "npm": "~3.8.x"
   },
   "dependencies": {
-    "app": "^0.1.0",
     "classlist.js": "^1.1.20150312",
     "field-kit": "^2.1.0",
     "focus-trap": "^2.3.0",
@@ -22,6 +21,10 @@
     "browserify": "^13.0.0",
     "browserify-incremental": "^3.1.1",
     "dirty-chai": "^1.2.2",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-react": "^6.10.3",
     "proxyquireify": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": "~3.8.x"
   },
   "dependencies": {
+    "app": "^0.1.0",
     "classlist.js": "^1.1.20150312",
     "field-kit": "^2.1.0",
     "focus-trap": "^2.3.0",


### PR DESCRIPTION
**WHY**: Code climate telling us:
"'app' should be listed in the project's dependencies. Run 'npm i -S app' to add it"