### PR TITLE
Support "Back to SP" link in OIDC

### DIFF
--- a/.reek
+++ b/.reek
@@ -38,6 +38,9 @@ RepeatedConditional:
 TooManyConstants:
   exclude:
     - Analytics
+TooManyInstanceVariables:
+  exclude:
+    - OpenidConnectAuthorizeForm
 TooManyStatements:
   max_statements: 6
   exclude:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,9 @@ class ApplicationController < ActionController::Base
   end
 
   def decorated_session
-    @_decorated_session ||= DecoratedSession.new(sp: current_sp, view_context: view_context).call
+    @_decorated_session ||= DecoratedSession.new(
+      sp: current_sp, view_context: view_context, sp_session: sp_session
+    ).call
   end
 
   private

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,9 +1,10 @@
 class ServiceProviderSessionDecorator
   DEFAULT_LOGO = 'generic.svg'.freeze
 
-  def initialize(sp:, view_context:)
+  def initialize(sp:, view_context:, sp_session:)
     @sp = sp
     @view_context = view_context
+    @sp_session = sp_session
   end
 
   def sp_logo
@@ -39,10 +40,18 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_return_url
-    sp.return_to_sp_url
+    if request_url.present?
+      OpenidConnectRedirector.from_request_url(request_url).decline_redirect_uri
+    else
+      sp.return_to_sp_url
+    end
   end
 
   private
 
-  attr_reader :sp, :view_context
+  attr_reader :sp, :view_context, :sp_session
+
+  def request_url
+    sp_session[:request_url]
+  end
 end

--- a/app/services/decorated_session.rb
+++ b/app/services/decorated_session.rb
@@ -1,12 +1,15 @@
 class DecoratedSession
-  def initialize(sp:, view_context:)
+  def initialize(sp:, view_context:, sp_session:)
     @sp = sp
     @view_context = view_context
+    @sp_session = sp_session
   end
 
   def call
     if sp.is_a? ServiceProvider
-      ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+      ServiceProviderSessionDecorator.new(
+        sp: sp, view_context: view_context, sp_session: sp_session
+      )
     else
       SessionDecorator.new
     end
@@ -14,5 +17,5 @@ class DecoratedSession
 
   private
 
-  attr_reader :sp, :view_context
+  attr_reader :sp, :view_context, :sp_session
 end

--- a/app/services/openid_connect_redirector.rb
+++ b/app/services/openid_connect_redirector.rb
@@ -1,0 +1,75 @@
+class OpenidConnectRedirector
+  include ActionView::Helpers::TranslationHelper
+
+  def self.from_request_url(request_url)
+    params = URIService.params(request_url)
+
+    new(
+      redirect_uri: params[:redirect_uri],
+      service_provider: ServiceProvider.from_issuer(params[:client_id]),
+      state: params[:state]
+    )
+  end
+
+  def initialize(redirect_uri:, service_provider:, state:, errors: nil)
+    @redirect_uri = redirect_uri
+    @service_provider = service_provider
+    @state = state
+    @errors = errors
+  end
+
+  def validate
+    validate_redirect_uri
+    validate_redirect_uri_matches_sp_redirect_uri
+  end
+
+  def success_redirect_uri(code:)
+    URIService.add_params(validated_input_redirect_uri, code: code, state: state)
+  end
+
+  def decline_redirect_uri
+    URIService.add_params(
+      validated_input_redirect_uri,
+      error: 'access_denied',
+      state: state
+    )
+  end
+
+  def error_redirect_uri
+    URIService.add_params(
+      validated_input_redirect_uri,
+      error: 'invalid_request',
+      error_description: errors.full_messages.join(' '),
+      state: state
+    )
+  end
+
+  private
+
+  attr_reader :redirect_uri, :service_provider, :state, :errors
+
+  def validate_redirect_uri
+    _uri = URI(redirect_uri)
+  rescue ArgumentError, URI::InvalidURIError
+    errors.add(:redirect_uri, t('openid_connect.authorization.errors.redirect_uri_invalid'))
+  end
+
+  def validate_redirect_uri_matches_sp_redirect_uri
+    return if redirect_uri_matches_sp_redirect_uri?
+    errors.add(:redirect_uri, t('openid_connect.authorization.errors.redirect_uri_no_match'))
+  end
+
+  def redirect_uri_matches_sp_redirect_uri?
+    redirect_uri.present? &&
+      service_provider.active? &&
+      redirect_uri.start_with?(sp_redirect_uri)
+  end
+
+  def validated_input_redirect_uri
+    redirect_uri if redirect_uri_matches_sp_redirect_uri?
+  end
+
+  def sp_redirect_uri
+    service_provider.redirect_uri
+  end
+end

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -117,6 +117,7 @@ development:
   'urn:gov:gsa:openidconnect:sp:sinatra':
     redirect_uri: 'http://localhost:9292/'
     cert: 'sp_sinatra_demo'
