### PR TITLE
Allow USPS code prefill on PT

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -4,7 +4,7 @@ class FeatureManagement
   ].freeze
 
   ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED = %w[
-    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov
+    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov
   ].freeze
 
   def self.telephony_disabled?


### PR DESCRIPTION
**Why**: To allow the pentesters to complete creating an LOA3 account.
They don't have access to a US mailing address or phone number.