### PR TITLE
Move USPS verification specs to shared example

### DIFF
--- a/spec/features/idv/usps_verification_spec.rb
+++ b/spec/features/idv/usps_verification_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+feature 'USPS verification' do
+  include SamlAuthHelper
+  include IdvHelper
+
+  context 'signing in when profile is pending USPS verification' do
+    it_behaves_like 'signing in with pending USPS verification'
+    it_behaves_like 'signing in with pending USPS verification', :saml
+    it_behaves_like 'signing in with pending USPS verification', :oidc
+  end
+end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -271,26 +271,6 @@ feature 'OpenID Connect' do
       )
     end
 
-    context 'USPS verification' do
-      let(:phone_confirmed) { false }
-
-      it 'prompts to finish verifying profile, then redirects to SP' do
-        allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
-        visit oidc_auth_url
-
-        sign_in_live_with_2fa(user)
-
-        click_button t('forms.verify_profile.submit')
-
-        expect(current_path).to eq(sign_up_completed_path)
-        find('input').click
-
-        redirect_uri = URI(current_url)
-
-        expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-      end
-    end
-
     context 'phone verification' do
       let(:phone_confirmed) { true }
 

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -164,26 +164,6 @@ feature 'LOA3 Single Sign On', idv_job: true do
     context 'having previously selected USPS verification' do
       let(:phone_confirmed) { false }
 
-      it 'prompts for confirmation code at sign in' do
-        allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
-
-        saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
-        visit saml_authn_request
-        sign_in_live_with_2fa(user)
-
-        expect(current_path).to eq verify_account_path
-        expect(page).to have_content t('idv.messages.usps.resend')
-
-        click_button t('forms.verify_profile.submit')
-
-        expect(user.events.account_verified.size).to be(1)
-        expect(current_path).to eq(sign_up_completed_path)
-
-        find('input').click
-
-        expect(current_url).to eq saml_authn_request
-      end
-
       context 'provides an option to send another letter' do
         it 'without signing out' do
           user = create(:user, :signed_up)

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -17,18 +17,6 @@ feature 'verify profile with OTP' do
   context 'USPS letter' do
     let(:phone_confirmed) { false }
 
-    scenario 'received OTP via USPS' do
-      sign_in_live_with_2fa(user)
-
-      expect(current_path).to eq verify_account_path
-
-      fill_in t('forms.verify_profile.name'), with: otp
-      click_button t('forms.verify_profile.submit')
-
-      expect(current_path).to eq account_path
-      expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
-    end
-
     xscenario 'OTP has expired' do
       # see https://github.com/18F/identity-private/issues/1108#issuecomment-293328267
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -359,5 +359,12 @@ module Features
       set_up_2fa_with_valid_phone
       enter_2fa_code
     end
+
+    def sign_in_via_branded_page(user)
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit(user.email, user.password)
+      click_submit_default
+    end
   end
 end

--- a/spec/support/idv_examples/usps_verification.rb
+++ b/spec/support/idv_examples/usps_verification.rb
@@ -1,0 +1,45 @@
+shared_examples 'signing in with pending USPS verification' do |sp|
+  it 'prompts for confirmation code at sign in' do
+    otp = 'abc123'
+    profile = create(
+      :profile,
+      deactivation_reason: :verification_pending,
+      phone_confirmed: false,
+      pii: { otp: otp, ssn: '123-45-6789', dob: '1970-01-01' }
+    )
+    user = profile.user
+
+    visit_idp_from_sp_with_loa3(sp)
+
+    if %i[saml oidc].include?(sp)
+      sign_in_via_branded_page(user)
+    else
+      sign_in_live_with_2fa(user)
+    end
+
+    expect(current_path).to eq verify_account_path
+    expect(page).to have_content t('idv.messages.usps.resend')
+
+    fill_in t('forms.verify_profile.name'), with: otp
+    click_button t('forms.verify_profile.submit')
+
+    expect(user.events.account_verified.size).to eq 1
+    expect(page).to_not have_content(t('account.index.verification.reactivate_button'))
+
+    if %i[saml oidc].include?(sp)
+      expect(current_path).to eq(sign_up_completed_path)
+
+      click_button t('forms.buttons.continue')
+
+      if sp == :saml
+        expect(current_url).to eq @saml_authn_request
+      elsif sp == :oidc
+        redirect_uri = URI(current_url)
+
+        expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+      end
+    else
+      expect(current_path).to eq account_path
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To continue consolidating SAML and OIDC specs