### PR TITLE
Move tests for max idv attempts to shared example

### DIFF
--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -13,4 +13,9 @@ feature 'account creation after LOA3 request', idv_job: true do
     it_behaves_like 'selecting usps address verification method', :saml
     it_behaves_like 'selecting usps address verification method', :oidc
   end
+
+  context 'retries limited by max step attempt limits' do
+    it_behaves_like 'idv max step attempts', :saml
+    it_behaves_like 'idv max step attempts', :oidc
+  end
 end

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -69,68 +69,6 @@ feature 'IdV session', idv_job: true do
       expect(page).to have_css('.modal-warning', text: t('idv.modal.sessions.heading'))
     end
 
-    scenario 'allows 3 attempts in 24 hours' do
-      user = sign_in_and_2fa_user
-
-      max_attempts_less_one.times do
-        visit verify_session_path
-        complete_idv_profile_fail
-
-        expect(current_path).to eq verify_session_result_path
-      end
-
-      user.reload
-      expect(user.idv_attempted_at).to_not be_nil
-
-      visit destroy_user_session_url
-      sign_in_and_2fa_user(user)
-
-      visit verify_session_path
-      complete_idv_profile_fail
-
-      expect(page).to have_css('.alert-error', text: t('idv.modal.sessions.heading'))
-
-      visit verify_session_path
-
-      expect(page).to have_content(t('idv.errors.hardfail'))
-      expect(current_url).to eq verify_fail_url
-
-      user.reload
-      expect(user.idv_attempted_at).to_not be_nil
-    end
-
-    scenario 'finance shows failure flash message after max attempts' do
-      sign_in_and_2fa_user
-      visit verify_session_path
-      fill_out_idv_form_ok
-      click_idv_continue
-
-      max_attempts_less_one.times do
-        fill_out_financial_form_fail
-        click_idv_continue
-
-        expect(current_path).to eq verify_finance_result_path
-      end
-
-      fill_out_financial_form_fail
-      click_idv_continue
-      expect(page).to have_css('.alert-error', text: t('idv.modal.financials.heading'))
-    end
-
-    scenario 'finance shows failure modal after max attempts', js: true do
-      sign_in_and_2fa_user
-      visit verify_session_path
-      max_attempts_less_one.times do
-        fill_out_idv_form_fail
-        click_idv_continue
-        click_button t('idv.modal.button.warning')
-      end
-
-      fill_out_idv_form_fail
-      click_idv_continue
-      expect(page).to have_css('.modal-fail', text: t('idv.modal.sessions.heading'))
-    end
-
     scenario 'successful steps are not re-entrant, but are sticky on failure', js: true do
       user = sign_in_and_2fa_user
 
@@ -424,11 +362,6 @@ feature 'IdV session', idv_job: true do
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
       expect(user.profiles).to be_empty
     end
-  end
-
-  def complete_idv_profile_fail
-    fill_out_idv_form_fail
-    click_button 'Continue'
   end
 
   def click_accordion

--- a/spec/features/idv/max_attempts_spec.rb
+++ b/spec/features/idv/max_attempts_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+feature 'IdV max attempts' do
+  include IdvHelper
+
+  scenario 'profile shows failure modal after max attempts', :email, :idv_job, :js do
+    sign_in_and_2fa_user
+    visit verify_session_path
+
+    max_attempts_less_one.times do
+      fill_out_idv_form_fail
+      click_idv_continue
+      click_button t('idv.modal.button.warning')
+
+      expect(current_path).to eq verify_session_result_path
+    end
+
+    fill_out_idv_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.modal-fail', text: t('idv.modal.sessions.heading'))
+  end
+
+  scenario 'finance shows failure modal after max attempts', :email, :idv_job, :js do
+    sign_in_and_2fa_user
+    visit verify_session_path
+    fill_out_idv_form_ok
+    click_idv_continue
+
+    max_attempts_less_one.times do
+      fill_out_financial_form_fail
+      click_idv_continue
+      click_button t('idv.modal.button.warning')
+
+      expect(current_path).to eq verify_finance_result_path
+    end
+
+    fill_out_financial_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.modal-fail', text: t('idv.modal.financials.heading'))
+  end
+
+  scenario 'phone shows failure modal after max attempts', :email, :idv_job, :js do
+    sign_in_and_2fa_user
+    visit verify_session_path
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+    click_idv_address_choose_phone
+
+    max_attempts_less_one.times do
+      fill_out_phone_form_fail
+      click_idv_continue
+      click_button t('idv.modal.button.warning')
+
+      expect(current_path).to eq verify_phone_result_path
+    end
+
+    fill_out_phone_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.modal-fail', text: t('idv.modal.phone.heading'))
+  end
+end

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -3,27 +3,6 @@ require 'rails_helper'
 feature 'Verify phone' do
   include IdvHelper
 
