### PR TITLE
Revert bummr to 0.1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     bullet (5.5.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    bummr (0.2.0)
+    bummr (0.1.8)
       rainbow
       thor
     byebug (9.0.6)


### PR DESCRIPTION
__Why__

* `0.2.0` was yanked: https://rubygems.org/gems/bummr/versions/0.2.0

__How__

* Revert Gemfile.lock to bummr (0.1.8)