### PR TITLE
Revert timestamp back to date and time format

### DIFF
--- a/app/views/profile/_event_item.html.slim
+++ b/app/views/profile/_event_item.html.slim
@@ -3,4 +3,4 @@
    .sm-col.sm-col-6.px1
      .bold.truncate = event.pretty_event_type
    .sm-col.sm-col-6.px1.sm-right-align
-     = event.happened_at.to_date.to_formatted_s(:long)
+     = event.happened_at


### PR DESCRIPTION
**WHY**:
- we moved to date and time at https://github.com/18F/identity-idp/commit/89efa592bc8357812eb04ab3f32e108355047e4b
- stuff was moved around at https://github.com/18F/identity-idp/commit/0b09dd351cb35232052bf08412e8c9e04cffc09f#diff-01b26e55784bf0cdbf16b6e791f68830
and the formatting was messed up