### PR TITLE
Preserve request_id param across multiple visits

### DIFF
--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -11,4 +11,8 @@ module FullyAuthenticatable
     ServiceProviderRequest.from_uuid(sp_session[:request_id]).delete
     session.delete(:sp)
   end
+
+  def request_id
+    sp_session[:request_id]
+  end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -10,7 +10,7 @@ module OpenidConnect
     before_action :load_authorize_form_from_session, only: %i[create destroy]
 
     def index
-      return confirm_two_factor_authenticated(@request_id) unless user_fully_authenticated?
+      return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated?
       return redirect_to verify_url if identity_needs_verification?
 
       track_index_action_analytics

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -12,7 +12,7 @@ class SamlIdpController < ApplicationController
   skip_before_action :handle_two_factor_authentication, only: :logout
 
   def auth
-    return confirm_two_factor_authenticated(@request_id) unless user_fully_authenticated?
+    return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated?
     process_fully_authenticated_user do |needs_idv|
       return store_location_and_redirect_to_verify_url if needs_idv
     end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -8,7 +8,7 @@ module SignUp
     prepend_before_action :disable_account_creation, only: %i[new create]
 
     def show
-      return redirect_to sign_up_email_path if session[:sp].blank?
+      return redirect_to sign_up_email_path if params[:request_id].blank?
 
       analytics.track_event(Analytics::USER_REGISTRATION_INTRO_VISIT)
     end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -45,7 +45,7 @@ SecureHeaders::Configuration.default do |config|
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
     samesite: {
-      lax: true # mark all cookies as SameSite=Strict.
+      strict: true # mark all cookies as SameSite=Strict.
     },
   }
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -118,12 +118,11 @@ describe SignUp::RegistrationsController, devise: true do
   describe '#show' do
     it 'tracks page visit' do
       stub_analytics
-      session[:sp] = { loa3: true }
 
       expect(@analytics).to receive(:track_event).
         with(Analytics::USER_REGISTRATION_INTRO_VISIT)
 
-      get :show
+      get :show, request_id: 'foo'
     end
 
     it 'cannot be viewed by signed in users' do
@@ -132,6 +131,12 @@ describe SignUp::RegistrationsController, devise: true do
       get :show
 
       expect(response).to redirect_to profile_path
+    end
+
+    it 'redirects to sign_up_email_path if request_id param is missing' do
+      get :show
+
+      expect(response).to redirect_to sign_up_email_path
     end
   end
 end

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -117,6 +117,20 @@ feature 'LOA1 Single Sign On' do
     end
   end
 
+  context 'visiting IdP via SP, then going back to SP and visiting IdP again' do
+    it 'maintains the request_id in the params' do
+      authn_request = auth_request.create(saml_settings)
+      visit authn_request
+      sp_request_id = ServiceProviderRequest.last.uuid
+
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+
+      visit authn_request
+
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+    end
+  end
+
   def sign_in_and_require_viewing_personal_key(user)
     login_as(user, scope: :user, run_callbacks: false)
     Warden.on_next_request do |proxy|


### PR DESCRIPTION
**Why**: Before, we were passing in the request_id param to the
landing page via the `@request_id` variable, which does not get
set on each request unless `sp_session[:request_id]` is blank.
If you visit the IdP via the SP, then go back to the SP and visit
the IdP again within the session validity period, `@request_id`
will be blank on the second request, and so the param will be lost.

**How**: Read the value from the session instead.