### PR TITLE
Require user to confirm phone with OTP during IdV

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -163,16 +163,21 @@ module TwoFactorAuthenticatable
   end
 
   def update_idv_state
-    now = Time.zone.now
     if idv_context?
-      Idv::Session.new(
-        user_session: user_session,
-        current_user: current_user,
-        issuer: sp_session[:issuer]
-      ).params['phone_confirmed_at'] = now
+      confirm_idv_session_phone
     elsif profile_context?
       Idv::ProfileActivator.new(user: current_user).call
     end
+  end
+
+  def confirm_idv_session_phone
+    idv_session = Idv::Session.new(
+      user_session: user_session,
+      current_user: current_user,
+      issuer: sp_session[:issuer]
+    )
+    idv_session.user_phone_confirmation = true
+    idv_session.params['phone_confirmed_at'] = Time.zone.now
   end
 
   def reset_otp_session_data

--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -33,7 +33,7 @@ module Verify
     def track_final_idv_event
       result = {
         success: true,
-        new_phone_added: idv_session.params['phone_confirmed_at'].present?,
+        new_phone_added: idv_session.params['phone'] != current_user.phone,
       }
       analytics.track_event(Analytics::IDV_FINAL, result)
     end

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -71,7 +71,7 @@ module Verify
     end
 
     def confirm_step_needed
-      redirect_to verify_review_path if idv_session.phone_confirmation == true
+      redirect_to verify_review_path if idv_session.vendor_phone_confirmation == true
     end
 
     def idv_form

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -4,7 +4,7 @@ module Idv
       if complete?
         update_idv_session
       else
-        idv_session.phone_confirmation = false
+        idv_session.vendor_phone_confirmation = false
       end
 
       FormResponse.new(success: complete?, errors: errors)
@@ -17,9 +17,10 @@ module Idv
     end
 
     def update_idv_session
-      idv_session.phone_confirmation = true
+      idv_session.vendor_phone_confirmation = true
       idv_session.address_verification_mechanism = :phone
       idv_session.params = idv_form_params
+      idv_session.user_phone_confirmation = idv_form_params[:phone_confirmed_at].present?
     end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -7,7 +7,8 @@ module Idv
       financials_confirmation
       normalized_applicant_params
       params
-      phone_confirmation
+      vendor_phone_confirmation
+      user_phone_confirmation
       pii
       profile_confirmation
       profile_id
@@ -70,8 +71,12 @@ module Idv
       user_session.delete(:idv)
     end
 
+    def phone_confirmed?
+      vendor_phone_confirmation == true && user_phone_confirmation == true
+    end
+
     def complete_session
-      complete_profile if phone_confirmation == true
+      complete_profile if phone_confirmed?
       create_usps_entry if address_verification_mechanism == 'usps'
     end
 
@@ -94,7 +99,7 @@ module Idv
     end
 
     def address_mechanism_chosen?
-      phone_confirmation == true || address_verification_mechanism == 'usps'
+      vendor_phone_confirmation == true || address_verification_mechanism == 'usps'
     end
 
     private
@@ -131,7 +136,7 @@ module Idv
       @_profile_maker ||= Idv::ProfileMaker.new(
         applicant: Proofer::Applicant.new(applicant_params),
         normalized_applicant: Proofer::Applicant.new(normalized_applicant_params),
-        phone_confirmed: phone_confirmation || false,
+        phone_confirmed: vendor_phone_confirmation || false,
         user: current_user,
         vendor: vendor
       )

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -380,6 +380,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
           expect(subject.user_session[:idv][:params]['phone_confirmed_at']).to_not be_nil
         end
 
+        it 'updates idv session user_phone_confirmation attributes' do
+          expect(subject.user_session[:idv][:user_phone_confirmation]).to eq(true)
+        end
+
         it 'does not update user phone attributes' do
           expect(subject.current_user.reload.phone).to eq '+1 (202) 555-1212'
           expect(subject.current_user.reload.phone_confirmed_at).to eq @previous_phone_confirmed_at

--- a/spec/controllers/verify/address_controller_spec.rb
+++ b/spec/controllers/verify/address_controller_spec.rb
@@ -9,7 +9,7 @@ describe Verify::AddressController do
 
   describe '#index' do
     it 'redirects if phone mechanism selected' do
