### PR TITLE
Redirect to branded page after canceling

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,9 @@
 class UsersController < ApplicationController
   def destroy
+    path_after_cancellation = decorated_session.cancel_link_path
     destroy_user
     flash[:success] = t('sign_up.cancel.success')
-    redirect_to root_path
+    redirect_to path_after_cancellation
   end
 
   private

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -65,8 +65,8 @@ class ServiceProviderSessionDecorator
     end
   end
 
-  def cancel_link_url
-    sign_up_start_url(request_id: sp_session[:request_id])
+  def cancel_link_path
+    sign_up_start_path(request_id: sp_session[:request_id])
   end
 
   private

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -37,7 +37,7 @@ class SessionDecorator
 
   def requested_attributes; end
 
-  def cancel_link_url
-    root_url
+  def cancel_link_path
+    root_path
   end
 end

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -13,4 +13,4 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
 
-= render 'shared/cancel', link: decorated_session.cancel_link_url
+= render 'shared/cancel', link: decorated_session.cancel_link_path

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,5 +25,14 @@ describe UsersController do
 
       expect { delete :destroy }.to change(User, :count).by(-1)
     end
+
+    it 'redirects to the branded start page if the user came from an SP' do
+      session[:sp] = { issuer: 'http://localhost:3000', request_id: 'foo' }
+
+      delete :destroy
+
+      expect(response).
+        to redirect_to sign_up_start_path(request_id: 'foo')
+    end
   end
 end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -93,14 +93,14 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#cancel_link_url' do
+  describe '#cancel_link_path' do
     it 'returns sign_up_start_url with the request_id as a param' do
       subject = ServiceProviderSessionDecorator.new(
         sp: sp, view_context: view_context, sp_session: { request_id: 'foo' }
       )
 
-      expect(subject.cancel_link_url).
-        to eq 'http://www.example.com/sign_up/start?request_id=foo'
+      expect(subject.cancel_link_path).
+        to eq '/sign_up/start?request_id=foo'
     end
   end
 end

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe SessionDecorator do
     end
   end
 
-  describe '#cancel_link_url' do
-    it 'returns root url' do
-      expect(subject.cancel_link_url).to eq 'http://www.example.com/'
+  describe '#cancel_link_path' do
+    it 'returns root path' do
+      expect(subject.cancel_link_path).to eq '/'
     end
   end
 end

--- a/spec/features/saml/loa1/account_creation_spec.rb
+++ b/spec/features/saml/loa1/account_creation_spec.rb
@@ -14,4 +14,19 @@ feature 'Canceling Account Creation' do
       expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
     end
   end
+
+  context 'From the enter password page', email: true do
+    it 'redirects to the branded start page' do
+      authn_request = auth_request.create(saml_settings)
+      visit authn_request
+      sp_request_id = ServiceProviderRequest.last.uuid
+      click_link t('sign_up.registrations.create_account')
+      submit_form_with_valid_email
+      click_confirmation_link_in_email('test@test.com')
+      screenshot_and_save_page
+      click_button t('links.cancel_account_creation')
+
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+    end
+  end
 end

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -35,9 +35,9 @@ describe 'sign_up/registrations/new.html.slim' do
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
   end
 
-  it 'includes a link to return to the decorated_session cancel_link_url' do
+  it 'includes a link to return to the decorated_session cancel_link_path' do
     render
 
-    expect(rendered).to have_link(t('links.cancel'), href: @decorated_session.cancel_link_url)
+    expect(rendered).to have_link(t('links.cancel'), href: @decorated_session.cancel_link_path)
   end
 end


### PR DESCRIPTION
**Why**: If you came from an SP, canceling account creation should
take you back to the branded start page.