### PR TITLE
Return to branded page consistently when canceling

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -10,4 +10,6 @@ p.mt-tiny.mb0#email-description
   = f.input :email, required: true, input_html: { 'aria-describedby': 'email-description' }
   = f.button :submit, t('forms.buttons.continue'), class: 'mt2'
 
-= render 'shared/cancel', link: new_user_session_path
+.mt2.pt1.border-top
+  = link_to t('links.cancel'), decorated_session.cancel_link_path, class: 'h5'
+

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -1,12 +1,18 @@
 require 'rails_helper'
 
 describe 'devise/passwords/new.html.slim' do
-  let(:user) { build_stubbed(:user) }
-
   before do
     @password_reset_email_form = PasswordResetEmailForm.new('')
-
-    allow(view).to receive(:current_user).and_return(user)
+    sp = build_stubbed(
+      :service_provider,
+      friendly_name: 'Awesome Application!',
+      return_to_sp_url: 'www.awesomeness.com'
+    )
+    view_context = ActionController::Base.new.view_context
+    @decorated_session = DecoratedSession.new(
+      sp: sp, view_context: view_context, sp_session: {}
+    ).call
+    allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end
 
   it 'has a localized title' do
@@ -25,5 +31,11 @@ describe 'devise/passwords/new.html.slim' do
     render
 
     expect(rendered).to have_xpath("//form[@autocomplete='off']")
+  end
+
+  it 'has a cancel link that points to the decorated_session cancel_link_path' do
+    render
+
+    expect(rendered).to have_link(t('links.cancel'), href: @decorated_session.cancel_link_path)
   end
 end


### PR DESCRIPTION
**Why**: Consistency is key. In this case, the cancel link on the
forgot password page was always linking to the home page.

**How**: Don't use the `shared/cancel` partial because the user will
never be signing up or going through IdV if they are accessing the
Forgot Password page, so we can directly link to the decorated session's
`cancel_link_path` which contains the logic to determine whether it
should point to the home page or the branded page.