### PR TITLE
Start page visual adjustments

### DIFF
--- a/app/views/sign_up/registrations/_sp_registration_heading.html.slim
+++ b/app/views/sign_up/registrations/_sp_registration_heading.html.slim
@@ -1,5 +1,5 @@
 h1.h3.mb3.blue.regular
   strong
-    = t('headings.create_account_with_sp.sp_text', sp: decorated_session.sp_name)
-    '
-  = t('headings.create_account_with_sp.app_text')
+    = decorated_session.sp_name
+  '
+  = t('headings.create_account_with_sp.sp_text')

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -1,17 +1,17 @@
 - title t('titles.registrations.start')
 
-.px4.mt2.mb0.center
+.sm-px4.mt2.mb0.center
   = image_tag(asset_url('user-access.svg'), width: '352', alt: '')
 
   = render decorated_session.registration_heading
 
   = link_to t('sign_up.registrations.create_account'),
     sign_up_email_path(request_id: params[:request_id]),
-    class: 'sm-col-10 col-12 btn btn-primary btn-wide mb1 fs-20p'
+    class: 'sm-col-10 col-12 btn btn-primary btn-wide mb2 fs-20p'
 
   = link_to t('links.sign_in'),
     new_user_session_path(request_id: params[:request_id]),
-    class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb1 fs-20p'
+    class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb2 fs-20p'
 
 - if loa3_requested?
   = render 'required_pii_accordion'

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -4,8 +4,7 @@ en:
     confirmations:
       new: Send another confirmation email
     create_account_with_sp:
-      sp_text: '%{sp} is using login.gov'
-      app_text: ' to make signing in easy and secure.'
+      sp_text: is using login.gov to make signing in easy and secure.
     create_account_without_sp: Create a login.gov account
     edit_info:
       email: Change your email

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -5,7 +5,6 @@ es:
       new: Enviar otro correo electrónico de confirmación
     create_account_with_sp:
       sp_text: NOT TRANSLATED YET
-      app_text: NOT TRANSLATED YET
     create_account_without_sp: Crear una cuenta de login.gov
     edit_info:
       email: Cambiar su correo electrónico

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -224,8 +224,8 @@ feature 'OpenID Connect' do
         )
 
         sp_content = [
-          t('headings.create_account_with_sp.sp_text', sp: 'Example iOS App'),
-          t('headings.create_account_with_sp.app_text'),
+          'Example iOS App',
+          t('headings.create_account_with_sp.sp_text'),
         ].join(' ')
 
         expect(page).to have_content(sp_content)

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -49,8 +49,8 @@ feature 'LOA1 Single Sign On' do
     it 'shows user the start page without accordion' do
       saml_authn_request = auth_request.create(saml_settings)
       sp_content = [
-        t('headings.create_account_with_sp.sp_text', sp: 'Your friendly Government Agency'),
-        t('headings.create_account_with_sp.app_text'),
+        'Your friendly Government Agency',
+        t('headings.create_account_with_sp.sp_text'),
       ].join(' ')
 
       visit saml_authn_request

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -38,8 +38,8 @@ feature 'LOA3 Single Sign On' do
     it 'shows user the start page with accordion' do
       saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
       sp_content = [
-        t('headings.create_account_with_sp.sp_text', sp: 'Test SP'),
-        t('headings.create_account_with_sp.app_text'),
+        'Test SP',
+        t('headings.create_account_with_sp.sp_text'),
       ].join(' ')
 
       visit saml_authn_request

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -41,9 +41,9 @@ describe 'sign_up/registrations/show.html.slim' do
       render
 
       sp_content = [
-        t('headings.create_account_with_sp.sp_text', sp: @sp.friendly_name),
-        t('headings.create_account_with_sp.app_text'),
-      ].join('')
+        @sp.friendly_name,
+        t('headings.create_account_with_sp.sp_text'),
+      ].join(' ')
 
       expect(rendered).to have_content(sp_content)
     end


### PR DESCRIPTION
Small adjustments to spacing of the start page to better accommodate mobile users. Also updating the SP name to be bolded as requested.

![screen shot 2017-05-09 at 5 30 49 pm](https://cloud.githubusercontent.com/assets/1178494/25873641/4ca834c2-34dd-11e7-9b0f-64580007a053.png)

