### PR TITLE
Delegated proofing outline

### DIFF
--- a/app/controllers/concerns/delegated_proofing_concern.rb
+++ b/app/controllers/concerns/delegated_proofing_concern.rb
@@ -1,0 +1,7 @@
+module DelegatedProofingConcern
+  extend ActiveSupport::Concern
+
+  def delegated_proofing_session?
+    ServiceProvider.from_issuer(sp_session[:issuer]).supports_delegated_proofing?
+  end
+end

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -59,7 +59,12 @@ module SamlIdpAuthConcern
   end
 
   def identity_needs_verification?
-    loa3_requested? && current_user.decorate.identity_not_verified?
+    loa3_requested? &&
+      (current_user.decorate.identity_not_verified? && !pending_delegated_profile?)
+  end
+
+  def pending_delegated_profile?
+    current_user.decorate.pending_profile? && delegated_proofing_session?
   end
 
   def loa3_requested?

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -30,9 +30,7 @@ module VerifyProfileConcern
   end
 
   def pending_delegated_profile_to_same_issuer?
-    pending_profile = decorated_user.pending_profile
-
-    pending_profile.present? && pending_profile.delegated_proofing_issuer == sp_session[:issuer]
+    sp_session[:issuer] == decorated_user.pending_profile&.delegated_proofing_issuer
   end
 
   def decorated_user

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -16,7 +16,6 @@ module VerifyProfileConcern
   end
 
   def verify_profile_route
-    decorated_user = current_user.decorate
     if decorated_user.needs_profile_phone_verification?
       flash[:notice] = t('account.index.verification.instructions')
       return 'verify_profile_phone'
@@ -26,6 +25,17 @@ module VerifyProfileConcern
 
   def profile_needs_verification?
     return false if current_user.blank?
-    current_user.decorate.pending_profile_requires_verification?
+    decorated_user.pending_profile_requires_verification? &&
+      !pending_delegated_profile_to_same_issuer?
+  end
+
+  def pending_delegated_profile_to_same_issuer?
+    pending_profile = decorated_user.pending_profile
+
+    pending_profile.present? && pending_profile.delegated_proofing_issuer == sp_session[:issuer]
+  end
+
+  def decorated_user
+    @_decorated_user ||= current_user.decorate
   end
 end

--- a/app/controllers/delegated_proofing_controller.rb
+++ b/app/controllers/delegated_proofing_controller.rb
@@ -7,10 +7,7 @@ class DelegatedProofingController < ApplicationController
     if result.success?
       render json: { success: true }
     else
-      render json: {
-               success: false,
-               errors: result.errors,
-             },
+      render json: { success: false, errors: result.errors },
              status: :bad_request
     end
   end
@@ -29,6 +26,6 @@ class DelegatedProofingController < ApplicationController
   end
 
   def delegated_proofing_form
-    DelegatedProofingForm.new(params)
+    @_delegated_proofing_form ||= DelegatedProofingForm.new(params)
   end
 end

--- a/app/controllers/delegated_proofing_controller.rb
+++ b/app/controllers/delegated_proofing_controller.rb
@@ -1,4 +1,34 @@
 class DelegatedProofingController < ApplicationController
+  before_action :require_authorized_api_client
+
   def create
+    result = delegated_proofing_form.submit
+
+    if result.success?
+      render json: { success: true }
+    else
+      render json: {
+               success: false,
+               errors: result.errors,
+             },
+             status: :bad_request
+    end
+  end
+
+  private
+
+  def require_authorized_api_client
+    return if current_service_provider.active?
+
+    render json: { success: false },
+           status: :unauthorized
+  end
+
+  def current_service_provider
+    @_current_service_provider ||= ServiceProvider.from_issuer(params[:client_id])
+  end
+
+  def delegated_proofing_form
+    DelegatedProofingForm.new(params)
   end
 end

--- a/app/controllers/delegated_proofing_controller.rb
+++ b/app/controllers/delegated_proofing_controller.rb
@@ -1,0 +1,4 @@
+class DelegatedProofingController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -2,6 +2,7 @@ module OpenidConnect
   class AuthorizationController < ApplicationController
     include FullyAuthenticatable
     include VerifyProfileConcern
+    include DelegatedProofingConcern
 
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :validate_authorize_form, only: [:index]
@@ -45,7 +46,12 @@ module OpenidConnect
     end
 
     def identity_needs_verification?
