### PR TITLE
Update when verification failure page is shown

### DIFF
--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -7,6 +7,8 @@ class VerifyController < ApplicationController
   def index
     if active_profile?
       redirect_to verify_activated_path
+    elsif idv_attempter.exceeded?
+      redirect_to verify_fail_url
     else
       analytics.track_event(Analytics::IDV_INTRO_VISIT)
     end

--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -51,7 +51,7 @@ module Verify
           class: button_css_classes
         )
       else
-        helper.link_to button_link_text, account_path, class: button_css_classes
+        helper.link_to button_link_text, verify_fail_path, class: button_css_classes
       end
     end
 

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -21,6 +21,19 @@ describe VerifyController do
 
       get :index
     end
+
+    it 'redirects to failure page if number of attempts has been exceeded' do
+      profile = create(
+        :profile,
+        user: create(:user, idv_attempts: 3, idv_attempted_at: Time.zone.now)
+      )
+
+      stub_sign_in(profile.user)
+
+      get :index
+
+      expect(response).to redirect_to verify_fail_url
+    end
   end
 
   describe '#activated' do


### PR DESCRIPTION
This PR makes the following changes:

> after failing verification and seeing the red modal, I'm sent to the failed to verify page instead of the profile page
> 
> returning within the 24-hour period to re-verify sends me to the failed to verify page instead of the help us verify you page.