### PR TITLE
Format rack-attack logging as JSON

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -124,8 +124,10 @@ end
 ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, req|
   discriminator = req.env['rack.attack.match_discriminator'] || req.env['warden'].user&.uuid
 
-  Rails.logger.warn(discriminator: discriminator,
-                    event: 'throttle',
-                    type: req.env['rack.attack.matched'],
-                    user_ip: req.remote_ip)
+  Rails.logger.warn({
+    discriminator: discriminator,
+    event: 'throttle',
+    type: req.env['rack.attack.matched'],
+    user_ip: req.remote_ip,
+  }.to_json)
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -78,7 +78,7 @@ describe 'throttling requests' do
           user_ip: '1.2.3.4',
         }
 
-        expect(Rails.logger).to have_received(:warn).with(analytics_hash)
+        expect(Rails.logger).to have_received(:warn).with(analytics_hash.to_json)
       end
     end
   end
@@ -165,7 +165,7 @@ describe 'throttling requests' do
           user_ip: '1.2.3.4',
         }
 
-        expect(Rails.logger).to have_received(:warn).with(analytics_hash)
+        expect(Rails.logger).to have_received(:warn).with(analytics_hash.to_json)
       end
     end
   end
@@ -220,7 +220,7 @@ describe 'throttling requests' do
       }
 
       expect(last_response.status).to eq(429)
-      expect(Rails.logger).to have_received(:warn).exactly(:twice).with(analytics_hash)
+      expect(Rails.logger).to have_received(:warn).exactly(:twice).with(analytics_hash.to_json)
 
       delete destroy_user_session_path
 
@@ -247,7 +247,7 @@ describe 'throttling requests' do
       }
 
       expect(last_response.status).to eq(429)
-      expect(Rails.logger).to have_received(:warn).with(analytics_hash)
+      expect(Rails.logger).to have_received(:warn).with(analytics_hash.to_json)
     end
 
     it 'uses the throttled_response for the blocklisted_response' do


### PR DESCRIPTION
**Why**:
Was previously being logged as a Ruby hash, which ELK doesn't parse

Tested by tailing `log/development.log`

before:

```
{:discriminator=>nil, :event=>"throttle", :type=>"allow from localhost", :user_ip=>"127.0.0.1"}
```

after:

```
{"discriminator":null,"event":"throttle","type":"allow from localhost","user_ip":"127.0.0.1"}
```