### PR TITLE
Retain language preference when cancelling sign up

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,5 +1,6 @@
 class ServiceProviderSessionDecorator
   include Rails.application.routes.url_helpers
+  include LocaleHelper
 
   DEFAULT_LOGO = 'generic.svg'.freeze
 

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -1,5 +1,6 @@
 class SessionDecorator
   include Rails.application.routes.url_helpers
+  include LocaleHelper
 
   def return_to_service_provider_partial
     'shared/null'
@@ -38,6 +39,6 @@ class SessionDecorator
   def requested_attributes; end
 
   def cancel_link_path
-    root_path
+    root_path(locale: locale_url_param)
   end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -19,7 +19,7 @@ feature 'Sign Up' do
     end
 
     it 'redirects user to the home page' do
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq root_path
     end
   end
 
@@ -35,6 +35,14 @@ feature 'Sign Up' do
       click_on t('links.cancel_account_creation')
 
       expect(current_path).to eq root_path
+    end
+  end
+
+  context 'user cancels with language preference set' do
+    it 'redirects user to the translated home page' do
+      visit sign_up_email_path(locale: 'es')
+      click_on t('links.cancel')
+      expect(current_path).to eq '/es'
     end
   end
 


### PR DESCRIPTION
Explicitly pass along the locale when referencing `root_path` in cancel links. This will prevent the language preference from being lost.