### PR TITLE
Restore informational flash message style

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -23,7 +23,6 @@ $ico-offset: 1rem;
   }
 }
 
-.alert-notice,
 .alert-success {
   background-color: #ebfcef;
   padding-left: $space-4;


### PR DESCRIPTION
Our informational flash messages are being displayed with the `success` style, this change lets them fall back to the default flash message styling.

**From this:**
![screen shot 2017-04-13 at 2 10 03 pm](https://cloud.githubusercontent.com/assets/1178494/25017982/aeae0ab4-2053-11e7-9745-a52aa1a58159.png)

**To this:**
![screen shot 2017-04-13 at 2 09 53 pm](https://cloud.githubusercontent.com/assets/1178494/25017979/a6a41a02-2053-11e7-905c-1233248424d4.png)