### PR TITLE
Log useful error message when failing to load key.

### DIFF
--- a/app/services/request_key_manager.rb
+++ b/app/services/request_key_manager.rb
@@ -1,15 +1,21 @@
 class RequestKeyManager
-  cattr_accessor :private_key do
+  def self.read_key_file(key_file, passphrase)
     OpenSSL::PKey::RSA.new(
-      File.read(Rails.root.join('keys', 'saml.key.enc')),
-      Figaro.env.saml_passphrase
+      File.read(key_file),
+      passphrase
     )
+  rescue OpenSSL::PKey::RSAError
+    raise OpenSSL::PKey::RSAError, "Failed to load #{key_file.inspect}. Bad passphrase?"
+  end
+  private_class_method :read_key_file
+
+  cattr_accessor :private_key do
+    key_file = Rails.root.join('keys', 'saml.key.enc')
+    read_key_file(key_file, Figaro.env.saml_passphrase)
   end
 
   cattr_accessor :equifax_ssh_key do
-    OpenSSL::PKey::RSA.new(
-      File.read(Rails.root.join('keys', 'equifax_rsa')),
-      Figaro.env.equifax_ssh_passphrase
-    )
+    key_file = Rails.root.join('keys', 'equifax_rsa')
+    read_key_file(key_file, Figaro.env.equifax_ssh_passphrase)
   end
 end

--- a/spec/services/request_key_manager_spec.rb
+++ b/spec/services/request_key_manager_spec.rb
@@ -1,9 +1,17 @@
 require 'rails_helper'
 
 describe RequestKeyManager do
-  describe '#equifax_ssh_key' do
+  describe '.equifax_ssh_key' do
     it 'initializes' do
       ssh_key = described_class.equifax_ssh_key
+
+      expect(ssh_key).to be_a OpenSSL::PKey::RSA
+    end
+  end
+
+  describe '.private_key' do
+    it 'initializes' do
+      ssh_key = described_class.private_key
 
       expect(ssh_key).to be_a OpenSSL::PKey::RSA
     end


### PR DESCRIPTION
**Why**:

This is a common error to encounter in deployment, and right now we get
an extremely unhelpful message. There isn't even any way to tell what
key file failed to load without looking at the line number in the
backtrace and consulting the IDP source code.

```
OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key: nested asn1 error
```

With this change, we will at least log a better message to help
understand what's happening.