### PR TITLE
Respond with 404 for all nonexistent assets

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,5 +157,7 @@ Rails.application.routes.draw do
   # The line below will route all requests that aren't
   # defined route to the 404 page. Therefore, anything you put after this rule
   # will be ignored.
-  match '*path', via: :all, to: 'pages#page_not_found'
+  constraints(format: /html/) do
+    match '*path', via: :all, to: 'pages#page_not_found'
+  end
 end

--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Missing pages and assets', type: :request do
+  describe 'missing page' do
+    it 'responds with 404' do
+      get '/nonexistent-page'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing PNG' do
+    it 'responds with 404' do
+      get '/mobile-icon.png'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing CSS' do
+    it 'responds with 404' do
+      get '/application-random-hash.css'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing JS' do
+    it 'responds with 404' do
+      get '/application-random-hash.js'
+
+      expect(response.status).to eq 404
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Before, we were only responding with a 404 to requests for
the HTML format, and we noticed 500 errors when browsers requested
nonexistent PNG and CSS files.