### PR TITLE
Always set RAILS_ENV=production on servers.

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,8 @@
+# if we're on a server, always default to production
+if File.exist?('/etc/login.gov/info/domain')
+  ENV['RAILS_ENV'] ||= 'production'.freeze
+end
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.


### PR DESCRIPTION
**Why**: On servers, it would be damaging to accidentally run not in
production mode. Rather than making users always specify production,
always run in production mode if `/etc/login.gov/info/domain` exists.