### PR TITLE
Add OpenID logout URL

### DIFF
--- a/.reek
+++ b/.reek
@@ -17,6 +17,7 @@ FeatureEnvy:
     - EncryptedSidekiqRedis#zrem
     - UserDecorator#should_acknowledge_personal_key?
     - Pii::Attributes#[]=
+    - OpenidConnectLogoutForm#load_identity
 InstanceVariableAssumption:
   exclude:
     - User
@@ -41,6 +42,7 @@ TooManyConstants:
 TooManyInstanceVariables:
   exclude:
     - OpenidConnectAuthorizeForm
+    - OpenidConnectRedirector
 TooManyStatements:
   max_statements: 6
   exclude:

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -1,0 +1,18 @@
+module OpenidConnect
+  class LogoutController < ApplicationController
+    def index
+      @logout_form = OpenidConnectLogoutForm.new(params)
+
+      result = @logout_form.submit
+
+      analytics.track_event(Analytics::OPENID_CONNECT_LOGOUT, result.to_h.except(:redirect_uri))
+
+      if (redirect_uri = result.extra[:redirect_uri])
+        sign_out
+        redirect_to redirect_uri
+      else
+        render :error
+      end
+    end
+  end
+end

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -1,0 +1,92 @@
+class OpenidConnectLogoutForm
+  include ActiveModel::Model
+  include ActionView::Helpers::TranslationHelper
+
+  ATTRS = %i[
+    id_token_hint
+    post_logout_redirect_uri
+    state
+  ].freeze
+
+  attr_reader(*ATTRS)
+
+  RANDOM_VALUE_MINIMUM_LENGTH = OpenidConnectAuthorizeForm::RANDOM_VALUE_MINIMUM_LENGTH
+
+  validates :id_token_hint, presence: true
+  validates :post_logout_redirect_uri, presence: true
+  validates :state, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
+
+  validate :validate_redirect_uri
+  validate :validate_identity
+
+  def initialize(params)
+    ATTRS.each do |key|
+      instance_variable_set(:"@#{key}", params[key])
+    end
+
+    @identity = load_identity
+    @openid_connect_redirector = build_openid_connect_redirector
+  end
+
+  def submit
+    @success = valid?
+
+    identity.deactivate if success
+
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+  end
+
+  private
+
+  attr_reader :identity,
+              :openid_connect_redirector,
+              :success
+
+  def load_identity
+    payload, _headers = JWT.decode(id_token_hint, RequestKeyManager.private_key.public_key, true,
+                                   algorithm: 'RS256').map(&:with_indifferent_access)
+    Identity.where(
+      uuid: payload[:sub],
+      service_provider: payload[:aud]
+    ).first
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def build_openid_connect_redirector
+    OpenidConnectRedirector.new(
+      redirect_uri: post_logout_redirect_uri,
+      service_provider: service_provider,
+      state: state,
+      errors: errors,
+      error_attr: :post_logout_redirect_uri
+    )
+  end
+
+  def validate_redirect_uri
+    openid_connect_redirector.validate
+  end
+
+  def validate_identity
+    errors.add(:id_token_hint, t('openid_connect.logout.errors.id_token_hint')) unless identity
+  end
+
+  def service_provider
+    @_service_provider ||= ServiceProvider.from_issuer(identity&.service_provider)
+  end
+
+  def extra_analytics_attributes
+    {
+      client_id: service_provider.issuer,
+      redirect_uri: redirect_uri,
+    }
+  end
+
+  def redirect_uri
+    if success
+      openid_connect_redirector.logout_redirect_uri
+    else
+      openid_connect_redirector.error_redirect_uri
+    end
+  end
+end

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -22,6 +22,7 @@ class OpenidConnectConfigurationPresenter
       service_documentation: 'https://pages.18f.gov/identity-dev-docs/',
       token_endpoint: api_openid_connect_token_url,
       userinfo_endpoint: api_openid_connect_userinfo_url,
+      end_session_endpoint: openid_connect_logout_url,
     }
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -58,6 +58,7 @@ class Analytics
   OPENID_CONNECT_ALLOW = 'OpenID Connect: allow app'.freeze
   OPENID_CONNECT_BEARER_TOKEN = 'OpenID Connect: bearer token authentication'.freeze
   OPENID_CONNECT_DECLINE = 'OpenID Connect: decline app'.freeze
+  OPENID_CONNECT_LOGOUT = 'OpenID Connect: logout'.freeze
   OPENID_CONNECT_REQUEST_AUTHORIZATION = 'OpenID Connect: authorization request'.freeze
   OPENID_CONNECT_TOKEN = 'OpenID Connect: token'.freeze
   PASSWORD_CHANGED = 'Password Changed'.freeze

--- a/app/services/openid_connect_redirector.rb
+++ b/app/services/openid_connect_redirector.rb
@@ -11,11 +11,12 @@ class OpenidConnectRedirector
     )
   end
 
