### PR TITLE
Update IdV to work with Equifax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:18F/identity-equifax-api-client-gem.git
-  revision: 979a3342a2d08ee6ea2c444b846e4e15d50a0891
+  revision: 4308a502baf7b65e8b463ecafc2d428d530b4349
   branch: master
   specs:
     equifax (1.0.0)
@@ -228,7 +228,7 @@ GEM
       rails (>= 3.1.1)
     diff-lcs (1.3)
     docile (1.1.5)
-    dotenv (2.2.0)
+    dotenv (2.2.1)
     dotiw (3.1.1)
       actionpack (>= 3)
       i18n
@@ -298,7 +298,7 @@ GEM
     httpi (2.4.2)
       rack
       socksify
-    i18n (0.8.1)
+    i18n (0.8.4)
     i18n-tasks (0.9.15)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
@@ -351,7 +351,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     minitest (5.10.2)
     multi_json (1.12.1)
     multi_xml (0.6.0)
@@ -360,8 +360,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     newrelic_rpm (4.1.0.333)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     nori (2.6.0)
     notiffany (0.1.1)
       nenv (~> 0.1)

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -10,7 +10,7 @@ module Idv
         idv_session.financials_confirmation = false
       end
 
-      FormResponse.new(success: success, errors: errors, extra: extra_analytics_attributes)
+      FormResponse.new(success: success, errors: errors)
     end
 
     def form_valid_but_vendor_validation_failed?
@@ -36,12 +36,6 @@ module Idv
     def vendor_params
       finance_type = idv_form.finance_type
       { finance_type => idv_form.idv_params[finance_type] }
-    end
-
-    def extra_analytics_attributes
-      {
-        vendor: { reasons: vendor_reasons },
-      }
     end
   end
 end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -7,7 +7,7 @@ module Idv
         idv_session.phone_confirmation = false
       end
 
-      FormResponse.new(success: complete?, errors: errors, extra: extra_analytics_attributes)
+      FormResponse.new(success: complete?, errors: errors)
     end
 
     def form_valid_but_vendor_validation_failed?
@@ -36,10 +36,6 @@ module Idv
       idv_session.phone_confirmation = true
       idv_session.address_verification_mechanism = :phone
       idv_session.params = idv_form.idv_params
-    end
-
-    def extra_analytics_attributes
-      { vendor: { reasons: vendor_reasons } }
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -56,7 +56,7 @@ module Idv
     end
 
     def vendor_params
