### PR TITLE
Restore custom html5 validation messages

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -2,19 +2,16 @@ const I18n = window.LoginGov.I18n;
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
-  if (form && window.onbeforeunload) {
-    form.addEventListener('submit', () => {
-      if (form.checkValidity()) window.onbeforeunload = false;
-    });
-
+  if (form) {
     const fields = ['dob', 'ssn', 'zipcode'];
 
-    fields.forEach(function(f) {
-      const input = document.querySelector(`.${f}`);
+    fields.forEach(function(fieldType) {
+      const input = document.querySelector(`.${fieldType}`);
+
       if (input) {
-        input.addEventListener('input', () => {
+        input.addEventListener('change', () => {
           if (input.validity.patternMismatch) {
-            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${f}`));
+            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${fieldType}`));
           } else {
             input.setCustomValidity('');
           }

--- a/app/assets/javascripts/app/utils/auto-logout.js
+++ b/app/assets/javascripts/app/utils/auto-logout.js
@@ -1,5 +1,3 @@
 export default () => {
-  window.onbeforeunload = null;
-  window.onunload = null;
   window.location.href = '/timeout';
 };


### PR DESCRIPTION
**Why**: To provide the user with helpful feedback on the formatting
of certain types of input.

**How**: By removing some vestigial onbeforeunload code that was
preventing our custom messages from being set.

The proof:

**ssn**:
<img width="511" alt="screen shot 2017-04-20 at 10 44 56 am" src="https://cloud.githubusercontent.com/assets/1421848/25236728/92b45184-25b6-11e7-9d2e-12677be0d214.png">

**dob**
<img width="488" alt="screen shot 2017-04-20 at 10 46 44 am" src="https://cloud.githubusercontent.com/assets/1421848/25236771/b3067f8e-25b6-11e7-8778-1ad21662cc40.png">

**zip**
<img width="345" alt="screen shot 2017-04-20 at 10 44 34 am" src="https://cloud.githubusercontent.com/assets/1421848/25236741/98f16f0a-25b6-11e7-9f59-73c5080d3163.png">
