### PR TITLE
Don't create Profile in ProfileMaker#new

### DIFF
--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -1,17 +1,30 @@
 module Idv
   class ProfileMaker
-    attr_reader :pii_attributes, :profile
+    attr_reader :pii_attributes
 
     def initialize(applicant:, user:, normalized_applicant:, vendor:, phone_confirmed:)
-      @profile = Profile.new(user: user, deactivation_reason: :verification_pending)
-      @pii_attributes = pii_from_applicant(applicant, normalized_applicant)
+      self.pii_attributes = pii_from_applicant(applicant, normalized_applicant)
+      self.user = user
+      self.vendor = vendor
+      self.phone_confirmed = phone_confirmed
+    end
+
+    def save_profile
+      profile = Profile.new(
+        deactivation_reason: :verification_pending,
+        phone_confirmed: phone_confirmed,
+        user: user,
+        vendor: vendor
+      )
       profile.encrypt_pii(user.user_access_key, pii_attributes)
-      profile.vendor = vendor
-      profile.phone_confirmed = phone_confirmed
       profile.save!
+      profile
     end
 
     private
+
+    attr_accessor :user, :vendor, :phone_confirmed
+    attr_writer :pii_attributes
 
     # rubocop:disable MethodLength, AbcSize
     # This method is single statement spread across many lines for readability

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -49,7 +49,7 @@ module Idv
     end
 
     def cache_applicant_profile_id
-      profile = profile_maker.profile
+      profile = profile_maker.save_profile
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
       self.personal_key = profile.personal_key

--- a/spec/controllers/verify/confirmations_controller_spec.rb
+++ b/spec/controllers/verify/confirmations_controller_spec.rb
@@ -23,7 +23,7 @@ describe Verify::ConfirmationsController do
       vendor: :mock,
       phone_confirmed: true
     )
-    profile = profile_maker.profile
+    profile = profile_maker.save_profile
     idv_session.pii = profile_maker.pii_attributes
     idv_session.profile_id = profile.id
     idv_session.personal_key = profile.personal_key

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Idv::ProfileMaker do
-  describe '#new' do
+  describe '#save_profile' do
     it 'creates Profile with encrypted PII' do
       applicant = Proofer::Applicant.new first_name: 'Some', last_name: 'One'
       normalized_applicant = Proofer::Applicant.new first_name: 'Somebody', last_name: 'Oneatatime'
@@ -16,7 +16,7 @@ describe Idv::ProfileMaker do
         phone_confirmed: false
       )
 
-      profile = profile_maker.profile
+      profile = profile_maker.save_profile
       pii = profile_maker.pii_attributes
 
       expect(profile).to be_a Profile


### PR DESCRIPTION
**Why**: So that a database write does not happen as the side-effect of a service class's initializer.

This is something that has confused me several times while reading the code. I think this helps make things a bit more clear regarding when the profile record is actually created.

I'm also considering a change to make `ProfileMaker#make_profile` into `MakeProfile#call`.