### PR TITLE
Fix setup script to work with Rails 5 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ fast_test: $(CONFIG)
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 
 run: $(CONFIG)
-	mailcatcher
 	foreman start -p $(PORT)
 
 load_test: $(CONFIG)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,12 @@ more information.
 Once it is up and running, the app will be accessible at
 `http://localhost:3000/` by default.
 
-Email messages will be visible in MailCatcher at `http://localhost:1080/`.
+To view email messages, Mailcatcher must be running. You can check if it's
+running by visiting http://localhost:1080/. To run Mailcatcher:
+
+```
+$ mailcatcher
+```
 
 If you would like to run the application on a different port:
 

--- a/bin/setup
+++ b/bin/setup
@@ -56,9 +56,9 @@ Dir.chdir APP_ROOT do
   run "gem install mailcatcher"
 
   puts "\n== Preparing database =="
-  run "bin/rake db:reset RAILS_ENV=development"
+  run 'bin/rake db:environment:set RAILS_ENV=development db:reset'
   run 'bin/rake dev:prime RAILS_ENV=development'
-  run 'bin/rake db:reset RAILS_ENV=test'
+  run 'bin/rake db:environment:set RAILS_ENV=test db:reset'
 
   puts "\n== Removing old logs and tempfiles =="
   run "rm -f log/*"


### PR DESCRIPTION
**Why**: Rails 5 now requires the DB environment to be set with
`db:environment:set` before running DB-related tasks.

I also removed `mailcatcher` from the Makefile because it stays
running even after `ctrl-c`, and doing another `make run` while
it's running will exit with an error.