### PR TITLE
Add timestamp to ActiveJob logs

### DIFF
--- a/.reek
+++ b/.reek
@@ -14,6 +14,7 @@ DuplicateMethodCall:
     - UserFlowExporter#self.massage_assets
 FeatureEnvy:
   exclude:
+    - ActiveJob::Logging::LogSubscriber#json_for
     - track_registration
     - append_info_to_payload
     - generate_slo_request

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,7 @@ Metrics/BlockLength:
     - 'config/initializers/secure_headers.rb'
     - 'config/routes.rb'
     - 'spec/**/*.rb'
+    - 'config/initializers/active_job_logger_patch.rb'
 
 Metrics/ClassLength:
   Description: Avoid classes longer than 100 lines of code.

--- a/config/initializers/active_job_logger_patch.rb
+++ b/config/initializers/active_job_logger_patch.rb
@@ -5,7 +5,32 @@ ActiveSupport.on_load :active_job do
   module ActiveJob
     module Logging
       class LogSubscriber
+        def enqueue(event)
+          info { json_for(event: event, event_type: 'Enqueued') }
+        end
+
+        def perform_start(event)
+          info { json_for(event: event, event_type: 'Performing') }
+        end
+
+        def perform(event)
+          info { json_for(event: event, event_type: 'Performed') }
+        end
+
         private
+
+        def json_for(event:, event_type:)
+          job = event.payload[:job]
+
+          {
+            timestamp: Time.zone.now,
+            event_type: event_type,
+            job_class: job.class.name,
+            job_queue: queue_name(event),
+            job_id: job.job_id,
+            duration: "#{event.duration.round(2)}ms",
+          }.to_json
+        end
 
         def args_info(_job)
           ''


### PR DESCRIPTION
**Why**: Rails doesn't include timestamps by default, so we need to
override the `enqueue` method to add a timestamp. It's helpful to
know when a particular background job was enqueued when troubleshooting.