### PR TITLE
Set default URL options

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   config.cache_classes = true
   config.eager_load = true
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.asset_host = Figaro.env.domain_name
   config.action_controller.default_url_options = { host: Figaro.env.domain_name }
   config.action_controller.perform_caching = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,8 @@ Rails.application.configure do
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false
+  config.action_controller.asset_host = Figaro.env.domain_name
+  config.action_controller.default_url_options = { host: Figaro.env.domain_name }
   config.action_controller.perform_caching = true
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
**Why**: It's a best practice to define the host for assets and URLs,
just like we do for mailers.