### PR TITLE
Fix deprecation warnings for Rails 5.1

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -19,7 +19,7 @@ module SamlIdpAuthConcern
     return if @result.success?
 
     analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
-    render nothing: true, status: :unauthorized
+    head :unauthorized
   end
 
   def store_saml_request

--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -13,7 +13,7 @@ module OpenidConnect
     end
 
     def options
-      render nothing: true
+      head :ok
     end
   end
 end

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -17,7 +17,7 @@ class ServiceProviderController < ApplicationController
     if authorization_token == Figaro.env.dashboard_api_token
       yield
     else
-      render nothing: true, status: 401
+      head :unauthorized
     end
   end
 

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -112,7 +112,7 @@ module Verify
     end
 
     def initialize_idv_session
-      idv_session.params.merge!(profile_params)
+      idv_session.params = profile_params.to_h
       idv_session.applicant = idv_session.vendor_params
     end
 

--- a/app/forms/idv/profile_form.rb
+++ b/app/forms/idv/profile_form.rb
@@ -85,7 +85,7 @@ module Idv
 
       return if date && dob_in_the_past?(date)
 
-      errors.set :dob, [I18n.t('idv.errors.bad_dob')]
+      errors.add :dob, I18n.t('idv.errors.bad_dob')
     end
 
     def dob_in_the_past?(date)

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -23,7 +23,7 @@ class ServiceProviderUpdater
     if service_provider['active'] == true
       create_or_update_service_provider(issuer, service_provider)
     else
-      ServiceProvider.destroy_all(issuer: issuer, native: false)
+      ServiceProvider.where(issuer: issuer, native: false).destroy_all
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ APP_NAME = 'login.gov'.freeze
 module Upaya
   class Application < Rails::Application
     config.active_job.queue_adapter = :sidekiq
-    config.active_record.raise_in_transactional_callbacks = true
     config.autoload_paths << Rails.root.join('app', 'mailers', 'concerns')
     config.time_zone = 'UTC'
 
@@ -30,7 +29,7 @@ module Upaya
       end
     end
 
-    config.middleware.insert_before 0, 'Rack::Cors' do
+    config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
         resource '/.well-known/openid-configuration', headers: :any, methods: [:get]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,8 +2,8 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
   config.cache_classes = true
   config.eager_load = false
-  config.serve_static_files = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/teaspoon.rb
+++ b/config/initializers/teaspoon.rb
@@ -3,7 +3,7 @@ unless Rails.env.production?
 
   module Teaspoon
     class SuiteController
-      skip_before_filter :handle_two_factor_authentication
+      skip_before_action :handle_two_factor_authentication
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationController do
   describe '#disable_caching' do
     controller do
       def index
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -57,7 +57,7 @@ describe ApplicationController do
       before_action :confirm_two_factor_authenticated
 
       def index
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -147,13 +147,13 @@ describe ApplicationController do
       prepend_before_action :session_expires_at
 
       def index
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
     context 'when URL contains the host parameter' do
       it 'does not redirect to the host' do
-        get :index, timeout: true, host: 'www.monfresh.com'
+        get :index, params: { timeout: true, host: 'www.monfresh.com' }
 
         expect(response.header['Location']).to_not match 'www.monfresh.com'
       end
@@ -161,7 +161,7 @@ describe ApplicationController do
 
     context 'when URL does not contain the timeout parameter' do
       it 'does not redirect anywhere' do
-        get :index, host: 'www.monfresh.com'
+        get :index, params: { host: 'www.monfresh.com' }
 
         expect(response).to_not be_redirect
       end
@@ -169,7 +169,7 @@ describe ApplicationController do
 
     context 'when URL contains the request_id parameter' do
       it 'preserves the request_id parameter' do
-        get :index, timeout: true, request_id: '123'
+        get :index, params: { timeout: true, request_id: '123' }
 
         expect(response.header['Location']).to match '123'
       end

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -17,7 +17,7 @@ describe 'IdvStepConcern' do
       before_action :confirm_idv_attempts_allowed
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -79,7 +79,7 @@ describe 'IdvStepConcern' do
       before_action :confirm_idv_session_started
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -121,7 +121,7 @@ describe 'IdvStepConcern' do
       before_action :confirm_idv_needed
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -31,7 +31,7 @@ describe MfaConfirmationController do
 
     context 'password is empty' do
       it 'redirects with error message and increments password attempts' do
-        post :create, user: { password: '' }
+        post :create, params: { user: { password: '' } }
 
         expect(response).to redirect_to(user_password_confirm_path)
         expect(flash[:error]).to eq t('errors.confirm_password_incorrect')
@@ -41,7 +41,7 @@ describe MfaConfirmationController do
 
     context 'password is wrong' do
       it 'redirects with error message and increments password attempts' do
-        post :create, user: { password: 'wrong' }
+        post :create, params: { user: { password: 'wrong' } }
 
         expect(response).to redirect_to(user_password_confirm_path)
         expect(flash[:error]).to eq t('errors.confirm_password_incorrect')
@@ -51,7 +51,7 @@ describe MfaConfirmationController do
 
     context 'password is correct' do
       it 'redirects to 2FA and resets password attempts' do
-        post :create, user: { password: 'password' }
+        post :create, params: { user: { password: 'password' } }
 
         expect(response).to redirect_to(user_two_factor_authentication_path(reauthn: true))
         expect(session[:password_attempts]).to eq 0
@@ -70,7 +70,7 @@ describe MfaConfirmationController do
 
         max_allowed_attempts = Figaro.env.password_max_attempts.to_i
         max_allowed_attempts.times do
-          post :create, user: { password: 'wrong' }
+          post :create, params: { user: { password: 'wrong' } }
         end
 
         expect(response).to redirect_to(root_path)
@@ -89,10 +89,10 @@ describe MfaConfirmationController do
 
         max_allowed_attempts = Figaro.env.password_max_attempts.to_i
         (max_allowed_attempts - 1).times do
-          post :create, user: { password: 'wrong' }
+          post :create, params: { user: { password: 'wrong' } }
         end
 
-        post :create, user: { password: 'password' }
+        post :create, params: { user: { password: 'password' } }
 
         expect(response).to redirect_to user_two_factor_authentication_path(reauthn: true)
       end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
   end
 
   describe '#index' do
-    subject(:action) { get :index, params }
+    subject(:action) { get :index, params: params }
 
     context 'user is signed in' do
       let(:user) { create(:user, :signed_up) }

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -26,9 +26,11 @@ RSpec.describe OpenidConnect::LogoutController do
   describe '#index' do
     subject(:action) do
       get :index,
-          id_token_hint: id_token_hint,
-          post_logout_redirect_uri: post_logout_redirect_uri,
-          state: state
+          params: {
+            id_token_hint: id_token_hint,
+            post_logout_redirect_uri: post_logout_redirect_uri,
+            state: state,
+          }
     end
 
     context 'user is signed in' do

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe OpenidConnect::TokenController do
   describe '#create' do
     subject(:action) do
       post :create,