-      subject.idv_session.phone_confirmation = true
+      subject.idv_session.vendor_phone_confirmation = true
 
       get :index
 

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -66,7 +66,10 @@ describe Verify::ConfirmationsController do
 
     context 'user used 2FA phone as phone of record' do
       before do
-        subject.idv_session.phone_confirmation = true
+        subject.idv_session.params['phone'] = user.phone
+        subject.idv_session.params['phone_confirmed_at'] = Time.zone.now
+        subject.idv_session.vendor_phone_confirmation = true
+        subject.idv_session.user_phone_confirmation = true
       end
 
       it 'activates profile' do
@@ -148,6 +151,7 @@ describe Verify::ConfirmationsController do
     context 'user confirmed a new phone' do
       it 'tracks that event' do
         stub_analytics
+        subject.idv_session.params['phone'] = '+1 (202) 555-9876'
         subject.idv_session.params['phone_confirmed_at'] = Time.zone.now
 
         result = {

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -26,7 +26,7 @@ describe Verify::PhoneController do
     end
 
     it 'redirects to review when step is complete' do
-      subject.idv_session.phone_confirmation = true
+      subject.idv_session.vendor_phone_confirmation = true
 
       get :new
 
@@ -73,7 +73,7 @@ describe Verify::PhoneController do
         expect(@analytics).to have_received(:track_event).with(
           Analytics::IDV_PHONE_CONFIRMATION_FORM, result
         )
-        expect(subject.idv_session.phone_confirmation).to be_falsy
+        expect(subject.idv_session.vendor_phone_confirmation).to be_falsy
       end
     end
 

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -36,7 +36,7 @@ describe Verify::ReviewController do
       issuer: nil
     )
     idv_session.profile_confirmation = true
