### PR TITLE
Allow multiple USPS confirmation codes

### DIFF
--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -9,7 +9,7 @@ module Users
       @verify_account_form = VerifyAccountForm.new(user: current_user)
 
       return unless FeatureManagement.reveal_usps_code?
-      @code = JSON.parse(user_session[:decrypted_pii])['otp']['raw']
+      @code = session[:last_usps_confirmation_code]
     end
 
     def create
@@ -28,8 +28,7 @@ module Users
     def build_verify_account_form
       VerifyAccountForm.new(
         user: current_user,
-        otp: params_otp,
-        pii_attributes: decrypted_pii
+        otp: params_otp
       )
     end
 
@@ -40,13 +39,6 @@ module Users
     def confirm_verification_needed
       return if current_user.decorate.pending_profile_requires_verification?
       redirect_to account_url
-    end
-
-    def decrypted_pii
-      @_decrypted_pii ||= begin
-        cacher = Pii::Cacher.new(current_user, user_session)
-        cacher.fetch
-      end
     end
   end
 end

--- a/app/controllers/verify/come_back_later_controller.rb
+++ b/app/controllers/verify/come_back_later_controller.rb
@@ -2,19 +2,14 @@ module Verify
   class ComeBackLaterController < ApplicationController
     include IdvSession
 
-    before_action :confirm_idv_session_completed
-    before_action :confirm_usps_verification_method_chosen
+    before_action :confirm_user_needs_usps_confirmation
 
     def show; end
 
     private
 
-    def confirm_idv_session_completed
-      redirect_to account_path if idv_session.profile.blank?
-    end
-
-    def confirm_usps_verification_method_chosen
-      redirect_to account_path unless idv_session.address_verification_mechanism == 'usps'
+    def confirm_user_needs_usps_confirmation
+      redirect_to account_path unless current_user.decorate.needs_profile_usps_verification?
     end
   end
 end

--- a/app/controllers/verify/review_controller.rb
+++ b/app/controllers/verify/review_controller.rb
@@ -47,6 +47,9 @@ module Verify
       init_profile
       redirect_to verify_confirmations_path
       analytics.track_event(Analytics::IDV_REVIEW_COMPLETE)
+
+      return unless FeatureManagement.reveal_usps_code?
+      session[:last_usps_confirmation_code] = idv_session.usps_otp
     end
 
     private

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,6 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  has_many :usps_confirmation_codes
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
   validates :ssn_signature, uniqueness: { scope: :active, if: :active? }

--- a/app/models/usps_confirmation_code.rb
+++ b/app/models/usps_confirmation_code.rb
@@ -1,0 +1,16 @@
+class UspsConfirmationCode < ApplicationRecord
+  belongs_to :profile
+
+  def self.first_with_otp(otp)
+    find do |usps_confirmation_code|
+      Pii::Fingerprinter.verify(
+        Base32::Crockford.normalize(otp),
+        usps_confirmation_code.otp_fingerprint
+      )
+    end
+  end
+
+  def expired?
+    code_sent_at < Figaro.env.usps_confirmation_max_days.to_i.days.ago
+  end
+end

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -40,15 +40,9 @@ module Idv
         zipcode: Pii::Attribute.new(raw: appl.zipcode, norm: norm_appl.zipcode),
         dob: Pii::Attribute.new(raw: appl.dob, norm: norm_appl.dob),
         ssn: Pii::Attribute.new(raw: appl.ssn, norm: norm_appl.ssn),
-        phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone),
-        otp: generate_otp
+        phone: Pii::Attribute.new(raw: appl.phone, norm: norm_appl.phone)
       )
     end
     # rubocop:enable MethodLength, AbcSize
-
-    def generate_otp(length: 10)
-      # Crockford encoding is 5 bits per character
-      Base32::Crockford.encode(SecureRandom.random_number(2**(5 * length)), length: length)
-    end
   end
 end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -20,7 +20,7 @@ module Idv
       vendor_session_id
     ].freeze
 
-    attr_reader :current_user
+    attr_reader :current_user, :usps_otp
 
     def initialize(user_session:, current_user:, issuer:)
       @user_session = user_session
