### PR TITLE
Use base airbnb-eslint to avoid react linters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  'extends': 'airbnb',
+  'extends': 'airbnb-base',
   'parser': 'babel-eslint',
   'env': {
     'browser': true,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.3",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",
@@ -25,7 +26,8 @@
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^3.19.0",
-    "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-import": "^2.2.0",
     "proxyquireify": "^3.2.1"
   }
 }


### PR DESCRIPTION
**Why**: Eslint wasn't runnung properly locally because of missing peer
dependencies, we also had an unment peer dependency warning for plugins
we didn't need or use

If you pull this down and run locally, make sure to run:

```
npm cache clean
rm -rf node_modules
npm install
```

before `make lint`