### PR TITLE
Update spacing in co-branded/non-branded header

### DIFF
--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -1,0 +1,23 @@
+.nav-branded {
+  height: 56px;
+
+  a { line-height: 14px; }
+}
+
+.nav-nonbranded {
+  height: 38px;
+
+  a { line-height: 14px; }
+}
+
+@media #{$breakpoint-sm} {
+  .nav-branded,
+  .nav-nonbranded {
+    height: 72px;
+  }
+
+  .nav-nonbranded {
+    a { line-height: 17px; }
+    img { height: 17px; }
+  }
+}

--- a/app/assets/stylesheets/components/_space-misc.scss
+++ b/app/assets/stylesheets/components/_space-misc.scss
@@ -11,6 +11,7 @@
 
 .mb-12p { margin-bottom: 12px; }
 .mt-12p { margin-top: 12px; }
+.px-12p { padding-left: 12px; padding-right: 12px; }
 .py-12p { padding-bottom: 12px; padding-top: 12px; }
 
 .mb-40p { margin-bottom: 40px; }

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -12,6 +12,13 @@
   white-space: nowrap;
 }
 
+.vertical-align::before {
+  content: ' ';
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+}
+
 @media #{$breakpoint-sm} {
   // scss-lint:disable ImportantRule
   .sm-display-inline-block { display: inline-block !important; }

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -10,6 +10,7 @@
 @import 'icon';
 @import 'list';
 @import 'modal';
+@import 'nav';
 @import 'password';
 @import 'profile-section';
 @import 'personal-key';

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -50,7 +50,7 @@ html lang="#{I18n.locale}" class='no-js'
         = yield(:nav)
       - else
         = render decorated_session.nav_partial
-      .container.sm-pt4
+      .container
         div class="px2 py2 sm-py5 sm-px6 mx-auto sm-mb5 border-box card #{yield(:card_cls)}"
           = render 'shared/flashes'
           == yield

--- a/app/views/shared/_nav_branded.html.slim
+++ b/app/views/shared/_nav_branded.html.slim
@@ -1,8 +1,7 @@
-nav.py2.sm-pt3.sm-pb0.bg-light-blue.center
-  .my1.sm-mb0.relative
-    = image_tag(asset_url('logo.svg'), width: 124,
-      alt: APP_NAME, class: 'align-middle')
-    .px2.inline-block
-      span.absolute.top-0.bottom-0.border-right
-    = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 50,
-      alt: decorated_session.sp_name, class: 'align-middle')
+nav.nav-branded.vertical-align.bg-light-blue.center.relative
+  = image_tag(asset_url('logo.svg'), height: 14,
+    alt: APP_NAME, class: 'inline-block align-middle')
+  .px-12p.inline-block
+    span.absolute.top-0.bottom-0.border-right.my1.sm-my2
+  = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 40,
+    alt: decorated_session.sp_name, class: 'inline-block align-middle')

--- a/app/views/shared/_nav_lite.html.slim
+++ b/app/views/shared/_nav_lite.html.slim
@@ -1,4 +1,4 @@
-nav.py2.sm-pt4.sm-pb0.bg-light-blue.center
+nav.nav-nonbranded.vertical-align.bg-light-blue.center
   = link_to \
-    image_tag(asset_url('logo.svg'), width: 181, alt: APP_NAME, class: 'align-bottom'),
-    root_path, class: 'p1 sm-p0 inline-block'
+    image_tag(asset_url('logo.svg'), height: 14, alt: APP_NAME, class: 'align-middle'),
+    root_path, class: 'inline-block align-middle'


### PR DESCRIPTION
This tightens up the header design on mobile and makes some additional adjustments for co-branded vs login.gov only.

![screen shot 2017-05-18 at 4 28 35 pm](https://cloud.githubusercontent.com/assets/1178494/26222255/53dd5e32-3be7-11e7-8700-8adff5d67200.png)

![screen shot 2017-05-18 at 4 29 03 pm](https://cloud.githubusercontent.com/assets/1178494/26222259/558987d8-3be7-11e7-87bd-0c41ec9ea163.png)