-           grant_type: grant_type,
-           code: code,
-           client_assertion_type: OpenidConnectTokenForm::CLIENT_ASSERTION_TYPE,
-           client_assertion: client_assertion
+           params: {
+             grant_type: grant_type,
+             code: code,
+             client_assertion_type: OpenidConnectTokenForm::CLIENT_ASSERTION_TYPE,
+             client_assertion: client_assertion,
+           }
     end
 
     let(:user) { create(:user) }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,7 +4,7 @@ describe PagesController do
   describe 'analytics' do
     controller do
       def index
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -28,7 +28,7 @@ describe PagesController do
   describe 'content expiry' do
     controller do
       def index
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 

--- a/spec/controllers/reauthn_required_controller_spec.rb
+++ b/spec/controllers/reauthn_required_controller_spec.rb
@@ -6,7 +6,7 @@ describe ReauthnRequiredController do
   describe '#confirm_recently_authenticated' do
     controller do
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -29,23 +29,25 @@ describe SamlIdpController do
         )
         sign_in user
 
-        post :logout, SAMLResponse: 'PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4' \
-                                    '8c2FtbDJwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWwycD0idX' \
-                                    'JuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIiBEZ' \
-                                    'XN0aW5hdGlvbj0iaHR0cHM6Ly9teWFjY291bnQudXNjaXMuZGhz' \
-                                    'Lmdvdi9hcGkvc2FtbC9sb2dvdXQiIElEPSJhMzZkYWloNWNqYmo' \
-                                    'zMWI5NDYwZGJiajNqZDQ2N2I0IiBJblJlc3BvbnNlVG89Il81Zj' \
-                                    'dlYjU3MC01YjQ3LTRhMzAtYjUzNi0yY2YyOThhY2NmNmYiIElzc' \
-                                    '3VlSW5zdGFudD0iMjAxNS0xMi0wMlQxNToyNzo0OS4zNzFaIiBW' \
-                                    'ZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI' \
-                                    '9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb2' \
-                                    '4iPmV4dGVybmFsYXBwX3ByXzMwYTwvc2FtbDI6SXNzdWVyPjxzY' \
-                                    'W1sMnA6U3RhdHVzPjxzYW1sMnA6U3RhdHVzQ29kZSBWYWx1ZT0i' \
-                                    'dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnN0YXR1czpVbmt' \
-                                    'ub3duUHJpbmNpcGFsIi8+PHNhbWwycDpTdGF0dXNNZXNzYWdlPk' \
-                                    '5vIHVzZXIgaXMgbG9nZ2VkIGluPC9zYW1sMnA6U3RhdHVzTWVzc' \
-                                    '2FnZT48L3NhbWwycDpTdGF0dXM+PC9zYW1sMnA6TG9nb3V0UmVz' \
-                                        'cG9uc2U+'
+        post :logout, params: {
+          SAMLResponse: 'PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4' \
+                        '8c2FtbDJwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWwycD0idX' \
+                        'JuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIiBEZ' \
+                        'XN0aW5hdGlvbj0iaHR0cHM6Ly9teWFjY291bnQudXNjaXMuZGhz' \
+                        'Lmdvdi9hcGkvc2FtbC9sb2dvdXQiIElEPSJhMzZkYWloNWNqYmo' \
+                        'zMWI5NDYwZGJiajNqZDQ2N2I0IiBJblJlc3BvbnNlVG89Il81Zj' \
+                        'dlYjU3MC01YjQ3LTRhMzAtYjUzNi0yY2YyOThhY2NmNmYiIElzc' \
+                        '3VlSW5zdGFudD0iMjAxNS0xMi0wMlQxNToyNzo0OS4zNzFaIiBW' \
+                        'ZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI' \
+                        '9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb2' \
+                        '4iPmV4dGVybmFsYXBwX3ByXzMwYTwvc2FtbDI6SXNzdWVyPjxzY' \
+                        'W1sMnA6U3RhdHVzPjxzYW1sMnA6U3RhdHVzQ29kZSBWYWx1ZT0i' \
+                        'dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnN0YXR1czpVbmt' \
+                        'ub3duUHJpbmNpcGFsIi8+PHNhbWwycDpTdGF0dXNNZXNzYWdlPk' \
+                        '5vIHVzZXIgaXMgbG9nZ2VkIGluPC9zYW1sMnA6U3RhdHVzTWVzc' \
+                        '2FnZT48L3NhbWwycDpTdGF0dXM+PC9zYW1sMnA6TG9nb3V0UmVz' \
+                        'cG9uc2U+',
+        }
         expect(response).to redirect_to root_url
       end
     end

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -17,7 +17,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: nil
+      get :create, params: { confirmation_token: nil }
 
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_email_resend_path
@@ -34,7 +34,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: ''
+      get :create, params: { confirmation_token: '' }
 
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_email_resend_path
@@ -51,7 +51,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: "''"
+      get :create, params: { confirmation_token: "''" }
 
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_email_resend_path
@@ -68,7 +68,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: '""'
+      get :create, params: { confirmation_token: '""' }
 
       expect(flash[:error]).to eq t('errors.messages.confirmation_invalid_token')
       expect(response).to redirect_to sign_up_email_resend_path
@@ -87,7 +87,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: 'foo'
+      get :create, params: { confirmation_token: 'foo' }
     end
 
     it 'tracks expired token' do
@@ -107,7 +107,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: 'foo'
+      get :create, params: { confirmation_token: 'foo' }
 
       expect(flash[:error]).
         to eq t('errors.messages.confirmation_period_expired', period: '24 hours')
@@ -131,7 +131,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: 'foo'
+      get :create, params: { confirmation_token: 'foo' }
     end
   end
 
@@ -157,7 +157,7 @@ describe SignUp::EmailConfirmationsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_CONFIRMATION, analytics_hash)
 
-      get :create, confirmation_token: 'foo'
+      get :create, params: { confirmation_token: 'foo' }
     end
   end
 end

--- a/spec/controllers/sign_up/email_resend_controller_spec.rb
+++ b/spec/controllers/sign_up/email_resend_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SignUp::EmailResendController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::EMAIL_CONFIRMATION_RESEND, result)
 
-        expect { post :create, user_params }.
+        expect { post :create, params: user_params }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(response).to redirect_to sign_up_verify_email_path
@@ -31,7 +31,7 @@ RSpec.describe SignUp::EmailResendController do
       end
 
       it 'does not send an email and displays the same message as if the user existed' do
-        expect { post :create, @user_params }.
+        expect { post :create, params: @user_params }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
         expect(response).to redirect_to sign_up_verify_email_path
@@ -49,7 +49,7 @@ RSpec.describe SignUp::EmailResendController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::EMAIL_CONFIRMATION_RESEND, result)
 
