### PR TITLE
Verify phone number with twilio before saving to user

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,4 +1,7 @@
 class TwilioService
+  SMS_ERROR_CODE = 21_211
+  INVALID_ERROR_CODE = 21_614
+
   cattr_accessor :telephony_service do
     Twilio::REST::Client
   end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -38,4 +38,7 @@ en:
       usps_otp_expired: Your confirmation code has expired. Please request another
         letter for a new code.
       weak_password: Your password is not strong enough. %{feedback}
+      invalid_phone_number: The phone number entered is not valid.
+      invalid_sms_number: The phone number entered doesn't support text messaging.
+      otp_failed: Your one time password failed to send.
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -35,4 +35,7 @@ es:
       unauthorized_service_provider: Proveedor de servicio no autorizado
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
+      invalid_phone_number: NOT TRANSLATED YET
+      invalid_sms_number: NOT TRANSLATED YET
+      otp_failed: NOT TRANSLATED YET
     not_authorized: No está autorizado para realizar esta acción.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -38,4 +38,7 @@ fr:
       unauthorized_service_provider: Fournisseur de service non autorisé
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
+      invalid_phone_number: NOT TRANSLATED YET
+      invalid_sms_number: NOT TRANSLATED YET
+      otp_failed: NOT TRANSLATED YET
     not_authorized: Vous n'êtes pas autorisé(e) à effectuer cette action.

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -62,13 +62,13 @@ feature 'Changing authentication factor' do
       complete_2fa_confirmation
 
       allow(VoiceOtpSenderJob).to receive(:perform_later)
-      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(SmsOtpSenderJob).to receive(:perform_now)
 
       update_phone_number(guam_phone)
 
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
-      expect(SmsOtpSenderJob).to have_received(:perform_later)
+      expect(SmsOtpSenderJob).to have_received(:perform_now)
       expect(page).to_not have_content(t('links.two_factor_authentication.resend_code.phone'))
     end
 
@@ -133,6 +133,7 @@ feature 'Changing authentication factor' do
 
   context 'user has authenticator app enabled' do
     it 'allows them to change their email, password, or phone' do
+      stub_twilio_service
       sign_in_with_totp_enabled_user
 
       Timecop.travel(Figaro.env.reauthn_window.to_i + 1) do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -46,6 +46,18 @@ feature 'Sign Up' do
     end
   end
 
+  scenario 'renders an error when twilio api responds with an error' do
+    twilio_error = Twilio::REST::RestError.new('', TwilioService::SMS_ERROR_CODE, '400')
+
+    allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)
+    sign_up_and_set_password
+    fill_in 'Phone', with: '202-555-1212'
+    click_send_security_code
+
+    expect(current_path).to eq(phone_setup_path)
+    expect(page).to have_content(unsupported_sms_message)
+  end
+
   context 'with js', js: true do
     context 'sp loa1' do
       it 'allows the user to toggle the modal' do

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -48,7 +48,7 @@ feature 'User edit' do
 
     scenario 'confirms with selected OTP delivery method and updates user delivery preference' do
       allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_later)
+      allow(VoiceOtpSenderJob).to receive(:perform_now)
 
       fill_in 'Phone', with: '555-555-5000'
       choose 'Phone call'
@@ -59,7 +59,7 @@ feature 'User edit' do
 
       expect(current_path).to eq(login_otp_path(otp_delivery_preference: :voice))
       expect(SmsOtpSenderJob).to_not have_received(:perform_later)
-      expect(VoiceOtpSenderJob).to have_received(:perform_later)
+      expect(VoiceOtpSenderJob).to have_received(:perform_now)
       expect(user.otp_delivery_preference).to eq('voice')
     end
   end

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -4,12 +4,12 @@ feature 'Phone confirmation during sign up' do
   context 'visitor can sign up and confirm a valid phone for OTP' do
     before do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(SmsOtpSenderJob).to receive(:perform_now)
       @user = sign_in_before_2fa
       fill_in 'Phone', with: '555-555-5555'
       click_send_security_code
 
-      expect(SmsOtpSenderJob).to have_received(:perform_later).with(
+      expect(SmsOtpSenderJob).to have_received(:perform_now).with(
         code: @user.reload.direct_otp,
         phone: '+1 (555) 555-5555',
         otp_created_at: @user.direct_otp_sent_at.to_s

--- a/spec/support/features/localization_helper.rb
+++ b/spec/support/features/localization_helper.rb
@@ -4,6 +4,18 @@ module Features
       t('errors.messages.improbable_phone')
     end
 
+    def unsupported_phone_message
+      t('errors.messages.invalid_phone_number')
+    end
+
+    def unsupported_sms_message
+      t('errors.messages.invalid_sms_number')
+    end
+
+    def failed_to_send_otp
+      t('errors.messages.otp_failed')
+    end
+
     def invalid_email_message
       t('valid_email.validations.email.invalid')
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -111,6 +111,7 @@ module Features
     end
 
     def click_send_security_code
+      stub_twilio_service
       click_button t('forms.buttons.send_security_code')
     end
 
@@ -367,6 +368,14 @@ module Features
       click_link t('links.sign_in')
       fill_in_credentials_and_submit(user.email, user.password)
       click_submit_default
+    end
+
+    def stub_twilio_service
+      twilio_service = instance_double(TwilioService)
+      allow(twilio_service).to receive(:send_sms)
+      allow(twilio_service).to receive(:place_call)
+
+      allow(TwilioService).to receive(:new).and_return(twilio_service)
     end
   end
 end


### PR DESCRIPTION
**Why**:
Users received no indication if a number was invalid
when setting up OTP.