### PR TITLE
IdV OTP delivery method selection

### DIFF
--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -1,20 +1,20 @@
 module PhoneConfirmation
-  def prompt_to_confirm_phone(phone:, context: 'confirmation')
+  def prompt_to_confirm_phone(phone:, context: 'confirmation', selected_delivery_method: nil)
     user_session[:unconfirmed_phone] = phone
     user_session[:context] = context
 
     redirect_to otp_send_path(
-      otp_delivery_selection_form: { otp_delivery_preference: otp_delivery_method(phone) }
+      otp_delivery_selection_form: {
+        otp_delivery_preference: otp_delivery_method(phone, selected_delivery_method),
+      }
     )
   end
 
   private
 
-  def otp_delivery_method(phone)
-    if PhoneNumberCapabilities.new(phone).sms_only?
-      :sms
-    else
-      current_user.otp_delivery_preference
-    end
+  def otp_delivery_method(phone, selected_delivery_method)
+    return :sms if PhoneNumberCapabilities.new(phone).sms_only?
+    return selected_delivery_method if selected_delivery_method.present?
+    current_user.otp_delivery_preference
   end
 end

--- a/app/controllers/verify/otp_delivery_method_controller.rb
+++ b/app/controllers/verify/otp_delivery_method_controller.rb
@@ -1,0 +1,57 @@
+module Verify
+  class OtpDeliveryMethodController < ApplicationController
+    include IdvSession
+    include PhoneConfirmation
+
+    before_action :confirm_phone_step_complete
+    before_action :confirm_step_needed
+    before_action :set_otp_delivery_method_presenter
+    before_action :set_otp_delivery_selection_form
+
+    def new; end
+
+    def create
+      result = @otp_delivery_selection_form.submit(otp_delivery_selection_params)
+      if result.success?
+        prompt_to_confirm_phone(
+          phone: idv_session.params[:phone],
+          context: 'idv',
+          selected_delivery_method: @otp_delivery_selection_form.otp_delivery_preference
+        )
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def confirm_phone_step_complete
+      redirect_to verify_review_path if idv_session.vendor_phone_confirmation != true
+    end
+
+    def confirm_step_needed
+      redirect_to verify_review_path if idv_session.address_verification_mechanism != 'phone' ||
+                                        idv_session.user_phone_confirmation == true
+    end
+
+    def otp_delivery_selection_params
+      params.require(:otp_delivery_selection_form).permit(
+        :otp_delivery_preference
+      )
+    end
+
+    def set_otp_delivery_method_presenter
+      @set_otp_delivery_method_presenter = OtpDeliveryMethodPresenter.new(
+        idv_session.params[:phone]
+      )
+    end
+
+    def set_otp_delivery_selection_form
+      @otp_delivery_selection_form = OtpDeliverySelectionForm.new(
+        current_user,
+        idv_session.params[:phone],
+        'idv'
+      )
+    end
+  end
+end

--- a/app/controllers/verify/phone_controller.rb
+++ b/app/controllers/verify/phone_controller.rb
@@ -2,7 +2,6 @@ module Verify
   class PhoneController < ApplicationController
     include IdvStepConcern
     include IdvFailureConcern
-    include PhoneConfirmation
 
     before_action :confirm_step_needed
     before_action :confirm_step_allowed
@@ -43,7 +42,7 @@ module Verify
 
     def redirect_to_next_step
       if phone_confirmation_required?
-        prompt_to_confirm_phone(phone: idv_session.params[:phone], context: 'idv')
+        redirect_to verify_otp_delivery_method_url
       else
         redirect_to verify_review_url
       end

--- a/app/presenters/verify/otp_delivery_method_presenter.rb
+++ b/app/presenters/verify/otp_delivery_method_presenter.rb
@@ -1,0 +1,24 @@
+module Verify
+  class OtpDeliveryMethodPresenter
+    attr_reader :phone
+
+    delegate :sms_only?, to: :phone_number_capabilites
+
+    def initialize(phone)
+      @phone = PhoneFormatter.new.format(phone)
+    end
+
+    def phone_unsupported_message
+      I18n.t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: phone_number_capabilites.unsupported_location
+      )
+    end
+
+    private
+
+    def phone_number_capabilites
+      @phone_number_capabilites ||= PhoneNumberCapabilities.new(phone)
+    end
+  end
+end

