### PR TITLE
Update translated JS to use locale dynamically from HTML

### DIFF
--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -46,11 +46,15 @@ window.LoginGov = window.LoginGov || {};
 ] %>
 
 window.LoginGov.I18n = {
+  currentLocale: function() { return this.__currentLocale || (this.__currentLocale = document.querySelector('html').lang); },
   strings: {},
-  t: function(key) { return this.strings[key]; },
+  t: function(key) { return this.strings[this.currentLocale()][key]; },
   key: function(key) { return key.replace(/[ -]/g, '_').replace(/\W/g, '').toLowerCase(); }
 };
 
-<% keys.each do |key| %>
-window.LoginGov.I18n.strings['<%= ActionController::Base.helpers.j key %>'] = '<%= ActionController::Base.helpers.j I18n.t(key) %>';
+<% I18n.available_locales.each do |locale| %>
+  window.LoginGov.I18n.strings['<%= ActionController::Base.helpers.j locale.to_s %>'] = {};
+  <% keys.each do |key| %>
+    window.LoginGov.I18n.strings['<%= ActionController::Base.helpers.j locale.to_s %>']['<%= ActionController::Base.helpers.j key %>'] = '<%= ActionController::Base.helpers.j I18n.t(key, locale: locale) %>';
+  <% end %>
 <% end %>


### PR DESCRIPTION
**Why**:
ERBs are compiled once, so they're stuck with whatever locale they
are compiled in. This makes one .js with all translated keys for all
locales that can be cached, and then looks up the locale from the
<html lang> attribute on every page.

<img width="565" alt="login_gov_-_not_translated_yet" src="https://user-images.githubusercontent.com/458784/27878389-197264ca-618c-11e7-8a6d-ece2ec9b9e34.png">


<img width="659" alt="login_gov_-_not_translated_yet_" src="https://user-images.githubusercontent.com/458784/27878392-1c6bb10e-618c-11e7-8eb8-0557d40b5e35.png">
