### PR TITLE
Adds USPS completion page and wires up USPS confirmation form

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -42,6 +42,7 @@ module SamlIdpAuthConcern
       loa3: loa3_requested?,
       request_id: @request_id,
       request_url: request.original_url,
+      requested_attributes: requested_attributes,
     }
   end
 

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -122,7 +122,7 @@ module OpenidConnect
         sp_request.issuer = @authorize_form.client_id
         sp_request.loa = @authorize_form.acr_values.sort.max
         sp_request.url = request.original_url
-        sp_request.requested_attributes = @authorize_decorator.requested_attributes
+        sp_request.requested_attributes = requested_attributes
       end
     end
 
@@ -134,7 +134,12 @@ module OpenidConnect
         loa3: @authorize_form.loa3_requested?,
         request_id: @request_id,
         request_url: request.original_url,
+        requested_attributes: requested_attributes,
       }
+    end
+
+    def requested_attributes
+      @_attributes ||= @authorize_decorator.requested_attributes
     end
   end
 end

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -9,9 +9,10 @@ module Users
 
     def create
       @verify_account_form = build_verify_account_form
+
       if @verify_account_form.submit
         flash[:success] = t('account.index.verification.success')
-        redirect_to after_sign_in_path_for(current_user)
+        redirect_to sign_up_completed_url
       else
         render :index
       end

--- a/app/forms/verify_account_form.rb
+++ b/app/forms/verify_account_form.rb
@@ -36,7 +36,7 @@ class VerifyAccountForm
 
   def validate_otp
     return if valid_otp?
-    errors.add :otp, :otp_incorrect
+    errors.add :otp, :confirmation_code_incorrect
   end
 
   def valid_otp?

--- a/app/inputs/inline_input.rb
+++ b/app/inputs/inline_input.rb
@@ -1,0 +1,17 @@
+class InlineInput < SimpleForm::Inputs::StringInput
+  def input(_wrapper_options)
+    input_html_classes.push('col-10 field monospace')
+    template.content_tag(
+      :div, builder.text_field(attribute_name, input_html_options),
+      class: 'col col-12 sm-col-4 mb4 sm-mb0'
+    )
+  end
+
+  def input_type
+    :text
+  end
+
+  def builder
+    @builder ||= :builder
+  end
+end

--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -2,8 +2,11 @@
 
 h1.h3.my0 = t('forms.verify_profile.title')
 p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
+
 = simple_form_for(@verify_account_form, url: verify_account_path,
   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.error :base
-  = f.input :otp, required: true, label: 'Secret code'
-  = f.button :submit, t('forms.verify_profile.submit'), class: 'mb1'
+  = f.input :otp, required: true, label: t('forms.verify_profile.name'), wrapper: :inline_form do
+    = f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10'
+    = f.button :submit, t('forms.verify_profile.submit')
+  end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,9 +1,11 @@
+# rubocop:disable Metrics/BlockLength
 SimpleForm.setup do |config|
   config.button_class = 'btn btn-primary'
   config.boolean_label_class = nil
   config.default_form_class = 'mt3 sm-mt4'
   config.error_notification_tag = :div
   config.error_notification_class = 'alert alert-error'
+  config.wrapper_mappings = { inline: :append }
 
   config.wrappers :base do |b|
     b.use :html5
@@ -23,5 +25,19 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: 'div', class: 'mt-tiny h6 red error-message' }
   end
 
+  config.wrappers :inline_form, tag: 'div' do |b|
+    b.use :label, class: 'bold block'
+    b.wrapper tag: 'div', class: 'col-12 clearfix' do |ba|
+      ba.use :input
+    end
+
+    b.wrapper tag: 'div' do |bb|
+      bb.use :error, wrap_with: { tag: 'span', class: 'mt-tiny h6 red error-message' }
+    end
+
+    b.optional :maxlength
+  end
+
   config.default_wrapper = :vertical_form
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -9,12 +9,13 @@ en:
     messages:
       already_confirmed: was already confirmed, please try signing in
       blank: Please fill in this field.
+      confirmation_code_incorrect: Incorrect code. Did you type it in correctly?
       confirmation_invalid_token: >
-        Invalid confirmation link. Either the link expired or you 
-        already confirmed your account. 
+        Invalid confirmation link. Either the link expired or you
+        already confirmed your account.
       confirmation_period_expired: >
         Expired confirmation link.
