### PR TITLE
Allow user to cancel and verify in same session

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -24,7 +24,7 @@ module Idv
       @user_session = user_session
       @current_user = current_user
       @issuer = issuer
-      @user_session[:idv] ||= new_idv_session
+      set_idv_session
     end
 
     def method_missing(method_sym, *arguments, &block)
@@ -101,6 +101,11 @@ module Idv
 
     attr_accessor :user_session, :issuer
 
+    def set_idv_session
+      return if session.present?
+      user_session[:idv] = new_idv_session
+    end
+
     def new_idv_session
       { params: {}, step_attempts: { financials: 0, phone: 0 } }
     end
@@ -111,7 +116,7 @@ module Idv
     end
 
     def session
-      user_session[:idv]
+      user_session.fetch(:idv, {})
     end
 
     def applicant_params

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -248,6 +248,26 @@ feature 'LOA3 Single Sign On' do
         expect(current_url).to eq saml_authn_request
       end
     end
+
+    context 'returning to verify after canceling during the same session' do
+      it 'allows the user to verify' do
+        user = create(:user, :signed_up)
+        saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
+
+        visit saml_authn_request
+        sign_in_live_with_2fa(user)
+        click_idv_begin
+        fill_out_idv_form_ok
+        click_idv_continue
+        click_idv_cancel
+        visit saml_authn_request
+        click_idv_begin
+        fill_out_idv_form_ok
+        click_idv_continue
+
+        expect(current_path).to eq verify_finance_path
+      end
+    end
   end
 
   context 'visiting sign_up_completed path before proofing' do


### PR DESCRIPTION
**Why**: It's a valid scenario that was causing an exception.

**How**: Refactor how existing IdV sessions get reused. Before,
we were only checking if `user_session[:idv]` was set, even if
it was set to an empty hash. Now, we only reuse it if it's not
empty. Otherwise, we initialize a new IdV session.