### PR TITLE
Remove italics from sign up page link

### DIFF
--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -8,7 +8,7 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   = f.input :email, label: t('forms.registration.labels.email'), required: true,
             input_html: { 'aria-describedby' => 'email-description' }
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
-  p.mb-40p.mt1.italic
+  p.mb-40p.mt1
     = link_to t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'


### PR DESCRIPTION
**Why**: Normalizing the presentation; the same link is
unitalicized on the previous screen

Proof:

<img width="517" alt="screen shot 2017-05-23 at 3 41 05 pm" src="https://cloud.githubusercontent.com/assets/1421848/26373295/f5d23a1a-3fce-11e7-91c0-8dbc0177871c.png">