@@ -91,8 +91,10 @@ module Idv
       if pii.is_a?(String)
         self.pii = Pii::Attributes.new_from_json(user_session[:decrypted_pii])
       end
+      confirmation_maker = UspsConfirmationMaker.new(pii: pii, issuer: issuer, profile: profile)
+      confirmation_maker.perform
 
-      UspsConfirmationMaker.new(pii: pii, issuer: issuer).perform
+      @usps_otp = confirmation_maker.otp
     end
 
     def alive?

--- a/app/services/idv/usps_mail.rb
+++ b/app/services/idv/usps_mail.rb
@@ -2,7 +2,6 @@ module Idv
   class UspsMail
     MAX_MAIL_EVENTS = Figaro.env.max_mail_events.to_i
     MAIL_EVENTS_WINDOW_DAYS = Figaro.env.max_mail_events_window_in_days.to_i
-    USPS_CONFIRMATION_WINDOW_DAYS = Figaro.env.usps_confirmation_max_days.to_i
 
     def initialize(current_user)
       @current_user = current_user
@@ -15,12 +14,6 @@ module Idv
 
     def any_mail_sent?
       user_mail_events.any?
-    end
-
-    def most_recent_otp_expired?
-      return false unless any_mail_sent?
-
-      user_mail_events.first.updated_at < USPS_CONFIRMATION_WINDOW_DAYS.days.ago
     end
 
     private

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -2,7 +2,7 @@ module Pii
   Attributes = Struct.new(
     :first_name, :middle_name, :last_name,
     :address1, :address2, :city, :state, :zipcode,
-    :ssn, :dob, :phone, :otp,
+    :ssn, :dob, :phone,
     :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
   ) do
     def self.new_from_hash(hash)

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -1,17 +1,26 @@
 class UspsConfirmationMaker
-  def initialize(pii:, issuer:)
+  def initialize(pii:, issuer:, profile:)
     @pii = pii
     @issuer = issuer
+    @profile = profile
+  end
+
+  def otp
+    @otp ||= generate_otp
   end
 
   def perform
     entry = UspsConfirmationEntry.new_from_hash(attributes)
     UspsConfirmation.create!(entry: entry.encrypted)
+    UspsConfirmationCode.create!(
+      profile: profile,
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+    )
   end
 
   private
 
-  attr_reader :pii, :issuer
+  attr_reader :pii, :issuer, :profile
 
   # rubocop:disable AbcSize, MethodLength
   # This method is single statement spread across many lines for readability
@@ -20,7 +29,7 @@ class UspsConfirmationMaker
       address1: pii[:address1].norm,
       address2: pii[:address2].norm,
       city: pii[:city].norm,
-      otp: pii[:otp].norm,
+      otp: otp,
       first_name: pii[:first_name].norm,
       last_name: pii[:last_name].norm,
       state: pii[:state].norm,
@@ -29,4 +38,9 @@ class UspsConfirmationMaker
     }
   end
   # rubocop:enable AbcSize, MethodLength
+
+  def generate_otp
+    # Crockford encoding is 5 bits per character
+    Base32::Crockford.encode(SecureRandom.random_number(2**(5 * 10)), length: 10)
+  end
 end

