### PR TITLE
Ignore production and deploy gems for local dev

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -51,7 +51,7 @@ Dir.chdir APP_ROOT do
   puts "\n== Installing dependencies =="
   run "gem install bundler --conservative"
   run 'gem install foreman --conservative && gem update foreman'
-  run "bundle check || bundle install"
+  run "bundle check || bundle install --without deploy production"
   run "npm install"
   run "npm run build"
   run "gem install mailcatcher"


### PR DESCRIPTION
**Why**:
- Those gems are not required to allow people outside of 18F to run the
app locally. In some cases, like the equifax gem, they are preventing
those folks from running the app.