### PR TITLE
Fix NoMethodError in find_by_email

### DIFF
--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -11,7 +11,7 @@ module UserEncryptedAttributeOverrides
     end
 
     def find_with_email(email)
-      email = email.downcase.strip
+      email = email.try(:downcase).try(:strip)
       return nil if email.blank?
 
       email_fingerprint = create_fingerprint(email)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -254,5 +254,9 @@ describe User do
 
       expect(User.find_with_email(' Test1@test.com ')).to eq user
     end
+
+    it 'does not blow up with malformed input' do
+      expect(User.find_with_email(foo: 'bar')).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
**Why**: protect against malformed data