--- a/db/migrate/20170905144239_create_usps_confirmation_codes.rb
+++ b/db/migrate/20170905144239_create_usps_confirmation_codes.rb
@@ -1,0 +1,12 @@
+class CreateUspsConfirmationCodes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :usps_confirmation_codes do |t|
+      t.integer :profile_id, null: false
+      t.string :otp_fingerprint, null: false
+      t.datetime :code_sent_at, null: false, default: ->{ 'CURRENT_TIMESTAMP' }
+      t.index :profile_id, using: :btree
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,189 +10,189 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626205402) do
+ActiveRecord::Schema.define(version: 20170905144239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "app_settings", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.string   "value",      limit: 255
+    t.string "name", limit: 255
+    t.string "value", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["name"], name: "index_app_settings_on_name"
   end
 
-  add_index "app_settings", ["name"], name: "index_app_settings_on_name", using: :btree
-
   create_table "authorizations", force: :cascade do |t|
-    t.string   "provider",      limit: 255
-    t.string   "uid",           limit: 255
-    t.integer  "user_id"
+    t.string "provider", limit: 255
+    t.string "uid", limit: 255
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "authorized_at"
+    t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid"
+    t.index ["user_id"], name: "index_authorizations_on_user_id"
   end
-
-  add_index "authorizations", ["provider", "uid"], name: "index_authorizations_on_provider_and_uid", using: :btree
-  add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
 
   create_table "events", force: :cascade do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "event_type", null: false
+    t.integer "user_id", null: false
+    t.integer "event_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
-
-  add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
 
   create_table "identities", force: :cascade do |t|
-    t.string   "service_provider",      limit: 255
+    t.string "service_provider", limit: 255
     t.datetime "last_authenticated_at"
-    t.integer  "user_id"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "session_uuid",          limit: 255
-    t.string   "uuid",                                          null: false
-    t.string   "nonce"
-    t.integer  "ial",                               default: 1
-    t.string   "access_token"
-    t.string   "scope"
-    t.string   "code_challenge"
-    t.string   "rails_session_id"
+    t.string "session_uuid", limit: 255
+    t.string "uuid", null: false
+    t.string "nonce"
+    t.integer "ial", default: 1
+    t.string "access_token"
+    t.string "scope"
+    t.string "code_challenge"
+    t.string "rails_session_id"
+    t.index ["access_token"], name: "index_identities_on_access_token", unique: true
+    t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
+    t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider"
+    t.index ["user_id"], name: "index_identities_on_user_id"
+    t.index ["uuid"], name: "index_identities_on_uuid", unique: true
   end
-
-  add_index "identities", ["access_token"], name: "index_identities_on_access_token", unique: true, using: :btree
-  add_index "identities", ["session_uuid"], name: "index_identities_on_session_uuid", unique: true, using: :btree
-  add_index "identities", ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", using: :btree
-  add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
-  add_index "identities", ["uuid"], name: "index_identities_on_uuid", unique: true, using: :btree
 
   create_table "otp_requests_trackers", force: :cascade do |t|
     t.datetime "otp_last_sent_at"
-    t.integer  "otp_send_count",    default: 0
-    t.string   "attribute_cost"
-    t.string   "phone_fingerprint", default: "", null: false
+    t.integer "otp_send_count", default: 0
+    t.string "attribute_cost"
+    t.string "phone_fingerprint", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["phone_fingerprint"], name: "index_otp_requests_trackers_on_phone_fingerprint", unique: true
+    t.index ["updated_at"], name: "index_otp_requests_trackers_on_updated_at"
   end
-
-  add_index "otp_requests_trackers", ["phone_fingerprint"], name: "index_otp_requests_trackers_on_phone_fingerprint", unique: true, using: :btree
-  add_index "otp_requests_trackers", ["updated_at"], name: "index_otp_requests_trackers_on_updated_at", using: :btree
 
   create_table "profiles", force: :cascade do |t|
-    t.integer  "user_id",                                           null: false
-    t.boolean  "active",                            default: false, null: false
+    t.integer "user_id", null: false
+    t.boolean "active", default: false, null: false
     t.datetime "verified_at"
     t.datetime "activated_at"
-    t.datetime "created_at",                                        null: false
-    t.datetime "updated_at",                                        null: false
-    t.string   "vendor"
-    t.text     "encrypted_pii"
-    t.string   "ssn_signature",          limit: 64
-    t.text     "encrypted_pii_recovery"
-    t.integer  "deactivation_reason"
-    t.boolean  "phone_confirmed",                   default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "vendor"
+    t.text "encrypted_pii"
+    t.string "ssn_signature", limit: 64
+    t.text "encrypted_pii_recovery"
+    t.integer "deactivation_reason"
+    t.boolean "phone_confirmed", default: false, null: false
+    t.index ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)"
+    t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
+    t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"
+    t.index ["user_id", "ssn_signature", "active"], name: "index_profiles_on_user_id_and_ssn_signature_and_active", unique: true, where: "(active = true)"
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
-
-  add_index "profiles", ["ssn_signature", "active"], name: "index_profiles_on_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree
-  add_index "profiles", ["ssn_signature"], name: "index_profiles_on_ssn_signature", using: :btree
-  add_index "profiles", ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)", using: :btree
-  add_index "profiles", ["user_id", "ssn_signature", "active"], name: "index_profiles_on_user_id_and_ssn_signature_and_active", unique: true, where: "(active = true)", using: :btree
-  add_index "profiles", ["user_id"], name: "index_profiles_on_user_id", using: :btree
 
   create_table "service_provider_requests", force: :cascade do |t|
