### PR TITLE
Remove unused Marshal code

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,6 +1,4 @@
 class SessionEncryptor
-  MARSHAL_SIGNATURE ||= 'BAh'.freeze
-
   def self.build_user_access_key
     key = Figaro.env.session_encryption_key
     UserAccessKey.new(password: key, salt: key)
@@ -13,16 +11,7 @@ class SessionEncryptor
   def self.load(value)
     decrypted = encryptor.decrypt(value, user_access_key)
 
-    if decrypted.start_with?(MARSHAL_SIGNATURE)
-      Rails.logger.info 'Marshalled session found'
-      # rubocop:disable Security/MarshalLoad
-      Marshal.load(::Base64.decode64(decrypted)).tap do |decoded_value|
-        dump(decoded_value)
-      end
-      # rubocop:enable Security/MarshalLoad
-    else
-      JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
-    end
+    JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
   end
 
   def self.dump(value)

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -7,25 +7,6 @@ describe SessionEncryptor do
 
       expect(SessionEncryptor.load(session)).to eq('foo' => 'bar')
     end
-
-    # rubocop:disable Security/MarshalLoad
-    context 'value previously serialized with Marshal and Base64 encoded' do
-      it 'decrypts the session and then calls .dump' do
-        plain = ::Base64.encode64(Marshal.dump(foo: 'bar'))
-        user_access_key = SessionEncryptor.user_access_key
-        session = SessionEncryptor.encryptor.encrypt(plain, user_access_key)
-        decrypted = SessionEncryptor.encryptor.decrypt(session, user_access_key)
-        decoded_session = Marshal.load(::Base64.decode64(decrypted))
-
-        allow(Rails.logger).to receive(:info)
-        allow(SessionEncryptor).to receive(:dump)
-
-        expect(SessionEncryptor.load(session)).to eq(foo: 'bar')
-        expect(Rails.logger).to have_received(:info).with('Marshalled session found')
-        expect(SessionEncryptor).to have_received(:dump).with(decoded_session)
-      end
-    end
-    # rubocop:enable Security/MarshalLoad
   end
 
   describe '#dump' do


### PR DESCRIPTION
**Why**: Sessions haven't been using Marshal since May 2017 or so.