### PR TITLE
Use a whitelist approach for URL parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,7 +69,11 @@ class ApplicationController < ActionController::Base
     return unless params[:timeout]
 
     flash[:notice] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
-    redirect_to url_for(params.except(:timeout))
+    redirect_to url_for(permitted_timeout_params)
+  end
+
+  def permitted_timeout_params
+    params.permit(:request_id)
   end
 
   def current_sp

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -138,4 +138,41 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#session_expires_at' do
+    before { routes.draw { get 'index' => 'anonymous#index' } }
+    after { Rails.application.reload_routes! }
+
+    controller do
+      prepend_before_action :session_expires_at
+
+      def index
+        render text: 'Hello'
+      end
+    end
+
+    context 'when URL contains the host parameter' do
+      it 'does not redirect to the host' do
+        get :index, timeout: true, host: 'www.monfresh.com'
+
+        expect(response.header['Location']).to_not match 'www.monfresh.com'
+      end
+    end
+
+    context 'when URL does not contain the timeout parameter' do
+      it 'does not redirect anywhere' do
+        get :index, host: 'www.monfresh.com'
+
+        expect(response).to_not be_redirect
+      end
+    end
+
+    context 'when URL contains the request_id parameter' do
+      it 'preserves the request_id parameter' do
+        get :index, timeout: true, request_id: '123'
+
+        expect(response.header['Location']).to match '123'
+      end
+    end
+  end
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -118,14 +118,14 @@ feature 'Sign in' do
     it 'refreshes the current page after session expires', js: true do
       allow(Devise).to receive(:timeout_in).and_return(1)
 
-      visit sign_up_email_path(foo: 'bar')
+      visit sign_up_email_path(request_id: '123abc')
       fill_in 'Email', with: 'test@example.com'
 
       expect(page).to have_content(
         t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
       )
       expect(page).to have_field('Email', with: '')
-      expect(current_url).to match Regexp.escape(sign_up_email_path(foo: 'bar'))
+      expect(current_url).to match Regexp.escape(sign_up_email_path(request_id: '123abc'))
     end
 
     it 'does not refresh the page after the session expires', js: true do


### PR DESCRIPTION
**Why**: Similarly to strong parameters, it's a best practice to use
a whitelist approach as opposed to excluding unwanted parameters.