### PR TITLE
Add UUID to logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     event.payload[:timestamp] = event.time
+    event.payload[:uuid] = SecureRandom.uuid
     event.payload.except(:params)
   end
   config.lograge.ignore_actions = ['Users::SessionsController#active']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.custom_options = lambda do |event|
     event.payload[:timestamp] = event.time
+    event.payload[:uuid] = SecureRandom.uuid
     event.payload.except(:params)
   end
   config.lograge.ignore_actions = ['Users::SessionsController#active']


### PR DESCRIPTION
**Why**: So we can de-duplicate lines that we parse from logs

---

Example log:

```
{"method":"GET","path":"/","format":"html","controller":"Users::SessionsController","action":"new","status":200,"duration":109.81,"user_id":"anonymous-uuid","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36","ip":"127.0.0.1","host":"localhost","timestamp":"2017-04-20 14:32:23 -0400","uuid":"7502398d-1609-4b86-8e18-2f703584afce"}
```

<img width="565" alt="identity-idp_ _-bash_ _80x32" src="https://cloud.githubusercontent.com/assets/458784/25246781/b5385500-25d6-11e7-9271-bf20af510a14.png">
