### PR TITLE
Set all existing migrations as being from Rails 4.

### DIFF
--- a/db/migrate/20161219225847_init_schema.rb
+++ b/db/migrate/20161219225847_init_schema.rb
@@ -1,4 +1,4 @@
-class InitSchema < ActiveRecord::Migration
+class InitSchema < ActiveRecord::Migration[4.2]
   def up
     
     # These are extensions that must be enabled in order to support this database

--- a/db/migrate/20170111142846_add_nonce_to_identities.rb
+++ b/db/migrate/20170111142846_add_nonce_to_identities.rb
@@ -1,4 +1,4 @@
-class AddNonceToIdentities < ActiveRecord::Migration
+class AddNonceToIdentities < ActiveRecord::Migration[4.2]
   def change
     # from OpenID Connect authorizations
     add_column :identities, :nonce, :string

--- a/db/migrate/20170125153626_add_ial_to_identities_again.rb
+++ b/db/migrate/20170125153626_add_ial_to_identities_again.rb
@@ -1,4 +1,4 @@
-class AddIalToIdentitiesAgain < ActiveRecord::Migration
+class AddIalToIdentitiesAgain < ActiveRecord::Migration[4.2]
   def change
     add_column :identities, :ial, :integer, default: 1
   end

--- a/db/migrate/20170127204804_add_access_token_to_identities.rb
+++ b/db/migrate/20170127204804_add_access_token_to_identities.rb
@@ -1,4 +1,4 @@
-class AddAccessTokenToIdentities < ActiveRecord::Migration
+class AddAccessTokenToIdentities < ActiveRecord::Migration[4.2]
   def change
     add_column :identities, :access_token, :string
 

--- a/db/migrate/20170131172556_add_otp_delivery_preference_to_user.rb
+++ b/db/migrate/20170131172556_add_otp_delivery_preference_to_user.rb
@@ -1,4 +1,4 @@
-class AddOtpDeliveryPreferenceToUser < ActiveRecord::Migration
+class AddOtpDeliveryPreferenceToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :otp_delivery_preference, :integer, default: 0, index: true, null: false
   end

--- a/db/migrate/20170201154458_add_scope_to_identities.rb
+++ b/db/migrate/20170201154458_add_scope_to_identities.rb
@@ -1,4 +1,4 @@
-class AddScopeToIdentities < ActiveRecord::Migration
+class AddScopeToIdentities < ActiveRecord::Migration[4.2]
   def change
     add_column :identities, :scope, :string
   end

--- a/db/migrate/20170203150129_add_code_challenge_to_identities.rb
+++ b/db/migrate/20170203150129_add_code_challenge_to_identities.rb
@@ -1,4 +1,4 @@
-class AddCodeChallengeToIdentities < ActiveRecord::Migration
+class AddCodeChallengeToIdentities < ActiveRecord::Migration[4.2]
   def change
     add_column :identities, :code_challenge, :string
   end

--- a/db/migrate/20170207192356_remove_unused_encrypted_otp_secret_columns.rb
+++ b/db/migrate/20170207192356_remove_unused_encrypted_otp_secret_columns.rb
@@ -1,4 +1,4 @@
-class RemoveUnusedEncryptedOtpSecretColumns < ActiveRecord::Migration
+class RemoveUnusedEncryptedOtpSecretColumns < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :encrypted_otp_secret_key_iv, :string
     remove_column :users, :encrypted_otp_secret_key_salt, :string

--- a/db/migrate/20170207192911_update_encrypted_otp_secret_key_length.rb
+++ b/db/migrate/20170207192911_update_encrypted_otp_secret_key_length.rb
@@ -1,4 +1,4 @@
-class UpdateEncryptedOtpSecretKeyLength < ActiveRecord::Migration
+class UpdateEncryptedOtpSecretKeyLength < ActiveRecord::Migration[4.2]
   def change
     change_column :users, :encrypted_otp_secret_key, :text
   end

--- a/db/migrate/20170215160237_add_rails_session_id_to_identities.rb
+++ b/db/migrate/20170215160237_add_rails_session_id_to_identities.rb
@@ -1,4 +1,4 @@
-class AddRailsSessionIdToIdentities < ActiveRecord::Migration
+class AddRailsSessionIdToIdentities < ActiveRecord::Migration[4.2]
   def change
     add_column :identities, :rails_session_id, :string
   end

