### PR TITLE
Enable Rack Attack if email sending isn't disabled

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module Upaya
     config.autoload_paths << Rails.root.join('app', 'mailers', 'concerns')
     config.time_zone = 'UTC'
 
-    config.middleware.use Rack::Attack unless Figaro.env.enable_load_testing_mode == 'true'
+    config.middleware.use Rack::Attack unless Figaro.env.disable_email_sending == 'true'
 
     config.browserify_rails.force = true
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'


### PR DESCRIPTION
**Why**: There might have been an incident where load testing was
performed on a server that didn't have email sending disabled.
Deciding whether or not to disable Rack Attack based on whether or
not email sending is disabled will help reduce the effect of future
incidents because the script will get throttled if email
sending is not disabled.