### PR TITLE
Specify host in default_url_options

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    { locale: locale_url_param }
+    { locale: locale_url_param, host: Figaro.env.domain_name }
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.action_controller.asset_host = Figaro.env.domain_name
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,6 @@ Rails.application.configure do
   config.eager_load = true
   config.consider_all_requests_local = false
   config.action_controller.asset_host = Figaro.env.domain_name
-  config.action_controller.default_url_options = { host: Figaro.env.domain_name }
   config.action_controller.perform_caching = true
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.assets.js_compressor = :uglifier

--- a/lib/headers_filter.rb
+++ b/lib/headers_filter.rb
@@ -2,9 +2,7 @@ require 'rack/headers_filter'
 
 # Expands on Rack::HeadersFilter to delete additional headers
 class HeadersFilter
-  HEADERS_TO_DELETE = Rack::HeadersFilter::SENSITIVE_HEADERS + %w[
-    HTTP_HOST
-  ]
+  HEADERS_TO_DELETE = Rack::HeadersFilter::SENSITIVE_HEADERS
 
   def initialize(app)
     @app = app
@@ -12,18 +10,10 @@ class HeadersFilter
 
   def call(env)
     HEADERS_TO_DELETE.each { |header| env.delete(header) }
-    ascii_encode_headers(env)
     app.call(env)
   end
 
   private
-
-  def ascii_encode_headers(env)
-    headers = env.select { |key, _value| key.starts_with? 'HTTP_' }
-    headers.each do |header, value|
-      env[header] = value.encode('ascii-8bit', invalid: :replace, undef: :replace, replace: '?')
-    end
-  end
 
   attr_reader :app
 end

--- a/spec/lib/headers_filter_spec.rb
+++ b/spec/lib/headers_filter_spec.rb
@@ -14,18 +14,8 @@ RSpec.describe HeadersFilter do
 
       middleware.call(env)
 
-      expect(env).to_not have_key('HTTP_HOST')
+      expect(env).to have_key('HTTP_HOST')
       expect(env).to_not have_key('HTTP_X_FORWARDED_HOST')
-    end
-
-    it 'encodes headers as 8 bit ASCII' do
-      env = {
-        'HTTP_USER_AGENT' => 'Mózillá/5.0',
-      }
-
-      middleware.call(env)
-
-      expect(env['HTTP_USER_AGENT'].ascii_only?).to eq(true)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,14 @@ RSpec.configure do |config|
     I18n.locale = :en
   end
 
+  config.before(:each, js: true) do
+    allow(Figaro.env).to receive(:domain_name).and_return('127.0.0.1')
+  end
+
+  config.before(:each, type: :controller) do
+    @request.host = Figaro.env.domain_name
+  end
+
   config.before(:each) do
     allow(ValidateEmail).to receive(:mx_valid?).and_return(true)
   end

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'Headers' do
     expect(response.code.to_i).to eq(404)
   end
 
-  it 'ASCII encodes UTF8 headers' do
-    get root_path, headers: { 'User-Agent' => 'Mózillá/5.0' }
+  it 'does not raise an error when HTTP_HOST Header is encoded with ASCII-8BIT' do
+    get root_path, headers: { 'Host' => '¿’¿”'.force_encoding(Encoding::ASCII_8BIT) }
 
-    expect(request.env['HTTP_USER_AGENT'].ascii_only?).to eq(true)
+    expect(response.status).to eq 200
   end
 end


### PR DESCRIPTION
**Why**: In production, we noticed the following 500 error:
Encoding::CompatibilityError:
incompatible character encodings: ASCII-8BIT and UTF-8

This was caused by someone setting the HTTP_HOST header to an invalid
URI, such as `¿’¿”`. By default Rails uses this HTTP_HOST header value
to generate URLs for assets and URL helpers. The HTTP_HOST header is
encoded with ASCII-8BIT, and when Rails generates the HTML to render
the page, it tries to concatenate this ASCII-8BIT host value with UTF-8
characters (the default encoding in the app), which causes the
`Encoding::CompatibilityError`.

**How**:
- Ensure the asset host is set to the server on which the app is
running. This was already done in `production.rb` but I also added it
to `development.rb`:
`config.action_controller.asset_host = Figaro.env.domain_name`
- Ensure a default host is set for URL generation by setting
`config.action_controller.default_url_options`. This was already done in
`production.rb`, but because we also defined a `default_url_options`
method in ApplicationController (that did not include the `host` key),
it overrode the setting in `production.rb`. I fixed this by removing the
method from ApplicationController and setting the options in
`development.rb` and `production.rb`. This was necessary because I was
not able to find a way to set this in ApplicationController without it
affecting integration and controller specs. For example, JS specs depend
on the host being `127.0.0.1`, but non-JS integration specs assume the
host is `www.example.com`. Controller specs assume the host is
`test.host`. I believe most of these test issues are due to
checking for and visiting full URLs instead of paths. I will try to fix
this in a separate PR.
- Don't remove the HTTP_HOST header from `env` because it prevents us
from writing a failing test. If the HOST header is deleted, the test
environment will provide its own valid host for URL helpers
(as opposed to letting Rails use the value from the HOST header).