### PR TITLE
Add locale to URLs in mailers

### DIFF
--- a/.reek
+++ b/.reek
@@ -101,6 +101,7 @@ UtilityFunction:
     - SessionDecorator
     - WorkerHealthChecker::Middleware#call
     - UserEncryptedAttributeOverrides#create_fingerprint
+    - LocaleHelper#locale_url_param
 'app/controllers':
   InstanceVariableAssumption:
     enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include UserSessionContext
   include VerifyProfileConcern
+  include LocaleHelper
 
   FLASH_KEYS = %w[alert error notice success warning].freeze
 
@@ -51,8 +52,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    active_locale = I18n.locale
-    { locale: active_locale == I18n.default_locale ? nil : active_locale }
+    { locale: locale_url_param }
   end
 
   private

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -1,0 +1,6 @@
+module LocaleHelper
+  def locale_url_param
+    active_locale = I18n.locale
+    active_locale == I18n.default_locale ? nil : active_locale
+  end
+end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,14 +1,21 @@
 class CustomDeviseMailer < Devise::Mailer
   include Mailable
+  include LocaleHelper
   before_action :attach_images
   layout 'layouts/user_mailer'
   default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
+
+  def reset_password_instructions(*)
+    @locale = locale_url_param
+    super
+  end
 
   def confirmation_instructions(record, token, options = {})
     presenter = ConfirmationEmailPresenter.new(record, view_context)
     @first_sentence = presenter.first_sentence
     @confirmation_period = presenter.confirmation_period
     @request_id = options[:request_id]
+    @locale = locale_url_param
     super
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,6 @@
 class UserMailer < ActionMailer::Base
   include Mailable
+  include LocaleHelper
   before_action :attach_images
   default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
 
@@ -8,8 +9,7 @@ class UserMailer < ActionMailer::Base
   end
 
   def signup_with_your_email(email)
-    @root_url = root_url
-    @new_user_password_url = new_user_password_url
+    @root_url = root_url(locale: locale_url_param)
     mail(to: email, subject: t('mailer.email_reuse_notice.subject'))
   end
 

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -12,15 +12,15 @@ table.button.expanded.large.radius
                 center
                   = link_to t('mailer.confirmation_instructions.link_text'), \
                     sign_up_create_email_confirmation_url(_request_id: \
-                    @request_id, confirmation_token: @token), \
+                    @request_id, confirmation_token: @token, locale: @locale), \
                     target: '_blank', \
                     class: 'float-center', align: 'center'
       td.expander
 
 p = link_to sign_up_create_email_confirmation_url(_request_id: @request_id, \
-    confirmation_token: @token), \
+    confirmation_token: @token, locale: @locale), \
     sign_up_create_email_confirmation_url(_request_id: @request_id, \
-    confirmation_token: @token), target: '_blank'
+    confirmation_token: @token, locale: @locale), target: '_blank'
 
 table.spacer
   tbody

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -11,13 +11,13 @@ table.button.expanded.large.radius
               td
                 center
                   = link_to t('mailer.reset_password.link_text'),
-                    edit_password_url(@resource, reset_password_token: @token),
+                    edit_password_url(@resource, reset_password_token: @token, locale: @locale),
                       target: '_blank', class: 'float-center', align: 'center'
       td.expander
 
 p
-  = link_to edit_password_url(@resource, reset_password_token: @token), \
-            edit_password_url(@resource, reset_password_token: @token), \
+  = link_to edit_password_url(@resource, reset_password_token: @token, locale: @locale), \
+            edit_password_url(@resource, reset_password_token: @token, locale: @locale), \
             target: '_blank'
 
 table.spacer

--- a/spec/helpers/locale_helper_spec.rb
+++ b/spec/helpers/locale_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe LocaleHelper do
+  include LocaleHelper
+
+  describe '#locale_url_param' do
+    context 'in the default locale' do
+      before { I18n.locale = :en }
+
+      it 'is nil' do
+        expect(locale_url_param).to be_nil
+      end
+    end
+
+    context 'in French (a non-default locale)' do
+      before { I18n.locale = :fr }
+
+      it 'is that locale' do
+        expect(locale_url_param).to eq(:fr)
+      end
+    end
+
+    context 'in Spanish (a non-default locale)' do
+      before { I18n.locale = :es }
+
+      it 'is that locale' do
+        expect(locale_url_param).to eq(:es)
+      end
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -67,6 +67,14 @@ describe UserMailer, type: :mailer do
       )
       expect_email_body_to_have_help_and_contact_links
     end
+
+    context 'in a non-default locale' do
+      before { I18n.locale = :fr }
+
+      it 'links to the correct locale' do
+        expect(mail.html_part.body).to include(root_url(locale: :fr))
+      end
+    end
   end
 
   describe 'phone_changed' do

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -26,6 +26,21 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     )
   end
 
+  context 'in a non-default locale' do
+    before { assign(:locale, 'fr') }
+
+    it 'puts the locale in the URL' do
+      assign(:resource, build_stubbed(:user, confirmed_at: Time.zone.now))
+      assign(:token, 'foo')
+      render
+
+      expect(rendered).to have_link(
+        'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo',
+        href: 'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo'
+      )
+    end
+  end
+
   it 'mentions updating an account when user has already been confirmed' do
     user = build_stubbed(:user, confirmed_at: Time.zone.now)
     presenter = ConfirmationEmailPresenter.new(user, self)


### PR DESCRIPTION
**Why**: For a consistently localized experience