### PR TITLE
Remove idv_session from VendorValidator

### DIFF
--- a/app/services/idv/financials_validator.rb
+++ b/app/services/idv/financials_validator.rb
@@ -2,13 +2,9 @@ module Idv
   class FinancialsValidator < VendorValidator
     private
 
-    def session_id
-      idv_session.vendor_session_id
-    end
-
     def try_submit
       try_agent_action do
-        idv_agent.submit_financials(vendor_params, session_id)
+        idv_agent.submit_financials(vendor_params, vendor_session_id)
       end
     end
   end

--- a/app/services/idv/phone_validator.rb
+++ b/app/services/idv/phone_validator.rb
@@ -2,13 +2,9 @@ module Idv
   class PhoneValidator < VendorValidator
     private
 
-    def session_id
-      idv_session.vendor_session_id
-    end
-
     def try_submit
       try_agent_action do
-        idv_agent.submit_phone(vendor_params, session_id)
+        idv_agent.submit_phone(vendor_params, vendor_session_id)
       end
     end
   end

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -37,14 +37,20 @@ module Idv
       end
     end
 
+    def idv_vendor
+      @_idv_vendor ||= Idv::Vendor.new
+    end
+
     def vendor_errors
       @_vendor_errors ||= vendor_validator.errors
     end
 
     def vendor_validator
       @_vendor_validator ||= vendor_validator_class.new(
-        idv_session: idv_session,
-        vendor_params: vendor_params
+        applicant: idv_session.applicant,
+        vendor: (idv_session.vendor || idv_vendor.pick),
+        vendor_params: vendor_params,
+        vendor_session_id: idv_session.vendor_session_id
       )
     end
   end

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -2,11 +2,13 @@
 module Idv
   class VendorValidator
     delegate :success?, :errors, to: :result
-    attr_reader :idv_session, :vendor_params
+    attr_reader :applicant, :vendor, :vendor_params, :vendor_session_id
 
-    def initialize(idv_session:, vendor_params:)
-      @idv_session = idv_session
+    def initialize(applicant:, vendor:, vendor_params:, vendor_session_id:)
+      @applicant = applicant
+      @vendor = vendor
       @vendor_params = vendor_params
+      @vendor_session_id = vendor_session_id
     end
 
     def reasons
@@ -15,14 +17,10 @@ module Idv
 
     private
 
-    def idv_vendor
-      @_idv_vendor ||= Idv::Vendor.new
-    end
-
     def idv_agent
       @_agent ||= Idv::Agent.new(
-        applicant: idv_session.applicant,
-        vendor: (idv_session.vendor || idv_vendor.pick)
+        applicant: applicant,
+        vendor: vendor
       )
     end
 

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -3,13 +3,9 @@ require 'rails_helper'
 describe Idv::FinancialsValidator do
   let(:user) { build(:user) }
 
-  let(:idv_session) do
-    idvs = Idv::Session.new(user_session: {}, current_user: user, issuer: nil)
-    idvs.vendor = :mock
-    idvs
-  end
-
-  let(:session_id) { idv_session.vendor_session_id }
+  let(:applicant) { Proofer::Applicant.new({}) }
+  let(:vendor) { :mock }
+  let(:vendor_session_id) { SecureRandom.uuid }
 
   let(:params) do
     { ccn: '123-45-6789' }
@@ -17,15 +13,22 @@ describe Idv::FinancialsValidator do
 
   let(:confirmation) { instance_double(Proofer::Confirmation) }
 
-  subject { Idv::FinancialsValidator.new(idv_session: idv_session, vendor_params: params) }
+  subject do
+    Idv::FinancialsValidator.new(
+      applicant: applicant,
+      vendor: vendor,
+      vendor_params: params,
+      vendor_session_id: vendor_session_id
+    )
+  end
 
   def stub_agent_calls
     agent = instance_double(Idv::Agent)
     allow(Idv::Agent).to receive(:new).
-      with(applicant: idv_session.applicant, vendor: :mock).
+      with(applicant: applicant, vendor: vendor).
       and_return(agent)
     expect(agent).to receive(:submit_financials).
-      with(params, idv_session.vendor_session_id).and_return(confirmation)
+      with(params, vendor_session_id).and_return(confirmation)
   end
 
   describe '#success?' do

--- a/spec/services/idv/phone_validator_spec.rb
+++ b/spec/services/idv/phone_validator_spec.rb
@@ -3,13 +3,9 @@ require 'rails_helper'
 describe Idv::PhoneValidator do
   let(:user) { build(:user) }
 
-  let(:idv_session) do
-    idvs = Idv::Session.new(user_session: {}, current_user: user, issuer: nil)
-    idvs.vendor = :mock
-    idvs
-  end
-
-  let(:session_id) { idv_session.vendor_session_id }
+  let(:applicant) { Proofer::Applicant.new({}) }
+  let(:vendor) { :mock }
+  let(:vendor_session_id) { SecureRandom.uuid }
 
   let(:params) do
     { phone: '202-555-1212' }
@@ -17,15 +13,22 @@ describe Idv::PhoneValidator do
 
   let(:confirmation) { instance_double(Proofer::Confirmation) }
 
-  subject { Idv::PhoneValidator.new(idv_session: idv_session, vendor_params: params) }
+  subject do
+    Idv::PhoneValidator.new(
+      applicant: applicant,
+      vendor: vendor,
+      vendor_params: params,
+      vendor_session_id: vendor_session_id
+    )
+  end
 
   def stub_agent_calls
     agent = instance_double(Idv::Agent)
     allow(Idv::Agent).to receive(:new).
-      with(applicant: idv_session.applicant, vendor: :mock).
+      with(applicant: applicant, vendor: vendor).
       and_return(agent)
     expect(agent).to receive(:submit_phone).
-      with(params, idv_session.vendor_session_id).and_return(confirmation)
+      with(params, vendor_session_id).and_return(confirmation)
   end
 
   describe '#success?' do


### PR DESCRIPTION
**Why**:
Removing references to the session will make it easier to
extract VendorValidator work into a background job

--

This is one of probably many PRs that will be for async requests to vendors