### PR TITLE
Update OIDC Logout to work with expired id_tokens

### DIFF
--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -43,8 +43,11 @@ class OpenidConnectLogoutForm
               :success
 
   def load_identity
-    payload, _headers = JWT.decode(id_token_hint, RequestKeyManager.private_key.public_key, true,
-                                   algorithm: 'RS256').map(&:with_indifferent_access)
+    payload, _headers = JWT.decode(
+      id_token_hint, RequestKeyManager.private_key.public_key, true,
+      algorithm: 'RS256', leeway: Float::INFINITY
+    ).map(&:with_indifferent_access)
+
     Identity.where(
       uuid: payload[:sub],
       service_provider: payload[:aud]

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe OpenidConnectLogoutForm do
             to include(t('openid_connect.logout.errors.id_token_hint'))
         end
       end
+
+      context 'with an expired, but otherwise valid id_token_hint' do
+        let(:id_token_hint) do
+          IdTokenBuilder.new(
+            identity: identity,
+            code: code,
+            custom_expiration: 5.days.ago.to_i
+          ).id_token
+        end
+
+        it 'is valid' do
+          expect(valid?).to eq(true)
+          expect(form.errors[:id_token_hint]).to be_blank
+        end
+      end
     end
 
     context 'post_logout_redirect_uri' do


### PR DESCRIPTION
**Why**:
To provide a smooth experience when trying to log out. The spec
states that:
> Previously issued ID Token passed to the logout endpoint
> as a hint about the End-User's current authenticated session
> with the Client.

which we can interpret as "allows expired tokens" as well.