### PR TITLE
Improve defensiveness of logout logic

### DIFF
--- a/app/services/single_logout_handler.rb
+++ b/app/services/single_logout_handler.rb
@@ -32,7 +32,7 @@ SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user) do
   end
 
   def slo_not_implemented_at_sp?
-    identity.sp_metadata[:assertion_consumer_logout_service_url].nil?
+    identity.sp_metadata[:assertion_consumer_logout_service_url].blank?
   end
 
   def identity

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -52,6 +52,7 @@ test:
       - 'http://localhost:7654/'
     cert: 'saml_test_sp'
     friendly_name: 'Test SP'
+    assertion_consumer_logout_service_url: ''
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -472,6 +472,27 @@ feature 'OpenID Connect' do
     end
   end
 
+  context 'canceling sign in with active identities present' do
+    it 'signs the user out and returns to the home page' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+
+      user = create(:user, :signed_up)
+
+      visit_idp_from_sp_with_loa1
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit(user.email, user.password)
+      click_submit_default
+      visit destroy_user_session_url
+
+      visit_idp_from_sp_with_loa1
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit(user.email, user.password)
+      click_link t('links.cancel')
+
+      expect(current_url).to eq root_url
+    end
+  end
+
   def visit_idp_from_sp_with_loa1(state: SecureRandom.hex)
     client_id = 'urn:gov:gsa:openidconnect:sp:server'
     nonce = SecureRandom.hex


### PR DESCRIPTION
**Why**: A bug was discovered where an OIDC Service Provider's
configuration included attributes that are only meant for SAML,
namely `assertion_consumer_logout_service_url`. That attribute was
set to an empty string, but the logic in
`SingleLogoutHandler#slo_not_implemented_at_sp?` was checking for
`nil?` only, which caused `SamlIdpController#logout` to proceed all the
way to call `generate_slo_request` with a nil URL (instead of
returning early at `finish_slo_at_idp`), which resulted in an
exception in `SecureHeadersWhitelister.extract_domain` due to the `nil`
URL.

**How**: In addition to the empty SAML attribute, reproducing this bug
also requires that the user have an active identity with the OIDC SP.
In SAML, identities get deactivated during the logout process, but
OIDC identities remain active (which could be another bug).
This is why the spec signs the user in fully to the SP first to create
the identity, then signs out, then signs in again, but cancels the
sign in process on the 2FA screen.

Using `blank?` instead of `nil?` fixes the bug.