### PR TITLE
Fix logic for "No PII" banner

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -61,6 +61,6 @@ class FeatureManagement
   end
 
   def self.no_pii_mode?
-    Idv::Vendor.new.pick == :mock
+    enable_identity_verification? && Idv::Vendor.new.pick == :mock
   end
 end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -159,4 +159,49 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '.no_pii_mode?' do
+    let(:proofing_vendor) { :mock }
+    let(:enable_identity_verification) { false }
+
+    before do
+      allow_any_instance_of(Idv::Vendor).to receive(:pick).and_return(proofing_vendor)
+      allow(Figaro.env).to receive(:enable_identity_verification).
+        and_return(enable_identity_verification.to_json)
+    end
+
+    subject(:no_pii_mode?) { FeatureManagement.no_pii_mode? }
+
+    context 'with mock ID-proofing vendors' do
+      let(:proofing_vendor) { :mock }
+
+      context 'with identity verification enabled' do
+        let(:enable_identity_verification) { true }
+
+        it { expect(no_pii_mode?).to eq(true) }
+      end
+
+      context 'with identity verification disabled' do
+        let(:enable_identity_verification) { false }
+
+        it { expect(no_pii_mode?).to eq(false) }
+      end
+    end
+
+    context 'with real ID-proofing vendors' do
+      let(:proofing_vendor) { :not_mock }
+
+      context 'with identity verification enabled' do
+        let(:enable_identity_verification) { true }
+
+        it { expect(no_pii_mode?).to eq(false) }
+      end
+
+      context 'with identity verification disabled' do
+        let(:enable_identity_verification) { false }
+
+        it { expect(no_pii_mode?).to eq(false) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
This prevents it from showing in production (where we
have LOA3 functionality disabled) before we launch LOA3

--- 

Quick follow-up to https://github.com/18F/identity-idp/pull/1553 once I realized the banner would end up showing in production when we definitely don't want it there 🙈 
