### PR TITLE
Fix <title> tag double HTML escaping

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,7 +12,10 @@ html lang="#{I18n.locale}" class='no-js'
       meta http-equiv="refresh" content="#{yield(:meta_refresh)}"
 
     title
-      = content_for?(:title) ? APP_NAME + ' - ' + yield(:title) : APP_NAME
+      = APP_NAME
+      - if content_for?(:title)
+        = ' - '
+        = yield(:title)
 
     == stylesheet_link_tag 'application', media: 'all'
     <!--[if IE 8]>

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -57,6 +57,17 @@ describe 'layouts/application.html.slim' do
     end
   end
 
+  context '<title>' do
+    it 'does not double-escape HTML in the title tag' do
+      view.title("Something with 'single quotes'")
+
+      render
+
+      doc = Nokogiri::HTML(rendered)
+      expect(doc.at_css('title').text).to eq("login.gov - Something with 'single quotes'")
+    end
+  end
+
   context 'session expiration' do
     it 'renders a javascript page refresh' do
       allow(view).to receive(:user_fully_authenticated?).and_return(false)


### PR DESCRIPTION
**Why**: To fix rendering in browsers

---

before:

<img width="246" alt="screenshot_8_18_17__11_21_am 2" src="https://user-images.githubusercontent.com/458784/29472766-022fb286-840a-11e7-8786-be53216e7094.png">

after:

<img width="235" alt="screenshot_8_18_17__11_21_am" src="https://user-images.githubusercontent.com/458784/29472770-0656c0ac-840a-11e7-8e2c-84c998e2f4f5.png">

