### PR TITLE
Translate HTML5 required input message

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -1,19 +1,35 @@
+import 'classlist.js';
+
 const I18n = window.LoginGov.I18n;
 
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.querySelector('form');
-  if (form) {
-    const fields = ['dob', 'personal-key', 'ssn', 'zipcode'];
+  const forms = document.querySelectorAll('form');
 
-    fields.forEach(function(f) {
-      const input = document.querySelector(`.${f}`);
-      if (input) {
-        input.addEventListener('input', () => {
-          if (input.validity.patternMismatch) {
-            input.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${I18n.key(f)}`));
-          } else {
-            input.setCustomValidity('');
-          }
+  function addListenerMulti(el, events, fn) {
+    events.split(' ').forEach(e => el.addEventListener(e, fn, false));
+  }
+
+  if (forms.length !== 0) {
+    [].forEach.call(forms, function(form) {
+      const inputs = form.querySelectorAll('.field');
+
+      if (inputs.length !== 0) {
+        [].forEach.call(inputs, function(input) {
+          const types = ['dob', 'personal-key', 'ssn', 'zipcode'];
+
+          addListenerMulti(input, 'input invalid', (e) => {
+            e.target.setCustomValidity('');
+
+            if (e.target.validity.valueMissing) {
+              e.target.setCustomValidity(I18n.t('simple_form.required.text'));
+            } else if (e.target.validity.patternMismatch) {
+              types.forEach(function(type) {
+                if (e.target.classList.contains(type)) {
+                  e.target.setCustomValidity(I18n.t(`idv.errors.pattern_mismatch.${I18n.key(type)}`));
+                }
+              });
+            }
+          });
         });
       }
     });

--- a/app/assets/javascripts/misc/i18n-strings.js.erb
+++ b/app/assets/javascripts/misc/i18n-strings.js.erb
@@ -19,6 +19,7 @@ window.LoginGov = window.LoginGov || {};
   'instructions.password.strength.iv',
   'instructions.password.strength.v',
   'links.remove',
+  'simple_form.required.text',
   'valid_email.validations.email.invalid',
   'zxcvbn.feedback.a_word_by_itself_is_easy_to_guess',
   'zxcvbn.feedback.add_another_word_or_two_uncommon_words_are_better',


### PR DESCRIPTION
This provides translated messages for HTML5 form validations. While implementing I noticed some elements of the existing logic was not working working as expected so I did some refactoring to make sure the form validation was being applied to all forms and fields on the page instead of just the first occurrence.

![screen shot 2017-08-23 at 5 06 20 pm](https://user-images.githubusercontent.com/1178494/29638444-4e6d4216-8825-11e7-829d-aa19f5dc07dc.png)

![screen shot 2017-08-23 at 5 05 54 pm](https://user-images.githubusercontent.com/1178494/29638455-53038c54-8825-11e7-8355-a368c67d8120.png)
