### PR TITLE
Complete session in verify review controller

### DIFF
--- a/app/controllers/verify/confirmations_controller.rb
+++ b/app/controllers/verify/confirmations_controller.rb
@@ -42,7 +42,6 @@ module Verify
 
     def finish_idv_session
       @code = personal_key
-      idv_session.complete_session
       idv_session.personal_key = nil
       flash.now[:success] = t('idv.messages.confirm')
       flash[:allow_confirmations_continue] = true

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -77,6 +77,7 @@ module Verify
     def init_profile
       idv_session.cache_applicant_profile_id
       idv_session.cache_encrypted_pii(current_user.user_access_key)
+      idv_session.complete_session
     end
 
     def idv_params

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -65,7 +65,7 @@ module Idv
     end
 
     def profile
-      @_profile ||= Profile.find(profile_id)
+      @_profile ||= Profile.find_by(id: profile_id)
     end
 
     def clear

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -57,47 +57,70 @@ describe Verify::ConfirmationsController do
         :confirm_idv_vendor_session_started
       )
     end
+
+    describe '#confirm_profile_has_been_created' do
+      before do
+        stub_idv_session
+      end
+
+      controller do
+        before_action :confirm_profile_has_been_created
+
+        def index
+          render plain: 'Hello'
+        end
+      end
+
+      context 'profile has been created' do
+        it 'does not redirect' do
+          get :index
+
+          expect(response).to_not be_redirect
+        end
+      end
+
+      context 'profile has not been created' do
+        before do
+          subject.idv_session.profile_id = nil
+        end
+
+        it 'redirects to the account path' do
+          get :index
+
+          expect(response).to redirect_to account_path
+        end
+      end
+    end
   end
 
-  context 'session started' do
+  describe '#show' do
     before do
       stub_idv_session
+    end
+
+    it 'sets code instance variable' do
+      subject.idv_session.cache_applicant_profile_id
+      code = subject.idv_session.personal_key
+
+      get :show
+
+      expect(assigns(:code)).to eq(code)
+    end
+
+    it 'sets flash[:allow_confirmations_continue] to true' do
+      get :show
+
+      expect(flash[:allow_confirmations_continue]).to eq true
+    end
+
+    it 'sets flash.now[:success]' do
+      get :show
+      expect(flash[:success]).to eq t('idv.messages.confirm')
     end
 
     context 'user used 2FA phone as phone of record' do
       before do
         subject.idv_session.params['phone'] = user.phone
-        subject.idv_session.params['phone_confirmed_at'] = Time.zone.now
-        subject.idv_session.vendor_phone_confirmation = true
-        subject.idv_session.user_phone_confirmation = true
-      end
-
-      it 'activates profile' do
-        get :show
-        profile.reload
-
-        expect(profile).to be_active
-        expect(profile.verified_at).to_not be_nil
-      end
-
-      it 'sets code instance variable' do
-        subject.idv_session.cache_applicant_profile_id
-        code = subject.idv_session.personal_key
-
-        get :show
-
-        expect(assigns(:code)).to eq(code)
-      end
-
-      it 'sets flash[:allow_confirmations_continue] to true' do
-        get :show
-
-        expect(flash[:allow_confirmations_continue]).to eq true
-      end
-
-      it 'sets flash.now[:success]' do
-        get :show
-        expect(flash[:success]).to eq t('idv.messages.confirm')
       end
 
       it 'tracks final IdV event' do
@@ -113,46 +136,15 @@ describe Verify::ConfirmationsController do
 
         get :show
       end
-
-      it 'creates an `account_verified` event once per confirmation' do
-        event_creator = instance_double(CreateVerifiedAccountEvent)
-        expect(CreateVerifiedAccountEvent).to receive(:new).and_return(event_creator)
-        expect(event_creator).to receive(:call)
-
-        get :show
-      end
-    end
-
-    context 'user picked USPS confirmation' do
-      before do
-        subject.idv_session.address_verification_mechanism = 'usps'
-      end
-
-      it 'leaves profile deactivated' do
-        expect(UspsConfirmation.count).to eq 0
-
-        get :show
-        profile.reload
-
-        expect(profile).to_not be_active
-        expect(profile.verified_at).to be_nil
-        expect(profile.deactivation_reason).to eq 'verification_pending'
-        expect(UspsConfirmation.count).to eq 1
-      end
-
-      it 'redirects to come back later page' do
-        subject.session[:sp] = { loa3: true }
-        patch :update
-
-        expect(response).to redirect_to verify_come_back_later_path
-      end
     end
 
     context 'user confirmed a new phone' do
-      it 'tracks that event' do
-        stub_analytics
+      before do
         subject.idv_session.params['phone'] = '+1 (202) 555-9876'
-        subject.idv_session.params['phone_confirmed_at'] = Time.zone.now
+      end
+
+      it 'tracks final IdV event' do
+        stub_analytics
 
         result = {
           success: true,
@@ -167,37 +159,43 @@ describe Verify::ConfirmationsController do
     end
   end
 
-  context 'IdV session not yet started' do
-    it 'redirects to /idv/sessions' do
-      stub_sign_in(user)
-
-      get :show
-
-      expect(response).to redirect_to(verify_session_path)
-    end
-  end
-
   describe '#update' do
-    context 'sp present' do
-      it 'redirects to the sign up completed url' do
-        stub_idv_session
-        subject.session[:sp] = 'true'
-        stub_sign_in
+    before do
+      stub_idv_session
+    end
 
+    context 'user selected phone verification' do
+      before do
+        subject.idv_session.address_verification_mechanism = 'phone'
+        subject.idv_session.vendor_phone_confirmation = true
+        subject.idv_session.user_phone_confirmation = true
+        subject.idv_session.complete_session
+      end
+
+      it 'redirects to sign up completed for an sp' do
+        subject.session[:sp] = { loa3: true }
         patch :update
 
         expect(response).to redirect_to sign_up_completed_url
       end
-    end
 
-    context 'no sp present' do
-      it 'redirects to the account page' do
-        stub_idv_session
-        stub_sign_in
-
+      it 'redirects to the account path when no sp present' do
         patch :update
 
         expect(response).to redirect_to account_path
+      end
+    end
+
+    context 'user selected usps verification' do
+      before do
+        subject.idv_session.address_verification_mechanism = 'usps'
+        subject.idv_session.complete_session
+      end
+
+      it 'redirects to come back later path' do
+        patch :update
+
+        expect(response).to redirect_to verify_come_back_later_path
       end
     end
   end


### PR DESCRIPTION
**Why**: We were creating a profile in the verify/review#create method.
That method redirects to verify/confirmations#show which then calls
`#complete_session`. This means that the profile exists in quasi
complete state between these requests. This commit makes a small change
so the profile is created and completed in one step. Additionally, this
commit cleans up the confirmations controller specs.