### PR TITLE
Remove redundant PII warning

### DIFF
--- a/.reek
+++ b/.reek
@@ -106,7 +106,6 @@ UtilityFunction:
     - WorkerHealthChecker::Middleware#call
     - UserEncryptedAttributeOverrides#create_fingerprint
     - LocaleHelper#locale_url_param
-    - Verify::Base#mock_vendor_partial
     - IdvSession#timed_out_vendor_error
 'app/controllers':
   InstanceVariableAssumption:

--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -11,14 +11,6 @@ module Verify
 
     attr_reader :error, :remaining_attempts, :idv_form
 
-    def mock_vendor_partial
-      if FeatureManagement.no_pii_mode?
-        'verify/sessions/no_pii_warning'
-      else
-        'shared/null'
-      end
-    end
-
     def title
       I18n.t("idv.titles.#{step_name}")
     end

--- a/app/views/verify/finance/new.html.slim
+++ b/app/views/verify/finance/new.html.slim
@@ -1,5 +1,4 @@
 - title @view_model.title
-= render @view_model.mock_vendor_partial
 
 h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -1,5 +1,4 @@
 - title @view_model.title
-= render @view_model.mock_vendor_partial
 
 h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -1,5 +1,4 @@
 - title @view_model.title
-= render @view_model.mock_vendor_partial
 
 h1.h2.my0 = t('idv.titles.session.phone')
 p.mt-tiny.mb2 = t('idv.messages.phone.intro')

--- a/app/views/verify/sessions/_no_pii_warning.html.slim
+++ b/app/views/verify/sessions/_no_pii_warning.html.slim
@@ -1,1 +1,0 @@
-.mt1.mb2.h6.caps.bold.red = t('idv.messages.sessions.no_pii')

--- a/app/views/verify/sessions/new.html.slim
+++ b/app/views/verify/sessions/new.html.slim
@@ -1,5 +1,4 @@
 - title @view_model.title
-= render @view_model.mock_vendor_partial
 
 h1.h3.my0 = @view_model.title
 = simple_form_for(@view_model.idv_form, url: verify_session_path,

--- a/spec/view_models/verify/base_spec.rb
+++ b/spec/view_models/verify/base_spec.rb
@@ -1,28 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Verify::Base do
-  describe '#mock_vendor_partial' do
-    context 'idv vendor is mock' do
-      it 'returns no pii warning partial' do
-        allow(Figaro.env).to receive(:proofing_vendors).and_return('mock')
-
-        partial = Verify::Base.new(remaining_attempts: 1, idv_form: nil).mock_vendor_partial
-
-        expect(partial).to eq 'verify/sessions/no_pii_warning'
-      end
-    end
-
-    context 'idv vendor is not mock' do
-      it 'returns null partial' do
-        allow(Figaro.env).to receive(:proofing_vendors).and_return('other')
-
-        partial = Verify::Base.new(remaining_attempts: 1, idv_form: nil).mock_vendor_partial
-
-        expect(partial).to eq 'shared/null'
-      end
-    end
-  end
-
   describe '#message' do
     let(:timed_out) { false }
     let(:view_model) do


### PR DESCRIPTION
**Why**: We added a banner that displays the "Do not use real personal
information" message across the entire site in dev and in the lower
envs. That made the warnings on the verification forms redundant.