### PR TITLE
Allow international phone numbers

### DIFF
--- a/app/assets/javascripts/app/phone-internationalization.js
+++ b/app/assets/javascripts/app/phone-internationalization.js
@@ -17,7 +17,12 @@ const areaCodeFromUSPhone = (phone) => {
   return null;
 };
 
-const unsupportedPhoneOTPDeliveryWarningMessage = (phone) => {
+const selectedInternationCodeOption = () => {
+  const dropdown = document.querySelector('#two_factor_setup_form_international_code');
+  return dropdown.item(dropdown.selectedIndex);
+};
+
+const unsupportedUSPhoneOTPDeliveryWarningMessage = (phone) => {
   const areaCode = areaCodeFromUSPhone(phone);
   const country = getPhoneUnsupportedAreaCodeCountry(areaCode);
   if (country) {
@@ -25,6 +30,23 @@ const unsupportedPhoneOTPDeliveryWarningMessage = (phone) => {
     return messageTemplate.replace('%{location}', country);
   }
   return null;
+};
+
+const unsupportedInternationalPhoneOTPDeliveryWarningMessage = () => {
+  const selectedOption = selectedInternationCodeOption();
+  if (selectedOption.dataset.smsOnly === 'true') {
+    const messageTemplate = I18n.t('devise.two_factor_authentication.otp_delivery_preference.phone_unsupported');
+    return messageTemplate.replace('%{location}', selectedOption.dataset.countryName);
+  }
+  return null;
+};
+
+const unsupportedPhoneOTPDeliveryWarningMessage = (phone) => {
+  const internationCodeOption = selectedInternationCodeOption();
+  if (internationCodeOption.dataset.countryCode === '1') {
+    return unsupportedUSPhoneOTPDeliveryWarningMessage(phone);
+  }
+  return unsupportedInternationalPhoneOTPDeliveryWarningMessage();
 };
 
 const updateOTPDeliveryMethods = () => {
@@ -53,9 +75,13 @@ const updateOTPDeliveryMethods = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-  const input = document.querySelector('#two_factor_setup_form_phone');
-  if (input) {
-    input.addEventListener('keyup', updateOTPDeliveryMethods);
+  const phoneInput = document.querySelector('#two_factor_setup_form_phone');
+  const codeInput = document.querySelector('#two_factor_setup_form_international_code');
+  if (phoneInput) {
+    phoneInput.addEventListener('keyup', updateOTPDeliveryMethods);
+  }
+  if (codeInput) {
+    codeInput.addEventListener('change', updateOTPDeliveryMethods);
     updateOTPDeliveryMethods();
   }
 });

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -22,7 +22,7 @@ module Users
     private
 
     def user_params
-      params.require(:update_user_phone_form).permit(:phone)
+      params.require(:update_user_phone_form).permit(:phone, :international_code)
     end
 
     def process_updates

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -84,9 +84,7 @@ module Verify
       normalized_phone = idv_params[:phone]
       return false if normalized_phone.blank?
 
-      formatted_phone = normalized_phone.phony_formatted(
-        format: :international, normalize: :US, spaces: ' '
-      )
+      formatted_phone = PhoneFormatter.new.format(normalized_phone)
       formatted_phone != current_user.phone &&
         idv_session.address_verification_mechanism == 'phone'
     end

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -4,6 +4,7 @@ module Idv
     include FormPhoneValidator
 
     attr_reader :idv_params, :user, :phone
+    attr_accessor :international_code
 
     def initialize(idv_params, user)
       @idv_params = idv_params
@@ -11,14 +12,13 @@ module Idv
       self.phone = (idv_params[:phone] || user.phone).phony_formatted(
         format: :international, normalize: :US, spaces: ' '
       )
+      self.international_code = PhoneFormatter::DEFAULT_COUNTRY
     end
 
     def submit(params)
       submitted_phone = params[:phone]
 
-      formatted_phone = submitted_phone.phony_formatted(
-        format: :international, normalize: :US, spaces: ' '
-      )
+      formatted_phone = PhoneFormatter.new.format(submitted_phone, country_code: international_code)
 
       self.phone = formatted_phone
 

--- a/app/forms/two_factor_setup_form.rb
+++ b/app/forms/two_factor_setup_form.rb
@@ -3,16 +3,14 @@ class TwoFactorSetupForm
   include FormPhoneValidator
   include OtpDeliveryPreferenceValidator
 
-  attr_accessor :phone
+  attr_accessor :phone, :international_code
 
   def initialize(user)
     @user = user
   end
 
   def submit(params)
-    self.phone = params[:phone].phony_formatted(
-      format: :international, normalize: :US, spaces: ' '
-    )
+    process_phone_number_params(params)
     self.otp_delivery_preference = params[:otp_delivery_preference]
 
     @success = valid?
@@ -20,6 +18,11 @@ class TwoFactorSetupForm
     update_otp_delivery_preference_for_user if success && otp_delivery_preference_changed?
 
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+  end
+
+  def process_phone_number_params(params)
+    self.international_code = params[:international_code]
+    self.phone = PhoneFormatter.new.format(params[:phone], country_code: international_code)
   end
 
   private

--- a/app/forms/update_user_phone_form.rb
+++ b/app/forms/update_user_phone_form.rb
@@ -2,7 +2,7 @@ class UpdateUserPhoneForm
   include ActiveModel::Model
   include FormPhoneValidator
 
-  attr_accessor :phone
+  attr_accessor :phone, :international_code
   attr_reader :user
 
   def persisted?
@@ -12,10 +12,14 @@ class UpdateUserPhoneForm
   def initialize(user)
     @user = user
     self.phone = @user.phone
+    self.international_code = Phonelib.parse(phone).country || PhoneFormatter::DEFAULT_COUNTRY
   end
 
   def submit(params)
-    check_phone_change(params)
+    self.phone = params[:phone]
+    self.international_code = params[:international_code]
+
+    check_phone_change
 
     FormResponse.new(success: valid?, errors: errors.messages)
   end
@@ -28,10 +32,8 @@ class UpdateUserPhoneForm
 
   attr_reader :phone_changed
 
-  def check_phone_change(params)
-    formatted_phone = params[:phone].phony_formatted(
-      format: :international, normalize: :US, spaces: ' '
-    )
+  def check_phone_change
+    formatted_phone = PhoneFormatter.new.format(phone, country_code: international_code)
 
     return unless formatted_phone != @user.phone
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -66,4 +66,28 @@ module FormHelper
     ]
   end
   # rubocop:enable MethodLength, WordArray
+
+  def international_phone_codes
+    PhoneNumberCapabilities::INTERNATIONAL_CODES.map do |key, value|
+      [
+        international_phone_code_label(value),
+        key,
+        { data: international_phone_codes_data(value) },
+      ]
+    end
+  end
+
+  private
+
+  def international_phone_code_label(code_data)
+    "#{code_data['name']} +#{code_data['country_code']}"
+  end
+
+  def international_phone_codes_data(code_data)
+    {
+      sms_only: code_data['sms_only'],
+      country_code: code_data['country_code'],
+      country_name: code_data['name'],
+    }
+  end
 end

--- a/app/services/phone_formatter.rb
+++ b/app/services/phone_formatter.rb
@@ -1,0 +1,12 @@
+class PhoneFormatter
+  DEFAULT_COUNTRY = 'US'.freeze
+
+  def format(phone, country_code: nil)
+    normalized_phone = if country_code
+                         phone&.phony_normalized(country_code: country_code)
+                       else
+                         phone&.phony_normalized(default_country_code: DEFAULT_COUNTRY)
+                       end
+    normalized_phone&.phony_formatted(format: :international, spaces: ' ')
+  end
+end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -1,10 +1,29 @@
 class PhoneNumberCapabilities
   VOICE_UNSUPPORTED_US_AREA_CODES = {
     '648' => 'American Samoa',
+    '264' => 'Anguilla',
+    '268' => 'Antigua and Barbuda',
+    '246' => 'Barbados',
+    '441' => 'Bermuda',
+    '345' => 'Cayman Islands',
+    '767' => 'Dominica',
+    '809' => 'Dominican Republic',
+    '473' => 'Grenada',
     '671' => 'Guam',
+    '876' => 'Jamaica',
     '670' => 'Northern Mariana Islands',
+    '869' => 'Saint Kitts and Nevis',
+    '758' => 'Saint Lucia',
+    '784' => 'Saint Vincent Grenadines',
+    '868' => 'Trinidad and Tobago',
+    '649' => 'Turks and Caicos Islands',
+    '284' => 'British Virgin Islands',
     '340' => 'United States Virgin Islands',
   }.freeze
+
+  INTERNATIONAL_CODES = YAML.load_file(
+    Rails.root.join('config', 'country_dialing_codes.yml')
+  ).freeze
 
   attr_reader :phone
 
@@ -13,16 +32,42 @@ class PhoneNumberCapabilities
   end
 
   def sms_only?
-    VOICE_UNSUPPORTED_US_AREA_CODES[area_code].present?
+    if international_code == '1'
+      VOICE_UNSUPPORTED_US_AREA_CODES[area_code].present?
+    elsif country_code_data
+      country_code_data['sms_only']
+    end
   end
 
   def unsupported_location
-    VOICE_UNSUPPORTED_US_AREA_CODES[area_code]
+    if international_code == '1'
+      VOICE_UNSUPPORTED_US_AREA_CODES[area_code]
+    elsif country_code_data
+      country_code_data['name']
+    end
   end
 
   private
 
   def area_code
-    @area_code ||= Phony.split(Phony.normalize(phone, cc: '1')).second
+    @area_code ||= phone_number_components.second
+  end
+
+  def country_code_data
+    @country_code_data ||= INTERNATIONAL_CODES.select do |_, value|
+      value['country_code'] == international_code
+    end.values.first
+  end
+
+  def international_code
+    @international_code ||= phone_number_components.first
+  end
+
+  def phone_number_components
+    return [] if phone.blank?
+
+    @phone_number_components ||= Phony.split(
+      PhonyRails.normalize_number(phone.to_s, default_country_code: :us).slice(1..-1)
+    )
   end
 end

--- a/app/validators/form_phone_validator.rb
+++ b/app/validators/form_phone_validator.rb
@@ -3,8 +3,11 @@ module FormPhoneValidator
 
   included do
     validates_plausible_phone :phone,
-                              country_code: 'US',
                               presence: true,
-                              message: :improbable_phone
+                              message: :improbable_phone,
+                              international_code: ->(form) { form.international_code }
+    validates :international_code, inclusion: {
+      in: PhoneNumberCapabilities::INTERNATIONAL_CODES.keys,
+    }
   end
 end

--- a/app/views/users/phones/edit.html.slim
+++ b/app/views/users/phones/edit.html.slim
@@ -4,6 +4,9 @@
 h1.h3.my0 = t('headings.edit_info.phone')
 = simple_form_for(@update_user_phone_form, url: manage_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
+  = f.input :international_code,
+        collection: international_phone_codes,
+        include_blank: false
   = f.input :phone, as: :tel, required: true, input_html: { class: 'phone', value: nil },
     label: t('account.index.phone')
   = f.button :submit, t('forms.buttons.submit.confirm_change'), class: 'mt2'

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -8,6 +8,11 @@ p.mt-tiny.mb0
     data: { unsupported_area_codes: @unsupported_area_codes },
     method: :patch,
     url: phone_setup_path) do |f|
+  .clearfix
+    .sm-col.sm-col-8
+      = f.input :international_code,
+        collection: international_phone_codes,
+        include_blank: false
   = f.label :phone, class: 'block'
     strong.left = t('devise.two_factor_authentication.otp_phone_label')
     span#otp_phone_label_info.ml1.italic

--- a/app/views/verify/review/new.html.slim
+++ b/app/views/verify/review/new.html.slim
@@ -7,5 +7,5 @@ h1.h3.my0 = t('idv.titles.session.review')
 .mt4
   = accordion('review-verified-info', t('idv.messages.review.intro')) do
     - phone = @idv_params[:phone]
-    - formatted_phone = phone&.phony_formatted(format: :international, normalize: :US, spaces: ' ')
+    - formatted_phone = PhoneFormatter.new.format(phone)
     = render 'shared/pii_review', pii: @idv_params, phone: formatted_phone

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -1,0 +1,804 @@
+US:
+  name: United States of America
+  country_code: '1'
+  sms_only: false
+AF:
+  name: Afghanistan
+  country_code: '93'
+  sms_only: true
+AL:
+  name: Albania
+  country_code: '355'
+  sms_only: true
+DZ:
+  name: Algeria
+  country_code: '213'
+  sms_only: true
+AD:
+  name: Andorra
+  country_code: '376'
+  sms_only: true
+AO:
+  name: Angola
+  country_code: '244'
+  sms_only: true
+AR:
+  name: Argentina
+  country_code: '54'
+  sms_only: true
+AM:
+  name: Armenia
+  country_code: '374'
+  sms_only: true
+AW:
+  name: Aruba
+  country_code: '297'
+  sms_only: true
+AU:
+  name: Australia/Cocos/Christmas Island
+  country_code: '61'
+  sms_only: false
+AT:
+  name: Austria
+  country_code: '43'
+  sms_only: false
+AZ:
+  name: Azerbaijan
+  country_code: '994'
+  sms_only: true
+BH:
+  name: Bahrain
+  country_code: '973'
+  sms_only: false
+BD:
+  name: Bangladesh
+  country_code: '880'
+  sms_only: true
+BY:
+  name: Belarus
+  country_code: '375'
+  sms_only: true
+BE:
+  name: Belgium
+  country_code: '32'
+  sms_only: false
+BZ:
+  name: Belize
+  country_code: '501'
+  sms_only: true
+BJ:
+  name: Benin
+  country_code: '229'
+  sms_only: true
+BT:
+  name: Bhutan
+  country_code: '975'
+  sms_only: true
+BO:
+  name: Bolivia
+  country_code: '591'
+  sms_only: true
+BA:
+  name: Bosnia and Herzegovina
+  country_code: '387'
+  sms_only: true
+BW:
+  name: Botswana
+  country_code: '267'
+  sms_only: true
+BR:
+  name: Brazil
+  country_code: '55'
+  sms_only: false
+BN:
+  name: Brunei
+  country_code: '673'
+  sms_only: true
+BG:
+  name: Bulgaria
+  country_code: '359'
+  sms_only: false
+BF:
+  name: Burkina Faso
+  country_code: '226'
+  sms_only: true
+BI:
+  name: Burundi
+  country_code: '257'
+  sms_only: true
+KH:
+  name: Cambodia
+  country_code: '855'
+  sms_only: true
+CM:
+  name: Cameroon
+  country_code: '237'
+  sms_only: true
+CA:
+  name: Canada
+  country_code: '1'
+  sms_only: true
+CV:
+  name: Cape Verde
+  country_code: '238'
+  sms_only: true
+CF:
+  name: Central Africa
+  country_code: '236'
+  sms_only: true
+TD:
+  name: Chad
+  country_code: '235'
+  sms_only: true
+CL:
+  name: Chile
+  country_code: '56'
+  sms_only: true
+CN:
+  name: China
+  country_code: '86'
+  sms_only: false
+CO:
+  name: Colombia
+  country_code: '57'
+  sms_only: true
+KM:
+  name: Comoros
+  country_code: '269'
+  sms_only: true
+CG:
+  name: Congo
+  country_code: '242'
+  sms_only: true
+CD:
+  name: Congo (Democratic Republic of the)
+  country_code: '243'
+  sms_only: true
+CK:
+  name: Cook Islands
+  country_code: '682'
+  sms_only: true
+CR:
+  name: Costa Rica
+  country_code: '506'
+  sms_only: true
+HR:
+  name: Croatia
+  country_code: '385'
+  sms_only: true
+CU:
+  name: Cuba
+  country_code: '53'
+  sms_only: true
+CY:
+  name: Cyprus
+  country_code: '357'
+  sms_only: false
+CZ:
+  name: Czech Republic
+  country_code: '420'
+  sms_only: false
+DK:
+  name: Denmark
+  country_code: '45'
+  sms_only: false
+DJ:
+  name: Djibouti
+  country_code: '253'
+  sms_only: true
+TL:
+  name: East Timor
+  country_code: '670'
+  sms_only: true
+EC:
+  name: Ecuador
+  country_code: '593'
+  sms_only: true
+EG:
+  name: Egypt
+  country_code: '20'
+  sms_only: true
+SV:
+  name: El Salvador
+  country_code: '503'
+  sms_only: true
+GQ:
+  name: Equatorial Guinea
+  country_code: '240'
+  sms_only: true
+ER:
+  name: Eritrea
+  country_code: '291'
+  sms_only: true
+EE:
+  name: Estonia
+  country_code: '372'
+  sms_only: false
+ET:
+  name: Ethiopia
+  country_code: '251'
+  sms_only: true
+FK:
+  name: Falkland Islands
+  country_code: '500'
+  sms_only: true
+FO:
+  name: Faroe Islands
+  country_code: '298'
+  sms_only: true
+FJ:
+  name: Fiji
+  country_code: '679'
+  sms_only: true
+FI:
+  name: Finland/Aland Islands
+  country_code: '358'
+  sms_only: false
+FR:
+  name: France
+  country_code: '33'
+  sms_only: false
+GF:
+  name: French Guiana
+  country_code: '594'
+  sms_only: true
+PF:
+  name: French Polynesia
+  country_code: '689'
+  sms_only: true
+GA:
+  name: Gabon
+  country_code: '241'
+  sms_only: true
+GM:
+  name: Gambia
+  country_code: '220'
+  sms_only: true
+GE:
+  name: Georgia
+  country_code: '995'
+  sms_only: true
+DE:
+  name: Germany
+  country_code: '49'
+  sms_only: false
+GH:
+  name: Ghana
+  country_code: '233'
+  sms_only: true
+GI:
+  name: Gibraltar
+  country_code: '350'
+  sms_only: true
+GR:
+  name: Greece
+  country_code: '30'
+  sms_only: true
+GL:
+  name: Greenland
+  country_code: '299'
+  sms_only: true
+GP:
+  name: Guadeloupe
+  country_code: '590'
+  sms_only: true
+GT:
+  name: Guatemala
+  country_code: '502'
+  sms_only: true
+GN:
+  name: Guinea
+  country_code: '224'
+  sms_only: true
+GW:
+  name: Guinea-Bissau
+  country_code: '245'
+  sms_only: true
+GY:
+  name: Guyana
+  country_code: '592'
+  sms_only: true
+HT:
+  name: Haiti
+  country_code: '509'
+  sms_only: true
+HN:
+  name: Honduras
+  country_code: '504'
+  sms_only: true
+HK:
+  name: Hong Kong
+  country_code: '852'
+  sms_only: false
+HU:
+  name: Hungary
+  country_code: '36'
+  sms_only: true
+IS:
+  name: Iceland
+  country_code: '354'
+  sms_only: true
+IN:
+  name: India
+  country_code: '91'
+  sms_only: false
+ID:
+  name: Indonesia
+  country_code: '62'
+  sms_only: true
+IR:
+  name: Iran
+  country_code: '98'
+  sms_only: true
+IQ:
+  name: Iraq
+  country_code: '964'
+  sms_only: true
+IE:
+  name: Ireland
+  country_code: '353'
+  sms_only: false
+IL:
+  name: Israel
+  country_code: '972'
+  sms_only: false
+IT:
+  name: Italy
+  country_code: '39'
+  sms_only: false
+CI:
+  name: Ivory Coast
+  country_code: '225'
+  sms_only: true
+JP:
+  name: Japan
+  country_code: '81'
+  sms_only: false
+JO:
+  name: Jordan
+  country_code: '962'
+  sms_only: true
+KZ:
+  name: Kazakhstan
+  country_code: '7'
+  sms_only: true
+KE:
+  name: Kenya
+  country_code: '254'
+  sms_only: true
+KP:
+  name: Korea (Democratic People's Republic of)
+  country_code: '850'
+  sms_only: true
+KR:
+  name: Korea (Republic of)
+  country_code: '82'
+  sms_only: true
+KW:
+  name: Kuwait
+  country_code: '965'
+  sms_only: true
+KG:
+  name: Kyrgyzstan
+  country_code: '996'
+  sms_only: true
+LA:
+  name: Laos People's Democratic Republic
+  country_code: '856'
+  sms_only: true
+LV:
+  name: Latvia
+  country_code: '371'
+  sms_only: false
+LB:
+  name: Lebanon
+  country_code: '961'
+  sms_only: true
+LS:
+  name: Lesotho
+  country_code: '266'
+  sms_only: true
+LR:
+  name: Liberia
+  country_code: '231'
+  sms_only: true
+LY:
+  name: Libya
+  country_code: '218'
+  sms_only: true
+LI:
+  name: Liechtenstein
+  country_code: '423'
+  sms_only: true
+LT:
+  name: Lithuania
+  country_code: '370'
+  sms_only: false
+LU:
+  name: Luxembourg
+  country_code: '352'
+  sms_only: false
+MO:
+  name: Macau
+  country_code: '853'
+  sms_only: true
+MK:
+  name: Macedonia
+  country_code: '389'
+  sms_only: true
+MG:
+  name: Madagascar
+  country_code: '261'
+  sms_only: true
+MW:
+  name: Malawi
+  country_code: '265'
+  sms_only: true
+MY:
+  name: Malaysia
+  country_code: '60'
+  sms_only: true
+MV:
+  name: Maldives
+  country_code: '960'
+  sms_only: true
+ML:
+  name: Mali
+  country_code: '223'
+  sms_only: true
+MT:
+  name: Malta
+  country_code: '356'
+  sms_only: false
+MH:
+  name: Marshall Islands
+  country_code: '692'
+  sms_only: true
+MQ:
+  name: Martinique
+  country_code: '596'
+  sms_only: true
+MR:
+  name: Mauritania
+  country_code: '222'
+  sms_only: true
+MU:
+  name: Mauritius
+  country_code: '230'
+  sms_only: true
+YT:
+  name: Mayotte
+  country_code: '262'
+  sms_only: true
+MX:
+  name: Mexico
+  country_code: '52'
+  sms_only: false
+FM:
+  name: Micronesia
+  country_code: '691'
+  sms_only: true
+MD:
+  name: Moldo
+  country_code: '373'
+  sms_only: true
+MC:
+  name: Monaco
+  country_code: '377'
+  sms_only: true
+MN:
+  name: Mongolia
+  country_code: '976'
+  sms_only: true
+ME:
+  name: Montenegro
+  country_code: '382'
+  sms_only: true
+MA:
+  name: Morocco
+  country_code: '212'
+  sms_only: true
+MZ:
+  name: Mozambique
+  country_code: '258'
+  sms_only: true
+MM:
+  name: Myanmar
+  country_code: '95'
+  sms_only: true
+NA:
+  name: Namibia
+  country_code: '264'
+  sms_only: true
+NP:
+  name: Nepal
+  country_code: '977'
+  sms_only: true
+NL:
+  name: Netherlands
+  country_code: '31'
+  sms_only: false
+BQ:
+  name: Netherlands Antilles
+  country_code: '599'
+  sms_only: true
+NC:
+  name: New Caledonia
+  country_code: '687'
+  sms_only: true
+NZ:
+  name: New Zealand
+  country_code: '64'
+  sms_only: false
+NI:
+  name: Nicaragua
+  country_code: '505'
+  sms_only: true
+NE:
+  name: Niger
+  country_code: '227'
+  sms_only: true
+NG:
+  name: Nigeria
+  country_code: '234'
+  sms_only: true
+NO:
+  name: Norway
+  country_code: '47'
+  sms_only: false
+OM:
+  name: Oman
+  country_code: '968'
+  sms_only: true
+PK:
+  name: Pakistan
+  country_code: '92'
+  sms_only: true
+PW:
+  name: Palau
+  country_code: '680'
+  sms_only: true
+PS:
+  name: Palestine
+  country_code: '970'
+  sms_only: true
+PA:
+  name: Panama
+  country_code: '507'
+  sms_only: true
+PG:
+  name: Papua New Guinea
+  country_code: '675'
+  sms_only: true
+PY:
+  name: Paraguay
+  country_code: '595'
+  sms_only: true
+PE:
+  name: Peru
+  country_code: '51'
+  sms_only: false
+PH:
+  name: Philippines
+  country_code: '63'
+  sms_only: true
+PL:
+  name: Poland
+  country_code: '48'
+  sms_only: false
+PT:
+  name: Portugal
+  country_code: '351'
+  sms_only: true
+QA:
+  name: Qatar
+  country_code: '974'
+  sms_only: true
+RO:
+  name: Romania
+  country_code: '40'
+  sms_only: false
+RU:
+  name: Russia
+  country_code: '7'
+  sms_only: true
+RW:
+  name: Rwanda
+  country_code: '250'
+  sms_only: true
+RE:
+  name: Reunion
+  country_code: '262'
+  sms_only: true
+PM:
+  name: Saint Pierre and Miquelon
+  country_code: '508'
+  sms_only: true
+WS:
+  name: Samoa
+  country_code: '685'
+  sms_only: true
+SM:
+  name: San Marino
+  country_code: '378'
+  sms_only: true
+ST:
+  name: Sao Tome and Principe
+  country_code: '239'
+  sms_only: true
+SA:
+  name: Saudi Arabia
+  country_code: '966'
+  sms_only: true
+SN:
+  name: Senegal
+  country_code: '221'
+  sms_only: true
+RS:
+  name: Serbia
+  country_code: '381'
+  sms_only: true
+SC:
+  name: Seychelles
+  country_code: '248'
+  sms_only: true
+SL:
+  name: Sierra Leone
+  country_code: '232'
+  sms_only: true
+SG:
+  name: Singapore
+  country_code: '65'
+  sms_only: true
+SK:
+  name: Slovakia
+  country_code: '421'
+  sms_only: false
+SI:
+  name: Slovenia
+  country_code: '386'
+  sms_only: true
+SB:
+  name: Solomon Islands
+  country_code: '677'
+  sms_only: true
+SO:
+  name: Somalia
+  country_code: '252'
+  sms_only: true
+ZA:
+  name: South Africa
+  country_code: '27'
+  sms_only: false
+SS:
+  name: South Sudan
+  country_code: '211'
+  sms_only: true
+ES:
+  name: Spain
+  country_code: '34'
+  sms_only: false
+LK:
+  name: Sri Lanka
+  country_code: '94'
+  sms_only: true
+SD:
+  name: Sudan
+  country_code: '249'
+  sms_only: true
+SR:
+  name: Suriname
+  country_code: '597'
+  sms_only: true
+SZ:
+  name: Swaziland
+  country_code: '268'
+  sms_only: true
+SE:
+  name: Sweden
+  country_code: '46'
+  sms_only: true
+CH:
+  name: Switzerland
+  country_code: '41'
+  sms_only: false
+SY:
+  name: Syria
+  country_code: '963'
+  sms_only: true
+TW:
+  name: Taiwan
+  country_code: '886'
+  sms_only: true
+TJ:
+  name: Tajikistan
+  country_code: '992'
+  sms_only: true
+TZ:
+  name: Tanzania, United Republic of
+  country_code: '255'
+  sms_only: true
+TH:
+  name: Thailand
+  country_code: '66'
+  sms_only: true
+TG:
+  name: Togo
+  country_code: '228'
+  sms_only: true
+TO:
+  name: Tonga
+  country_code: '676'
+  sms_only: true
+TN:
+  name: Tunisia
+  country_code: '216'
+  sms_only: true
+TR:
+  name: Turkey
+  country_code: '90'
+  sms_only: true
+TM:
+  name: Turkmenistan
+  country_code: '993'
+  sms_only: true
+TV:
+  name: Tuvalu
+  country_code: '688'
+  sms_only: true
+UG:
+  name: Uganda
+  country_code: '256'
+  sms_only: true
+UA:
+  name: Ukraine
+  country_code: '380'
+  sms_only: true
+AE:
+  name: United Arab Emirates
+  country_code: '971'
+  sms_only: true
+GB:
+  name: United Kingdom
+  country_code: '44'
+  sms_only: false
+UY:
+  name: Uruguay
+  country_code: '598'
+  sms_only: true
+UZ:
+  name: Uzbekistan
+  country_code: '998'
+  sms_only: true
+VU:
+  name: Vanuatu
+  country_code: '678'
+  sms_only: true
+VE:
+  name: Venezuela
+  country_code: '58'
+  sms_only: true
+VN:
+  name: Vietnam
+  country_code: '84'
+  sms_only: true
+VG:
+  name: Virgin Islands (British)
+  country_code: '1'
+  sms_only: true
+VI:
+  name: Virgin Islands (U.S.)
+  country_code: '1'
+  sms_only: true
+YE:
+  name: Yemen
+  country_code: '967'
+  sms_only: true
+ZM:
+  name: Zambia
+  country_code: '260'
+  sms_only: true
+ZW:
+  name: Zimbabwe
+  country_code: '263'
+  sms_only: true

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -16,8 +16,8 @@ en:
         confirmation instructions" to get another one.
       expired: has expired, please request a new one
       format_mismatch: Please match the requested format.
-      improbable_phone: Invalid phone number. Please make sure you enter a 10-digit
-        phone number.
+      improbable_phone: Invalid phone number. Please make sure you enter a valid phone
+        number.
       missing_field: Please fill in this field.
       no_password_reset_profile: No profile has been recently deactivated due to a
         password reset

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -16,8 +16,7 @@ es:
         en "Reenviar instrucciones de confirmación" para obtener otro.
       expired: ha caducado, por favor solicite uno nuevo
       format_mismatch: Por favor, use el formato solicitado.
-      improbable_phone: El número de teléfono no es válido. Asegúrese de ingresar
-        un número de teléfono de 10 dígitos.
+      improbable_phone: NOT TRANSLATED YET
       missing_field: Por favor, rellene este campo.
       no_password_reset_profile: Ningún perfil ha sido desactivado recientemente por
         un restablecimiento de contraseña.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -19,8 +19,7 @@ fr:
         un autre.
       expired: est expiré, veuillez en demander un nouveau
       format_mismatch: Veuillez vous assurer de respecter le format requis.
-      improbable_phone: Numéro de téléphone non valide. Veuillez vous assurer d'entrer
-        un numéro de téléphone à 10 chiffres.
+      improbable_phone: NOT TRANSLATED YET
       missing_field: Veuillez remplir ce champ.
       no_password_reset_profile: Aucun profil récemment désactivé en raison d'une
         réinitialisation de mot de passe

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -16,7 +16,7 @@ describe Users::PhonesController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, update_user_phone_form: { phone: new_phone }
+        put :update, update_user_phone_form: { phone: new_phone, international_code: 'US' }
       end
 
       it 'lets user know they need to confirm their new phone' do
@@ -37,7 +37,7 @@ describe Users::PhonesController do
       it 'does not delete the phone' do
         stub_sign_in(user)
 
-        put :update, update_user_phone_form: { phone: '' }
+        put :update, update_user_phone_form: { phone: '', international_code: 'US' }
 
         expect(user.reload.phone).to be_present
         expect(response).to render_template(:edit)
@@ -51,7 +51,7 @@ describe Users::PhonesController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, update_user_phone_form: { phone: second_user.phone }
+        put :update, update_user_phone_form: { phone: second_user.phone, international_code: 'US' }
       end
 
       it 'processes successfully and informs user' do
@@ -74,7 +74,7 @@ describe Users::PhonesController do
         user = build(:user, phone: '123-123-1234')
         stub_sign_in(user)
 
-        put :update, update_user_phone_form: { phone: invalid_phone }
+        put :update, update_user_phone_form: { phone: invalid_phone, international_code: 'US' }
 
         expect(user.phone).not_to eq invalid_phone
         expect(response).to render_template(:edit)
@@ -85,7 +85,7 @@ describe Users::PhonesController do
       it 'redirects to profile page without any messages' do
         stub_sign_in(user)
 
-        put :update, update_user_phone_form: { phone: user.phone }
+        put :update, update_user_phone_form: { phone: user.phone, international_code: 'US' }
 
         expect(response).to redirect_to account_url
         expect(flash.keys).to be_empty

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -28,7 +28,11 @@ describe Users::TwoFactorAuthenticationSetupController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
 
-      patch :set, two_factor_setup_form: { phone: '703-555-010', otp_delivery_preference: :sms }
+      patch :set, two_factor_setup_form: {
+        phone: '703-555-010',
+        otp_delivery_preference: :sms,
+        international_code: 'US',
+      }
 
       expect(response).to render_template(:index)
     end
@@ -50,7 +54,8 @@ describe Users::TwoFactorAuthenticationSetupController do
         patch(
           :set,
           two_factor_setup_form: { phone: '703-555-0100',
-                                   otp_delivery_preference: 'voice' }
+                                   otp_delivery_preference: 'voice',
+                                   international_code: 'US' }
         )
 
         expect(response).to redirect_to(
@@ -81,7 +86,8 @@ describe Users::TwoFactorAuthenticationSetupController do
         patch(
           :set,
           two_factor_setup_form: { phone: '703-555-0100',
-                                   otp_delivery_preference: :sms }
+                                   otp_delivery_preference: :sms,
+                                   international_code: 'US' }
         )
 
         expect(response).to redirect_to(
@@ -110,7 +116,9 @@ describe Users::TwoFactorAuthenticationSetupController do
 
         patch(
           :set,
-          two_factor_setup_form: { phone: '703-555-0100', otp_delivery_preference: :sms }
+          two_factor_setup_form: { phone: '703-555-0100',
+                                   otp_delivery_preference: :sms,
+                                   international_code: 'US' }
         )
 
         expect(response).to redirect_to(

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -52,7 +52,7 @@ describe Verify::PhoneController do
       end
 
       it 'renders #new' do
-        put :create, idv_phone_form: { phone: '703' }
+        put :create, idv_phone_form: { phone: '703', international_code: 'US' }
 
         expect(flash[:warning]).to be_nil
         expect(subject.idv_session.params).to be_empty
@@ -61,7 +61,7 @@ describe Verify::PhoneController do
       it 'tracks form error and does not make a vendor API call' do
         expect(Idv::PhoneValidator).to_not receive(:new)
 
-        put :create, idv_phone_form: { phone: '703' }
+        put :create, idv_phone_form: { phone: '703', international_code: 'US' }
 
         result = {
           success: false,
@@ -87,7 +87,7 @@ describe Verify::PhoneController do
         user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
         stub_verify_steps_one_and_two(user)
 
-        put :create, idv_phone_form: { phone: good_phone }
+        put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
 
         result = { success: true, errors: {} }
 
@@ -101,7 +101,7 @@ describe Verify::PhoneController do
           user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
           stub_verify_steps_one_and_two(user)
 
-          put :create, idv_phone_form: { phone: good_phone }
+          put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
 
           expect(response).to redirect_to verify_phone_result_path
 
@@ -118,7 +118,7 @@ describe Verify::PhoneController do
           user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
           stub_verify_steps_one_and_two(user)
 
-          put :create, idv_phone_form: { phone: good_phone }
+          put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
 
           expect(response).to redirect_to verify_phone_result_path
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -73,6 +73,46 @@ feature 'Two Factor Authentication' do
         expect(phone_radio_button).to_not be_disabled
       end
     end
+
+    context 'with international phone that does not support phone delivery' do
+      scenario 'renders an error if a user submits with phone selected' do
+        sign_in_before_2fa
+        select 'Turkey +90', from: 'International code'
+        fill_in 'Phone', with: '555-555-5000'
+        choose 'Phone call'
+        click_send_security_code
+
+        expect(current_path).to eq(phone_setup_path)
+        expect(page).to have_content t(
+          'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+          location: 'Turkey'
+        )
+      end
+
+      scenario 'disables the phone option and displays a warning with js', :js do
+        sign_in_before_2fa
+        select 'Turkey +90', from: 'International code'
+        fill_in 'Phone', with: '555-555-5000'
+        phone_radio_button = page.find(
+          '#two_factor_setup_form_otp_delivery_preference_voice',
+          visible: :all
+        )
+
+        expect(page).to have_content t(
+          'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+          location: 'Turkey'
+        )
+        expect(phone_radio_button).to be_disabled
+
+        select 'Canada +1', from: 'International code'
+
+        expect(page).not_to have_content t(
+          'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+          location: 'Turkey'
+        )
+        expect(phone_radio_button).to_not be_disabled
+      end
+    end
   end
 
   def attempt_to_bypass_2fa_setup

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -9,7 +9,7 @@ describe Idv::PhoneForm do
   describe '#submit' do
     context 'when the form is valid' do
       it 'returns a successful form response' do
-        result = subject.submit(phone: '703-555-1212')
+        result = subject.submit(phone: '703-555-1212', international_code: 'US')
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(true)
@@ -17,7 +17,7 @@ describe Idv::PhoneForm do
       end
 
       it 'adds phone key to idv_params' do
-        subject.submit(phone: '703-555-1212')
+        subject.submit(phone: '703-555-1212', international_code: 'US')
 
         expected_params = {
           phone: '7035551212',
@@ -29,7 +29,7 @@ describe Idv::PhoneForm do
 
     context 'when the form is invalid' do
       it 'returns an unsuccessful form response' do
-        result = subject.submit(phone: 'Im not a phone number 🙃')
+        result = subject.submit(phone: 'Im not a phone number 🙃', international_code: 'US')
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(false)
@@ -38,7 +38,7 @@ describe Idv::PhoneForm do
     end
 
     it 'adds phone_confirmed_at key to idv_params when submitted phone equals user phone' do
-      subject.submit(phone: '+1 (202) 555-1212')
+      subject.submit(phone: '+1 (202) 555-1212', international_code: 'US')
 
       expected_params = {
         phone: '2025551212',

--- a/spec/forms/two_factor_setup_form_spec.rb
+++ b/spec/forms/two_factor_setup_form_spec.rb
@@ -2,7 +2,15 @@ require 'rails_helper'
 
 describe TwoFactorSetupForm, type: :model do
   let(:user) { build_stubbed(:user) }
-  let(:valid_phone) { '+1 (202) 202-2020' }
+  let(:phone) { '+1 (202) 202-2020' }
+  let(:international_code) { 'US' }
+  let(:params) do
+    {
+      phone: phone,
+      international_code: 'US',
+      otp_delivery_preference: 'sms',
+    }
+  end
   subject { TwoFactorSetupForm.new(user) }
 
   it_behaves_like 'an otp delivery preference form'
@@ -14,12 +22,28 @@ describe TwoFactorSetupForm, type: :model do
   end
 
   describe 'phone validation' do
-    it 'uses the phony_rails gem with country option set to US' do
+    it 'uses the phony_rails gem' do
       phone_validator = subject._validators.values.flatten.
                         detect { |v| v.class == PhonyPlausibleValidator }
 
-      expect(phone_validator.options).
-        to eq(country_code: 'US', presence: true, message: :improbable_phone)
+      expect(phone_validator.options[:presence]).to eq(true)
+      expect(phone_validator.options[:message]).to eq(:improbable_phone)
+      expect(phone_validator.options).to include(:international_code)
+    end
+
+    it do
+      should validate_inclusion_of(:international_code).
+        in_array(PhoneNumberCapabilities::INTERNATIONAL_CODES.keys)
+    end
+
+    it 'validates that the number matches the requested international code' do
+      params[:phone] = '123 123 1234'
+      params[:international_code] = 'MA'
+      result = subject.submit(params)
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to include(:phone)
     end
   end
 
@@ -34,14 +58,17 @@ describe TwoFactorSetupForm, type: :model do
         }
         result = instance_double(FormResponse)
 
+        params[:phone] = user.phone
+
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit(phone: user.phone, otp_delivery_preference: 'sms')).
-          to eq result
+        expect(form.submit(params)).to eq result
       end
     end
 
     context 'when phone is not already taken' do
+      let(:phone) { '+1 (703) 555-1212' }
+
       it 'is valid' do
         extra = {
           otp_delivery_preference: 'sms',
@@ -50,14 +77,13 @@ describe TwoFactorSetupForm, type: :model do
 
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(subject.submit(phone: '+1 (703) 555-1212', otp_delivery_preference: 'sms')).
-          to eq result
+        expect(subject.submit(params)).to eq result
       end
     end
 
     context 'when phone is same as current user' do
       it 'is valid' do
-        user = build_stubbed(:user, phone: valid_phone)
+        user = build_stubbed(:user, phone: phone)
         form = TwoFactorSetupForm.new(user)
         extra = {
           otp_delivery_preference: 'sms',
@@ -66,12 +92,13 @@ describe TwoFactorSetupForm, type: :model do
 
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit(phone: valid_phone, otp_delivery_preference: 'sms')).
-          to eq result
+        expect(form.submit(params)).to eq result
       end
     end
 
     context 'when phone is empty' do
+      let(:phone) { '' }
+
       it 'does not add already taken errors' do
         errors = {
           phone: [t('errors.messages.improbable_phone')],
@@ -83,8 +110,7 @@ describe TwoFactorSetupForm, type: :model do
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra).and_return(result)
-        expect(subject.submit(phone: '', otp_delivery_preference: 'sms')).
-          to eq result
+        expect(subject.submit(params)).to eq result
       end
     end
   end
@@ -97,7 +123,7 @@ describe TwoFactorSetupForm, type: :model do
 
         expect(UpdateUser).to_not receive(:new)
 
-        form.submit(phone: '+1 (703) 555-1212', otp_delivery_preference: 'sms')
+        form.submit(params)
       end
     end
 
@@ -113,7 +139,7 @@ describe TwoFactorSetupForm, type: :model do
 
         expect(updated_user).to receive(:call)
 
-        form.submit(phone: '+1 (703) 555-1212', otp_delivery_preference: 'sms')
+        form.submit(params)
       end
     end
   end

--- a/spec/services/phone_formatter_spec.rb
+++ b/spec/services/phone_formatter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe PhoneFormatter do
+  describe '#format' do
+    it 'formats international numbers correctly' do
+      phone = '+404004004000'
+      formatted_phone = PhoneFormatter.new.format(phone)
+
+      expect(formatted_phone).to eq('+40 400 400 4000')
+    end
+
+    it 'formats U.S. numbers correctly' do
+      phone = '+12025005000'
+      formatted_phone = PhoneFormatter.new.format(phone)
+
+      expect(formatted_phone).to eq('+1 (202) 500-5000')
+    end
+
+    it 'uses +1 as the default international code' do
+      phone = '2025005000'
+      formatted_phone = PhoneFormatter.new.format(phone)
+
+      expect(formatted_phone).to eq('+1 (202) 500-5000')
+    end
+
+    it 'uses the international code for the country specified in the country code option' do
+      phone = '123123123'
+      formatted_phone = PhoneFormatter.new.format(phone, country_code: 'MA')
+
+      expect(formatted_phone).to eq('+212 12 3123 123')
+    end
+
+    it 'returns nil for nil' do
+      formatted_phone = PhoneFormatter.new.format(nil)
+
+      expect(formatted_phone).to be_nil
+    end
+
+    it 'returns nil for nonsense' do
+      phone = '☎️📞📱📳'
+      formatted_phone = PhoneFormatter.new.format(phone)
+      expect(formatted_phone).to be_nil
+    end
+  end
+end

--- a/spec/services/phone_number_capabilities_spec.rb
+++ b/spec/services/phone_number_capabilities_spec.rb
@@ -13,12 +13,27 @@ describe PhoneNumberCapabilities do
       let(:phone) { '+1 (671) 555-5000' }
       it { expect(subject.sms_only?).to eq(true) }
     end
+
+    context 'voice is supported for the international code' do
+      let(:phone) { '+55 (555) 555-5000' }
+      it { expect(subject.sms_only?).to eq(false) }
+    end
+
+    context 'voice is not supported for the international code' do
+      let(:phone) { '+212 1234 12345' }
+      it { expect(subject.sms_only?).to eq(true) }
+    end
   end
 
   describe '#unsupported_location' do
-    it 'returns the name of the unsupported locality' do
+    it 'returns the name of the unsupported area code location' do
       locality = PhoneNumberCapabilities.new('+1 (671) 555-5000').unsupported_location
       expect(locality).to eq('Guam')
+    end
+
+    it 'returns the name of the unsupported international code location' do
+      locality = PhoneNumberCapabilities.new('+212 1234 12345').unsupported_location
+      expect(locality).to eq('Morocco')
     end
   end
 end

--- a/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
+++ b/spec/support/shared_examples_for_otp_delivery_preference_validation.rb
@@ -1,5 +1,12 @@
 shared_examples 'an otp delivery preference form' do
   let(:phone) { '+1 (555) 555-5000' }
+  let(:params) do
+    {
+      phone: phone,
+      otp_delivery_preference: 'voice',
+      international_code: 'US',
+    }
+  end
 
   context 'voice' do
     it 'is valid when supported for the phone' do
@@ -13,7 +20,7 @@ shared_examples 'an otp delivery preference form' do
       allow(PhoneNumberCapabilities).to receive(:new).with(phone).and_return(capabilities)
       allow(capabilities).to receive(:sms_only?).and_return(false)
 
-      result = subject.submit(phone: phone, otp_delivery_preference: 'voice')
+      result = subject.submit(params)
 
       expect(result.success?).to eq(true)
     end
@@ -29,7 +36,7 @@ shared_examples 'an otp delivery preference form' do
       allow(PhoneNumberCapabilities).to receive(:new).with(phone).and_return(capabilities)
       allow(capabilities).to receive(:sms_only?).and_return(true)
 
-      result = subject.submit(phone: phone, otp_delivery_preference: 'voice')
+      result = subject.submit(params)
 
       expect(result.success?).to eq(false)
       expect(result.errors).to include(:phone)

--- a/spec/support/shared_examples_for_phone_validation.rb
+++ b/spec/support/shared_examples_for_phone_validation.rb
@@ -1,4 +1,8 @@
+require 'shoulda/matchers'
+
 shared_examples 'a phone form' do
+  include Shoulda::Matchers::ActiveModel
+
   describe 'phone presence validation' do
     it 'is invalid when phone is blank' do
       subject.submit(phone: '')
@@ -8,12 +12,26 @@ shared_examples 'a phone form' do
   end
 
   describe 'phone validation' do
-    it 'uses the phony_rails gem with country option set to US' do
+    it 'uses the phony_rails gem' do
       phone_validator = subject._validators.values.flatten.
                         detect { |v| v.class == PhonyPlausibleValidator }
 
-      expect(phone_validator.options).
-        to eq(country_code: 'US', presence: true, message: :improbable_phone)
+      expect(phone_validator.options[:presence]).to eq(true)
+      expect(phone_validator.options[:message]).to eq(:improbable_phone)
+      expect(phone_validator.options).to include(:international_code)
+    end
+
+    it do
+      should validate_inclusion_of(:international_code).
+        in_array(PhoneNumberCapabilities::INTERNATIONAL_CODES.keys)
+    end
+
+    it 'validates that the number matches the requested international code' do
+      result = subject.submit(phone: '123 123 1234', international_code: 'MA')
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to include(:phone)
     end
   end
 
@@ -24,7 +42,7 @@ shared_examples 'a phone form' do
         allow(User).to receive(:exists?).with(email: 'new@gmail.com').and_return(false)
         allow(User).to receive(:exists?).with(phone: second_user.phone).and_return(true)
 
-        result = subject.submit(phone: second_user.phone)
+        result = subject.submit(phone: second_user.phone, international_code: 'US')
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(true)
       end
@@ -32,7 +50,7 @@ shared_examples 'a phone form' do
 
     context 'when phone is not already taken' do
       it 'is valid' do
-        result = subject.submit(phone: '+1 (703) 555-1212')
+        result = subject.submit(phone: '+1 (703) 555-1212', international_code: 'US')
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to be true
       end
@@ -40,7 +58,7 @@ shared_examples 'a phone form' do
 
     context 'when phone is same as current user' do
       it 'is valid' do
-        result = subject.submit(phone: user.phone)
+        result = subject.submit(phone: user.phone, international_code: 'US')
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to be true
       end
@@ -49,7 +67,7 @@ shared_examples 'a phone form' do
 
   describe '#submit' do
     it 'formats the phone before assigning it' do
-      subject.submit(phone: '703-555-1212')
+      subject.submit(phone: '703-555-1212', international_code: 'US')
 
       expect(subject.phone).to eq '+1 (703) 555-1212'
     end


### PR DESCRIPTION
Remove US country code option from phone normalization
    
**Why**: We want to allow users to have international numbers, which means we need to be prepared to format international numbers.

Remove US country code from phone validation
    
**Why**: In order to support international numbers, we need to remove the validation that requires phone numbers have a US country code