### PR TITLE
Allow user to send another letter in USPS verification flow

### DIFF
--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -4,6 +4,8 @@ module Users
     before_action :confirm_verification_needed
 
     def index
+      usps_mail = Idv::UspsMail.new(current_user)
+      @mail_spammed = usps_mail.mail_spammed?
       @verify_account_form = VerifyAccountForm.new(user: current_user)
 
       return unless FeatureManagement.reveal_usps_code?

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -23,7 +23,13 @@ module Verify
       @idv_params = idv_params
       analytics.track_event(Analytics::IDV_REVIEW_VISIT)
 
-      flash.now[:success] = flash_message_content
+      usps_mail_service = Idv::UspsMail.new(current_user)
+      flash_now = flash.now
+      if usps_mail_service.mail_spammed?
+        flash_now[:error] = t('idv.errors.mail_limit_reached')
+      else
+        flash_now[:success] = flash_message_content
+      end
     end
 
     def create

--- a/app/controllers/verify/usps_controller.rb
+++ b/app/controllers/verify/usps_controller.rb
@@ -2,21 +2,30 @@ module Verify
   class UspsController < ApplicationController
     include IdvStepConcern
 
-    before_action :confirm_step_needed
+    before_action :confirm_mail_not_spammed
 
     def index
       @applicant = idv_session.normalized_applicant_params
+      decorated_usps = UspsDecorator.new(idv_session)
+      @title = decorated_usps.title
+      @button = decorated_usps.button
     end
 
     def create
+      create_user_event(:usps_mail_sent, current_user)
       idv_session.address_verification_mechanism = :usps
       redirect_to verify_review_url
     end
 
+    def usps_mail_service
+      @_usps_mail_service ||= Idv::UspsMail.new(current_user)
+    end
+
     private
 
-    def confirm_step_needed
-      redirect_to verify_review_path if idv_session.address_mechanism_chosen?
+    def confirm_mail_not_spammed
+      redirect_to verify_review_path if idv_session.address_mechanism_chosen? &&
+                                        usps_mail_service.mail_spammed?
     end
   end
 end

--- a/app/decorators/usps_decorator.rb
+++ b/app/decorators/usps_decorator.rb
@@ -1,0 +1,21 @@
+class UspsDecorator
+  attr_reader :idv_session
+
+  def initialize(idv_session)
+    @idv_session = idv_session
+  end
+
+  def title
+    letter_already_sent? ? I18n.t('idv.titles.mail.resend') : I18n.t('idv.titles.mail.verify')
+  end
+
+  def button
+    letter_already_sent? ? I18n.t('idv.buttons.mail.resend') : I18n.t('idv.buttons.mail.send')
+  end
+
+  private
+
+  def letter_already_sent?
+    @idv_session.address_verification_mechanism == 'usps'
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,7 @@ class Event < ActiveRecord::Base
     authenticator_enabled: 6,
     authenticator_disabled: 7,
     account_verified: 8,
+    usps_mail_sent: 9,
   }
 
   validates :event_type, presence: true

--- a/app/services/idv/usps_mail.rb
+++ b/app/services/idv/usps_mail.rb
@@ -1,0 +1,33 @@
+module Idv
+  class UspsMail
+    MAX_MAIL_EVENTS = Figaro.env.max_mail_events.to_i
+    MAIL_EVENTS_WINDOW_DAYS = Figaro.env.max_mail_events_window_in_days.to_i
+
+    def initialize(current_user)
+      @current_user = current_user
+    end
+
+    def mail_spammed?
+      max_events? && updated_within_last_month?
+    end
+
+    private
+
+    attr_reader :current_user
+
+    def user_mail_events
+      @_user_mail_events ||= current_user.events.
+                             usps_mail_sent.
+                             order('updated_at DESC').
+                             limit(MAX_MAIL_EVENTS)
+    end
+
+    def max_events?
+      user_mail_events.count == MAX_MAIL_EVENTS
+    end
+
+    def updated_within_last_month?
+      user_mail_events.last.updated_at > MAIL_EVENTS_WINDOW_DAYS.days.ago
+    end
+  end
+end

