### PR TITLE
Deployment to staging: patch for 1.008

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,10 @@ class ApplicationController < ActionController::Base
 
   def decorated_session
     @_decorated_session ||= DecoratedSession.new(
-      sp: current_sp, view_context: view_context, sp_session: sp_session
+      sp: current_sp,
+      view_context: view_context,
+      sp_session: sp_session,
+      service_provider_request: service_provider_request
     ).call
   end
 
@@ -74,9 +77,12 @@ class ApplicationController < ActionController::Base
   end
 
   def sp_from_request_id
-    issuer = ServiceProviderRequest.from_uuid(params[:request_id]).issuer
-    sp = ServiceProvider.from_issuer(issuer)
+    sp = ServiceProvider.from_issuer(service_provider_request.issuer)
     sp if sp.is_a? ServiceProvider
+  end
+
+  def service_provider_request
+    @service_provider_request ||= ServiceProviderRequest.from_uuid(params[:request_id])
   end
 
   def after_sign_in_path_for(user)

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -23,8 +23,6 @@ module SamlIdpAuthConcern
   end
 
   def store_saml_request
-    return if sp_session[:request_id]
-
     @request_id = SecureRandom.uuid
     ServiceProviderRequest.find_or_create_by(uuid: @request_id) do |sp_request|
       sp_request.issuer = current_issuer
@@ -35,15 +33,7 @@ module SamlIdpAuthConcern
   end
 
   def add_sp_metadata_to_session
-    return if sp_session[:request_id]
-
-    session[:sp] = {
-      issuer: current_issuer,
-      loa3: loa3_requested?,
-      request_id: @request_id,
-      request_url: request.original_url,
-      requested_attributes: requested_attributes,
-    }
+    StoreSpMetadataInSession.new(session: session, request_id: @request_id).call
   end
 
   def requested_authn_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -76,8 +76,6 @@ module OpenidConnect
     end
 
     def store_request
-      return if sp_session[:request_id]
-
       client_id = @authorize_form.client_id
 
       @request_id = SecureRandom.uuid
@@ -90,15 +88,7 @@ module OpenidConnect
     end
 
     def add_sp_metadata_to_session
-      return if sp_session[:request_id]
-
-      session[:sp] = {
-        issuer: @authorize_form.client_id,
-        loa3: @authorize_form.loa3_requested?,
-        request_id: @request_id,
-        request_url: request.original_url,
-        requested_attributes: requested_attributes,
-      }
+      StoreSpMetadataInSession.new(session: session, request_id: @request_id).call
     end
 
     def requested_attributes

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -1,0 +1,13 @@
+class SignOutController < ApplicationController
+  include FullyAuthenticatable
+
+  skip_before_action :handle_two_factor_authentication
+
+  def destroy
+    path_after_cancellation = decorated_session.cancel_link_path
+    sign_out
+    flash[:success] = t('devise.sessions.signed_out')
+    redirect_to path_after_cancellation
+    delete_branded_experience
+  end
+end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -3,10 +3,11 @@ class ServiceProviderSessionDecorator
 
   DEFAULT_LOGO = 'generic.svg'.freeze
 
-  def initialize(sp:, view_context:, sp_session:)
+  def initialize(sp:, view_context:, sp_session:, service_provider_request:)
     @sp = sp
     @view_context = view_context
     @sp_session = sp_session
+    @service_provider_request = service_provider_request
   end
 
   def sp_logo
@@ -71,10 +72,10 @@ class ServiceProviderSessionDecorator
 
   private
 
-  attr_reader :sp, :view_context, :sp_session
+  attr_reader :sp, :view_context, :sp_session, :service_provider_request
 
   def request_url
-    sp_session[:request_url]
+    sp_session[:request_url] || service_provider_request.url
   end
 
   def openid_connect_redirector

--- a/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthCode
       if reauthn
         account_path
       else
-        destroy_user_session_path
+        sign_out_path
       end
     end
 

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -22,7 +22,7 @@ module TwoFactorAuthCode
       if confirmation_for_phone_change || reauthn
         account_path
       else
-        destroy_user_session_path
+        sign_out_path
       end
     end
 

--- a/app/services/decorated_session.rb
+++ b/app/services/decorated_session.rb
@@ -1,14 +1,18 @@
 class DecoratedSession