--- a/app/views/verify/otp_delivery_method/new.html.slim
+++ b/app/views/verify/otp_delivery_method/new.html.slim
@@ -1,0 +1,33 @@
+h1.h3.my0 = t('idv.titles.otp_delivery_method')
+p = t('idv.messages.otp_delivery_method.phone_number_html',
+      phone: @set_otp_delivery_method_presenter.phone)
+= simple_form_for(@otp_delivery_selection_form, url: verify_otp_delivery_method_url,
+  html: { autocomplete: 'off', method: 'put', role: 'form', class: 'mt2' }) do |f|
+  fieldset.mb3.p0.border-none
+    legend.mb1.h4.serif.bold = t('devise.two_factor_authentication.otp_delivery_preference.title')
+    label.btn-border.col-12.sm-col-5.sm-mr2.mb2.sm-mb0
+      .radio
+        = radio_button_tag 'otp_delivery_selection_form[otp_delivery_preference]', :sms, true,
+          class: :otp_delivery_preference_sms
+        span.indicator
+        = t('devise.two_factor_authentication.otp_delivery_preference.sms')
+    - if @set_otp_delivery_method_presenter.sms_only?
+      label.btn-border.col-12.sm-col-5.btn-disabled
+        .radio
+          = radio_button_tag 'otp_delivery_selection_form[otp_delivery_preference]', :voice, false,
+            disabled: true,
+            class: :otp_delivery_preference_voice
+          span.indicator
+          = t('devise.two_factor_authentication.otp_delivery_preference.voice')
+      p.mt2.mb0 = @set_otp_delivery_method_presenter.phone_unsupported_message
+    - else
+      label.btn-border.col-12.sm-col-5
+        .radio
+          = radio_button_tag 'otp_delivery_selection_form[otp_delivery_preference]', :voice, false,
+            class: :otp_delivery_preference_voice
+          span.indicator
+          = t('devise.two_factor_authentication.otp_delivery_preference.voice')
+  = f.submit t('idv.buttons.send_confirmation_code'), type: :submit, class: 'btn btn-primary'
+.mt2.pt1.border-top
+  = t('instructions.mfa.wrong_number_html',
+    link: link_to(t('forms.two_factor.try_again'), verify_phone_path))

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -12,6 +12,7 @@ en:
         send: Send a letter
       return_to_account: Return to account
       return_to_sp: Return to %{sp}
+      send_confirmation_code: Send confirmation code
     cancel:
       modal_header: Are you sure you want to cancel?
       warning_header: If you cancel now
@@ -126,6 +127,8 @@ en:
       help_center: Visit our Help Center to learn more about verifying your account.
       loading: Verifying your identity
       mail_sent: Your letter is on its way
+      otp_delivery_method:
+        phone_number_html: We will send a code to <strong>%{phone}</strong>
       personal_details_verified: Personal details verified!
       personal_key: This is your new personal key. Write it down and keep it in a
         safe place. You will need it if you ever lose your password.
@@ -205,6 +208,7 @@ en:
       mail:
         resend: Want another letter?
         verify: Want a letter?
+      otp_delivery_method: Get a code by phone
       phone: Phone number of record
       review: Review and submit
       select_verification: Activate your account

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -12,6 +12,7 @@ es:
         send: Enviar una carta
       return_to_account: NOT TRANSLATED YET
       return_to_sp: NOT TRANSLATED YET
+      send_confirmation_code: NOT TRANSLATED YET
     cancel:
       modal_header: "¿Está seguro que desea cancelar?"
       warning_header: Si usted cancela ahora
@@ -128,6 +129,8 @@ es:
         la verificación de su cuenta.
       loading: NOT TRANSLATED YET
       mail_sent: Su carta está en camino
+      otp_delivery_method:
+        phone_number_html: NOT TRANSLATED YET
       personal_details_verified: "¡Detalles personales verificados!"
       personal_key: Esta es su nueva clave personal. Escríbala y guárdela en un lugar
         seguro. La necesitará si pierde su contraseña.
@@ -211,6 +214,7 @@ es:
       mail:
         resend: "¿Desea otra carta?"
         verify: "¿Desea una carta?"