-      @authorize_form.loa3_requested? && current_user.decorate.identity_not_verified?
+      @authorize_form.loa3_requested? &&
+        (current_user.decorate.identity_not_verified? && !pending_delegated_profile?)
+    end
+
+    def pending_delegated_profile?
+      current_user.decorate.pending_profile? && delegated_proofing_session?
     end
 
     def build_authorize_form_from_params

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -8,6 +8,7 @@ class SamlIdpController < ApplicationController
   include SamlIdpLogoutConcern
   include FullyAuthenticatable
   include VerifyProfileConcern
+  include DelegatedProofingConcern
 
   skip_before_action :verify_authenticity_token
   skip_before_action :handle_two_factor_authentication, only: :logout

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -37,7 +37,7 @@ module SignUp
     end
 
     def verify_confirmed
-      if current_user.decorate.identity_not_verified? && !deleted_proofing_session?
+      if current_user.decorate.identity_not_verified? && !delegated_proofing_session?
         redirect_to verify_path
       end
     end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -1,6 +1,7 @@
 module SignUp
   class CompletionsController < ApplicationController
     include SecureHeadersConcern
+    include DelegatedProofingConcern
 
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
@@ -36,7 +37,9 @@ module SignUp
     end
 
     def verify_confirmed
-      redirect_to verify_path if current_user.decorate.identity_not_verified?
+      if current_user.decorate.identity_not_verified? && !deleted_proofing_session?
+        redirect_to verify_path
+      end
     end
 
     def loa3?

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -1,6 +1,7 @@
 module Verify
   class ConfirmationsController < ApplicationController
     include IdvSession
+    include DelegatedProofingConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_idv_vendor_session_started

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -2,12 +2,14 @@ module Verify
   class ReviewController < ApplicationController
     include IdvStepConcern
     include PhoneConfirmation
+    include DelegatedProofingConcern
 
     before_action :confirm_idv_steps_complete
     before_action :confirm_current_password, only: [:create]
 
     def confirm_idv_steps_complete
       return redirect_to(verify_session_path) unless idv_profile_complete?
+      return if delegated_proofing_session?
       return redirect_to(verify_finance_path) unless idv_finance_complete?
       return redirect_to(verify_address_path) unless idv_address_complete?
     end

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -2,6 +2,7 @@ module Verify
   class SessionsController < ApplicationController
     include IdvSession
     include IdvFailureConcern
+    include DelegatedProofingConcern
 
     before_action :confirm_two_factor_authenticated, except: [:destroy]
     before_action :confirm_idv_attempts_allowed
@@ -99,10 +100,6 @@ module Verify
 
     def profile_params
       params.require(:profile).permit(*Pii::Attributes.members)
-    end
-
-    def delegated_proofing_session?
-      ServiceProvider.from_issuer(sp_session[:issuer]).supports_delegated_proofing?
     end
   end
 end

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -64,7 +64,11 @@ module Verify
       flash[:success] = t('idv.messages.sessions.success',
                           pii_message: pii_msg)
 
-      redirect_to verify_finance_path
+      if delegated_proofing_session?
+        redirect_to verify_review_path
+      else
+        redirect_to verify_finance_path
+      end
     end
 
     def process_failure
@@ -95,6 +99,10 @@ module Verify
 
     def profile_params
       params.require(:profile).permit(*Pii::Attributes.members)
+    end
+
+    def delegated_proofing_session?
+      ServiceProvider.from_issuer(sp_session[:issuer]).supports_delegated_proofing?
     end
   end
 end

