### PR TITLE
Add new single health check endpoint

### DIFF
--- a/app/controllers/health/abstract_health_controller.rb
+++ b/app/controllers/health/abstract_health_controller.rb
@@ -1,0 +1,9 @@
+module Health
+  class AbstractHealthController < ApplicationController
+    def index
+      summary = health_checker.check
+
+      render json: summary, status: (summary.healthy? ? :ok : :internal_error)
+    end
+  end
+end

--- a/app/controllers/health/database_controller.rb
+++ b/app/controllers/health/database_controller.rb
@@ -1,9 +1,9 @@
 module Health
-  class DatabaseController < ApplicationController
-    def index
-      summary = DatabaseHealthChecker.check
+  class DatabaseController < AbstractHealthController
+    private
 
-      render json: summary, status: (summary.healthy ? :ok : :internal_error)
+    def health_checker
+      DatabaseHealthChecker
     end
   end
 end

--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -1,0 +1,12 @@
+module Health
+  class HealthController < AbstractHealthController
+    private
+
+    def health_checker
+      MultiHealthChecker.new(
+        database: DatabaseHealthChecker,
+        workers: WorkerHealthChecker
+      )
+    end
+  end
+end

--- a/app/controllers/health/workers_controller.rb
+++ b/app/controllers/health/workers_controller.rb
@@ -1,11 +1,9 @@
 module Health
-  class WorkersController < ApplicationController
-    def index
-      summary = WorkerHealthChecker.summary
+  class WorkersController < AbstractHealthController
+    private
 
-      status = summary.all_healthy? ? :ok : :internal_error
-
-      render json: summary, status: status
+    def health_checker
+      WorkerHealthChecker
     end
   end
 end

--- a/app/services/database_health_checker.rb
+++ b/app/services/database_health_checker.rb
@@ -5,6 +5,8 @@ module DatabaseHealthChecker
     def as_json(*args)
       to_h.as_json(*args)
     end
+
+    alias_method :healthy?, :healthy
   end
 
   # @return [Summary]

--- a/app/services/multi_health_checker.rb
+++ b/app/services/multi_health_checker.rb
@@ -1,0 +1,29 @@
+class MultiHealthChecker
+  Summary = Struct.new(:statuses) do
+    def healthy?
+      statuses.values.all?(&:healthy?)
+    end
+
+    def to_h
+      super.merge(healthy: healthy?)
+    end
+
+    def as_json(*args)
+      to_h.as_json(*args)
+    end
+  end
+
+  def initialize(checkers)
+    @checkers = checkers.to_h
+  end
+
+  def check
+    statuses = checkers.map { |name, checker| [name, checker.check] }.to_h
+
+    Summary.new(statuses)
+  end
+
+  private
+
+  attr_reader :checkers
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint.new
 
   # Non i18n routes. Alphabetically sorted.
+  get '/api/health' => 'health/health#index'
   get '/api/health/database' => 'health/database#index'
   get '/api/health/workers' => 'health/workers#index'
   get '/api/openid_connect/certs' => 'openid_connect/certs#index'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,6 @@ require File.expand_path(File.dirname(__FILE__) + '/environment')
 health_check = Whenever.seconds(Figaro.env.queue_health_check_frequency_seconds.to_i, :seconds)
 
 every health_check, roles: [:job_creator] do
-  runner 'WorkerHealthChecker.check'
   runner 'WorkerHealthChecker.enqueue_dummy_jobs'
 end
 

--- a/spec/controllers/health/health_controller_spec.rb
+++ b/spec/controllers/health/health_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Health::HealthController do
+  describe '#index' do
+    subject(:action) { get :index }
+
+    before do
+      allow(WorkerHealthChecker).to receive(:check).
+        and_return(WorkerHealthChecker::Summary.new(statuses))
+    end
+
+    let(:statuses) { [WorkerHealthChecker::Status.new('voice', 0.minutes.ago, true)] }
+
+    context 'when all checked resources are healthy' do
+      it 'is a 200' do
+        action
+
+        expect(response.status).to eq(200)
+      end
+
+      it 'renders the result' do
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json[:healthy]).to eq(true)
+        expect(json[:statuses][:workers][:all_healthy]).to eq(true)
+        expect(json[:statuses][:database][:healthy]).to eq(true)
+      end
+    end
+
+    context 'when one resource is unhealthy' do
+      before do
+        expect(DatabaseHealthChecker).to receive(:simple_query).
+          and_raise(RuntimeError.new('canceling statement due to statement timeout'))
+      end
+
+      it 'is a 500' do
+        action
+
+        expect(response.status).to eq(500)
+      end
+
+      it 'renders the error' do
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json[:healthy]).to eq(false)
+        expect(json[:statuses][:database][:result]).
+          to include('canceling statement due to statement timeout')
+      end
+    end
+  end
+end

--- a/spec/controllers/health/workers_controller_spec.rb
+++ b/spec/controllers/health/workers_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Health::WorkersController do
   describe '#index' do
     before do
-      allow(WorkerHealthChecker).to receive(:summary).
+      allow(WorkerHealthChecker).to receive(:check).
         and_return(WorkerHealthChecker::Summary.new(statuses))
     end
 

--- a/spec/services/multi_health_checker_spec.rb
+++ b/spec/services/multi_health_checker_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe MultiHealthChecker do
+  subject(:checker) { MultiHealthChecker.new(checkers) }
+
+  describe '#check' do
+    let(:summary_class) do
+      Class.new do
+        def initialize(healthy)
+          @healthy = healthy
+        end
+
+        def healthy?
+          @healthy
+        end
+      end
+    end
+
+    subject(:check) { checker.check }
+
+    let(:healthy_checker) { double(check: summary_class.new(true)) }
+    let(:unhealthy_checker) { double(check: summary_class.new(false)) }
+
+    context 'with all healthy checkers' do
+      let(:checkers) do
+        {
+          check_a: healthy_checker,
+          check_b: healthy_checker,
+        }
+      end
+
+      it 'returns a healthy result' do
+        expect(check.healthy?).to eq(true)
+      end
+
+      it 'returns a JSON-ready summary' do
+        json = check.as_json
+
+        expect(json['healthy']).to eq(true)
+        expect(json['statuses']['check_a']).to be
+        expect(json['statuses']['check_b']).to be
+      end
+    end
+
+    context 'with a single unhealthy checker' do
+      let(:checkers) do
+        {
+          check_a: healthy_checker,
+          check_b: unhealthy_checker,
+        }
+      end
+
+      it 'returns a healthy result' do
+        expect(check.healthy?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: A single endpoint is clearer to monitor

**How**: Create an implicit "checker" interface and aggregate
across worker and database health checks