### PR TITLE
Specify format when rendering view in controller

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -16,7 +16,7 @@ module SignUp
     def new
       @register_user_email_form = RegisterUserEmailForm.new
       analytics.track_event(Analytics::USER_REGISTRATION_ENTER_EMAIL_VISIT)
-      render :new, locals: { request_id: nil }
+      render :new, locals: { request_id: nil }, formats: :html
     end
 
     def create

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -35,6 +35,13 @@ describe SignUp::RegistrationsController, devise: true do
 
       expect(response).to redirect_to account_path
     end
+
+    it 'gracefully handles invalid formats' do
+      @request.env['HTTP_ACCEPT'] = "nessus=bad_bad_value'"
+      get :new
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
**Why**: In this specific controller, we are explicitly rendering
the view (as opposed to letting the Rails magic handle the rendering)
in order to pass in local variables. By not specifying `formats: :html`,
the app will raise a `ActionView::MissingTemplate` error if someone
tries to pass in a different Accept header. To prevent unnecessary
500 errors from showing up in our logs, we can specify the HTML
format and the page will still render if any other format is passed in.