-        post :create, @user_params
+        post :create, params: @user_params
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe SignUp::EmailResendController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::EMAIL_CONFIRMATION_RESEND, result)
 
-        expect { post :create, user_params }.
+        expect { post :create, params: user_params }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
         expect(response).to redirect_to sign_up_verify_email_path
@@ -80,7 +80,7 @@ RSpec.describe SignUp::EmailResendController do
       it 'renders new' do
         user_params = { resend_email_confirmation_form: { email: 'a@b.' } }
 
-        post :create, user_params
+        post :create, params: user_params
 
         expect(response).to render_template(:new)
       end
@@ -92,7 +92,7 @@ RSpec.describe SignUp::EmailResendController do
 
         user_params = { resend_email_confirmation_form: { email: 'TEST@example.com ' } }
 
-        expect { post :create, user_params }.
+        expect { post :create, params: user_params }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -17,7 +17,10 @@ describe SignUp::PasswordsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::PASSWORD_CREATION, analytics_hash)
 
-      post :create, password_form: { password: 'NewVal!dPassw0rd' }, confirmation_token: token
+      post :create, params: {
+        password_form: { password: 'NewVal!dPassw0rd' },
+        confirmation_token: token,
+      }
 
       user.reload
       expect(user.valid_password?('NewVal!dPassw0rd')).to eq true
@@ -40,7 +43,7 @@ describe SignUp::PasswordsController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::PASSWORD_CREATION, analytics_hash)
 
-      post :create, password_form: { password: 'NewVal' }, confirmation_token: token
+      post :create, params: { password_form: { password: 'NewVal' }, confirmation_token: token }
     end
   end
 end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -45,7 +45,7 @@ describe SignUp::RegistrationsController, devise: true do
         allow(@analytics).to receive(:track_event)
         allow(subject).to receive(:create_user_event)
 
-        post :create, user: { email: 'new@example.com' }
+        post :create, params: { user: { email: 'new@example.com' } }
 
         user = User.find_with_email('new@example.com')
 
@@ -63,7 +63,7 @@ describe SignUp::RegistrationsController, devise: true do
       end
 
       it 'sets the email in the session and redirects to sign_up_verify_email_path' do
-        post :create, user: { email: 'test@test.com' }
+        post :create, params: { user: { email: 'test@test.com' } }
 
         expect(session[:email]).to eq('test@test.com')
         expect(response).to redirect_to(sign_up_verify_email_path)
@@ -73,7 +73,7 @@ describe SignUp::RegistrationsController, devise: true do
         user = create(:user)
         stub_sign_in(user)
 
-        post :create, user: { email: user.email }
+        post :create, params: { user: { email: user.email } }
 
         expect(response).to redirect_to account_path
       end
@@ -95,7 +95,7 @@ describe SignUp::RegistrationsController, devise: true do
         with(Analytics::USER_REGISTRATION_EMAIL, analytics_hash)
       expect(subject).to_not receive(:create_user_event)
 
-      post :create, user: { email: 'TEST@example.com ' }
+      post :create, params: { user: { email: 'TEST@example.com ' } }
     end
 
     it 'tracks unsuccessful user registration' do
@@ -111,7 +111,7 @@ describe SignUp::RegistrationsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::USER_REGISTRATION_EMAIL, analytics_hash)
 
-      post :create, user: { email: 'invalid@', request_id: '' }
+      post :create, params: { user: { email: 'invalid@', request_id: '' } }
     end
   end
 
@@ -122,7 +122,7 @@ describe SignUp::RegistrationsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::USER_REGISTRATION_INTRO_VISIT)
 
-      get :show, request_id: 'foo'
+      get :show, params: { request_id: 'foo' }
     end
 
     it 'cannot be viewed by signed in users' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -16,7 +16,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           )
           allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
 
-          get :show, otp_delivery_preference: 'sms'
+          get :show, params: { otp_delivery_preference: 'sms' }
 
           expect(assigns(:presenter).code_value).to eq(subject.current_user.direct_otp)
         end
@@ -25,7 +25,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       context 'when FeatureManagement.prefill_otp_codes? is false' do
         it 'does not set @code_value' do
           allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(false)
-          get :show, otp_delivery_preference: 'sms'
+          get :show, params: { otp_delivery_preference: 'sms' }
 
           expect(assigns(:code_value)).to be_nil
         end
@@ -46,14 +46,14 @@ describe TwoFactorAuthentication::OtpVerificationController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::MULTI_FACTOR_AUTH_ENTER_OTP_VISIT, analytics_hash)
 
-      get :show, otp_delivery_preference: 'sms'
+      get :show, params: { otp_delivery_preference: 'sms' }
     end
 
     context 'when there is no session (signed out or locked out), and the user reloads the page' do
       it 'redirects to the home page' do
         expect(controller.user_session).to be_nil
 
-        get :show, otp_delivery_preference: 'sms'
+        get :show, params: { otp_delivery_preference: 'sms' }
 
         expect(response).to redirect_to(new_user_session_path)
       end
@@ -79,7 +79,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           with(Analytics::MULTI_FACTOR_AUTH, properties)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
 
-        post :create, code: '12345', otp_delivery_preference: 'sms'
+        post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
       end
 
       it 'increments second_factor_attempts_count' do
@@ -113,7 +113,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, properties)
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
-        post :create, code: '12345', otp_delivery_preference: 'sms'
+        post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
       end
     end
 
@@ -125,14 +125,20 @@ describe TwoFactorAuthentication::OtpVerificationController do
       end
 
       it 'redirects to the profile' do
-        post :create, code: subject.current_user.reload.direct_otp, otp_delivery_preference: 'sms'
+        post :create, params: {
+          code: subject.current_user.reload.direct_otp,
+          otp_delivery_preference: 'sms',
+        }
 
         expect(response).to redirect_to account_path
       end
 
       it 'resets the second_factor_attempts_count' do
         subject.current_user.update(second_factor_attempts_count: 1)
-        post :create, code: subject.current_user.reload.direct_otp, otp_delivery_preference: 'sms'
+        post :create, params: {
+          code: subject.current_user.reload.direct_otp,
+          otp_delivery_preference: 'sms',
+        }
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
       end
@@ -151,7 +157,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::MULTI_FACTOR_AUTH, properties)
 
-        post :create, code: subject.current_user.reload.direct_otp, otp_delivery_preference: 'sms'
+        post :create, params: {
+          code: subject.current_user.reload.direct_otp,
+          otp_delivery_preference: 'sms',
+        }
       end
     end
 
@@ -167,7 +176,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
       describe 'when user submits an invalid OTP' do
         before do
-          post :create, code: '12345', otp_delivery_preference: 'sms'
+          post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
         end
 
         it 'resets attempts count' do
@@ -181,7 +190,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
       describe 'when user submits a valid OTP' do
         before do
