### PR TITLE
Gracefully handle unknown formats

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_auth_token
+  rescue_from ActionController::UnknownFormat, with: :render_not_found
 
   helper_method :decorated_session, :reauthn?, :user_fully_authenticated?
 
@@ -150,5 +151,9 @@ class ApplicationController < ActionController::Base
 
   def sp_session
     session.fetch(:sp, {})
+  end
+
+  def render_not_found
+    render template: 'pages/page_not_found', layout: false, status: 404, formats: :html
   end
 end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe 'Headers' do
 
     expect(response.code.to_i).to eq(200)
   end
+
+  it 'does not blow up with bad formats in the headers' do
+    get root_path, headers: { 'Accept' => 'acunetix/wvs' }
+
+    expect(response.code.to_i).to eq(404)
+  end
+
+  it 'does not blow up with bad formats in the path' do
+    get '/fr/users/password/new.zip'
+
+    expect(response.code.to_i).to eq(404)
+  end
 end


### PR DESCRIPTION
**Why**: Bad input should not cause us to throw exceptions