### PR TITLE
Add validation error when mail OTP is expired

### DIFF
--- a/app/forms/verify_account_form.rb
+++ b/app/forms/verify_account_form.rb
@@ -3,6 +3,7 @@ class VerifyAccountForm
 
   validates :otp, presence: true
   validate :validate_otp
+  validate :validate_otp_not_expired
   validate :validate_pending_profile
 
   attr_accessor :otp, :pii_attributes
@@ -28,6 +29,12 @@ class VerifyAccountForm
 
   def pending_profile
     @_pending_profile ||= user.decorate.pending_profile
+  end
+
+  def validate_otp_not_expired
+    return unless Idv::UspsMail.new(user).most_recent_otp_expired?
+
+    errors.add :otp, :usps_otp_expired
   end
 
   def validate_pending_profile

--- a/app/services/idv/usps_mail.rb
+++ b/app/services/idv/usps_mail.rb
@@ -2,6 +2,7 @@ module Idv
   class UspsMail
     MAX_MAIL_EVENTS = Figaro.env.max_mail_events.to_i
     MAIL_EVENTS_WINDOW_DAYS = Figaro.env.max_mail_events_window_in_days.to_i
+    USPS_CONFIRMATION_WINDOW_DAYS = Figaro.env.usps_confirmation_max_days.to_i
 
     def initialize(current_user)
       @current_user = current_user
@@ -14,6 +15,12 @@ module Idv
 
     def any_mail_sent?
       user_mail_events.any?
+    end
+
+    def most_recent_otp_expired?
+      return false unless any_mail_sent?
+
+      user_mail_events.first.updated_at < USPS_CONFIRMATION_WINDOW_DAYS.days.ago
     end
 
     private

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -35,5 +35,7 @@ en:
       requires_phone: requires you to enter your phone number.
       unauthorized_authn_context: Unauthorized authentication context
       unauthorized_service_provider: Unauthorized Service Provider
+      usps_otp_expired: Your confirmation code has expired. Please request another
+        letter for a new code.
       weak_password: Your password is not strong enough. %{feedback}
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -33,5 +33,6 @@ es:
       requires_phone: requiere que ingrese su número de teléfono.
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_service_provider: Proveedor de servicio no autorizado
+      usps_otp_expired: NOT TRANSLATED YET
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
     not_authorized: No está autorizado para realizar esta acción.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -36,5 +36,6 @@ fr:
       requires_phone: vous demande d'entrer votre numéro de téléphone.
       unauthorized_authn_context: Contexte d'authentification non autorisé
       unauthorized_service_provider: Fournisseur de service non autorisé
+      usps_otp_expired: NOT TRANSLATED YET
       weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
     not_authorized: Vous n'êtes pas autorisé(e) à effectuer cette action.

--- a/spec/forms/verify_account_form_spec.rb
+++ b/spec/forms/verify_account_form_spec.rb
@@ -59,6 +59,19 @@ describe VerifyAccountForm do
         expect(subject.errors[:otp]).to eq [t('errors.messages.confirmation_code_incorrect')]
       end
     end
+
+    context 'when OTP is expired' do
+      before do
+        usps_mail = double(Idv::UspsMail)
+        allow(usps_mail).to receive(:most_recent_otp_expired?).and_return(true)
+        allow(Idv::UspsMail).to receive(:new).with(user).and_return(usps_mail)
+      end
+
+      it 'is invalid' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:otp]).to eq [t('errors.messages.usps_otp_expired')]
+      end
+    end
   end
 
   describe '#submit' do

--- a/spec/services/idv/usps_mail_spec.rb
+++ b/spec/services/idv/usps_mail_spec.rb
@@ -44,4 +44,30 @@ describe Idv::UspsMail do
       end
     end
   end
+
+  describe '#most_recent_otp_expired?' do
+    context 'when no mail has been sent' do
+      it 'returns false' do
+        expect(subject.most_recent_otp_expired?).to eq false
+      end
+    end
+
+    context 'when the most recent mail was sent less than 10 days ago' do
+      it 'returns false' do
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 5.days.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 12.days.ago)
+
+        expect(subject.most_recent_otp_expired?).to eq false
+      end
+    end
+
+    context 'when the most recent mail was sent more than 10 days ago' do
+      it 'returns true' do
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 11.days.ago)
+        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 12.days.ago)
+
+        expect(subject.most_recent_otp_expired?).to eq true
+      end
+    end
+  end
 end

--- a/spec/support/idv_examples/usps_verification.rb
+++ b/spec/support/idv_examples/usps_verification.rb
@@ -1,21 +1,17 @@
 shared_examples 'signing in with pending USPS verification' do |sp|
-  it 'prompts for confirmation code at sign in' do
-    otp = 'abc123'
-    profile = create(
+  let(:otp) { 'abc123' }
+  let(:profile) do
+    create(
       :profile,
       deactivation_reason: :verification_pending,
       phone_confirmed: false,
       pii: { otp: otp, ssn: '123-45-6789', dob: '1970-01-01' }
     )
-    user = profile.user
+  end
+  let(:user) { profile.user }
 
-    visit_idp_from_sp_with_loa3(sp)
-
-    if %i[saml oidc].include?(sp)
-      sign_in_via_branded_page(user)
-    else
-      sign_in_live_with_2fa(user)
-    end
+  it 'prompts for confirmation code at sign in' do
+    sign_in_from_sp(sp)
 
     expect(current_path).to eq verify_account_path
     expect(page).to have_content t('idv.messages.usps.resend')
@@ -40,6 +36,33 @@ shared_examples 'signing in with pending USPS verification' do |sp|
       end
     else
       expect(current_path).to eq account_path
+    end
+  end
+
+  it 'renders an error for an expired USPS OTP' do
+    sign_in_from_sp(sp)
+
+    Event.create(event_type: :usps_mail_sent, user: user, updated_at: 11.days.ago)
+
+    fill_in t('forms.verify_profile.name'), with: otp
+    click_button t('forms.verify_profile.submit')
+
+    expect(current_path).to eq verify_account_path
+    expect(page).to have_content t('errors.messages.usps_otp_expired')
+
+    user.reload
+
+    expect(user.events.account_verified.size).to eq 0
+    expect(user.active_profile).to be_nil
+  end
+
+  def sign_in_from_sp(sp)
+    visit_idp_from_sp_with_loa3(sp)
+
+    if %i[saml oidc].include?(sp)
+      sign_in_via_branded_page(user)
+    else
+      sign_in_live_with_2fa(user)
     end
   end
 end


### PR DESCRIPTION
**Why**: So that users can't use an expired mail OTP to verify their
identity.