### PR TITLE
Add feature flag to prepopulate USPS code

### DIFF
--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -5,6 +5,9 @@ module Users
 
     def index
       @verify_account_form = VerifyAccountForm.new(user: current_user)
+
+      return unless FeatureManagement.reveal_usps_code?
+      @code = JSON.parse(user_session[:decrypted_pii])['otp']['raw']
     end
 
     def create

--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -7,6 +7,5 @@ p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.error :base
   = f.input :otp, required: true, label: t('forms.verify_profile.name'), wrapper: :inline_form do
-    = f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10'
+    = f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10', value: @code
     = f.button :submit, t('forms.verify_profile.submit')
-  end

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,6 +1,10 @@
 class FeatureManagement
   PT_DOMAIN_NAME = 'idp.pt.login.gov'.freeze
 
+  ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED = %w[
+    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov
+  ].freeze
+
   def self.telephony_disabled?
     Figaro.env.telephony_disabled == 'true'
   end
@@ -42,5 +46,13 @@ class FeatureManagement
 
   def self.enable_identity_verification?
     Figaro.env.enable_identity_verification == 'true'
+  end
+
+  def self.reveal_usps_code?
+    Rails.env.development? || current_env_allowed_to_see_usps_code?
+  end
+
+  def self.current_env_allowed_to_see_usps_code?
+    ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED.include?(Figaro.env.domain_name)
   end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -281,11 +281,12 @@ feature 'OpenID Connect' do
       let(:phone_confirmed) { false }
 
       it 'prompts to finish verifying profile, then redirects to SP' do
+        allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
+
         visit oidc_auth_url
 
         sign_in_live_with_2fa(user)
 
-        fill_in t('forms.verify_profile.name'), with: usps_otp_code_for(user)
         click_button t('forms.verify_profile.submit')
 
         expect(current_path).to eq(sign_up_completed_path)

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -160,13 +160,14 @@ feature 'LOA3 Single Sign On' do
       let(:phone_confirmed) { false }
 
       it 'prompts for confirmation code at sign in' do
+        allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
+
         saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
         visit saml_authn_request
         sign_in_live_with_2fa(user)
 
         expect(current_path).to eq verify_account_path
 
-        fill_in t('forms.verify_profile.name'), with: usps_otp_code_for(user)
         click_button t('forms.verify_profile.submit')
 
         expect(current_path).to eq(sign_up_completed_path)

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -130,4 +130,33 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#reveal_usps_code?' do
+    context 'server domain name is dev, qa, or int' do
+      it 'returns true' do
+        %w[idp.dev.login.gov idp.int.login.gov idp.qa.login.gov].each do |domain|
+          allow(Figaro.env).to receive(:domain_name).and_return(domain)
+
+          expect(FeatureManagement.reveal_usps_code?).to eq(true)
+        end
+      end
+    end
+
+    context 'Rails env is development' do
+      it 'returns true' do
+        allow(Rails.env).to receive(:development?).and_return(true)
+
+        expect(FeatureManagement.reveal_usps_code?).to eq(true)
+      end
+    end
+
+    context 'Rails env is not development and server is not dev, qa, or int' do
+      it 'returns false' do
+        allow(Rails.env).to receive(:development?).and_return(false)
+        allow(Figaro.env).to receive(:domain_name).and_return('foo.login.gov')
+
+        expect(FeatureManagement.reveal_usps_code?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -7,10 +7,6 @@ module IdvHelper
     Features::SessionHelper::VALID_PASSWORD
   end
 
-  def usps_otp_code_for(user)
-    user.profiles.first.decrypt_pii(user.unlock_user_access_key(user.password))[:otp]
-  end
-
   def fill_out_idv_form_ok
     fill_in 'profile_first_name', with: 'José'
     fill_in 'profile_last_name', with: 'One'


### PR DESCRIPTION
**Why**: To make it easier to test mailing address verification without
having to actually wait to receive a letter from the USPS or having to
grab your code from the database.

The field will be prepopulated by default in development, and on the
following productions servers: dev, int, qa.