### PR TITLE
Remove environments from Capistrano

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,1 +1,0 @@
-set :bastion_host, 'jumphost.dev.login.gov'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,0 @@
-set :bastion_host, 'jumphost.qa.login.gov'


### PR DESCRIPTION
**Why**: We deploy these via Jenkins now

--

Removing these files means capistrano will think the environments don't exist, so we can't accidentally try to deploy via capistrano to QA or DEV