### PR TITLE
Run user_flow specs in available locales

### DIFF
--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  Faker::Config.locale = 'en-US'
+  Faker::Config.locale = :en
 
   factory :service_provider do
     cert { 'saml_test_sp' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  Faker::Config.locale = 'en-US'
+  Faker::Config.locale = :en
 
   factory :user do
     confirmed_at Time.zone.now

--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -1,224 +1,230 @@
 require 'rails_helper'
-include IdvHelper
-include SamlAuthHelper
 
 feature 'SP-initiated authentication with login.gov', user_flow: true do
-  context 'with a valid SP' do
-    context 'when LOA3' do
-      before do
-        visit loa3_authnrequest
-      end
+  include IdvHelper
+  include SamlAuthHelper
 
-      it 'prompts the user to create an account or sign in' do
-        screenshot_and_save_page
-      end
-
-      context 'when choosing Create Account' do
-        before do
-          click_link t('sign_up.registrations.create_account')
-        end
-
-        it 'prompts for email address' do
-          screenshot_and_save_page
-        end
-
-        context 'with a valid email address submitted' do
+  I18n.available_locales.each do |locale|
+    context "with locale=#{locale}" do
+      context 'with a valid SP' do
+        context 'when LOA3' do
           before do
-            @email = Faker::Internet.safe_email
-            fill_in 'Email', with: @email
-            click_button t('forms.buttons.submit.default')
-            @user = User.find_with_email(@email)
+            visit "#{loa3_authnrequest}&locale=#{locale}"
           end
 
-          it 'informs the user to check email' do
+          it 'prompts the user to create an account or sign in' do
             screenshot_and_save_page
           end
 
-          context 'with a confirmed email address' do
+          context 'when choosing Create Account' do
             before do
-              confirm_last_user
+              click_link t('sign_up.registrations.create_account')
             end
 
-            it 'prompts the user for a password' do
+            it 'prompts for email address' do
               screenshot_and_save_page
             end
 
-            context 'with a valid password' do
+            context 'with a valid email address submitted' do
               before do
-                fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
-                click_button t('forms.buttons.continue')
+                @email = Faker::Internet.safe_email
+                fill_in 'user_email', with: @email
+                click_button t('forms.buttons.submit.default')
+                @user = User.find_with_email(@email)
               end
 
-              it 'prompts the user to configure 2FA' do
+              it 'informs the user to check email' do
                 screenshot_and_save_page
               end
 
-              context 'with a valid phone number' do
+              context 'with a confirmed email address' do
                 before do
-                  fill_in 'Phone', with: Faker::PhoneNumber.cell_phone
+                  confirm_last_user
                 end
 
-                context 'with SMS delivery' do
+                it 'prompts the user for a password' do
+                  screenshot_and_save_page
+                end
+
+                context 'with a valid password' do
                   before do
-                    choose t('devise.two_factor_authentication.otp_delivery_preference.sms')
-                    click_send_security_code
+                    fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
+                    click_button t('forms.buttons.continue')
                   end
 
-                  it 'prompts for OTP' do
+                  it 'prompts the user to configure 2FA' do
                     screenshot_and_save_page
                   end
 
-                  context 'with valid OTP confirmation' do
+                  context 'with a valid phone number' do
                     before do
-                      fill_in 'code', with: @user.reload.direct_otp
-                      click_button t('forms.buttons.submit.default')
+                      fill_in 'two_factor_setup_form_phone', with: Faker::PhoneNumber.cell_phone
                     end
 
-                    it 'prompts the user to verify oneself' do
-                      screenshot_and_save_page
-                    end
-
-                    context 'when choosing Yes, continue' do
+                    context 'with SMS delivery' do
                       before do
-                        click_link t('idv.index.continue_link')
+                        choose t('devise.two_factor_authentication.otp_delivery_preference.sms')
+                        click_send_security_code
                       end
 
-                      it 'prompts for personal information' do
+                      it 'prompts for OTP' do
                         screenshot_and_save_page
                       end
 
-                      context 'with valid personal information entered' do
+                      context 'with valid OTP confirmation' do
                         before do
-                          fill_in t('idv.form.first_name'), with: Faker::Name.first_name
-                          fill_in t('idv.form.last_name'), with: Faker::Name.last_name
-                          fill_in 'profile_address1', with: '123 Main St'
-                          fill_in 'profile_city', with: Faker::Address.city
-                          find('#profile_state').find(:xpath,
-                                                      "option[#{(1..50).to_a.sample}]").
-                            select_option
-                          fill_in 'profile_zipcode', with: Faker::Address.zip_code
-                          fill_in t('idv.form.dob'), with: "09/09/#{(1900..2000).to_a.sample}"
-                          fill_in 'profile_ssn', with: "999-99-#{(1000..9999).to_a.sample}"
-                          click_button t('forms.buttons.continue')
+                          fill_in 'code', with: @user.reload.direct_otp
+                          click_button t('forms.buttons.submit.default')
                         end
 
-                        it 'prompts for the last 8 digits of a credit card' do
+                        it 'prompts the user to verify oneself' do
                           screenshot_and_save_page
                         end
 
-                        context 'with last 8 digits of credit card' do
+                        context 'when choosing Yes, continue' do
                           before do
-                            fill_out_financial_form_ok
+                            click_link t('idv.index.continue_link')
                           end
 
-                          it 'prompts to activate account by phone or mail' do
-                            screenshot_and_save_page
-                          end
-                        end
-
-                        context 'without a credit card' do
-                          before do
-                            click_link t('idv.form.use_financial_account')
-                          end
-
-                          it 'prompts user to provide a financial account number' do
+                          it 'prompts for personal information' do
                             screenshot_and_save_page
                           end
 
-                          context 'with a valid financial account' do
+                          context 'with valid personal information entered' do
                             before do
-                              select t('idv.form.mortgage'), from: 'idv_finance_form_finance_type'
-                              fill_in 'idv_finance_form_mortgage', with: '12345678'
-                              # click_idv_continue doesn't work with the JavaScript on this page
-                              # and enabling js: true causes unexpected behavior
-                              form = page.find('#new_idv_finance_form')
-                              class << form
-                                def submit!
-                                  Capybara::RackTest::Form.new(driver, native).submit({})
-                                end
-                              end
-                              form.submit!
+                              fill_in 'profile_first_name', with: Faker::Name.first_name
+                              fill_in 'profile_last_name', with: Faker::Name.last_name
+                              fill_in 'profile_address1', with: '123 Main St'
+                              fill_in 'profile_city', with: Faker::Address.city
+                              find('#profile_state').
+                                find(:xpath, "option[#{(1..50).to_a.sample}]").
+                                select_option
+                              fill_in 'profile_zipcode', with: Faker::Address.zip_code
+                              fill_in 'profile_dob', with: "09/09/#{(1900..2000).to_a.sample}"
+                              fill_in 'profile_ssn', with: "999-99-#{(1000..9999).to_a.sample}"
+                              click_button t('forms.buttons.continue')
                             end
 
-                            it 'prompts to activate account by phone or mail' do
+                            it 'prompts for the last 8 digits of a credit card' do
                               screenshot_and_save_page
                             end
 
-                            context 'when activating by phone' do
+                            context 'with last 8 digits of credit card' do
                               before do
-                                click_idv_address_choose_phone
+                                fill_out_financial_form_ok
                               end
 
-                              it 'prompts the user to confirm or enter phone number' do
+                              it 'prompts to activate account by phone or mail' do
                                 screenshot_and_save_page
                               end
                             end
 
-                            context 'when activating by mail' do
+                            context 'without a credit card' do
                               before do
-                                click_idv_address_choose_usps
+                                click_link t('idv.form.use_financial_account')
                               end
 
-                              it 'prompts the user to confirm' do
+                              it 'prompts user to provide a financial account number' do
                                 screenshot_and_save_page
                               end
 
-                              context 'when confirming to mail' do
+                              context 'with a valid financial account' do
                                 before do
-                                  click_on t('idv.buttons.mail.send')
+                                  select t('idv.form.mortgage'),
+                                         from: 'idv_finance_form_finance_type'
+                                  fill_in 'idv_finance_form_mortgage', with: '12345678'
+                                  # click_idv_continue doesn't work with the JavaScript on this page
+                                  # and enabling js: true causes unexpected behavior
+                                  form = page.find('#new_idv_finance_form')
+                                  class << form
+                                    def submit!
+                                      Capybara::RackTest::Form.new(driver, native).submit({})
+                                    end
+                                  end
+                                  form.submit!
                                 end
 
-                                it 'prompts user for password to encrypt profile' do
+                                it 'prompts to activate account by phone or mail' do
                                   screenshot_and_save_page
                                 end
 
-                                context 'when confirming password' do
+                                context 'when activating by phone' do
                                   before do
-                                    fill_in 'user_password',
-                                            with: Features::SessionHelper::VALID_PASSWORD
-                                    click_button t('forms.buttons.submit.default')
+                                    click_idv_address_choose_phone
                                   end
 
-                                  it 'provides a new personal key and prompts for verification' do
+                                  it 'prompts the user to confirm or enter phone number' do
+                                    screenshot_and_save_page
+                                  end
+                                end
+
+                                context 'when activating by mail' do
+                                  before do
+                                    click_idv_address_choose_usps
+                                  end
+
+                                  it 'prompts the user to confirm' do
                                     screenshot_and_save_page
                                   end
 
-                                  context 'when clicking Continue' do
+                                  context 'when confirming to mail' do
                                     before do
-                                      click_acknowledge_personal_key
+                                      click_on t('idv.buttons.mail.send')
                                     end
 
-                                    it 'displays the user profile' do
+                                    it 'prompts user for password to encrypt profile' do
                                       screenshot_and_save_page
+                                    end
+
+                                    context 'when confirming password' do
+                                      before do
+                                        fill_in 'user_password',
+                                                with: Features::SessionHelper::VALID_PASSWORD
+                                        click_button t('forms.buttons.submit.default')
+                                      end
+
+                                      it 'provides a new personal key and prompts to verify' do
+                                        screenshot_and_save_page
+                                      end
+
+                                      context 'when clicking Continue' do
+                                        before do
+                                          click_acknowledge_personal_key
+                                        end
+
+                                        it 'displays the user profile' do
+                                          screenshot_and_save_page
+                                        end
+                                      end
                                     end
                                   end
                                 end
+
+                                # Disabling this spec because of js: true issue
+                                # Will re-enable this once resolved
+                                # context 'when choosing to cancel' do
+                                #   before do
+                                #     click_button t('links.cancel_idv')
+                                #   end
+
+                                #   it 'prompts to continue verification or visit profile' do
+                                #     screenshot_and_save_page
+                                #   end
+                                # end
                               end
                             end
-
-                            # Disabling this spec because of js: true issue
-                            # Will re-enable this once resolved
-                            # context 'when choosing to cancel' do
-                            #   before do
-                            #     click_button t('links.cancel_idv')
-                            #   end
-
-                            #   it 'prompts to continue verification or visit profile' do
-                            #     screenshot_and_save_page
-                            #   end
-                            # end
                           end
-                        end
-                      end
 
-                      context 'with invalid personal information entered' do
-                        before do
-                          fill_out_idv_form_fail
-                          click_button t('forms.buttons.continue')
-                        end
+                          context 'with invalid personal information entered' do
+                            before do
+                              fill_out_idv_form_fail
+                              click_button t('forms.buttons.continue')
+                            end
 
-                        it 'presents a modal with current retries remaining' do
-                          screenshot_and_save_page
+                            it 'presents a modal with current retries remaining' do
+                              screenshot_and_save_page
+                            end
+                          end
                         end
                       end
                     end
@@ -227,147 +233,147 @@ feature 'SP-initiated authentication with login.gov', user_flow: true do
               end
             end
           end
-        end
-      end
 
-      # context 'when choosing to sign in' do
-      #   TODO: duplicate scenarios from Create Account here
-      # end
-    end
-
-    context 'when LOA1' do
-      before do
-        visit authnrequest_get
-      end
-
-      it 'prompts the user to create an account or sign in' do
-        screenshot_and_save_page
-      end
-
-      context 'when choosing Create Account' do
-        before do
-          click_link t('sign_up.registrations.create_account')
+          # context 'when choosing to sign in' do
+          #   TODO: duplicate scenarios from Create Account here
+          # end
         end
 
-        it 'prompts for email address' do
-          screenshot_and_save_page
-        end
-
-        context 'with a valid email address submitted' do
+        context 'when LOA1' do
           before do
-            @email = Faker::Internet.safe_email
-            fill_in 'Email', with: @email
-            click_button t('forms.buttons.submit.default')
-            @user = User.find_with_email(@email)
+            visit "#{authnrequest_get}&locale=#{locale}"
           end
 
-          it 'informs the user to check email' do
+          it 'prompts the user to create an account or sign in' do
             screenshot_and_save_page
           end
 
-          context 'with a confirmed email address' do
+          context 'when choosing Create Account' do
             before do
-              confirm_last_user
+              click_link t('sign_up.registrations.create_account')
             end
 
-            it 'prompts the user for a password' do
+            it 'prompts for email address' do
               screenshot_and_save_page
             end
 
-            context 'with a valid password' do
+            context 'with a valid email address submitted' do
               before do
-                fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
-                click_button t('forms.buttons.continue')
-              end
-
-              it 'prompts the user to configure 2FA' do
-                screenshot_and_save_page
-              end
-
-              context 'with a valid phone number' do
-                before do
-                  fill_in 'Phone', with: Faker::PhoneNumber.cell_phone
-                end
-
-                context 'with SMS delivery' do
-                  before do
-                    choose t('devise.two_factor_authentication.otp_delivery_preference.sms')
-                    click_send_security_code
-                  end
-
-                  it 'prompts for OTP' do
-                    screenshot_and_save_page
-                  end
-                end
-
-                context 'with Voice delivery' do
-                  before do
-                    choose t('devise.two_factor_authentication.otp_delivery_preference.voice')
-                    click_send_security_code
-                  end
-
-                  it 'prompts for OTP' do
-                    screenshot_and_save_page
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-
-      context 'when choosing to sign in' do
-        before do
-          @user = create(:user, :signed_up)
-          click_link t('links.sign_in')
-        end
-
-        context 'with valid credentials entered' do
-          before do
-            fill_in_credentials_and_submit(@user.email, @user.password)
-          end
-
-          it 'prompts for 2FA delivery method' do
-            screenshot_and_save_page
-          end
-
-          context 'with SMS OTP selected (default)' do
-            it 'prompts for OTP verification' do
-              screenshot_and_save_page
-            end
-
-            context 'with valid OTP confirmation' do
-              before do
-                fill_in 'code', with: @user.reload.direct_otp
+                @email = Faker::Internet.safe_email
+                fill_in 'user_email', with: @email
                 click_button t('forms.buttons.submit.default')
+                @user = User.find_with_email(@email)
               end
 
-              # Skipping since we have nothing to show: this occurs on the SP
-              xit 'redirects back to SP' do
+              it 'informs the user to check email' do
                 screenshot_and_save_page
+              end
+
+              context 'with a confirmed email address' do
+                before do
+                  confirm_last_user
+                end
+
+                it 'prompts the user for a password' do
+                  screenshot_and_save_page
+                end
+
+                context 'with a valid password' do
+                  before do
+                    fill_in 'password_form_password', with: Features::SessionHelper::VALID_PASSWORD
+                    click_button t('forms.buttons.continue')
+                  end
+
+                  it 'prompts the user to configure 2FA' do
+                    screenshot_and_save_page
+                  end
+
+                  context 'with a valid phone number' do
+                    before do
+                      fill_in 'two_factor_setup_form_phone', with: Faker::PhoneNumber.cell_phone
+                    end
+
+                    context 'with SMS delivery' do
+                      before do
+                        choose t('devise.two_factor_authentication.otp_delivery_preference.sms')
+                        click_send_security_code
+                      end
+
+                      it 'prompts for OTP' do
+                        screenshot_and_save_page
+                      end
+                    end
+
+                    context 'with Voice delivery' do
+                      before do
+                        choose t('devise.two_factor_authentication.otp_delivery_preference.voice')
+                        click_send_security_code
+                      end
+
+                      it 'prompts for OTP' do
+                        screenshot_and_save_page
+                      end
+                    end
+                  end
+                end
               end
             end
           end
-        end
 
-        context 'without a valid username and password' do
-          context 'when choosing "Forgot your password?"' do
+          context 'when choosing to sign in' do
             before do
-              click_link t('links.passwords.forgot')
+              @user = create(:user, :signed_up)
+              click_link t('links.sign_in')
             end
 
-            it 'prompts for my email address' do
-              screenshot_and_save_page
-            end
-
-            context 'with not_a_real_email_dot.com submitted' do
+            context 'with valid credentials entered' do
               before do
-                fill_in 'password_reset_email_form_email', with: 'not_a_real_email_dot.com'
-                click_button t('forms.buttons.continue')
+                fill_in_credentials_and_submit(@user.email, @user.password)
               end
 
-              it 'displays a useful error' do
+              it 'prompts for 2FA delivery method' do
                 screenshot_and_save_page
+              end
+
+              context 'with SMS OTP selected (default)' do
+                it 'prompts for OTP verification' do
+                  screenshot_and_save_page
+                end
+
+                context 'with valid OTP confirmation' do
+                  before do
+                    fill_in 'code', with: @user.reload.direct_otp
+                    click_button t('forms.buttons.submit.default')
+                  end
+
+                  # Skipping since we have nothing to show: this occurs on the SP
+                  xit 'redirects back to SP' do
+                    screenshot_and_save_page
+                  end
+                end
+              end
+            end
+
+            context 'without a valid username and password' do
+              context 'when choosing "Forgot your password?"' do
+                before do
+                  click_link t('links.passwords.forgot')
+                end
+
+                it 'prompts for my email address' do
+                  screenshot_and_save_page
+                end
+
+                context 'with not_a_real_email_dot.com submitted' do
+                  before do
+                    fill_in 'password_reset_email_form_email', with: 'not_a_real_email_dot.com'
+                    click_button t('forms.buttons.continue')
+                  end
+
+                  it 'displays a useful error' do
+                    screenshot_and_save_page
+                  end
+                end
               end
             end
           end

--- a/spec/features/flows/visitor_flows_spec.rb
+++ b/spec/features/flows/visitor_flows_spec.rb
@@ -1,186 +1,190 @@
 require 'rails_helper'
 
 feature 'Visitors requesting login.gov directly', devise: true, user_flow: true do
-  context 'when visiting the homepage' do
-    before do
-      visit root_path
-    end
-
-    it 'loads the home page' do
-      screenshot_and_save_page
-    end
-
-    describe 'showing the password' do
-      it 'allows me to see my password', js: true do
-        visit new_user_session_path
-        fill_in 'Password', with: 'my password'
-        screenshot_and_save_page
-      end
-    end
-
-    context 'when attempting to sign in' do
-      context 'with a valid account' do
+  I18n.available_locales.each do |locale|
+    context "with locale=#{locale}" do
+      context 'when visiting the homepage' do
         before do
-          @user = create(:user, :signed_up)
-          fill_in 'Email', with: @user.email
-          fill_in 'Password', with: @user.password
-          page.find('.btn-primary').click
+          visit root_path(locale: locale)
         end
 
-        it 'sends OTP via previously chosen method' do
+        it 'loads the home page' do
           screenshot_and_save_page
         end
 
-        context 'with a valid OTP' do
-          before do
-            fill_in 'code', with: @user.reload.direct_otp
-            click_button t('forms.buttons.submit.default')
-          end
-
-          it 'redirects to profile' do
+        describe 'showing the password' do
+          it 'allows me to see my password', js: true do
+            visit new_user_session_path(locale: locale)
+            fill_in 'user_password', with: 'my password'
             screenshot_and_save_page
           end
         end
 
-        context 'with an invalid OTP submitted' do
-          before do
-            fill_in 'code', with: '123abc'
-            click_button t('forms.buttons.submit.default')
-          end
-
-          it 'displays a useful error' do
-            screenshot_and_save_page
-          end
-
-          context 'with a second invalid OTP submitted' do
+        context 'when attempting to sign in' do
+          context 'with a valid account' do
             before do
-              fill_in 'code', with: '123abc'
-              click_button t('forms.buttons.submit.default')
+              @user = create(:user, :signed_up)
+              fill_in 'user_email', with: @user.email
+              fill_in 'user_password', with: @user.password
+              page.find('.btn-primary').click
             end
 
-            it 'displays a useful error' do
+            it 'sends OTP via previously chosen method' do
               screenshot_and_save_page
             end
 
-            context 'with a third invalid OTP submitted' do
+            context 'with a valid OTP' do
+              before do
+                fill_in 'code', with: @user.reload.direct_otp
+                click_button t('forms.buttons.submit.default')
+              end
+
+              it 'redirects to profile' do
+                screenshot_and_save_page
+              end
+            end
+
+            context 'with an invalid OTP submitted' do
               before do
                 fill_in 'code', with: '123abc'
                 click_button t('forms.buttons.submit.default')
               end
 
-              it 'displays a useful error and locks the user account' do
+              it 'displays a useful error' do
                 screenshot_and_save_page
               end
+
+              context 'with a second invalid OTP submitted' do
+                before do
+                  fill_in 'code', with: '123abc'
+                  click_button t('forms.buttons.submit.default')
+                end
+
+                it 'displays a useful error' do
+                  screenshot_and_save_page
+                end
+
+                context 'with a third invalid OTP submitted' do
+                  before do
+                    fill_in 'code', with: '123abc'
+                    click_button t('forms.buttons.submit.default')
+                  end
+
+                  it 'displays a useful error and locks the user account' do
+                    screenshot_and_save_page
+                  end
+                end
+              end
+            end
+          end
+
+          context 'without valid credentials' do
+            before do
+              fill_in 'user_email', with: Faker::Internet.safe_email
+              fill_in 'user_password', with: 'my password'
+              page.find('.btn-primary').click
+            end
+
+            it 'displays a useful error message' do
+              screenshot_and_save_page
+            end
+          end
+        end
+
+        context 'when choosing create account' do
+          before do
+            click_link t('links.create_account')
+          end
+
+          it 'informs the user about login.gov' do
+            screenshot_and_save_page
+          end
+
+          context 'when creating account with valid email' do
+            before do
+              sign_up_with(Faker::Internet.safe_email)
+            end
+
+            it 'notifies user to check email' do
+              screenshot_and_save_page
+            end
+
+            context 'when confirming email' do
+              before do
+                confirm_last_user
+              end
+
+              it 'prompts user to set password' do
+                screenshot_and_save_page
+              end
+            end
+          end
+
+          context 'when attempting with an invalid email' do
+            before do
+              sign_up_with('kevin@kevin')
+            end
+
+            it 'informs the user to try again' do
+              screenshot_and_save_page
             end
           end
         end
       end
 
-      context 'without valid credentials' do
+      context 'when choosing \'Forgot your password?' do
         before do
-          fill_in 'Email', with: Faker::Internet.safe_email
-          fill_in 'Password', with: 'my password'
-          page.find('.btn-primary').click
+          visit new_user_password_path(locale: locale)
         end
 
-        it 'displays a useful error message' do
-          screenshot_and_save_page
-        end
-      end
-    end
-
-    context 'when choosing create account' do
-      before do
-        click_link t('links.create_account')
-      end
-
-      it 'informs the user about login.gov' do
-        screenshot_and_save_page
-      end
-
-      context 'when creating account with valid email' do
-        before do
-          sign_up_with(Faker::Internet.safe_email)
-        end
-
-        it 'notifies user to check email' do
+        it 'prompts for email address' do
           screenshot_and_save_page
         end
 
-        context 'when confirming email' do
+        context 'when submitting email for an existing account' do
           before do
-            confirm_last_user
+            @user = create(:user, :signed_up)
+            fill_in 'password_reset_email_form_email', with: @user.email
+            click_button t('forms.buttons.continue')
           end
 
-          it 'prompts user to set password' do
+          it 'informs the user to check their email' do
+            screenshot_and_save_page
+          end
+
+          context 'when following link in email', email: true do
+            before do
+              open_last_email
+              click_email_link_matching(/reset_password_token/)
+            end
+
+            it 'prompts the user to enter a new password' do
+              screenshot_and_save_page
+            end
+
+            context 'when submitting a valid password' do
+              before do
+                fill_in t('forms.passwords.edit.labels.password'), with: 'NewVal!dPassw0rd'
+                click_button t('forms.passwords.edit.buttons.submit')
+              end
+
+              it 'redirects to the homepage with a helpful message' do
+                screenshot_and_save_page
+              end
+            end
+          end
+        end
+
+        context 'when submitting email not associated with an account' do
+          before do
+            fill_in 'password_reset_email_form_email', with: 'non-existent-email@example.com'
+            click_button t('forms.buttons.continue')
+          end
+
+          it 'informs the user to check their email' do
             screenshot_and_save_page
           end
         end
-      end
-
-      context 'when attempting with an invalid email' do
-        before do
-          sign_up_with('kevin@kevin')
-        end
-
-        it 'informs the user to try again' do
-          screenshot_and_save_page
-        end
-      end
-    end
-  end
-
-  context 'when choosing \'Forgot your password?' do
-    before do
-      visit new_user_password_path
-    end
-
-    it 'prompts for email address' do
-      screenshot_and_save_page
-    end
-
-    context 'when submitting email for an existing account' do
-      before do
-        @user = create(:user, :signed_up)
-        fill_in 'Email', with: @user.email
-        click_button t('forms.buttons.continue')
-      end
-
-      it 'informs the user to check their email' do
-        screenshot_and_save_page
-      end
-
-      context 'when following link in email', email: true do
-        before do
-          open_last_email
-          click_email_link_matching(/reset_password_token/)
-        end
-
-        it 'prompts the user to enter a new password' do
-          screenshot_and_save_page
-        end
-
-        context 'when submitting a valid password' do
-          before do
-            fill_in t('forms.passwords.edit.labels.password'), with: 'NewVal!dPassw0rd'
-            click_button t('forms.passwords.edit.buttons.submit')
-          end
-
-          it 'redirects to the homepage with a helpful message' do
-            screenshot_and_save_page
-          end
-        end
-      end
-    end
-
-    context 'when submitting email not associated with an account' do
-      before do
-        fill_in 'Email', with: 'non-existent-email@example.com'
-        click_button t('forms.buttons.continue')
-      end
-
-      it 'informs the user to check their email' do
-        screenshot_and_save_page
       end
     end
   end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -24,8 +24,8 @@ module Features
     end
 
     def fill_in_credentials_and_submit(email, password)
-      fill_in 'Email', with: email
-      fill_in 'Password', with: password
+      fill_in 'user_email', with: email
+      fill_in 'user_password', with: password
       click_button t('links.next')
     end
 


### PR DESCRIPTION
**Why**: Help proof content in other languages

---

It's not 100% passing in all locales (ex we're missing some translations so there are ambiguous "NOT TRANSLATED YET" parts, especially in select pickers) but many of the specs work and the formatter still works

I think it's worth adding so we can help get quick feedback for translations