-  def initialize(redirect_uri:, service_provider:, state:, errors: nil)
+  def initialize(redirect_uri:, service_provider:, state:, errors: nil, error_attr: :redirect_uri)
     @redirect_uri = redirect_uri
     @service_provider = service_provider
     @state = state
     @errors = errors
+    @error_attr = error_attr
   end
 
   def validate
@@ -44,19 +45,23 @@ class OpenidConnectRedirector
     )
   end
 
+  def logout_redirect_uri
+    URIService.add_params(validated_input_redirect_uri, state: state)
+  end
+
   private
 
-  attr_reader :redirect_uri, :service_provider, :state, :errors
+  attr_reader :redirect_uri, :service_provider, :state, :errors, :error_attr
 
   def validate_redirect_uri
     _uri = URI(redirect_uri)
   rescue ArgumentError, URI::InvalidURIError
-    errors.add(:redirect_uri, t('openid_connect.authorization.errors.redirect_uri_invalid'))
+    errors.add(error_attr, t('openid_connect.authorization.errors.redirect_uri_invalid'))
   end
 
   def validate_redirect_uri_matches_sp_redirect_uri
     return if redirect_uri_matches_sp_redirect_uri?
-    errors.add(:redirect_uri, t('openid_connect.authorization.errors.redirect_uri_no_match'))
+    errors.add(error_attr, t('openid_connect.authorization.errors.redirect_uri_no_match'))
   end
 
   def redirect_uri_matches_sp_redirect_uri?

--- a/app/views/openid_connect/logout/error.html.slim
+++ b/app/views/openid_connect/logout/error.html.slim
@@ -1,0 +1,3 @@
+ul
+  - @logout_form.errors.full_messages.each do |message|
+    li = message

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -21,3 +21,6 @@ en:
         no_authorization: No Authorization header provided
         malformed_authorization: Malformed Authorization header
         not_found: Could not find authorization for the contents of the provided access_token or it may have expired
+    logout:
+      errors:
+        id_token_hint: id_token_hint was not recognized

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -16,6 +16,9 @@ es:
         invalid_authentication: NOT TRANSLATED YET
         invalid_code: NOT TRANSLATED YET
         invalid_code_verifier: NOT TRANSLATED YET
+    logout:
+      errors:
+        id_token_hint: NOT TRANSLATED YET
     user_info:
       errors:
         no_authorization: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
        as: :openid_connect_allow
   delete '/openid_connect/authorize' => 'openid_connect/authorization#destroy',
          as: :openid_connect_deny