+      otp_delivery_method: NOT TRANSLATED YET
       phone: Número de teléfono del registro
       review: Revise y envíe
       select_verification: Active su cuenta

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -12,6 +12,7 @@ fr:
         send: Envoyer une lettre
       return_to_account: NOT TRANSLATED YET
       return_to_sp: NOT TRANSLATED YET
+      send_confirmation_code: NOT TRANSLATED YET
     cancel:
       modal_header: Souhaitez-vous vraiment annuler?
       warning_header: Si vous annulez maintenant
@@ -136,6 +137,8 @@ fr:
         façon dont nous vérifions votre compte.
       loading: NOT TRANSLATED YET
       mail_sent: Votre lettre est en route
+      otp_delivery_method:
+        phone_number_html: NOT TRANSLATED YET
       personal_details_verified: Information personnelle vérifiée!
       personal_key: Il s'agit de votre nouvelle clé personnelle. Notez-la et conservez-la
         dans un endroit sécuritaire. Vous en aurez besoin si vous perdez votre mot
@@ -223,6 +226,7 @@ fr:
       mail:
         resend: Vous voulez une autre lettre?
         verify: Vous voulez une lettre?
+      otp_delivery_method: NOT TRANSLATED YET
       phone: Numéro de téléphone enregistré
       review: Réviser et soumettre
       select_verification: Activer votre compte

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,8 @@ Rails.application.routes.draw do
       put '/verify/finance' => 'verify/finance#create'
       get '/verify/finance/other' => 'verify/finance_other#new'
       get '/verify/finance/result' => 'verify/finance#show'
+      get '/verify/otp_delivery_method' => 'verify/otp_delivery_method#new'
+      put '/verify/otp_delivery_method' => 'verify/otp_delivery_method#create'
       get '/verify/phone' => 'verify/phone#new'
       put '/verify/phone' => 'verify/phone#create'
       get '/verify/phone/result' => 'verify/phone#show'

--- a/spec/controllers/verify/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/verify/otp_delivery_method_controller_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+describe Verify::OtpDeliveryMethodController do
+  let(:user) { build(:user) }
+
+  before do
+    stub_verify_steps_one_and_two(user)
+    subject.idv_session.address_verification_mechanism = 'phone'
+    subject.idv_session.params[:phone] = '5555555000'
+    subject.idv_session.vendor_phone_confirmation = true
+    subject.idv_session.user_phone_confirmation = false
+  end
+
+  describe '#new' do
+    context 'user has not selected phone verification method' do
+      before do
+        subject.idv_session.address_verification_mechanism = 'usps'
+      end
+
+      it 'redirects to the review controller' do
+        get :new
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has confirmed phone number' do
+      before do
+        subject.idv_session.user_phone_confirmation = true
+      end
+
+      it 'redirects to the review controller' do
+        get :new
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has not completed phone step' do
+      before do
+        subject.idv_session.vendor_phone_confirmation = false
+      end
+
+      it 'redirects to the review controller' do
+        get :new
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has selected phone verification and not confirmed phone' do
+      it 'renders' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:params) do
+      {
+        otp_delivery_selection_form: {
+          otp_delivery_preference: :sms,
+        },
+      }
+    end
+
+    context 'user has not selected phone verification method' do
+      before do
+        subject.idv_session.address_verification_mechanism = 'usps'
+      end
+
+      it 'redirects to the review controller' do
+        post :create, params
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has confirmed phone number' do
+      before do
+        subject.idv_session.user_phone_confirmation = true
+      end
+
+      it 'redirects to the review controller' do
+        post :create, params
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has not completed phone step' do
+      before do
+        subject.idv_session.vendor_phone_confirmation = false
+      end
+
+      it 'redirects to the review controller' do
+        post :create, params
+        expect(response).to redirect_to verify_review_path
+      end
+    end
+
+    context 'user has selected sms' do
+      it 'redirects to the otp send path for sms' do
+        post :create, params
+        expect(response).to redirect_to otp_send_path(params)
+      end
+    end
+
+    context 'user has selected voice' do
+      let(:params) do
+        {
+          otp_delivery_selection_form: {
+            otp_delivery_preference: :voice,
+          },
+        }
+      end
+
+      it 'redirects to the otp send path for voice' do
+        post :create, params
+        expect(response).to redirect_to otp_send_path(params)
+      end
+    end
+
+    context 'form is invalid' do
+      let(:params) do
+        {
+          otp_delivery_selection_form: {
+            otp_delivery_preference: :🎷,
+          },
+        }
+      end
+
+      it 'renders the new template' do
+        post :create, params
+        expect(response).to render_template :new
+      end
+    end
+  end
+end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -43,7 +43,7 @@ describe Verify::PhoneController do
         subject.idv_session.user_phone_confirmation = nil
       end
 
