### PR TITLE
Explicitly give PEM data to saml_idp gem

### DIFF
--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -4,7 +4,9 @@ SamlIdp.configure do |config|
   protocol = Rails.env.development? ? 'http://' : 'https://'
   api_base = protocol + Figaro.env.domain_name + '/api'
 
-  config.x509_certificate = File.read(Rails.root.join('certs', 'saml.crt'))
+  config.x509_certificate = OpenSSL::X509::Certificate.new(
+    File.read(Rails.root.join('certs', 'saml.crt'))
+  ).to_pem
   config.secret_key = RequestKeyManager.private_key.to_pem
 
   config.algorithm = OpenSSL::Digest::SHA256


### PR DESCRIPTION
**Why**: Some of our certs have comments and leading data,
and the saml_idp gem is not very defensive, so this makes sure
that we expose the right data

(ex in our QA environment, the SAML metadata exposes a bunch of data it should not and causes errors with the QA example SP)