### PR TITLE
Update YamlNormalizer to handle arrays of hashes

### DIFF
--- a/lib/yaml_normalizer.rb
+++ b/lib/yaml_normalizer.rb
@@ -7,20 +7,8 @@ class YamlNormalizer
     argv.each do |file|
       $stderr.puts file
       data = YAML.load_file(file)
-      chomp_each(data)
+      handle_hash(data)
       dump(file, data)
-    end
-  end
-
-  def self.chomp_each(hash)
-    hash.each do |_key, value|
-      if value.is_a?(String)
-        trim(value)
-      elsif value.is_a?(Array)
-        strip_array(value)
-      elsif value
-        chomp_each(value)
-      end
     end
   end
 
@@ -28,8 +16,26 @@ class YamlNormalizer
     File.open(file, 'w') { |io| io.puts YAML.dump(data) }
   end
 
-  def self.strip_array(value)
-    value.each { |str| trim(str) if str }
+  def self.handle_hash(hash)
+    hash.each do |_key, value|
+      handle_value(value)
+    end
+  end
+
+  def self.handle_array(array)
+    array.each { |value| handle_value(value) }
+  end
+
+  def self.handle_value(value)
+    if value.is_a?(String)
+      trim(value)
+    elsif value.is_a?(Array)
+      handle_array(value)
+    elsif value.kind_of?(Hash)
+      handle_hash(value)
+    elsif value
+      raise ArgumentError, "unknown YAML value #{value}"
+    end
   end
 
   def self.trim(str)

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'I18n' do
       end
 
       it 'is formatted as normalized YAML (run scripts/normalize-yaml)' do
-        normalized_yaml = YAML.dump(YamlNormalizer.chomp_each(YAML.load_file(full_path)))
+        normalized_yaml = YAML.dump(YamlNormalizer.handle_hash(YAML.load_file(full_path)))
 
         expect(File.read(full_path)).to eq(normalized_yaml)
       end

--- a/spec/lib/yaml_normalizer_spec.rb
+++ b/spec/lib/yaml_normalizer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe YamlNormalizer do
     end
   end
 
-  describe '.chomp_each' do
+  describe '.handle_hash' do
     context 'trailing newlines' do
       let(:original) do
         {
@@ -53,7 +53,7 @@ RSpec.describe YamlNormalizer do
       end
 
       it 'in-place, recursively trims trailing newlines from all strings in a hash' do
-        YamlNormalizer.chomp_each(original)
+        YamlNormalizer.handle_hash(original)
 
         expect(original).to eq(trimmed)
       end
@@ -64,7 +64,7 @@ RSpec.describe YamlNormalizer do
       let(:trimmed) { { a: 'a : ', b: 'b', c: 'c : ' } }
 
       it 'trims trailing spaces, except after a colon' do
-        YamlNormalizer.chomp_each(original)
+        YamlNormalizer.handle_hash(original)
 
         expect(original).to eq(trimmed)
       end
@@ -75,7 +75,7 @@ RSpec.describe YamlNormalizer do
       let(:trimmed) { { a: 'a b c', b: "a\nb" } }
 
       it 'trims leading newlines but not intermediate ones' do
-        YamlNormalizer.chomp_each(original)
+        YamlNormalizer.handle_hash(original)
 
         expect(original).to eq(trimmed)
       end
@@ -86,9 +86,28 @@ RSpec.describe YamlNormalizer do
       let(:trimmed) { { a: nil } }
 
       it 'does not blow up' do
-        YamlNormalizer.chomp_each(original)
+        YamlNormalizer.handle_hash(original)
 
         expect(original).to eq(trimmed)
+      end
+    end
+
+    context 'array of hashes' do
+      let(:original) { { a: [{ b: 'b ' }] } }
+      let(:trimmed) { { a: [{ b: 'b' }] } }
+
+      it 'does not blow up' do
+        YamlNormalizer.handle_hash(original)
+
+        expect(original).to eq(trimmed)
+      end
+    end
+
+    context 'unknown object' do
+      let(:original) { { a: Object.new } }
+
+      it 'raises' do
+        expect { YamlNormalizer.handle_hash(original) }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
**Why**: To normalize more translation files

---

this is needed to normalize the static site content