### PR TITLE
Move USPS verification selection to shared example

### DIFF
--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -8,4 +8,9 @@ feature 'account creation after LOA3 request', idv_job: true do
     it_behaves_like 'idv account creation', :saml
     it_behaves_like 'idv account creation', :oidc
   end
+
+  context 'choosing USPS address verification' do
+    it_behaves_like 'selecting usps address verification method', :saml
+    it_behaves_like 'selecting usps address verification method', :oidc
+  end
 end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -35,42 +35,6 @@ feature 'LOA3 Single Sign On', idv_job: true do
       @saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
     end
 
-    it 'allows the user to select verification via USPS letter', email: true do
-      visit @saml_authn_request
-
-      register_user(email)
-
-      click_idv_begin
-
-      fill_out_idv_form_ok
-      click_idv_continue
-      fill_out_financial_form_ok
-      click_idv_continue
-
-      click_idv_address_choose_usps
-
-      click_on t('idv.buttons.mail.send')
-
-      expect(current_path).to eq verify_review_path
-      expect(page).to_not have_content t('idv.messages.phone.phone_of_record')
-
-      fill_in :user_password, with: user_password
-
-      expect { click_submit_default }.
-        to change { UspsConfirmation.count }.from(0).to(1)
-
-      expect(current_url).to eq verify_confirmations_url
-      click_acknowledge_personal_key
-
-      expect(User.find_with_email(email).events.account_verified.size).to be(0)
-      expect(current_url).to eq(account_url)
-      expect(page).to have_content(t('account.index.verification.reactivate_button'))
-
-      usps_confirmation_entry = UspsConfirmation.last.decrypted_entry
-      expect(usps_confirmation_entry.issuer).
-        to eq('https://rp1.serviceprovider.com/auth/saml/metadata')
-    end
-
     it 'shows user the start page with accordion' do
       saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
       sp_content = [

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -351,13 +351,15 @@ module Features
       click_send_security_code
     end
 
-    def register_user(email)
+    def register_user(email = 'test@test.com')
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       click_link t('sign_up.registrations.create_account')
-      submit_form_with_valid_email
+      submit_form_with_valid_email(email)
       click_confirmation_link_in_email(email)
       submit_form_with_valid_password
       set_up_2fa_with_valid_phone
       enter_2fa_code
+      User.find_with_email(email)
     end
 
     def sign_in_via_branded_page(user)

--- a/spec/support/idv_examples/account_creation.rb
+++ b/spec/support/idv_examples/account_creation.rb
@@ -1,6 +1,5 @@
 shared_examples 'idv account creation' do |sp|
   it 'redirects to SP after IdV is complete', email: true do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     email = 'test@test.com'
 
     visit_idp_from_sp_with_loa3(sp)

--- a/spec/support/idv_examples/usps_verification_selection.rb
+++ b/spec/support/idv_examples/usps_verification_selection.rb
@@ -1,0 +1,52 @@
+shared_examples 'selecting usps address verification method' do |sp|
+  it 'allows the user to select verification via USPS letter', email: true do
+    visit_idp_from_sp_with_loa3(sp)
+
+    user = register_user
+
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+
+    click_idv_address_choose_usps
+
+    click_on t('idv.buttons.mail.send')
+
+    expect(current_path).to eq verify_review_path
+    expect(page).to_not have_content t('idv.messages.phone.phone_of_record')
+
+    fill_in :user_password, with: user_password
+
+    expect { click_submit_default }.
+      to change { UspsConfirmation.count }.from(0).to(1)
+
+    expect(current_path).to eq verify_confirmations_path
+    click_acknowledge_personal_key
+
+    user.reload
+
+    expect(user.events.account_verified.size).to be(0)
+    expect(user.profiles.count).to eq 1
+
+    profile = user.profiles.first
+
+    expect(profile.active?).to eq false
+    expect(profile.deactivation_reason).to eq 'verification_pending'
+    expect(profile.phone_confirmed).to eq false
+
+    usps_confirmation_entry = UspsConfirmation.last.decrypted_entry
+
+    expect(current_path).to eq(account_path)
+    expect(page).to have_content(t('account.index.verification.reactivate_button'))
+
+    if sp == :saml
+      expect(usps_confirmation_entry.issuer).
+        to eq('https://rp1.serviceprovider.com/auth/saml/metadata')
+    elsif sp == :oidc
+      expect(usps_confirmation_entry.issuer).
+        to eq('urn:gov:gsa:openidconnect:sp:server')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: We want tests for the case where the user selects USPS
verification for both the SAML and OIDC protocols.