### PR TITLE
Fix invalid personal key returning wrong value

### DIFF
--- a/app/forms/personal_key_form.rb
+++ b/app/forms/personal_key_form.rb
@@ -13,7 +13,11 @@ class PersonalKeyForm
   def submit
     @success = valid_personal_key?
 
-    UpdateUser.new(user: user, attributes: { personal_key: nil }).call if success
+    if success
+      UpdateUser.new(user: user, attributes: { personal_key: nil }).call
+    else
+      reset_sensitive_fields
+    end
 
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
@@ -26,5 +30,9 @@ class PersonalKeyForm
     {
       multi_factor_auth_method: 'personal key',
     }
+  end
+
+  def reset_sensitive_fields
+    self.personal_key = nil
   end
 end

--- a/app/services/personal_key_generator.rb
+++ b/app/services/personal_key_generator.rb
@@ -33,7 +33,7 @@ class PersonalKeyGenerator
     normed = plaintext_code.gsub(/\W/, '')
     split_length = RandomPhrase::WORD_LENGTH
     normed_length = normed.length
-    return INVALID_CODE unless normed_length == personal_key_length * split_length
+    return unless normed_length == personal_key_length * split_length
     encode_code(code: normed, length: normed_length, split: split_length)
   rescue ArgumentError, RegexpError
     INVALID_CODE

--- a/app/services/personal_key_generator.rb
+++ b/app/services/personal_key_generator.rb
@@ -33,7 +33,7 @@ class PersonalKeyGenerator
     normed = plaintext_code.gsub(/\W/, '')
     split_length = RandomPhrase::WORD_LENGTH
     normed_length = normed.length
-    return unless normed_length == personal_key_length * split_length
+    return INVALID_CODE unless normed_length == personal_key_length * split_length
     encode_code(code: normed, length: normed_length, split: split_length)
   rescue ArgumentError, RegexpError
     INVALID_CODE

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -28,9 +28,9 @@ describe PersonalKeyForm do
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: extra).and_return(result)
-        expect(form.personal_key).to be_nil
         expect(form.submit).to eq result
         expect(user.personal_key).to_not be_nil
+        expect(form.personal_key).to be_nil
       end
     end
   end

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -28,6 +28,7 @@ describe PersonalKeyForm do
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: extra).and_return(result)
+        expect(form.personal_key).to be_nil
         expect(form.submit).to eq result
         expect(user.personal_key).to_not be_nil
       end


### PR DESCRIPTION
Return a blank value if the input in a personal key field does not meet a certain length.