### PR TITLE
Fix verification by mail redirect logic

### DIFF
--- a/app/controllers/verify/usps_controller.rb
+++ b/app/controllers/verify/usps_controller.rb
@@ -11,7 +11,12 @@ module Verify
     def create
       create_user_event(:usps_mail_sent, current_user)
       idv_session.address_verification_mechanism = :usps
-      redirect_to verify_review_url
+
+      if current_user.decorate.needs_profile_usps_verification?
+        redirect_to account_path
+      else
+        redirect_to verify_review_url
+      end
     end
 
     def usps_mail_service


### PR DESCRIPTION
For issue https://github.com/18F/identity-private/issues/1890

Fixes an issue that was redirecting users to `/verify` instead of `/account` after clicking the "Send another letter" button.

There are now two tests to check the verification letter flow. One if the user doesn't log out before entering their confirmation letter (this probably will never happen in real life) and one if they do log out.