### PR TITLE
Add reset-pw page+route+controller, link partial

### DIFF
--- a/app/assets/javascripts/misc/password-reset-modal.js
+++ b/app/assets/javascripts/misc/password-reset-modal.js
@@ -1,0 +1,7 @@
+const modal = new window.LoginGov.Modal({ el: '#password-reset-modal' });
+const modalTrigger = document.getElementById('password-reset');
+
+modalTrigger.addEventListener('click', (event) => {
+  event.preventDefault();
+  modal.show();
+});

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -24,7 +24,9 @@
 }
 
 .scale-down {
-  transform: scale(.8);
+  // trigger anti-aliasing in chrome
+  backface-visibility: hidden;
+  transform: scale(.7);
 }
 
 @media #{$breakpoint-sm} {

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -19,6 +19,14 @@
   vertical-align: middle;
 }
 
+.block-center {
+  margin: 0 auto;
+}
+
+.scale-down {
+  transform: scale(.8);
+}
+
 @media #{$breakpoint-sm} {
   // scss-lint:disable ImportantRule
   .sm-display-inline-block { display: inline-block !important; }

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -183,10 +183,6 @@ module TwoFactorAuthenticatable
     if decorated_user.should_acknowledge_personal_key?(session)
       user_session[:first_time_personal_key_view] = 'true'
       sign_up_personal_key_path
-    elsif @updating_existing_number
-      account_path
-    elsif decorated_user.password_reset_profile.present?
-      reactivate_account_path
     else
       account_path
     end

--- a/app/controllers/reset_password_controller.rb
+++ b/app/controllers/reset_password_controller.rb
@@ -1,0 +1,9 @@
+class ResetPasswordController < ApplicationController
+  def index; end
+
+  def update
+    flash[:notice] = 'Great! You have you personal key. We\'ll ask for that in a minute.'
+
+    redirect_to new_user_password_path
+  end
+end

--- a/app/controllers/reset_password_controller.rb
+++ b/app/controllers/reset_password_controller.rb
@@ -2,8 +2,19 @@ class ResetPasswordController < ApplicationController
   def index; end
 
   def update
-    flash[:notice] = 'Great! You have you personal key. We\'ll ask for that in a minute.'
+    if personal_key == 'true'
+      flash[:notice] = t('notices.password_reset')
+      session[:personal_key] = true
+    else
+      session[:personal_key] = false
+    end
 
     redirect_to new_user_password_path
+  end
+
+  private
+
+  def personal_key
+    params.require(:personal_key)
   end
 end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -33,6 +33,14 @@ class ServiceProviderSessionDecorator
     'shared/nav_branded'
   end
 
+  def forgot_password_partial
+    if sp_session[:loa3]
+      'reset_password/link'
+    else
+      'forgot_password/link'
+    end
+  end
+
   def new_session_heading
     I18n.t('headings.sign_in_with_sp', sp: sp_name)
   end

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -13,6 +13,10 @@ class SessionDecorator
     'shared/nav_lite'
   end
 
+  def forgot_password_partial
+    'forgot_password/link'
+  end
+
   def registration_heading
     'sign_up/registrations/registration_heading'
   end

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,13 +1,20 @@
+- reset_context = loa3_requested? ? 'loa3' : 'basic'
+
 - title t('titles.passwords.forgot')
 
-h1.h3.my0 = t('headings.passwords.forgot')
+h1.h3.my0 = t("headings.passwords.forgot.#{reset_context}")
 p.mt-tiny.mb0#email-description