-  def initialize(sp:, view_context:, sp_session:)
+  def initialize(sp:, view_context:, sp_session:, service_provider_request:)
     @sp = sp
     @view_context = view_context
     @sp_session = sp_session
+    @service_provider_request = service_provider_request
   end
 
   def call
     if sp.is_a? ServiceProvider
       ServiceProviderSessionDecorator.new(
-        sp: sp, view_context: view_context, sp_session: sp_session
+        sp: sp,
+        view_context: view_context,
+        sp_session: sp_session,
+        service_provider_request: service_provider_request
       )
     else
       SessionDecorator.new
@@ -17,5 +21,5 @@ class DecoratedSession
 
   private
 
-  attr_reader :sp, :view_context, :sp_session
+  attr_reader :sp, :view_context, :sp_session, :service_provider_request
 end

--- a/app/views/two_factor_authentication/personal_key_verification/show.html.slim
+++ b/app/views/two_factor_authentication/personal_key_verification/show.html.slim
@@ -8,4 +8,4 @@ p.mt-tiny.mb0 = t('devise.two_factor_authentication.personal_key_prompt')
   = render 'partials/personal_key/entry_fields', f: f, attribute_name: :personal_key
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn btn-primary'
 
-= render 'shared/cancel', link: destroy_user_session_path
+= render 'shared/cancel', link: sign_out_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
   get '/sign_up/completed' => 'sign_up/completions#show', as: :sign_up_completed
   post '/sign_up/completed' => 'sign_up/completions#update'
 
+  match '/sign_out' => 'sign_out#destroy', via: %i[get post delete]
+
   delete '/users' => 'users#destroy', as: :destroy_user
 
   if FeatureManagement.enable_identity_verification?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,5 +153,7 @@ Rails.application.routes.draw do
   # The line below will route all requests that aren't
   # defined route to the 404 page. Therefore, anything you put after this rule
   # will be ignored.
-  match '*path', via: :all, to: 'pages#page_not_found'
+  constraints(format: /html/) do
+    match '*path', via: :all, to: 'pages#page_not_found'
+  end
 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -292,11 +292,11 @@ describe SamlIdpController do
         sp_request_id = ServiceProviderRequest.last.uuid
 
         expect(session[:sp]).to eq(
-          loa3: false,
           issuer: saml_settings.issuer,
-          request_id: sp_request_id,
+          loa3: false,
           request_url: @saml_request.request.original_url,
-          requested_attributes: [:email]
+          request_id: sp_request_id,
+          requested_attributes: ['email']
         )
       end
 

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe SignOutController do
+  describe '#destroy' do
+    it 'redirects to decorated_session.cancel_link_path with flash message' do
+      stub_sign_in_before_2fa
+      allow(controller.decorated_session).to receive(:cancel_link_path).and_return('foo')
+
+      get :destroy
+
+      expect(response).to redirect_to 'foo'
+      expect(flash[:success]).to eq t('devise.sessions.signed_out')
+    end
+
+    it 'calls #sign_out and #delete_branded_experience' do
+      expect(controller).to receive(:sign_out).and_call_original
+      expect(controller).to receive(:delete_branded_experience)
+
+      get :destroy
+    end
+  end
+end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -3,7 +3,12 @@ require 'rails_helper'
 RSpec.describe ServiceProviderSessionDecorator do
   let(:view_context) { ActionController::Base.new.view_context }
   subject do
-    ServiceProviderSessionDecorator.new(sp: sp, view_context: view_context, sp_session: {})
+    ServiceProviderSessionDecorator.new(
+      sp: sp,
+      view_context: view_context,
+      sp_session: {},
+      service_provider_request: ServiceProviderRequest.new
+    )
   end
   let(:sp) { build_stubbed(:service_provider) }
   let(:sp_name) { subject.sp_name }
@@ -59,7 +64,10 @@ RSpec.describe ServiceProviderSessionDecorator do
     it 'returns the agency name if friendly name is not present' do
       sp = build_stubbed(:service_provider, friendly_name: nil)
       subject = ServiceProviderSessionDecorator.new(
-        sp: sp, view_context: view_context, sp_session: {}
+        sp: sp,
+        view_context: view_context,
+        sp_session: {},
+        service_provider_request: ServiceProviderRequest.new
       )
       expect(subject.sp_name).to eq sp.agency
       expect(subject.sp_name).to_not be_nil
