### PR TITLE
Also run `eslint` on spec files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
       'app/idv-finance-helper',
       'app/radio-btn',
       'app/print-personal-key',
+      'app/utils/ms-formatter',
     ],
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	@echo "--- fasterer ---"
 	bundle exec fasterer
 	@echo "--- eslint ---"
-	node_modules/.bin/eslint app
+	node_modules/.bin/eslint app spec
 
 lintfix:
 	@echo "--- rubocop fix ---"

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,6 +1,7 @@
 //= require support/sinon
 //= require support/chai
 const dirtyChai = require('dirty-chai');
+
 chai.use(dirtyChai);
 // PhantomJS (Teaspoons default driver) doesn't have support for
 // Function.prototype.bind, which has caused confusion.


### PR DESCRIPTION
**WHY**: codeclimate does this, we should too