### PR TITLE
Ignore 'allow_on_prod_chef_env' when seeding DB

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,6 @@ service_providers.each do |issuer, config|
     sp.approved = true
     sp.active = true
     sp.native = true
-    sp.attributes = config
+    sp.attributes = config.except('allow_on_prod_chef_env')
   end
 end


### PR DESCRIPTION
**Why**: `allow_on_prod_chef_env` in not a column in the
service_providers table. We don't want to create this column, so we
should ignore this attribute when seeding the DB with new service
providers. Otherwise, running `rake db:seed` will crash because
that column is not present.