### PR TITLE
Remove cron dependency for worker health checker

### DIFF
--- a/app/controllers/health/workers_controller.rb
+++ b/app/controllers/health/workers_controller.rb
@@ -1,6 +1,8 @@
 module Health
   class WorkersController < ApplicationController
     def index
+      WorkerHealthChecker.enqueue_dummy_jobs
+
       summary = WorkerHealthChecker.summary
 
       status = summary.all_healthy? ? :ok : :internal_error

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -26,9 +26,6 @@ password_max_attempts: '3'
 # If a queue does not have a healthy job after this many seconds, report it as unhealthy
 queue_health_check_dead_interval_seconds: '240'
 
-# How often to enqueue simple jobs to make sure the background queues are running
-queue_health_check_frequency_seconds: '120'
-
 # The number of words in the personal key phrase
 recovery_code_length: '4'
 

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -22,7 +22,6 @@ Figaro.require_keys(
   'password_pepper',
   'password_strength_enabled',
   'queue_health_check_dead_interval_seconds',
-  'queue_health_check_frequency_seconds',
   'reauthn_window',
   'recovery_code_length',
   'redis_url',

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,13 +9,6 @@ env :PATH, ENV['PATH']
 
 require File.expand_path(File.dirname(__FILE__) + '/environment')
 
-health_check = Whenever.seconds(Figaro.env.queue_health_check_frequency_seconds.to_i, :seconds)
-
-every health_check, roles: [:job_creator] do
-  runner 'WorkerHealthChecker.check'
-  runner 'WorkerHealthChecker.enqueue_dummy_jobs'
-end
-
 if FeatureManagement.enable_usps_verification?
   mail_batch = Whenever.seconds(Figaro.env.usps_mail_batch_hours.to_i, :hours)
 

--- a/spec/controllers/health/workers_controller_spec.rb
+++ b/spec/controllers/health/workers_controller_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Health::WorkersController do
       expect(json['statuses'].first['healthy']).to eq(true)
     end
 
+    it 'enqueues dummy jobs' do
+      expect(WorkerHealthChecker).to receive(:enqueue_dummy_jobs)
+
+      action
+    end
+
     context 'with all healthy statuses' do
       it 'is a 200' do
         action


### PR DESCRIPTION
**Why**: cron (leader host) is not compatible with autoscaling groups