-        You can click "Resend confirmation instructions" to get another one. 
+        You can click "Resend confirmation instructions" to get another one.
       expired: has expired, please request a new one
       format_mismatch: Please match the requested format.
       improbable_phone: Invalid phone number. Please make sure you enter a 10-digit phone number.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -10,6 +10,7 @@ es:
     messages:
       already_confirmed: Ya está confirmado, por favor intenta iniciar sesión.
       blank: Por favor, rellenar este campo.
+      confirmation_code_incorrect: NOT TRANSLATED YET
       confirmation_invalid_token:
         El enlace de confirmación en el que ha hecho clic ya no es válido. Esto puede haber
         sido causado al hacer clic en un enlace antiguo de su correo electrónico, o puede ser que ya haya

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -44,6 +44,7 @@ en:
       personal_key: Personal key
       try_again: Use another phone number
     verify_profile:
-      title: Verify your identity
-      submit: Submit
-      instructions: Enter your secret code
+      name: Confirmation code
+      instructions: Enter the ten-character code in the letter we sent you.
+      submit: Confirm account
+      title: Confirm your account

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -43,6 +43,7 @@ es:
       personal_key: Código de recuperación
       try_again: Inténtalo de nuevo
     verify_profile:
+      name: NOT TRANSLATED YET
       title: NOT TRANSLATED YET
       submit: NOT TRANSLATED YET
       instructions: NOT TRANSLATED YET

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -154,7 +154,8 @@ en:
         no_pii: Do not use real personal information (demo purposes only)
       usps:
         bad_address: I can't get mail at this address
-        byline: To activate by mail, we will mail a letter with a confirmation code to your street address.
+        byline: We will mail a letter with a confirmation code to your verified
+          address on file.
         success: It should arrive in 5 to 10 business days.
       personal_details_verified: Personal details verified!
     modal:

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
           loa3: false,
           issuer: 'urn:gov:gsa:openidconnect:test',
           request_id: sp_request_id,
-          request_url: request.original_url
+          request_url: request.original_url,
+          requested_attributes: %w[given_name family_name birthdate]
         )
       end
     end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -295,7 +295,8 @@ describe SamlIdpController do
           loa3: false,
           issuer: saml_settings.issuer,
           request_id: sp_request_id,
-          request_url: @saml_request.request.original_url
+          request_url: @saml_request.request.original_url,
+          requested_attributes: [:email]
         )
       end
 

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -54,10 +54,12 @@ RSpec.describe Users::VerifyAccountController do
     end
 
     context 'with a valid form' do
-      it 'redirects to the account verification page' do
+      let(:success) { true }
+
+      it 'redirects to the sign_up/completions page' do
         action
 
-        expect(response).to redirect_to(verify_account_path)
+        expect(response).to redirect_to(sign_up_completed_url)
       end
     end
 

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -346,29 +346,6 @@ feature 'IdV session' do
       end
     end
 
-    scenario 'pick USPS address verification' do
-      sign_in_and_2fa_user
-      visit verify_session_path
-
-      fill_out_idv_form_ok
-      click_idv_continue
-      fill_out_financial_form_ok
-      click_idv_continue
-      click_idv_address_choose_usps
-      click_on t('idv.buttons.send_letter')
-
-      expect(current_path).to eq verify_review_path
-
-      fill_in :user_password, with: user_password
-      click_submit_default
-
-      expect(current_url).to eq verify_confirmations_url
-      click_acknowledge_personal_key
-
-      expect(current_url).to eq(account_url)
-      expect(page).to have_content(t('account.index.verification.reactivate_button'))
-    end
-
     context 'cancel from USPS/Phone verification screen' do
       context 'without js' do
         it 'returns user to profile path' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -285,11 +285,14 @@ feature 'OpenID Connect' do
 
         sign_in_live_with_2fa(user)
 
-        fill_in 'Secret code', with: otp
+        fill_in t('forms.verify_profile.name'), with: usps_otp_code_for(user)
         click_button t('forms.verify_profile.submit')
-        click_button t('openid_connect.authorization.index.allow')
 
+        expect(current_path).to eq(sign_up_completed_path)
+        find('input').click
+        click_button t('openid_connect.authorization.index.allow')
         redirect_uri = URI(current_url)
+
         expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
       end
     end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -22,7 +22,7 @@ feature 'verify profile with OTP' do
 
       expect(current_path).to eq verify_account_path
 
