### PR TITLE
Provide better 'bad key' value error message

### DIFF
--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -1,22 +1,37 @@
 class ConfigValidator
+  ENV_PREFIX = Figaro::Application::FIGARO_ENV_PREFIX
+
   def validate(env = ENV)
     bad_keys = keys_with_bad_values(env, candidate_keys(env))
     return unless bad_keys.any?
-    raise warning(bad_keys).tr("\\\n", ' ')
+    raise warning(bad_keys).tr("\n", ' ')
   end
 
   private
 
   def candidate_keys(env)
-    env.keys.delete_if { |key| key.starts_with?(Figaro::Application::FIGARO_ENV_PREFIX) }
+    env.keys.keep_if { |key| candidate_key?(env, key) }
+  end
+
+  def candidate_key?(env, key)
+    # A key is associated with a configuration setting if there are two
+    # settings in the environment: one with and without the Figaro prefix.
+    # We're only interested in the configuration settings and not other
+    # environment variables.
+
+    env.include?(key) and env.include?(ENV_PREFIX + key)
   end
 
   def keys_with_bad_values(env, keys)
-    keys.keep_if { |key| %w[yes no].include?(env[key]) }
+    # Configuration settings for boolean values need to be "true/false"
+    # and not "yes/no".
+
+    keys.keep_if { |key| %w[yes no].include?(env[key].strip.downcase) }
   end
 
   def warning(bad_keys)
-    "You have invalid values for #{bad_keys.uniq.to_sentence} in " \
-    "config/application.yml. Please change them to true or false."
+    "You have invalid values (yes/no) for #{bad_keys.uniq.to_sentence} " \
+    "in config/application.yml or your environment. " \
+    "Please change them to true or false."
   end
 end

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -5,19 +5,34 @@ describe ConfigValidator do
     it 'raises if one or more candidate key values is set to yes or no' do
       bad_key = 'bad_key'
       other_bad_key = 'other_bad_key'
-      noncandidate_key = '_FIGARO_KEY'
+      up_bad_key = 'up_bad_key'
+      cap_bad_key = 'cap_bad_key'
+      noncandidate_key = 'KEY'
       good_key = 'good_key'
 
       env = {
         bad_key => 'yes',
         other_bad_key => 'no',
+        up_bad_key => 'YES   ',
+        cap_bad_key => ' No',
         noncandidate_key => 'yes',
         good_key => 'foo',
       }
 
+      # Figaro sets 2 environment variables for each configuration:
+      # 1 with and 1 without the Figaro prefix. Settings that don't
+      # have both are not part of the configuration.  This mimics
+      # Figaro by adding the settings with the prefix.
+
+      [bad_key, other_bad_key, up_bad_key, cap_bad_key, good_key].each do |key|
+        env[ConfigValidator::ENV_PREFIX + key] = env[key]
+      end
+
+      list = "#{bad_key}, #{other_bad_key}, #{up_bad_key}, and #{cap_bad_key}"
+
       expect { ConfigValidator.new.validate(env) }.to raise_error(
         RuntimeError,
-        /You have invalid values for #{bad_key} and #{other_bad_key}/
+        %r{You have invalid values \(yes\/no\) for #{list}}
       )
     end
   end


### PR DESCRIPTION
**Why**:
- Provide clearer message when environment variables have
yes/no values instead of true/false - prior message pointed
to application.yml instead of environment, wasting debug time

**How**:
- Remove incorrect 'config/application.yml' reference, as values
come from environment instead
- Indicate source is 'environment' in error message if ENV is used
- Specifically check for 'yes' or 'no' in environment variable value
- Remove unnecessary '\\' - makes clearer that only '\n' is being
removed