### PR TITLE
Enable voice calling to Mexico

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -473,7 +473,7 @@ YT:
 MX:
   name: Mexico
   country_code: '52'
-  sms_only: true
+  sms_only: false
 FM:
   name: Micronesia
   country_code: '691'


### PR DESCRIPTION
**Why**: Because it is enabled in our Twilio configuration