### PR TITLE
Prevent access to TOTP prompt when not enabled

### DIFF
--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -3,6 +3,7 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
 
     skip_before_action :handle_two_factor_authentication
+    before_action :confirm_totp_enabled
 
     def show
       @presenter = presenter_for_two_factor_authentication_method
@@ -18,6 +19,14 @@ module TwoFactorAuthentication
       else
         handle_invalid_otp
       end
+    end
+
+    private
+
+    def confirm_totp_enabled
+      return if current_user.totp_enabled?
+
+      redirect_to user_two_factor_authentication_path
     end
   end
 end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -6,7 +6,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
       before do
         sign_in_before_2fa
         @secret = subject.current_user.generate_totp_secret
-        subject.current_user.otp_secret_key = @secret
+        subject.current_user.update(otp_secret_key: @secret)
       end
 
       it 'redirects to the profile' do
@@ -125,6 +125,26 @@ describe TwoFactorAuthentication::TotpVerificationController do
         it 'resets second_factor_locked_at' do
           expect(subject.current_user.reload.second_factor_locked_at).to eq nil
         end
+      end
+    end
+
+    context 'when the user does not have an authenticator app enabled' do
+      it 'redirects to user_two_factor_authentication_path' do
+        stub_sign_in_before_2fa
+        post :create, code: '123456'
+
+        expect(response).to redirect_to user_two_factor_authentication_path
+      end
+    end
+  end
+
+  describe '#show' do
+    context 'when the user does not have an authenticator app enabled' do
+      it 'redirects to user_two_factor_authentication_path' do
+        stub_sign_in_before_2fa
+        get :show
+
+        expect(response).to redirect_to user_two_factor_authentication_path
       end
     end
   end


### PR DESCRIPTION
**Why**: We noticed an error in our logs due to someone attempting
to validate a TOTP code while the `otp_secret_key` was not set.
I'll look into this in more detail, but most likely, this user visited
the `login/two_factor/authenticator` path directly without having an
authenticator app enabled, and caused the exception by submitting the
form.