--- a/app/forms/delegated_proofing_form.rb
+++ b/app/forms/delegated_proofing_form.rb
@@ -1,0 +1,77 @@
+class DelegatedProofingForm
+  include ActiveModel::Model
+  include ActionView::Helpers::TranslationHelper
+
+  ATTRS = %i[
+    user_id
+    client_id
+    given_name_matches
+    family_name_matches
+    address_matches
+    birthdate_matches
+    social_security_number_matches
+    phone_matches
+  ]
+
+  attr_reader(*ATTRS)
+
+  validates :user_id, presence: true
+  validates :client_id, presence: true
+
+  validate :check_client_id_matches_user_id
+
+  def initialize(params)
+    ATTRS.each do |key|
+      instance_variable_set("@#{key}", params[key])
+    end
+  end
+
+  def submit
+    success = valid?
+
+    mark_profile_as_verified if success && all_attributes_match? && pending_profile_matches?
+
+    # TODO: success of API request vs success of actually marking as verified?
+
+    FormResponse.new(success: success, errors: errors)
+  end
+
+  private
+
+  def check_client_id_matches_user_id
+    return if identity.service_provider == service_provider.issuer
+
+    errors.add(:user_id, 'user does not match')
+  end
+
+  def mark_profile_as_verified
+    user = identity.user
+    Idv::ProfileActivator.new(user: user).call if user
+  end
+
+  def all_attributes_match?
+    # TODO: special-case SSN-optional for GOES (based on SP)
+    given_name_matches &&
+      family_name_matches &&
+      address_matches &&
+      birthdate_matches &&
+      social_security_number_matches &&
+      phone_matches
+  end
+
+  def pending_profile_matches?
+    pending_profile&.delegated_proofing_issuer == service_provider.issuer
+  end
+
+  def service_provider
+    @_service_provider ||= ServiceProvider.from_issuer(client_id)
+  end
+
+  def identity
+    @_identity ||= Identity.find_by(uuid: user_id) || NullIdentity.new
+  end
+
+  def pending_profile
+    @_pending_profile ||= identity.user.decorate.pending_profile
+  end
+end

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -34,4 +34,8 @@ class NullServiceProvider
   def redirect_uris
     []
   end
+
+  def supports_delegated_proofing?
+    false
+  end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -74,6 +74,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def loa3_session?
-    identity.ial == 3
+    identity.ial == 3 ||
+      identity.service_provider == identity.user.decorate.pending_profile&.delegated_proofing_issuer
   end
 end

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -47,14 +47,10 @@ class IdTokenBuilder
   end
 
   def acr
-    ial = identity.ial
-    case ial
-    when 1
+    if identity.user.decorate.identity_verified?
       Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
-    when 3
-      Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
     else
-      raise "Unknown ial #{ial}"
+      Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
     end
   end
 

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -48,9 +48,9 @@ class IdTokenBuilder
 
   def acr
     if identity.user.decorate.identity_verified?
-      Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
-    else
       Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+    else
+      Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
     end
   end
 

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -2,12 +2,16 @@ module Idv
   class ProfileMaker
     attr_reader :pii_attributes, :profile
 
-    def initialize(applicant:, user:, normalized_applicant:, vendor:, phone_confirmed:)
+    def initialize(
+      applicant:, user:, normalized_applicant:, vendor:, phone_confirmed:,
+      delegated_proofing_issuer:
+    )
       @profile = Profile.new(user: user, deactivation_reason: :verification_pending)
       @pii_attributes = pii_from_applicant(applicant, normalized_applicant)
       profile.encrypt_pii(user.user_access_key, pii_attributes)
       profile.vendor = vendor
       profile.phone_confirmed = phone_confirmed
+      profile.delegated_proofing_issuer = delegated_proofing_issuer
       profile.save!
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -125,8 +125,13 @@ module Idv
         normalized_applicant: Proofer::Applicant.new(normalized_applicant_params),
         phone_confirmed: phone_confirmation || false,
         user: current_user,
-        vendor: vendor
+        vendor: vendor,
+        delegated_proofing_issuer: delegated_proofing_issuer
       )
+    end
+
+    def delegated_proofing_issuer
+      issuer if ServiceProvider.from_issuer(issuer).supports_delegated_proofing?
     end
   end
 end

--- a/app/services/pii/session_store.rb
+++ b/app/services/pii/session_store.rb
@@ -18,7 +18,9 @@ module Pii
 
     def load
       session = session_store.send(:load_session_from_redis, session_uuid) || {}
-      Pii::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_pii))
+      json = session.dig('warden.user.user.session', :decrypted_pii) ||
+        session.dig('warden.user.user.session', :idv, :decrypted_pii)
+      Pii::Attributes.new_from_json(json)
     end
 
     # @api private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,9 @@ Rails.application.routes.draw do
   post '/account/verify_phone' => 'users/verify_profile_phone#create'
 
   get '/api/health/workers' => 'health/workers#index'
