### PR TITLE
Improve password creation instructions

### DIFF
--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -11,6 +11,8 @@ h1.h3.my0 = t('headings.passwords.change')
   = f.full_error :reset_password_token
   = f.input :password, label: t('forms.passwords.edit.labels.password'), required: true
   = render 'devise/shared/password_strength'
-  = f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb1'
+  = f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3'
+
+= render 'shared/password_accordion'
 
 == javascript_include_tag 'misc/pw-strength'

--- a/app/views/shared/_password_accordion.html.slim
+++ b/app/views/shared/_password_accordion.html.slim
@@ -1,0 +1,2 @@
+= accordion('password-info', t('instructions.password.help_text_header')) do
+  = simple_format(t('instructions.password.help_text'))

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -1,12 +1,8 @@
 - title t('titles.confirmations.show')
 
 h1.h3.my0 = t('forms.confirmation.show_hdr')
-p.my2#password-description
-  strong = t('instructions.password.info.lead', min_length: Devise.password_length.first)
-  | &nbsp;
-  = t('instructions.password.info.point_1')
-p.mb0
-  = t('instructions.password.info.point_2')
+p.mt2.mb0#password-description
+  = t('instructions.password.info.lead', min_length: Devise.password_length.first)
 = simple_form_for(@password_form,
     url: sign_up_create_password_path,
     method: :post,
@@ -16,7 +12,9 @@ p.mb0
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
-  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb1'
+  = f.button :submit, t('forms.buttons.continue'), class: 'btn-wide mb3'
+
+= render 'shared/password_accordion'
 
 = render 'shared/cancel', link: destroy_user_session_path
 

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -9,7 +9,10 @@ p.mt-tiny.mb0#password-description
   = f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
             input_html: { 'aria-describedby': 'password-description' }
   = render 'devise/shared/password_strength'
-  = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2'
+  = f.button :submit, t('forms.buttons.submit.update'), class: 'mt2 mb3'
+
+= render 'shared/password_accordion'
+
 = render 'shared/cancel', link: profile_path
 
 == javascript_include_tag 'misc/pw-strength'

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -21,15 +21,15 @@ en:
       forgot: >
         If you don’t know your current password, you can reset it. Type the email address
         associated with your account to receive more on-screen instructions.
+      help_text_header: Password safety tips
+      help_text: >
+        The longer and more unusual the password, the harder it is to guess. So avoid using common
+        phrases. Also avoid repeating passwords from other online accounts such as banks, email and
+        social media.
       info:
-        lead: Your password must be at least %{min_length} characters long.
-        point_1: >
-          It can be a mix of alphanumeric and special characters and individual
-          words in a phrase.
-        point_2: >
-          Create a password that’s secure, but still easy for you to remember.
-          And don’t use the same one you use with your other online accounts, such as
-          bank, email, and social media.
+        lead: > 
+          It must be at least %{min_length} characters long and not be a commonly used password.
+          That's it!
       strength:
         i: Very weak
         ii: Weak

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -19,15 +19,10 @@ es:
       forgot: >
         Si no sabe su contraseña actual, puede restablecerla. Escriba la dirección de correo electrónico
         asociada a su cuenta para recibir más instrucciones en la pantalla.
+      help_text_header: NOT TRANSLATED YET
+      help_text: NOT TRANSLATED YET
       info:
         lead: Su contraseña debe tener al menos %{min_length} caracteres.
-        point_1: >
-          Puede ser una mezcla de caracteres alfanuméricos y especiales y
-          palabras individuales en una frase.
-        point_2: >
-          Cree una contraseña segura, pero fácil de recordar.
-          No use el mismo que utiliza con otras cuentas en línea, como
-          bancos, correo electrónico y medios sociales.
       strength:
         i: Muy débil
         ii: Débil

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -4,7 +4,7 @@ en:
     account_locked: Account locked
     confirmations:
       new: Resend confirmation instructions for your account
-      show: Create a password for your account
+      show: Choose a password
     edit_info:
       email: Edit your email address
       password: Edit your password

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -15,7 +15,7 @@ feature 'Email confirmation during sign up' do
     expect(page).to have_content t('forms.confirmation.show_hdr')
 
     fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
-    click_button t('forms.buttons.submit.default')
+    click_button t('forms.buttons.continue')
 
     expect(current_url).to eq phone_setup_url
     expect(page).to_not have_content t('devise.confirmations.confirmed_but_must_set_password')

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -5,7 +5,7 @@ feature 'Visitor sets password during signup' do
     create(:user, :unconfirmed)
     confirm_last_user
     fill_in 'password_form_password', with: ''
-    click_button t('forms.buttons.submit.default')
+    click_button t('forms.buttons.continue')
 
     expect(page).to have_content t('errors.messages.blank')
     expect(current_url).to eq sign_up_create_password_url
@@ -20,7 +20,7 @@ feature 'Visitor sets password during signup' do
     it 'does not allow the user to submit the form' do
       fill_in 'password_form_password', with: ''
 
-      expect(page).to_not have_button(t('forms.buttons.submit.default'))
+      expect(page).to_not have_button(t('forms.buttons.continue'))
     end
   end
 
@@ -77,7 +77,7 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
       fill_in 'password_form_password', with: 'Q!2e'
 
-      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
 
       expect(page).to have_content('characters')
       expect(current_url).to eq sign_up_create_password_url
@@ -90,7 +90,7 @@ feature 'Visitor sets password during signup' do
       confirm_last_user
       fill_in 'password_form_password', with: 'password'
 
-      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
 
       expect(page).to have_content t('zxcvbn.feedback.This is a top-10 common password')
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -54,7 +54,7 @@ module Features
     def sign_up_and_set_password
       user = sign_up
       fill_in 'password_form_password', with: VALID_PASSWORD
-      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
       user
     end
 
@@ -335,12 +335,12 @@ module Features
 
     def submit_form_with_invalid_password
       fill_in 'Password', with: 'invalid'
-      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
     end
 
     def submit_form_with_valid_password(password = VALID_PASSWORD)
       fill_in 'Password', with: password
-      click_button t('forms.buttons.submit.default')
+      click_button t('forms.buttons.continue')
     end
 
     def set_up_2fa_with_valid_phone

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -17,8 +17,6 @@ describe 'sign_up/passwords/new.html.slim' do
   end
 
   it 'renders the proper help text' do
-    expect(rendered).to have_content(t('instructions.password.info.point_2'))
-    expect(rendered).to have_content(t('instructions.password.info.point_1'))
     expect(rendered).to have_content(
       t('instructions.password.info.lead', min_length: Devise.password_length.first)
     )


### PR DESCRIPTION
Added an accordion and several small content changes to better explain password requirements.

**New user flow:**
![screen shot 2017-04-27 at 3 40 32 pm](https://cloud.githubusercontent.com/assets/1178494/25502595/3fd2ec50-2b65-11e7-9e4e-c7c5c4cb482f.png)

**Edit password:**
![screen shot 2017-04-27 at 3 39 33 pm](https://cloud.githubusercontent.com/assets/1178494/25502600/445d32d0-2b65-11e7-9b45-9c0b795be909.png)

**Password reset:**
![screen shot 2017-04-27 at 3 37 57 pm](https://cloud.githubusercontent.com/assets/1178494/25502601/47a28abc-2b65-11e7-99b1-7d78fc880e11.png)
