### PR TITLE
Prevent Verify by mail flow redirect bug

### DIFF
--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -2,6 +2,7 @@ module IdvSession
   extend ActiveSupport::Concern
 
   def confirm_idv_session_started
+    return if current_user.decorate.needs_profile_usps_verification?
     redirect_to verify_session_url if idv_session.params.blank?
   end
 

--- a/app/controllers/verify/usps_controller.rb
+++ b/app/controllers/verify/usps_controller.rb
@@ -5,10 +5,7 @@ module Verify
     before_action :confirm_mail_not_spammed
 
     def index
-      @applicant = idv_session.normalized_applicant_params
-      decorated_usps = UspsDecorator.new(idv_session)
-      @title = decorated_usps.title
-      @button = decorated_usps.button
+      @decorated_usps = UspsDecorator.new(usps_mail_service)
     end
 
     def create

--- a/app/decorators/usps_decorator.rb
+++ b/app/decorators/usps_decorator.rb
@@ -1,8 +1,8 @@
 class UspsDecorator
-  attr_reader :idv_session
+  attr_reader :usps_mail_service
 
-  def initialize(idv_session)
-    @idv_session = idv_session
+  def initialize(usps_mail_service)
+    @usps_mail_service = usps_mail_service
   end
 
   def title
@@ -16,6 +16,6 @@ class UspsDecorator
   private
 
   def letter_already_sent?
-    @idv_session.address_verification_mechanism == 'usps'
+    @usps_mail_service.any_mail_sent?
   end
 end

--- a/app/services/idv/usps_mail.rb
+++ b/app/services/idv/usps_mail.rb
@@ -12,6 +12,10 @@ module Idv
       max_events? && updated_within_last_month?
     end
 
+    def any_mail_sent?
+      user_mail_events.any?
+    end
+
     private
 
     attr_reader :current_user

--- a/app/views/verify/usps/index.html.slim
+++ b/app/views/verify/usps/index.html.slim
@@ -2,7 +2,7 @@
   = image_tag(asset_url('check-email.svg'), size: '48x48', alt: 'check email',\
     class: 'absolute top-n24 left-0 right-0 mx-auto')
   h1.h2
-    = @title
+    = @decorated_usps.title
   p
     = t('idv.messages.usps.byline')
 
@@ -10,7 +10,7 @@
     strong
       = t('idv.messages.usps.success')
 
-= button_to @button, verify_usps_path, method: 'put',
+= button_to @decorated_usps.button, verify_usps_path, method: 'put',
   class: 'btn btn-primary btn-wide', form_class: 'inline-block mr2'
 
 = link_to t('idv.messages.usps.bad_address'), verify_phone_path

--- a/spec/decorators/usps_decorator_spec.rb
+++ b/spec/decorators/usps_decorator_spec.rb
@@ -1,23 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe UspsDecorator do
+  let(:user) { create(:user) }
   subject(:decorator) do
-    user = create(
-      :user,
-      :signed_up,
-      profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })]
-    )
-
-    idv_session = Idv::Session.new(user_session: {}, current_user: user, issuer: nil)
-    UspsDecorator.new(idv_session)
+    usps_mail_service = Idv::UspsMail.new(user)
+    UspsDecorator.new(usps_mail_service)
   end
 
   describe '#title' do
     context 'a letter has not been sent' do
-      let(:idv_session) { subject.idv_session }
-
       it 'provides text to send' do
-        subject.idv_session.address_verification_mechanism = nil
+        allow(subject.usps_mail_service).to receive(:any_mail_sent?).and_return(false)
         expect(subject.title).to eq(
           I18n.t('idv.titles.mail.verify')
         )
@@ -26,7 +19,7 @@ RSpec.describe UspsDecorator do
 
     context 'a letter has been sent' do
       it 'provides text to resend' do
-        subject.idv_session.address_verification_mechanism = 'usps'
+        allow(subject.usps_mail_service).to receive(:any_mail_sent?).and_return(true)
         expect(subject.title).to eq(
           I18n.t('idv.titles.mail.resend')
         )
