### PR TITLE
Adds a link to the marketing help site

### DIFF
--- a/app/views/profile/_pii.html.slim
+++ b/app/views/profile/_pii.html.slim
@@ -38,4 +38,4 @@
     .col.col-12.sm-col-6
       = image_tag asset_url('lock.svg'), width: 8, class: 'mr1'
       = t('profile.security.text')
-    = link_to t('profile.security.link'), root_url
+    = link_to t('profile.security.link'), MarketingSite.help_url


### PR DESCRIPTION
**Why**: The 'help center' link on the profile page went to the root
url, which isn't going to help anyone