### PR TITLE
Adds missing .svg extension to success icon

### DIFF
--- a/app/views/profile/_verified_account_badge.html.slim
+++ b/app/views/profile/_verified_account_badge.html.slim
@@ -1,5 +1,5 @@
 .sm-col.sm-col-4.mt1.sm-mt0.relative
   .verification-badge.mx-auto
     span
-      = image_tag asset_url('alert/success'), width: 16, class: 'mr1 align-middle'
+      = image_tag asset_url('alert/success.svg'), width: 16, class: 'mr1 align-middle'
       = t('headings.profile.verified_account')


### PR DESCRIPTION
**Why**: Not having the extension was causing the asset not to get
precompiled by rails, thereby displaying a broken image on int