### PR TITLE
Fix translations in Spanish

### DIFF
--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -13,11 +13,13 @@ es:
     cancel:
       modal_header: "¿Está seguro que desea cancelar?"
       warning_header: Si usted cancela ahora
-      warning_points: '["No podremos verificar su identidad", "No mantendremos un
-        registro de su nombre, dirección, fecha de nacimiento o número de Seguro Social",
-        "No podrá acceder a su información con seguridad usando login.gov "," Usted
-        todavía tiene una cuenta de login.gov con su email"," Puede administrar esa
-        cuenta en su página de perfil "]'
+      warning_points:
+      - No podremos verificar su identidad
+      - No mantendremos un registro de su nombre, dirección, fecha de nacimiento o
+        número de Seguro Social
+      - No podrá acceder a su información con seguridad usando login.gov
+      - Usted todavía tiene una cuenta de login.gov con su email
+      - Puede administrar esa cuenta en su página de perfil
     errors:
       bad_dob: Su fecha de nacimiento debe ser una fecha válida.
       duplicate_ssn: Ya existe una cuenta con la información que proporcionó.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -28,12 +28,12 @@ es:
         or: o
       sms:
         confirm_code_html: Le enviamos en un mensaje de texto a %{number}. ¿Necesita
-          otro código? %{Resend_code_link}. Puede estar sujeto a cargos de mensajería
+          otro código? %{resend_code_link}. Puede estar sujeto a cargos de mensajería
           y datos.
         fallback_html: Si no puede recibir mensajes de texto ahora, puede %{link}
       voice:
         confirm_code_html: Acabamos de llamarle al %{number}. ¿Desea que le llamemos
-          de nuevo? %{Resend_code_link}
+          de nuevo? %{resend_code_link}
         fallback_html: Si no puede recibir una llamada de teléfono ahora, puede %{link}
       wrong_number_html: "¿Ingresó el número de teléfono equivocado? %{link}"
     password:

--- a/config/locales/sign_up/es.yml
+++ b/config/locales/sign_up/es.yml
@@ -8,8 +8,9 @@ es:
       modal_header: "¿Está seguro de que desea cancelar?"
       success: Su cuenta ha sido eliminada. No guardamos su información.
       warning_header: Si cancela ahora
-      warning_points: '["No tendrá una cuenta de login.gov", "No guardaremos un registro
-        de su email, contraseña y número de teléfono", "No podrá acceder de forma
-        segura a su información a través de login.gov "]'
+      warning_points:
+      - No tendrá una cuenta de login.gov
+      - No guardaremos un registro de su email, contraseña y número de teléfono
+      - No podrá acceder de forma segura a su información a través de login.gov
     registrations:
       create_account: Crear una cuenta

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -44,28 +44,40 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       expect(rendered).to have_selector("form[action='/users'][method='post']")
     end
 
-    it 'informs the user that an OTP has been sent to their number via #help_text' do
-      build_stubbed(:user)
-
-      code_link = link_to(
-        t('links.two_factor_authentication.resend_code.sms'),
-        otp_send_path(
-          otp_delivery_selection_form: {
-            otp_delivery_preference: 'sms',
-            resend: true,
-          }
+    context 'OTP copy' do
+      let(:help_text) do
+        code_link = link_to(
+          t('links.two_factor_authentication.resend_code.sms'),
+          otp_send_path(
+            otp_delivery_selection_form: {
+              otp_delivery_preference: 'sms',
+              resend: true,
+            }
+          )
         )
-      )
 
-      help_text = t(
-        "instructions.mfa.#{presenter_data[:otp_delivery_preference]}.confirm_code_html",
-        number: "<strong>#{presenter_data[:phone_number]}</strong>",
-        resend_code_link: code_link
-      )
+        t(
+          "instructions.mfa.#{presenter_data[:otp_delivery_preference]}.confirm_code_html",
+          number: "<strong>#{presenter_data[:phone_number]}</strong>",
+          resend_code_link: code_link
+        )
+      end
 
-      render
+      it 'informs the user that an OTP has been sent to their number via #help_text' do
+        render
 
-      expect(rendered).to include help_text
+        expect(rendered).to include help_text
+      end
+
+      context 'in other locales' do
+        before { I18n.locale = :es }
+
+        it 'translates correctly' do
+          render
+
+          expect(rendered).to include help_text
+        end
+      end
     end
 
     context 'user signed up' do


### PR DESCRIPTION
**Why**:
- An interpolation key came back capitalized incorrectly
- A separate value (an array) was a JSON string rather than
  a literal array

----

Found these by testing out Spanish translations in dev