-          post :create, code: subject.current_user.direct_otp, otp_delivery_preference: 'sms'
+          post :create, params: {
+            code: subject.current_user.direct_otp,
+            otp_delivery_preference: 'sms',
+          }
         end
 
         it 'resets attempts count' do
@@ -215,8 +227,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
           before do
             post(
               :create,
-              code: subject.current_user.direct_otp,
-              otp_delivery_preference: 'sms'
+              params: {
+                code: subject.current_user.direct_otp,
+                otp_delivery_preference: 'sms',
+              }
             )
           end
 
@@ -244,7 +258,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         end
 
         context 'user enters an invalid code' do
-          before { post :create, code: '999', otp_delivery_preference: 'sms' }
+          before { post :create, params: { code: '999', otp_delivery_preference: 'sms' } }
 
           it 'does not increment second_factor_attempts_count' do
             expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
@@ -293,8 +307,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
           before do
             post(
               :create,
-              code: subject.current_user.direct_otp,
-              otp_delivery_preference: 'sms'
+              params: {
+                code: subject.current_user.direct_otp,
+                otp_delivery_preference: 'sms',
+              }
             )
           end
 
@@ -347,8 +363,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
         before do
           post(
             :create,
-            code: subject.current_user.direct_otp,
-            otp_delivery_preference: 'sms'
+            params: {
+              code: subject.current_user.direct_otp,
+              otp_delivery_preference: 'sms',
+            }
           )
         end
 
@@ -399,7 +417,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       end
 
       context 'user enters an invalid code' do
-        before { post :create, code: '999', otp_delivery_preference: 'sms' }
+        before { post :create, params: { code: '999', otp_delivery_preference: 'sms' } }
 
         it 'does not increment second_factor_attempts_count' do
           expect(subject.current_user.reload.second_factor_attempts_count).to eq 0

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -30,7 +30,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
       end
 
       it 'redirects to the profile' do
-        post :create, payload
+        post :create, params: payload
 
         expect(response).to redirect_to account_path
       end
@@ -38,7 +38,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
       it 'calls handle_valid_otp' do
         expect(subject).to receive(:handle_valid_otp).and_call_original
 
-        post :create, payload
+        post :create, params: payload
       end
 
       it 'tracks the valid authentication event' do
@@ -48,7 +48,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(@analytics).to receive(:track_event).
           with(Analytics::MULTI_FACTOR_AUTH, analytics_hash)
 
-        post :create, payload
+        post :create, params: payload
       end
     end
 
@@ -68,7 +68,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
       end
 
       it 'renders the show page' do
-        post :create, payload
+        post :create, params: payload
 
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_personal_key')
@@ -90,11 +90,11 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
       it 'calls handle_invalid_otp' do
         expect(subject).to receive(:handle_invalid_otp).and_call_original
 
-        post :create, payload
+        post :create, params: payload
       end
 
       it 're-renders the personal key entry screen' do
-        post :create, payload
+        post :create, params: payload
 
         expect(response).to render_template(:show)
         expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_personal_key')
@@ -113,7 +113,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, properties)
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
-        post :create, payload
+        post :create, params: payload
       end
     end
   end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -13,7 +13,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(subject.current_user).to receive(:authenticate_totp).and_return(true)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
 
-        post :create, code: generate_totp_code(@secret)
+        post :create, params: { code: generate_totp_code(@secret) }
 
         expect(response).to redirect_to account_path
       end
@@ -24,7 +24,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
           attributes: { second_factor_attempts_count: 1 }
         ).call
 
-        post :create, code: generate_totp_code(@secret)
+        post :create, params: { code: generate_totp_code(@secret) }
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
       end
@@ -38,7 +38,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         }
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, attributes)
 
-        post :create, code: generate_totp_code(@secret)
+        post :create, params: { code: generate_totp_code(@secret) }
       end
     end
 
@@ -47,7 +47,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         sign_in_before_2fa
         @secret = subject.current_user.generate_totp_secret
         subject.current_user.otp_secret_key = @secret
-        post :create, code: 'abc'
+        post :create, params: { code: 'abc' }
       end
 
       it 'increments second_factor_attempts_count' do
@@ -81,7 +81,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, attributes)
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
 
-        post :create, code: '12345'
+        post :create, params: { code: '12345' }
       end
     end
 
@@ -101,7 +101,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
 
       describe 'when user submits an invalid TOTP' do
         before do
-          post :create, code: '12345'
+          post :create, params: { code: '12345' }
         end
 
         it 'resets attempts count' do
@@ -115,7 +115,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
 
       describe 'when user submits a valid TOTP' do
         before do
-          post :create, code: generate_totp_code(@secret)
+          post :create, params: { code: generate_totp_code(@secret) }
         end
 
         it 'resets attempts count' do
@@ -131,7 +131,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
     context 'when the user does not have an authenticator app enabled' do
       it 'redirects to user_two_factor_authentication_path' do
         stub_sign_in_before_2fa
-        post :create, code: '123456'
+        post :create, params: { code: '123456' }
 
         expect(response).to redirect_to user_two_factor_authentication_path
       end

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -23,7 +23,7 @@ describe Users::EmailsController do
           email_changed: true,
         }
 
-        put :update, update_user_email_form: { email: new_email }
+        put :update, params: { update_user_email_form: { email: new_email } }
 
         expect(response).to redirect_to account_url
         expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
@@ -48,7 +48,7 @@ describe Users::EmailsController do
           email_changed: false,
         }
 
-        put :update, update_user_email_form: { email: '' }
+        put :update, params: { update_user_email_form: { email: '' } }
 
         expect(user.reload.email).to be_present
         expect(@analytics).to have_received(:track_event).
@@ -70,7 +70,7 @@ describe Users::EmailsController do
           email_changed: true,
         }
 
-        put :update, update_user_email_form: { email: second_user.email.upcase }
+        put :update, params: { update_user_email_form: { email: second_user.email.upcase } }
 
         expect(response).to redirect_to account_url
         expect(flash[:notice]).to eq t('devise.registrations.email_update_needs_confirmation')
@@ -95,7 +95,7 @@ describe Users::EmailsController do
           email_changed: false,
         }
 
-        put :update, update_user_email_form: { email: invalid_email }
+        put :update, params: { update_user_email_form: { email: invalid_email } }
 
         expect(user.reload.email).not_to eq invalid_email
         expect(@analytics).to have_received(:track_event).
@@ -117,7 +117,7 @@ describe Users::EmailsController do
           email_changed: false,
         }
 
-        put :update, update_user_email_form: { email: user.email }
+        put :update, params: { update_user_email_form: { email: user.email } }
 
         expect(response).to redirect_to account_url
         expect(flash.keys).to be_empty

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -12,7 +12,7 @@ describe Users::PasswordsController do
         allow(@analytics).to receive(:track_event)
 
         params = { password: 'salty new password' }
