### PR TITLE
Remove CBP Jobs CERT env from IdP PROD

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -295,14 +295,12 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
-    allow_on_prod_chef_env: 'true'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:cert:app':
     redirect_uri: 'gov.dhs.cbp.jobs.applicant.cert://result'
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
-    allow_on_prod_chef_env: 'true'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod':
     redirect_uri: 'https://careers.cbp.dhs.gov/hrm/app'


### PR DESCRIPTION
**Why**: The CBP Jobs SP in their CERT env should not be allowed to be used in our PROD env