### PR TITLE
Sanitize UTF8 characters from headers

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -9,7 +9,6 @@ class Analytics
       event_properties: attributes.except(:user_id),
       user_id: attributes[:user_id] || uuid,
     }
-
     ahoy.track(event, analytics_hash.merge!(request_attributes))
   end
 

--- a/lib/headers_filter.rb
+++ b/lib/headers_filter.rb
@@ -12,10 +12,18 @@ class HeadersFilter
 
   def call(env)
     HEADERS_TO_DELETE.each { |header| env.delete(header) }
+    ascii_encode_headers(env)
     app.call(env)
   end
 
   private
+
+  def ascii_encode_headers(env)
+    headers = env.select { |key, _value| key.starts_with? 'HTTP_' }
+    headers.each do |header, value|
+      env[header] = value.encode('ascii-8bit', invalid: :replace, undef: :replace, replace: '?')
+    end
+  end
 
   attr_reader :app
 end

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -10,7 +10,7 @@ feature 'Internationalization' do
 
   context 'visit homepage with locale set in header' do
     before do
-      page.driver.header 'Accept-Language', locale
+      page.driver.header 'Accept-Language', locale.to_s
       visit root_path
     end
 

--- a/spec/lib/headers_filter_spec.rb
+++ b/spec/lib/headers_filter_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe HeadersFilter do
       expect(env).to_not have_key('HTTP_HOST')
       expect(env).to_not have_key('HTTP_X_FORWARDED_HOST')
     end
+
+    it 'encodes headers as 8 bit ASCII' do
+      env = {
+        'HTTP_USER_AGENT' => 'Mózillá/5.0',
+      }
+
+      middleware.call(env)
+
+      expect(env['HTTP_USER_AGENT'].ascii_only?).to eq(true)
+    end
   end
 end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -24,4 +24,10 @@ RSpec.describe 'Headers' do
 
     expect(response.code.to_i).to eq(404)
   end
+
+  it 'ASCII encodes UTF8 headers' do
+    get root_path, headers: { 'User-Agent' => 'Mózillá/5.0' }
+
+    expect(request.env['HTTP_USER_AGENT'].ascii_only?).to eq(true)
+  end
 end


### PR DESCRIPTION
**Why**: Rack encodes headers into 8 bit ASCII which results in encoding
compatibility errors further down the stack when the app tries to
manipulate them. This commit encodes the headers and replaces
incompatible characters with `?` characters so the headers do not cause
the app to respond with 500s.