### PR TITLE
Sign user out before rendering 'lockout' page

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -45,8 +45,12 @@ module TwoFactorAuthenticatable
 
   def handle_second_factor_locked_user(type)
     analytics.track_event(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
-    render 'two_factor_authentication/shared/max_login_attempts_reached', locals: { type: type }
+    decorator = current_user.decorate
     sign_out
+    render(
+      'two_factor_authentication/shared/max_login_attempts_reached',
+      locals: { type: type, decorator: decorator }
+    )
   end
 
   def require_current_password

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -51,8 +51,12 @@ module Users
     end
 
     def process_locked_out_user
-      render 'two_factor_authentication/shared/max_login_attempts_reached', locals: { type: 'otp' }
+      decorator = current_user.decorate
       sign_out
+      render(
+        'two_factor_authentication/shared/max_login_attempts_reached',
+        locals: { type: 'otp', decorator: decorator }
+      )
     end
 
     def now

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -10,16 +10,16 @@ class UserDecorator
   delegate :email, to: :user
   delegate :totp_enabled?, to: :user
 
-  def lockout_time_remaining
-    (Devise.direct_otp_valid_for - (Time.zone.now - user.second_factor_locked_at)).to_i
-  end
-
   def lockout_time_remaining_in_words
     current_time = Time.zone.now
 
     distance_of_time_in_words(
       current_time, current_time + lockout_time_remaining, true, highest_measures: 2
     )
+  end
+
+  def lockout_time_remaining
+    (Devise.direct_otp_valid_for - (Time.zone.now - user.second_factor_locked_at)).to_i
   end
 
   def confirmation_period_expired_error

--- a/app/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb
+++ b/app/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb
@@ -1,5 +1,5 @@
-<% lockout_time_in_words = current_user.decorate.lockout_time_remaining_in_words %>
-<% lockout_time_remaining = current_user.decorate.lockout_time_remaining %>
+<% lockout_time_in_words = decorator.lockout_time_remaining_in_words %>
+<% lockout_time_remaining = decorator.lockout_time_remaining %>
 <% title t('titles.account_locked') %>
 
 <h1 class="h3 my0">

--- a/spec/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/shared/max_login_attempts_reached.html.erb_spec.rb
@@ -4,9 +4,7 @@ describe 'two_factor_authentication/shared/max_login_attempts_reached.html.erb' 
   context 'locked out account' do
     it 'includes localized error message with time remaining' do
       user_decorator = instance_double(UserDecorator)
-      user = build(:user)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(user).to receive(:decorate).and_return(user_decorator)
+      allow(view).to receive(:decorator).and_return(user_decorator)
       allow(view).to receive(:type).and_return('otp')
       allow(user_decorator).to receive(:lockout_time_remaining_in_words).and_return('1000 years')
       allow(user_decorator).to receive(:lockout_time_remaining).and_return(10_000)


### PR DESCRIPTION
**WHY**: Otherwise, session timeout modal shows up before the lockout
period is over.

This updates the specs so that they will fail if the order is reversed
again (would only fail with a "sleep 2" before)