### PR TITLE
Check href when testing links

### DIFF
--- a/spec/views/verify/review/new.html.slim_spec.rb
+++ b/spec/views/verify/review/new.html.slim_spec.rb
@@ -48,7 +48,8 @@ describe 'verify/review/new.html.slim' do
     end
 
     it 'renders a link telling user why financial info is not visible' do
-      expect(rendered).to have_link t('idv.messages.review.financial_info')
+      expect(rendered).
+        to have_link(t('idv.messages.review.financial_info'), href: MarketingSite.help_url)
     end
   end
 end


### PR DESCRIPTION
**Why**: Testing for the link text alone is not enough. We also
want to make sure the link is pointing to the right place.