### PR TITLE
Return SP user to branded page when canceling

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,4 +1,6 @@
 class ServiceProviderSessionDecorator
+  include Rails.application.routes.url_helpers
+
   DEFAULT_LOGO = 'generic.svg'.freeze
 
   def initialize(sp:, view_context:, sp_session:)
@@ -45,6 +47,10 @@ class ServiceProviderSessionDecorator
     else
       sp.return_to_sp_url
     end
+  end
+
+  def cancel_link_url
+    sign_up_start_url(request_id: sp_session[:request_id])
   end
 
   private

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -1,4 +1,6 @@
 class SessionDecorator
+  include Rails.application.routes.url_helpers
+
   def return_to_service_provider_partial
     'shared/null'
   end
@@ -28,4 +30,8 @@ class SessionDecorator
   def sp_logo; end
 
   def sp_return_url; end
+
+  def cancel_link_url
+    root_url
+  end
 end

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -13,4 +13,4 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
-= render 'shared/cancel', link: root_path
+= render 'shared/cancel', link: decorated_session.cancel_link_url

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -92,4 +92,15 @@ RSpec.describe ServiceProviderSessionDecorator do
       end
     end
   end
+
+  describe '#cancel_link_url' do
+    it 'returns sign_up_start_url with the request_id as a param' do
+      subject = ServiceProviderSessionDecorator.new(
+        sp: sp, view_context: view_context, sp_session: { request_id: 'foo' }
+      )
+
+      expect(subject.cancel_link_url).
+        to eq 'http://www.example.com/sign_up/start?request_id=foo'
+    end
+  end
 end

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -60,4 +60,10 @@ RSpec.describe SessionDecorator do
       expect(subject.sp_name).to be_nil
     end
   end
+
+  describe '#cancel_link_url' do
+    it 'returns root url' do
+      expect(subject.cancel_link_url).to eq 'http://www.example.com/'
+    end
+  end
 end

--- a/spec/features/saml/loa1/account_creation_spec.rb
+++ b/spec/features/saml/loa1/account_creation_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'Canceling Account Creation' do
+  include SamlAuthHelper
+
+  context 'From the enter email page', email: true do
+    it 'redirects to the branded start page' do
+      authn_request = auth_request.create(saml_settings)
+      visit authn_request
+      sp_request_id = ServiceProviderRequest.last.uuid
+      click_link t('sign_up.registrations.create_account')
+      click_link t('links.cancel')
+
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+    end
+  end
+end

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -6,6 +6,12 @@ describe 'sign_up/registrations/new.html.slim' do
     allow(view).to receive(:controller_name).and_return('registrations')
     allow(view).to receive(:current_user).and_return(nil)
     allow(view).to receive(:request_id).and_return(nil)
+
+    view_context = ActionController::Base.new.view_context
+    @decorated_session = DecoratedSession.new(
+      sp: nil, view_context: view_context, sp_session: {}
+    ).call
+    allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end
 
   it 'has a localized title' do
@@ -29,9 +35,9 @@ describe 'sign_up/registrations/new.html.slim' do
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
 
-  it 'includes a link to return to the home page' do
+  it 'includes a link to return to the decorated_session cancel_link_url' do
     render
 
-    expect(rendered).to have_link(t('links.cancel'), href: root_path)
+    expect(rendered).to have_link(t('links.cancel'), href: @decorated_session.cancel_link_url)
   end
 end


### PR DESCRIPTION
**Why**: If a user came from a Service Provider, then clicks
"Create Account", and clicks "Cancel", they should be taken back
to the branded page they saw originally, as opposed to the non-branded
home page.

Note that this only fixes the link on one page. Fixes for the links
on subsequent pages in the account creation flow will come in a separate
PR.