### PR TITLE
Add sign out link to account page on mobile

### DIFF
--- a/app/assets/stylesheets/components/_background.scss
+++ b/app/assets/stylesheets/components/_background.scss
@@ -1,5 +1,6 @@
 .bg-gray-lighter { background-color: $gray-lighter; }
 .bg-light-blue { background-color: $blue-light; }
+.bg-lightest-blue { background-color: $blue-lightest; }
 
 @media #{$breakpoint-sm} {
   .sm-bg-light-blue { background-color: $blue-light; }

--- a/app/assets/stylesheets/components/_profile-section.scss
+++ b/app/assets/stylesheets/components/_profile-section.scss
@@ -3,6 +3,11 @@
   border-bottom: $border-width solid $border-color;
   border-radius: 0;
   margin-bottom: 0;
+
+  .bg-lightest-blue img {
+    margin-top: -2px;
+    vertical-align: middle;
+  }
 }
 
 @media #{$breakpoint-sm} {

--- a/app/views/accounts/_header.html.slim
+++ b/app/views/accounts/_header.html.slim
@@ -1,4 +1,4 @@
-.clearfix.py2.sm-py0.mb2.bg-light-blue.sm-bg-none
+.clearfix.py2.sm-py0.mb2.bg-lightest-blue.sm-bg-none
   .sm-col.sm-col-8
     h2.h3.my0.mx2.center.sm-left-align
       .sm-hide.regular.sans-serif.inline

--- a/app/views/accounts/_nav_auth.html.slim
+++ b/app/views/accounts/_nav_auth.html.slim
@@ -17,3 +17,5 @@ nav.bg-white
           p.m0
             = link_to t('links.sign_out'), destroy_user_session_path,
               class: 'pl1'
+      .right.sm-hide
+        = link_to t('links.sign_out'), destroy_user_session_path

--- a/app/views/accounts/_pii.html.slim
+++ b/app/views/accounts/_pii.html.slim
@@ -1,8 +1,8 @@
 .mb3.profile-info-box
-  .bg-light-blue.py1.px2.h6.caps.clearfix
+  .bg-lightest-blue.py1.px2.h6.caps.clearfix
     .col.col-11
       = t('headings.account.profile_info')
-      = image_tag asset_url('user.svg'), width: 8, class: 'ml1 mt-tiny'
+      = image_tag asset_url('user.svg'), width: 8, class: 'ml1'
     .col.col-1.right-align
       = image_tag asset_url('lock.svg'), width: 8, class: 'mr1'
   .p2

--- a/app/views/accounts/_verified_header.html.slim
+++ b/app/views/accounts/_verified_header.html.slim
@@ -1,4 +1,4 @@
-.clearfix.pt2.pb3.sm-py0.mb3.bg-light-blue.sm-bg-none
+.clearfix.pt2.pb3.sm-py0.mb3.bg-lightest-blue.sm-bg-none
   .sm-col.sm-col-8
     h2.h3.m0.center.sm-left-align
       span.regular.sans-serif.sm-hide

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -14,9 +14,9 @@ h1.hide = t('titles.account')
 = render @view_model.header_partial, view_model: @view_model
 
 .mb3.profile-info-box
-  .bg-light-blue.py1.px2.h6.caps
+  .bg-lightest-blue.py1.px2.h6.caps
     = t('account.index.login')
-    = image_tag asset_url('sign-in.svg'), width: 12, class: 'ml1 mt-tiny'
+    = image_tag asset_url('sign-in.svg'), width: 12, class: 'ml1'
   = render 'account_item',
     name: t('account.index.email'),
     content: current_user.email,
@@ -30,9 +30,9 @@ h1.hide = t('titles.account')
     action: @view_model.edit_action_partial
 
 .mb3.profile-info-box
-  .bg-light-blue.py1.px2.h6.caps
+  .bg-lightest-blue.py1.px2.h6.caps
     = t('headings.account.two_factor')
-    = image_tag asset_url('2fa-account.svg'), width: 8, class: 'ml1 mt-tiny'
+    = image_tag asset_url('2fa-account.svg'), width: 8, class: 'ml1'
 
   = render 'account_item',
     name: t('account.index.phone'),
@@ -53,8 +53,8 @@ h1.hide = t('titles.account')
 = render @view_model.pii_partial, decrypted_pii: @view_model.decrypted_pii
 
 .mb3.profile-info-box
-  .bg-light-blue.pb1.pt1.px2.h6.caps.clearfix
+  .bg-lightest-blue.pb1.pt1.px2.h6.caps.clearfix
     = t('headings.account.account_history')
-    = image_tag asset_url('history.svg'), width: 12, class: 'ml1 mt-tiny'
+    = image_tag asset_url('history.svg'), width: 12, class: 'ml1'
   - @view_model.recent_events.each do |event|
     = render @view_model.recent_event_partial, event: event

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -149,7 +149,7 @@ feature 'Sign in' do
 
     it 'fails to sign in the user, with CSRF error' do
       user = sign_in_and_2fa_user
-      click_link(t('links.sign_out'))
+      click_link(t('links.sign_out'), match: :first)
 
       Timecop.travel(Devise.timeout_in + 1.minute) do
         expect(page).to_not have_content(t('forms.buttons.continue'))

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Sign out' do
   scenario 'user signs out successfully' do
     sign_in_and_2fa_user
-    click_link(t('links.sign_out'))
+    click_link(t('links.sign_out'), match: :first)
 
     expect(page).to have_content t('devise.sessions.signed_out')
   end


### PR DESCRIPTION
Adds sign out link on mobile view.

Also two visual changes requested by @rtwell that are unrelated to the sign out link, but found on the same account page.
- Used the lighter blue background color for section headers
- Vertically aligned icons in section headers

![screen shot 2017-05-19 at 5 49 34 pm](https://cloud.githubusercontent.com/assets/1178494/26268093/885b0716-3cbb-11e7-8e3b-2a03cb2b459a.png)
