### PR TITLE
Refactor Idv::ProfileStep

### DIFF
--- a/.reek
+++ b/.reek
@@ -49,7 +49,6 @@ TooManyMethods:
     - OpenidConnectAuthorizeForm
     - Idv::Session
     - User
-    - Idv::ProfileStep
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
-  revision: b2ba7fd3eedc933b2e508a3bf3c6b520be6fe3da
+  revision: b25f4f40e6b61fc9f586d870e5aaa90f1449c5d9
   branch: master
   specs:
     proofer (1.0.0)

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -7,7 +7,7 @@ module Idv
       @success = complete?
 
       increment_attempts_count if form_valid?
-      update_idv_session
+      update_idv_session if success
 
       FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
     end
@@ -62,25 +62,10 @@ module Idv
     end
 
     def update_idv_session
-      idv_session.profile_confirmation = success
-      idv_session.resolution = proofer_resolution
-      idv_session.vendor_session_id = proofer_resolution.session_id
-      idv_session.normalized_applicant_params = normalized_applicant_to_hash
-      idv_session.resolution_successful = proofer_resolution.success?
-    end
-
-    def proofer_resolution
-      @resolution ||= vendor_validator.result
-    end
-
-    def normalized_applicant
-      @normalized_applicant ||= proofer_resolution.vendor_resp.normalized_applicant
-    end
-
-    def normalized_applicant_to_hash
-      normalized_applicant.instance_variables.each_with_object({}) do |var, hash|
-        hash[var.to_s.delete('@')] = normalized_applicant.instance_variable_get(var)
-      end
+      idv_session.profile_confirmation = true
+      idv_session.vendor_session_id = vendor_validator.session_id
+      idv_session.normalized_applicant_params = vendor_validator.normalized_applicant.to_hash
+      idv_session.resolution_successful = true
     end
 
     def extra_analytics_attributes

--- a/app/services/idv/profile_validator.rb
+++ b/app/services/idv/profile_validator.rb
@@ -1,7 +1,13 @@
 module Idv
   class ProfileValidator < VendorValidator
+    delegate :session_id, to: :result
+
     def result
       @_result ||= try_start
+    end
+
+    def normalized_applicant
+      result.vendor_resp.normalized_applicant
     end
 
     private

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -11,7 +11,6 @@ module Idv
       profile_confirmation
       profile_id
       personal_key
-      resolution
       resolution_successful
       step_attempts
       vendor
@@ -40,7 +39,7 @@ module Idv
     end
 
     def proofing_started?
-      resolution.present? && applicant.present? && resolution_successful
+      applicant.present? && resolution_successful
     end
 
     def cache_applicant_profile_id

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -9,7 +9,6 @@ describe Verify::ConfirmationsController do
     idv_session = Idv::Session.new(subject.user_session, user)
     idv_session.vendor = :mock
     idv_session.applicant = idv_session.vendor_params
-    idv_session.resolution = resolution
     idv_session.normalized_applicant_params = { first_name: 'Somebody' }
     idv_session.resolution_successful = resolution.success?
     user.unlock_user_access_key(password)

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -185,7 +185,6 @@ describe Verify::FinanceController do
   def stub_subject
     user = stub_sign_in
     idv_session = Idv::Session.new(subject.user_session, user)
-    idv_session.resolution = Proofer::Resolution.new success: true, session_id: 'some-id'
     idv_session.applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
     idv_session.vendor = subject.idv_vendor.pick
     allow(subject).to receive(:confirm_idv_session_started).and_return(true)

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -35,8 +35,6 @@ describe Verify::ReviewController do
     idv_session.phone_confirmation = true
     idv_session.financials_confirmation = true
     idv_session.params = user_attrs
-    vendor = Proofer::Vendor::Mock.new(applicant: idv_session.vendor_params)
-    idv_session.resolution = vendor.start
     idv_session.normalized_applicant_params = user_attrs.merge(
       zipcode: norm_zipcode, first_name: normalized_first_name
     )

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -247,19 +247,19 @@ describe Verify::SessionsController do
         it 'fails if previous address has bad zipcode' do
           post :create, profile: user_attrs.merge(previous_address).merge(prev_zipcode: bad_zipcode)
 
-          expect(idv_session.resolution.success?).to eq false
+          expect(idv_session.resolution_successful).to be_nil
         end
 
         it 'fails if current address has bad zipcode' do
           post :create, profile: user_attrs.merge(previous_address).merge(zipcode: bad_zipcode)
 
-          expect(idv_session.resolution.success?).to eq false
+          expect(idv_session.resolution_successful).to be_nil
         end
 
         it 'respects both addresses' do
           post :create, profile: user_attrs.merge(previous_address)
 
-          expect(idv_session.resolution.success?).to eq true
+          expect(idv_session.resolution_successful).to eq true
         end
       end
     end

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -5,7 +5,6 @@ describe Idv::FinancialsStep do
   let(:idv_session) do
     idvs = Idv::Session.new({}, user)
     idvs.vendor = :mock
