### PR TITLE
Re-add mailcatcher to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec rackup config.ru --port ${PORT:-3000}
 worker: bundle exec sidekiq --config config/sidekiq.yml
+mailcatcher: mailcatcher -f


### PR DESCRIPTION
**Why**: This allows mailcatcher to be started/stopped alongside the
application. This means that developers won't have to worry about making
sure mailcatcher is running as a daemon while working on the idp.