### PR TITLE
Temporarily disable rack-attack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module Upaya
     config.autoload_paths << Rails.root.join('app', 'mailers', 'concerns')
     config.time_zone = 'UTC'
 
-    config.middleware.use Rack::Attack unless Figaro.env.disable_email_sending == 'true'
+    # config.middleware.use Rack::Attack unless Figaro.env.disable_email_sending == 'true'
 
     config.browserify_rails.force = true
     config.browserify_rails.commandline_options = '-t [ babelify --presets [ es2015 ] ]'

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'throttling requests' do
+xdescribe 'throttling requests' do
   include Rack::Test::Methods
 
   def app


### PR DESCRIPTION
**Why**: We had configuration issues in production

--

Redo of #1443 (but this time onto master instead of a release branch directly)