--- a/db/migrate/20170215175444_create_service_providers.rb
+++ b/db/migrate/20170215175444_create_service_providers.rb
@@ -1,4 +1,4 @@
-class CreateServiceProviders < ActiveRecord::Migration
+class CreateServiceProviders < ActiveRecord::Migration[4.2]
   def change
     create_table :service_providers do |t|
       t.string   "issuer", null: false

--- a/db/migrate/20170222182714_add_native_to_service_provider.rb
+++ b/db/migrate/20170222182714_add_native_to_service_provider.rb
@@ -1,4 +1,4 @@
-class AddNativeToServiceProvider < ActiveRecord::Migration
+class AddNativeToServiceProvider < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :native, :boolean, default: false, null: false
   end

--- a/db/migrate/20170306214524_add_usps_confirmations.rb
+++ b/db/migrate/20170306214524_add_usps_confirmations.rb
@@ -1,4 +1,4 @@
-class AddUspsConfirmations < ActiveRecord::Migration
+class AddUspsConfirmations < ActiveRecord::Migration[4.2]
   def change
     create_table :usps_confirmations, force: :cascade do |t|
       t.text     :entry, null: false

--- a/db/migrate/20170321170516_create_service_provider_requests.rb
+++ b/db/migrate/20170321170516_create_service_provider_requests.rb
@@ -1,4 +1,4 @@
-class CreateServiceProviderRequests < ActiveRecord::Migration
+class CreateServiceProviderRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :service_provider_requests do |t|
       t.string :issuer, null: false

--- a/db/migrate/20170321170517_drop_plaintext_columns.rb
+++ b/db/migrate/20170321170517_drop_plaintext_columns.rb
@@ -1,4 +1,4 @@
-class DropPlaintextColumns < ActiveRecord::Migration
+class DropPlaintextColumns < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :phone_plain
     remove_column :users, :otp_secret_key

--- a/db/migrate/20170413152832_add_profile_phone_confirmed.rb
+++ b/db/migrate/20170413152832_add_profile_phone_confirmed.rb
@@ -1,4 +1,4 @@
-class AddProfilePhoneConfirmed < ActiveRecord::Migration
+class AddProfilePhoneConfirmed < ActiveRecord::Migration[4.2]
   def change
     add_column :profiles, :phone_confirmed, :boolean, default: false, null: false
   end

--- a/db/migrate/20170512214024_add_requested_attributes_to_service_provider_request.rb
+++ b/db/migrate/20170512214024_add_requested_attributes_to_service_provider_request.rb
@@ -1,4 +1,4 @@
-class AddRequestedAttributesToServiceProviderRequest < ActiveRecord::Migration
+class AddRequestedAttributesToServiceProviderRequest < ActiveRecord::Migration[4.2]
   def change
     add_column :service_provider_requests, :requested_attributes, :string, array: true, default: []
   end

--- a/db/migrate/20170531204549_add_multiple_redirect_uris_to_service_providers.rb
+++ b/db/migrate/20170531204549_add_multiple_redirect_uris_to_service_providers.rb
@@ -1,4 +1,4 @@
-class AddMultipleRedirectUrisToServiceProviders < ActiveRecord::Migration
+class AddMultipleRedirectUrisToServiceProviders < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :redirect_uris, :string, array: true, default: []
   end

--- a/db/migrate/20170621202836_create_otp_requests_tracker.rb
+++ b/db/migrate/20170621202836_create_otp_requests_tracker.rb
@@ -1,4 +1,4 @@
-class CreateOtpRequestsTracker < ActiveRecord::Migration
+class CreateOtpRequestsTracker < ActiveRecord::Migration[4.2]
   def change
     create_table :otp_requests_trackers do |t|
       t.text :encrypted_phone

--- a/db/migrate/20170626205402_remove_encrypted_phone_from_otp_requests_tracker.rb
+++ b/db/migrate/20170626205402_remove_encrypted_phone_from_otp_requests_tracker.rb
@@ -1,4 +1,4 @@
-class RemoveEncryptedPhoneFromOtpRequestsTracker < ActiveRecord::Migration
+class RemoveEncryptedPhoneFromOtpRequestsTracker < ActiveRecord::Migration[4.2]
   def change
     remove_column :otp_requests_trackers, :encrypted_phone, :string
   end


### PR DESCRIPTION
**Why**:

Migrations must be versioned as of Rails 5.

http://blog.bigbinary.com/2016/03/01/migrations-are-versioned-in-rails-5.html

Fixes: https://github.com/18F/identity-private/issues/2354