### PR TITLE
Set SameSite=Lax to fix OIDC CSP issue

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -45,7 +45,7 @@ SecureHeaders::Configuration.default do |config|
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
     samesite: {
-      strict: true # mark all cookies as SameSite=Strict.
+      lax: true # SameSite setting.
     },
   }
 


### PR DESCRIPTION
We received a bug report on our current release candidate in the **int** environment and after a bunch of debugging (https://github.com/18F/identity-private/issues/1915) we found that setting SameSite back to Lax allowed OIDC to work and set the correct CSP headers.

