### PR TITLE
Wrap text inside input buttons

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -2,6 +2,10 @@
   .btn { font-size: $button-font-size-sm; }
 }
 
+.btn {
+  white-space: normal;
+}
+
 %btn-basic {
   background: transparent;
   border: 0;

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -8,7 +8,7 @@ $radio-checkbox-space: 1.5rem;
   }
 }
 
-.input-submit {
+input[type=submit] {
   white-space: normal;
 }
 

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -8,9 +8,13 @@ $radio-checkbox-space: 1.5rem;
   }
 }
 
+// scss-lint:disable QualifyingElement
+// Disabling for now as our current designs don't have any instances
+// of input buttons that shouldn't have line breaks on small screen sizes
 input[type=submit] {
   white-space: normal;
 }
+// scss-lint:enable QualifyingElement
 
 label {
   display: inline-block;

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -8,14 +8,6 @@ $radio-checkbox-space: 1.5rem;
   }
 }
 
-// scss-lint:disable QualifyingElement
-// Disabling for now as our current designs don't have any instances
-// of input buttons that shouldn't have line breaks on small screen sizes
-input[type=submit] {
-  white-space: normal;
-}
-// scss-lint:enable QualifyingElement
-
 label {
   display: inline-block;
   margin-bottom: $space-tiny;


### PR DESCRIPTION
**Why**: <input> elements styled as buttons don't break text in the same
way as <button> elements

Screenshot:

<img width="352" alt="screen shot 2017-04-18 at 3 59 53 pm" src="https://cloud.githubusercontent.com/assets/1421848/25150841/575c115a-2451-11e7-84e0-f76a620b8492.png">
