### PR TITLE
Make otp_rate_limiter_spec more robust

### DIFF
--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -32,10 +32,8 @@ class OtpRateLimiter
   end
 
   def increment
-    now = Time.zone.now
-
     entry_for_current_phone.otp_send_count += 1
-    entry_for_current_phone.otp_last_sent_at = now
+    entry_for_current_phone.otp_last_sent_at = Time.zone.now
     entry_for_current_phone.save!
   end
 

--- a/spec/services/otp_rate_limiter_spec.rb
+++ b/spec/services/otp_rate_limiter_spec.rb
@@ -23,11 +23,13 @@ RSpec.describe OtpRateLimiter do
   end
 
   describe '#increment' do
-    it 'sets the otp_last_sent_at' do
-      now = Time.zone.now
+    it 'updates otp_last_sent_at' do
+      tracker = OtpRequestsTracker.find_or_create_with_phone(current_user.phone)
+      old_otp_last_sent_at = tracker.reload.otp_last_sent_at
       otp_rate_limiter.increment
+      new_otp_last_sent_at = tracker.reload.otp_last_sent_at
 
-      expect(rate_limited_phone.otp_last_sent_at.to_i).to eq(now.to_i)
+      expect(new_otp_last_sent_at).to be > old_otp_last_sent_at
     end
 
     it 'increments the otp_send_count' do


### PR DESCRIPTION
**Why**: We were comparing datetimes without freezing Time.zone.now,
leading to flickering specs.

**How**: Instead of comparing `otp_last_sent_at` with the current time,
check that the current `otp_last_sent_at` is greater than the previous
one.