-      applicant_params_ascii.merge(uuid: current_user.uuid)
+      applicant_params_ascii.merge('uuid' => current_user.uuid)
     end
 
     def profile

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -138,7 +138,6 @@ describe Verify::FinanceController do
         result = {
           success: true,
           errors: {},
-          vendor: { reasons: ['Good number'] },
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -154,7 +153,6 @@ describe Verify::FinanceController do
         result = {
           success: false,
           errors: { ccn: ['The ccn could not be verified.'] },
-          vendor: { reasons: ['Bad number'] },
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -171,7 +169,6 @@ describe Verify::FinanceController do
         result = {
           success: false,
           errors: { ccn: ['Credit card number should be only last 8 digits.'] },
-          vendor: { reasons: nil },
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -66,7 +66,6 @@ describe Verify::PhoneController do
           errors: {
             phone: [invalid_phone_message],
           },
-          vendor: { reasons: nil },
         }
 
         expect(@analytics).to have_received(:track_event).with(
@@ -89,7 +88,7 @@ describe Verify::PhoneController do
 
         put :create, idv_phone_form: { phone: good_phone }
 
-        result = { success: true, errors: {}, vendor: { reasons: ['Good number'] } }
+        result = { success: true, errors: {} }
 
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION, result
@@ -107,7 +106,6 @@ describe Verify::PhoneController do
           errors: {
             phone: ['The phone number could not be verified.'],
           },
-          vendor: { reasons: ['Bad number'] },
         }
 
         expect(flash[:warning]).to match t('idv.modal.phone.heading')

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -94,7 +94,7 @@ describe Verify::SessionsController do
         it 'assigned user UUID to applicant' do
           post :create, profile: user_attrs
 
-          expect(subject.idv_session.applicant[:uuid]).to eq subject.current_user.uuid
+          expect(subject.idv_session.applicant['uuid']).to eq subject.current_user.uuid
         end
       end
 

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -20,7 +20,6 @@ describe Idv::FinancialsStep do
   describe '#submit' do
     it 'returns FormResponse with success: false for invalid params' do
       step = build_step(finance_type: :ccn, ccn: '1234')
-      extra = { vendor: { reasons: nil } }
       errors = { ccn: [t('idv.errors.invalid_ccn')] }
 
       response = instance_double(FormResponse)
@@ -29,13 +28,12 @@ describe Idv::FinancialsStep do
 
       expect(submission).to eq response
       expect(FormResponse).to have_received(:new).
-        with(success: false, errors: errors, extra: extra)
+        with(success: false, errors: errors)
       expect(idv_session.financials_confirmation).to eq false
     end
 
     it 'returns FormResponse with success: true for mock-happy CCN' do
       step = build_step(finance_type: :ccn, ccn: '12345678')
-      extra = { vendor: { reasons: ['Good number'] } }
 
       response = instance_double(FormResponse)
       allow(FormResponse).to receive(:new).and_return(response)
@@ -44,7 +42,7 @@ describe Idv::FinancialsStep do
 
       expect(submission).to eq response
       expect(FormResponse).to have_received(:new).
-        with(success: true, errors: {}, extra: extra)
+        with(success: true, errors: {})
       expect(idv_session.financials_confirmation).to eq true
       expect(idv_session.params).to eq idv_finance_form.idv_params
     end
@@ -52,7 +50,6 @@ describe Idv::FinancialsStep do
     it 'returns FormResponse with success: false for mock-sad CCN' do
       step = build_step(finance_type: :ccn, ccn: '00000000')
 
-      extra = { vendor: { reasons: ['Bad number'] } }
       errors = { ccn: ['The ccn could not be verified.'] }
 
       response = instance_double(FormResponse)
@@ -61,7 +58,7 @@ describe Idv::FinancialsStep do
 
       expect(submission).to eq response
       expect(FormResponse).to have_received(:new).
-        with(success: false, errors: errors, extra: extra)
+        with(success: false, errors: errors)
       expect(idv_session.financials_confirmation).to eq false
     end
   end

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -25,12 +25,11 @@ describe Idv::PhoneStep do
       step = build_step(phone: '555')
 
       errors = { phone: [invalid_phone_message] }
-      extra = { vendor: { reasons: nil } }
 
       result = instance_double(FormResponse)
 
       expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
+        with(success: false, errors: errors).and_return(result)
       expect(step.submit).to eq result
       expect(idv_session.phone_confirmation).to eq false
     end
@@ -39,9 +38,8 @@ describe Idv::PhoneStep do
       step = build_step(phone: '555-555-0000')
 
       result = instance_double(FormResponse)
-      extra = { vendor: { reasons: ['Good number'] } }
 
-      expect(FormResponse).to receive(:new).with(success: true, errors: {}, extra: extra).
+      expect(FormResponse).to receive(:new).with(success: true, errors: {}).
         and_return(result)
       expect(step.submit).to eq result
       expect(idv_session.phone_confirmation).to eq true
@@ -52,12 +50,11 @@ describe Idv::PhoneStep do
       step = build_step(phone: '555-555-5555')
 
       errors = { phone: ['The phone number could not be verified.'] }
-      extra = { vendor: { reasons: ['Bad number'] } }
 
       result = instance_double(FormResponse)
 
       expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
+        with(success: false, errors: errors).and_return(result)
       expect(step.submit).to eq result
       expect(idv_session.phone_confirmation).to eq false
     end

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -142,7 +142,7 @@ describe Idv::ProfileStep do
       step.submit
 
       expect(idv_session.params).to eq user_attrs
-      expect(idv_session.applicant).to eq user_attrs.merge(uuid: user.uuid)
+      expect(idv_session.applicant).to eq user_attrs.merge('uuid' => user.uuid)
     end
   end
 


### PR DESCRIPTION
**Why**: During UAT testing with Equifax, we came across some ID
verification issues, some of which required changes to the equifax
gem, and some of which required changes to the IdP code.

**How**:
- Remove extra analytics attributes for vendor reasons in the Financials
and Phone steps because Equifax does not return any reasons for those
verifications.
- Update `vendor_params` so that all keys are Strings for consistency
- Update equifax gem to latest commit on master