### PR TITLE
Update digital analytics program i18n

### DIFF
--- a/app/views/shared/_dap_analytics.html.erb
+++ b/app/views/shared/_dap_analytics.html.erb
@@ -1,4 +1,4 @@
-<%= t('notices.dap_html') %>
+<!-- <%= t('notices.dap_participation') %> -->
 <% dap_source = 'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA' %>
 <%= nonced_javascript_tag({src: dap_source, async: true, id: '_fed_an_ua_tag'}) do %>
 <% end %>

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -2,8 +2,8 @@
 en:
   notices:
     account_reactivation: Great! You have your personal key.
-    dap_html: "<!-- We participate in the US government’s analytics program. --> <!--
-      See the data at analytics.usa.gov. -->"
+    dap_participation: We participate in the US government’s analytics program. See
+      the data at analytics.usa.gov.
     forgot_password:
       first_paragraph_end: with a link to reset your password. Follow the link to
         continue resetting your password.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -2,8 +2,8 @@
 es:
   notices:
     account_reactivation: "¡Estupendo! Tiene su clave personal."
-    dap_html: "<!-- Participamos en el programa analítico del Gobierno de Estados
-      Unidos. --> <!-- Vea los datos en analytics.usa.gov (en inglés). -->"
+    dap_participation: Participamos en el programa analítico del Gobierno de Estados
+      Unidos. Vea los datos en analytics.usa.gov (en inglés).
     forgot_password:
       first_paragraph_end: con un enlace para restablecer su contraseña. Siga el enlace
         para continuar restableciendo su contraseña.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -2,8 +2,8 @@
 fr:
   notices:
     account_reactivation: NOT TRANSLATED YET
-    dap_html: "<!-- Nous participons au programme d'analytique du gouvernement des
-      États-Unis. --> <!-- Consultez les données à analytics.usa.gov. -->"
+    dap_participation: Nous participons au programme d'analytique du gouvernement
+      des États-Unis. Consultez les données à analytics.usa.gov.
     forgot_password:
       first_paragraph_end: avec un lien pour réinitialiser votre mot de passe. Suivez
         le lien pour continuer à réinitialiser votre mot de passe.

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -9,7 +9,7 @@ feature 'Email confirmation during sign up' do
     open_email(email)
     visit_in_email(t('mailer.confirmation_instructions.link_text'))
 
-    expect(page.html).not_to include(t('notices.dap_html'))
+    expect(page.html).not_to include(t('notices.dap_participation'))
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
     expect(page).to have_title t('titles.confirmations.show')
     expect(page).to have_content t('forms.confirmation.show_hdr')
@@ -73,7 +73,7 @@ feature 'Email confirmation during sign up' do
       visit destroy_user_session_url
       visit sign_up_create_email_confirmation_url(confirmation_token: @raw_confirmation_token)
 
-      expect(page.html).to include(t('notices.dap_html'))
+      expect(page.html).to include(t('notices.dap_participation'))
       expect(page).to have_content(
         t('devise.confirmations.already_confirmed', action: 'Please sign in.')
       )

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -28,7 +28,7 @@ feature 'Password Recovery' do
       open_last_email
       click_email_link_matching(/reset_password_token/)
 
-      expect(page.html).not_to include(t('notices.dap_html'))
+      expect(page.html).not_to include(t('notices.dap_participation'))
       expect(current_path).to eq edit_user_password_path
     end
   end


### PR DESCRIPTION
**Why**:
It keeps HTML tags out of the translation pipeline. Sending HTML
through translations is error-prone so this just focuses on the
copy.


(FWIW we had issues with the Spanish translations that I caught manually -- so this was just a quick clean-up I could make to help us out for next time)