--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -6,6 +6,11 @@ p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
 = simple_form_for(@verify_account_form, url: verify_account_path,
   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.error :base
-  = f.input :otp, required: true, label: t('forms.verify_profile.name'), wrapper: :inline_form do
+  = f.input :otp, required: true, label: t('forms.verify_profile.name'),
+    wrapper_html: { class: 'mb3' }, wrapper: :inline_form do
     = f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10', value: @code
     = f.button :submit, t('forms.verify_profile.submit')
+- unless @mail_spammed
+  = link_to t('idv.messages.usps.resend'), verify_usps_path,
+    class: 'block mb2'
+= link_to t('idv.messages.usps.bad_address'), verify_phone_path

--- a/app/views/verify/usps/index.html.slim
+++ b/app/views/verify/usps/index.html.slim
@@ -2,7 +2,7 @@
   = image_tag(asset_url('check-email.svg'), size: '48x48', alt: 'check email',\
     class: 'absolute top-n24 left-0 right-0 mx-auto')
   h1.h2
-    = t('idv.titles.verify_mail')
+    = @title
   p
     = t('idv.messages.usps.byline')
 
@@ -10,7 +10,7 @@
     strong
       = t('idv.messages.usps.success')
 
-= button_to t('idv.buttons.send_letter'), verify_usps_path, method: 'put',
+= button_to @button, verify_usps_path, method: 'put',
   class: 'btn btn-primary btn-wide', form_class: 'inline-block mr2'
 
 = link_to t('idv.messages.usps.bad_address'), verify_phone_path

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -12,6 +12,8 @@ email_from: 'no-reply@login.gov'
 idv_max_attempts: '3'
 idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
+max_mail_events: '4'
+max_mail_events_window_in_days: '30'
 
 # The scores 0, 1, 2, 3 or 4 are given when the number of guesses to crack the
 # password are less than 10^3, 10^6, 10^8, 10^10, and >= 10^10 respectively.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -27,7 +27,7 @@ en:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
-      otp_incorrect: Security code is incorrect
+      otp_incorrect: Incorrect code. Did you type it correctly?
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
       requires_phone: requires you to enter your phone number.

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -10,3 +10,4 @@ en:
     phone_changed: Phone number changed
     phone_confirmed: Phone confirmed
     eastern_timestamp: '%{timestamp} (Eastern)'
+    usps_mail_sent: Letter sent

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -10,3 +10,4 @@ es:
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado
     eastern_timestamp: '%{timestamp} (zona horaria del Este)'
+    usps_mail_sent: Carta enviada

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -7,7 +7,9 @@ en:
       continue: Continue identity verification
       cancel: Cancel and return to your profile
       help: Continue to Help Center
-      send_letter: Send a letter
+      mail:
+        send: Send a letter
+        resend: Send another letter
     cancel:
       modal_header: Are you sure you want to cancel?
       warning_header: If you cancel now
@@ -25,6 +27,7 @@ en:
       incorrect_password: The password you entered is not correct.
       invalid_ccn: Credit card number should be only last 8 digits.
       missing_finance: You must provide a financial account number.
+      mail_limit_reached: You have have requested too much mail in the last month.
       pattern_mismatch:
         dob: Your date of birth must be entered in as mm/dd/yyyy
         "personal-key": >
@@ -156,6 +159,7 @@ en:
         bad_address: I can't get mail at this address
         byline: We will mail a letter with a confirmation code to your verified
           address on file.
+        resend: Send me another letter.
         success: It should arrive in 5 to 10 business days.
       personal_details_verified: Personal details verified!
     modal:
@@ -199,6 +203,9 @@ en:
       financials: Provide a financial account number
       hardfail: We were unable to verify your identity
       intro: Help us identify you
+      mail:
+        verify: Want a letter?
+        resend: Want another letter?
       phone: Phone number of record
       review: Review and submit
       select_verification: Activate your account
@@ -206,4 +213,3 @@ en:
       session:
         phone: Get a code by telephone
         review: Encrypt your verified data by entering your password
-      verify_mail: Want a letter?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -7,7 +7,9 @@ es:
       continue: NOT TRANSLATED YET
       cancel: NOT TRANSLATED YET
       help: NOT TRANSLATED YET
-      send_letter: NOT TRANSLATED YET
+      mail:
+        send: NOT TRANSLATED YET
+        resend: NOT TRANSLATED YET
     cancel:
       modal_header: NOT TRANSLATED YET
       warning_header: NOT TRANSLATED YET
@@ -20,6 +22,7 @@ es:
       incorrect_password: NOT TRANSLATED YET
       invalid_ccn: NOT TRANSLATED YET
       missing_finance: NOT TRANSLATED YET
+      mail_limit_reached: NOT TRANSLATED YET
       pattern_mismatch:
         dob: NOT TRANSLATED YET
         "personal-key": NOT TRANSLATED YET
@@ -118,6 +121,7 @@ es:
       usps:
         bad_address: NOT TRANSLATED YET
         byline: NOT TRANSLATED YET
+        resend: NOT TRANSLATED YET
         success: NOT TRANSLATED YET
       personal_details_verified: NOT TRANSLATED YET
     modal:
@@ -154,6 +158,9 @@ es:
       financials: NOT TRANSLATED YET
       hardfail: NOT TRANSLATED YET
       intro: NOT TRANSLATED YET
+      mail:
+        verify: NOT TRANSLATED YET
+        resend: NOT TRANSLATED YET
       phone: NOT TRANSLATED YET
       review: NOT TRANSLATED YET
       select_verification: NOT TRANSLATED YET
@@ -161,4 +168,3 @@ es:
       session:
         phone: NOT TRANSLATED YET
         review: NOT TRANSLATED YET
-      verify_mail: NOT TRANSLATED YET

--- a/spec/controllers/verify/usps_controller_spec.rb
+++ b/spec/controllers/verify/usps_controller_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 require 'proofer/vendor/mock'
 
 describe Verify::UspsController do
-  let(:user) { build(:user) }
+  let(:user) { create(:user) }
 
   describe 'before_actions' do
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started
+        :confirm_idv_session_started,
+        :confirm_mail_not_spammed
       )
     end
   end
