### PR TITLE
Allow user to sign in with invalid request_id

### DIFF
--- a/app/services/null_service_provider_request.rb
+++ b/app/services/null_service_provider_request.rb
@@ -4,4 +4,10 @@ class NullServiceProviderRequest
   def issuer; end
 
   def delete; end
+
+  def url; end
+
+  def loa; end
+
+  def requested_attributes; end
 end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -19,7 +19,7 @@ class StoreSpMetadataInSession
   attr_reader :session, :request_id
 
   def sp_request
-    @sp_request ||= ServiceProviderRequest.find_by(uuid: request_id)
+    @sp_request ||= ServiceProviderRequest.from_uuid(request_id)
   end
 
   def loa3_requested?

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -246,4 +246,17 @@ feature 'Sign in' do
       expect(page).to have_content t('devise.failure.invalid')
     end
   end
+
+  context 'invalid request_id' do
+    it 'allows the user to sign in and does not try to redirect to any SP' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      user = create(:user, :signed_up)
+
+      visit new_user_session_path(request_id: 'invalid')
+      fill_in_credentials_and_submit(user.email, user.password)
+      click_submit_default
+
+      expect(current_path).to eq account_path
+    end
+  end
 end


### PR DESCRIPTION
**Why**: If someone attempts to visit the sign in page with an
invalid (i.e. expired) `request_id` (which has happened in production),
we should allow the user to sign in instead of getting a 500 error.

**How**: Use `ServiceProviderRequest.from_uuid` instead of `find_by`
because the former returns a null object if there is no match. We were
already using `from_uuid` everywhere else except in
`StoreSpMetadataInSession`.