### PR TITLE
Add aria-hidden to accordian content div

### DIFF
--- a/app/assets/javascripts/app/components/accordion.js
+++ b/app/assets/javascripts/app/components/accordion.js
@@ -72,6 +72,7 @@ class Accordion extends Events {
     this.content.classList.add('shown');
     this.content.classList.remove('animate-out');
     this.content.classList.add('animate-in');
+    this.content.setAttribute('aria-hidden', 'false');
     this.emit('accordion.show');
   }
 
@@ -81,6 +82,7 @@ class Accordion extends Events {
     this.shownIcon.classList.add('display-none');
     this.content.classList.remove('animate-in');
     this.content.classList.add('animate-out');
+    this.content.setAttribute('aria-hidden', 'true');
     this.emit('accordion.hide');
     this.header.focus();
   }

--- a/app/views/shared/_accordion.html.slim
+++ b/app/views/shared/_accordion.html.slim
@@ -18,6 +18,7 @@
   .accordion-content.clearfix.pt1(
     id="#{target_id}"
     role="region"
+    aria-hidden="true"
   )
     .px2
       = yield


### PR DESCRIPTION
**Why**:
This tells the screen reader the content in this div
is hidden. When the accordian is expanded, aria-
hidden is changed to false, letting the screen
reader know there is new content on screen.