@@ -21,6 +22,22 @@ describe Verify::UspsController do
     end
 
     it 'renders confirmation page' do
+      get :index
+
+      expect(response).to be_ok
+    end
+
+    it 'redirects if the user has sent too much mail' do
+      allow(controller.usps_mail_service).to receive(:mail_spammed?).and_return(true)
+      allow(subject.idv_session).to receive(:address_mechanism_chosen?).
+        and_return(true)
+      get :index
+
+      expect(response).to redirect_to verify_review_path
+    end
+
+    it 'allows a user to request another letter' do
+      allow(controller.usps_mail_service).to receive(:mail_spammed?).and_return(false)
       get :index
 
       expect(response).to be_ok

--- a/spec/decorators/usps_decorator_spec.rb
+++ b/spec/decorators/usps_decorator_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe UspsDecorator do
+  subject(:decorator) do
+    user = create(
+      :user,
+      :signed_up,
+      profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })]
+    )
+
+    idv_session = Idv::Session.new({}, user)
+    UspsDecorator.new(idv_session)
+  end
+
+  describe '#title' do
+    context 'a letter has not been sent' do
+      let(:idv_session) { subject.idv_session }
+
+      it 'provides text to send' do
+        subject.idv_session.address_verification_mechanism = nil
+        expect(subject.title).to eq(
+          I18n.t('idv.titles.mail.verify')
+        )
+      end
+    end
+
+    context 'a letter has been sent' do
+      it 'provides text to resend' do
+        subject.idv_session.address_verification_mechanism = 'usps'
+        expect(subject.title).to eq(
+          I18n.t('idv.titles.mail.resend')
+        )
+      end
+    end
+  end
+
+  describe '#button' do
+    context 'a letter has not been sent' do
+      it 'provides text to send' do
+        subject.idv_session.address_verification_mechanism = nil
+        expect(subject.button).to eq(
+          I18n.t('idv.buttons.mail.send')
+        )
+      end
+    end
+
+    context 'a letter has been sent' do
+      it 'provides text to resend' do
+        subject.idv_session.address_verification_mechanism = 'usps'
+        expect(subject.button).to eq(
+          I18n.t('idv.buttons.mail.resend')
+        )
+      end
+    end
+  end
+end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -64,7 +64,7 @@ feature 'LOA3 Single Sign On' do
 
       click_idv_address_choose_usps
 
-      click_on t('idv.buttons.send_letter')
+      click_on t('idv.buttons.mail.send')
 
       expect(current_path).to eq verify_review_path
 

--- a/spec/services/idv/usps_mail_spec.rb
+++ b/spec/services/idv/usps_mail_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Idv::UspsMail do
+  let(:user) { create(:user) }
+  let(:subject) { Idv::UspsMail.new(user) }
+
+  describe '#mail_spammed?' do
+    context 'when no mail has been sent' do
+      it 'is never spammed' do
+        expect(subject.mail_spammed?).to eq false
+      end
+    end
+
+    context 'when too much mail has been sent' do
+      it 'is spammed if all the updates have been within the last month' do
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 2.weeks.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.week.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.day.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.hour.ago)
+
+        expect(subject.mail_spammed?).to eq true
+      end
+
+      it 'is not spammed if the most distant update was more than a month ago' do
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 2.months.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.week.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.day.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 1.hour.ago)
+
+        expect(subject.mail_spammed?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, if the user was not able to successfully use their "Secret code" that they received in the mail, they would be at an impasse. This PR allows the user to restart the USPS flow and receive a new letter.


<img width="643" alt="screen shot 2017-05-19 at 10 04 39 am" src="https://cloud.githubusercontent.com/assets/4803473/26254633/d7e88f22-3c7c-11e7-8b77-1c044ef1d77a.png">

After clicking "Send a letter" the user is led back to the account page where they see a link to verify their identity with their mail code.

They navigate there and see:

<img width="655" alt="screen shot 2017-05-19 at 10 14 56 am" src="https://cloud.githubusercontent.com/assets/4803473/26254631/d7cc497a-3c7c-11e7-895d-80dfc6b1ee5b.png">

After confirming their account they get this page, a repeat of the initial view, but "Want another letter?" instead of "Want a letter?"

<img width="655" alt="screen shot 2017-05-19 at 10 12 33 am" src="https://cloud.githubusercontent.com/assets/4803473/26254630/d7cbab50-3c7c-11e7-9269-9cdc78cf819b.png">


**Considerations*:  It isn't clear to me whether or not we should have a limit on the number of times that a user is allowed to request a new letter. See https://github.com/18F/identity-private/issues/1890#issuecomment-302487087 for more.