### PR TITLE
Add controller/view/xlations/specs for recovery flow reboot

### DIFF
--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -19,6 +19,17 @@
   vertical-align: middle;
 }
 
+
+.block-center {
+  margin: 0 auto;
+}
+
+.scale-down {
+  // trigger anti-aliasing in chrome
+  backface-visibility: hidden;
+  transform: scale(.7);
+}
+
 @media #{$breakpoint-sm} {
   // scss-lint:disable ImportantRule
   .sm-display-inline-block { display: inline-block !important; }

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -186,7 +186,7 @@ module TwoFactorAuthenticatable
     elsif @updating_existing_number
       account_path
     elsif decorated_user.password_reset_profile.present?
-      reactivate_account_path
+      manage_reactivate_account_path
     else
       account_path
     end

--- a/app/controllers/reactivate_account_controller.rb
+++ b/app/controllers/reactivate_account_controller.rb
@@ -1,0 +1,20 @@
+class ReactivateAccountController < ApplicationController
+  before_action :confirm_two_factor_authenticated
+  before_action :confirm_password_reset_profile
+
+  def index
+    user_session[:acknowledge_personal_key] ||= true
+  end
+
+  def update
+    user_session.delete(:acknowledge_personal_key)
+    redirect_to verify_url
+  end
+
+  protected
+
+  def confirm_password_reset_profile
+    return if current_user.decorate.password_reset_profile
+    redirect_to root_url
+  end
+end

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -3,6 +3,7 @@ class VerifyController < ApplicationController
 
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_needed, only: %i[cancel fail]
+  before_action :profile_needs_reactivation?, only: [:index]
 
   def index
     if active_profile?
@@ -25,6 +26,15 @@ class VerifyController < ApplicationController
   end
 
   private
+
+  def profile_needs_reactivation?
+    return unless password_reset_profile && user_session[:acknowledge_personal_key] == true
+    redirect_to manage_reactivate_account_url
+  end
+
+  def password_reset_profile
+    current_user.decorate.password_reset_profile
+  end
 
   def active_profile?
     current_user.active_profile.present?

--- a/app/views/reactivate_account/index.html.slim
+++ b/app/views/reactivate_account/index.html.slim
@@ -1,0 +1,22 @@
+- title t('titles.reactivate_account')
+
+h1.h3.mt0.mb2 = t('headings.account.reactivate')
+
+p.mb4 = t('instructions.account.reactivate.intro')
+
+h2.h4.pb1.border-bottom = t('instructions.account.reactivate.begin')
+
+h3.fs-20p.sans-serif.mt4 = t('instructions.account.reactivate.with_key')
+
+p.mb0 = t('instructions.account.reactivate.explanation')
+
+.scale-down
+  = render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX'
+
+.block-center.center.col-10
+  .col-12.mb2
+    = link_to t('links.account.reactivate.with_key'), reactivate_account_path,
+      class: 'btn btn-primary block'
+  = form_tag manage_reactivate_account_path, method: :put, class: 'col-12' do
+    = button_tag t('links.account.reactivate.without_key'), type: 'submit',
+      class: 'btn btn-secondary block col-12'

--- a/app/views/users/reactivate_account/index.html.slim
+++ b/app/views/users/reactivate_account/index.html.slim
@@ -1,4 +1,4 @@
-- title t('titles.reactivate_profile')
+- title t('titles.reactivate_account')
 
 h1.h3.my0 = t('forms.reactivate_profile.title')
 p.mt-tiny.mb0 = t('forms.reactivate_profile.instructions')

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -18,6 +18,7 @@ en:
       account_history: Account history
       login_info: Your account
       profile_info: Profile information
+      reactivate: Reactivate your account
       two_factor: Two-factor authentication
       verified_account: Verified Account
     personal_key: Here is your personal key

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -18,6 +18,7 @@ es:
       account_history: La historia de la cuenta
       login_info: Información de la cuenta
       profile_info: NOT TRANSLATED YET
+      reactivate: NOT TRANSLATED YET
       two_factor: Autenticación de dos factores
       verified_account: Cuenta verificada
     personal_key: Asegúrese de que siempre puede iniciar sesión

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -17,6 +17,16 @@ en:
           %{resend_code_link}
         fallback_html: If you can't take a phone call right now, you can %{link}
       wrong_number_html: Entered the wrong phone number? %{link}
+    account:
+      reactivate:
+        begin: Let's get started.
+        explanation: >
+          When you created your account, we gave you a list of words and asked
+          you to store them in a safe place. It looked similar to this:
+        intro: >
+          We take extra steps to keep your personal information secure and private,
+          so resetting your password takes a little extra effort.
+        with_key: Do you have your personal key?
     forgot_password:
       close_window: You can close this browser window once you have reset your password.
     password:
@@ -28,7 +38,7 @@ en:
         phrases. Also avoid repeating passwords from other online accounts such as banks, email and
         social media.
       info:
-        lead: > 
+        lead: >
           It must be at least %{min_length} characters long and not be a commonly used password.
           That's it!
       strength:

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -15,6 +15,12 @@ es:
         confirm_code_html: NOT TRANSLATED YET
         fallback_html: NOT TRANSLATED YET
       wrong_number_html: ¿Ha ingresado el número de teléfono equivocado? %{link}