-    t.string   "issuer",                            null: false
-    t.string   "loa",                               null: false
-    t.string   "url",                               null: false
-    t.string   "uuid",                              null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.string   "requested_attributes", default: [],              array: true
+    t.string "issuer", null: false
+    t.string "loa", null: false
+    t.string "url", null: false
+    t.string "uuid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "requested_attributes", default: [], array: true
+    t.index ["uuid"], name: "index_service_provider_requests_on_uuid", unique: true
   end
-
-  add_index "service_provider_requests", ["uuid"], name: "index_service_provider_requests_on_uuid", unique: true, using: :btree
 
   create_table "service_providers", force: :cascade do |t|
-    t.string   "issuer",                                                       null: false
-    t.string   "friendly_name"
-    t.text     "description"
-    t.text     "metadata_url"
-    t.text     "acs_url"
-    t.text     "assertion_consumer_logout_service_url"
-    t.text     "cert"
-    t.text     "logo"
-    t.string   "fingerprint"
-    t.string   "signature"
-    t.string   "block_encryption",                      default: "aes256-cbc", null: false
-    t.text     "sp_initiated_login_url"
-    t.text     "return_to_sp_url"
-    t.string   "agency"
-    t.json     "attribute_bundle"
-    t.string   "redirect_uri"
+    t.string "issuer", null: false
+    t.string "friendly_name"
+    t.text "description"
+    t.text "metadata_url"
+    t.text "acs_url"
+    t.text "assertion_consumer_logout_service_url"
+    t.text "cert"
+    t.text "logo"
+    t.string "fingerprint"
+    t.string "signature"
+    t.string "block_encryption", default: "aes256-cbc", null: false
+    t.text "sp_initiated_login_url"
+    t.text "return_to_sp_url"
+    t.string "agency"
+    t.json "attribute_bundle"
+    t.string "redirect_uri"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "active",                                default: false,        null: false
-    t.boolean  "approved",                              default: false,        null: false
-    t.boolean  "native",                                default: false,        null: false
-    t.string   "redirect_uris",                         default: [],                        array: true
+    t.boolean "active", default: false, null: false
+    t.boolean "approved", default: false, null: false
+    t.boolean "native", default: false, null: false
+    t.string "redirect_uris", default: [], array: true
+    t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 
-  add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree
-
   create_table "users", force: :cascade do |t|
-    t.string   "encrypted_password",           limit: 255, default: ""
-    t.string   "reset_password_token",         limit: 255
+    t.string "encrypted_password", limit: 255, default: ""
+    t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                            default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",           limit: 255
-    t.string   "last_sign_in_ip",              limit: 255
+    t.string "current_sign_in_ip", limit: 255
+    t.string "last_sign_in_ip", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "confirmation_token",           limit: 255
+    t.string "confirmation_token", limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email",            limit: 255
-    t.integer  "role"
-    t.integer  "second_factor_attempts_count",             default: 0
-    t.string   "uuid",                         limit: 255,              null: false
+    t.string "unconfirmed_email", limit: 255
+    t.integer "role"
+    t.integer "second_factor_attempts_count", default: 0
+    t.string "uuid", limit: 255, null: false
     t.datetime "reset_requested_at"
     t.datetime "second_factor_locked_at"
     t.datetime "locked_at"
-    t.integer  "failed_attempts",                          default: 0
-    t.string   "unlock_token",                 limit: 255
+    t.integer "failed_attempts", default: 0
+    t.string "unlock_token", limit: 255
     t.datetime "phone_confirmed_at"
-    t.text     "encrypted_otp_secret_key"
-    t.string   "direct_otp"
+    t.text "encrypted_otp_secret_key"
+    t.string "direct_otp"
     t.datetime "direct_otp_sent_at"
     t.datetime "idv_attempted_at"
