### PR TITLE
Update flash message for address verification

### DIFF
--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -23,12 +23,7 @@ module Verify
       @idv_params = idv_params
       analytics.track_event(Analytics::IDV_REVIEW_VISIT)
 
-      phone_of_record_msg = ActionController::Base.helpers.content_tag(
-        :strong, t('idv.messages.phone.phone_of_record')
-      )
-
-      flash.now[:success] = t('idv.messages.review.info_verified_html',
-                              phone_message: phone_of_record_msg)
+      flash.now[:success] = flash_message_content
     end
 
     def create
@@ -38,6 +33,17 @@ module Verify
     end
 
     private
+
+    def flash_message_content
+      if idv_session.address_verification_mechanism == 'usps'
+        t('idv.titles.verify_mail')
+      else
+        phone_of_record_msg = ActionController::Base.helpers.content_tag(
+          :strong, t('idv.messages.phone.phone_of_record')
+        )
+        t('idv.messages.review.info_verified_html', phone_message: phone_of_record_msg)
+      end
+    end
 
     def idv_profile_complete?
       idv_session.profile_confirmation == true

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -170,6 +170,20 @@ describe Verify::ReviewController do
         )
       end
     end
+
+    context 'user chooses address verification' do
+      before do
+        idv_session.address_verification_mechanism = 'usps'
+      end
+
+      it 'displays a helpful flash message to the user' do
+        get :new
+
+        expect(flash.now[:success]).to eq(
+          t('idv.titles.verify_mail')
+        )
+      end
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
This displays the correct flash message when address verification is chosen.

**Before:**
![screen shot 2017-05-02 at 12 08 19 pm](https://cloud.githubusercontent.com/assets/1178494/25627314/258648be-2f30-11e7-8406-9f91f183228f.png)

**After:**
![screen shot 2017-05-02 at 12 07 48 pm](https://cloud.githubusercontent.com/assets/1178494/25627316/287e11fa-2f30-11e7-84df-cc1f8a1912db.png)
