### PR TITLE
Increase width of USPS confirmation code input

### DIFF
--- a/app/inputs/inline_input.rb
+++ b/app/inputs/inline_input.rb
@@ -3,7 +3,7 @@ class InlineInput < SimpleForm::Inputs::StringInput
     input_html_classes.push('col-10 field monospace')
     template.content_tag(
       :div, builder.text_field(attribute_name, input_html_options),
-      class: 'col col-12 sm-col-4 mb4 sm-mb0'
+      class: 'col col-12 sm-col-5 mb4 sm-mb0'
     )
   end
 


### PR DESCRIPTION
**Why**: So that the input is wide enough to display 10 alpha-numeric
characters