### PR TITLE
Extract Idv::ProoferValidator#result

### DIFF
--- a/.reek
+++ b/.reek
@@ -24,6 +24,7 @@ FeatureEnvy:
     - Pii::Attributes#[]=
     - OpenidConnectLogoutForm#load_identity
     - Idv::ProfileMaker#pii_from_applicant
+    - Idv::Step#vendor_validator_result
 InstanceVariableAssumption:
   exclude:
     - User
@@ -53,6 +54,7 @@ TooManyInstanceVariables:
   exclude:
     - OpenidConnectAuthorizeForm
     - OpenidConnectRedirector
+    - Idv::VendorResult
 TooManyStatements:
   max_statements: 6
   exclude:

--- a/app/services/idv/financials_step.rb
+++ b/app/services/idv/financials_step.rb
@@ -30,7 +30,7 @@ module Idv
     end
 
     def vendor_reasons
-      vendor_validator.reasons if form_valid?
+      vendor_validator_result.reasons if form_valid?
     end
 
     def vendor_params

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -29,7 +29,7 @@ module Idv
     end
 
     def vendor_reasons
-      vendor_validator.reasons if form_valid?
+      vendor_validator_result.reasons if form_valid?
     end
 
     def update_idv_session

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -63,8 +63,8 @@ module Idv
 
     def update_idv_session
       idv_session.profile_confirmation = true
-      idv_session.vendor_session_id = vendor_validator.session_id
-      idv_session.normalized_applicant_params = vendor_validator.normalized_applicant.to_hash
+      idv_session.vendor_session_id = vendor_validator_result.session_id
+      idv_session.normalized_applicant_params = vendor_validator_result.normalized_applicant.to_hash
       idv_session.resolution_successful = true
     end
 
@@ -76,7 +76,7 @@ module Idv
     end
 
     def vendor_reasons
-      vendor_validator.reasons if form_valid?
+      vendor_validator_result.reasons if form_valid?
     end
   end
 end

--- a/app/services/idv/profile_validator.rb
+++ b/app/services/idv/profile_validator.rb
@@ -1,13 +1,7 @@
 module Idv
   class ProfileValidator < VendorValidator
-    delegate :session_id, to: :result
-
     def result
       @_result ||= try_start
-    end
-
-    def normalized_applicant
-      result.vendor_resp.normalized_applicant
     end
 
     private

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -21,7 +21,23 @@ module Idv
     end
 
     def vendor_validation_passed?
-      vendor_validator.success?
+      vendor_validator_result.success?
+    end
+
+    def vendor_validator_result
+      @_vendor_validator_result ||= extract_vendor_result(vendor_validator.result)
+    end
+
+    def extract_vendor_result(result)
+      vendor_resp = result.vendor_resp
+
+      Idv::VendorResult.new(
+        success: result.success?,
+        errors: result.errors,
+        reasons: vendor_resp.reasons,
+        normalized_applicant: vendor_resp.try(:normalized_applicant),
+        session_id: result.try(:session_id)
+      )
     end
 
     def errors
@@ -42,7 +58,7 @@ module Idv
     end
 
     def vendor_errors
-      @_vendor_errors ||= vendor_validator.errors
+      @_vendor_errors ||= vendor_validator_result.errors
     end
 
     def vendor_validator

--- a/app/services/idv/vendor_result.rb
+++ b/app/services/idv/vendor_result.rb
@@ -1,0 +1,26 @@
+module Idv
+  class VendorResult
+    attr_reader :success, :errors, :reasons, :session_id, :normalized_applicant
+
+    def self.new_from_json(json)
+      parsed = JSON.parse(json, symbolize_names: true)
+
+      applicant = parsed[:normalized_applicant]
+      parsed[:normalized_applicant] = Proofer::Applicant.new(applicant) if applicant
+
+      new(**parsed)
+    end
+
+    def initialize(success:, errors:, reasons:, session_id:, normalized_applicant:)
+      @success = success
+      @errors = errors
+      @reasons = reasons
+      @session_id = session_id
+      @normalized_applicant = normalized_applicant
+    end
+
+    def success?
+      success
+    end
+  end
+end

--- a/app/services/idv/vendor_validator.rb
+++ b/app/services/idv/vendor_validator.rb
@@ -1,7 +1,6 @@
 # abstract base class for proofing vendor validation
 module Idv
   class VendorValidator
-    delegate :success?, :errors, to: :result
     attr_reader :applicant, :vendor, :vendor_params, :vendor_session_id
 
     def initialize(applicant:, vendor:, vendor_params:, vendor_session_id:)