@@ -37,7 +30,7 @@ RSpec.describe UspsDecorator do
   describe '#button' do
     context 'a letter has not been sent' do
       it 'provides text to send' do
-        subject.idv_session.address_verification_mechanism = nil
+        allow(subject.usps_mail_service).to receive(:any_mail_sent?).and_return(false)
         expect(subject.button).to eq(
           I18n.t('idv.buttons.mail.send')
         )
@@ -46,7 +39,7 @@ RSpec.describe UspsDecorator do
 
     context 'a letter has been sent' do
       it 'provides text to resend' do
-        subject.idv_session.address_verification_mechanism = 'usps'
+        allow(subject.usps_mail_service).to receive(:any_mail_sent?).and_return(true)
         expect(subject.button).to eq(
           I18n.t('idv.buttons.mail.resend')
         )

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -4,6 +4,24 @@ feature 'LOA3 Single Sign On' do
   include SamlAuthHelper
   include IdvHelper
 
+  def perform_id_verification_with_usps_without_confirming_code_then_sign_out(user)
+    saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
+    visit saml_authn_request
+    sign_in_live_with_2fa(user)
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+    click_idv_address_choose_usps
+    click_on t('idv.buttons.mail.send')
+    fill_in :user_password, with: user.password
+    click_submit_default
+    click_acknowledge_personal_key
+    first(:link, t('links.sign_out')).click
+    click_submit_default
+  end
+
   context 'First time registration' do
     let(:email) { 'test@test.com' }
     before do
@@ -186,6 +204,7 @@ feature 'LOA3 Single Sign On' do
         sign_in_live_with_2fa(user)
 
         expect(current_path).to eq verify_account_path
+        expect(page).to have_content t('idv.messages.usps.resend')
 
         click_button t('forms.verify_profile.submit')
 
@@ -195,6 +214,21 @@ feature 'LOA3 Single Sign On' do
         find('input').click
 
         expect(current_url).to eq saml_authn_request
+      end
+
+      it 'provides an option to send another letter' do
+        user = create(:user, :signed_up)
+
+        perform_id_verification_with_usps_without_confirming_code_then_sign_out(user)
+
+        sign_in_live_with_2fa(user)
+
+        expect(current_path).to eq verify_account_path
+
+        click_link(t('idv.messages.usps.resend'))
+
+        expect(user.events.account_verified.size).to be(0)
+        expect(current_path).to eq(verify_usps_path)
       end
     end
 

--- a/spec/views/verify/usps/index.html.slim_spec.rb
+++ b/spec/views/verify/usps/index.html.slim_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'verify/usps/index.html.slim' do
+  it 'calls UspsDecorator#title and #button' do
+    user = build_stubbed(:user, :signed_up)
+    usps_mail_service = Idv::UspsMail.new(user)
+
+    usps_decorator = instance_double(UspsDecorator)
+    allow(UspsDecorator).to receive(:new).with(usps_mail_service).
+      and_return(usps_decorator)
+    @decorated_usps = usps_decorator
+
+    expect(usps_decorator).to receive(:title)
+    expect(usps_decorator).to receive(:button)
+
+    render
+  end
+end


### PR DESCRIPTION
For issue: https://github.com/18F/identity-private/issues/1890

### The situation
As @andrewhughey had stated in https://github.com/18F/identity-private/issues/1890#issuecomment-307799695, here is the flow that this PR is fixing:

create account (email, password, 2FA)
verify identity (person info, financial info)
choose to confirm address by mail
send letter
see profile / flash message that letter was sent
**sign out**
**sign in**
asked for code from letter but oh no! I never got a letter
choose send new letter

**expected**: send new letter screen

**actual**: restart identity verification

---
### The solution
This PR adds logic to prevent the user from being redirected back to identity verification, sending them to the "Send another letter" confirmation screen instead, as expected. 

The faulty redirect was happening because the a request to send more mail was triggering the `IdvSession` service, which redirects to verification if verification hasn't been completed. To fix this, we added [an exception](https://github.com/18F/identity-idp/compare/master...bsh-verify-mail#diff-2768401aa5fc10e88f8565c22e9c261eR5) that prevents that redirect if a user has mail already sent mail.
