### PR TITLE
Remove unused rake task

### DIFF
--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -19,21 +19,6 @@ namespace :rotate do
     end
   end
 
-  desc 'encrypt plain OTP secret key'
-  task encrypt_otp: :environment do
-    num_users = User.where.not(otp_secret_key: nil).count
-    progress = new_progress_bar('Users', num_users)
-
-    User.where.not(otp_secret_key: nil).find_in_batches.with_index do |users, _batch|
-      users.each do |user|
-        encrypted_attribute = EncryptedAttribute.new_from_decrypted(user.otp_secret_key).encrypted
-        id = user.id
-        execute "UPDATE users SET encrypted_otp_secret_key='#{encrypted_attribute}' WHERE id=#{id}"
-        progress&.increment
-      end
-    end
-  end
-
   def new_progress_bar(label, num)
     return if ENV['PROGRESS'] == 'no'
     ProgressBar.create(


### PR DESCRIPTION
**Why**: This rake task was only meant to be used temporarily to encrypt
plain text OTP secret keys in legacy DBs when we weren't encrypting the
`otp_secret_key` yet.