@@ -73,7 +81,10 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp = build_stubbed(:service_provider, logo: sp_logo)
 
         subject = ServiceProviderSessionDecorator.new(
-          sp: sp, view_context: view_context, sp_session: {}
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequest.new
         )
 
         expect(subject.sp_logo).to eq sp_logo
@@ -85,7 +96,10 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp = build_stubbed(:service_provider, logo: nil)
 
         subject = ServiceProviderSessionDecorator.new(
-          sp: sp, view_context: view_context, sp_session: {}
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequest.new
         )
 
         expect(subject.sp_logo).to eq 'generic.svg'
@@ -96,7 +110,10 @@ RSpec.describe ServiceProviderSessionDecorator do
   describe '#cancel_link_path' do
     it 'returns sign_up_start_url with the request_id as a param' do
       subject = ServiceProviderSessionDecorator.new(
-        sp: sp, view_context: view_context, sp_session: { request_id: 'foo' }
+        sp: sp,
+        view_context: view_context,
+        sp_session: { request_id: 'foo' },
+        service_provider_request: ServiceProviderRequest.new
       )
 
       expect(subject.cancel_link_path).

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -487,9 +487,12 @@ feature 'OpenID Connect' do
       visit_idp_from_sp_with_loa1
       click_link t('links.sign_in')
       fill_in_credentials_and_submit(user.email, user.password)
+      sp_request_id = ServiceProviderRequest.last.uuid
+      sp = ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server')
       click_link t('links.cancel')
 
-      expect(current_url).to eq root_url
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+      expect(page).to have_content t('links.back_to_sp', sp: sp.friendly_name)
     end
   end
 

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -152,6 +152,23 @@ feature 'LOA1 Single Sign On' do
     end
   end
 
+  context 'canceling sign in after email and password' do
+    it 'returns to the branded landing page' do
+      user = create(:user, :signed_up)
+      authn_request = auth_request.create(saml_settings)
+
+      visit authn_request
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit(user.email, user.password)
+      sp_request_id = ServiceProviderRequest.last.uuid
+      sp = ServiceProvider.from_issuer('http://localhost:3000')
+      click_link t('links.cancel')
+
+      expect(current_url).to eq sign_up_start_url(request_id: sp_request_id)
+      expect(page).to have_content t('links.back_to_sp', sp: sp.friendly_name)
+    end
+  end
+
   def sign_in_and_require_viewing_personal_key(user)
     login_as(user, scope: :user, run_callbacks: false)
     Warden.on_next_request do |proxy|

--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Missing pages and assets', type: :request do
+  describe 'missing page' do
+    it 'responds with 404' do
+      get '/nonexistent-page'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing PNG' do
+    it 'responds with 404' do
+      get '/mobile-icon.png'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing CSS' do
+    it 'responds with 404' do
+      get '/application-random-hash.css'
+
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'missing JS' do
+    it 'responds with 404' do
+      get '/application-random-hash.js'
+
+      expect(response.status).to eq 404
+    end
+  end
+end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -243,7 +243,7 @@ module Features
       expect(current_url).to eq sign_up_email_url(request_id: sp_request_id)
       expect(page).to have_css('img[src*=sp-logos]')
 
-      submit_form_with_valid_email
+      submit_form_with_valid_email(email)
 
       expect(current_url).to eq sign_up_verify_email_url(request_id: sp_request_id)
       expect(last_email.html_part.body).to have_content "?_request_id=#{sp_request_id}"

--- a/spec/support/shared_examples_for_otp_forms.rb
+++ b/spec/support/shared_examples_for_otp_forms.rb
@@ -8,7 +8,7 @@ shared_examples_for 'an otp form' do
   describe 'tertiary form actions' do
     it 'allows the user to cancel out of the sign in process' do
       render
-      expect(rendered).to have_link(t('links.cancel'), href: destroy_user_session_path)
+      expect(rendered).to have_link(t('links.cancel'), href: sign_out_path)
     end
   end
 end

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -5,8 +5,20 @@ describe 'devise/passwords/new.html.slim' do
 
   before do
     @password_reset_email_form = PasswordResetEmailForm.new('')
