### PR TITLE
Listen to `input` event to provide copy/paste support for password strength checker JS

### DIFF
--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -6,26 +6,26 @@ const I18n = window.LoginGov.I18n;
 // we map those scores to:
 // 1. a CSS class to the pw strength module
 // 2. text describing the score
+const scale = {
+  0: ['pw-very-weak', I18n.t('instructions.password.strength.i')],
+  1: ['pw-weak', I18n.t('instructions.password.strength.ii')],
+  2: ['pw-so-so', I18n.t('instructions.password.strength.iii')],
+  3: ['pw-good', I18n.t('instructions.password.strength.iv')],
+  4: ['pw-great', I18n.t('instructions.password.strength.v')],
+};
+
+// fallback if zxcvbn lookup fails / field is empty
+const fallback = ['pw-na', '...'];
+
 function getStrength(z) {
-  const scale = {
-    0: ['pw-very-weak', I18n.t('instructions.password.strength.i')],
-    1: ['pw-weak', I18n.t('instructions.password.strength.ii')],
-    2: ['pw-so-so', I18n.t('instructions.password.strength.iii')],
-    3: ['pw-good', I18n.t('instructions.password.strength.iv')],
-    4: ['pw-great', I18n.t('instructions.password.strength.v')],
-  };
-
-  // fallback if zxcvbn lookup fails / field is empty
-  const fallback = ['pw-na', '...'];
-
   return z && z.password.length ? scale[z.score] : fallback;
 }
-
 
 function getFeedback(z) {
   if (!z || z.score > 2) return '';
 
   const { warning, suggestions } = z.feedback;
+
   function lookup(str) {
     const strFormatted = str.replace(/\./g, '_');
     return I18n.t(`zxcvbn.feedback.${strFormatted}`);
@@ -34,13 +34,13 @@ function getFeedback(z) {
   if (!warning && !suggestions.length) return '';
   if (warning) return lookup(warning);
 
-  return `${suggestions.map(function(s) { return lookup(s); }).join('; ')}`;
+  return `${suggestions.map(s => lookup(s)).join('; ')}`;
 }
 
-function disableSubmit(submitEl, score) {
+function disableSubmit(submitEl, score = 0) {
   if (!submitEl) return;
 
-  if (!score || score < 3) {
+  if (score < 3) {
     submitEl.setAttribute('disabled', true);
   } else {
     submitEl.removeAttribute('disabled');
@@ -48,6 +48,7 @@ function disableSubmit(submitEl, score) {
 }
 
 function analyzePw() {
+  const userAgent = window.navigator.userAgent;
   const input = document.querySelector(
     '#password_form_password, #reset_password_form_password, #update_user_password_form_password',
   );
@@ -63,7 +64,7 @@ function analyzePw() {
   // thus, first step is unhiding it
   pwCntnr.className = '';
 
-  input.addEventListener('keyup', function(e) {
+  function checkPasswordStrength(e) {
     const z = zxcvbn(e.target.value);
     const [cls, strength] = getStrength(z);
     const feedback = getFeedback(z);
@@ -72,7 +73,13 @@ function analyzePw() {
     pwFeedback.innerHTML = feedback;
 
     disableSubmit(submit, z.score);
-  });
+  }
+
+  if (/(msie 9)/i.test(userAgent)) {
+    input.addEventListener('keyup', checkPasswordStrength);
+  }
+
+  input.addEventListener('input', checkPasswordStrength);
 }
 
 document.addEventListener('DOMContentLoaded', analyzePw);


### PR DESCRIPTION
**Why**: Previously we listened to the keyup event, which doesn't fire
if the user enters a password using right-click -> paste, or pastes a
password into the input field on a mobile device

**How**: Listen to the input event, also, listen to the keyup event on
IE9, as the input event doesn't fire on backspace.

I tested this on the following browsers/devices:

* mac OSX — chrome, safari, firefox
* iOS — safari, chrome
* windows 8 — IE edge, IE 9 (emulated)

I'm not able to test this on a windows or android phone, unfortunately.