### PR TITLE
Adjust spacing of cancel link

### DIFF
--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -11,6 +11,6 @@ p.mt-tiny.mb0#email-description = t('instructions.registration.email')
   p.mb-40p.mt1
     = link_to t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'
 
-  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide mb4'
+  = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide'
 
 = render 'shared/cancel', link: decorated_session.cancel_link_path


### PR DESCRIPTION
Removed extra margin above the cancel link on email address step for consistency with other screens.

![image](https://user-images.githubusercontent.com/1178494/29670450-acc2be56-88b4-11e7-962e-3878d6985d3a.png)