-    t.integer  "idv_attempts",                             default: 0
-    t.string   "recovery_code"
-    t.string   "password_salt"
-    t.string   "encryption_key"
-    t.string   "unique_session_id"
-    t.string   "recovery_salt"
-    t.string   "password_cost"
-    t.string   "recovery_cost"
-    t.string   "email_fingerprint",                        default: "", null: false
-    t.text     "encrypted_email",                          default: "", null: false
-    t.string   "attribute_cost"
-    t.text     "encrypted_phone"
-    t.integer  "otp_delivery_preference",                  default: 0,  null: false
+    t.integer "idv_attempts", default: 0
+    t.string "recovery_code"
+    t.string "password_salt"
+    t.string "encryption_key"
+    t.string "unique_session_id"
+    t.string "recovery_salt"
+    t.string "password_cost"
+    t.string "recovery_cost"
+    t.string "email_fingerprint", default: "", null: false
+    t.text "encrypted_email", default: "", null: false
+    t.string "attribute_cost"
+    t.text "encrypted_phone"
+    t.integer "otp_delivery_preference", default: 0, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
+    t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
+    t.index ["unlock_token"], name: "index_users_on_unlock_token"
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
-  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
-  add_index "users", ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true, using: :btree
-  add_index "users", ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-  add_index "users", ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", using: :btree
-  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", using: :btree
-  add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
+  create_table "usps_confirmation_codes", force: :cascade do |t|
+    t.integer "profile_id", null: false
+    t.string "otp_fingerprint", null: false
+    t.datetime "code_sent_at", default: -> { "now()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_usps_confirmation_codes_on_profile_id"
+  end
 
   create_table "usps_confirmations", force: :cascade do |t|
-    t.text     "entry",      null: false
+    t.text "entry", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -327,7 +327,7 @@ describe Users::SessionsController, devise: true do
           :profile,
           deactivation_reason: :verification_pending,
           phone_confirmed: false,
-          pii: { otp: 'abc123', ssn: '6666', dob: '1920-01-01' }
+          pii: { ssn: '6666', dob: '1920-01-01' }
         )
         user = profile.user
 

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -5,18 +5,21 @@ RSpec.describe Users::VerifyAccountController do
 
   let(:has_pending_profile) { true }
   let(:success) { true }
-  let(:otp) { 'abc123' }
+  let(:otp) { 'ABC123' }
   let(:submitted_otp) { otp }
-  let(:pii_attributes) { Pii::Attributes.new_from_hash(otp: otp) }
   let(:pending_profile) { build(:profile) }
 
   before do
     user = stub_sign_in
     decorated_user = stub_decorated_user_with_pending_profile(user)
+    create(
+      :usps_confirmation_code,
+      profile: pending_profile,
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+    )
     allow(decorated_user).to receive(:needs_profile_phone_verification?).and_return(false)
     allow(decorated_user).to receive(:needs_profile_usps_verification?).
       and_return(has_pending_profile)
-    allow(controller).to receive(:decrypted_pii).and_return(pii_attributes)
   end
 
   describe '#index' do

--- a/spec/controllers/verify/come_back_later_controller_spec.rb
+++ b/spec/controllers/verify/come_back_later_controller_spec.rb
@@ -2,25 +2,17 @@ require 'rails_helper'
 
 describe Verify::ComeBackLaterController do
   let(:user) { build_stubbed(:user, :signed_up) }
-  let(:address_verification_mechanism) { 'usps' }
-  let(:profile) { build_stubbed(:profile, user: user) }
-  let(:idv_session) do
-    Idv::Session.new(
-      user_session: { context: :idv },
-      current_user: user,
-      issuer: nil
-    )
-  end
+  let(:needs_profile_usps_verification) { true }
 
   before do
-    allow(idv_session).to receive(:address_verification_mechanism).
-      and_return(address_verification_mechanism)
-    allow(idv_session).to receive(:profile).
-      and_return(profile)
-    allow(subject).to receive(:idv_session).and_return(idv_session)
+    user_decorator = instance_double(UserDecorator)
+    allow(user_decorator).to receive(:needs_profile_usps_verification?).
+      and_return(needs_profile_usps_verification)
+    allow(user).to receive(:decorate).and_return(user_decorator)
+    allow(subject).to receive(:current_user).and_return(user)
   end
 
