### PR TITLE
Remove `render_views` calls in controller specs

### DIFF
--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -82,7 +82,7 @@ describe Users::EmailsController do
     end
 
     context 'user updates with invalid email' do
-      it 'does not updated the user email to be the invalid email' do
+      it 'does not change the user email' do
         stub_sign_in(user)
         stub_analytics
         allow(@analytics).to receive(:track_event)

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -35,9 +35,7 @@ describe Users::EmailsController do
     end
 
     context 'user enters an empty email address' do
-      render_views
-
-      it 'displays an error message and does not delete the email' do
+      it 'does not delete the email' do
         stub_sign_in(user)
 
         stub_analytics
@@ -52,7 +50,6 @@ describe Users::EmailsController do
 
         put :update, update_user_email_form: { email: '' }
 
-        expect(response.body).to have_content invalid_email_message
         expect(user.reload.email).to be_present
         expect(@analytics).to have_received(:track_event).
           with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
@@ -85,12 +82,11 @@ describe Users::EmailsController do
     end
 
     context 'user updates with invalid email' do
-      render_views
-
-      it 'displays error about invalid email' do
+      it 'does not updated the user email to be the invalid email' do
         stub_sign_in(user)
         stub_analytics
         allow(@analytics).to receive(:track_event)
+        invalid_email = 'foo'
 
         analytics_hash = {
           success: false,
@@ -99,17 +95,15 @@ describe Users::EmailsController do
           email_changed: false,
         }
 
-        put :update, update_user_email_form: { email: 'foo' }
+        put :update, update_user_email_form: { email: invalid_email }
 
-        expect(response.body).to have_content(t('valid_email.validations.email.invalid'))
+        expect(user.reload.email).not_to eq invalid_email
         expect(@analytics).to have_received(:track_event).
           with(Analytics::EMAIL_CHANGE_REQUEST, analytics_hash)
       end
     end
 
     context 'user submits the form without changing their email' do
-      render_views
-
       it 'redirects to profile page without any messages' do
         stub_sign_in(user)
 

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -34,14 +34,13 @@ describe Users::PhonesController do
     end
 
     context 'user enters an empty phone' do
-      render_views
-
-      it 'displays an error message and does not delete the phone' do
+      it 'does not delete the phone' do
         stub_sign_in(user)
+
         put :update, update_user_phone_form: { phone: '' }
 
-        expect(response.body).to have_content invalid_phone_message
         expect(user.reload.phone).to be_present
+        expect(response).to render_template(:edit)
       end
     end
 
@@ -70,13 +69,15 @@ describe Users::PhonesController do
     end
 
     context 'user updates with invalid phone' do
-      render_views
-
-      it 'displays error about invalid phone' do
+      it 'does not change the user phone number' do
+        invalid_phone = '123'
+        user = build(:user, phone: '123-123-1234')
         stub_sign_in(user)
-        put :update, update_user_phone_form: { phone: '123' }
 
-        expect(response.body).to have_content('number is invalid')
+        put :update, update_user_phone_form: { phone: invalid_phone }
+
+        expect(user.phone).not_to eq invalid_phone
+        expect(response).to render_template(:edit)
       end
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -3,15 +3,8 @@ require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
 describe Users::SessionsController, devise: true do
-  render_views
 
   describe 'GET /users/sign_in' do
-    it 'sets the autocomplete attribute to off on the sign in form' do
-      get :new
-
-      expect(response.body).to include('<form autocomplete="off"')
-    end
-
     it 'clears the session when user is not yet 2fa-ed' do
       sign_in_before_2fa
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
 describe Users::SessionsController, devise: true do
-
   describe 'GET /users/sign_in' do
     it 'clears the session when user is not yet 2fa-ed' do
       sign_in_before_2fa

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -12,8 +12,6 @@ describe Users::TotpSetupController, devise: true do
 
   describe '#new' do
     context 'user has not yet enabled authenticator app' do
-      render_views
-
       before do
         stub_sign_in
         get :new
@@ -31,10 +29,6 @@ describe Users::TotpSetupController, devise: true do
         expect(
           subject.current_user.decorate.qrcode(subject.user_session[:new_totp_secret])
         ).not_to be_nil
-      end
-
-      it 'presents a QR code to the user' do
-        expect(response.body).to include('QR Code for Authenticator App')
       end
     end
 

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -42,8 +42,6 @@ describe Verify::PhoneController do
 
   describe '#create' do
     context 'when form is invalid' do
-      render_views
-
       before do
         user = build(:user, phone: '+1 (415) 555-0130')
         stub_verify_steps_one_and_two(user)
@@ -54,7 +52,6 @@ describe Verify::PhoneController do
       it 'renders #new' do
         put :create, idv_phone_form: { phone: '703' }
 
-        expect(response.body).to have_content invalid_phone_message
         expect(flash[:warning]).to be_nil
         expect(subject.idv_session.params).to be_empty
       end

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -40,7 +40,6 @@ describe Verify::SessionsController do
   end
 
   context 'user has created account' do
-    render_views
 
     before do
       stub_sign_in(user)
@@ -54,7 +53,6 @@ describe Verify::SessionsController do
         get :new
 
         expect(response.status).to eq 200
-        expect(response.body).to include t('idv.form.first_name')
       end
 
       it 'redirects if step is complete' do
@@ -121,11 +119,11 @@ describe Verify::SessionsController do
       end
 
       context 'empty SSN' do
-        it 'shows normal form with error' do
+        it 'renders the form' do
           post :create, profile: user_attrs.merge(ssn: '')
 
           expect(response).to_not redirect_to(verify_session_dupe_path)
-          expect(response.body).to match t('errors.messages.blank')
+          expect(response).to render_template(:new)
         end
       end
 
@@ -138,7 +136,6 @@ describe Verify::SessionsController do
 
           expect(response).to render_template(:new)
           expect(flash[:warning]).to be_nil
-          expect(response.body).to match t('errors.messages.blank')
         end
       end
 

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -40,7 +40,6 @@ describe Verify::SessionsController do
   end
 
   context 'user has created account' do
-
     before do
       stub_sign_in(user)
       allow(subject).to receive(:idv_session).and_return(idv_session)

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -9,6 +9,12 @@ describe 'devise/sessions/new.html.slim' do
     allow(view).to receive(:decorated_session).and_return(SessionDecorator.new)
   end
 
+  it 'sets autocomplete attribute off' do
+    render
+
+    expect(rendered).to match(/<form autocomplete="off"/)
+  end
+
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('titles.visitors.index'))
 

--- a/spec/views/users/totp_setup/new.html.slim_spec.rb
+++ b/spec/views/users/totp_setup/new.html.slim_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'users/totp_setup/new.html.slim' do
+  let(:user) { build_stubbed(:user, :signed_up) }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    @qrcode = 'qrcode.png'
+  end
+
+  it 'renders the QR code image' do
+    render
+
+    expect(rendered).to have_css('img[src^="/images/qrcode.png"]')
+  end
+end


### PR DESCRIPTION
**WHY**: In all of these cases, we could test the controllers without
rendering the views with the actual error messages.

This will speed up the tests