+
+  post '/api/identity/verify' => 'delegated_proofing#create'
+
   get '/api/openid_connect/certs' => 'openid_connect/certs#index'
   post '/api/openid_connect/token' => 'openid_connect/token#create'
   match '/api/openid_connect/token' => 'openid_connect/token#options', via: :options

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -54,6 +54,13 @@ test:
     friendly_name: 'Test SP'
     assertion_consumer_logout_service_url: ''
 
+  'urn:gov:gsa.openidconnect:delegated-proofing':
+    redirect_uris:
+      - 'http://localhost:7654/'
+    cert: 'saml_test_sp'
+    friendly_name: 'Test Delegated Proofing SP'
+    supports_delegated_proofing: true
+
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':
     metadata_url: 'http://localhost:3000/test/saml/metadata'

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -108,6 +108,7 @@ development:
     return_to_sp_url: 'http://localhost:3003'
     attribute_bundle:
       - email
+    supports_delegated_proofing: true
 
   'https://dashboard.login.gov':
     friendly_name: 'Dashboard'

--- a/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
+++ b/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
@@ -1,5 +1,5 @@
 class AddDelegatedProofingToServiceProviders < ActiveRecord::Migration
   def change
-    add_column :service_providers, :support_delegated_proofing, :boolean, default: false
+    add_column :service_providers, :supports_delegated_proofing, :boolean, default: false
   end
 end

--- a/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
+++ b/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
@@ -1,5 +1,7 @@
 class AddDelegatedProofingToServiceProviders < ActiveRecord::Migration
   def change
     add_column :service_providers, :supports_delegated_proofing, :boolean, default: false
+
+    add_column :profiles, :delegated_proofing_issuer, :string
   end
 end

--- a/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
+++ b/db/migrate/20170615152625_add_delegated_proofing_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddDelegatedProofingToServiceProviders < ActiveRecord::Migration
+  def change
+    add_column :service_providers, :support_delegated_proofing, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531204549) do
+ActiveRecord::Schema.define(version: 20170615152625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 20170531204549) do
     t.boolean  "approved",                              default: false,        null: false
     t.boolean  "native",                                default: false,        null: false
     t.string   "redirect_uris",                         default: [],                        array: true
+    t.boolean  "support_delegated_proofing",            default: false
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20170615152625) do
     t.boolean  "approved",                              default: false,        null: false
     t.boolean  "native",                                default: false,        null: false
     t.string   "redirect_uris",                         default: [],                        array: true
-    t.boolean  "support_delegated_proofing",            default: false
+    t.boolean  "supports_delegated_proofing",           default: false
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,18 +69,19 @@ ActiveRecord::Schema.define(version: 20170615152625) do
   add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "profiles", force: :cascade do |t|
-    t.integer  "user_id",                                           null: false
-    t.boolean  "active",                            default: false, null: false
+    t.integer  "user_id",                                              null: false
+    t.boolean  "active",                               default: false, null: false
     t.datetime "verified_at"
     t.datetime "activated_at"
-    t.datetime "created_at",                                        null: false
-    t.datetime "updated_at",                                        null: false
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
     t.string   "vendor"
     t.text     "encrypted_pii"
-    t.string   "ssn_signature",          limit: 64
+    t.string   "ssn_signature",             limit: 64
     t.text     "encrypted_pii_recovery"
     t.integer  "deactivation_reason"
-    t.boolean  "phone_confirmed",                   default: false, null: false
+    t.boolean  "phone_confirmed",                      default: false, null: false
+    t.string   "delegated_proofing_issuer"
   end
 
   add_index "profiles", ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree

--- a/spec/controllers/concerns/delegated_proofing_concern_spec.rb
+++ b/spec/controllers/concerns/delegated_proofing_concern_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DelegatedProofingConcern do
+  controller(ApplicationController) do
+    include DelegatedProofingConcern
+  end
+
+  describe '#delegated_proofing_session?' do
+    context 'without an SP' do
+      it { expect(controller.delegated_proofing_session?).to eq(false) }
+    end
+
+    context 'with an SP in the session' do
+      let(:issuer) { 'some_issuer' }
+
+      before { controller.session[:sp] = { issuer: issuer } }
+
+      context 'with an SP that does not support delegated proofing' do
+        it { expect(controller.delegated_proofing_session?).to eq(false) }
+      end
+
+      context 'with an SP that supports delegated proofing' do
+        let(:issuer) { 'urn:gov:gsa.openidconnect:delegated-proofing' }
+
+        it { expect(controller.delegated_proofing_session?).to eq(true) }
+      end
+    end
+  end
+end