-  context 'user has selected USPS address verification and has a complete profile' do
+  context 'user needs USPS address verification' do
     it 'renders the show template' do
       get :show
 
@@ -28,18 +20,8 @@ describe Verify::ComeBackLaterController do
     end
   end
 
-  context 'user has not selected USPS address verification' do
-    let(:address_verification_mechanism) { 'phone' }
-
-    it 'redirects to the account path' do
-      get :show
-
-      expect(response).to redirect_to account_path
-    end
-  end
-
-  context 'does not have a complete profile' do
-    let(:profile) { nil }
+  context 'user does not need USPS address verification' do
+    let(:needs_profile_usps_verification) { false }
 
     it 'redirects to the account path' do
       get :show

--- a/spec/controllers/verify/usps_controller_spec.rb
+++ b/spec/controllers/verify/usps_controller_spec.rb
@@ -45,17 +45,50 @@ describe Verify::UspsController do
   end
 
   describe '#create' do
-    before do
-      stub_verify_steps_one_and_two(user)
+    context 'first time through the idv process' do
+      before do
+        stub_verify_steps_one_and_two(user)
+      end
+
+      it 'sets session to :usps and redirects' do
+        expect(subject.idv_session.address_verification_mechanism).to be_nil
+
+        put :create
+
+        expect(response).to redirect_to verify_review_path
+        expect(subject.idv_session.address_verification_mechanism).to eq :usps
+      end
     end
 
-    it 'sets session to :usps and redirects' do
-      expect(subject.idv_session.address_verification_mechanism).to be_nil
+    context 'resending a letter' do
+      let(:has_pending_profile) { true }
+      let(:pending_profile) { create(:profile, phone_confirmed: false) }
 
-      put :create
+      before do
+        stub_sign_in(user)
+        stub_decorated_user_with_pending_profile(user)
+        allow(user.decorate).to receive(:needs_profile_usps_verification?).and_return(true)
+      end
 
-      expect(response).to redirect_to verify_review_path
-      expect(subject.idv_session.address_verification_mechanism).to eq :usps
+      it 'calls the UspsConfirmationMaker to send another letter and redirects' do
+        pii = { first_name: 'Samuel', last_name: 'Sampson' }
+        pii_cacher = instance_double(Pii::Cacher)
+        allow(pii_cacher).to receive(:fetch).and_return(pii)
+        allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
+
+        session[:sp] = { issuer: '123abc' }
+
+        usps_confirmation_maker = instance_double(UspsConfirmationMaker)
+        allow(UspsConfirmationMaker).to receive(:new).
+          with(pii: pii, issuer: '123abc', profile: pending_profile).
+          and_return(usps_confirmation_maker)
+
+        expect(usps_confirmation_maker).to receive(:perform)
+
+        put :create
+
+        expect(response).to redirect_to verify_come_back_later_path
+      end
     end
   end
 end

--- a/spec/factories/usps_confirmation_codes.rb
+++ b/spec/factories/usps_confirmation_codes.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  Faker::Config.locale = :en
+
+  factory :usps_confirmation_code do
+    profile
+    otp_fingerprint Pii::Fingerprinter.fingerprint('ABCDE12345')
+  end
+end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -251,7 +251,7 @@ feature 'OpenID Connect' do
         :profile,
         deactivation_reason: :verification_pending,
         phone_confirmed: phone_confirmed,
-        pii: { otp: otp, ssn: '6666', dob: '1920-01-01' }
+        pii: { ssn: '6666', dob: '1920-01-01' }
       )
     end
     let(:oidc_auth_url) do

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -116,13 +116,12 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
   context 'continuing verification' do
     let(:user) { profile.user }
-    let(:otp) { 'abc123' }
     let(:profile) do
       create(
         :profile,
         deactivation_reason: :verification_pending,
         phone_confirmed: phone_confirmed,
-        pii: { otp: otp, ssn: '6666', dob: '1920-01-01' }
+        pii: { ssn: '6666', dob: '1920-01-01' }
       )
     end
 
