### PR TITLE
Use OpenStruct instead of MockResponse

### DIFF
--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -42,9 +42,7 @@ module Idv
       Proofer::Resolution.new(
         success: false,
         errors: { agent: [err_msg] },
-        vendor_resp: Proofer::Vendor::MockResponse.new(
-          reasons: [err_msg]
-        )
+        vendor_resp: OpenStruct.new(reasons: [err_msg])
       )
     end
   end


### PR DESCRIPTION
**Why**: The Proofing::Vendor::MockResponse class doesn't
do anything besides inherit from OpenStruct.