### PR TITLE
Add return to SP link to start page

### DIFF
--- a/app/views/devise/sessions/_return_to_service_provider.html.slim
+++ b/app/views/devise/sessions/_return_to_service_provider.html.slim
@@ -1,4 +1,4 @@
 .sm-col.py1.sm-p0
-  = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
+  = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
     decorated_session.sp_return_url,
     class: 'inline-block truncate align-bottom sm-maxw-190p'

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -11,7 +11,11 @@
 
   = link_to t('links.sign_in'),
     new_user_session_path(request_id: params[:request_id]),
-    class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb2 fs-20p'
+    class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb1 fs-20p'
+
+  .sm-col-10.col-12.mx-auto
+    p = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
+                  decorated_session.sp_return_url
 
 - if loa3_requested?
   = render 'required_pii_accordion'

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   links:
-    back_to_sp: "‹ Back to %{sp}"
+    back_to_sp: Back to %{sp}
     contact: Contact
     copy: Copy
     create_account: Create account

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -1,7 +1,7 @@
 ---
 es:
   links:
-    back_to_sp: "‹ Volver a %{sp}"
+    back_to_sp: "Volver a %{sp}"
     contact: Contactar
     copy: NOT TRANSLATED YET
     create_account: Crear cuenta

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -12,6 +12,10 @@ describe 'sign_up/registrations/show.html.slim' do
       expect(rendered).to have_content(
         t('headings.create_account_without_sp', sp: nil)
       )
+
+      expect(rendered).not_to have_link(
+        t('links.back_to_sp_alt', sp: 'Awesome Application!')
+      )
     end
 
     it 'has a localized title' do
@@ -30,11 +34,16 @@ describe 'sign_up/registrations/show.html.slim' do
 
   context 'when SP is present' do
     before do
-      @sp = build_stubbed(:service_provider, friendly_name: 'Awesome Application!')
-      view_context = ActionController::Base.new.view_context
-      allow(view).to receive(:decorated_session).and_return(
-        ServiceProviderSessionDecorator.new(sp: @sp, view_context: view_context, sp_session: {})
+      @sp = build_stubbed(
+        :service_provider,
+        friendly_name: 'Awesome Application!',
+        return_to_sp_url: 'www.awesomeness.com'
       )
+      view_context = ActionController::Base.new.view_context
+      @decorated_session = DecoratedSession.new(
+        sp: @sp, view_context: view_context, sp_session: {}
+      ).call
+      allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
 
     it 'includes sp-specific copy' do
@@ -46,6 +55,15 @@ describe 'sign_up/registrations/show.html.slim' do
       ].join(' ')
 
       expect(rendered).to have_content(sp_content)
+    end
+
+    it 'displays a back to sp link' do
+      render
+
+      expect(rendered).to have_link(
+        t('links.back_to_sp', sp: 'Awesome Application!'),
+        href: @decorated_session.sp_return_url
+      )
     end
   end
 end


### PR DESCRIPTION
Adds a link on the initial sign up start page that allows users to return to the SP.

![screen shot 2017-05-18 at 2 41 59 pm](https://cloud.githubusercontent.com/assets/1178494/26218174/0f7e8b94-3bd8-11e7-88f0-d128db32004f.png)