-    idv_session.phone_confirmation = true
+    idv_session.vendor_phone_confirmation = true
     idv_session.financials_confirmation = true
     idv_session.params = user_attrs
     idv_session.normalized_applicant_params = user_attrs.merge(
@@ -77,7 +77,7 @@ describe Verify::ReviewController do
 
     context 'user has missed address step' do
       before do
-        idv_session.phone_confirmation = false
+        idv_session.vendor_phone_confirmation = false
       end
 
       it 'redirects to address step' do

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -413,6 +413,29 @@ feature 'IdV session' do
 
       expect(current_path).to eq account_path
     end
+
+    scenario 'being unable to verify account without OTP phone confirmation' do
+      different_phone = '555-555-9876'
+      user = sign_in_live_with_2fa
+      visit verify_session_path
+
+      fill_out_idv_form_ok
+      click_idv_continue
+      fill_out_financial_form_ok
+      click_idv_continue
+      click_idv_address_choose_phone
+      fill_out_phone_form_ok(different_phone)
+      click_idv_continue
+      fill_in :user_password, with: user_password
+      click_submit_default
+
+      visit verify_confirmations_path
+      click_acknowledge_personal_key
+
+      user.reload
+
+      expect(user.active_profile).to be_nil
+    end
   end
 
   def complete_idv_profile_fail

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -10,12 +10,13 @@ describe Idv::PhoneStep do
     idvs.applicant = Proofer::Applicant.new first_name: 'Some'
     idvs
   end
+  let(:idv_form_params) { { phone: '555-555-0000', phone_confirmed_at: nil } }
   let(:idv_phone_form) { Idv::PhoneForm.new(idv_session.params, user) }
 
-  def build_step(phone, vendor_validator_result)
+  def build_step(vendor_validator_result)
     described_class.new(
       idv_session: idv_session,
-      idv_form_params: { phone: phone },
+      idv_form_params: idv_form_params,
       vendor_validator_result: vendor_validator_result
     )
   end
@@ -23,7 +24,6 @@ describe Idv::PhoneStep do
   describe '#submit' do
     it 'returns true for mock-happy phone' do
       step = build_step(
-        '555-555-0000',
         Idv::VendorResult.new(
           success: true,
           errors: {}
@@ -35,15 +35,15 @@ describe Idv::PhoneStep do
       expect(result).to be_kind_of(FormResponse)
       expect(result.success?).to eq(true)
       expect(result.errors).to be_empty
-      expect(idv_session.phone_confirmation).to eq true
+      expect(idv_session.vendor_phone_confirmation).to eq true
       expect(idv_session.params).to eq idv_phone_form.idv_params
     end
 
     it 'returns false for mock-sad phone' do
+      idv_form_params[:phone] = '555-555-5555'
       errors = { phone: ['The phone number could not be verified.'] }
 
       step = build_step(
-        '555-555-5555',
         Idv::VendorResult.new(
           success: false,
           errors: errors
@@ -55,7 +55,32 @@ describe Idv::PhoneStep do
       expect(result).to be_kind_of(FormResponse)
       expect(result.success?).to eq(false)
       expect(result.errors).to eq(errors)
-      expect(idv_session.phone_confirmation).to eq false
+      expect(idv_session.vendor_phone_confirmation).to eq false
+    end
+
+    it 'marks the phone number as confirmed by user if it matches 2FA phone' do
+      idv_form_params[:phone_confirmed_at] = Time.zone.now
+      step = build_step(
+        Idv::VendorResult.new(
+          success: true,
+          errors: {}
+        )
+      )
+      step.submit
+
+      expect(idv_session.user_phone_confirmation).to eq(true)
+    end
+
+    it 'does not mark the phone number as confirmed by user if it does not match 2FA phone' do
+      step = build_step(
+        Idv::VendorResult.new(
+          success: true,
+          errors: {}
+        )
+      )
+      step.submit
+
+      expect(idv_session.user_phone_confirmation).to eq(false)
     end
   end
 end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -33,4 +33,90 @@ describe Idv::Session do
       end
     end
   end
+
+  describe '#complete_session' do
+    context 'with phone verifed by vendor' do
+      before do
+        subject.address_verification_mechanism = :phone
+        subject.vendor_phone_confirmation = true
+        allow(subject).to receive(:complete_profile)
+      end
+
+      it 'completes the profile if the user has completed OTP phone confirmation' do
+        subject.user_phone_confirmation = true
+        subject.complete_session
+
+        expect(subject).to have_received(:complete_profile)
+      end
+
+      it 'does not complete the profile if the user has not completed OTP phone confirmation' do
+        subject.user_phone_confirmation = nil
+        subject.complete_session
+
+        expect(subject).not_to have_received(:complete_profile)
+      end
+    end
+  end
+
+  describe '#phone_confirmed?' do
+    it 'returns true if the user and vendor have confirmed the phone' do
+      subject.user_phone_confirmation = true
+      subject.vendor_phone_confirmation = true
+
+      expect(subject.phone_confirmed?).to eq(true)
+    end
+
+    it 'returns false if the user has not confirmed the phone' do
+      subject.user_phone_confirmation = nil
+      subject.vendor_phone_confirmation = true
+
+      expect(subject.phone_confirmed?).to eq(false)
+    end
+
+    it 'returns false if the vendor has not confirmed the phone' do
+      subject.user_phone_confirmation = true
+      subject.vendor_phone_confirmation = nil
+
+      expect(subject.phone_confirmed?).to eq(false)
+    end
+
+    it 'returns false if neither the user nor the vendor has confirmed the phone' do
+      subject.user_phone_confirmation = nil
+      subject.vendor_phone_confirmation = nil
+
+      expect(subject.phone_confirmed?).to eq(false)
+    end
+  end
+
+  describe '#address_mechanism_chosen?' do
+    context 'phone verification chosen' do
+      before do
+        subject.address_verification_mechanism = 'phone'
+      end
+
+      it 'returns true if the vendor has confirmed the phone number' do
+        subject.vendor_phone_confirmation = true
+
+        expect(subject.address_mechanism_chosen?).to eq(true)
+      end
+
+      it 'returns false if the vendor has not confirmed the phone number' do
+        subject.vendor_phone_confirmation = nil
+
+        expect(subject.address_mechanism_chosen?).to eq(false)
+      end
+    end
+
+    it 'returns true if the user has selected usps address verification' do
+      subject.address_verification_mechanism = 'usps'
+
+      expect(subject.address_mechanism_chosen?).to eq(true)
+    end
+
+    it 'returns false if the user has not selected phone or usps address verification' do
+      subject.address_verification_mechanism = nil
+
+      expect(subject.address_mechanism_chosen?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
**Why**: Users should verify that they possess their phone of record
before we verify their profile. This was not happening before because we
were not actually checking that the phone number had been verified
before activating the profile.