+    friendly_name: 'Example Sinatra App'
 
 production:
   'https://idp.dev.login.gov':

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe ServiceProviderSessionDecorator do
   let(:view_context) { ActionController::Base.new.view_context }
-  subject { ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context) }
+  subject do
+    ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context, sp_session: {})
+  end
   let(:sp) { build_stubbed(:service_provider) }
   let(:sp_name) { subject.sp_name }
 
@@ -56,7 +58,9 @@ RSpec.describe ServiceProviderSessionDecorator do
 
     it 'returns the agency name if friendly name is not present' do
       sp = build_stubbed(:service_provider, friendly_name: nil)
-      subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+      subject = ServiceProviderSessionDecorator.new(
+        sp: sp, view_context: view_context, sp_session: {}
+      )
       expect(subject.sp_name).to eq sp.agency
       expect(subject.sp_name).to_not be_nil
     end
@@ -68,7 +72,9 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp_logo = 'real_logo.svg'
         sp = build_stubbed(:service_provider, logo: sp_logo)
 
-        subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp, view_context: view_context, sp_session: {}
+        )
 
         expect(subject.sp_logo).to eq sp_logo
       end
@@ -78,7 +84,9 @@ RSpec.describe ServiceProviderSessionDecorator do
       it 'returns the default logo' do
         sp = build_stubbed(:service_provider, logo: nil)
 
-        subject = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp, view_context: view_context, sp_session: {}
+        )
 
         expect(subject.sp_logo).to eq 'generic.svg'
       end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -349,9 +349,22 @@ feature 'OpenID Connect' do
     end
   end
 
-  def visit_idp_from_sp_with_loa1
+  context 'going back to the SP' do
+    it 'links back to the SP from the sign in page' do
+      state = SecureRandom.hex
+
+      visit_idp_from_sp_with_loa1(state: state)
+
+      click_link t('links.sign_in')
+
+      cancel_callback_url = "http://localhost:7654/auth/result?error=access_denied&state=#{state}"
+
+      expect(page).to have_link(t('links.back_to_sp', sp: 'Test SP'), href: cancel_callback_url)
+    end
+  end
+
+  def visit_idp_from_sp_with_loa1(state: SecureRandom.hex)
     client_id = 'urn:gov:gsa:openidconnect:sp:server'
