### PR TITLE
Only send 10-digit phone number to equifax

### DIFF
--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -42,7 +42,7 @@ module Verify
       SubmitIdvJob.new(
         vendor_validator_class: Idv::PhoneValidator,
         idv_session: idv_session,
-        vendor_params: idv_form.phone
+        vendor_params: idv_session.params[:phone]
       ).call
     end
 

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -81,7 +81,13 @@ module Verify
     end
 
     def phone_confirmation_required?
-      idv_params[:phone] != current_user.phone &&
+      normalized_phone = idv_params[:phone]
+      return false if normalized_phone.blank?
+
+      formatted_phone = normalized_phone.phony_formatted(
+        format: :international, normalize: :US, spaces: ' '
+      )
+      formatted_phone != current_user.phone &&
         idv_session.address_verification_mechanism == 'phone'
     end
 

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -31,7 +31,8 @@ module Idv
     attr_writer :phone
 
     def update_idv_params(phone)
-      idv_params[:phone] = phone
+      normalized_phone = phone.gsub(/\D/, '')[1..-1]
+      idv_params[:phone] = normalized_phone
 
       return if phone != user.phone
 

--- a/app/views/shared/_pii_review.html.slim
+++ b/app/views/shared/_pii_review.html.slim
@@ -12,8 +12,9 @@
   .mt3.h6 = t('idv.review.ssn')
   .h4.bold.ico-absolute.ico-absolute-success #{pii[:ssn]}
 
-  .h6.mt3 = t('idv.messages.phone.phone_of_record')
-  .h4.bold.ico-absolute.ico-absolute-success #{pii[:phone]}
+  - if phone
+    .h6.mt3 = t('idv.messages.phone.phone_of_record')
+    .h4.bold.ico-absolute.ico-absolute-success #{phone}
 
   .mt3.mb3
     = link_to t('idv.messages.review.financial_info'), MarketingSite.help_url

--- a/app/views/users/verify_password/new.html.slim
+++ b/app/views/users/verify_password/new.html.slim
@@ -6,4 +6,5 @@ h1.h3.my0 = t('idv.titles.session.review')
 
 .mt4
   = accordion('review-verified-info', t('idv.messages.review.intro')) do
-    = render 'shared/pii_review', pii: @verify_password_form.decrypted_pii
+    - decrypted_pii = @verify_password_form.decrypted_pii
+    = render 'shared/pii_review', pii: decrypted_pii, phone: decrypted_pii[:phone].raw

--- a/app/views/verify/review/new.html.slim
+++ b/app/views/verify/review/new.html.slim
@@ -6,4 +6,6 @@ h1.h3.my0 = t('idv.titles.session.review')
 
 .mt4
   = accordion('review-verified-info', t('idv.messages.review.intro')) do
-    = render 'shared/pii_review', pii: @idv_params
+    - phone = @idv_params[:phone]
+    - formatted_phone = phone&.phony_formatted(format: :international, normalize: :US, spaces: ' ')
+    = render 'shared/pii_review', pii: @idv_params, phone: formatted_phone

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -85,6 +85,7 @@ feature 'LOA3 Single Sign On' do
       click_on t('idv.buttons.mail.send')
 
       expect(current_path).to eq verify_review_path
+      expect(page).to_not have_content t('idv.messages.phone.phone_of_record')
 
       fill_in :user_password, with: user_password
 

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -20,7 +20,7 @@ describe Idv::PhoneForm do
         subject.submit(phone: '703-555-1212')
 
         expected_params = {
-          phone: '+1 (703) 555-1212',
+          phone: '7035551212',
         }
 
         expect(subject.idv_params).to eq expected_params
@@ -41,7 +41,7 @@ describe Idv::PhoneForm do
       subject.submit(phone: '+1 (202) 555-1212')
 
       expected_params = {
-        phone: user.phone,
+        phone: '2025551212',
         phone_confirmed_at: user.phone_confirmed_at,
       }
 


### PR DESCRIPTION
**Why**: That's the only format they accept

**How**:
- Normalize the phone in the Form Object, and make sure
the background job sends this normalized phone
- Format the phone when displaying back to the user