### PR TITLE
Return FormResponse from IdV form submission

### DIFF
--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -11,7 +11,7 @@ module Users
     def update
       @update_user_phone_form = UpdateUserPhoneForm.new(current_user)
 
-      if @update_user_phone_form.submit(user_params)
+      if @update_user_phone_form.submit(user_params).success?
         process_updates
         bypass_sign_in current_user
       else

--- a/app/forms/idv/finance_form.rb
+++ b/app/forms/idv/finance_form.rb
@@ -44,11 +44,14 @@ module Idv
     def submit(params)
       @params = params
       finance_value = update_finance_values(params)
-      return false unless valid?
 
-      clear_idv_params_finance
-      idv_params[finance_type] = finance_value
-      true
+      success = valid?
+      if success
+        clear_idv_params_finance
+        idv_params[finance_type] = finance_value
+      end
+
+      FormResponse.new(success: success, errors: errors.messages)
     end
 
     def self.finance_other_type_choices

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -20,11 +20,10 @@ module Idv
 
       self.phone = formatted_phone
 
-      return false unless valid?
+      success = valid?
+      update_idv_params(formatted_phone) if success
 
-      update_idv_params(formatted_phone)
-
-      true
+      FormResponse.new(success: success, errors: errors.messages)
     end
 
     private

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -40,6 +40,8 @@ module Idv
     def submit(params)
       initialize_params(params)
       profile.ssn_signature = ssn_signature
+
+      FormResponse.new(success: valid?, errors: errors.messages)
     end
 
     private

--- a/app/forms/update_user_phone_form.rb
+++ b/app/forms/update_user_phone_form.rb
@@ -17,7 +17,7 @@ class UpdateUserPhoneForm
   def submit(params)
     check_phone_change(params)
 
-    valid?
+    FormResponse.new(success: valid?, errors: errors.messages)
   end
 
   def phone_changed?

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -8,7 +8,7 @@ module Idv
     end
 
     def form_valid?
-      form_validate(params)
+      form_validate(params).success?
     end
 
     private

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -7,14 +7,34 @@ describe Idv::PhoneForm do
   it_behaves_like 'a phone form'
 
   describe '#submit' do
-    it 'adds phone key to idv_params when valid' do
-      subject.submit(phone: '703-555-1212')
+    context 'when the form is valid' do
+      it 'returns a successful form response' do
+        result = subject.submit(phone: '703-555-1212')
 
-      expected_params = {
-        phone: '+1 (703) 555-1212',
-      }
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
 
-      expect(subject.idv_params).to eq expected_params
+      it 'adds phone key to idv_params' do
+        subject.submit(phone: '703-555-1212')
+
+        expected_params = {
+          phone: '+1 (703) 555-1212',
+        }
+
+        expect(subject.idv_params).to eq expected_params
+      end
+    end
+
+    context 'when the form is invalid' do
+      it 'returns an unsuccessful form response' do
+        result = subject.submit(phone: 'Im not a phone number 🙃')
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(:phone)
+      end
     end
 
     it 'adds phone_confirmed_at key to idv_params when submitted phone equals user phone' do

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -19,6 +19,28 @@ describe Idv::ProfileForm do
     }
   end
 
+  describe '#submit' do
+    context 'when the form is valid' do
+      it 'returns a successful form response' do
+        result = subject.submit(profile_attrs)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when the form is invalid' do
+      before { profile_attrs[:dob] = nil }
+
+      it 'returns an unsuccessful form response' do
+        result = subject.submit(profile_attrs)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(:dob)
+      end
+    end
+  end
+
   describe 'presence validations' do
     it 'is invalid when required attribute is not present' do
       %i[first_name last_name ssn dob address1 city state zipcode].each do |attr|

--- a/spec/services/idv/financials_step_spec.rb
+++ b/spec/services/idv/financials_step_spec.rb
@@ -22,27 +22,22 @@ describe Idv::FinancialsStep do
       step = build_step(finance_type: :ccn, ccn: '1234')
       errors = { ccn: [t('idv.errors.invalid_ccn')] }
 
-      response = instance_double(FormResponse)
-      allow(FormResponse).to receive(:new).and_return(response)
-      submission = step.submit
+      result = step.submit
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
 
-      expect(submission).to eq response
-      expect(FormResponse).to have_received(:new).
-        with(success: false, errors: errors)
       expect(idv_session.financials_confirmation).to eq false
     end
 
     it 'returns FormResponse with success: true for mock-happy CCN' do
       step = build_step(finance_type: :ccn, ccn: '12345678')
 
-      response = instance_double(FormResponse)
-      allow(FormResponse).to receive(:new).and_return(response)
+      result = step.submit
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(true)
+      expect(result.errors).to be_empty
 
-      submission = step.submit
-
-      expect(submission).to eq response
-      expect(FormResponse).to have_received(:new).
-        with(success: true, errors: {})
       expect(idv_session.financials_confirmation).to eq true
       expect(idv_session.params).to eq idv_finance_form.idv_params
     end