@@ -148,7 +147,7 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
           click_button(t('idv.buttons.mail.resend'))
 
-          expect(current_path).to eq(account_path)
+          expect(current_path).to eq(verify_come_back_later_path)
         end
 
         it 'after signing out' do
@@ -168,7 +167,7 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
           click_button(t('idv.buttons.mail.resend'))
 
-          expect(current_path).to eq(account_path)
+          expect(current_path).to eq(verify_come_back_later_path)
         end
       end
     end

--- a/spec/models/usps_confirmation_code_spec.rb
+++ b/spec/models/usps_confirmation_code_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe UspsConfirmationCode do
+  let(:otp) { 'ABC123' }
+  let(:profile) { build(:profile) }
+
+  describe '.first_with_otp' do
+    it 'return the record with the matching OTP' do
+      create(:usps_confirmation_code)
+      good_confirmation_code = create(
+        :usps_confirmation_code,
+        otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+      )
+
+      expect(described_class.first_with_otp(otp)).to eq(good_confirmation_code)
+    end
+
+    it 'normalizes the entered otp before searching' do
+      confirmation_code = create(
+        :usps_confirmation_code,
+        otp_fingerprint: Pii::Fingerprinter.fingerprint('ABC000')
+      )
+
+      expect(described_class.first_with_otp('abcooo')).to eq(confirmation_code)
+    end
+
+    it 'returns nil if no record matches the OTP' do
+      create(:usps_confirmation_code)
+
+      expect(described_class.first_with_otp(otp)).to be_nil
+    end
+  end
+
+  describe '#expired?' do
+    it 'returns false for a valid otp' do
+      confirmation_code = build(
+        :usps_confirmation_code,
+        code_sent_at: Time.zone.now
+      )
+
+      expect(confirmation_code.expired?).to eq(false)
+    end
+
+    it 'returns true for an expired otp' do
+      confirmation_code = build(
+        :usps_confirmation_code,
+        code_sent_at: (Figaro.env.usps_confirmation_max_days.to_i + 1).days.ago
+      )
+
+      expect(confirmation_code.expired?).to eq(true)
+    end
+  end
+end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -27,10 +27,6 @@ describe Idv::ProfileMaker do
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name.raw).to eq 'Some'
       expect(pii.first_name.norm).to eq 'Somebody'
-
-      otp = pii.otp.raw
-      expect(otp.length).to eq(10)
-      expect(otp).to eq(Base32::Crockford.normalize(otp))
     end
   end
 end

--- a/spec/services/idv/usps_mail_spec.rb
+++ b/spec/services/idv/usps_mail_spec.rb
@@ -44,30 +44,4 @@ describe Idv::UspsMail do
       end
     end
   end
-
-  describe '#most_recent_otp_expired?' do
-    context 'when no mail has been sent' do
-      it 'returns false' do
-        expect(subject.most_recent_otp_expired?).to eq false
-      end
-    end
-
-    context 'when the most recent mail was sent less than 10 days ago' do
-      it 'returns false' do
-        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 5.days.ago)
-        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 12.days.ago)
-
-        expect(subject.most_recent_otp_expired?).to eq false
-      end
-    end
-
-    context 'when the most recent mail was sent more than 10 days ago' do
-      it 'returns true' do
-        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 11.days.ago)
-        Event.create(event_type: :usps_mail_sent, user: user, updated_at: 12.days.ago)
-
-        expect(subject.most_recent_otp_expired?).to eq true
-      end
-    end
-  end
 end