@@ -11,8 +10,8 @@ module Idv
       @vendor_session_id = vendor_session_id
     end
 
-    def reasons
-      result.vendor_resp.reasons
+    def result
+      @_result ||= try_submit
     end
 
     private
@@ -22,10 +21,6 @@ module Idv
         applicant: applicant,
         vendor: vendor
       )
-    end
-
-    def result
-      @_result ||= try_submit
     end
 
     def try_agent_action

--- a/spec/services/idv/financials_validator_spec.rb
+++ b/spec/services/idv/financials_validator_spec.rb
@@ -31,27 +31,24 @@ describe Idv::FinancialsValidator do
       with(params, vendor_session_id).and_return(confirmation)
   end
 
-  describe '#success?' do
-    it 'returns Proofer::Confirmation#success?' do
+  describe '#result' do
+    it 'has success' do
       stub_agent_calls
 
       success_string = 'true'
-
       expect(confirmation).to receive(:success?).and_return(success_string)
 
-      expect(subject.success?).to eq success_string
+      expect(subject.result.success?).to eq success_string
     end
-  end
 
-  describe '#error' do
-    it 'returns Proofer::Confirmation#errors' do
+    it 'has errors' do
       stub_agent_calls
 
       error_string = 'mucho errors'
 
       expect(confirmation).to receive(:errors).and_return(error_string)
 
-      expect(subject.errors).to eq error_string
+      expect(subject.result.errors).to eq error_string
     end
   end
 end

--- a/spec/services/idv/phone_validator_spec.rb
+++ b/spec/services/idv/phone_validator_spec.rb
@@ -31,27 +31,25 @@ describe Idv::PhoneValidator do
       with(params, vendor_session_id).and_return(confirmation)
   end
 
-  describe '#success?' do
-    it 'returns Proofer::Confirmation#success?' do
+  describe '#result' do
+    it 'has success' do
       stub_agent_calls
 
       success_string = 'true'
 
       expect(confirmation).to receive(:success?).and_return(success_string)
 
-      expect(subject.success?).to eq success_string
+      expect(subject.result.success?).to eq success_string
     end
-  end
 
-  describe '#error' do
-    it 'returns Proofer::Confirmation#errors' do
+    it 'has errors' do
       stub_agent_calls
 
       error_string = 'mucho errors'
 
       expect(confirmation).to receive(:errors).and_return(error_string)
 
-      expect(subject.errors).to eq error_string
+      expect(subject.result.errors).to eq error_string
     end
   end
 end

--- a/spec/services/idv/vendor_result_spec.rb
+++ b/spec/services/idv/vendor_result_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Idv::VendorResult do
+  let(:success) { true }
+  let(:errors) { { foo: ['is not valid'] } }
+  let(:reasons) { %w[foo bar baz] }
+  let(:session_id) { SecureRandom.uuid }
+  let(:normalized_applicant) do
+    Proofer::Applicant.new(
+      last_name: 'Ever',
+      first_name: 'Greatest'
+    )
+  end
+
+  subject(:vendor_result) do
+    Idv::VendorResult.new(
+      success: success,
+      errors: errors,
+      reasons: reasons,
+      session_id: session_id,
+      normalized_applicant: normalized_applicant
+    )
+  end
+
+  describe '#success?' do
+    it 'is the success value' do
+      expect(vendor_result.success?).to eq(success)
+    end
+  end
+
+  describe '#to_json' do
+    it 'serializes normalized_applicant correctly' do
+      json = vendor_result.to_json
+
+      parsed = JSON.parse(json, symbolize_names: true)
+      expect(parsed[:normalized_applicant][:last_name]).to eq(normalized_applicant.last_name)
+    end
+  end
+
+  describe '.new_from_json' do
+    subject(:new_from_json) { Idv::VendorResult.new_from_json(vendor_result.to_json) }
+
+    it 'has simple attributes' do
+      expect(new_from_json.success?).to eq(vendor_result.success?)
+      expect(new_from_json.errors).to eq(vendor_result.errors)
+      expect(new_from_json.reasons).to eq(vendor_result.reasons)
+      expect(new_from_json.session_id).to eq(vendor_result.session_id)
+    end
+
+    it 'turns applicant into a full object' do
+      expect(new_from_json.normalized_applicant.last_name).to eq(normalized_applicant.last_name)
+    end
+
+    context 'without an applicant' do
+      let(:normalized_applicant) { nil }
+
+      it 'does not have an applicant' do
+        expect(new_from_json.normalized_applicant).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
Extracting this into a serializable object will make it
easier to refactor these classes into background jobs.

---

Follow-up to https://github.com/18F/identity-idp/pull/1513