### PR TITLE
Add quotes to value in application.yml

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -49,7 +49,7 @@ use_dashboard_service_providers: 'false'
 dashboard_url: 'https://dashboard.demo.login.gov'
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
 
-usps_mail_batch_hours: 24
+usps_mail_batch_hours: '24'
 
 development:
   async_job_refresh_interval_seconds: '5'


### PR DESCRIPTION
To resolve build warning:

`WARNING: Use strings for Figaro configuration. 24 was converted to "24".`