### PR TITLE
Renames account recovery to account reactivation

### DIFF
--- a/app/controllers/concerns/account_reactivation_concern.rb
+++ b/app/controllers/concerns/account_reactivation_concern.rb
@@ -1,4 +1,4 @@
-module AccountRecoveryConcern
+module AccountReactivationConcern
   extend ActiveSupport::Concern
 
   def confirm_password_reset_profile

--- a/app/controllers/reactivate_account_controller.rb
+++ b/app/controllers/reactivate_account_controller.rb
@@ -1,5 +1,5 @@
 class ReactivateAccountController < ApplicationController
-  include AccountRecoveryConcern
+  include AccountReactivationConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :confirm_password_reset_profile

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class VerifyPasswordController < ApplicationController
-    include AccountRecoveryConcern
+    include AccountReactivationConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_password_reset_profile

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -1,10 +1,10 @@
 module Users
   class VerifyPersonalKeyController < ApplicationController
-    include AccountRecoveryConcern
+    include AccountReactivationConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_password_reset_profile
-    before_action :init_account_recovery, only: [:new]
+    before_action :init_account_reactivation, only: [:new]
 
     def new
       @personal_key_form = VerifyPersonalKeyForm.new(
@@ -25,10 +25,10 @@ module Users
 
     private
 
-    def init_account_recovery
+    def init_account_reactivation
       return if reactivate_account_session.started?
 
-      flash.now[:notice] = t('notices.account_recovery')
+      flash.now[:notice] = t('notices.account_reactivation')
       reactivate_account_session.start
     end
 

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -1,6 +1,6 @@
 class VerifyController < ApplicationController
   include IdvSession
-  include AccountRecoveryConcern
+  include AccountReactivationConcern
 
   before_action :confirm_two_factor_authenticated
   before_action :confirm_idv_needed, only: %i[cancel fail]

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   notices:
-    account_recovery: Great! You have your personal key.
+    account_reactivation: Great! You have your personal key.
     dap_html: >
       <!-- We participate in the US government’s analytics program. -->
       <!-- See the data at analytics.usa.gov. -->

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -1,7 +1,7 @@
 ---
 es:
   notices:
-    account_recovery: NOT TRANSLATED YET
+    account_reactivation: NOT TRANSLATED YET
     dap_html: NOT TRANSLATED YET
     forgot_password:
       use_diff_email:

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -20,71 +20,72 @@ describe Users::VerifyPasswordController do
     end
   end
 
-  context 'without personal key flag set' do
-    let(:profiles) { [create(:profile, deactivation_reason: :password_reset)] }
-
-    describe '#new' do
-      it 'redirects to the root url' do
-        get :new
-        expect(response).to redirect_to(root_url)
-      end
-    end
-
-    describe '#update' do
-      it 'redirects to the root url' do
-        get :new
-        expect(response).to redirect_to(root_url)
-      end
-    end
-  end
-
   context 'with password reset profile' do
     let(:profiles) { [create(:profile, deactivation_reason: :password_reset)] }
     let(:response_ok) { FormResponse.new(success: true, errors: {}, extra: { personal_key: key }) }
     let(:response_bad) { FormResponse.new(success: false, errors: {}) }
     let(:key) { 'key' }
 
-    before do
-      allow(subject.reactivate_account_session).to receive(:personal_key?).and_return(personal_key)
-    end
+    context 'without personal key flag set' do
+      describe '#new' do
+        it 'redirects to the root url' do
+          get :new
+          expect(response).to redirect_to(root_url)
+        end
+      end
 
-    describe '#new' do
-      it 'renders the `new` template' do
-        get :new
-
-        expect(response).to render_template(:new)
+      describe '#update' do
+        it 'redirects to the root url' do
+          get :new
+          expect(response).to redirect_to(root_url)
+        end
       end
     end
 
-    describe '#update' do
-      let(:form) { instance_double(VerifyPasswordForm) }
-
+    context 'with personal key flag set' do
       before do
-        expect(controller).to receive(:verify_password_form).and_return(form)
+        allow(subject.reactivate_account_session).to receive(:personal_key?).
+          and_return(personal_key)
       end
 
-      context 'with valid password' do
-        before do
-          allow(form).to receive(:submit).and_return(response_ok)
-          put :update, user: { password: user.password }
-        end
-
-        it 'redirects to the account page' do
-          expect(response).to redirect_to(account_url)
-        end
-
-        it 'sets a new personal key as a flash message' do
-          expect(flash[:personal_key]).to eq(key)
-        end
-      end
-
-      context 'without valid password' do
-        it 'renders the new template' do
-          allow(form).to receive(:submit).and_return(response_bad)
-
-          put :update, user: { password: user.password }
+      describe '#new' do
+        it 'renders the `new` template' do
+          get :new
 
           expect(response).to render_template(:new)
+        end
+      end
+
+      describe '#update' do
+        let(:form) { instance_double(VerifyPasswordForm) }
+
+        before do
+          expect(controller).to receive(:verify_password_form).and_return(form)
+        end
+
+        context 'with valid password' do
+          before do
+            allow(form).to receive(:submit).and_return(response_ok)
+            put :update, user: { password: user.password }
+          end
+
+          it 'redirects to the account page' do
+            expect(response).to redirect_to(account_url)
+          end
+
+          it 'sets a new personal key as a flash message' do
+            expect(flash[:personal_key]).to eq(key)
+          end
+        end
+
+        context 'without valid password' do
+          it 'renders the new template' do
+            allow(form).to receive(:submit).and_return(response_bad)
+
+            put :update, user: { password: user.password }
+
+            expect(response).to render_template(:new)
+          end
         end
       end
     end

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -33,7 +33,7 @@ describe Users::VerifyPersonalKeyController do
       it 'displays a flash message to the user' do
         get :new
 
-        expect(subject.flash[:notice]).to eq(t('notices.account_recovery'))
+        expect(subject.flash[:notice]).to eq(t('notices.account_reactivation'))
       end
     end
   end


### PR DESCRIPTION
**Why**: The feature in question is account reactivation, this improves
naming consistency

Also, moves around some specs to prevent a duplicate profile error.