-
+    sp = build_stubbed(
+      :service_provider,
+      friendly_name: 'Awesome Application!',
+      return_to_sp_url: 'www.awesomeness.com'
+    )
+    view_context = ActionController::Base.new.view_context
+    @decorated_session = DecoratedSession.new(
+      sp: sp,
+      view_context: view_context,
+      sp_session: {},
+      service_provider_request: ServiceProviderRequest.new
+    ).call
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end
 
   it 'has a localized title' do

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -54,7 +54,10 @@ describe 'devise/sessions/new.html.slim' do
       )
       view_context = ActionController::Base.new.view_context
       @decorated_session = DecoratedSession.new(
-        sp: sp, view_context: view_context, sp_session: {}
+        sp: sp,
+        view_context: view_context,
+        sp_session: {},
+        service_provider_request: ServiceProviderRequest.new
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -6,7 +6,12 @@ describe 'layouts/application.html.slim' do
   before do
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
     allow(view).to receive(:decorated_session).and_return(
-      DecoratedSession.new(sp: nil, view_context: nil, sp_session: {}).call
+      DecoratedSession.new(
+        sp: nil,
+        view_context: nil,
+        sp_session: {},
+        service_provider_request: ServiceProviderRequest.new
+      ).call
     )
     allow(view.request).to receive(:original_url).and_return('http://test.host/foobar')
     allow(view).to receive(:current_user).and_return(User.new)
@@ -76,7 +81,12 @@ describe 'layouts/application.html.slim' do
       allow(view).to receive(:current_user).and_return(nil)
       allow(view).to receive(:user_fully_authenticated?).and_return(false)
       allow(view).to receive(:decorated_session).and_return(
-        DecoratedSession.new(sp: nil, view_context: nil, sp_session: {}).call
+        DecoratedSession.new(
+          sp: nil,
+          view_context: nil,
+          sp_session: {},
+          service_provider_request: nil
+        ).call
       )
       allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
 

--- a/spec/views/shared/_nav_branded.html.slim_spec.rb
+++ b/spec/views/shared/_nav_branded.html.slim_spec.rb
@@ -9,7 +9,10 @@ describe 'shared/_nav_branded.html.slim' do
         :service_provider, logo: 'generic.svg', friendly_name: 'Best SP ever'
       )
       decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp_with_logo, view_context: view_context, sp_session: {}
+        sp: sp_with_logo,
+        view_context: view_context,
+        sp_session: {},
+        service_provider_request: nil
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render
@@ -24,7 +27,10 @@ describe 'shared/_nav_branded.html.slim' do
     before do
       sp_without_logo = build_stubbed(:service_provider, friendly_name: 'No logo no problem')
       decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp_without_logo, view_context: view_context, sp_session: {}
+        sp: sp_without_logo,
+        view_context: view_context,
+        sp_session: {},
+        service_provider_request: nil
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'sign_up/registrations/new.html.slim' do
 
     view_context = ActionController::Base.new.view_context
     @decorated_session = DecoratedSession.new(
-      sp: nil, view_context: view_context, sp_session: {}
+      sp: nil, view_context: view_context, sp_session: {}, service_provider_request: nil
     ).call
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -41,7 +41,7 @@ describe 'sign_up/registrations/show.html.slim' do
       )
       view_context = ActionController::Base.new.view_context
       @decorated_session = DecoratedSession.new(
-        sp: @sp, view_context: view_context, sp_session: {}
+        sp: @sp, view_context: view_context, sp_session: {}, service_provider_request: nil
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end

--- a/spec/views/verify/fail.html.slim_spec.rb
+++ b/spec/views/verify/fail.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'verify/fail.html.slim' do
     before do
       sp = build_stubbed(:service_provider, friendly_name: 'Awesome Application!')
       @decorated_session = ServiceProviderSessionDecorator.new(
-        sp: sp, view_context: view_context, sp_session: {}
+        sp: sp, view_context: view_context, sp_session: {}, service_provider_request: nil
       )
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end


### PR DESCRIPTION
Deploy patch to staging for 1.008. These changes will also be part 1.009.

Changes include: 
- Allow multiple account creating in same session #1542 
- Respond with 404 for all nonexistent assets #1543 
- Return to branded page when canceling sign in. #1526 

