### PR TITLE
Reskins accordion to match updated styles

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -16,7 +16,7 @@
 }
 
 .accordion {
-  border: 1px solid $blue-medium;
+  border: 1px solid $border-color;
   border-radius: $border-radius-md;
   box-shadow: 0 2px 4px rgba(0, 0, 0, .5);
 
@@ -46,7 +46,7 @@
   }
 
   .accordion-header-control[aria-expanded="true"] {
-    border-bottom: 1px solid $blue-medium;
+    border-bottom: 1px solid $border-color;
 
     .minus-icon {
       display: initial;
@@ -69,7 +69,7 @@
 
   .accordion-footer {
     background-color: $blue-lightest;
-    border-top: 1px solid $blue-medium;
+    border-top: 1px solid $border-color;
     color: $blue;
     cursor: pointer;
     text-align: center;

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -16,6 +16,9 @@
 }
 
 .accordion {
+  border: 1px solid $blue-light;
+  border-radius: $border-radius-md;
+
   .accordion-content {
     opacity: 1;
   }
@@ -62,9 +65,11 @@
   }
 
   .accordion-footer {
-    border-color: $blue;
+    background-color: $blue-light;
+    border: 1px solid $blue-light;
     color: $blue;
     cursor: pointer;
+    text-align: center;
 
     img {
       display: inline-block;

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -18,7 +18,6 @@
 .accordion {
   border: 1px solid $border-color;
   border-radius: $border-radius-md;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, .5);
 
   .accordion-content {
     opacity: 1;

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -16,8 +16,9 @@
 }
 
 .accordion {
-  border: 1px solid $blue-light;
+  border: 1px solid $blue-medium;
   border-radius: $border-radius-md;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, .5);
 
   .accordion-content {
     opacity: 1;
@@ -45,6 +46,8 @@
   }
 
   .accordion-header-control[aria-expanded="true"] {
+    border-bottom: 1px solid $blue-medium;
+
     .minus-icon {
       display: initial;
     }
@@ -65,8 +68,8 @@
   }
 
   .accordion-footer {
-    background-color: $blue-light;
-    border: 1px solid $blue-light;
+    background-color: $blue-lightest;
+    border-top: 1px solid $blue-medium;
     color: $blue;
     cursor: pointer;
     text-align: center;

--- a/app/assets/stylesheets/components/_border.scss
+++ b/app/assets/stylesheets/components/_border.scss
@@ -10,10 +10,6 @@
 .rounded-xl { border-radius: $border-radius-xl; }
 .rounded-xxl { border-radius: $border-radius-xxl; }
 
-.border-blue-medium {
-  border-color: $blue-medium;
-}
-
 @media #{$breakpoint-sm} {
   .sm-border-none { border: 0; }
   .sm-rounded-md { border-radius: $border-radius-md; }

--- a/app/assets/stylesheets/components/_border.scss
+++ b/app/assets/stylesheets/components/_border.scss
@@ -10,6 +10,10 @@
 .rounded-xl { border-radius: $border-radius-xl; }
 .rounded-xxl { border-radius: $border-radius-xxl; }
 
+.border-blue-medium {
+  border-color: $blue-medium;
+}
+
 @media #{$breakpoint-sm} {
   .sm-border-none { border: 0; }
   .sm-rounded-md { border-radius: $border-radius-md; }

--- a/app/assets/stylesheets/components/_profile-section.scss
+++ b/app/assets/stylesheets/components/_profile-section.scss
@@ -1,13 +1,13 @@
 .profile-info-box {
   border: 0;
-  border-bottom: $border-width solid $blue-lighter;
+  border-bottom: $border-width solid $border-color;
   border-radius: 0;
   margin-bottom: 0;
 }
 
 @media #{$breakpoint-sm} {
   .profile-info-box {
-    border: $border-width solid $blue-lighter;
+    border: $border-width solid $border-color;
     border-radius: $border-radius-md;
     margin-bottom: $space-3;
   }

--- a/app/assets/stylesheets/variables/_colors.scss
+++ b/app/assets/stylesheets/variables/_colors.scss
@@ -1,6 +1,5 @@
 $aqua: #7fdbff !default;
-$blue: #0071bc !default;
-$blue-lighter: #dce4ee !default;
+$blue: #0071bb !default;
 $blue-light: #ebf3fa !default;
 $blue-lightest: #f2f9ff !default;
 $navy: #112e51 !default;

--- a/app/assets/stylesheets/variables/_web.scss
+++ b/app/assets/stylesheets/variables/_web.scss
@@ -78,7 +78,7 @@ $border-radius-md: 6px !default;
 $border-radius-lg: 8px !default;
 $border-radius-xl: 16px !default;
 $border-radius-xxl: 24px !default;
-$border-color: #cedbec !default;
+$border-color: #cedced !default;
 
 $table-header-font-weight: $bold-font-weight !default;
 $table-cell-padding-x: $space-2 !default;

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -1,5 +1,5 @@
-.mb4.col-12.border.rounded-md.border-blue.fs-16p.accordion
-  .accordion-header.py1.px2(
+.mb4.col-12.fs-16p.accordion
+  .accordion-header.py2.px2(
     class=('display-none' if options[:hide_header])
     role="heading"
   )
@@ -11,16 +11,17 @@
     )
       span.mb0.mr2
         = header_text
-      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
-      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
-  .accordion-content.accordion-init.clearfix(
+      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon mt1'
+      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon mt1'
+  .border-bottom.border-blue-light
+  .accordion-content.accordion-init.clearfix.mt-tiny(
     id="#{target_id}"
     role="region"
   )
     .px2
       = yield
     - unless options[:hide_close_link]
-      .h4.px0.pb0.text-decoration-none.accordion-footer.center.col-12.border-top(
+      .h4.px0.py2.text-decoration-none.accordion-footer.col-12(
         aria-controls="#{target_id}"
         tabindex="0"
       )

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -1,5 +1,5 @@
 .mb4.col-12.fs-16p.accordion
-  .accordion-header.py2.px2(
+  .accordion-header(
     class=('display-none' if options[:hide_header])
     role="heading"
   )
@@ -8,12 +8,12 @@
       aria-expanded="true"
       role="button"
       tabindex="0"
+      class="py1 px2 mt-tiny mb-tiny"
     )
       span.mb0.mr2
         = header_text
-      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon mt1'
-      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon mt1'
-  .border-bottom.border-blue-light
+      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
+      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
   .accordion-content.accordion-init.clearfix.mt-tiny(
     id="#{target_id}"
     role="region"
@@ -21,9 +21,10 @@
     .px2
       = yield
     - unless options[:hide_close_link]
-      .h4.px0.py2.text-decoration-none.accordion-footer.col-12(
+      .py1.accordion-footer(
         aria-controls="#{target_id}"
         tabindex="0"
       )
-        = image_tag(asset_url('up-carat-thin.svg'), width: 16, class: 'mr1')
-        = t('users.personal_key.close')
+        .pb-tiny.pt-tiny
+          = image_tag(asset_url('up-carat-thin.svg'), width: 14, class: 'mr1')
+          = t('users.personal_key.close')


### PR DESCRIPTION
   **Why**: As our styleguide evolves, so should the code. Also removes
    extraneous classes


Screenshots:

![screen shot 2017-04-14 at 8 32 14 am](https://cloud.githubusercontent.com/assets/1421848/25043363/6896a082-20ed-11e7-99be-2310c56832c1.png)

![screen shot 2017-04-14 at 8 32 01 am](https://cloud.githubusercontent.com/assets/1421848/25043366/6d1bd4ce-20ed-11e7-9fda-0203be9a360c.png)

