### PR TITLE
Redact more phone numbers in error messages

### DIFF
--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -17,14 +17,5 @@ class SmsOtpSenderJob < ApplicationJob
       to: phone,
       body: I18n.t('jobs.sms_otp_sender_job.message', code: code, app: APP_NAME)
     )
-  rescue Twilio::REST::RestError => error
-    sanitize_phone_number(error.message)
-    raise
-  end
-
-  def sanitize_phone_number(str)
-    return unless str =~ /is not a valid phone number/
-
-    str.gsub!(/\+[\d\(\)\- ]+/) { |match| match.gsub(/\d/, '#') }
   end
 end

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -64,18 +64,5 @@ describe SmsOtpSenderJob do
         expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to eq []
       end
     end
-
-    it 'sanitizes phone numbers embedded in error messages from Twilio' do
-      raw_message = "The 'To' number +1 (888) 555-5555 is not a valid phone number"
-      error_code = '21211'
-      status_code = 400
-      sanitized_message = "The 'To' number +# (###) ###-#### is not a valid phone number"
-
-      expect_any_instance_of(TwilioService).to receive(:send_sms).
-        and_raise(Twilio::REST::RestError.new(raw_message, error_code, status_code))
-
-      expect { perform }.
-        to raise_error(Twilio::REST::RestError, sanitized_message)
-    end
   end
 end


### PR DESCRIPTION
**Why**: Remove PII

---

Found a phone number in an error message from Twilio -- previously we were only redacting errors from SMS but we need to redact phone calls as well.