### PR TITLE
Check length of flash message key before display

### DIFF
--- a/app/views/shared/_flashes.html.slim
+++ b/app/views/shared/_flashes.html.slim
@@ -1,4 +1,5 @@
 - if flash.any?
   - flash.to_hash.slice(*ApplicationController::FLASH_KEYS).each do |type, message|
+    - if message.present?
       div class="alert alert-#{type}" role='alert'
         = safe_join([message.html_safe])

--- a/spec/views/shared/_flashes.html.slim_spec.rb
+++ b/spec/views/shared/_flashes.html.slim_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'shared/_flashes.html.slim' do
+  it 'renders nothing when flash key, but not message, is present' do
+    allow(view).to receive(:flash).and_return(error: '')
+    render
+
+    expect(rendered).not_to have_selector('div[role="alert"]')
+  end
+
+  it 'renders a flash message when both key and value are present' do
+    allow(view).to receive(:flash).and_return('error' => 'an error')
+    render
+
+    expect(rendered).to have_selector('div[role="alert"]')
+  end
+end


### PR DESCRIPTION
**Why**: Not checking for the the existence of a message means empty
flash messages can potentially render when devise hits a route that has
an accompanying flash message set to a blank string.

This seemed like the most straightforward way to stop the flash message from appearing. Bug only seems to occur when user enters an invalid personal key three times, then remains on the lockout screen until redirected back to the home page. Devise always calls the '/unauthenticated' route once the user is redirected in this case; that might be behavior we'll want to revisit at some point.