### PR TITLE
Limit OTP guesses to 3 in all contexts

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -88,7 +88,7 @@ module TwoFactorAuthenticatable
   # You can pass in any "type" with a corresponding I18n key in
   # devise.two_factor_authentication.invalid_#{type}
   def handle_invalid_otp(type: 'otp')
-    update_invalid_user if current_user.two_factor_enabled? && authentication_context?
+    update_invalid_user
 
     flash.now[:error] = t("devise.two_factor_authentication.invalid_#{type}")
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -61,7 +61,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
   end
 
   describe '#create' do
-    context 'when the user enters an invalid OTP' do
+    context 'when the user enters an invalid OTP during authentication context' do
       before do
         sign_in_before_2fa
 
@@ -92,6 +92,17 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
       it 'displays flash error message' do
         expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_otp')
+      end
+    end
+
+    context 'when the user enters an invalid OTP during reauthentication context' do
+      it 'increments second_factor_attempts_count' do
+        sign_in_before_2fa
+        controller.user_session[:context] = 'reauthentication'
+
+        post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
+
+        expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
       end
     end
 
@@ -260,8 +271,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
         context 'user enters an invalid code' do
           before { post :create, params: { code: '999', otp_delivery_preference: 'sms' } }
 
-          it 'does not increment second_factor_attempts_count' do
-            expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
+          it 'increments second_factor_attempts_count' do
+            expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
           end
 
           it 'does not clear session data' do
@@ -419,8 +430,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
       context 'user enters an invalid code' do
         before { post :create, params: { code: '999', otp_delivery_preference: 'sms' } }
 
-        it 'does not increment second_factor_attempts_count' do
-          expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
+        it 'increments second_factor_attempts_count' do
+          expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
         end
 
         it 'does not clear session data' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -33,6 +33,20 @@ feature 'Two Factor Authentication' do
       expect(user.voice?).to eq true
     end
 
+    context 'user enters OTP incorrectly 3 times' do
+      it 'locks the user out' do
+        sign_in_before_2fa
+
+        submit_2fa_setup_form_with_valid_phone_and_choose_phone_call_delivery
+        3.times do
+          fill_in('code', with: 'bad-code')
+          click_button t('forms.buttons.submit.default')
+        end
+
+        expect(page).to have_content t('titles.account_locked')
+      end
+    end
+
     context 'with U.S. phone that does not support phone delivery method' do
       let(:guam_phone) { '671-555-5555' }
 


### PR DESCRIPTION
**Why**: Previously, we allowed unlimited OTP guesses when confirming
a phone number because we didn't think this posed any security risks.
In hindsight this was a poor decision since it can portray our app as
being insecure and affects our reputation and confidence in the system.
We should be defaulting to safe everywhere.

**How**: Remove any conditional logic that determines whether or not
guesses should be limited. Everyone will now be limited to 3 OTP guesses
regardless of context.