-    state = SecureRandom.hex
     nonce = SecureRandom.hex
 
     visit openid_connect_authorize_path(

--- a/spec/services/openid_connect_redirector_spec.rb
+++ b/spec/services/openid_connect_redirector_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe OpenidConnectRedirector do
+  include Rails.application.routes.url_helpers
+
+  let(:redirect_uri) { 'http://localhost:7654/' }
+  let(:state) { SecureRandom.hex }
+  let(:service_provider) { ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server') }
+  let(:errors) { ActiveModel::Errors.new(nil) }
+
+  subject(:redirector) do
+    OpenidConnectRedirector.new(
+      redirect_uri: redirect_uri,
+      service_provider: service_provider,
+      state: state,
+      errors: errors
+    )
+  end
+
+  describe '.from_request_url' do
+    it 'builds a redirector from an OpenID request_url' do
+      request_url = openid_connect_authorize_url(
+        client_id: service_provider.issuer,
+        redirect_uri: redirect_uri,
+        state: state
+      )
+
+      result = OpenidConnectRedirector.from_request_url(request_url)
+
+      expect(result).to be_a(OpenidConnectRedirector)
+      expect(result.send(:redirect_uri)).to eq(redirect_uri)
+      expect(result.send(:service_provider)).to eq(service_provider)
+      expect(result.send(:state)).to eq(state)
+    end
+  end
+
+  describe '#validate' do
+    context 'with a valid redirect_uri' do
+      let(:redirect_uri) { 'http://localhost:7654/result/more/extra' }
+      it 'is valid' do
+        redirector.validate
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with a malformed redirect_uri' do
+      let(:redirect_uri) { ':aaaa' }
+      it 'has errors' do
+        redirector.validate
+        expect(errors[:redirect_uri]).
+          to include(t('openid_connect.authorization.errors.redirect_uri_invalid'))
+      end
+    end
+
+    context 'with a redirect_uri not registered to the service provider' do
+      let(:redirect_uri) { 'http://localhost:3000/test' }
+      it 'has errors' do
+        redirector.validate
+        expect(errors[:redirect_uri]).
+          to include(t('openid_connect.authorization.errors.redirect_uri_no_match'))
+      end
+    end
+  end
+
+  describe '#success_redirect_uri' do
+    it 'adds the code and state to the URL' do
+      code = SecureRandom.hex
+      expect(redirector.success_redirect_uri(code: code)).
+        to eq(URIService.add_params(redirect_uri, code: code, state: state))
+    end
+  end
+
+  describe '#decline_redirect_uri' do
+    it 'adds the state and access_denied to the URL' do
+      expect(redirector.decline_redirect_uri).
+        to eq(URIService.add_params(redirect_uri, state: state, error: 'access_denied'))
+    end
+  end
+
+  describe '#error_redirect_uri' do
+    before { expect(errors).to receive(:full_messages).and_return(['some attribute is missing']) }
+
+    it 'adds the errors to the URL' do
+      expect(redirector.error_redirect_uri).
+        to eq(URIService.add_params(redirect_uri,
+                                    state: state,
+                                    error: 'invalid_request',
+                                    error_description: 'some attribute is missing'))
+    end
+  end
+end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -53,7 +53,9 @@ describe 'devise/sessions/new.html.slim' do
         return_to_sp_url: 'www.awesomeness.com'
       )
       view_context = ActionController::Base.new.view_context
-      @decorated_session = DecoratedSession.new(sp: sp, view_context: view_context).call
+      @decorated_session = DecoratedSession.new(
+        sp: sp, view_context: view_context, sp_session: {}
+      ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
 

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -6,7 +6,7 @@ describe 'layouts/application.html.slim' do
   before do
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
     allow(view).to receive(:decorated_session).and_return(
-      DecoratedSession.new(sp: nil, view_context: nil).call
+      DecoratedSession.new(sp: nil, view_context: nil, sp_session: {}).call
     )
     allow(view.request).to receive(:original_url).and_return('http://test.host/foobar')
     allow(view).to receive(:current_user).and_return(User.new)
@@ -77,7 +77,7 @@ describe 'layouts/application.html.slim' do
       allow(view).to receive(:current_user).and_return(nil)
       allow(view).to receive(:user_fully_authenticated?).and_return(false)
       allow(view).to receive(:decorated_session).and_return(
-        DecoratedSession.new(sp: nil, view_context: nil).call
+        DecoratedSession.new(sp: nil, view_context: nil, sp_session: {}).call
       )
       allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
 

--- a/spec/views/openid_connect/authorization/index.html.slim_spec.rb
+++ b/spec/views/openid_connect/authorization/index.html.slim_spec.rb
@@ -12,7 +12,9 @@ describe 'openid_connect/authorization/index.html.slim' do
       friendly_name: 'Awesome Application!',
       logo: 'generic.svg'
     )
-    decorated_session = DecoratedSession.new(sp: sp, view_context: view_context).call
+    decorated_session = DecoratedSession.new(
+      sp: sp, view_context: view_context, sp_session: {}
+    ).call
     allow(view).to receive(:decorated_session).and_return(decorated_session)
   end
 
@@ -37,7 +39,7 @@ describe 'openid_connect/authorization/index.html.slim' do
     it 'renders the default logo' do
       sp_without_logo = build_stubbed(:service_provider)
       decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp_without_logo, view_context: view_context
+        sp: sp_without_logo, view_context: view_context, sp_session: {}
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render

--- a/spec/views/shared/_nav_branded.html.slim_spec.rb
+++ b/spec/views/shared/_nav_branded.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'shared/_nav_branded.html.slim' do
         :service_provider, logo: 'generic.svg', friendly_name: 'Best SP ever'
       )
       decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp_with_logo, view_context: view_context
+        sp: sp_with_logo, view_context: view_context, sp_session: {}
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render
@@ -24,7 +24,7 @@ describe 'shared/_nav_branded.html.slim' do
     before do
       sp_without_logo = build_stubbed(:service_provider, friendly_name: 'No logo no problem')
       decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp_without_logo, view_context: view_context
+        sp: sp_without_logo, view_context: view_context, sp_session: {}
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -32,8 +32,9 @@ describe 'sign_up/registrations/show.html.slim' do
     before do
       @sp = build_stubbed(:service_provider, friendly_name: 'Awesome Application!')
       view_context = ActionController::Base.new.view_context
-      allow(view).to receive(:decorated_session).
-        and_return(ServiceProviderSessionDecorator.new(sp: @sp, view_context: view_context))
+      allow(view).to receive(:decorated_session).and_return(
+        ServiceProviderSessionDecorator.new(sp: @sp, view_context: view_context, sp_session: {})
+      )
     end
 
     it 'includes sp-specific copy' do

--- a/spec/views/verify/fail.html.slim_spec.rb
+++ b/spec/views/verify/fail.html.slim_spec.rb
@@ -6,7 +6,9 @@ describe 'verify/fail.html.slim' do
   context 'when SP is present' do
     before do
       sp = build_stubbed(:service_provider, friendly_name: 'Awesome Application!')
-      @decorated_session = ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context)
+      @decorated_session = ServiceProviderSessionDecorator.new(
+        sp: sp, view_context: view_context, sp_session: {}
+      )
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
 


### PR DESCRIPTION
**Why**: It was only implemented for SAML

--

I opted to pull a lot of the redirect_uri manipulating and checking into a service class. It's kind of a validator and a service, it's a weird in-between, but it encapsulates all the logic around this redirect URI so I'm happy with it for now but open to other opinions

This makes the "Back to SP" link call back to the client