### PR TITLE
Preserve query params when using language selector

### DIFF
--- a/app/assets/javascripts/app/i18n-dropdown.js
+++ b/app/assets/javascripts/app/i18n-dropdown.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const eventType = event.type;
 
       event.preventDefault();
-      if (eventType == 'click' || (eventType == 'keypress' && event.which == 13)) {
+      if (eventType === 'click' || (eventType === 'keypress' && event.which === 13)) {
         this.parentNode.classList.toggle('focused');
         dropdown.classList.toggle('display-none');
         toggleAriaExpanded(this);

--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -16,7 +16,8 @@ footer.footer.bg-light-blue.sm-bg-navy
       ul.list-reset.mb0.white.center
         - I18n.available_locales.each do |locale|
           li.border-bottom
-            = link_to t("i18n.locale.#{locale}"), { locale: locale },
+            = link_to t("i18n.locale.#{locale}"),
+              request.query_parameters.merge(locale: locale),
               class: 'block py-12p px2 text-decoration-none blue fs-13p'
 
   .container.py1.px2.lg-px0(class="#{'sm-py0' if show_language_dropdown}")
@@ -36,8 +37,9 @@ footer.footer.bg-light-blue.sm-bg-navy
               ul.i18n-desktop-dropdown.list-reset.mb0.white.display-none
                 - I18n.available_locales.each do |locale|
                   li.border-bottom.border-navy
-                    = link_to t("i18n.locale.#{locale}"), { locale: locale },
-                    class: 'block pl-24p py2 text-decoration-none white'
+                    = link_to t("i18n.locale.#{locale}"),
+                      request.query_parameters.merge(locale: locale),
+                      class: 'block pl-24p py2 text-decoration-none white'
         = link_to t('links.help'), MarketingSite.help_url,
           class: 'caps h6 blue sm-white text-decoration-none mr3', target: '_blank'
         = link_to t('links.contact'), MarketingSite.contact_url,

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -134,6 +134,19 @@ feature 'LOA1 Single Sign On' do
     end
   end
 
+  context 'visiting IdP via SP, then using the language selector' do
+    it 'preserves the request_id in the url' do
+      authn_request = auth_request.create(saml_settings)
+      visit authn_request
+
+      within(:css, '.i18n-desktop-dropdown', visible: false) do
+        find_link(t('i18n.locale.es'), visible: false).click
+      end
+
+      expect(current_url).to match(%r{http://www.example.com/es/sign_up/start\?request_id=.+})
+    end
+  end
+
   context 'visiting IdP via SP, then going back to SP and visiting IdP again' do
     it 'displays the branded page' do
       authn_request = auth_request.create(saml_settings)


### PR DESCRIPTION
This makes sure any query params that are present in the url when using the language selector are preserved.  I've also included some related changes to the language selector Javascript that came up in the linter that I didn't catch in my previous a11y PR.