### PR TITLE
Increase header email column size, truncate email

### DIFF
--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -6,6 +6,12 @@
 
 .invisible { visibility: hidden; }
 
+.truncate-inline {
+  max-width: 80%;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 @media #{$breakpoint-sm} {
   // scss-lint:disable ImportantRule
   .sm-display-inline-block { display: inline-block !important; }

--- a/app/views/accounts/_account_item.html.slim
+++ b/app/views/accounts/_account_item.html.slim
@@ -2,7 +2,7 @@
   .col.col-8
     .bold.col.col-12.sm-col-6
       = name
-    .col.col-8.sm-col-6
+    .col.col-12.sm-col-6.truncate
       = content if local_assigns.key? :content
   .col.col-4.right-align
     - if local_assigns.key? :path

--- a/app/views/accounts/_header.html.slim
+++ b/app/views/accounts/_header.html.slim
@@ -1,11 +1,11 @@
 .clearfix.py2.sm-py0.mb2.bg-light-blue.sm-bg-none
   .sm-col.sm-col-8
-    h2.h3.m0.center.sm-left-align
+    h2.h3.my0.mx2.center.sm-left-align
       .sm-hide.regular.sans-serif.inline
         span
           = t('account.welcome')
           ',
-        p.mb0.bold
+        p.mb0.bold.truncate
           = view_model.header_personalization
       span.sm-show
         = t('headings.account.login_info')

--- a/app/views/accounts/_nav_auth.html.slim
+++ b/app/views/accounts/_nav_auth.html.slim
@@ -1,16 +1,19 @@
 nav.bg-white
   .container.px2.sm-py3.pt2.pb0
     .clearfix
-      .mb1.sm-m0.col.col-7
+      .mb1.sm-m0.col.col-4
         = link_to \
           image_tag(asset_url('logo.svg'),
             alt: APP_NAME,
             class: 'align-bottom',
             width: 170), root_path
-      .right-align.col.col-5
-        span.sm-display-inline-block.display-none.border-right.border-silver.pr1
-          = t('account.welcome')
-          '
-          span.bold = greeting
-        = link_to t('links.sign_out'), destroy_user_session_path,
-          class: 'px1'
+      .right-align.col.col-8.sm-display-inline-block.display-none.pr1
+        .inline-block.mr1.truncate-inline
+          p.inline-block.truncate.m0
+            = t('account.welcome')
+            '
+            strong = greeting
+        .inline-block.right.border-silver.border-left
+          p.m0
+            = link_to t('links.sign_out'), destroy_user_session_path,
+              class: 'pl1'


### PR DESCRIPTION
**Why**: Currently, longer emails can break into multiple lines in the
header.

**How**: Increased column size for welcome message+email. Truncate very
long emails. It was necessary to add a truncate wrapper class to the
parent element, since we want to selectively truncate only a portion of
the content, not the entire line.

Screenshots:

**Shorter email**:
<img width="330" alt="screen shot 2017-05-02 at 12 07 55 pm" src="https://cloud.githubusercontent.com/assets/1421848/25627327/33084064-2f30-11e7-90ab-2b091d647997.png">

**Longer email**:
<img width="413" alt="screen shot 2017-05-02 at 12 08 59 pm" src="https://cloud.githubusercontent.com/assets/1421848/25627334/382119e0-2f30-11e7-8e09-323cdb542c98.png">

