### PR TITLE
Allow multiple account creation in same session

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -23,8 +23,6 @@ module SamlIdpAuthConcern
   end
 
   def store_saml_request
-    return if sp_session[:request_id]
-
     @request_id = SecureRandom.uuid
     ServiceProviderRequest.find_or_create_by(uuid: @request_id) do |sp_request|
       sp_request.issuer = current_issuer
@@ -35,15 +33,7 @@ module SamlIdpAuthConcern
   end
 
   def add_sp_metadata_to_session
-    return if sp_session[:request_id]
-
-    session[:sp] = {
-      issuer: current_issuer,
-      loa3: loa3_requested?,
-      request_id: @request_id,
-      request_url: request.original_url,
-      requested_attributes: requested_attributes,
-    }
+    StoreSpMetadataInSession.new(session: session, request_id: @request_id).call
   end
 
   def requested_authn_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -76,8 +76,6 @@ module OpenidConnect
     end
 
     def store_request
-      return if sp_session[:request_id]
-
       client_id = @authorize_form.client_id
 
       @request_id = SecureRandom.uuid
@@ -90,15 +88,7 @@ module OpenidConnect
     end
 
     def add_sp_metadata_to_session
-      return if sp_session[:request_id]
-
-      session[:sp] = {
-        issuer: @authorize_form.client_id,
-        loa3: @authorize_form.loa3_requested?,
-        request_id: @request_id,
-        request_url: request.original_url,
-        requested_attributes: requested_attributes,
-      }
+      StoreSpMetadataInSession.new(session: session, request_id: @request_id).call
     end
 
     def requested_attributes

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -292,11 +292,11 @@ describe SamlIdpController do
         sp_request_id = ServiceProviderRequest.last.uuid
 
         expect(session[:sp]).to eq(
-          loa3: false,
           issuer: saml_settings.issuer,
-          request_id: sp_request_id,
+          loa3: false,
           request_url: @saml_request.request.original_url,
-          requested_attributes: [:email]
+          request_id: sp_request_id,
+          requested_attributes: ['email']
         )
       end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -243,7 +243,7 @@ module Features
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
       expect(page).to have_css('img[src*=sp-logos]')
 
-      submit_form_with_valid_email
+      submit_form_with_valid_email(email)
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
       expect(last_email.html_part.body).to have_content "?_request_id=#{sp_request_id}"


### PR DESCRIPTION
**Why**: We noticed some users were running into an exception
while trying to set their password. It turned out they were
signing up for multiple accounts in the same session, but
using different browsers, which is a common use case for users
starting the process in a mobile app, and then confirming their
email in a separate app or mobile browser.

The bug was that we were only storing the request in the DB if the
session didn't already contain the `request_id`, and we also deleted
the request after a successful redirect back to the SP. Here's a
concrete example, which I wrote a test for:

- User starts by entering their email in browser 1, request 1 is stored
in the DB and in the session
- User confirms their email in browser 2, which looks up request 1 in
the DB, and stores it in the session
- User continues the account creation process successfully and continues
on to the SP. At this point, request 1 is deleted from the DB
- User goes back to browser 1 and makes a new request while the original
session is still alive. Since the session is still alive and still
contains request 1, the app doesn't store this new request, but the same
`request_id` is passed on to the email confirmation
- User confirms their email in browser 2, which passes because we don't
validate the request_id at this point.
- User tries to create their password, but when they submit the form,
they get an exception because the app is trying to look up the request
in the DB that matches the orginal `request_id`, but it was deleted
earlier.

**How**: Always store a request in the DB every time a new request is
made by the SP. Don't reuse requests. The reason we reused requests
before was to make it easier to delete requests in the DB that were no
longer needed, but I obviously didn't think it through. We'll need to
come up with a rake task or some other way to prevent the
`ServiceProviderRequests` table from growing too large.