### PR TITLE
Use single link in account password reset partial

### DIFF
--- a/app/views/accounts/_password_reset.html.slim
+++ b/app/views/accounts/_password_reset.html.slim
@@ -1,4 +1,3 @@
 .mb4.alert.alert-warning
   p = t('account.index.reactivation.instructions')
-  p.mb0 = link_to t('account.index.reactivation.personal_key'), reactivate_account_path
-  p.mb0.mt2 = link_to t('account.index.reactivation.reverify'), verify_path
+  p.mb0 = link_to t('account.index.reactivation.link'), manage_reactivate_account_path

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -15,9 +15,7 @@ en:
       previous_address: Previous address
       reactivation:
         instructions: Your profile was recently deactivated due to a password reset.
-          You can use your personal key to reactivate your profile.
-        personal_key: Reactivate your profile with your personal key.
-        reverify: No personal key? Reverify all your information instead.
+        link: Reactivate your profile now.
       ssn: Social Security Number
       verification:
         instructions: Your account requires a secret code to be verified.

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -15,8 +15,7 @@ es:
       previous_address: NOT TRANSLATED YET
       reactivation:
         instructions: NOT TRANSLATED YET
-        personal_key: NOT TRANSLATED YET
-        reverify: NOT TRANSLATED YET
+        link:  NOT TRANSLATED YET
       ssn: NOT TRANSLATED YET
       verification:
         instructions: NOT TRANSLATED YET

--- a/spec/views/accounts/show.html.slim_spec.rb
+++ b/spec/views/accounts/show.html.slim_spec.rb
@@ -92,9 +92,8 @@ describe 'accounts/show.html.slim' do
     it 'contains link to reactivate profile via personal key or reverification' do
       render
 
-      expect(rendered).to have_link(t('account.index.reactivation.personal_key'),
-                                    href: reactivate_account_path)
-      expect(rendered).to have_link(t('account.index.reactivation.reverify'), href: verify_path)
+      expect(rendered).to have_link(t('account.index.reactivation.link'),
+                                    href: manage_reactivate_account_path)
     end
   end
 


### PR DESCRIPTION
**Why**: We have a new page with two choices for reactivating an
account, so having two links on the /account page is redundant

![screen shot 2017-06-05 at 11 46 19 am](https://cloud.githubusercontent.com/assets/1421848/26792036/142ad84c-49e7-11e7-8c8f-9d61f874deef.png)
