### PR TITLE
Add an error page for bad SAML requests

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -11,7 +11,9 @@ module SamlIdpAuthConcern
   private
 
   def validate_service_provider_and_authn_context
-    @result = SamlRequestValidator.new.call(
+    @saml_request_validator = SamlRequestValidator.new
+
+    @result = @saml_request_validator.call(
       service_provider: current_service_provider,
       authn_context: requested_authn_context
     )
@@ -19,7 +21,7 @@ module SamlIdpAuthConcern
     return if @result.success?
 
     analytics.track_event(Analytics::SAML_AUTH, @result.to_h)
-    head :unauthorized
+    render 'saml_idp/auth/error', status: :bad_request
   end
 
   def store_saml_request

--- a/app/views/saml_idp/auth/error.html.slim
+++ b/app/views/saml_idp/auth/error.html.slim
@@ -1,0 +1,3 @@
+ul
+  - @saml_request_validator.errors.full_messages.each do |message|
+    li = message

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -190,14 +190,15 @@ describe SamlIdpController do
     end
 
     context 'authn_context is invalid' do
-      it 'renders nothing with a 401 error' do
+      it 'renders an error page' do
         stub_analytics
         allow(@analytics).to receive(:track_event)
 
         saml_get_auth(invalid_authn_context_settings)
 
-        expect(response.status).to eq(401)
-        expect(response.body).to be_empty
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.unauthorized_authn_context'))
 
         analytics_hash = {
           success: false,
@@ -236,7 +237,7 @@ describe SamlIdpController do
     end
 
     context 'service provider is invalid' do
-      it 'responds with a 401 Unauthorized error' do
+      it 'responds with an error page' do
         user = create(:user, :signed_up)
 
         stub_analytics
@@ -244,7 +245,9 @@ describe SamlIdpController do
 
         generate_saml_response(user, invalid_service_provider_settings)
 
-        expect(response.status).to eq(401)
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.unauthorized_service_provider'))
 
         analytics_hash = {
           success: false,
@@ -259,7 +262,7 @@ describe SamlIdpController do
     end
 
     context 'both service provider and authn_context are invalid' do
-      it 'responds with a 401 Unauthorized error' do
+      it 'responds with an error page' do
         user = create(:user, :signed_up)
 
         stub_analytics
@@ -267,7 +270,10 @@ describe SamlIdpController do
 
         generate_saml_response(user, invalid_service_provider_and_authn_context_settings)
 
-        expect(response.status).to eq(401)
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.unauthorized_authn_context'))
+        expect(response.body).to include(t('errors.messages.unauthorized_service_provider'))
 
         analytics_hash = {
           success: false,


### PR DESCRIPTION
**Why**: Provide feedback (usually for developers)

--

Currently using the same ugly error page we use for OIDC -- I think that's OK because the intended audience for this page is developers