### PR TITLE
Move _tag helpers into the template

### DIFF
--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -1,5 +1,4 @@
 class SignUpCompletionsShow
-  include ActionView::Helpers::AssetTagHelper
   include ActionView::Helpers::TagHelper
 
   def initialize(loa3_requested:, decorated_session:)
@@ -36,10 +35,8 @@ class SignUpCompletionsShow
     )
   end
 
-  def image
-    image_tag(
-      helper.asset_url("user-signup-#{requested_loa}.svg"), width: 97, alt: '', class: 'mb2'
-    )
+  def image_name
+    "user-signup-#{requested_loa}.svg"
   end
 
   def requested_attributes_partial
@@ -60,9 +57,5 @@ class SignUpCompletionsShow
 
   def requested_loa
     loa3_requested ? 'loa3' : 'loa1'
-  end
-
-  def helper
-    ActionController::Base.helpers
   end
 end

--- a/app/views/sign_up/completions/show.html.slim
+++ b/app/views/sign_up/completions/show.html.slim
@@ -3,7 +3,7 @@
 .clearfix
   .col-10.sm-col-8.mx-auto
     .center
-      = @view_model.image
+      = image_tag(asset_url(@view_model.image_name), width: 97, alt: '', class: 'mb2')
     h1.h3.mb3.my0.regular = @view_model.heading
 
     p = t('help_text.requested_attributes.intro_html', app_name: APP_NAME,


### PR DESCRIPTION
**Why**: Error in production due to "request.protocol" being nil,
using the asset_url helper in the view should provide access to the request

--

note: I was not able to reproduce the failure locally, but since this was a green-green-green refactor, hopefully it's not much worse