+  get '/openid_connect/logout' => 'openid_connect/logout#index'
 
   get '/otp/send' => 'users/two_factor_authentication#send_code'
   get '/phone_setup' => 'users/two_factor_authentication_setup#index'

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe OpenidConnect::LogoutController do
+  let(:state) { SecureRandom.hex }
+  let(:code) { SecureRandom.uuid }
+  let(:post_logout_redirect_uri) { 'gov.gsa.openidconnect.test://result/logout' }
+
+  let(:user) { build(:user) }
+  let(:service_provider) { 'urn:gov:gsa:openidconnect:test' }
+  let(:identity) do
+    create(:identity,
+           service_provider: service_provider,
+           user: user,
+           access_token: SecureRandom.hex,
+           session_uuid: SecureRandom.uuid)
+  end
+
+  let(:id_token_hint) do
+    IdTokenBuilder.new(
+      identity: identity,
+      code: code,
+      custom_expiration: 1.day.from_now.to_i
+    ).id_token
+  end
+
+  describe '#index' do
+    subject(:action) do
+      get :index,
+          id_token_hint: id_token_hint,
+          post_logout_redirect_uri: post_logout_redirect_uri,
+          state: state
+    end
+
+    context 'user is signed in' do
+      before { sign_in user }
+
+      context 'with valid params' do
+        it 'destroys the session' do
+          expect(controller).to receive(:sign_out).and_call_original
+
+          action
+        end
+
+        it 'redirects back to the client' do
+          action
+
+          expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+        end
+
+        it 'tracks analytics' do
+          stub_analytics
+          expect(@analytics).to receive(:track_event).
+            with(Analytics::OPENID_CONNECT_LOGOUT,
+                 success: true, client_id: service_provider, errors: {})
+
+          action
+        end
+      end
+
+      context 'with a bad redirect URI' do
+        let(:post_logout_redirect_uri) { 'https://example.com' }
+
+        it 'renders an error page' do
+          action
+
+          expect(response).to render_template(:error)
+        end
+
+        it 'does not destroy the session' do
+          expect(controller).to_not receive(:sign_out)
+
+          action
+        end
+
+        it 'tracks analytics' do
+          stub_analytics
+          expect(@analytics).to receive(:track_event).
+            with(Analytics::OPENID_CONNECT_LOGOUT,
+                 success: false,
+                 client_id: service_provider,
+                 errors: hash_including(:post_logout_redirect_uri))
+
+          action
+        end
+      end
+    end
+
+    context 'user is not signed in' do
+      it 'redirects back with an error' do
+        action
+
+        expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
+      end
+    end
+  end
+end

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+RSpec.describe OpenidConnectLogoutForm do
+  let(:state) { SecureRandom.hex }
+  let(:code) { SecureRandom.uuid }
+  let(:post_logout_redirect_uri) { 'gov.gsa.openidconnect.test://result/logout' }
+
+  let(:service_provider) { 'urn:gov:gsa:openidconnect:test' }
+  let(:identity) do
+    create(:identity,
+           service_provider: service_provider,
+           user: build(:user),
+           access_token: SecureRandom.hex,
+           session_uuid: SecureRandom.uuid)
+  end
+
+  let(:id_token_hint) do
+    IdTokenBuilder.new(
+      identity: identity,
+      code: code,
+      custom_expiration: 1.day.from_now.to_i
+    ).id_token
+  end
+
+  subject(:form) do
+    OpenidConnectLogoutForm.new(
+      id_token_hint: id_token_hint,
+      post_logout_redirect_uri: post_logout_redirect_uri,
+      state: state
+    )
+  end
+
+  describe '#submit' do
+    subject(:result) { form.submit }
+
+    context 'with a valid form' do
+      it 'deactivates the identity' do
+        expect { result }.to change { identity.reload.session_uuid }.to(nil)
+      end
+
+      it 'has a redirect URI without errors' do
+        expect(URIService.params(result.extra[:redirect_uri])).to_not have_key(:error)
+      end
+
+      it 'has a successful response' do
+        expect(result).to be_success
+      end
+    end
+
+    context 'with an invalid form' do
+      let(:state) { nil }
+
+      it 'is not successful' do
+        expect(result).to_not be_success
+      end
+
+      it 'has an error code in the redirect URI' do
+        expect(URIService.params(result.extra[:redirect_uri])[:error]).to eq('invalid_request')
+      end
+    end
+  end
+
+  describe '#valid?' do
+    subject(:valid?) { form.valid? }
+
+    context 'validating state' do
+      context 'when state is missing' do
+        let(:state) { nil }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:state]).to be_present
+        end
+      end
+
+      context 'when state is shorter than the minimum length' do
+        let(:state) { 'a' }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:state]).to be_present
+        end
+      end
+    end
+
+    context 'validating id_token_hint' do
+      context 'without an id_token_hint' do
+        let(:id_token_hint) { nil }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:id_token_hint]).to be_present
+        end
+      end
+
+      context 'with an id_token_hint that is not a JWT' do
+        let(:id_token_hint) { 'asdasd' }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:id_token_hint]).
+            to include(t('openid_connect.logout.errors.id_token_hint'))
+        end
+      end
+
+      context 'with a payload that does not correspond to an identity' do
+        let(:id_token_hint) do
+          JWT.encode({ sub: '123', aud: '456' }, RequestKeyManager.private_key, 'RS256')
+        end
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:id_token_hint]).
+            to include(t('openid_connect.logout.errors.id_token_hint'))
+        end
+      end
+    end
+
+    context 'post_logout_redirect_uri' do
+      context 'without a post_logout_redirect_uri' do
+        let(:post_logout_redirect_uri) { nil }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:post_logout_redirect_uri]).to be_present
+        end
+      end
+
+      context 'with URI that does not match what is registered' do
+        let(:post_logout_redirect_uri) { 'https://example.com' }
+
+        it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:post_logout_redirect_uri]).
+            to include(t('openid_connect.authorization.errors.redirect_uri_no_match'))
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe OpenidConnectConfigurationPresenter do
         expect(configuration[:authorization_endpoint]).to eq(openid_connect_authorize_url)
         expect(configuration[:token_endpoint]).to eq(api_openid_connect_token_url)
         expect(configuration[:userinfo_endpoint]).to eq(api_openid_connect_userinfo_url)
+        expect(configuration[:end_session_endpoint]).to eq(openid_connect_logout_url)
         expect(configuration[:jwks_uri]).to eq(api_openid_connect_certs_url)
         expect(configuration[:service_documentation]).to eq('https://pages.18f.gov/identity-dev-docs/')
         expect(configuration[:response_types_supported]).to eq(%w[code])

--- a/spec/services/openid_connect_redirector_spec.rb
+++ b/spec/services/openid_connect_redirector_spec.rb
@@ -88,4 +88,11 @@ RSpec.describe OpenidConnectRedirector do
                                     error_description: 'some attribute is missing'))
     end
   end
+
+  describe '#logout_redirect_uri' do
+    it 'adds the state to the URL' do
+      expect(redirector.logout_redirect_uri).
+        to eq(URIService.add_params(redirect_uri, state: state))
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
Support RP-initiated logouts and implement this part of the spec:   https://openid.net/specs/openid-connect-session-1_0.html#RPLogout