-      it 'redirects renders the form' do
+      it 'renders the form' do
         subject.idv_session.vendor_phone_confirmation = true
         get :new
 
@@ -132,7 +132,7 @@ describe Verify::PhoneController do
       end
 
       context 'when different from user phone' do
-        it 'redirects to result page and does not set phone_confirmed_at' do
+        it 'redirects to otp page and does not set phone_confirmed_at' do
           user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
           stub_verify_steps_one_and_two(user)
 

--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -14,6 +14,11 @@ feature 'account creation after LOA3 request', idv_job: true do
     it_behaves_like 'selecting usps address verification method', :oidc
   end
 
+  context 'choosing phone address verification otp delivery method' do
+    it_behaves_like 'idv otp delivery method selection', :saml
+    it_behaves_like 'idv otp delivery method selection', :oidc
+  end
+
   context 'retries limited by max step attempt limits' do
     it_behaves_like 'idv max step attempts', :saml
     it_behaves_like 'idv max step attempts', :oidc

--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -162,6 +162,7 @@ feature 'IdV session', idv_job: true do
 
       fill_out_phone_form_ok(good_phone_value)
       click_idv_continue
+      choose_idv_otp_delivery_method_sms
       enter_correct_otp_code_for_user(user)
 
       page.find('.accordion').click
@@ -190,6 +191,7 @@ feature 'IdV session', idv_job: true do
       click_idv_address_choose_phone
       fill_out_phone_form_ok(phone)
       click_idv_continue
+      choose_idv_otp_delivery_method_sms
 
       click_link t('forms.two_factor.try_again')
 
@@ -198,6 +200,7 @@ feature 'IdV session', idv_job: true do
 
       fill_out_phone_form_ok(different_phone)
       click_idv_continue
+      choose_idv_otp_delivery_method_sms
 
       # Verify that OTP confirmation can't be skipped
       visit verify_review_path
@@ -373,6 +376,7 @@ feature 'IdV session', idv_job: true do
       click_idv_address_choose_phone
       fill_out_phone_form_ok(different_phone)
       click_idv_continue
+      choose_idv_otp_delivery_method_sms
 
       click_on t('links.cancel')
 

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -60,6 +60,7 @@ feature 'Verify phone' do
       click_idv_address_choose_phone
       fill_out_phone_form_ok
       click_idv_continue
+      choose_idv_otp_delivery_method_sms
       enter_correct_otp_code_for_user(user)
 
       visit verify_phone_path
@@ -105,5 +106,6 @@ feature 'Verify phone' do
     click_idv_address_choose_phone
     fill_out_phone_form_ok(phone)
     click_idv_continue
+    choose_idv_otp_delivery_method_sms
   end
 end

--- a/spec/presenters/verify/otp_delivery_method_presenter_spec.rb
+++ b/spec/presenters/verify/otp_delivery_method_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Verify::OtpDeliveryMethodPresenter do
+  let(:phone) { '555-555-0000' }
+  let(:formatted_phone) { '+1 (555) 555-0000' }
+  let(:phone_number_capabilities) { PhoneNumberCapabilities.new(formatted_phone) }
+
+  subject { Verify::OtpDeliveryMethodPresenter.new(phone) }
+
+  before do
+    allow(PhoneNumberCapabilities).to receive(:new).
+      with(formatted_phone).
+      and_return(phone_number_capabilities)
+  end
+
+  describe '#phone_unsupported_message' do
+    it 'returns a message saying the phone is unsupported in the location' do
+      unsupported_location = '🌃🌇🏙🌇🌃'
+      allow(phone_number_capabilities).to receive(:sms_only?).and_return(true)
+      allow(phone_number_capabilities).to receive(:unsupported_location).
+        and_return(unsupported_location)
+
+      expect(subject.phone_unsupported_message).to eq(
+        t(
+          'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+          location: unsupported_location
+        )
+      )
+    end
+  end
+end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -75,6 +75,22 @@ module IdvHelper
     click_link t('idv.buttons.activate_by_mail')
   end
 
