### PR TITLE
Don't log headers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,12 @@ module Upaya
       end
     end
 
+    config.lograge.custom_options = lambda do |event|
+      event.payload[:timestamp] = event.time
+      event.payload[:uuid] = SecureRandom.uuid
+      event.payload.except(:params, :headers)
+    end
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,11 +19,6 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: Figaro.env.email_from }
 
   config.lograge.enabled = true
-  config.lograge.custom_options = lambda do |event|
-    event.payload[:timestamp] = event.time
-    event.payload[:uuid] = SecureRandom.uuid
-    event.payload.except(:params)
-  end
   config.lograge.ignore_actions = ['Users::SessionsController#active']
   config.lograge.formatter = Lograge::Formatters::Json.new
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,11 +34,6 @@ Rails.application.configure do
 
   config.log_level = :info
   config.lograge.enabled = true
-  config.lograge.custom_options = lambda do |event|
-    event.payload[:timestamp] = event.time
-    event.payload[:uuid] = SecureRandom.uuid
-    event.payload.except(:params)
-  end
   config.lograge.ignore_actions = ['Users::SessionsController#active']
   config.lograge.formatter = Lograge::Formatters::Json.new
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,6 @@ Rails.application.configure do
 
   config.middleware.use RackSessionAccess::Middleware
   config.lograge.enabled = true
-  config.lograge.custom_options = ->(event) { event.payload }
 
   config.after_initialize do
     Bullet.enable = true


### PR DESCRIPTION
**Why**:
1. They were being serialized incorrectly
2. They could potentially contain sensitive data

----

before (note the `"headers":"#<ActionDispatch::Http::Headers:0x007ff1b05abcd0>"`)

```
{"method":"GET","path":"/api/health/workers.json","format":"json","controller":"Health::WorkersController","action":"index","status":200,"duration":504.3,"headers":"#<ActionDispatch::Http::Headers:0x007ff1b05abcd0>","user_id":"anonymous-uuid","user_agent":"curl/7.54.0","ip":"::1","host":"localhost","timestamp":"2017-08-31 14:43:36 -0400","uuid":"c8f71f70-815f-4d42-bed1-44b18104c9f0"}
```

after

```
{"method":"GET","path":"/api/health/workers.json","format":"json","controller":"Health::WorkersController","action":"index","status":200,"duration":519.54,"user_id":"anonymous-uuid","user_agent":"curl/7.54.0","ip":"::1","host":"localhost","timestamp":"2017-08-31 14:44:27 -0400","uuid":"9b59e2a8-1ec9-464c-b186-49ce4df7b998"}
```