### PR TITLE
Update equifax gem to latest commit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:18F/identity-equifax-api-client-gem.git
-  revision: 889aad815bda2ff2a41cd2b108e2afae7f50d8b8
+  revision: 8021646f4a67216b0a1bdb99e501ad652104f889
   branch: master
   specs:
     equifax (1.0.0)


### PR DESCRIPTION
**Why**: To pick up the latest changes that resolve issues we
discovered while testing in staging.