### PR TITLE
Remove OtpRequestsTracker#encrypted_phone

### DIFF
--- a/app/models/otp_requests_tracker.rb
+++ b/app/models/otp_requests_tracker.rb
@@ -1,22 +1,13 @@
 class OtpRequestsTracker < ActiveRecord::Base
-  include EncryptableAttribute
-
-  encrypted_attribute_without_setter(name: :phone)
-
   def self.find_or_create_with_phone(phone)
     tries ||= 1
     phone ||= phone.strip
     phone_fingerprint ||= Pii::Fingerprinter.fingerprint(phone)
 
     where(phone_fingerprint: phone_fingerprint).
-      first_or_create(phone: phone, otp_send_count: 0, otp_last_sent_at: Time.zone.now)
+      first_or_create(otp_send_count: 0, otp_last_sent_at: Time.zone.now)
   rescue ActiveRecord::RecordNotUnique
     retry unless (tries -= 1).zero?
     raise
-  end
-
-  def phone=(phone)
-    set_encrypted_attribute(name: :phone, value: phone)
-    self.phone_fingerprint = phone.present? ? encrypted_attributes[:phone].fingerprint : ''
   end
 end

--- a/db/migrate/20170626205402_remove_encrypted_phone_from_otp_requests_tracker.rb
+++ b/db/migrate/20170626205402_remove_encrypted_phone_from_otp_requests_tracker.rb
@@ -1,0 +1,5 @@
+class RemoveEncryptedPhoneFromOtpRequestsTracker < ActiveRecord::Migration
+  def change
+    remove_column :otp_requests_trackers, :encrypted_phone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170621202836) do
+ActiveRecord::Schema.define(version: 20170626205402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 20170621202836) do
   add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "otp_requests_trackers", force: :cascade do |t|
-    t.text     "encrypted_phone"
     t.datetime "otp_last_sent_at"
     t.integer  "otp_send_count",    default: 0
     t.string   "attribute_cost"


### PR DESCRIPTION
**Why**:
We don't need it, and having a custom setter for it
was duplicating code in the User model

---

Follow-up to #1464