### PR TITLE
Filter non-live SP configs from live prod env

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -245,6 +245,7 @@ production:
     cert: 'sp_micropurchase'
     agency: 'TTS Acquisition'
     logo: '18f.svg'
+    allow_on_prod_chef_env: 'true'
     friendly_name: 'Micro-purchase'
     return_to_sp_url: 'https://micropurchase.18f.gov'
     attribute_bundle:
@@ -293,21 +294,25 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    allow_on_prod_chef_env: 'true'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:cert:app':
     redirect_uri: 'gov.dhs.cbp.jobs.applicant.cert://result'
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    allow_on_prod_chef_env: 'true'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod':
     redirect_uri: 'https://careers.cbp.dhs.gov/hrm/app'
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    allow_on_prod_chef_env: 'true'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod:app':
     redirect_uri: 'gov.dhs.cbp.jobs.applicant://result'
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    allow_on_prod_chef_env: 'true'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@ service_providers = YAML.load_file(Rails.root.join('config', 'service_providers.
                     fetch(Rails.env, {})
 
 service_providers.each do |issuer, config|
+  next if Figaro.env.chef_env == 'prod' && config['allow_on_prod_chef_env'] != 'true'
   ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
     sp.approved = true
     sp.active = true


### PR DESCRIPTION
**Why**: We have a single Rails environment called 'production'
but that applies to all AWS environments. Use the CHEF_ENV
environment variable to determine whether we are in the actual
production environment, and filter out SPs that are not explicitly
marked as 'live'.