-    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
     idvs
   end
   let(:idv_finance_form) { Idv::FinanceForm.new(idv_session.params) }

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -6,7 +6,6 @@ describe Idv::FinancialsValidator do
   let(:idv_session) do
     idvs = Idv::Session.new({}, user)
     idvs.vendor = :mock
-    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
     idvs
   end
 

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -7,7 +7,6 @@ describe Idv::PhoneStep do
   let(:idv_session) do
     idvs = Idv::Session.new({}, user)
     idvs.vendor = :mock
-    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
     idvs.applicant = Proofer::Applicant.new first_name: 'Some'
     idvs
   end

--- a/spec/services/idv/phone_validator_spec.rb
+++ b/spec/services/idv/phone_validator_spec.rb
@@ -6,7 +6,6 @@ describe Idv::PhoneValidator do
   let(:idv_session) do
     idvs = Idv::Session.new({}, user)
     idvs.vendor = :mock
-    idvs.resolution = Proofer::Resolution.new session_id: 'some-id'
     idvs
   end
 

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -40,7 +40,6 @@ describe Idv::ProfileStep do
         with(success: true, errors: {}, extra: extra).and_return(result)
       expect(step.submit).to eq result
       expect(idv_session.profile_confirmation).to eq true
-      expect(idv_session.resolution).to be_a Proofer::Resolution
     end
 
     it 'fails with invalid SSN' do
@@ -57,7 +56,7 @@ describe Idv::ProfileStep do
       expect(FormResponse).to receive(:new).
         with(success: false, errors: errors, extra: extra).and_return(result)
       expect(step.submit).to eq result
-      expect(idv_session.profile_confirmation).to eq false
+      expect(idv_session.profile_confirmation).to be_nil
     end
 
     it 'fails when form validation fails' do
@@ -74,7 +73,7 @@ describe Idv::ProfileStep do
       expect(FormResponse).to receive(:new).
         with(success: false, errors: errors, extra: extra).and_return(result)
       expect(step.submit).to eq result
-      expect(idv_session.profile_confirmation).to eq false
+      expect(idv_session.profile_confirmation).to be_nil
     end
 
     it 'fails with invalid first name' do
@@ -91,7 +90,7 @@ describe Idv::ProfileStep do
       expect(FormResponse).to receive(:new).
         with(success: false, errors: errors, extra: extra).and_return(result)
       expect(step.submit).to eq result
-      expect(idv_session.profile_confirmation).to eq false
+      expect(idv_session.profile_confirmation).to be_nil
     end
 
     it 'fails with invalid ZIP code on current address' do
@@ -108,7 +107,7 @@ describe Idv::ProfileStep do
       expect(FormResponse).to receive(:new).
         with(success: false, errors: errors, extra: extra).and_return(result)
       expect(step.submit).to eq result
-      expect(idv_session.profile_confirmation).to eq false
+      expect(idv_session.profile_confirmation).to be_nil
     end
 
     it 'fails with invalid ZIP code on previous address' do
@@ -125,7 +124,7 @@ describe Idv::ProfileStep do
       expect(FormResponse).to receive(:new).
         with(success: false, errors: errors, extra: extra).and_return(result)
       expect(step.submit).to eq result
-      expect(idv_session.profile_confirmation).to eq false
+      expect(idv_session.profile_confirmation).to be_nil
     end
 
     it 'increments attempts count if the form is valid' do

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -8,6 +8,7 @@ describe SessionEncryptor do
       expect(SessionEncryptor.load(session)).to eq('foo' => 'bar')
     end
 
+    # rubocop:disable Security/MarshalLoad
     context 'value previously serialized with Marshal and Base64 encoded' do
       it 'decrypts the session and then calls .dump' do
         plain = ::Base64.encode64(Marshal.dump(foo: 'bar'))
@@ -24,6 +25,7 @@ describe SessionEncryptor do
         expect(SessionEncryptor).to have_received(:dump).with(decoded_session)
       end
     end
+    # rubocop:enable Security/MarshalLoad
   end
 
   describe '#dump' do

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -36,13 +36,6 @@ module ControllerHelper
     user_session = {}
     stub_sign_in(user)
     idv_session = Idv::Session.new(user_session, user)
-    idv_session.resolution = Proofer::Resolution.new(
-      success: true,
-      session_id: 'some-id',
-      vendor_resp: Proofer::Vendor::MockResponse.new(
-        normalized_applicant: Proofer::Applicant.new(first_name: 'Somebody')
-      )
-    )
     idv_session.applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
     idv_session.vendor = subject.idv_vendor.pick
     allow(subject).to receive(:confirm_idv_session_started).and_return(true)


### PR DESCRIPTION
**Why**: This is a follow up to #1358 that updates the proofer gem to
take advantage of `Proofer::Applicant#to_hash`, and refactors
ProfileStep and Idv::Session to reduce their complexity.