-  scenario 'phone step redirects to fail after max attempts', idv_job: true do
-    sign_in_and_2fa_user
-    visit verify_session_path
-    fill_out_idv_form_ok
-    click_idv_continue
-    fill_out_financial_form_ok
-    click_idv_continue
-    click_idv_address_choose_phone
-
-    max_attempts_less_one.times do
-      fill_out_phone_form_fail
-      click_idv_continue
-
-      expect(current_path).to eq verify_phone_result_path
-    end
-
-    fill_out_phone_form_fail
-    click_idv_continue
-    expect(page).to have_css('.alert-error', text: t('idv.modal.phone.heading'))
-  end
-
   context 'Idv phone and user phone are different', idv_job: true do
     scenario 'prompts to confirm phone' do
       user = create(

--- a/spec/support/idv_examples/max_attempts.rb
+++ b/spec/support/idv_examples/max_attempts.rb
@@ -1,0 +1,100 @@
+shared_examples 'idv max step attempts' do |sp|
+  it 'allows 3 attempts in 24 hours', :email do
+    visit_idp_from_sp_with_loa3(sp)
+    user = register_user
+
+    max_attempts_less_one.times do
+      visit verify_session_path
+      fill_out_idv_form_fail
+      click_idv_continue
+
+      expect(current_path).to eq verify_session_result_path
+    end
+
+    user.reload
+    expect(user.idv_attempted_at).to_not be_nil
+
+    fill_out_idv_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.alert-error', text: t('idv.modal.sessions.heading'))
+
+    visit_idp_from_sp_with_loa3(sp)
+    expect(page).to have_content(t('idv.messages.hardfail'))
+    expect(current_url).to eq verify_fail_url
+
+    visit verify_session_path
+    expect(page).to have_content(t('idv.errors.hardfail'))
+    expect(current_url).to eq verify_fail_url
+
+    user.reload
+    expect(user.idv_attempted_at).to_not be_nil
+  end
+
+  scenario 'profile shows failure flash message after max attempts', :email do
+    visit_idp_from_sp_with_loa3(sp)
+    register_user
+
+    click_idv_begin
+
+    max_attempts_less_one.times do
+      fill_out_idv_form_fail
+      click_idv_continue
+
+      expect(current_path).to eq verify_session_result_path
+    end
+
+    fill_out_idv_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.alert-error', text: t('idv.modal.sessions.heading'))
+    expect(current_path).to eq verify_session_result_path
+  end
+
+  scenario 'fincance shows failure flash message after max attempts', :email do
+    visit_idp_from_sp_with_loa3(sp)
+    register_user
+
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+
+    max_attempts_less_one.times do
+      fill_out_financial_form_fail
+      click_idv_continue
+
+      expect(current_path).to eq verify_finance_result_path
+    end
+
+    fill_out_financial_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.alert-error', text: t('idv.modal.financials.heading'))
+    expect(current_path).to eq verify_finance_result_path
+  end
+
+  scenario 'phone shows failure flash after max attempts', :email do
+    visit_idp_from_sp_with_loa3(sp)
+    register_user
+
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+    click_idv_address_choose_phone
+
+    max_attempts_less_one.times do
+      fill_out_phone_form_fail
+      click_idv_continue
+
+      expect(current_path).to eq verify_phone_result_path
+    end
+
+    fill_out_phone_form_fail
+    click_idv_continue
+
+    expect(page).to have_css('.alert-error', text: t('idv.modal.phone.heading'))
+    expect(current_path).to eq verify_phone_result_path
+  end
+end


### PR DESCRIPTION
**Why**: We want to be able to test that code to limit the number of idv
attempts works for both the OIDC and SAML flows.

Note that the specs that require Javascript are included in a new
feature spec file, since the code to send a request from a SP does not
work with JS enabled.