### PR TITLE
Remove HTTP Host header entirely

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,8 @@ module Upaya
       event.payload.except(:params, :headers)
     end
 
-    config.middleware.insert_before 0, Rack::HeadersFilter
+    require 'headers_filter'
+    config.middleware.insert_before 0, HeadersFilter
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do

--- a/lib/headers_filter.rb
+++ b/lib/headers_filter.rb
@@ -1,0 +1,21 @@
+require 'rack/headers_filter'
+
+# Expands on Rack::HeadersFilter to delete additional headers
+class HeadersFilter
+  HEADERS_TO_DELETE = Rack::HeadersFilter::SENSITIVE_HEADERS + %w[
+    HTTP_HOST
+  ]
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    HEADERS_TO_DELETE.each { |header| env.delete(header) }
+    app.call(env)
+  end
+
+  private
+
+  attr_reader :app
+end

--- a/spec/lib/headers_filter_spec.rb
+++ b/spec/lib/headers_filter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe HeadersFilter do
+  let(:app) { double('App', call: nil) }
+
+  let(:middleware) { HeadersFilter.new(app) }
+
+  describe '#call' do
+    it 'removes untrusted headers from the env' do
+      env = {
+        'HTTP_HOST' => 'foobar.com',
+        'HTTP_X_FORWARDED_HOST' => 'evil.com',
+      }
+
+      middleware.call(env)
+
+      expect(env).to_not have_key('HTTP_HOST')
+      expect(env).to_not have_key('HTTP_X_FORWARDED_HOST')
+    end
+  end
+end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe 'Headers' do
 
     expect(response.body).to_not include('evil.com')
   end
+
+  it 'does not blow up with a malicious host value' do
+    get root_path, headers: { 'Host' => "mTpvPME6'));select pg_sleep(9); --" }
+
+    expect(response.code.to_i).to eq(200)
+  end
 end


### PR DESCRIPTION
**Why**: Malformed host headers cause exceptions

--

I basically rewrote the middleware gem we added in https://github.com/18F/identity-idp/pull/1663 because that gem only delete a particular 5 headers, not including `HTTP_HOST` so in order to delete that I had to get around it

I would be open to removing the dependency entirely, but this seemed like an easier way to just re-use the list of headers we don't trust

