### PR TITLE
Fix user flows

### DIFF
--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-feature 'SP-initiated authentication with login.gov', user_flow: true do
+feature 'SP-initiated authentication with login.gov', :user_flow do
   include IdvHelper
   include SamlAuthHelper
 
   I18n.available_locales.each do |locale|
     context "with locale=#{locale}" do
       context 'with a valid SP' do
-        context 'when LOA3' do
+        context 'when LOA3', :idv_job do
           before do
             visit "#{loa3_authnrequest}&locale=#{locale}"
           end
@@ -58,7 +58,7 @@ feature 'SP-initiated authentication with login.gov', user_flow: true do
 
                   context 'with a valid phone number' do
                     before do
-                      fill_in 'user_phone_form_phone', with: Faker::PhoneNumber.cell_phone
+                      complete_phone_form_with_valid_phone
                     end
 
                     context 'with SMS delivery' do
@@ -290,7 +290,7 @@ feature 'SP-initiated authentication with login.gov', user_flow: true do
 
                   context 'with a valid phone number' do
                     before do
-                      fill_in 'user_phone_form_phone', with: Faker::PhoneNumber.cell_phone
+                      complete_phone_form_with_valid_phone
                     end
 
                     context 'with SMS delivery' do
@@ -380,5 +380,13 @@ feature 'SP-initiated authentication with login.gov', user_flow: true do
         end
       end
     end
+  end
+
+  def complete_phone_form_with_valid_phone
+    phone = Faker::PhoneNumber.cell_phone
+    until PhonyRails.plausible_number? phone, country_code: :us
+      phone = Faker::PhoneNumber.cell_phone
+    end
+    fill_in 'user_phone_form_phone', with: phone
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,12 @@ RSpec.configure do |config|
       VendorValidatorJob.perform_now(*args)
     end
   end
+
+  config.around(:each, user_flow: true) do |example|
+    Capybara.current_driver = :rack_test
+    example.run
+    Capybara.use_default_driver
+  end
 end
 
 Sidekiq::Testing.inline!


### PR DESCRIPTION
Add idv_job metadata to LOA3 user flow specs

**Why**: Setting `idv_job` to true is necessary for LOA3 specs to
simulate the background jobs running to verify the user's identity.

Use valid phone in phone form during user flows

**Why**: Faker::PhoneNumber does not always produce valid phone numbers,
which leads to flickering specs. This change loops until a valid phone
number is generated

Use rack_test driver for user flow specs

**Why**: The rake_test_desktop driver does not support the
`screenshot_and_save_page` function. Using the rack test driver allows
us to save screenshot and save pages for the user flows.