### PR TITLE
Update UI for other financial accounts page

### DIFF
--- a/app/assets/javascripts/app/idv-finance-helper.js
+++ b/app/assets/javascripts/app/idv-finance-helper.js
@@ -27,19 +27,24 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const financeSelect = document.querySelector('.js-finance-choice-select');
+  const financeRadios = document.querySelectorAll('.js-finance-choice-select');
+  const financeChecked = document.querySelector('.js-finance-choice-select:checked');
   const submitButton = document.querySelector('.js-finance-submit');
 
-  if (financeSelect) {
+  if (financeSelect || financeRadios) {
     const inputWrappers = document.querySelectorAll('.js-finance-wrapper');
     hideAll(inputWrappers);
 
-    showInput(financeSelect.value || 'blank');
+    showInput(financeChecked.value || 'blank');
     submitButton.disabled = !financeSelect.value;
 
-    financeSelect.addEventListener('change', () => {
-      removeError();
-      showInput(financeSelect.value || 'blank');
-      submitButton.disabled = !financeSelect.value;
+    Array.prototype.forEach.call(financeRadios, function (radio) {
+      radio.addEventListener('change', () => {
+        console.log(this)
+        // removeError();
+        // showInput(this.value || 'blank');
+        // submitButton.disabled = !financeSelect.value;
+      });
     });
   }
 });

--- a/app/assets/javascripts/app/idv-finance-helper.js
+++ b/app/assets/javascripts/app/idv-finance-helper.js
@@ -26,25 +26,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  const financeSelect = document.querySelector('.js-finance-choice-select');
   const financeRadios = document.querySelectorAll('.js-finance-choice-select');
   const financeChecked = document.querySelector('.js-finance-choice-select:checked');
   const submitButton = document.querySelector('.js-finance-submit');
 
-  if (financeSelect || financeRadios) {
+  if (financeRadios) {
     const inputWrappers = document.querySelectorAll('.js-finance-wrapper');
     hideAll(inputWrappers);
 
-    showInput(financeChecked.value || 'blank');
-    submitButton.disabled = !financeSelect.value;
+    if (financeChecked) {
+      showInput(financeChecked.value || '');
+    }
 
     Array.prototype.forEach.call(financeRadios, function (radio) {
-      radio.addEventListener('change', () => {
-        console.log(this)
-        // removeError();
-        // showInput(this.value || 'blank');
-        // submitButton.disabled = !financeSelect.value;
+      radio.addEventListener('change', (e) => {
+        e = e || window.event;
+        removeError();
+        showInput(e.target.value || '');
+        submitButton.disabled = false;
       });
     });
+
+    submitButton.disabled = true;
   }
 });

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,4 +1,5 @@
 $radio-checkbox-space: 1.5rem;
+$radio-padding: 24px;
 
 @media #{$breakpoint-sm} {
   input,
@@ -83,8 +84,16 @@ input::-webkit-inner-spin-button {
 .checkbox,
 .radio {
   cursor: pointer;
-  padding-left: 24px;
+  padding-left: $radio-padding;
   position: relative;
+}
+
+.radio.radio-with-inputs {
+  padding-left: 0;
+
+  .option {
+    padding-left: $radio-padding;
+  }
 }
 
 .checkbox input,
@@ -155,6 +164,17 @@ input::-webkit-inner-spin-button {
 .radio input:disabled ~ .indicator {
   background-color: $gray-light;
   border-color: $gray;
+}
+
+.radio > div {
+  margin-bottom: $space-1;
+  margin-top: $space-1;
+
+  > input {
+    opacity: 1;
+    position: static;
+    z-index: 1;
+  }
 }
 
 .select-alt {

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -8,21 +8,23 @@ p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
     = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
       :first, :last,
       { include_blank: t('idv.form.select_financial_account') },
-      class: 'col-12 field js-finance-choice-select')
+      class: 'col-12 field')
   .clearfix.mxn1
     .col.col-12.sm-col-8.px1
-      = f.input :blank,
-                label: t('idv.form.select_financial_account'),
-                label_html: { class: 'hide' },
-                disabled: true,
-                wrapper_html: { class: 'js-finance-wrapper', data: { type: :blank } }
       - Idv::FinanceForm.finance_other_type_inputs.each do |key, label, html_options|
-        = f.input key,
-                  label: label,
-                  label_html: { class: 'hide' },
-                  required: false,
-                  wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
-                  input_html: html_options
+        label #{label}
+        label.btn-border.col-12.sm-mr2.mb2.sm-mb0
+          .radio.radio-with-input
+            = radio_button_tag 'test-again', key, true,
+              class: 'js-finance-choice-select'
+            span.indicator
+            = label
+            = f.input key,
+                      label: label,
+                      label_html: { class: 'hide' },
+                      required: false,
+                      wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
+                      input_html: html_options
     .col.col-12.sm-col-4.px1
       = f.button :submit,
                  t('forms.buttons.continue'),

--- a/app/views/verify/finance_other/new.html.slim
+++ b/app/views/verify/finance_other/new.html.slim
@@ -4,28 +4,23 @@ h1.h3.my0 = @view_model.title
 p.mt-tiny.mb0 = t('idv.messages.finance.intro_account')
 = simple_form_for(@view_model.idv_form, url: verify_finance_path,
     html: { autocomplete: 'off', method: 'put', role: 'form' }) do |f|
-  .select-alt.mb2
-    = f.collection_select(:finance_type, Idv::FinanceForm.finance_other_type_choices,
-      :first, :last,
-      { include_blank: t('idv.form.select_financial_account') },
-      class: 'col-12 field')
   .clearfix.mxn1
-    .col.col-12.sm-col-8.px1
+    .col.col-12.px1
       - Idv::FinanceForm.finance_other_type_inputs.each do |key, label, html_options|
-        label #{label}
-        label.btn-border.col-12.sm-mr2.mb2.sm-mb0
-          .radio.radio-with-input
-            = radio_button_tag 'test-again', key, true,
+        label.btn-border.col-12.mb2
+          .radio.radio-with-inputs
+            = radio_button_tag 'idv_finance_form[finance_type]', key, false,
               class: 'js-finance-choice-select'
             span.indicator
-            = label
+            span.option
+              = label
             = f.input key,
-                      label: label,
-                      label_html: { class: 'hide' },
+                      label: "Account number",
+                      label_html: { class: 'bold' },
                       required: false,
                       wrapper_html: { class: 'js-finance-wrapper', data: { type: key } },
                       input_html: html_options
-    .col.col-12.sm-col-4.px1
+    .col.col-12.px1
       = f.button :submit,
                  t('forms.buttons.continue'),
                  disabled: true,


### PR DESCRIPTION
This is a PR for the UI modifications to the "other" financial account page detailed in this issue: https://github.com/18F/identity-private/issues/2307. I didn't get to fully complete this issue, but I'll outline what has been done and what still needs to be done so that folks can pick up where I left off!

Changes made:
- [x] Removed the select field within the form on `/verify/finance/other`
- [x] Added a series of radio input fields on `/verify/finance/other`
  - [x] Submitting the form field with a radio button selected works

Still left to do:
- [ ] Testing. Changing from select field to radio box broke a lot of tests, mostly involving the use of JS on the page. I'm guessing a few small fixes will fix a lot of the tests here.
- [ ] Figure out active state UI for the checkboxes. They should be consistent with the style used in the call/text instance.
