### PR TITLE
Create generic lockout message

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -55,7 +55,7 @@ module Users
       sign_out
       render(
         'two_factor_authentication/shared/max_login_attempts_reached',
-        locals: { type: 'otp', decorator: decorator }
+        locals: { type: 'generic', decorator: decorator }
       )
     end
 

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -115,6 +115,8 @@ en:
         That security code is invalid. You can try entering it again or request a new
         one-time security code.
       invalid_personal_key: That personal key is invalid.
+      max_generic_login_attempts_reached: >
+        Your account is temporarily locked.
       max_otp_login_attempts_reached: >
         Your account is temporarily locked because you have entered the one-time
         security code incorrectly too many times.

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -103,6 +103,8 @@ es:
         Esa contraseña no es válida. Puede intentar volver a ingresarlo o solicitar una nueva
         Código de acceso único.
       invalid_personal_key: Ese código de recuperación no es válido.
+      max_generic_login_attempts_reached:
+        Su cuenta ha sido bloqueada temporalmente.
       max_otp_login_attempts_reached:
         Su cuenta ha sido bloqueada temporalmente porque ha ingresado el código de acceso único
         de forma incorrecta demasiadas veces.

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -150,7 +150,7 @@ feature 'Two Factor Authentication' do
         signin(user.email, user.password)
 
         expect(page).to have_content t('devise.two_factor_authentication.' \
-                                       'max_otp_login_attempts_reached')
+                                       'max_generic_login_attempts_reached')
 
         visit profile_path
         expect(current_path).to eq root_path


### PR DESCRIPTION
**WHY**: When a user tries to log in when locked out, we know they are
locked out but we don't know if it is because of entering an OTP or
personal key too many times.

Previously, we were hardcoding the "OTP" lockout message. Now, we are
displaying a generic message telling them that they are locked out.