### PR TITLE
Show first name of verified account in nav header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def shared_nav(greeting:)
+    content_for(:nav) do
+      render('shared/nav_auth', greeting: greeting)
+    end
+  end
+
   def title(title)
     content_for(:title) { title }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,4 @@
 module ApplicationHelper
-  def shared_nav(greeting:)
-    content_for(:nav) do
-      render('shared/nav_auth', greeting: greeting)
-    end
-  end
-
   def title(title)
     content_for(:title) { title }
   end

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -1,5 +1,4 @@
-- content_for(:nav) do
-  = render 'shared/nav_auth'
+= shared_nav(greeting: @view_model.header_personalization)
 
 - title t('titles.profile')
 

--- a/app/views/profile/index.html.slim
+++ b/app/views/profile/index.html.slim
@@ -1,4 +1,5 @@
-= shared_nav(greeting: @view_model.header_personalization)
+- content_for(:nav) do
+  = render 'shared/nav_auth', greeting: @view_model.header_personalization
 
 - title t('titles.profile')
 

--- a/app/views/shared/_nav_auth.html.slim
+++ b/app/views/shared/_nav_auth.html.slim
@@ -11,6 +11,6 @@ nav.bg-white
         span.sm-display-inline-block.display-none.border-right.border-silver.pr1
           = t('shared.nav_auth.welcome')
           '
-          span.bold = current_user.email
+          span.bold = greeting
         = link_to t('links.sign_out'), destroy_user_session_path,
           class: 'px1'

--- a/spec/view_models/profile_index_spec.rb
+++ b/spec/view_models/profile_index_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe ProfileIndex do
+  let(:fake_pii) { Struct.new(:first_name) }
+  let(:user) { build_stubbed(:user) }
+  let(:decorated_user) { user.decorate }
+  let(:decrypted_pii) { fake_pii.new('Alex') }
+
+  describe '#header_personalization' do
+    it 'returns an email address when user does not have a verified profile' do
+      view_model = ProfileIndex.new(
+        decrypted_pii: nil,
+        personal_key: nil,
+        decorated_user: decorated_user
+      )
+
+      expect(view_model.header_personalization).to eq(user.email)
+    end
+
+    it 'returns the users first name when they have a verified profile' do
+      view_model = ProfileIndex.new(
+        decrypted_pii: decrypted_pii,
+        personal_key: nil,
+        decorated_user: decorated_user
+      )
+
+      expect(view_model.header_personalization).to eq('Alex')
+    end
+  end
+end

--- a/spec/views/shared/_nav_auth.html.slim_spec.rb
+++ b/spec/views/shared/_nav_auth.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'shared/_nav_auth.html.slim' do
     before do
       @user = build_stubbed(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(@user)
+      allow(view).to receive(:greeting).and_return(@user.email)
       render
     end
 


### PR DESCRIPTION
**Why**: The designs specified that we should show the email of a
user in the nav auth header, and the user's first name when the account
is verified

Screenshots:

**verified**
![screen shot 2017-04-25 at 12 48 57 pm](https://cloud.githubusercontent.com/assets/1421848/25397235/9f139e28-29b5-11e7-81d8-e2610cf3f2e0.png)

**unverified**
![screen shot 2017-04-25 at 12 52 38 pm](https://cloud.githubusercontent.com/assets/1421848/25397396/1f5ab242-29b6-11e7-8195-11507fd624fb.png)

