### PR TITLE
Revert SameSite=Strict cookie setting

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -45,7 +45,7 @@ SecureHeaders::Configuration.default do |config|
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
     samesite: {
-      strict: true # mark all cookies as SameSite=Strict.
+      lax: true # mark all cookies as SameSite=Strict.
     },
   }
 


### PR DESCRIPTION
**Why**: Chrome continues to be buggy with SameSite=Strict
so we are reverting to SameSite=Lax until we can rearchitect to avoid
the bug.