### PR TITLE
Handle invalid OIDC requests before persisting

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -56,6 +56,13 @@ class OpenidConnectAuthorizeForm
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
+  # Similar to submit, but only helps generate errors
+  def check_submit
+    @success = valid?
+    @identity = NullIdentity.new
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+  end
+
   def loa3_requested?
     ial == 3
   end
@@ -128,7 +135,8 @@ class OpenidConnectAuthorizeForm
   end
 
   def success_redirect_uri
-    openid_connect_redirector.success_redirect_uri(code: identity.session_uuid)
+    code = identity.session_uuid
+    openid_connect_redirector.success_redirect_uri(code: code) if code
   end
 
   def error_redirect_uri

--- a/app/models/null_identity.rb
+++ b/app/models/null_identity.rb
@@ -12,4 +12,8 @@ class NullIdentity
   def sp_metadata
     {}
   end
+
+  def session_uuid
+    nil
+  end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -130,6 +130,25 @@ RSpec.describe OpenidConnect::AuthorizationController do
     end
 
     context 'user is not signed in' do
+      context 'without valid acr_values' do
+        before { params.delete(:acr_values) }
+
+        it 'handles the error and does not blow up' do
+          action
+
+          expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+        end
+      end
+
+      context 'with a bad redirect_uri' do
+        before { params[:redirect_uri] = '!!!' }
+
+        it 'renders the error page' do
+          action
+          expect(controller).to render_template('openid_connect/authorization/error')
+        end
+      end
+
       it 'redirects to SP landing page with the request_id in the params' do
         action
         sp_request_id = ServiceProviderRequest.last.uuid

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -34,63 +34,21 @@ RSpec.describe OpenidConnectAuthorizeForm do
   let(:code_challenge_method) { nil }
 
   describe '#submit' do
-    let(:user) { create(:user) }
-    let(:rails_session_id) { SecureRandom.hex }
-    subject(:result) { form.submit(user, rails_session_id) }
+    subject(:result) { form.submit }
 
     context 'with valid params' do
       it 'is successful' do
         allow(FormResponse).to receive(:new)
 
-        form.submit(user, rails_session_id)
-
-        identity = user.identities.where(service_provider: client_id).first
+        form.submit
 
         extra_attributes = {
           client_id: client_id,
-          redirect_uri: "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}",
+          redirect_uri: nil,
         }
 
         expect(FormResponse).to have_received(:new).
           with(success: true, errors: {}, extra: extra_attributes)
-      end
-
-      it 'links an identity for this client with the code as the session_uuid' do
-        redirect_uri = URI(result.to_h[:redirect_uri])
-        code = URIService.params(redirect_uri)[:code]
-
-        identity = user.identities.where(service_provider: client_id).first
-        expect(identity.session_uuid).to eq(code)
-        expect(identity.nonce).to eq(nonce)
-      end
-
-      it 'sets the max ial/loa from the request on the identity' do
-        result
-
-        identity = user.identities.where(service_provider: client_id).first
-        expect(identity.ial).to eq(3)
-      end
-
-      context 'with PKCE' do
-        let(:code_challenge) { 'abcdef' }
-        let(:code_challenge_method) { 'S256' }
-
-        it 'records the code_challenge on the identity' do
-          allow(FormResponse).to receive(:new)
-
-          form.submit(user, rails_session_id)
-
-          identity = user.identities.where(service_provider: client_id).first
-
-          extra_attributes = {
-            client_id: client_id,
-            redirect_uri: "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}",
-          }
-
-          expect(identity.code_challenge).to eq(code_challenge)
-          expect(FormResponse).to have_received(:new).
-            with(success: true, errors: {}, extra: extra_attributes)
-        end
       end
     end
 
@@ -124,26 +82,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
           to include(t('openid_connect.authorization.errors.redirect_uri_no_match'))
 
         expect(result.extra[:redirect_uri]).to be_nil
-      end
-    end
-  end
-
-  describe '#check_submit' do
-    subject(:result) { form.check_submit }
-
-    context 'with valid params' do
-      it 'generates a result without a redirect_uri' do
-        expect(result.success?).to eq(true)
-        expect(result.extra[:redirect_uri]).to be_blank
-      end
-    end
-
-    context 'with invalid params' do
-      let(:acr_values) { nil }
-
-      it 'generates an error object with a redirect_uri' do
-        expect(result.success?).to eq(false)
-        expect(result.extra[:redirect_uri]).to be_present
       end
     end
   end
@@ -309,6 +247,47 @@ RSpec.describe OpenidConnectAuthorizeForm do
       form = OpenidConnectAuthorizeForm.new(client_id: 'foobar')
 
       expect(form.client_id).to eq 'foobar'
+    end
+  end
+
+  describe '#link_identity_to_service_provider' do
+    let(:user) { create(:user) }
+    let(:rails_session_id) { SecureRandom.hex }
+
+    context 'with PKCE' do
+      let(:code_challenge) { 'abcdef' }
+      let(:code_challenge_method) { 'S256' }
+
+      it 'records the code_challenge on the identity' do
+        form.link_identity_to_service_provider(user, rails_session_id)
+
+        identity = user.identities.where(service_provider: client_id).first
+
+        expect(identity.code_challenge).to eq(code_challenge)
+        expect(identity.nonce).to eq(nonce)
+        expect(identity.ial).to eq(3)
+      end
+    end
+  end
+
+  describe '#success_redirect_uri' do
+    let(:user) { create(:user) }
+    let(:rails_session_id) { SecureRandom.hex }
+
+    context 'when the identity has been linked' do
+      it 'returns a redirect URI with the code from the identity session_uuid' do
+        form.link_identity_to_service_provider(user, rails_session_id)
+        identity = user.identities.where(service_provider: client_id).first
+
+        expect(form.success_redirect_uri).
+          to eq "#{redirect_uri}?code=#{identity.session_uuid}&state=#{state}"
+      end
+    end
+
+    context 'when the identity has not been linked' do
+      it 'returns nil' do
+        expect(form.success_redirect_uri).to be_nil
+      end
     end
   end
 end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -128,6 +128,26 @@ RSpec.describe OpenidConnectAuthorizeForm do
     end
   end
 
+  describe '#check_submit' do
+    subject(:result) { form.check_submit }
+
+    context 'with valid params' do
+      it 'generates a result without a redirect_uri' do
+        expect(result.success?).to eq(true)
+        expect(result.extra[:redirect_uri]).to be_blank
+      end
+    end
+
+    context 'with invalid params' do
+      let(:acr_values) { nil }
+
+      it 'generates an error object with a redirect_uri' do
+        expect(result.success?).to eq(false)
+        expect(result.extra[:redirect_uri]).to be_present
+      end
+    end
+  end
+
   describe '#valid?' do
     subject(:valid?) { form.valid? }
 


### PR DESCRIPTION
**Why**: Saving invalid forms to the database causes errors