### PR TITLE
Improve logic in Idv::UspsMail#mail_spammed?

### DIFF
--- a/app/services/idv/usps_mail.rb
+++ b/app/services/idv/usps_mail.rb
@@ -8,6 +8,7 @@ module Idv
     end
 
     def mail_spammed?
+      return false if user_mail_events.empty?
       max_events? && updated_within_last_month?
     end
 
@@ -23,7 +24,7 @@ module Idv
     end
 
     def max_events?
-      user_mail_events.count == MAX_MAIL_EVENTS
+      user_mail_events.size == MAX_MAIL_EVENTS
     end
 
     def updated_within_last_month?

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -180,6 +180,7 @@ test:
   idp_sso_target_url: 'http://identityprovider.example.com/saml/auth'
   logins_per_ip_limit: '2'
   logins_per_ip_period: '60'
+  max_mail_events: '2'
   newrelic_license_key: 'xxx'
   otp_delivery_blocklist_bantime: '1'
   otp_delivery_blocklist_findtime: '1'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -11,6 +11,8 @@ Figaro.require_keys(
   'idp_sso_target_url',
   'logins_per_ip_limit',
   'logins_per_ip_period',
+  'max_mail_events',
+  'max_mail_events_window_in_days',
   'min_password_score',
   'otp_delivery_blocklist_bantime',
   'otp_delivery_blocklist_findtime',


### PR DESCRIPTION
**Why**: If the `max_mail_events` Figaro key is not set on the server,
or if it's set to zero, and if the user has not requested any letters,
`max_events?` will return `true`, which will then cause
`updated_within_last_month?` to throw a NoMethod error because it can't
call `update_at` on a nil object.

**How**:
- Return `false` early in `mail_spammed?` if the user has not requested
any letters.
- Add `max_mail_events` and `max_mail_events_window_in_days` to the list
of required Figaro keys.
- Set `max_mail_events` to 2 in the test environment to avoid creating
more entries in the DB than is necessary.
- Use `#size` instead of `#count` for performance reasons.