### PR TITLE
Remove mailcatcher from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ group :development, :test do
   gem 'bullet'
   gem 'front_matter_parser'
   gem 'i18n-tasks'
-  gem 'mailcatcher', require: false
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5.2'
   gem 'slim_lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,14 +342,6 @@ GEM
       systemu (~> 2.6.2)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    mailcatcher (0.6.5)
-      eventmachine (= 1.0.9.1)
-      mail (~> 2.3)
-      rack (~> 1.5)
-      sinatra (~> 1.2)
-      skinny (~> 0.2.3)
-      sqlite3 (~> 1.3)
-      thin (~> 1.5.0)
     mandrill-api (1.0.53)
       excon (>= 0.16.0, < 1.0)
       json (>= 1.7.7, < 2.0)
@@ -559,9 +551,6 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    skinny (0.2.4)
-      eventmachine (~> 1.0.0)
-      thin (>= 1.5, < 1.7)
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -583,7 +572,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -707,7 +695,6 @@ DEPENDENCIES
   i18n-tasks
   json-jwt
   lograge
-  mailcatcher
   mandrill_dm
   net-sftp
   newrelic_rpm
@@ -767,4 +754,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ fast_test: $(CONFIG)
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 
 run: $(CONFIG)
+	mailcatcher
 	foreman start -p $(PORT)
 
 load_test: $(CONFIG)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: bundle exec rackup config.ru --port ${PORT:-3000}
 worker: bundle exec sidekiq --config config/sidekiq.yml
-mail: bundle exec mailcatcher -f

--- a/bin/setup
+++ b/bin/setup
@@ -53,6 +53,7 @@ Dir.chdir APP_ROOT do
   run 'gem install foreman --conservative && gem update foreman'
   run "bundle check || bundle install"
   run "npm install"
+  run "gem install mailcatcher"
 
   puts "\n== Preparing database =="
   run "bin/rake db:reset RAILS_ENV=development"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
   redis:
     image: redis
   mailcatcher:
-    image: yappabe/mailcatcher
+    image: rordi/docker-mailcatcher
+    container_name: mailcatcher
     ports:
       - 1080:1080


### PR DESCRIPTION
**Why**: A couple of reasons:
- The README says not to include it in the Gemfile
- It depends on sinatra versions less than 2.0, which is preventing us
from updating the `rack-protection` gem to version 2.0, which fixes
a security vulnerability.