### PR TITLE
Only render New Relic javascript if key and app ID are present

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -39,7 +39,7 @@ html lang="#{I18n.locale}" class='no-js'
 
     - if Figaro.env.google_analytics_key.present?
       = render 'shared/google_analytics/page_tracking'
-    - if Figaro.env.newrelic_browser_key.present?
+    - if Figaro.env.newrelic_browser_key.present? && Figaro.env.newrelic_browser_app_id.present?
       = render 'shared/newrelic/browser_instrumentation'
 
   body class="#{Rails.env}-env site sm-bg-light-blue"

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -110,4 +110,26 @@ describe 'layouts/application.html.slim' do
       expect(view).not_to render_template(partial: 'shared/_dap_analytics')
     end
   end
+
+  context 'when new relic browser key and app id are present' do
+    it 'it render the new relic javascript' do
+      allow(Figaro.env).to receive(:newrelic_browser_key).and_return('foo')
+      allow(Figaro.env).to receive(:newrelic_browser_app_id).and_return('foo')
+
+      render
+
+      expect(view).to render_template(partial: 'shared/newrelic/_browser_instrumentation')
+    end
+  end
+
+  context 'when new relic browser key and app id are not present' do
+    it 'it does not render the new relic javascript' do
+      allow(Figaro.env).to receive(:newrelic_browser_key).and_return('')
+      allow(Figaro.env).to receive(:newrelic_browser_app_id).and_return('')
+
+      render
+
+      expect(view).to_not render_template(partial: 'shared/newrelic/_browser_instrumentation')
+    end
+  end
 end


### PR DESCRIPTION
Having `newrelic_browser_app_id` undefined was causing some issues with the app's javascript.  This adds an additional check to make sure the ID is defined, otherwise doesn't render the New Relic javascript.