### PR TITLE
[WIP] Cancellation UX changes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,10 @@ module ApplicationHelper
     params[:confirmation_token].present? || (current_user && !current_user.two_factor_enabled?)
   end
 
+  def user_can_exit_early?
+    !user_fully_authenticated? && !user_signing_up? && user_verifying_identity?
+  end
+
   def session_with_trust?
     current_user || page_with_trust?
   end
@@ -60,7 +64,7 @@ module ApplicationHelper
   end
 
   def cancel_link_text
-    if !user_signing_up? && user_verifying_identity?
+    if user_can_exit_early?
       t('links.cancel')
     elsif user_signing_up?
       t('links.cancel_account_creation')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,14 +64,15 @@ module ApplicationHelper
   end
 
   def cancel_link_text
+    cancel_link = t('links.cancel')
     if user_unverified_and_in_2fa?
-      t('links.cancel')
+      cancel_link
     elsif user_signing_up?
       t('links.cancel_account_creation')
     elsif user_verifying_identity?
       t('links.cancel_idv')
     else
-      t('links.cancel')
+      cancel_link
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
     params[:confirmation_token].present? || (current_user && !current_user.two_factor_enabled?)
   end
 
-  def user_can_exit_early?
+  def user_unverified_and_in_2fa?
     !user_fully_authenticated? && !user_signing_up? && user_verifying_identity?
   end
 
@@ -64,7 +64,7 @@ module ApplicationHelper
   end
 
   def cancel_link_text
-    if user_can_exit_early?
+    if user_unverified_and_in_2fa?
       t('links.cancel')
     elsif user_signing_up?
       t('links.cancel_account_creation')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,7 +60,9 @@ module ApplicationHelper
   end
 
   def cancel_link_text
-    if user_signing_up?
+    if !user_signing_up? && user_verifying_identity?
+      t('links.cancel')
+    elsif user_signing_up?
       t('links.cancel_account_creation')
     elsif user_verifying_identity?
       t('links.cancel_idv')

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,7 +1,7 @@
 - cancel = sign_up_or_idv_no_js_link || link
 
 .mt2.pt1.border-top
-  - if !user_signing_up? && user_verifying_identity?
+  - if user_can_exit_early?
     = link_to cancel_link_text, '/', class: 'h5'
   - elsif user_signing_up? || user_verifying_identity?
     - method = user_signing_up? ? :delete : :get

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,7 +1,7 @@
 - cancel = sign_up_or_idv_no_js_link || link
 
 .mt2.pt1.border-top
-  - if user_can_exit_early?
+  - if user_unverified_and_in_2fa?
     = link_to cancel_link_text, '/', class: 'h5'
   - elsif user_signing_up? || user_verifying_identity?
     - method = user_signing_up? ? :delete : :get

--- a/app/views/shared/_cancel.html.slim
+++ b/app/views/shared/_cancel.html.slim
@@ -1,7 +1,9 @@
 - cancel = sign_up_or_idv_no_js_link || link
 
 .mt2.pt1.border-top
-  - if user_signing_up? || user_verifying_identity?
+  - if !user_signing_up? && user_verifying_identity?
+    = link_to cancel_link_text, '/', class: 'h5'
+  - elsif user_signing_up? || user_verifying_identity?
     - method = user_signing_up? ? :delete : :get
 
     = button_to cancel_link_text, cancel, method: method,

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -88,6 +88,15 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
         expect(current_path).to match(account_path)
       end
+
+      it 'returns user to profile page if they have previously signed up but have not gone through 2fa' do
+        sign_in_user
+        loa3_sp_session
+
+        click_on t('links.cancel')
+
+        expect(current_path).to match(root_path)
+      end
     end
 
     context 'without js' do

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -120,6 +120,15 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
         expect(current_url).to eq(account_url)
       end
+
+      it 'returns user to profile page if they have previously signed up but have not gone through 2fa' do
+        sign_in_user
+        loa3_sp_session
+
+        click_on t('links.cancel')
+
+        expect(current_path).to match(root_path)
+      end
     end
   end
 


### PR DESCRIPTION
[WIP] Addresses issues listed here: https://github.com/18F/identity-private/issues/2124 

Using this [mural](https://app.mural.ly/t/gsa6/m/gsa6/1493407770857/b439b1df065f5d80f1883559b09d9e6d53835d5a) as a guide.

Create account
- [ ] Change modal text to this: https://murally.blob.core.windows.net/uploads/gsa6/1498261218375.png?se=2017-08-10T20%3A38%3A20Z&sp=r&sv=2016-05-31&sr=b&sig=9nbDPFRjOQ8jal1cgOwLFHNLGNm1qvg084FVa6MIBGg%3D

Sign in 
- [x] Change text and link within validation step _if_ user is logging in.
- [ ] When a user is returned to the login page from this validation step, the "< return to SP" link should be present


Recover Password:
- [ ] ....?

cc @mkhandekar 