-  = t('instructions.password.forgot')
+  = t("instructions.password.forgot.#{reset_context}")
 = simple_form_for(@password_reset_email_form,
                   url: user_password_path,
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
 
-  = f.input :email, required: true, input_html: { 'aria-describedby': 'email-description' }
+  = f.input :email, required: true, label: t('forms.email.label'),
+            input_html: { 'aria-describedby': 'email-description' }
   = f.button :submit, t('forms.buttons.continue'), class: 'mt2'
 
-= render 'shared/cancel', link: new_user_session_path
+- if loa3_requested?
+  .mt2.pt1.border-top
+    = link_to 'cancel', root_path
+- else
+  = render 'shared/cancel', link: new_user_session_path

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -16,6 +16,6 @@ p.my3
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial
   .sm-col-right.mxn1
-    = link_to t('links.passwords.forgot'), new_password_path(resource_name), class: 'px1'
+    = render decorated_session.forgot_password_partial
     = link_to t('links.create_account'), sign_up_email_url(request_id: params[:request_id]), \
       class: 'px1 border-left border-silver'

--- a/app/views/forgot_password/_link.html.slim
+++ b/app/views/forgot_password/_link.html.slim
@@ -1,0 +1,1 @@
+= link_to t('links.passwords.forgot'), new_user_password_path, class: 'px1'

--- a/app/views/partials/personal_key/_key.slim
+++ b/app/views/partials/personal_key/_key.slim
@@ -1,4 +1,4 @@
-#personal-key(class="col-12 border-box mt4 mb3 py2 px2 sm-px4 fs-20p sans-serif\
+#personal-key(class="col-12 border-box py2 px2 sm-px4 fs-20p sans-serif\
                       border border-dashed border-red rounded-xl relative clearfix")
   = image_tag asset_url('scissors.svg'), width: 24,
     class: 'absolute ico-scissors'

--- a/app/views/reset_password/_link.html.slim
+++ b/app/views/reset_password/_link.html.slim
@@ -1,0 +1,1 @@
+= link_to t('links.passwords.forgot'), reset_password_path, class: 'px1'

--- a/app/views/reset_password/_modal.html.slim
+++ b/app/views/reset_password/_modal.html.slim
@@ -1,0 +1,15 @@
+#password-reset-modal.display-none
+  = render layout: '/shared/modal_layout' do
+    .p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
+      h2.my2.fs-20p.sans-serif.regular.center
+        = t('instructions.password.reset.modal.heading')
+      hr.mb3.bw4.rounded
+      .mb5
+        = t('instructions.password.reset.modal.copy')
+      .center
+        = form_tag reset_password_path, method: :put do
+          = button_tag t('forms.buttons.continue'), type: 'submit',
+            class: 'btn btn-wide px2 py1 rounded-lg border bw2', name: :personal_key,
+            value: 'false'
+
+== javascript_include_tag 'misc/password-reset-modal'

--- a/app/views/reset_password/index.html.slim
+++ b/app/views/reset_password/index.html.slim
@@ -1,0 +1,23 @@
+- title t('titles.passwords.forgot')
+
+h1.h3.mt0.mb2 = t('headings.passwords.reset')
+
+p.mb4#email-description
+  = t('instructions.password.reset')
+
+h2.h4.pb1.border-bottom Let's get started.
+
+h3.fs-20p.sans-serif.mt4 Do you have your personal key?
+
+p When you created your account, we gave you a list of words and asked \
+  you to store them in a safe place. It looked similar to this:
+
+.scale-down
+  = render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX'
+
+.block-center.center.col-10
+  div
+    = button_to 'I have my key', reset_password_path, method: :put,
+                form_class: 'block btn-primary mb2', class: 'btn'
+  div
+    = link_to 'I don\'t have my key', verify_path, class: 'btn btn-secondary block'

--- a/app/views/reset_password/index.html.slim
+++ b/app/views/reset_password/index.html.slim
@@ -2,22 +2,23 @@
 
 h1.h3.mt0.mb2 = t('headings.passwords.reset')
 
-p.mb4#email-description
-  = t('instructions.password.reset')
+p.mb4 = t('instructions.password.reset.intro')
 
-h2.h4.pb1.border-bottom Let's get started.
+h2.h4.pb1.border-bottom = t('instructions.password.reset.begin')
 
-h3.fs-20p.sans-serif.mt4 Do you have your personal key?
+h3.fs-20p.sans-serif.mt4 = t('instructions.password.reset.with_key')
 
-p When you created your account, we gave you a list of words and asked \
-  you to store them in a safe place. It looked similar to this:
+p.mb0 = t('instructions.password.reset.explanation')
 
 .scale-down
   = render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX'
 
 .block-center.center.col-10
+  = form_tag reset_password_path, method: :put, class: 'mb2' do
+    = button_tag t('links.passwords.reset.with_key'), class: 'col-12 btn btn-primary',
+      name: :personal_key, type: 'submit', value: 'true'
   div
-    = button_to 'I have my key', reset_password_path, method: :put,
-                form_class: 'block btn-primary mb2', class: 'btn'
-  div
-    = link_to 'I don\'t have my key', verify_path, class: 'btn btn-secondary block'
+    = link_to t('links.passwords.reset.without_key'), verify_path,
+      class: 'btn btn-secondary block', id: 'password-reset'
+
+= render 'reset_password/modal'

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -4,7 +4,8 @@ p.mt-tiny.mb0
   = t('instructions.personal_key_html',
       accent: content_tag(:strong, t('instructions.personal_key_accent')))
 
-= render 'partials/personal_key/key', code: code
+.mt4.mb3
+  = render 'partials/personal_key/key', code: code
 
 .mb3.right-align
   = link_to t('users.personal_key.get_another'), manage_personal_key_path(resend: true),

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -16,7 +16,7 @@ en:
     confirmation:
       show_hdr: Create a strong password
     email:
-      label: Email Address
+      label: Email
     passwords:
       edit:
         buttons:

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -15,6 +15,8 @@ en:
         update: Update
     confirmation:
       show_hdr: Create a strong password
+    email:
+      label: Email Address
     passwords:
       edit:
         buttons:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -15,6 +15,8 @@ es:
         update: Actualización
     confirmation:
       show_hdr: Crear una contraseña segura
+    email:
+      label: NOT TRANSLATED YET
     passwords:
       edit:
         buttons:

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -13,7 +13,10 @@ en:
     passwords:
       change: Change your password
       confirm: Confirm your current password to continue
-      forgot: Forgot your password?
+      forgot:
+        basic: Forgot your password?
+        loa3: Confirm your email address
+      reset: Reset your password
     account:
       account_history: Account history
       login_info: Your account

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -13,7 +13,10 @@ es:
     passwords:
       change: Cambiar su contraseña
       confirm: Confirme la contraseña actual para continuar
-      forgot: ¿Olvidó su contraseña?
+      forgot:
+        basic: ¿Olvidó su contraseña?
+        loa3: NOT TRANSLATED YET
+      reset: NOT TRANSLATED YET
     account:
       account_history: La historia de la cuenta
       login_info: Información de la cuenta

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -24,9 +24,17 @@ en:
         basic: >
           Don’t know your password? Reset it after confirming your email address.
         loa3: Enter your email address to reset your password.
-      reset: >
-        We take extra steps to keep your personal information secure and private,
-        so resetting your password takes a little extra effort.
+      reset:
+        intro: >
+          We take extra steps to keep your personal information secure and private,
+          so resetting your password takes a little extra effort.
+        begin: Let's get started.
+        with_key: Do you have your personal key?
+        explanation: 'When you created your account, we gave you a list of words and asked
+          you to store them in a safe place. It looked similar to this:'
+        modal:
+          heading: Don't have your personal key?
+          copy: If you don't have your personal key, you will need to verify your identity again.
       help_text_header: Password safety tips
       help_text: >
         The longer and more unusual the password, the harder it is to guess. So avoid using common

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -20,15 +20,20 @@ en:
     forgot_password:
       close_window: You can close this browser window once you have reset your password.
     password:
-      forgot: >
-        Don’t know your password? Reset it after confirming your email address.
+      forgot:
+        basic: >
+          Don’t know your password? Reset it after confirming your email address.
+        loa3: Enter your email address to reset your password.
+      reset: >
+        We take extra steps to keep your personal information secure and private,
+        so resetting your password takes a little extra effort.
       help_text_header: Password safety tips
       help_text: >
         The longer and more unusual the password, the harder it is to guess. So avoid using common
         phrases. Also avoid repeating passwords from other online accounts such as banks, email and
         social media.
       info:
-        lead: > 
+        lead: >
           It must be at least %{min_length} characters long and not be a commonly used password.
           That's it!
       strength:

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -18,9 +18,19 @@ es:
     forgot_password:
       close_window: Puede cerrar esta ventana del navegador despues que haya restablecido su contraseña.
     password:
-      forgot: >
-        Si no sabe su contraseña actual, puede restablecerla. Escriba la dirección de correo electrónico
-        asociada a su cuenta para recibir más instrucciones en la pantalla.
+      forgot:
+        basic: >
+          Si no sabe su contraseña actual, puede restablecerla. Escriba la dirección de correo electrónico
+          asociada a su cuenta para recibir más instrucciones en la pantalla.
+        loa3: NOT TRANSLATED YET
+      reset:
+        intro: NOT TRANSLATED YET
+        begin: NOT TRANSLATED YET
+        with_key: NOT TRANSLATED YET
+        explanation: NOT TRANSLATED YET
+        modal:
+          heading: NOT TRANSLATED YET
+          copy: NOT TRANSLATED YET
       help_text_header: NOT TRANSLATED YET
       help_text: NOT TRANSLATED YET
       info:

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -9,6 +9,9 @@ en:
     next: Next
     passwords:
       forgot: Forgot your password?
+      reset:
+        with_key: I have my key
+        without_key: I don't have my key
     phone_confirmation:
       auth_app_fallback_html: ' or %{link}.'
       fallback_to_sms_html: Send me a text message with the code instead

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -9,6 +9,9 @@ es:
     next: Siguiente
     passwords:
       forgot: ¿Olvidó su contraseña?
+      reset:
+        with_key: NOT TRANSLATED YET
+        without_key: NOT TRANSLATED YET
     phone_confirmation:
       auth_app_fallback_html: NOT TRANSLATED YET
       fallback_to_sms_html: Envíame un mensaje de texto con el código en su lugar

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -15,6 +15,7 @@ en:
       no_email_sent_explanation_start: Didn’t receive an email?
       resend_email_success: We sent another password reset email.
     password_changed: You changed your password.
+    password_reset: Great! You have your personal key. We'll ask for that in a minute.
     resend_confirmation_email:
       success: We sent another confirmation email.
     send_code:
@@ -24,7 +25,7 @@ en:
         continue: Keep me signed in
         sign_out: Sign me out
         message_html: >
-          For your security, we will sign you out in %{time_left_in_session} unless 
+          For your security, we will sign you out in %{time_left_in_session} unless
           you tell us otherwise.
       partially_signed_in:
         continue: Continue signing in

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -12,6 +12,7 @@ es:
       no_email_sent_explanation_start: NOT TRANSLATED YET
       resend_email_success: NOT TRANSLATED YET
     password_changed: NOT TRANSLATED YET
+    password_reset: NOT TRANSLATED YET
     resend_confirmation_email:
       success: NOT TRANSLATED YET
     send_code:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     get '/' => 'users/sessions#new', as: :new_user_session
     post '/' => 'users/sessions#create', as: :user_session
+
     get '/active' => 'users/sessions#active'
 
     get '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#show'
@@ -93,6 +94,9 @@ Rails.application.routes.draw do
   get '/profile', to: redirect('/account')
   get '/profile/reactivate', to: redirect('/account/reactivate')
   get '/profile/verify', to: redirect('/account/verify')
+
+  get '/reset_password' => 'reset_password#index', as: :reset_password
+  put '/reset_password' => 'reset_password#update'
 
   post '/sign_up/create_password' => 'sign_up/passwords#create', as: :sign_up_create_password
   get '/sign_up/email/confirm' => 'sign_up/email_confirmations#create',

--- a/spec/controllers/reset_password_controller_spec.rb
+++ b/spec/controllers/reset_password_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ResetPasswordController do
+  describe '#index' do
+    it 'renders the page' do
+      get :index
+
+      expect(response).to render_template(:index)
+    end
+  end
+
+  describe '#update' do
+    context 'with personal_key: true' do
+      it 'redirects to new password page, sets session flag to true, and shows a flash message' do
+        put :update, personal_key: 'true'
+        expect(session[:personal_key]).to eq true
+        expect(flash[:notice]).to eq t('notices.password_reset')
+        expect(response).to redirect_to(new_user_password_url)
+      end
+    end
+
+    context 'with personal_key: false' do
+      it 'redirects and sets session key to false' do
+        put :update, personal_key: 'false'
+        expect(session[:personal_key]).to eq false
+        expect(flash[:notice]).to be_nil
+        expect(response).to redirect_to(new_user_password_url)
+      end
+    end
+  end
+end

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -16,7 +16,9 @@ feature 'Password recovery via personal key' do
     click_submit_default
     enter_correct_otp_code_for_user(user)
 
-    expect(current_path).to eq reactivate_account_path
+    expect(current_path).to eq account_path
+
+    click_on t('account.index.reactivation.personal_key')
 
     reactivate_profile(new_password, personal_key)
 
@@ -32,14 +34,10 @@ feature 'Password recovery via personal key' do
     click_submit_default
     enter_correct_otp_code_for_user(user)
 
-    expect(current_path).to eq reactivate_account_path
-
     visit manage_personal_key_path
 
     new_personal_key = scrape_personal_key
     click_acknowledge_personal_key
-
-    expect(current_path).to eq reactivate_account_path
 
     reactivate_profile(new_password, new_personal_key)
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -74,7 +74,6 @@ feature 'User profile' do
         reset_password_and_sign_back_in(user, user_password)
         click_submit_default
         enter_correct_otp_code_for_user(user)
-        click_on t('links.cancel')
         click_on t('account.index.reactivation.reverify')
         click_idv_begin
         complete_idv_profile_ok(user)

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -15,10 +15,18 @@ describe 'devise/passwords/new.html.slim' do
     render
   end
 
-  it 'has a localized header' do
-    render
+  context 'localized header' do
+    it 'displays the basic header' do
+      render
 
-    expect(rendered).to have_selector('h1', text: t('headings.passwords.forgot'))
+      expect(rendered).to have_selector('h1', text: t('headings.passwords.forgot.basic'))
+    end
+
+    it 'displays LOA3 header during LOA3 flow' do
+      allow(view).to receive(:loa3_requested?).and_return(true)
+      render
+      expect(rendered).to have_selector('h1', text: t('headings.passwords.forgot.loa3'))
+    end
   end
 
   it 'sets form autocomplete to off' do


### PR DESCRIPTION
**Why**: We are reevaulating the LOA3 reset password flow, and requiring
users to either have their personal key upon reset or reverify their
pii during the reset flow

The actual issue has more logic than this, so I'm attempting to break up the work a bit.

**This PR adds**
* new rest password controller and view
* new flash message on forgot_password page
* link to the proper reset password page depending on loa3 context
* changes to locale files
* In `TwoFactorAuthenticatable#after_otp_action_path` I changed the redirect path to `account` since we are eventually doing away with the reactivate account screen as it currently stands, and users will be confused if they click 'i don't have a personal key' and are then confronted with a screen that says 'enter your personal key'

**Testing**
0). Have a user with a verified acocunt
1). Visit the sign in page under LOA3
2). Click forgot password
3). You should be on the reset password index page
4). Click 'I don't have my key' to view the modal
5). Click 'I have my key' to be taken to the forgot password page. You should see a flash banner indicating that you acknowledged having your personal key

All other parts of the account recovery flow remain the same.

**Screenshots**
New forgot password screenshot:

![screen shot 2017-06-01 at 12 23 10 pm](https://cloud.githubusercontent.com/assets/1421848/26689859/31b0f45c-46c5-11e7-868a-4f27b2648f95.png)

Modal detail: 
![screen shot 2017-06-01 at 12 23 21 pm](https://cloud.githubusercontent.com/assets/1421848/26689871/3788fef6-46c5-11e7-8a12-9b5bac60a23f.png)

Forgot password new page, when user has a personal key:
![screen shot 2017-06-01 at 12 23 56 pm](https://cloud.githubusercontent.com/assets/1421848/26689961/9efd2710-46c5-11e7-9ba1-ff14c7f78993.png)