@@ -52,13 +47,11 @@ describe Idv::FinancialsStep do
 
       errors = { ccn: ['The ccn could not be verified.'] }
 
-      response = instance_double(FormResponse)
-      allow(FormResponse).to receive(:new).and_return(response)
-      submission = step.submit
+      result = step.submit
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
 
-      expect(submission).to eq response
-      expect(FormResponse).to have_received(:new).
-        with(success: false, errors: errors)
       expect(idv_session.financials_confirmation).to eq false
     end
   end

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -26,22 +26,22 @@ describe Idv::PhoneStep do
 
       errors = { phone: [invalid_phone_message] }
 
-      result = instance_double(FormResponse)
+      result = step.submit
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-      expect(step.submit).to eq result
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
       expect(idv_session.phone_confirmation).to eq false
     end
 
     it 'returns true for mock-happy phone' do
       step = build_step(phone: '555-555-0000')
 
-      result = instance_double(FormResponse)
+      result = step.submit
 
-      expect(FormResponse).to receive(:new).with(success: true, errors: {}).
-        and_return(result)
-      expect(step.submit).to eq result
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(true)
+      expect(result.errors).to be_empty
       expect(idv_session.phone_confirmation).to eq true
       expect(idv_session.params).to eq idv_phone_form.idv_params
     end
@@ -51,11 +51,11 @@ describe Idv::PhoneStep do
 
       errors = { phone: ['The phone number could not be verified.'] }
 
-      result = instance_double(FormResponse)
+      result = step.submit
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors).and_return(result)
-      expect(step.submit).to eq result
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
       expect(idv_session.phone_confirmation).to eq false
     end
   end

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -30,15 +30,17 @@ describe Idv::ProfileStep do
     it 'succeeds with good params' do
       step = build_step(user_attrs)
 
-      result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
         vendor: { reasons: ['Everything looks good'] },
       }
 
-      expect(FormResponse).to receive(:new).
-        with(success: true, errors: {}, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      result = step.submit
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(true)
+      expect(result.errors).to be_empty
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to eq true
     end
 
@@ -51,11 +53,12 @@ describe Idv::ProfileStep do
         vendor: { reasons: ['The SSN was suspicious'] },
       }
 
-      result = instance_double(FormResponse)
+      result = step.submit
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to be_nil
     end
 
@@ -68,11 +71,12 @@ describe Idv::ProfileStep do
         vendor: { reasons: nil },
       }
 
-      result = instance_double(FormResponse)
+      result = step.submit
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to be_nil
     end
 
@@ -80,16 +84,17 @@ describe Idv::ProfileStep do
       step = build_step(user_attrs.merge(first_name: 'Bad'))
 
       errors = { first_name: ['Unverified first name.'] }
-
-      result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
         vendor: { reasons: ['The name was suspicious'] },
       }
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      result = step.submit
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to be_nil
     end
 
@@ -97,16 +102,17 @@ describe Idv::ProfileStep do
       step = build_step(user_attrs.merge(zipcode: '00000'))
 
       errors = { zipcode: ['Unverified ZIP code.'] }
-
-      result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
         vendor: { reasons: ['The ZIP code was suspicious'] },
       }
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      result = step.submit
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to be_nil
     end
 
@@ -114,16 +120,17 @@ describe Idv::ProfileStep do
       step = build_step(user_attrs.merge(prev_zipcode: '00000'))
 
       errors = { zipcode: ['Unverified ZIP code.'] }
-
-      result = instance_double(FormResponse)
       extra = {
         idv_attempts_exceeded: false,
         vendor: { reasons: ['The ZIP code was suspicious'] },
       }
 
-      expect(FormResponse).to receive(:new).
-        with(success: false, errors: errors, extra: extra).and_return(result)
-      expect(step.submit).to eq result
+      result = step.submit
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to eq(errors)
+      expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to be_nil
     end
 

--- a/spec/support/shared_examples_for_phone_validation.rb
+++ b/spec/support/shared_examples_for_phone_validation.rb
@@ -24,19 +24,25 @@ shared_examples 'a phone form' do
         allow(User).to receive(:exists?).with(email: 'new@gmail.com').and_return(false)
         allow(User).to receive(:exists?).with(phone: second_user.phone).and_return(true)
 
-        expect(subject.submit(phone: second_user.phone)).to be true
+        result = subject.submit(phone: second_user.phone)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(true)
       end
     end
 
     context 'when phone is not already taken' do
       it 'is valid' do
-        expect(subject.submit(phone: '+1 (703) 555-1212')).to be true
+        result = subject.submit(phone: '+1 (703) 555-1212')
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be true
       end
     end
 
     context 'when phone is same as current user' do
       it 'is valid' do
-        expect(subject.submit(phone: user.phone)).to be true
+        result = subject.submit(phone: user.phone)
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to be true
       end
     end
   end


### PR DESCRIPTION
**Why**: As part of backgrounding vendor proofing, it will be helpful for the IdV form objects to behave like the rest of the form objects in the app so we can extract them from the `Idv::Step` subclasses and invoke them in the controller.