### PR TITLE
Update content on /verify/

### DIFF
--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -36,7 +36,7 @@ module Verify
 
     def flash_message_content
       if idv_session.address_verification_mechanism == 'usps'
-        t('idv.titles.verify_mail')
+        t('idv.messages.mail_sent')
       else
         phone_of_record_msg = ActionController::Base.helpers.content_tag(
           :strong, t('idv.messages.phone.phone_of_record')

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -7,7 +7,7 @@ en:
       continue: Continue identity verification
       cancel: Cancel and return to your profile
       help: Continue to Help Center
-      send_letter: Send letter
+      send_letter: Send a letter
     cancel:
       modal_header: Are you sure you want to cancel?
       warning_header: If you cancel now
@@ -125,6 +125,7 @@ en:
       hardfail: We can’t verify your identity right now.
       hardfail4: You can also go to %{sp} for more help in accessing services.
       help_center: Visit our Help Center to learn more about verifying your account.
+      mail_sent: Your letter is on its way
       phone:
         alert: This phone line must be
         in_your_name: in your name or a family member's name
@@ -153,8 +154,7 @@ en:
         no_pii: Do not use real personal information (demo purposes only)
       usps:
         bad_address: I can't get mail at this address
-        byline: We will mail a letter with a confirmation code to your verified
-          address on file.
+        byline: To activate by mail, we will mail a letter with a confirmation code to your street address.
         success: It should arrive in 5 to 10 business days.
       personal_details_verified: Personal details verified!
     modal:
@@ -205,4 +205,4 @@ en:
       session:
         phone: Get a code by telephone
         review: Encrypt your verified data by entering your password
-      verify_mail: Your letter is on its way
+      verify_mail: Want a letter?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -96,6 +96,7 @@ es:
       hardfail: NOT TRANSLATED YET
       hardfail4: NOT TRANSLATED YET
       help_center: NOT TRANSLATED YET
+      mail_sent: NOT TRANSLATED YET
       phone:
         alert: NOT TRANSLATED YET
         in_your_name: NOT TRANSLATED YET

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -180,7 +180,7 @@ describe Verify::ReviewController do
         get :new
 
         expect(flash.now[:success]).to eq(
-          t('idv.titles.verify_mail')
+          t('idv.messages.mail_sent')
         )
       end
     end


### PR DESCRIPTION
Addresses confusion around the LOA3 verification flow. I made content changes based on [this comment](https://github.com/18F/identity-private/issues/2017#issuecomment-300222964) by @esgoodman.

### Previous confusing text. "Your letter is on its way" and "Send letter" don't make sense together
![screen shot 2017-05-09 at 2 35 17 pm](https://cloud.githubusercontent.com/assets/4803473/25870380/7c253c36-34c9-11e7-8558-dce3271d0a02.png)

---

### Updated version
![screen shot 2017-05-09 at 2 36 04 pm](https://cloud.githubusercontent.com/assets/4803473/25870344/66672c2e-34c9-11e7-82a4-7a3409e2c504.png)

---

### "Your letter is on its way" still flashes after you send letter
![screen shot 2017-05-09 at 3 05 20 pm](https://cloud.githubusercontent.com/assets/4803473/25870517/ef27b68c-34c9-11e7-8cfa-d060caaacda6.png)
