### PR TITLE
Sort shared attributes list

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -27,7 +27,8 @@ module SignUp
 
     def view_model
       SignUpCompletionsShow.new(
-        loa3_requested: loa3?
+        loa3_requested: loa3?,
+        decorated_session: decorated_session
       )
     end
 

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -49,6 +49,10 @@ class ServiceProviderSessionDecorator
     'verify/hardfail4'
   end
 
+  def requested_attributes
+    sp_session[:requested_attributes]
+  end
+
   def sp_name
     sp.friendly_name || sp.agency
   end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -35,6 +35,8 @@ class SessionDecorator
 
   def sp_return_url; end
 
+  def requested_attributes; end
+
   def cancel_link_url
     root_url
   end

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -2,11 +2,21 @@ class SignUpCompletionsShow
   include ActionView::Helpers::AssetTagHelper
   include ActionView::Helpers::TagHelper
 
-  def initialize(loa3_requested:)
+  def initialize(loa3_requested:, decorated_session:)
     @loa3_requested = loa3_requested
+    @decorated_session = decorated_session
   end
 
-  attr_reader :loa3_requested
+  attr_reader :loa3_requested, :decorated_session
+
+  SORTED_ATTRIBUTE_MAPPING = [
+    [%i[given_name family_name], :full_name],
+    [[:address], :address],
+    [[:phone], :phone],
+    [[:email], :email],
+    [[:birthdate], :birthdate],
+    [[:social_security_number], :social_security_number],
+  ].freeze
 
   def heading
     safe_join([I18n.t(
@@ -30,7 +40,21 @@ class SignUpCompletionsShow
     )
   end
 
+  def requested_attributes_partial
+    'sign_up/completions/requested_attributes'
+  end
+
+  def requested_attributes_sorted
+    SORTED_ATTRIBUTE_MAPPING.map do |raw_attribute, display_attribute|
+      display_attribute if (requested_attributes & raw_attribute).present?
+    end.compact
+  end
+
   private
+
+  def requested_attributes
+    decorated_session.requested_attributes.map(&:to_sym)
+  end
 
   def requested_loa
     loa3_requested ? 'loa3' : 'loa1'

--- a/app/views/sign_up/completions/_requested_attributes.html.slim
+++ b/app/views/sign_up/completions/_requested_attributes.html.slim
@@ -1,0 +1,4 @@
+ul.mb3.list-reset.border-bottom.success-bullets.requested-attributes
+  - view_model.requested_attributes_sorted.each do |attribute|
+    li.border-top.bold
+      = t("help_text.requested_attributes.#{attribute}")

--- a/app/views/sign_up/completions/show.html.slim
+++ b/app/views/sign_up/completions/show.html.slim
@@ -8,10 +8,7 @@
 
     p = t('help_text.requested_attributes.intro_html', app_name: APP_NAME,
         sp: content_tag(:strong, decorated_session.sp_name))
-    ul.mb3.list-reset.border-bottom.success-bullets.requested-attributes
-      - session[:sp][:requested_attributes].each do |attribute|
-        li.border-top.bold
-          = t("help_text.requested_attributes.#{attribute}")
+    = render @view_model.requested_attributes_partial, view_model: @view_model
 
     = button_to t('forms.buttons.continue'), sign_up_completed_path, \
                 class: 'col-12 btn btn-wide px2 py-12p rounded-lg border border-green bw2'

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -9,8 +9,6 @@ en:
       address: Mailing address
       birthdate: Date of birth
       email: Email address
-      family_name: Last name
-      given_name: First name
-      name: Full name
+      full_name: Full name
       phone: Phone number
       social_security_number: Social Security number

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -8,9 +8,7 @@ es:
       address: NOT TRANSLATED YET
       birthdate: NOT TRANSLATED YET
       email: NOT TRANSLATED YET
-      family_name: NOT TRANSLATED YET
-      given_name: NOT TRANSLATED YET
-      name: NOT TRANSLATED YET
+      full_name: NOT TRANSLATED YET
       phone: NOT TRANSLATED YET
       social_security_number: NOT TRANSLATED YET
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -358,8 +358,7 @@ feature 'OpenID Connect' do
         expect(page).to have_content t('help_text.requested_attributes.email')
         expect(page).to_not have_content t('help_text.requested_attributes.address')
         expect(page).to_not have_content t('help_text.requested_attributes.birthdate')
-        expect(page).to have_content t('help_text.requested_attributes.given_name')
-        expect(page).to have_content t('help_text.requested_attributes.family_name')
+        expect(page).to have_content t('help_text.requested_attributes.full_name')
         expect(page).to_not have_content t('help_text.requested_attributes.phone')
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
       end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -35,8 +35,7 @@ feature 'LOA3 Single Sign On' do
         expect(page).to have_content t('help_text.requested_attributes.email')
         expect(page).to_not have_content t('help_text.requested_attributes.address')
         expect(page).to_not have_content t('help_text.requested_attributes.birthdate')
-        expect(page).to have_content t('help_text.requested_attributes.given_name')
-        expect(page).to have_content t('help_text.requested_attributes.family_name')
+        expect(page).to have_content t('help_text.requested_attributes.full_name')
         expect(page).to have_content t('help_text.requested_attributes.phone')
         expect(page).to have_content t('help_text.requested_attributes.social_security_number')
       end


### PR DESCRIPTION
This sorts the list of shared attributes in a predetermined order like so:

![screen shot 2017-05-24 at 3 08 45 pm](https://cloud.githubusercontent.com/assets/1178494/26421083/c0c814d8-4092-11e7-965c-8a20fe080627.png)

It also loosely matches the requested attributes `family_name` and `address1` to more generic translation strings `Full name` and `Address` instead of listing each element of name and address out individually.