### PR TITLE
Update password creation page

### DIFF
--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -8,6 +8,34 @@ module UnconfirmedUserConcern
     yield if block_given?
   end
 
+  def validate_token
+    with_unconfirmed_user do
+      result = EmailConfirmationTokenValidator.new(@user).submit
+
+      analytics.track_event(Analytics::EMAIL_CONFIRMATION, result.to_h)
+
+      if result.success?
+        process_successful_confirmation
+      else
+        process_unsuccessful_confirmation
+      end
+    end
+  end
+
+  def process_valid_confirmation_token
+    @confirmation_token = params[:confirmation_token]
+    flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password')
+    session[:user_confirmation_token] = @confirmation_token
+  end
+
+  def process_confirmed_user
+    create_user_event(:email_changed, @user)
+
+    flash[:success] = t('devise.confirmations.confirmed')
+    redirect_to after_confirmation_path_for(@user)
+    EmailNotifier.new(@user).send_email_changed_email
+  end
+
   def after_confirmation_path_for(user)
     if !user_signed_in?
       new_user_session_url
@@ -15,6 +43,29 @@ module UnconfirmedUserConcern
       account_path
     else
       phone_setup_url
+    end
+  end
+
+  def process_unsuccessful_confirmation
+    return process_already_confirmed_user if @user.confirmed?
+
+    @confirmation_token = params[:confirmation_token]
+    flash[:error] = unsuccessful_confirmation_error
+    redirect_to sign_up_email_resend_url(request_id: params[:_request_id])
+  end
+
+  def process_already_confirmed_user
+    action_text = t('devise.confirmations.sign_in') unless user_signed_in?
+    flash[:error] = t('devise.confirmations.already_confirmed', action: action_text)
+
+    redirect_to user_signed_in? ? account_path : new_user_session_url
+  end
+
+  def unsuccessful_confirmation_error
+    if @user.confirmation_period_expired?
+      @user.decorate.confirmation_period_expired_error
+    else
+      t('errors.messages.confirmation_invalid_token')
     end
   end
 end

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -3,17 +3,7 @@ module SignUp
     include UnconfirmedUserConcern
 
     def create
-      with_unconfirmed_user do
-        result = EmailConfirmationTokenValidator.new(@user).submit
-
-        analytics.track_event(Analytics::EMAIL_CONFIRMATION, result.to_h)
-
-        if result.success?
-          process_successful_confirmation
-        else
-          process_unsuccessful_confirmation
-        end
-      end
+      validate_token
     end
 
     private
@@ -21,49 +11,12 @@ module SignUp
     def process_successful_confirmation
       if !@user.confirmed?
         process_valid_confirmation_token
+        request_id = params.fetch(:_request_id, '')
+        redirect_to sign_up_enter_password_url(
+          request_id: request_id, confirmation_token: @confirmation_token
+        )
       else
         process_confirmed_user
-      end
-    end
-
-    def process_valid_confirmation_token
-      @confirmation_token = params[:confirmation_token]
-      flash[:notice] = t('devise.confirmations.confirmed_but_must_set_password')
-      session[:user_confirmation_token] = @confirmation_token
-      request_id = params.fetch(:_request_id, '')
-      redirect_to sign_up_enter_password_url(
-        request_id: request_id, confirmation_token: @confirmation_token
-      )
-    end
-
-    def process_confirmed_user
-      create_user_event(:email_changed, @user)
-
-      flash[:notice] = t('devise.confirmations.confirmed')
-      redirect_to after_confirmation_path_for(@user)
-      EmailNotifier.new(@user).send_email_changed_email
-    end
-
-    def process_unsuccessful_confirmation
-      return process_already_confirmed_user if @user.confirmed?
-
-      @confirmation_token = params[:confirmation_token]
-      flash[:error] = unsuccessful_confirmation_error
-      redirect_to sign_up_email_resend_url(request_id: params[:_request_id])
-    end
-
-    def process_already_confirmed_user
-      action_text = 'Please sign in.' unless user_signed_in?
-      flash[:error] = t('devise.confirmations.already_confirmed', action: action_text)
-
-      redirect_to user_signed_in? ? account_path : new_user_session_url
-    end
-
-    def unsuccessful_confirmation_error
-      if @user.confirmation_period_expired?
-        @user.decorate.confirmation_period_expired_error
-      else
-        t('errors.messages.confirmation_invalid_token')
       end
     end
   end

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -3,7 +3,7 @@ module SignUp
     include UnconfirmedUserConcern
 
     def new
-      with_unconfirmed_user
+      validate_token
     end
 
     def create
@@ -21,6 +21,24 @@ module SignUp
     end
 
     private
+
+    def process_successful_confirmation
+      if !@user.confirmed?
+        process_valid_confirmation_token
+        render_page
+      else
+        process_confirmed_user
+      end
+    end
+
+    def render_page
+      request_id = params.fetch(:_request_id, '')
+      render(
+        :new,
+        locals: { request_id: request_id, confirmation_token: @confirmation_token },
+        formats: :html
+      )
+    end
 
     def permitted_params
       params.require(:password_form).permit(:confirmation_token, :password, :request_id)

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -9,6 +9,7 @@ en:
         your email address in a few minutes.
       send_paranoid_instructions: You will receive an email with instructions for
         how to confirm your email address in a few minutes.
+      sign_in: Please sign in.
     failure:
       already_authenticated: ''
       inactive: Your account is not activated yet.

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -9,6 +9,7 @@ es:
         confirmar el uso de su email.
       send_paranoid_instructions: En pocos minutos recibirá un email con instrucciones
         para confirmar el uso de su email.
+      sign_in: Inicie la sesión de nuevo.
     failure:
       already_authenticated: ''
       inactive: Su cuenta aún no está activada.

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -9,6 +9,7 @@ fr:
         instructions pour confirmer votre adresse courriel.
       send_paranoid_instructions: Vous recevrez dans quelques instants un courriel
         avec des instructions pour confirmer votre adresse courriel.
+      sign_in: Veuillez vous connecter de nouveau.
     failure:
       already_authenticated: ''
       inactive: Votre compte n'est pas encore activé.

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -74,9 +74,9 @@ feature 'Email confirmation during sign up' do
       visit sign_up_create_email_confirmation_url(confirmation_token: @raw_confirmation_token)
 
       expect(page.html).to include(t('notices.dap_participation'))
-      expect(page).to have_content(
-        t('devise.confirmations.already_confirmed', action: 'Please sign in.')
-      )
+      action = t('devise.confirmations.sign_in')
+      expect(page).
+        to have_content t('devise.confirmations.already_confirmed', action: action)
       expect(current_url).to eq new_user_session_url
     end
   end

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -28,7 +28,7 @@ describe 'user edits their account', email: true do
     it 'displays a notice informing the user their email has been confirmed when user confirms' do
       get parse_email_for_link(last_email, /confirmation_token/)
 
-      expect(flash[:notice]).to eq t('devise.confirmations.confirmed')
+      expect(flash[:success]).to eq t('devise.confirmations.confirmed')
       expect(response).to render_template('user_mailer/email_changed')
     end
 
@@ -45,7 +45,7 @@ describe 'user edits their account', email: true do
       delete destroy_user_session_path
       get parse_email_for_link(last_email, /confirmation_token/)
 
-      expect(flash[:notice]).to eq t('devise.confirmations.confirmed')
+      expect(flash[:success]).to eq t('devise.confirmations.confirmed')
     end
   end
 end


### PR DESCRIPTION
**Why**: For a better user experience. We were using "notice" flashes
(blue with exclamation mark) — which imply further action is needed —
instead of "success" (green with checkmark).