### PR TITLE
Set up SMS OTP for translation

### DIFF
--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -15,7 +15,7 @@ class SmsOtpSenderJob < ActiveJob::Base
   def send_otp(twilio_service, code, phone)
     twilio_service.send_sms(
       to: phone,
-      body: "#{code} is your #{APP_NAME} one-time security code."
+      body: I18n.t('jobs.sms_otp_sender_job.message', code: code, app: APP_NAME)
     )
   end
 end

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -8,3 +8,5 @@ en:
       message_repeat: >
         Hello! Your login.gov one time security code is, %{code}, again, your
         security code is, %{code}. Press 1 to repeat your code.
+    sms_otp_sender_job:
+      message: "%{code} is your %{app} one-time security code."

--- a/config/locales/jobs/es.yml
+++ b/config/locales/jobs/es.yml
@@ -4,3 +4,5 @@ es:
     voice_otp_sender_job:
       message_final: NOT TRANSLATED YET
       message_repeat: NOT TRANSLATED YET
+    sms_otp_sender_job:
+      message: NOT TRANSLATED YET

--- a/config/locales/jobs/fr.yml
+++ b/config/locales/jobs/fr.yml
@@ -2,12 +2,12 @@
 fr:
   jobs:
     voice_otp_sender_job:
-      message_final: 'Bonjour! Votre code de sécurité à utilisation unique de login.gov
+      message_final: >
+        Bonjour! Votre code de sécurité à utilisation unique de login.gov
         est, %{code}, de nouveau, votre code de sécurité est, %{code}, au revoir!
-
-'
-      message_repeat: 'Bonjour! Votre code de sécurité à utilisation unique de login.gov
+      message_repeat: >
+        Bonjour! Votre code de sécurité à utilisation unique de login.gov
         est, %{code}, de nouveau, votre code de sécurité est, %{code}. Appuyez sur 1
         pour répéter votre code.
-
-'
+    sms_otp_sender_job:
+      message: NOT TRANSLATED YET

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -20,8 +20,7 @@ describe SmsOtpSenderJob do
 
       expect(msg.from).to match(/(\+19999999999|\+12222222222)/)
       expect(msg.to).to eq('555-5555')
-      expect(msg.body).to include('one-time security code')
-      expect(msg.body).to include('1234')
+      expect(msg.body).to eq(I18n.t('jobs.sms_otp_sender_job.message', code: '1234', app: APP_NAME))
     end
 
     it 'does not send if the OTP code is expired' do


### PR DESCRIPTION
**Why**: To support a more complete localization