--- a/spec/controllers/delegated_proofing_controller_spec.rb
+++ b/spec/controllers/delegated_proofing_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe DelegatedProofingController do
+  describe '#create' do
+    subject(:action) { post :create, params }
+    let(:client_id) { 'urn:gov:gsa.openidconnect:delegated-proofing' }
+
+    let(:params) do
+      {
+        user_id: SecureRandom.uuid,
+        client_id: client_id,
+        given_name_matches: true,
+        family_name_matches: true,
+        address_matches: true,
+        birthdate_matches: true,
+        social_security_number_matches: true,
+        phone_matches: true,
+      }
+    end
+
+    context 'without valid API credentials' do
+      before { params[:client_id] = SecureRandom.uuid }
+
+      it '401s' do
+        expect(action).to be_unauthorized
+      end
+    end
+
+    context 'with valid API credentials' do
+      context 'with a valid request' do
+        before do
+          expect(controller.send(:delegated_proofing_form)).to receive(:submit)
+            .and_return(FormResponse.new(success: true, errors: {}))
+        end
+
+        it 'is successful' do
+          expect(action).to be_ok
+        end
+      end
+
+      context 'with an invalid request' do
+        before { params.delete(:user_id) }
+
+        it '400s' do
+          expect(action).to be_bad_request
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -21,7 +21,8 @@ describe Verify::ConfirmationsController do
       user: user,
       normalized_applicant: normalized_applicant,
       vendor: :mock,
-      phone_confirmed: true
+      phone_confirmed: true,
+      delegated_proofing_issuer: nil,
     )
     profile = profile_maker.profile
     idv_session.pii = profile_maker.pii_attributes

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -5,8 +5,7 @@ feature 'Delegated Proofing' do
   include OpenidConnectHelper
 
   it 'allows accounts to be verified by a participating agency out-of-band', email: true do
-    # LOA3 auth request
-    client_id = 'urn:gov:gsa:openidconnect:sp:server'
+    client_id = 'urn:gov:gsa.openidconnect:delegated-proofing'
     state = SecureRandom.hex
     nonce = SecureRandom.hex
     email = 'test@test.com'
@@ -33,10 +32,10 @@ feature 'Delegated Proofing' do
     user_id = decoded_id_token[:sub]
 
     # make sure loa3 attributes are present, but labelled as loa1
-    expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
-    expect(decoded_id_token[:email]).to eq(user.email)
+    expect(decoded_id_token[:email]).to eq(email)
     expect(decoded_id_token[:given_name]).to eq('José')
     expect(decoded_id_token[:social_security_number]).to eq('666-66-1234')
+    expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
 
     page.driver.post api_identity_verify_path,
                      user_id: user_id,

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -19,7 +19,6 @@ feature 'Delegated Proofing' do
     sign_up_with_loa3_data(email: email)
 
     click_acknowledge_personal_key
-    click_on I18n.t('forms.buttons.continue')
 
     redirect_uri = URI(current_url)
     redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -38,6 +38,7 @@ feature 'Delegated Proofing' do
 
     page.driver.post api_identity_verify_path,
                      user_id: user_id,
+                     client_id: client_id, # TODO: authenticate via headers?
                      given_name_matches: true,
                      family_name_matches: true,
                      address_matches: true,

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'Delegated Proofing' do
+  it 'allows accounts to be verified by a participating agency out-of-band' do
+    # LOA3 auth request
+
+    # sign up
+
+    # payload -> agency
+
+    # agency -> API
+
+    # user logs in, sees LOA3 verified
+  end
+end

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -77,7 +77,7 @@ feature 'Delegated Proofing' do
     enter_2fa_code
     click_on 'Yes'
     user = User.find_with_email(email)
-    complete_idv_profile_ok(user.reload)
+    complete_idv_profile_ok(user.reload, fill_out_financial: false, fill_out_address: false)
   end
 
   def load_id_token_data(client_id:, code:)

