### PR TITLE
Fix flickering IdV flow spec

### DIFF
--- a/spec/features/idv/flow_spec.rb
+++ b/spec/features/idv/flow_spec.rb
@@ -195,8 +195,8 @@ feature 'IdV session', idv_job: true do
 
       click_link t('forms.two_factor.try_again')
 
-      expect(current_path).to eq(verify_phone_path)
       expect(page.find('#idv_phone_form_phone').value).to eq(phone)
+      expect(current_path).to eq(verify_phone_path)
 
       fill_out_phone_form_ok(different_phone)
       click_idv_continue


### PR DESCRIPTION
**Why**: The spec appeared to have intermittent failures when clicking
the "Try a different phone" link. It looks like the spec was checking
the current path before the page had finished loading. This commit
changes the spec so it looks for the phone input before checking the
current path. The phone input line will wait for the phone input to
appear meaning the page will have to have loaded and the current_path
value will be correct.