-        patch :update, update_user_password_form: params
+        patch :update, params: { update_user_password_form: params }
 
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PASSWORD_CHANGED, success: true, errors: {})
@@ -34,7 +34,7 @@ describe Users::PasswordsController do
         allow(updater).to receive(:personal_key).and_return(personal_key)
 
         params = { password: password }
-        patch :update, update_user_password_form: params
+        patch :update, params: { update_user_password_form: params }
 
         expect(flash[:personal_key]).to eq personal_key
         expect(updater).to have_received(:call)
@@ -50,7 +50,7 @@ describe Users::PasswordsController do
         allow(@analytics).to receive(:track_event)
 
         params = { password: 'new' }
-        patch :update, update_user_password_form: params
+        patch :update, params: { update_user_password_form: params }
 
         errors = {
           password: [

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -28,7 +28,7 @@ describe Users::PersonalKeysController do
       it 'populates the flash when resending code' do
         expect(flash[:sucess]).to be_nil
 
-        get :show, resend: true
+        get :show, params: { resend: true }
         expect(flash.now[:success]).to eq t('notices.send_code.personal_key')
       end
     end

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -16,9 +16,11 @@ describe Users::PhonesController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, user_phone_form: { phone: new_phone,
-                                        international_code: 'US',
-                                        otp_delivery_preference: 'sms' }
+        put :update, params: {
+          user_phone_form: { phone: new_phone,
+                             international_code: 'US',
+                             otp_delivery_preference: 'sms' },
+        }
       end
 
       it 'lets user know they need to confirm their new phone' do
@@ -39,9 +41,11 @@ describe Users::PhonesController do
       it 'does not delete the phone' do
         stub_sign_in(user)
 
-        put :update, user_phone_form: { phone: '',
-                                        international_code: 'US',
-                                        otp_delivery_preference: 'sms' }
+        put :update, params: {
+          user_phone_form: { phone: '',
+                             international_code: 'US',
+                             otp_delivery_preference: 'sms' },
+        }
 
         expect(user.reload.phone).to be_present
         expect(response).to render_template(:edit)
@@ -55,9 +59,11 @@ describe Users::PhonesController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :update, user_phone_form: { phone: second_user.phone,
-                                        international_code: 'US',
-                                        otp_delivery_preference: 'sms' }
+        put :update, params: {
+          user_phone_form: { phone: second_user.phone,
+                             international_code: 'US',
+                             otp_delivery_preference: 'sms' },
+        }
       end
 
       it 'processes successfully and informs user' do
@@ -80,9 +86,11 @@ describe Users::PhonesController do
         user = build(:user, phone: '123-123-1234')
         stub_sign_in(user)
 
-        put :update, user_phone_form: { phone: invalid_phone,
-                                        international_code: 'US',
-                                        otp_delivery_preference: 'sms' }
+        put :update, params: {
+          user_phone_form: { phone: invalid_phone,
+                             international_code: 'US',
+                             otp_delivery_preference: 'sms' },
+        }
 
         expect(user.phone).not_to eq invalid_phone
         expect(response).to render_template(:edit)
@@ -93,9 +101,11 @@ describe Users::PhonesController do
       it 'redirects to profile page without any messages' do
         stub_sign_in(user)
 
-        put :update, user_phone_form: { phone: user.phone,
-                                        international_code: 'US',
-                                        otp_delivery_preference: 'sms' }
+        put :update, params: {
+          user_phone_form: { phone: user.phone,
+                             international_code: 'US',
+                             otp_delivery_preference: 'sms' },
+        }
 
         expect(response).to redirect_to account_url
         expect(flash.keys).to be_empty

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -7,7 +7,7 @@ describe Users::ResetPasswordsController, devise: true do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        get :edit, reset_password_token: 'foo'
+        get :edit, params: { reset_password_token: 'foo' }
 
         analytics_hash = {
           success: false,
@@ -32,7 +32,7 @@ describe Users::ResetPasswordsController, devise: true do
         allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
 
-        get :edit, reset_password_token: 'foo'
+        get :edit, params: { reset_password_token: 'foo' }
 
         analytics_hash = {
           success: false,
@@ -56,7 +56,7 @@ describe Users::ResetPasswordsController, devise: true do
         allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
-        get :edit, reset_password_token: 'foo'
+        get :edit, params: { reset_password_token: 'foo' }
 
         expect(response).to render_template :edit
         expect(flash.keys).to be_empty
@@ -81,7 +81,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         params = { password: 'short', reset_password_token: raw_reset_token }
 
-        put :update, reset_password_form: params
+        put :update, params: { reset_password_form: params }
 
         analytics_hash = {
           success: false,
@@ -155,7 +155,7 @@ describe Users::ResetPasswordsController, devise: true do
           password = 'a really long passw0rd'
           params = { password: password, reset_password_token: raw_reset_token }
 
-          put :update, reset_password_form: params
+          put :update, params: { reset_password_form: params }
 
           analytics_hash = {
             success: true,
@@ -194,7 +194,7 @@ describe Users::ResetPasswordsController, devise: true do
         password = 'a really long passw0rd'
         params = { password: password, reset_password_token: raw_reset_token }
 
-        put :update, reset_password_form: params
+        put :update, params: { reset_password_form: params }
 
         analytics_hash = {
           success: true,
@@ -233,7 +233,7 @@ describe Users::ResetPasswordsController, devise: true do
         password = 'a really long passw0rd'
         params = { password: password, reset_password_token: raw_reset_token }
 
-        put :update, reset_password_form: params
+        put :update, params: { reset_password_form: params }
 
         analytics_hash = {
           success: true,
@@ -270,8 +270,11 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: 'nonexistent@example.com' } }.
-          to_not(change { ActionMailer::Base.deliveries.count })
+        expect do
+          put :create, params: {
+            password_reset_email_form: { email: 'nonexistent@example.com' },
+          }
+        end.to_not(change { ActionMailer::Base.deliveries.count })
 
         expect(response).to redirect_to forgot_password_path
       end
@@ -295,7 +298,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: tech_user.email } }.
+        expect { put :create, params: { password_reset_email_form: { email: tech_user.email } } }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
         expect(response).to redirect_to forgot_password_path
@@ -320,7 +323,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: admin.email } }.
+        expect { put :create, params: { password_reset_email_form: { email: admin.email } } }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
         expect(response).to redirect_to forgot_password_path
@@ -344,8 +347,9 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: 'Test@example.com' } }.
-          to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect do
+          put :create, params: { password_reset_email_form: { email: 'Test@example.com' } }
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(response).to redirect_to forgot_password_path
       end
@@ -368,7 +372,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: user.email } }.
+        expect { put :create, params: { password_reset_email_form: { email: user.email } } }.
           to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(ActionMailer::Base.deliveries.last.subject).