--- a/spec/features/api/delegated_proofing_spec.rb
+++ b/spec/features/api/delegated_proofing_spec.rb
@@ -1,15 +1,114 @@
 require 'rails_helper'
 
 feature 'Delegated Proofing' do
-  it 'allows accounts to be verified by a participating agency out-of-band' do
+  include IdvHelper
+  include OpenidConnectHelper
+
+  it 'allows accounts to be verified by a participating agency out-of-band', email: true do
     # LOA3 auth request
+    client_id = 'urn:gov:gsa:openidconnect:sp:server'
+    state = SecureRandom.hex
+    nonce = SecureRandom.hex
+    email = 'test@test.com'
 
-    # sign up
+    visit_openid_authorize_path(
+      client_id: client_id,
+      state: state,
+      nonce: nonce
+    )
 
-    # payload -> agency
+    sign_up_with_loa3_data(email: email)
 
-    # agency -> API
+    click_acknowledge_personal_key
+    click_on I18n.t('forms.buttons.continue')
+
+    redirect_uri = URI(current_url)
+    redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
+    expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    expect(redirect_params[:state]).to eq(state)
+    code = redirect_params[:code]
+    expect(code).to be_present
+
+    decoded_id_token = load_id_token_data(client_id: client_id, code: code)
+    user_id = decoded_id_token[:sub]
+
+    # make sure loa3 attributes are present, but labelled as loa1
+    expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
+    expect(decoded_id_token[:email]).to eq(user.email)
+    expect(decoded_id_token[:given_name]).to eq('José')
+    expect(decoded_id_token[:social_security_number]).to eq('666-66-1234')
+
+    page.driver.post api_identity_verify_path,
+                     user_id: user_id,
+                     given_name_matches: true,
+                     family_name_matches: true,
+                     address_matches: true,
+                     birthdate_matches: true,
+                     social_security_number_matches: true,
+                     phone_matches: true
+
+    expect(page.status_code).to eq(200)
 
     # user logs in, sees LOA3 verified
+    visit account_path
+    expect(page).to have_content I18n.t('headings.account.verified_account')
+  end
+
+  def visit_openid_authorize_path(client_id:, state:, nonce:)
+    visit openid_connect_authorize_path(
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email profile:name social_security_number',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      prompt: 'select_account',
+      nonce: nonce
+    )
+  end
+
+  def sign_up_with_loa3_data(email:)
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+
+    click_link t('sign_up.registrations.create_account')
+    submit_form_with_valid_email
+    click_confirmation_link_in_email(email)
+    submit_form_with_valid_password
+    set_up_2fa_with_valid_phone
+    enter_2fa_code
+    click_on 'Yes'
+    user = User.find_with_email(email)
+    complete_idv_profile_ok(user.reload)
+  end
+
+  def load_id_token_data(client_id:, code:)
+    jwt_payload = {
+      iss: client_id,
+      sub: client_id,
+      aud: api_openid_connect_token_url,
+      jti: SecureRandom.hex,
+      exp: 5.minutes.from_now.to_i,
+    }
+
+    client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
+    client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+
+    page.driver.post api_openid_connect_token_path,
+                     grant_type: 'authorization_code',
+                     code: code,
+                     client_assertion_type: client_assertion_type,
+                     client_assertion: client_assertion
+
+    expect(page.status_code).to eq(200)
+    token_response = JSON.parse(page.body).with_indifferent_access
+
+    id_token = token_response[:id_token]
+    expect(id_token).to be_present
+
+    decoded_id_token, _headers = JWT.decode(
+      id_token, sp_public_key, true, algorithm: 'RS256'
+    ).map(&:with_indifferent_access)
+
+    decoded_id_token
   end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'OpenID Connect' do
   include IdvHelper
+  include OpenidConnectHelper
 
   context 'with client_secret_jwt' do
     it 'succeeds' do
@@ -544,22 +545,5 @@ feature 'OpenID Connect' do
 
     token_response = JSON.parse(page.body).with_indifferent_access
     token_response[:id_token]
