### PR TITLE
Updates account reactivation links in /account

### DIFF
--- a/app/views/accounts/_password_reset.html.slim
+++ b/app/views/accounts/_password_reset.html.slim
@@ -1,3 +1,4 @@
 .mb4.alert.alert-warning
   p = t('account.index.reactivation.instructions')
-  p.mb0 = link_to t('account.index.reactivation.reactivate_button'), reactivate_account_path
+  p.mb0 = link_to t('account.index.reactivation.personal_key'), reactivate_account_path
+  p.mb0.mt2 = link_to t('account.index.reactivation.reverify'), verify_path

--- a/app/views/users/reactivate_account/index.html.slim
+++ b/app/views/users/reactivate_account/index.html.slim
@@ -8,3 +8,6 @@ p.mt-tiny.mb0 = t('forms.reactivate_profile.instructions')
   = render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key
   = f.input :password, required: true
   = f.button :submit, t('forms.reactivate_profile.submit'), class: 'mb1'
+
+.mt2.pt1.border-top
+  = link_to t('links.cancel'), account_path

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -14,8 +14,10 @@ en:
       phone: Phone number
       previous_address: Previous address
       reactivation:
-        instructions: For your security, you will need to verify your account information again.
-        reactivate_button: Verify your identity
+        instructions: Your profile was recently deactivated due to a password reset.
+          You can use your personal key to reactivate your profile.
+        personal_key: Reactivate your profile with your personal key.
+        reverify: No personal key? Reverify all your information instead.
       ssn: Social Security Number
       verification:
         instructions: Your account requires a secret code to be verified.

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -15,7 +15,8 @@ es:
       previous_address: NOT TRANSLATED YET
       reactivation:
         instructions: NOT TRANSLATED YET
-        reactivate_button: NOT TRANSLATED YET
+        personal_key: NOT TRANSLATED YET
+        reverify: NOT TRANSLATED YET
       ssn: NOT TRANSLATED YET
       verification:
         instructions: NOT TRANSLATED YET

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'User profile' do
   include IdvHelper
+  include PersonalKeyHelper
 
   context 'account status badges' do
     before do
@@ -66,32 +67,23 @@ feature 'User profile' do
       end
 
       it 'allows the user reactivate their profile by reverifying' do
-        profile = create(:profile, :active, pii: { ssn: '1234', dob: '1920-01-01' })
+        profile = create(:profile, :active, :verified, pii: { ssn: '1234', dob: '1920-01-01' })
         user = profile.user
 
-        sign_in_live_with_2fa(user)
-
-        profile.deactivate(:password_reset)
-        profile.reload
-        visit account_path
-
+        trigger_reset_password_and_click_email_link(user.email)
+        reset_password_and_sign_back_in(user, user_password)
+        click_submit_default
+        enter_correct_otp_code_for_user(user)
+        click_on t('links.cancel')
         click_on t('account.index.reactivation.reverify')
         click_idv_begin
-
-        # not using the helper method as the generic password doesn't seem to work
-        fill_out_idv_form_ok
-        click_idv_continue
-        fill_out_financial_form_ok
-        click_idv_continue
-        click_idv_address_choose_phone
-        fill_out_phone_form_ok(user.phone)
-        click_idv_continue
-        fill_in 'Password', with: user.password
-        click_submit_default
+        complete_idv_profile_ok(user)
         click_acknowledge_personal_key
 
         expect(current_path).to eq(account_path)
+
         visit account_path
+
         expect(page).not_to have_content(t('account.index.reactivation.instructions'))
       end
     end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -93,7 +93,7 @@ module IdvHelper
     click_idv_address_choose_phone
     fill_out_phone_form_ok(user.phone)
     click_idv_continue
-    fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
+    fill_in 'Password', with: user_password
     click_submit_default
   end
 end

--- a/spec/views/accounts/show.html.slim_spec.rb
+++ b/spec/views/accounts/show.html.slim_spec.rb
@@ -82,6 +82,20 @@ describe 'accounts/show.html.slim' do
         t('account.links.regenerate_personal_key'), href: manage_personal_key_path
       )
     end
+
+    it 'displays an alert with instructions to reactivate their profile' do
+      render
+
+      expect(rendered).to have_content(t('account.index.reactivation.instructions'))
+    end
+
+    it 'contains link to reactivate profile via personal key or reverification' do
+      render
+
+      expect(rendered).to have_link(t('account.index.reactivation.personal_key'),
+                                    href: reactivate_account_path)
+      expect(rendered).to have_link(t('account.index.reactivation.reverify'), href: verify_path)
+    end
   end
 
   context 'when the user does not have pending_profile' do


### PR DESCRIPTION
**Why**: Users may not have a personal key and need to reverify their
information after a password reset

Screenshot:

![screen shot 2017-05-19 at 4 46 48 pm](https://cloud.githubusercontent.com/assets/1421848/26266689/7716eca6-3cb4-11e7-882e-101f7b30b65a.png)