@@ -393,7 +397,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_EMAIL, analytics_hash)
 
-        expect { put :create, password_reset_email_form: { email: 'foo' } }.
+        expect { put :create, params: { password_reset_email_form: { email: 'foo' } } }.
           to change { ActionMailer::Base.deliveries.count }.by(0)
 
         expect(response).to render_template :new

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -145,7 +145,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
-      post :create, user: { email: user.email.upcase, password: user.password }
+      post :create, params: { user: { email: user.email.upcase, password: user.password } }
     end
 
     it 'tracks the unsuccessful authentication for existing user' do
@@ -161,7 +161,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
-      post :create, user: { email: user.email.upcase, password: 'invalid_password' }
+      post :create, params: { user: { email: user.email.upcase, password: 'invalid_password' } }
     end
 
     it 'tracks the authentication attempt for nonexistent user' do
@@ -175,7 +175,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
-      post :create, user: { email: 'foo@example.com', password: 'password' }
+      post :create, params: { user: { email: 'foo@example.com', password: 'password' } }
     end
 
     it 'tracks unsuccessful authentication for locked out user' do
@@ -195,7 +195,7 @@ describe Users::SessionsController, devise: true do
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
-      post :create, user: { email: user.email.upcase, password: user.password }
+      post :create, params: { user: { email: user.email.upcase, password: user.password } }
     end
 
     context 'LOA1 user' do
@@ -209,7 +209,7 @@ describe Users::SessionsController, devise: true do
         expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
         expect(EncryptedAttribute).to receive(:new_user_access_key).exactly(:once).and_call_original
 
-        post :create, user: { email: user.email.upcase, password: user.password }
+        post :create, params: { user: { email: user.email.upcase, password: user.password } }
       end
     end
 
@@ -228,7 +228,7 @@ describe Users::SessionsController, devise: true do
         expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
         expect(EncryptedAttribute).to receive(:new_user_access_key).exactly(:once).and_call_original
 
-        post :create, user: { email: user.email.upcase, password: user.password }
+        post :create, params: { user: { email: user.email.upcase, password: user.password } }
       end
 
       it 'caches unverified PII pending confirmation' do
@@ -239,7 +239,7 @@ describe Users::SessionsController, devise: true do
           user: user, pii: { ssn: '1234' }
         )
 
-        post :create, user: { email: user.email.upcase, password: user.password }
+        post :create, params: { user: { email: user.email.upcase, password: user.password } }
 
         expect(controller.user_session[:decrypted_pii]).to match '1234'
       end
@@ -248,7 +248,7 @@ describe Users::SessionsController, devise: true do
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
 
-        post :create, user: { email: user.email.upcase, password: user.password }
+        post :create, params: { user: { email: user.email.upcase, password: user.password } }
 
         expect(controller.user_session[:decrypted_pii]).to match '1234'
       end
@@ -275,7 +275,7 @@ describe Users::SessionsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PROFILE_ENCRYPTION_INVALID, profile_encryption_error)
 
-        post :create, user: { email: user.email, password: user.password }
+        post :create, params: { user: { email: user.email, password: user.password } }
 
         expect(controller.user_session[:decrypted_pii]).to be_nil
         expect(profile.reload).to_not be_active

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -53,7 +53,7 @@ describe Users::TotpSetupController, devise: true do
         allow(@analytics).to receive(:track_event)
 
         get :new
-        patch :confirm, code: 123
+        patch :confirm, params: { code: 123 }
       end
 
       it 'redirects with an error message' do
@@ -86,7 +86,7 @@ describe Users::TotpSetupController, devise: true do
         allow(form).to receive(:submit).and_return(response)
 
         get :new
-        patch :confirm, code: code
+        patch :confirm, params: { code: code }
       end
 
       it 'redirects to account_path with a success message' do

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -27,10 +27,12 @@ describe Users::TwoFactorAuthenticationSetupController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result)
 