+  def choose_idv_otp_delivery_method_sms
+    page.find(
+      'label',
+      text: t('devise.two_factor_authentication.otp_delivery_preference.sms')
+    ).click
+    click_on t('idv.buttons.send_confirmation_code')
+  end
+
+  def choose_idv_otp_delivery_method_voice
+    page.find(
+      'label',
+      text: t('devise.two_factor_authentication.otp_delivery_preference.voice')
+    ).click
+    click_on t('idv.buttons.send_confirmation_code')
+  end
+
   def click_idv_cancel_modal
     within('.modal') do
       click_on t('idv.buttons.cancel')

--- a/spec/support/idv_examples/otp_delivery_method.rb
+++ b/spec/support/idv_examples/otp_delivery_method.rb
@@ -1,0 +1,67 @@
+shared_examples 'idv otp delivery method selection' do |sp|
+  let(:phone) { '555-123-4567' }
+
+  before do
+    visit_idp_from_sp_with_loa3(sp)
+    register_user
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+    click_idv_address_choose_phone
+    fill_out_phone_form_ok(phone)
+    click_idv_continue
+  end
+
+  scenario 'selecting sms delivery method sends sems', :email do
+    allow(SmsOtpSenderJob).to receive(:perform_later)
+    choose_idv_otp_delivery_method_sms
+
+    expect(SmsOtpSenderJob).to have_received(:perform_later)
+    expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
+  end
+
+  scenario 'selecting voice delivery method sends voice call', :email do
+    allow(VoiceOtpSenderJob).to receive(:perform_later)
+    choose_idv_otp_delivery_method_voice
+
+    expect(VoiceOtpSenderJob).to have_received(:perform_later)
+    expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :voice)
+  end
+
+  scenario 'choosing to enter a different phone sends an OTP to that phone', :email do
+    different_phone = '9876543210'
+
+    choose_idv_otp_delivery_method_sms
+    click_link t('forms.two_factor.try_again')
+
+    expect(current_path).to eq verify_phone_path
+
+    fill_out_phone_form_ok(different_phone)
+    click_idv_continue
+
+    allow(SmsOtpSenderJob).to receive(:perform_later)
+    choose_idv_otp_delivery_method_sms
+
+    expect(SmsOtpSenderJob).to have_received(:perform_later).
+      with(hash_including(phone: different_phone))
+  end
+
+  context 'with a phone number that does not support voice calling' do
+    let(:phone) { '671-555-5000' }
+
+    scenario 'voice call option is disabled', :email do
+      voice_radio_button = page.find(
+        '#otp_delivery_selection_form_otp_delivery_preference_voice',
+        visible: false
+      )
+
+      expect(voice_radio_button.disabled?).to eq(true)
+      expect(page).to have_content t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: 'Guam'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Allow OTP delivery method selection during IdV

**Why**: Prior to this commit, the OTP delivery method was the user's
preference for their 2FA phone. The users phone number of record may not
have the same capabilities as the user's 2FA phone. This commit allows
the user to select a delivery method that is different than their 2FA
OTP delivery method.

Disable voice OTP in IdV when it's unsupported

**Why**: If the user enters a phone that we can't voice call, we want to
disable the option to make it clear that it is unavailable.

Add delivery method arg to phone confirmation

**Why**: On screens where the user selects a delivery method that may
not correspond to their delivery preference (e.g. IdV phone
confirmation), then we want to convey their delivery preference to the
`prommpt_to_confirm` method so that it can use that delivery method if
it is available.

Add context awareness to OTP selection form

**Why**: We don't want the OTP delivery selection form to update the
user's OTP delivery method preference in the IdV context since that is a
one-time thing. This has the additional benefit of letting us refactor
controllers so they can use the analytics params directly from the form
instead of having to merge in the context.