+    account:
+      reactivate:
+        begin: NOT TRANSLATED YET
+        explanation: NOT TRANSLATED YET
+        intro: NOT TRANSLATED YET
+        with_key: NOT TRANSLATED YET
     forgot_password:
       close_window: Puede cerrar esta ventana del navegador despues que haya restablecido su contraseña.
     password:

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   links:
+    account:
+      reactivate:
+        with_key: I have my key
+        without_key: I don't have my key
     back_to_sp: Back to %{sp}
     contact: Contact
     copy: Copy

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   links:
+    account:
+      reactivate:
+        with_key: NOT TRANSLATED YET
+        without_key: NOT TRANSLATED YET
     back_to_sp: "Volver a %{sp}"
     contact: Contactar
     copy: NOT TRANSLATED YET

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -15,7 +15,7 @@ en:
       confirm: Confirm the password for your account
       forgot: Reset the password for your account
     account: Account
-    reactivate_profile: Reactivate profile
+    reactivate_account: Reactivate your account
     personal_key: Just in case
     registrations:
       new: Sign up for a account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -15,7 +15,7 @@ es:
       confirm: NOT TRANSLATED YET
       forgot: NOT TRANSLATED YET
     account: NOT TRANSLATED YET
-    reactivate_profile: NOT TRANSLATED YET
+    reactivate_account: NOT TRANSLATED YET
     personal_key: NOT TRANSLATED YET
     registrations:
       new: NOT TRANSLATED YET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
   get '/account' => 'accounts#show'
   get '/account/reactivate' => 'users/reactivate_account#index', as: :reactivate_account
   post '/account/reactivate' => 'users/reactivate_account#create'
+  get '/account/reactivate/start' => 'reactivate_account#index', as: :manage_reactivate_account
+  put '/account/reactivate/start' => 'reactivate_account#update'
   get '/account/verify_phone' => 'users/verify_profile_phone#index', as: :verify_profile_phone
   post '/account/verify_phone' => 'users/verify_profile_phone#create'
 

--- a/spec/controllers/reactivate_account_controller_spec.rb
+++ b/spec/controllers/reactivate_account_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe ReactivateAccountController do
+  let(:user) { create(:user, profiles: profiles) }
+  let(:profiles) { [] }
+
+  before { stub_sign_in(user) }
+
+  describe 'before_actions' do
+    it 'requires the user to be logged in' do
+      expect(subject).to have_actions(
+        :confirm_two_factor_authenticated
+      )
+    end
+  end
+
+  describe '#index' do
+    context 'with a password reset profile' do
+      let(:profiles) { [create(:profile, deactivation_reason: :password_reset)] }
+
+      it 'renders the index template' do
+        get :index
+
+        expect(subject).to render_template(:index)
+      end
+
+      it 'sets a key on the user session for future redirect guidance' do
+        get :index
+
+        expect(subject.user_session[:acknowledge_personal_key]).to eq true
+      end
+    end
+
+    context 'wthout a password reset profile' do
+      let(:profiles) { [create(:profile, :active)] }
+      it 'redirects to the root url' do
+        get :index
+
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:profiles) { [create(:profile, deactivation_reason: :password_reset)] }
+
+    it 'redirects user to verify_url' do
+      put :update
+
+      expect(subject.user_session[:acknowledge_personal_key]).to be_nil
+      expect(response).to redirect_to verify_url
+    end
+  end
+end

--- a/spec/controllers/verify_controller_spec.rb
+++ b/spec/controllers/verify_controller_spec.rb
@@ -34,6 +34,16 @@ describe VerifyController do
 
       expect(response).to redirect_to verify_fail_url
     end
+
+    it 'redirects to account recovery if user has a password reset profile' do
+      profile = create(:profile, deactivation_reason: :password_reset)
+      stub_sign_in(profile.user)
+      allow(subject).to receive(:user_session).and_return(acknowledge_personal_key: true)
+
+      get :index
+
+      expect(response).to redirect_to manage_reactivate_account_url
+    end
   end
 
   describe '#activated' do

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -16,6 +16,10 @@ feature 'Password recovery via personal key' do
     click_submit_default
     enter_correct_otp_code_for_user(user)
 
+    expect(current_path).to eq manage_reactivate_account_path
+
+    click_on t('links.account.reactivate.with_key')
+
     expect(current_path).to eq reactivate_account_path
 
     reactivate_profile(new_password, personal_key)
@@ -32,8 +36,6 @@ feature 'Password recovery via personal key' do
     reset_password_and_sign_back_in(user, new_password)
     click_submit_default
     enter_correct_otp_code_for_user(user)
-
-    expect(current_path).to eq reactivate_account_path
 
     visit manage_personal_key_path
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -74,8 +74,7 @@ feature 'User profile' do
         reset_password_and_sign_back_in(user, user_password)
         click_submit_default
         enter_correct_otp_code_for_user(user)
-        click_on t('links.cancel')
-        click_on t('account.index.reactivation.reverify')
+        click_on t('links.account.reactivate.without_key')
         click_idv_begin
         complete_idv_profile_ok(user)
         click_acknowledge_personal_key


### PR DESCRIPTION
**Why**: We are changing around our accout recovery flow to better match
the existing experience

Linked issue is pretty large, this is a subset of the changes being made to the account recovery flow. Currently, this only adds the new reactivate_account_controller, routes, specs, and view. The user will still be redirected to the existing reactivate_account screen at `/account/reactivate`

Screenshot:

![screen shot 2017-06-02 at 2 11 09 pm](https://cloud.githubusercontent.com/assets/1421848/26738766/6988f018-479d-11e7-90ad-af5ee5a728c5.png)

Designs are still in progress and thus don't match the comps exactly. Updates will be made in a future PR as soon as these are finalized.