-      patch :set, user_phone_form: {
-        phone: '703-555-010',
-        otp_delivery_preference: :sms,
-        international_code: 'US',
+      patch :set, params: {
+        user_phone_form: {
+          phone: '703-555-010',
+          otp_delivery_preference: :sms,
+          international_code: 'US',
+        },
       }
 
       expect(response).to render_template(:index)
@@ -52,9 +54,11 @@ describe Users::TwoFactorAuthenticationSetupController do
 
         patch(
           :set,
-          user_phone_form: { phone: '703-555-0100',
-                             otp_delivery_preference: 'voice',
-                             international_code: 'US' }
+          params: {
+            user_phone_form: { phone: '703-555-0100',
+                               otp_delivery_preference: 'voice',
+                               international_code: 'US' },
+          }
         )
 
         expect(response).to redirect_to(
@@ -84,9 +88,11 @@ describe Users::TwoFactorAuthenticationSetupController do
 
         patch(
           :set,
-          user_phone_form: { phone: '703-555-0100',
-                             otp_delivery_preference: :sms,
-                             international_code: 'US' }
+          params: {
+            user_phone_form: { phone: '703-555-0100',
+                               otp_delivery_preference: :sms,
+                               international_code: 'US' },
+          }
         )
 
         expect(response).to redirect_to(
@@ -115,9 +121,11 @@ describe Users::TwoFactorAuthenticationSetupController do
 
         patch(
           :set,
-          user_phone_form: { phone: '703-555-0100',
-                             otp_delivery_preference: :sms,
-                             international_code: 'US' }
+          params: {
+            user_phone_form: { phone: '703-555-0100',
+                               otp_delivery_preference: :sms,
+                               international_code: 'US' },
+          }
         )
 
         expect(response).to redirect_to(

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -47,8 +47,10 @@ RSpec.describe Users::VerifyAccountController do
     subject(:action) do
       post(
         :create,
-        verify_account_form: {
-          otp: submitted_otp,
+        params: {
+          verify_account_form: {
+            otp: submitted_otp,
+          },
         }
       )
     end

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -66,7 +66,7 @@ describe Users::VerifyPasswordController do
         context 'with valid password' do
           before do
             allow(form).to receive(:submit).and_return(response_ok)
-            put :update, user: { password: user.password }
+            put :update, params: { user: { password: user.password } }
           end
 
           it 'redirects to the account page' do
@@ -82,7 +82,7 @@ describe Users::VerifyPasswordController do
           it 'renders the new template' do
             allow(form).to receive(:submit).and_return(response_bad)
 
-            put :update, user: { password: user.password }
+            put :update, params: { user: { password: user.password } }
 
             expect(response).to render_template(:new)
           end

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -55,13 +55,13 @@ describe Users::VerifyPersonalKeyController do
       end
 
       it 'redirects to the next step of the account recovery flow' do
-        post :create, personal_key: personal_key
+        post :create, params: { personal_key: personal_key }
 
         expect(response).to redirect_to(verify_password_url)
       end
 
       it 'stores that the personal key was entered in the user session' do
-        post :create, personal_key: personal_key
+        post :create, params: { personal_key: personal_key }
 
         expect(subject.reactivate_account_session.personal_key?).to eq(true)
       end
@@ -75,7 +75,7 @@ describe Users::VerifyPersonalKeyController do
           with(user: subject.current_user, personal_key: bad_key).
           and_return(form)
         allow(form).to receive(:submit).and_return(response_bad)
-        post :create, personal_key: bad_key
+        post :create, params: { personal_key: bad_key }
       end
 
       it 'sets an error in the flash' do

--- a/spec/controllers/verify/finance_controller_spec.rb
+++ b/spec/controllers/verify/finance_controller_spec.rb
@@ -41,7 +41,7 @@ describe Verify::FinanceController do
     context 'when form is invalid' do
       context 'when finance_account is missing' do
         it 'renders #new' do
-          put :create, idv_finance_form: { foo: 'bar' }
+          put :create, params: { idv_finance_form: { foo: 'bar' } }
 
           expect(response).to render_template :new
           expect(flash[:warning]).to be_nil
@@ -51,7 +51,7 @@ describe Verify::FinanceController do
 
       context 'when finance_type is invalid' do
         it 'renders #new with error' do
-          put :create, idv_finance_form: { finance_type: 'foo', finance_account: '123' }
+          put :create, params: { idv_finance_form: { finance_type: 'foo', finance_account: '123' } }
 
           expect(response).to render_template :new
           expect(flash[:warning]).to be_nil
@@ -61,7 +61,7 @@ describe Verify::FinanceController do
 
       context 'when finance_type is ccn' do
         it 'renders verify/finance/new with error' do
-          put :create, idv_finance_form: { finance_type: 'ccn', finance_account: 'abc' }
+          put :create, params: { idv_finance_form: { finance_type: 'ccn', finance_account: 'abc' } }
 
           expect(response).to render_template :new
           expect(flash[:warning]).to be_nil
@@ -72,7 +72,9 @@ describe Verify::FinanceController do
       %w[mortgage auto_loan home_equity_line].each do |finance_type|
         context "when finance_type is #{finance_type}" do
           it 'renders verify/finance_other/new with error' do
-            put :create, idv_finance_form: { finance_type: finance_type, finance_account: 'abc' }
+            put :create, params: {
+              idv_finance_form: { finance_type: finance_type, finance_account: 'abc' },
+            }
 
             expect(response).to render_template :new
             expect(flash[:warning]).to be_nil
@@ -87,7 +89,7 @@ describe Verify::FinanceController do
 
         allow(Idv::FinancialsValidator).to receive(:new)
 
-        put :create, idv_finance_form: { finance_type: :ccn, ccn: '123' }
+        put :create, params: { idv_finance_form: { finance_type: :ccn, ccn: '123' } }
 
         result = {
           success: false,
@@ -103,7 +105,7 @@ describe Verify::FinanceController do
 
     context 'when form is valid' do
       it 'redirects to the show page' do
-        put :create, idv_finance_form: { finance_type: :ccn, ccn: '12345678' }
+        put :create, params: { idv_finance_form: { finance_type: :ccn, ccn: '12345678' } }
 
         expect(response).to redirect_to(verify_finance_result_path)
       end
@@ -112,7 +114,7 @@ describe Verify::FinanceController do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
-        put :create, idv_finance_form: { finance_type: :ccn, ccn: '12345678' }
+        put :create, params: { idv_finance_form: { finance_type: :ccn, ccn: '12345678' } }
 
         result = {
           success: true,

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -70,7 +70,7 @@ describe Verify::PhoneController do
       end
 
       it 'renders #new' do
-        put :create, idv_phone_form: { phone: '703', international_code: 'US' }
+        put :create, params: { idv_phone_form: { phone: '703', international_code: 'US' } }
 
         expect(flash[:warning]).to be_nil
         expect(subject.idv_session.params).to be_empty
@@ -79,7 +79,7 @@ describe Verify::PhoneController do
       it 'tracks form error and does not make a vendor API call' do
         expect(Idv::PhoneValidator).to_not receive(:new)
 
-        put :create, idv_phone_form: { phone: '703' }
+        put :create, params: { idv_phone_form: { phone: '703' } }
 
         result = {
           success: false,
@@ -105,7 +105,7 @@ describe Verify::PhoneController do
         user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
         stub_verify_steps_one_and_two(user)
 
-        put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
+        put :create, params: { idv_phone_form: { phone: good_phone, international_code: 'US' } }
 
         result = { success: true, errors: {} }
 
@@ -119,7 +119,7 @@ describe Verify::PhoneController do
           user = build(:user, phone: good_phone, phone_confirmed_at: Time.zone.now)
           stub_verify_steps_one_and_two(user)
 
-          put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
+          put :create, params: { idv_phone_form: { phone: good_phone, international_code: 'US' } }
 
           expect(response).to redirect_to verify_phone_result_path
 
@@ -136,7 +136,7 @@ describe Verify::PhoneController do
           user = build(:user, phone: '+1 (415) 555-0130', phone_confirmed_at: Time.zone.now)
           stub_verify_steps_one_and_two(user)
 
-          put :create, idv_phone_form: { phone: good_phone, international_code: 'US' }
+          put :create, params: { idv_phone_form: { phone: good_phone, international_code: 'US' } }
 
           expect(response).to redirect_to verify_phone_result_path
 
@@ -275,7 +275,7 @@ describe Verify::PhoneController do
           vendor_params: normalized_phone
         ).and_call_original
 
-        put :create, idv_phone_form: { phone: good_phone }
+        put :create, params: { idv_phone_form: { phone: good_phone } }
       end
     end
   end

--- a/spec/controllers/verify/review_controller_spec.rb
+++ b/spec/controllers/verify/review_controller_spec.rb
@@ -61,7 +61,7 @@ describe Verify::ReviewController do
       before_action :confirm_idv_steps_complete
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -105,7 +105,7 @@ describe Verify::ReviewController do
       before_action :confirm_idv_phone_confirmed
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -163,7 +163,7 @@ describe Verify::ReviewController do
       before_action :confirm_current_password
 
       def show
-        render text: 'Hello'
+        render plain: 'Hello'
       end
     end
 
@@ -180,7 +180,7 @@ describe Verify::ReviewController do
 
     context 'user does not provide password' do
       it 'redirects to new' do
-        post :show, user: { password: '' }
+        post :show, params: { user: { password: '' } }
 
         expect(flash[:error]).to eq t('idv.errors.incorrect_password')
         expect(response).to redirect_to verify_review_path
@@ -189,7 +189,7 @@ describe Verify::ReviewController do
 
     context 'user provides wrong password' do
       it 'redirects to new' do
-        post :show, user: { password: 'wrong' }
+        post :show, params: { user: { password: 'wrong' } }
 
         expect(flash[:error]).to eq t('idv.errors.incorrect_password')
         expect(response).to redirect_to verify_review_path
@@ -198,7 +198,7 @@ describe Verify::ReviewController do
 
     context 'user provides correct password' do
       it 'allows request to proceed' do
-        post :show, user: { password: ControllerHelper::VALID_PASSWORD }
+        post :show, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(response.body).to eq 'Hello'
       end
@@ -293,7 +293,7 @@ describe Verify::ReviewController do
       end
 
       it 'redirects to original path' do
-        put :create, user: { password: 'wrong' }
+        put :create, params: { user: { password: 'wrong' } }
 
         expect(response).to redirect_to verify_review_path
       end
@@ -308,14 +308,14 @@ describe Verify::ReviewController do
       end
 
       it 'redirects to confirmation path' do
-        put :create, user: { password: ControllerHelper::VALID_PASSWORD }
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         expect(@analytics).to have_received(:track_event).with(Analytics::IDV_REVIEW_COMPLETE)
         expect(response).to redirect_to verify_confirmations_path
       end
 
       it 'creates Profile with applicant and normalized_applicant attributes' do
-        put :create, user: { password: ControllerHelper::VALID_PASSWORD }
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         profile = idv_session.profile
         uak = user.unlock_user_access_key(ControllerHelper::VALID_PASSWORD)

--- a/spec/controllers/verify/sessions_controller_spec.rb
+++ b/spec/controllers/verify/sessions_controller_spec.rb
@@ -93,7 +93,7 @@ describe Verify::SessionsController do
 
       context 'UUID' do
         it 'assigned user UUID to applicant' do
-          post :create, profile: user_attrs
+          post :create, params: { profile: user_attrs }
 
           expect(subject.idv_session.applicant['uuid']).to eq subject.current_user.uuid
         end
@@ -111,7 +111,7 @@ describe Verify::SessionsController do
           expect(@analytics).to receive(:track_event).
             with(Analytics::IDV_BASIC_INFO_SUBMITTED_FORM, result)
 
-          post :create, profile: user_attrs.merge(ssn: '666-66-1234')
+          post :create, params: { profile: user_attrs.merge(ssn: '666-66-1234') }
 
           expect(response).to redirect_to(verify_session_dupe_path)
           expect(flash[:error]).to match t('idv.errors.duplicate_ssn')
@@ -120,7 +120,7 @@ describe Verify::SessionsController do
 
       context 'empty SSN' do
         it 'renders the form' do
-          post :create, profile: user_attrs.merge(ssn: '')
+          post :create, params: { profile: user_attrs.merge(ssn: '') }
 
           expect(response).to_not redirect_to(verify_session_dupe_path)
           expect(response).to render_template(:new)
@@ -133,14 +133,14 @@ describe Verify::SessionsController do
         end
 
         it 'checks for required fields' do
-          post :create, profile: partial_attrs
+          post :create, params: { profile: partial_attrs }
 
           expect(response).to render_template(:new)
           expect(flash[:warning]).to be_nil
         end
 
         it 'does not increment attempts count' do
-          expect { post :create, profile: partial_attrs }.
+          expect { post :create, params: { profile: partial_attrs } }.
             to_not change(user, :idv_attempts)
         end
       end

--- a/spec/requests/constrained_route_spec.rb
+++ b/spec/requests/constrained_route_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe 'routes that require admin + 2FA' do
   def sign_in_user(user)
-    post_via_redirect(
+    post(
       new_user_session_path,
-      'user[email]' => user.email,
-      'user[password]' => user.password
+      params: { user: { email: user.email, password: user.password } }
     )
-    get_via_redirect otp_send_path(otp_delivery_selection_form: { otp_delivery_preference: 'sms' })
-    post_via_redirect(
-      login_two_factor_path(otp_delivery_preference: 'sms'),
-      'code' => user.reload.direct_otp
+    get otp_send_path, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
+    follow_redirect!
+    post(
+      login_two_factor_path,
+      params: { otp_delivery_preference: 'sms', code: user.reload.direct_otp }
     )
   end
 
@@ -31,10 +31,9 @@ describe 'routes that require admin + 2FA' do
       it 'prompts admin to 2FA' do
         user = create(:user, :signed_up, :admin)
 
-        post_via_redirect(
+        post(
           new_user_session_path,
-          'user[email]' => user.email,
-          'user[password]' => user.password
+          params: { user: { email: user.email, password: user.password } }
         )
 
         get endpoint

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   describe 'configuration endpoint' do
     it 'sets CORS headers to allow all origins' do
-      get openid_connect_configuration_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      get openid_connect_configuration_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
       aggregate_failures do
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
@@ -14,7 +14,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'certs endpoint' do
     it 'sets CORS headers to allow all origins' do
-      get api_openid_connect_certs_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
       aggregate_failures do
         expect(response).to be_ok
@@ -26,7 +26,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'token endpoint' do
     it 'responds to POST requests with the right CORS headers' do
-      post api_openid_connect_token_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
       aggregate_failures do
         expect(response).to_not be_not_found
@@ -55,7 +55,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
 
   describe 'userinfo endpoint' do
     it 'sets CORS headers to allow all origins' do
-      get api_openid_connect_userinfo_path, nil, 'HTTP_ORIGIN' => 'https://example.com'
+      get api_openid_connect_userinfo_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
       aggregate_failures do
         expect(response).to_not be_not_found

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -158,7 +158,7 @@ module SamlAuthHelper
 
   def saml_get_auth(settings)
     # GET redirect binding Authn Request
-    get(:auth, SAMLRequest: URI.decode(saml_request(settings)))
+    get :auth, params: { SAMLRequest: URI.decode(saml_request(settings)) }
   end
 
   private


### PR DESCRIPTION
**Why**: To reduce the noise when running tests, and to narrow down
the culprits when performing the upgrade to 5.1. Currently, there
are a few deprecation warnings generated by gems, but it's hard to
know which gem is causing it.

**How**:
- Use the awesome `rails5-spec-converter` gem to automatically update
all controller specs to use the new Rails 5 syntax that requires the
`params` hash.
- Remove `config.active_record.raise_in_transactional_callbacks = true`
which doesn't do anything
- Pass in a class to middleware instead of a string
- Update `config.serve_static_files` to
`config.public_file_server.enabled`
- Update `config.static_cache_control` to
`config.public_file_server.headers`
- Update `skip_before_filter` to `skip_before_action`
- Update `*_via_redirect` methods with regular `get`, `post`, etc.
and add `follow_redirect!` if necessary.
- Replace `render nothing: true` with `head`
- Use `to_h` to convert ActionController::Parameters instead of
`merge!`, which uses `to_hash` which apparently is not safe.
- Use `.where(conditions).destroy_all` instead of
`destroy_all(conditions)`
- Use `render plain` instead of `render text`