### PR TITLE
Fix return to SP link

### DIFF
--- a/.reek
+++ b/.reek
@@ -1,5 +1,8 @@
 Attribute:
   enabled: false
+ControlParameter:
+  exclude:
+    - OpenidConnectRedirector#initialize
 DuplicateMethodCall:
   exclude:
     - ApplicationController#disable_caching

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -14,7 +14,19 @@ class ServiceProviderSessionDecorator
   end
 
   def return_to_service_provider_partial
-    'devise/sessions/return_to_service_provider'
+    if sp_return_url.present?
+      'devise/sessions/return_to_service_provider'
+    else
+      'shared/null'
+    end
+  end
+
+  def return_to_sp_from_start_page_partial
+    if sp_return_url.present?
+      'sign_up/registrations/return_to_sp_from_start_page'
+    else
+      'shared/null'
+    end
   end
 
   def nav_partial
@@ -42,8 +54,8 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_return_url
-    if request_url.present?
-      OpenidConnectRedirector.from_request_url(request_url).decline_redirect_uri
+    if sp.redirect_uri.present? && openid_connect_redirector.valid?
+      openid_connect_redirector.decline_redirect_uri
     else
       sp.return_to_sp_url
     end
@@ -59,5 +71,9 @@ class ServiceProviderSessionDecorator
 
   def request_url
     sp_session[:request_url]
+  end
+
+  def openid_connect_redirector
+    @_openid_connect_redirector ||= OpenidConnectRedirector.from_request_url(request_url)
   end
 end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -5,6 +5,10 @@ class SessionDecorator
     'shared/null'
   end
 
+  def return_to_sp_from_start_page_partial
+    'shared/null'
+  end
+
   def nav_partial
     'shared/nav_lite'
   end

--- a/app/services/openid_connect_redirector.rb
+++ b/app/services/openid_connect_redirector.rb
@@ -15,8 +15,13 @@ class OpenidConnectRedirector
     @redirect_uri = redirect_uri
     @service_provider = service_provider
     @state = state
-    @errors = errors
+    @errors = errors || ActiveModel::Errors.new(self)
     @error_attr = error_attr
+  end
+
+  def valid?
+    validate
+    errors.blank?
   end
 
   def validate

--- a/app/views/sign_up/registrations/_return_to_sp_from_start_page.html.slim
+++ b/app/views/sign_up/registrations/_return_to_sp_from_start_page.html.slim
@@ -1,0 +1,3 @@
+.sm-col-10.col-12.mx-auto
+  p = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
+    decorated_session.sp_return_url

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -13,9 +13,7 @@
     new_user_session_path(request_id: params[:request_id]),
     class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb1 fs-20p'
 
-  .sm-col-10.col-12.mx-auto
-    p = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
-                  decorated_session.sp_return_url
+  = render decorated_session.return_to_sp_from_start_page_partial
 
 - if loa3_requested?
   = render 'required_pii_accordion'

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -69,6 +69,18 @@ feature 'LOA1 Single Sign On' do
       expect(page).to_not have_css('.accordion-header')
     end
 
+    it 'shows user the start page with a link back to the SP' do
+      saml_authn_request = auth_request.create(saml_settings)
+
+      visit saml_authn_request
+
+      cancel_callback_url = 'http://localhost:3000'
+
+      expect(page).to have_link(
+        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: cancel_callback_url
+      )
+    end
+
     it 'user can view and confirm personal key during sign up', :js do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :with_phone)

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -92,6 +92,18 @@ feature 'LOA3 Single Sign On' do
       expect(page).to have_css('.accordion-header-controls',
                                text: t('devise.registrations.start.accordion'))
     end
+
+    it 'shows user the start page with a link back to the SP' do
+      saml_authn_request = auth_request.create(saml_settings)
+
+      visit saml_authn_request
+
+      cancel_callback_url = 'http://localhost:3000'
+
+      expect(page).to have_link(
+        t('links.back_to_sp', sp: 'Your friendly Government Agency'), href: cancel_callback_url
+      )
+    end
   end
 
   context 'canceling verification' do

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -14,7 +14,7 @@ describe 'sign_up/registrations/show.html.slim' do
       )
 
       expect(rendered).not_to have_link(
-        t('links.back_to_sp_alt', sp: 'Awesome Application!')
+        t('links.back_to_sp', sp: 'Awesome Application!')
       )
     end
 


### PR DESCRIPTION
This is a follow up to https://github.com/18F/identity-idp/pull/1439

The method for checking whether the return link should be formatted in SAML vs OIDC format wasn't working correctly so this fixes that and also adds some additional checks just in case a `return_to_sp_url` hasn't been defined.