-  end
-
-  def sp_public_key
-    page.driver.get api_openid_connect_certs_path
-
-    expect(page.status_code).to eq(200)
-    certs_response = JSON.parse(page.body).with_indifferent_access
-
-    JSON::JWK.new(certs_response[:keys].first).to_key
-  end
-
-  def client_private_key
-    @client_private_key ||= begin
-      OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys', 'saml_test_sp.key'))
-      )
-    end
   end
 end

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe IdTokenBuilder do
     build(:identity,
           nonce: SecureRandom.hex,
           uuid: SecureRandom.uuid,
-          ial: 3,
           # this is a known value from an example developer guide
           # https://developer.pingidentity.com/en/resources/openid-connect-developers-guide.html
           access_token: 'dNZX1hEZ9wBCzNL40Upu646bdzQA',
@@ -51,8 +50,8 @@ RSpec.describe IdTokenBuilder do
       expect(decoded_payload[:nonce]).to eq(identity.nonce)
     end
 
-    it 'sets the acr to the request acr' do
-      expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF)
+    it 'sets the acr to match the user' do
+      expect(decoded_payload[:acr]).to eq(Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF)
     end
 
     it 'sets the jti to something meaningful' do

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -7,13 +7,15 @@ describe Idv::ProfileMaker do
       normalized_applicant = Proofer::Applicant.new first_name: 'Somebody', last_name: 'Oneatatime'
       user = create(:user, :signed_up)
       user.unlock_user_access_key(user.password)
+      delegated_proofing_issuer = 'some:issuer'
 
       profile_maker = described_class.new(
         applicant: applicant,
         user: user,
         normalized_applicant: normalized_applicant,
         vendor: :mock,
-        phone_confirmed: false
+        phone_confirmed: false,
+        delegated_proofing_issuer: delegated_proofing_issuer
       )
 
       profile = profile_maker.profile
@@ -21,6 +23,7 @@ describe Idv::ProfileMaker do
 
       expect(profile).to be_a Profile
       expect(profile.id).to_not be_nil
+      expect(profile.delegated_proofing_issuer).to eq(delegated_proofing_issuer)
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match 'Some'
 

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -85,14 +85,21 @@ module IdvHelper
     click_on t('idv.buttons.cancel')
   end
 
-  def complete_idv_profile_ok(user, password = user_password)
+  def complete_idv_profile_ok(user, password = user_password, fill_out_financial: true, fill_out_address: true)
     fill_out_idv_form_ok
     click_idv_continue
-    fill_out_financial_form_ok
-    click_idv_continue
-    click_idv_address_choose_phone
-    fill_out_phone_form_ok(user.phone)
-    click_idv_continue
+
+    if fill_out_financial
+      fill_out_financial_form_ok
+      click_idv_continue
+    end
+
+    if fill_out_address
+      click_idv_address_choose_phone
+      fill_out_phone_form_ok(user.phone)
+      click_idv_continue
+    end
+
     fill_in 'Password', with: password
     click_submit_default
   end

--- a/spec/support/features/openid_connect_helper.rb
+++ b/spec/support/features/openid_connect_helper.rb
@@ -1,0 +1,18 @@
+module OpenidConnectHelper
+  def sp_public_key
+    page.driver.get api_openid_connect_certs_path
+
+    expect(page.status_code).to eq(200)
+    certs_response = JSON.parse(page.body).with_indifferent_access
+
+    JSON::JWK.new(certs_response[:keys].first).to_key
+  end
+
+  def client_private_key
+    @client_private_key ||= begin
+      OpenSSL::PKey::RSA.new(
+        File.read(Rails.root.join('keys', 'saml_test_sp.key'))
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is super ugly and not ready to merge, but I wanted to get this out there to check the general approach with folks and see if it makes sense.

➡️ I wrote the feature/acceptance spec first and then tried to work backwards from there to make this happen, so please take a look at that first! ⬅️ 

The UI will need some polishing and explanations too.

## Delegated Proofing Goals

- Provide the ability to give un-verified attributes to an SP so that they can verify
- Add an API endpoint so that an SP can mark a profile as verified

## Implementation

- Add an attribute to `service_providers` to mark that they support delegated proofing
- Add an attribute to `profiles` that tracks which SP we delegated to for proofing
  - Helps keep a paper trail as well as make sure we only give non-verified attributes to that SP

## Room for Improvement

- Need to have a SAML version of this spec as well to ensure parity
- There's a lot of duplicated code, some awkward mixins
- Definitely needs more code coverage and TODOs removed
- Need to support an SSN-optional flow
- A real API authentication mechanism
- A feature flag? Or would the column on `service_providers` be enough?