### PR TITLE
Only create verified account event on verification

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -172,9 +172,7 @@ module TwoFactorAuthenticatable
     if idv_context?
       Idv::Session.new(user_session, current_user).params['phone_confirmed_at'] = now
     elsif profile_context?
-      profile = current_user.decorate.pending_profile
-      profile.verified_at = now
-      profile.activate
+      Idv::ProfileActivator.new(user: current_user).call
     end
   end
 

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -9,7 +9,7 @@ module Verify
     def show
       track_final_idv_event
 
-      finish_proofing_success
+      finish_idv_session
     end
 
     def update
@@ -38,17 +38,12 @@ module Verify
       analytics.track_event(Analytics::IDV_FINAL, result)
     end
 
-    def finish_proofing_success
+    def finish_idv_session
       @code = personal_key
       idv_session.complete_session
       idv_session.personal_key = nil
-      create_account_verified_event
       flash.now[:success] = t('idv.messages.confirm')
       flash[:allow_confirmations_continue] = true
-    end
-
-    def create_account_verified_event
-      CreateVerifiedAccountEvent.new(current_user).call
     end
 
     def personal_key

--- a/app/forms/verify_account_form.rb
+++ b/app/forms/verify_account_form.rb
@@ -48,7 +48,6 @@ class VerifyAccountForm
   end
 
   def activate_profile
-    pending_profile.verified_at = Time.zone.now
-    pending_profile.activate
+    Idv::ProfileActivator.new(user: user).call
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -17,9 +17,10 @@ class Profile < ActiveRecord::Base
 
   # rubocop:disable Rails/SkipsModelValidations
   def activate
+    now = Time.zone.now
     transaction do
       Profile.where('user_id=?', user_id).update_all(active: false)
-      update!(active: true, activated_at: Time.zone.now, deactivation_reason: nil)
+      update!(active: true, activated_at: now, deactivation_reason: nil, verified_at: now)
     end
   end
   # rubocop:enable Rails/SkipsModelValidations

--- a/app/services/idv/profile_activator.rb
+++ b/app/services/idv/profile_activator.rb
@@ -1,0 +1,16 @@
+module Idv
+  class ProfileActivator
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      user.decorate.pending_profile&.activate
+      CreateVerifiedAccountEvent.new(user).call
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -72,8 +72,7 @@ module Idv
     end
 
     def complete_profile
-      profile.verified_at = Time.zone.now
-      profile.activate
+      ProfileActivator.new(user: current_user).call
       move_pii_to_user_session
     end
 

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -47,6 +47,7 @@ feature 'LOA3 Single Sign On' do
       user_access_key = user.unlock_user_access_key(Features::SessionHelper::VALID_PASSWORD)
       profile_phone = user.active_profile.decrypt_pii(user_access_key).phone
 
+      expect(user.events.account_verified.size).to be(1)
       expect(xmldoc.phone_number.children.children.to_s).to eq(profile_phone)
     end
 
@@ -74,6 +75,7 @@ feature 'LOA3 Single Sign On' do
       expect(current_url).to eq verify_confirmations_url
       click_acknowledge_personal_key
 
+      expect(User.find_with_email(email).events.account_verified.size).to be(0)
       expect(current_url).to eq(account_url)
       expect(page).to have_content(t('account.index.verification.reactivate_button'))
     end
@@ -170,7 +172,9 @@ feature 'LOA3 Single Sign On' do
 
         click_button t('forms.verify_profile.submit')
 
+        expect(user.events.account_verified.size).to be(1)
         expect(current_path).to eq(sign_up_completed_path)
+
         find('input').click
 
         expect(current_url).to eq saml_authn_request


### PR DESCRIPTION
**Why**: Previously, the user would have an `Account Verified` event
created when they went through the IdV process, but selected to confirm
their profile information via USPS

**How**: Move the event creation from the `verify/confirmations`
controller to a service class. Also moved identitcal code to flag an
account as verified from to the `profile` model and
`profile_activator` service class