### PR TITLE
Align OTP radio buttons

### DIFF
--- a/app/views/users/shared/_otp_delivery_preference_selection.html.slim
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.slim
@@ -7,7 +7,7 @@
           class: :otp_delivery_preference_sms
         span.indicator
         = t('devise.two_factor_authentication.otp_delivery_preference.sms')
-    label.btn-border.col-12.sm-col-5
+    label.btn-border.col-12.sm-col-5.mb0
       .radio
         = radio_button_tag 'user_phone_form[otp_delivery_preference]', :voice, false,
           class: :otp_delivery_preference_voice

--- a/app/views/verify/otp_delivery_method/new.html.slim
+++ b/app/views/verify/otp_delivery_method/new.html.slim
@@ -12,7 +12,7 @@ p = t('idv.messages.otp_delivery_method.phone_number_html',
         span.indicator
         = t('devise.two_factor_authentication.otp_delivery_preference.sms')
     - if @set_otp_delivery_method_presenter.sms_only?
-      label.btn-border.col-12.sm-col-5.btn-disabled
+      label.btn-border.col-12.sm-col-5.mb0.btn-disabled
         .radio
           = radio_button_tag 'otp_delivery_selection_form[otp_delivery_preference]', :voice, false,
             disabled: true,
@@ -21,7 +21,7 @@ p = t('idv.messages.otp_delivery_method.phone_number_html',
           = t('devise.two_factor_authentication.otp_delivery_preference.voice')
       p.mt2.mb0 = @set_otp_delivery_method_presenter.phone_unsupported_message
     - else
-      label.btn-border.col-12.sm-col-5
+      label.btn-border.col-12.sm-col-5.mb0
         .radio
           = radio_button_tag 'otp_delivery_selection_form[otp_delivery_preference]', :voice, false,
             class: :otp_delivery_preference_voice


### PR DESCRIPTION
These radio buttons were not vertically aligned:
![screen shot 2017-08-15 at 1 28 10 pm](https://user-images.githubusercontent.com/1178494/29327544-82793dc6-81bd-11e7-80ae-4d5992c32ceb.png)

Now they are:
![screen shot 2017-08-15 at 1 26 25 pm](https://user-images.githubusercontent.com/1178494/29327547-87b429c2-81bd-11e7-9025-7a09b204406b.png)
