### PR TITLE
Shuffles some css and stops flashes of content

### DIFF
--- a/app/assets/javascripts/app/components/accordion.js
+++ b/app/assets/javascripts/app/components/accordion.js
@@ -8,7 +8,9 @@ class Accordion extends Events {
     this.el = el;
     this.controls = [].slice.call(el.querySelectorAll('[aria-controls]'));
     this.content = el.querySelector('.accordion-content');
-    this.headerControl = el.querySelector('.accordion-header-control');
+    this.header = el.querySelector('.accordion-header-controls');
+    this.collapsedIcon = el.querySelector('.plus-icon');
+    this.shownIcon = el.querySelector('.minus-icon');
 
     this.handleClick = this.handleClick.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
@@ -31,19 +33,18 @@ class Accordion extends Events {
       const { animationName } = event;
 
       if (animationName === 'accordionOut') {
-        this.content.classList.add('display-none');
+        this.content.classList.remove('shown');
       }
     });
   }
 
   onInitialize() {
-    this.content.classList.add('display-none');
     this.setExpanded(false);
-    this.content.classList.remove('accordion-init');
+    this.collapsedIcon.classList.remove('display-none');
   }
 
   handleClick() {
-    const expandedState = this.headerControl.getAttribute('aria-expanded');
+    const expandedState = this.header.getAttribute('aria-expanded');
 
     if (expandedState === 'false') {
       this.open();
@@ -61,12 +62,14 @@ class Accordion extends Events {
   }
 
   setExpanded(bool) {
-    this.headerControl.setAttribute('aria-expanded', bool);
+    this.header.setAttribute('aria-expanded', bool);
   }
 
   open() {
     this.setExpanded(true);
-    this.content.classList.remove('display-none');
+    this.collapsedIcon.classList.add('display-none');
+    this.shownIcon.classList.remove('display-none');
+    this.content.classList.add('shown');
     this.content.classList.remove('animate-out');
     this.content.classList.add('animate-in');
     this.emit('accordion.show');
@@ -74,10 +77,12 @@ class Accordion extends Events {
 
   close() {
     this.setExpanded(false);
+    this.collapsedIcon.classList.remove('display-none');
+    this.shownIcon.classList.add('display-none');
     this.content.classList.remove('animate-in');
     this.content.classList.add('animate-out');
     this.emit('accordion.hide');
-    this.headerControl.focus();
+    this.header.focus();
   }
 }
 

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -1,12 +1,15 @@
 .no-js {
   .accordion {
-    .accordion-header-control[aria-controls] {
-      background-image: none;
-      cursor: inherit;
+    .accordion-header {
+      cursor: initial;
     }
 
     .accordion-footer {
       display: none;
+    }
+
+    .accordion-content {
+      display: block;
     }
 
     [class*="btn-"] {
@@ -16,14 +19,11 @@
 }
 
 .accordion {
-  border: 1px solid $border-color;
+  border: $border-width solid $border-color;
   border-radius: $border-radius-md;
 
-  .accordion-content {
-    opacity: 1;
-  }
-
   .accordion-header {
+    color: $blue;
     cursor: pointer;
     position: relative;
 
@@ -34,47 +34,24 @@
     }
   }
 
-  .accordion-header-control[aria-expanded="false"] {
-    .minus-icon {
-      display: none;
-    }
+  .accordion-content {
+    border-top: $border-width solid $border-color;
+    display: none;
+    opacity: 1;
 
-    .plus-icon {
-      display: initial;
-    }
-  }
-
-  .accordion-header-control[aria-expanded="true"] {
-    border-bottom: 1px solid $border-color;
-
-    .minus-icon {
-      display: initial;
-    }
-
-    .plus-icon {
-      display: none;
-    }
-  }
-
-  .accordion-header-control {
-    color: $blue;
-    padding-right: 30px;
-
-    .accordion-content {
-      max-height: 0;
-      transition: max-height .3s linear;
+    &.shown {
+      display: block;
     }
   }
 
   .accordion-footer {
     background-color: $blue-lightest;
-    border-top: 1px solid $border-color;
+    border-top: $border-width solid $border-color;
     color: $blue;
     cursor: pointer;
     text-align: center;
 
     img {
-      display: inline-block;
       margin-top: -2px;
       vertical-align: middle;
     }

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -3,18 +3,17 @@
     class=('display-none' if options[:hide_header])
     role="heading"
   )
-    .accordion-header-control(
+    .accordion-header-controls.py1.px2.mt-tiny.mb-tiny(
       aria-controls="#{target_id}"
       aria-expanded="true"
       role="button"
       tabindex="0"
-      class="py1 px2 mt-tiny mb-tiny"
     )
       span.mb0.mr2
         = header_text
-      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon'
-      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon'
-  .accordion-content.accordion-init.clearfix.mt-tiny(
+      = image_tag asset_url('plus.svg'), width: 16, class: 'plus-icon display-none'
+      = image_tag asset_url('minus.svg'), width: 16, class: 'minus-icon display-none'
+  .accordion-content.clearfix.pt1(
     id="#{target_id}"
     role="region"
   )

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -248,17 +248,17 @@ feature 'IdV session' do
       _user = sign_in_and_2fa_user
 
       visit verify_session_path
-      expect(page).to have_css('.accordion-header-control',
+      expect(page).to have_css('.accordion-header-controls',
                                text: t('idv.form.previous_address_add'))
 
-      find('.accordion-header-control').click
+      click_accordion
       expect(page).to have_css('.accordion-header', text: t('links.remove'))
 
       fill_out_idv_previous_address_ok
       expect(find('#profile_prev_address1').value).to eq '456 Other Ave'
 
-      find('.accordion-header-control').click
-      find('.accordion-header-control').click
+      click_accordion
+      click_accordion
 
       expect(find('#profile_prev_address1').value).to eq ''
     end
@@ -401,5 +401,9 @@ feature 'IdV session' do
   def complete_idv_profile_fail
     fill_out_idv_form_fail
     click_button 'Continue'
+  end
+
+  def click_accordion
+    find('.accordion-header-controls').click
   end
 end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -46,7 +46,7 @@ feature 'LOA3 Single Sign On' do
 
       expect(current_path).to match sign_up_start_path
       expect(page).to have_content(sp_content)
-      expect(page).to have_css('.accordion-header-control',
+      expect(page).to have_css('.accordion-header-controls',
                                text: t('devise.registrations.start.accordion'))
     end
   end

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -54,7 +54,7 @@ feature 'View personal key' do
 
   context 'with javascript enabled', js: true do
     let(:invisible_selector) { generate_class_selector('invisible') }
-    let(:accordion_control_selector) { generate_class_selector('accordion-header-control') }
+    let(:accordion_control_selector) { generate_class_selector('accordion-header-controls') }
 
     it 'prompts the user to enter their personal key to confirm they have it' do
       sign_in_and_2fa_user
@@ -108,7 +108,7 @@ def expect_accordion_content_to_be_hidden_by_default
 end
 
 def expand_accordion
-  page.find('.accordion-header-control').click
+  page.find('.accordion-header-controls').click
 end
 
 def expect_accordion_content_to_become_visible

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -13,7 +13,7 @@ shared_examples_for 'personal key page' do
   end
 
   context 'informational text' do
-    let(:accordion_control_selector) { generate_class_selector('accordion-header-control') }
+    let(:accordion_control_selector) { generate_class_selector('accordion-header-controls') }
     let(:content_selector) { generate_class_selector('accordion-content') }
 
     scenario 'it displays the personal key info header' do


### PR DESCRIPTION
**Why**: To handle the case of a user with javascript enabled and to
support accessibility, we must have our accordions open by default.
This PR should remove the flashes of content when JS is enabled
and kicks in to hide/show various pieces of the accordion component.


**note**:  This is probably best tested in browser. The flash was intermittent, so there isn't a ton of value in me providing a gif of it working here. There are detailed steps in the linked issue!