### PR TITLE
Add reactivation warning modal, fallback, specs

### DIFF
--- a/app/assets/javascripts/misc/reactivate-account-modal.js
+++ b/app/assets/javascripts/misc/reactivate-account-modal.js
@@ -1,0 +1,13 @@
+const modal = new window.LoginGov.Modal({ el: '#reactivate-account-modal' });
+const modalTrigger = document.getElementById('no-key-reactivate');
+const modalDismiss = document.getElementById('no-key-reactivate-dismiss');
+
+modalTrigger.addEventListener('click', (event) => {
+  event.preventDefault();
+  modal.show();
+});
+
+modalDismiss.addEventListener('click', (event) => {
+  event.preventDefault();
+  modal.hide();
+});

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -19,9 +19,18 @@
   vertical-align: middle;
 }
 
-
 .block-center {
   margin: 0 auto;
+}
+
+.js-fallback {
+  display: none;
+}
+
+.no-js {
+  .js-fallback {
+    display: block;
+  }
 }
 
 .scale-down {

--- a/app/views/reactivate_account/_modal.html.slim
+++ b/app/views/reactivate_account/_modal.html.slim
@@ -1,0 +1,18 @@
+#reactivate-account-modal.display-none
+ = render layout: '/shared/modal_layout' do
+   .p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
+     h2.my2.fs-20p.sans-serif.regular.center
+       = t('instructions.account.reactivate.modal.heading')
+     hr.mb3.bw4.rounded
+     .mb5
+        = t('instructions.account.reactivate.modal.copy')
+     .center
+       = form_tag reactivate_account_path, method: :put do
+         = button_tag t('forms.buttons.continue'), type: 'submit',
+           class: 'btn btn-primary col-12 mb2 p2 rounded-lg', name: :personal_key
+       button.btn.col-12.p2.rounded-lg.border.border-blue.blue(
+         type='button', id='no-key-reactivate-dismiss'
+       )
+         = t('links.cancel')
+
+== javascript_include_tag 'misc/reactivate-account-modal'

--- a/app/views/reactivate_account/index.html.slim
+++ b/app/views/reactivate_account/index.html.slim
@@ -1,5 +1,10 @@
 - title t('titles.reactivate_account')
 
+.js-fallback
+  .alert.alert-warning
+    .bold
+       = t('instructions.account.reactivate.modal.copy')
+
 h1.h3.mt0.mb2 = t('headings.account.reactivate')
 
 p.mb4 = t('instructions.account.reactivate.intro')
@@ -19,4 +24,6 @@ p.mb0 = t('instructions.account.reactivate.explanation')
       class: 'btn btn-primary block'
   = form_tag reactivate_account_path, method: :put, class: 'col-12' do
     = button_tag t('links.account.reactivate.without_key'), type: 'submit',
-      class: 'btn btn-secondary block col-12'
+      class: 'btn btn-secondary block col-12', id: 'no-key-reactivate'
+
+= render 'reactivate_account/modal'

--- a/app/views/users/verify_personal_key/new.html.slim
+++ b/app/views/users/verify_personal_key/new.html.slim
@@ -6,11 +6,13 @@
 
       = render 'shared/personal_key_input', code: ''
       = hidden_field_tag :authenticity_token, form_authenticity_token
-    .mt2
-      = t('forms.personal_key.alternative')
-      = button_to(t('links.reverify'), { method: :put,
-          url: reactivate_account_path }, class: 'btn btn-link ml1')
-      .mt4
-        = button_tag t('forms.buttons.continue'), type: 'submit', class: 'btn btn-primary btn-wide'
+
+    .mt3
+      = button_tag t('forms.buttons.continue'), type: 'submit', class: 'btn btn-primary btn-wide'
+
+.mt2
+  = t('forms.personal_key.alternative')
+  = button_to(t('links.reverify'), reactivate_account_path, method: :put,
+    class: 'btn btn-link ml1', form_class: 'inline-block')
 
 = render 'shared/cancel', link: account_path

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -26,6 +26,9 @@ en:
         intro: >
           We take extra steps to keep your personal information secure and private,
           so resetting your password takes a little extra effort.
+        modal:
+          copy: If you don't have your personal key, you will need to verify your identity again.
+          heading: Don't have your personal key?
         with_key: Do you have your personal key?
     forgot_password:
       close_window: You can close this browser window once you have reset your password.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -20,6 +20,9 @@ es:
         begin: NOT TRANSLATED YET
         explanation: NOT TRANSLATED YET
         intro: NOT TRANSLATED YET
+        modal:
+          copy: NOT TRANSLATED YET
+          heading: NOT TRANSLATED YET
         with_key: NOT TRANSLATED YET
     forgot_password:
       close_window: Puede cerrar esta ventana del navegador despues que haya restablecido su contraseña.

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -85,7 +85,7 @@ module IdvHelper
     click_on t('idv.buttons.cancel')
   end
 
-  def complete_idv_profile_ok(user)
+  def complete_idv_profile_ok(user, password = user_password)
     fill_out_idv_form_ok
     click_idv_continue
     fill_out_financial_form_ok
@@ -93,7 +93,7 @@ module IdvHelper
     click_idv_address_choose_phone
     fill_out_phone_form_ok(user.phone)
     click_idv_continue
-    fill_in 'Password', with: user_password
+    fill_in 'Password', with: password
     click_submit_default
   end
 end

--- a/spec/views/reactivate_account/index.html.slim_spec.rb
+++ b/spec/views/reactivate_account/index.html.slim_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'reactivate_account/index.html.slim' do
+  it 'displays a fallback warning alert when js is off' do
+    render
+
+    expect(rendered).to have_content(t('instructions.account.reactivate.modal.copy'))
+  end
+end


### PR DESCRIPTION
**Why**: The user should know that they must reactivate their account
following a password reset. Using a modal to provide 'heads up'
information matches our current UX. A fallback alert message is also
provided when JS is disabled

**Screenshots**:

<img width="287" alt="screen shot 2017-06-13 at 9 01 22 am" src="https://user-images.githubusercontent.com/1421848/27097806-7a68828c-5043-11e7-9505-efa7efa35fa0.png">

![screen shot 2017-06-13 at 9 36 18 am](https://user-images.githubusercontent.com/1421848/27097812-7d813d2e-5043-11e7-91f4-7fad584d7373.png)