--- a/spec/services/usps_confirmation_maker_spec.rb
+++ b/spec/services/usps_confirmation_maker_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe UspsConfirmationMaker do
+  let(:otp) { '123ABC' }
+  let(:issuer) { 'this-is-an-issuer' }
+  let(:decrypted_attributes) do
+    {
+      address1: '123 main st', address2: '',
+      city: 'Baton Rouge', state: 'Louisiana', zipcode: '12345',
+      first_name: 'Robert', last_name: 'Robertson',
+      otp: otp, issuer: issuer
+    }
+  end
+  let(:pii) do
+    attributes = Pii::Attributes.new
+    decrypted_attributes.each do |key, value|
+      next unless attributes.respond_to? key
+      attributes[key] = Pii::Attribute.new(raw: value, norm: value)
+    end
+    attributes
+  end
+  let(:profile) { create(:profile) }
+
+  subject { described_class.new(pii: pii, issuer: issuer, profile: profile) }
+
+  describe '#perform' do
+    before do
+      allow(Base32::Crockford).to receive(:encode).and_return(otp)
+    end
+
+    it 'should create a UspsConfirmation with the encrypted attributes' do
+      expect { subject.perform }.to change { UspsConfirmation.count }.from(0).to(1)
+
+      usps_confirmation = UspsConfirmation.first
+      expect(usps_confirmation.decrypted_entry.to_h).to eq decrypted_attributes
+    end
+
+    it 'should create a UspsConfrimationCode with the profile and the encrypted OTP' do
+      expect { subject.perform }.to change { UspsConfirmationCode.count }.from(0).to(1)
+
+      usps_confirmation_code = UspsConfirmationCode.first
+
+      expect(usps_confirmation_code.profile).to eq profile
+      expect(usps_confirmation_code.otp_fingerprint).to eq Pii::Fingerprinter.fingerprint(otp)
+    end
+  end
+
+  describe '#otp' do
+    it 'should return a normalized, 10 digit code' do
+      otp = subject.otp
+
+      expect(otp.length).to eq 10
+      expect(Base32::Crockford.normalize(otp)).to eq otp
+    end
+  end
+end

--- a/spec/support/idv_examples/usps_verification_selection.rb
+++ b/spec/support/idv_examples/usps_verification_selection.rb
@@ -50,4 +50,52 @@ shared_examples 'selecting usps address verification method' do |sp|
         to eq('urn:gov:gsa:openidconnect:sp:server')
     end
   end
+
+  describe 'USPS OTP prefilling' do
+    it 'prefills USPS OTP if the reveal_usps_code feature flag is set', email: true do
+      visit_idp_from_sp_with_loa3(sp)
+      register_user
+
+      usps_confirmation_maker = instance_double(UspsConfirmationMaker)
+      allow(usps_confirmation_maker).to receive(:otp).and_return('123ABC')
+      allow(usps_confirmation_maker).to receive(:perform)
+      allow(UspsConfirmationMaker).to receive(:new).and_return(usps_confirmation_maker)
+      allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
+
+      complete_idv_profile_ok_with_usps
+
+      visit verify_account_path
+
+      expect(page.find('#verify_account_form_otp').value).to eq '123ABC'
+    end
+
+    it 'does not prefill USPS OTP if the reveal_usps_code feature flag is not set', email: true do
+      visit_idp_from_sp_with_loa3(sp)
+      register_user
+
+      usps_confirmation_maker = instance_double(UspsConfirmationMaker)
+      allow(usps_confirmation_maker).to receive(:otp).and_return('123ABC')
+      allow(usps_confirmation_maker).to receive(:perform)
+      allow(UspsConfirmationMaker).to receive(:new).and_return(usps_confirmation_maker)
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(false)
+
+      complete_idv_profile_ok_with_usps
+
+      visit verify_account_path
+
+      expect(page.find('#verify_account_form_otp').value).to be_nil
+    end
+  end
+
+  def complete_idv_profile_ok_with_usps
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    fill_out_financial_form_ok
+    click_idv_continue
+    click_idv_address_choose_usps
+    click_on t('idv.buttons.mail.send')
+    fill_in :user_password, with: user_password
+    click_submit_default
+  end
 end


### PR DESCRIPTION
**Why**: So that when a user resends a letter, it does not invalidate
the USPS confirmation code in preceding letters. This means that if a
user resends a letter before receiving their first letter, the code in
the first letter can still be used to verify their account.

**How**: This commit adds a new model named `UspsConfirmationCode`. This
model is associated with a profile and has an asymmetrically encrypted
OTP. When the user enters an OTP, the record with the matching OTP
fingerprint is found. This is used to determine whether the entered OTP
is valid for verifying their account.