### PR TITLE
Revert "Remove environments from Capistrano"

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,0 +1,1 @@
+set :bastion_host, 'jumphost.dev.login.gov'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,1 @@
+set :bastion_host, 'jumphost.qa.login.gov'


### PR DESCRIPTION
This reverts commit f0df213c2cf8ba360807eb6ea7634c4f0bed6191.

**Why**: Was pushed to master accidentally without peer review