### PR TITLE
Reorder phone confirmation and review page

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -187,7 +187,7 @@ module TwoFactorAuthenticatable
 
   def after_otp_verification_confirmation_path
     if idv_context?
-      verify_confirmations_path
+      verify_review_path
     elsif after_otp_action_required?
       after_otp_action_path
     else
@@ -231,9 +231,11 @@ module TwoFactorAuthenticatable
     user_session[:unconfirmed_phone] && idv_or_confirmation_context?
   end
 
+  # rubocop:disable MethodLength
   def phone_view_data
     {
       confirmation_for_phone_change: confirmation_for_phone_change?,
+      confirmation_for_idv: idv_context?,
       phone_number: display_phone_to_deliver_to,
       code_value: direct_otp_code,
       otp_delivery_preference: two_factor_authentication_method,
@@ -243,6 +245,7 @@ module TwoFactorAuthenticatable
       totp_enabled: current_user.totp_enabled?,
     }.merge(generic_data)
   end
+  # rubocop:enable MethodLength
 
   def authenticator_view_data
     {

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -21,6 +21,8 @@ module TwoFactorAuthCode
     def cancel_link
       if confirmation_for_phone_change || reauthn
         account_path
+      elsif confirmation_for_idv
+        verify_cancel_path
       else
         sign_out_path
       end
@@ -34,8 +36,9 @@ module TwoFactorAuthCode
       :phone_number,
       :unconfirmed_phone,
       :otp_delivery_preference,
+      :confirmation_for_phone_change,
       :voice_otp_delivery_unsupported,
-      :confirmation_for_phone_change
+      :confirmation_for_idv
     )
 
     def phone_number_tag

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -389,8 +389,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
           expect(subject.current_user.reload.phone_confirmed_at).to eq @previous_phone_confirmed_at
         end
 
-        it 'redirects to verify_confirmations_path' do
-          expect(response).to redirect_to(verify_confirmations_path)
+        it 'redirects to verify_review_path' do
+          expect(response).to redirect_to(verify_review_path)
         end
 
         it 'does not call UserMailer' do

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -25,12 +25,34 @@ describe Verify::PhoneController do
       stub_verify_steps_one_and_two(user)
     end
 
-    it 'redirects to review when step is complete' do
-      subject.idv_session.vendor_phone_confirmation = true
+    context 'when the phone number is the same as the user phone' do
+      before do
+        subject.idv_session.params = { phone: user.phone }
+      end
 
-      get :new
+      it 'redirects to review when step is complete' do
+        subject.idv_session.vendor_phone_confirmation = true
+        get :new
 
-      expect(response).to redirect_to verify_review_path
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'when the phone number is different from the user phone' do
+      before do
+        subject.idv_session.params = { phone: bad_phone }
+      end
+
+      it 'redirects to phone confirmation' do
+        subject.idv_session.vendor_phone_confirmation = true
+        get :new
+
+        expect(response).to redirect_to redirect_to(
+          otp_send_path(
+            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
+          )
+        )
+      end
     end
 
     it 'redirects to fail when step attempts are exceeded' do

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -56,13 +56,13 @@ feature 'Accessibility on IDV pages', :js, idv_job: true do
     end
 
     scenario 'review page' do
-      sign_in_and_2fa_user
+      user = sign_in_and_2fa_user
       visit verify_session_path
       fill_out_idv_form_ok
       click_button t('forms.buttons.continue')
       fill_out_and_submit_finance_form
       click_idv_address_choose_phone
-      fill_out_phone_form_ok
+      fill_out_phone_form_ok(user.phone)
       click_button t('forms.buttons.continue')
 
       expect(current_path).to eq verify_review_path

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -31,14 +31,18 @@ feature 'Verify phone' do
         phone: '+1 (416) 555-0190',
         password: Features::SessionHelper::VALID_PASSWORD
       )
+
       sign_in_and_2fa_user(user)
       visit verify_session_path
-
       complete_idv_profile_with_phone('555-555-0000')
 
+      fill_in 'code', with: 'not a valid code 😟'
+      click_submit_default
       expect(page).to have_link t('forms.two_factor.try_again'), href: verify_phone_path
 
       enter_correct_otp_code_for_user(user)
+      fill_in :user_password, with: user_password
+      click_submit_default
       click_acknowledge_personal_key
 
       expect(current_path).to eq account_path
@@ -89,10 +93,6 @@ feature 'Verify phone' do
     click_idv_continue
     click_idv_address_choose_phone
     fill_out_phone_form_ok(phone)
-    click_button t('forms.buttons.continue')
-    fill_in :user_password, with: user_password
-    click_submit_default
-    # choose default SMS delivery method for confirming this new number
-    click_submit_default
+    click_idv_continue
   end
 end

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -1,22 +1,55 @@
 require 'rails_helper'
 
 describe TwoFactorAuthCode::PhoneDeliveryPresenter do
+  include Rails.application.routes.url_helpers
+
+  let(:view) { ActionController::Base.new.view_context }
   let(:data) do
     {
-      code_value: '123abc',
-      totp_enabled: false,
-      phone_number: '***-***-5000',
-      unconfirmed_phone: false,
+      confirmation_for_phone_change: false,
+      confirmation_for_idv: false,
+      phone_number: '5555559876',
+      code_value: '999999',
       otp_delivery_preference: 'sms',
+      reenter_phone_number_path: '/verify/phone',
+      unconfirmed_phone: true,
+      totp_enabled: false,
+      personal_key_unavailable: true,
+      reauthn: false,
     }
   end
-  let(:view) { ActionController::Base.new.view_context }
-  let(:presenter) { TwoFactorAuthCode::PhoneDeliveryPresenter.new(data: data, view: view) }
+  let(:presenter) do
+    TwoFactorAuthCode::PhoneDeliveryPresenter.new(
+      data: data,
+      view: view
+    )
+  end
 
   it 'is a subclass of GenericDeliveryPresenter' do
     expect(TwoFactorAuthCode::PhoneDeliveryPresenter.superclass).to(
       be(TwoFactorAuthCode::GenericDeliveryPresenter)
     )
+  end
+
+  describe '#cancel_link' do
+    it 'returns the sign out path during authentication' do
+      expect(presenter.cancel_link).to eq sign_out_path
+    end
+
+    it 'returns the account path during reauthn' do
+      data[:reauthn] = true
+      expect(presenter.cancel_link).to eq account_path
+    end
+
+    it 'returns the account path during phone change confirmation' do
+      data[:confirmation_for_phone_change] = true
+      expect(presenter.cancel_link).to eq account_path
+    end
+
+    it 'returns the verification cancel path during identity verification' do
+      data[:confirmation_for_idv] = true
+      expect(presenter.cancel_link).to eq verify_cancel_path
+    end
   end
 
   describe '#fallback_links' do

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -56,6 +56,19 @@ describe Idv::Session do
         expect(subject).not_to have_received(:complete_profile)
       end
     end
+
+    context 'without a confirmed phone number' do
+      before do
+        subject.address_verification_mechanism = :phone
+        subject.vendor_phone_confirmation = false
+      end
+
+      it 'does not complete the user profile' do
+        allow(subject).to receive(:complete_profile)
+        subject.complete_session
+        expect(subject).not_to have_received(:complete_profile)
+      end
+    end
   end
 
   describe '#phone_confirmed?' do


### PR DESCRIPTION
**Why**: It is confusing for users to verify their phone number after
entering confirming their profile by entering their password. This
commit changes the order so the user verifies their phone immediately
after entering it