-      fill_in 'Secret code', with: otp
+      fill_in t('forms.verify_profile.name'), with: otp
       click_button t('forms.verify_profile.submit')
 
       expect(current_path).to eq account_path
@@ -35,11 +35,11 @@ feature 'verify profile with OTP' do
 
     scenario 'wrong OTP used' do
       sign_in_live_with_2fa(user)
-      fill_in 'Secret code', with: 'the wrong code'
+      fill_in t('forms.verify_profile.name'), with: 'the wrong code'
       click_button t('forms.verify_profile.submit')
 
       expect(current_path).to eq verify_account_path
-      expect(page).to have_content(t('errors.messages.otp_incorrect'))
+      expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
       expect(page.body).to_not match('the wrong code')
     end
   end

--- a/spec/forms/verify_account_form_spec.rb
+++ b/spec/forms/verify_account_form_spec.rb
@@ -41,7 +41,7 @@ describe VerifyAccountForm do
 
       it 'is invalid' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:otp]).to eq [t('errors.messages.otp_incorrect')]
+        expect(subject.errors[:otp]).to eq [t('errors.messages.confirmation_code_incorrect')]
       end
     end
   end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -7,6 +7,10 @@ module IdvHelper
     Features::SessionHelper::VALID_PASSWORD
   end
 
+  def usps_otp_code_for(user)
+    user.profiles.first.decrypt_pii(user.unlock_user_access_key(user.password))[:otp]
+  end
+
   def fill_out_idv_form_ok
     fill_in 'profile_first_name', with: 'José'
     fill_in 'profile_last_name', with: 'One'
@@ -59,6 +63,10 @@ module IdvHelper
     fill_in :idv_phone_form_phone, with: '(555) 555-5555'
   end
 
+  def click_idv_begin
+    click_on t('idv.index.continue_link')
+  end
+
   def click_idv_continue
     click_button t('forms.buttons.continue')
   end
@@ -89,7 +97,7 @@ module IdvHelper
     click_idv_address_choose_phone
     fill_out_phone_form_ok(user.phone)
     click_idv_continue
-    fill_in :user_password, with: Features::SessionHelper::VALID_PASSWORD
+    fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_submit_default
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -193,11 +193,10 @@ module Features
       end
     end
 
-    def loa3_sp_session
+    def loa3_sp_session(request_url: 'http://localhost:3000')
       Warden.on_next_request do |proxy|
         session = proxy.env['rack.session']
-        sp = ServiceProvider.from_issuer('http://localhost:3000')
-        session[:sp] = { loa3: true, issuer: sp.issuer }
+        session[:sp] = { loa3: true, request_url: request_url }
       end
     end
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -161,6 +161,15 @@ module SamlAuthHelper
     get(:auth, SAMLRequest: URI.decode(saml_request(settings)))
   end
 
+  def saml_register_loa3_user(email)
+    click_link t('sign_up.registrations.create_account')
+    submit_form_with_valid_email
+    click_confirmation_link_in_email(email)
+    submit_form_with_valid_password
+    set_up_2fa_with_valid_phone
+    enter_2fa_code
+  end
+
   private
 
   def saml_request(settings)


### PR DESCRIPTION
This PR adds a **confirmation page** and fixes up the **confirmation form** in which the user enters the OTP code they received in the mail, when selecting USPS verification.

**Confirmation screen**:
![screen shot 2017-05-09 at 11 05 05 am](https://cloud.githubusercontent.com/assets/1421848/25949312/1af8f2d8-3625-11e7-8447-678f322422fa.png)

**Code confirmation form**:
![screen shot 2017-05-11 at 8 35 22 am](https://cloud.githubusercontent.com/assets/1421848/25949300/07eebd6c-3625-11e7-8c05-11ea79384c94.png)

Manual testing is a bit cumbersome:

1). Sign in / create an account via a service provider (LOA3)
2). Fill in all the personal info, select USPS delivery
3). Enter your password, confirm your personal key
4). Manually go to /account (necessary because of an existing bug)
5). Click the pending profile alert
6). In your rails console, find your user, decrypt your pii and copy the `otp` code
7. Enter that code into the form on step 6
8. View the confirmation page

I'm marking this as ready for review although I suspect there will be some cleanup to do

EDIT: I added a screenshot for the confirmation page. I also tried to make it clearer that two pages were updated.
