### PR TITLE
Set a default value for lockout period

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -2,6 +2,7 @@ include ActionView::Helpers::DateHelper
 
 class UserDecorator
   MAX_RECENT_EVENTS = 5
+  DEFAULT_LOCKOUT_PERIOD = 10.minutes
 
   def initialize(user)
     @user = user
@@ -137,7 +138,12 @@ class UserDecorator
   end
 
   def lockout_period
-    Figaro.env.lockout_period_in_minutes.to_i.minutes
+    return DEFAULT_LOCKOUT_PERIOD if lockout_period_config.blank?
+    lockout_period_config.to_i.minutes
+  end
+
+  def lockout_period_config
+    @config ||= Figaro.env.lockout_period_in_minutes
   end
 
   def lockout_period_expired?

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -10,7 +10,6 @@ Figaro.require_keys(
   'equifax_ssh_passphrase',
   'hmac_fingerprinter_key',
   'idp_sso_target_url',
-  'lockout_period_in_minutes',
   'logins_per_ip_limit',
   'logins_per_ip_period',
   'max_mail_events',


### PR DESCRIPTION
**Why**: Instead of having to rely on devops to deploy Figaro config
changes before we can deploy code to our lower envs, we can make the
`lockout_period_in_minutes` optional, and set a default value for it.