### PR TITLE
Make phone step re-entrant

### DIFF
--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -50,13 +50,7 @@ module Verify
     end
 
     def phone_confirmation_required?
-      normalized_phone = idv_session.params[:phone]
-      return false if normalized_phone.blank?
-
-      formatted_phone = normalized_phone.phony_formatted(
-        format: :international, normalize: :US, spaces: ' '
-      )
-      formatted_phone != current_user.phone
+      idv_session.user_phone_confirmation != true
     end
 
     def submit_idv_job
@@ -88,7 +82,7 @@ module Verify
     end
 
     def confirm_step_needed
-      redirect_to_next_step if idv_session.vendor_phone_confirmation == true
+      redirect_to_next_step if idv_session.user_phone_confirmation == true
     end
 
     def idv_form

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -25,9 +25,9 @@ describe Verify::PhoneController do
       stub_verify_steps_one_and_two(user)
     end
 
-    context 'when the phone number is the same as the user phone' do
+    context 'when the phone number has been confirmed as user 2FA phone' do
       before do
-        subject.idv_session.params = { phone: user.phone }
+        subject.idv_session.user_phone_confirmation = true
       end
 
       it 'redirects to review when step is complete' do
@@ -38,20 +38,16 @@ describe Verify::PhoneController do
       end
     end
 
-    context 'when the phone number is different from the user phone' do
+    context 'when the phone number has not been confirmed as user 2FA phone' do
       before do
-        subject.idv_session.params = { phone: bad_phone }
+        subject.idv_session.user_phone_confirmation = nil
       end
 
-      it 'redirects to phone confirmation' do
+      it 'redirects renders the form' do
         subject.idv_session.vendor_phone_confirmation = true
         get :new
 
-        expect(response).to redirect_to redirect_to(
-          otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
-          )
-        )
+        expect(response).to render_template :new
       end
     end
 
@@ -257,6 +253,7 @@ describe Verify::PhoneController do
         before do
           user.idv_attempts = max_attempts - 1
           user.idv_attempted_at = two_days_ago
+          subject.idv_session.user_phone_confirmation = true
         end
 
         it 'allows and does not affect attempt counter' do

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -48,6 +48,23 @@ feature 'Verify phone' do
       expect(SmsOtpSenderJob).to have_received(:perform_later)
       expect(page).to_not have_content(t('links.two_factor_authentication.resend_code.phone'))
     end
+
+    scenario 'user cannot re-enter phone step and change phone after confirmation', :idv_job do
+      user = sign_in_and_2fa_user
+
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_idv_continue
+      fill_out_financial_form_ok
+      click_idv_continue
+      click_idv_address_choose_phone
+      fill_out_phone_form_ok
+      click_idv_continue
+      enter_correct_otp_code_for_user(user)
+
+      visit verify_phone_path
+      expect(current_path).to eq(verify_review_path)
+    end
   end
 
   scenario 'phone field only allows numbers', js: true, idv_job: true do


### PR DESCRIPTION
**Why**: When users enter a phone of record, and then get to the phone
confirmation screen, they are presented with a "use a different phone"
button. Clicking this button should take them back to the phone form
where they can modify their phone of record.