### PR TITLE
Make verify-by-mail codes less error-prone

### DIFF
--- a/.reek
+++ b/.reek
@@ -22,6 +22,7 @@ FeatureEnvy:
     - UserDecorator#should_acknowledge_personal_key?
     - Pii::Attributes#[]=
     - OpenidConnectLogoutForm#load_identity
+    - Idv::ProfileMaker#pii_from_applicant
 InstanceVariableAssumption:
   exclude:
     - User

--- a/app/forms/verify_account_form.rb
+++ b/app/forms/verify_account_form.rb
@@ -35,12 +35,14 @@ class VerifyAccountForm
   end
 
   def validate_otp
-    return if valid_otp?
+    return if otp.blank? || valid_otp?
     errors.add :otp, :confirmation_code_incorrect
   end
 
   def valid_otp?
-    ActiveSupport::SecurityUtils.secure_compare(otp, pii_attributes.otp.to_s)
+    otp.present? && ActiveSupport::SecurityUtils.secure_compare(
+      Base32::Crockford.normalize(otp), Base32::Crockford.normalize(pii_attributes.otp.to_s)
+    )
   end
 
   def reset_sensitive_fields

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -28,9 +28,14 @@ module Idv
         dob: Pii::Attribute.new(raw: appl.dob, norm: norm_appl.dob),
         ssn: Pii::Attribute.new(raw: appl.ssn, norm: norm_appl.ssn),
         phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone),
-        otp: SecureRandom.hex(5)
+        otp: generate_otp
       )
     end
     # rubocop:enable MethodLength, AbcSize
+
+    def generate_otp(length: 10)
+      # Crockford encoding is 5 bits per character
+      Base32::Crockford.encode(SecureRandom.random_number(2**(5 * length)), length: length)
+    end
   end
 end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -27,6 +27,10 @@ describe Idv::ProfileMaker do
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name.raw).to eq 'Some'
       expect(pii.first_name.norm).to eq 'Somebody'
+
+      otp = pii.otp.raw
+      expect(otp.length).to eq(10)
+      expect(otp).to eq(Base32::Crockford.normalize(otp))
     end
   end
 end


### PR DESCRIPTION
**Why**:
Use crockford encoding to make them case-insensitive and
normalize confusable letters and numbers.