### PR TITLE
Whitelist origins for CORS requests and update rack-cors gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,7 +419,7 @@ GEM
     rack (2.0.3)
     rack-attack (5.0.1)
       rack
-    rack-cors (0.4.1)
+    rack-cors (1.0.1)
     rack-headers_filter (0.0.1)
     rack-mini-profiler (0.10.5)
       rack (>= 1.2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,11 @@ module Upaya
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins '*'
+        origins do |source, _env|
+          ServiceProvider.pluck(:redirect_uris).flatten.map do |uri|
+            URI.join(uri, '/').to_s[0..-2]
+          end.include?(source)
+        end
         resource '/.well-known/openid-configuration', headers: :any, methods: [:get]
         resource '/api/openid_connect/certs', headers: :any, methods: [:get]
         resource '/api/openid_connect/token',

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -50,6 +50,7 @@ test:
   'urn:gov:gsa:openidconnect:sp:server':
     redirect_uris:
       - 'http://localhost:7654/'
+      - 'https://example.com'
     cert: 'saml_test_sp'
     friendly_name: 'Test SP'
     assertion_consumer_logout_service_url: ''

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -2,66 +2,132 @@ require 'rails_helper'
 
 RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   describe 'configuration endpoint' do
-    it 'sets CORS headers to allow all origins' do
-      get openid_connect_configuration_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+    context 'origin is included in ServiceProvider redirect_uris' do
+      it 'allows origin' do
+        get openid_connect_configuration_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
-      aggregate_failures do
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-        expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+          expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        end
+      end
+    end
+
+    context 'origin is not included in ServiceProvider redirect_uris' do
+      it 'does not allow origin' do
+        get openid_connect_configuration_path, headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+
+        aggregate_failures do
+          expect(response).to be_ok
+          expect(response['Access-Control-Allow-Origin']).to be_nil
+        end
       end
     end
   end
 
   describe 'certs endpoint' do
-    it 'sets CORS headers to allow all origins' do
-      get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+    context 'origin is included in ServiceProvider redirect_uris' do
+      it 'allows origin' do
+        get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
-      aggregate_failures do
-        expect(response).to be_ok
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-        expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        aggregate_failures do
+          expect(response).to be_ok
+          expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+          expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        end
+      end
+    end
+
+    context 'origin is not included in ServiceProvider redirect_uris' do
+      it 'does not allow origin' do
+        get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+
+        aggregate_failures do
+          expect(response).to be_ok
+          expect(response['Access-Control-Allow-Origin']).to be_nil
+        end
       end
     end
   end
 
   describe 'token endpoint' do
-    it 'responds to POST requests with the right CORS headers' do
-      post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+    context 'origin is included in ServiceProvider redirect_uris' do
+      it 'responds to POST requests with the right CORS headers' do
+        post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
-      aggregate_failures do
-        expect(response).to_not be_not_found
-        expect(response['Access-Control-Allow-Credentials']).to eq('true')
-        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        aggregate_failures do
+          expect(response).to_not be_not_found
+          expect(response['Access-Control-Allow-Credentials']).to eq('true')
+          expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
+          expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        end
+      end
+
+      it 'responds to OPTIONS requests with the right CORS headers' do
+        process(
+          :options,
+          api_openid_connect_token_path,
+          params: {},
+          headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+        )
+
+        aggregate_failures do
+          expect(response).to be_ok
+          expect(response.body).to be_empty
+          expect(response['Access-Control-Allow-Credentials']).to eq('true')
+          expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
+          expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        end
       end
     end
 
-    it 'responds to OPTIONS requests with the right CORS headers' do
-      process(
-        :options,
-        api_openid_connect_token_path,
-        params: {},
-        headers: { 'HTTP_ORIGIN' => 'https://example.com' }
-      )
+    context 'origin is not included in ServiceProvider redirect_uris' do
+      it 'does not allow POST requests from origin' do
+        post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
 
-      aggregate_failures do
-        expect(response).to be_ok
-        expect(response.body).to be_empty
-        expect(response['Access-Control-Allow-Credentials']).to eq('true')
-        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to be_nil
+          expect(response['Access-Control-Allow-Methods']).to be_nil
+        end
+      end
+
+      it 'does not allow OPTIONS requests from origin' do
+        process(
+          :options,
+          api_openid_connect_token_path,
+          params: {},
+          headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+        )
+
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to be_nil
+          expect(response['Access-Control-Allow-Methods']).to be_nil
+        end
       end
     end
   end
 
   describe 'userinfo endpoint' do
-    it 'sets CORS headers to allow all origins' do
-      get api_openid_connect_userinfo_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+    context 'origin is included in ServiceProvider redirect_uris' do
+      it 'responds to request from origin' do
+        get api_openid_connect_userinfo_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
 
-      aggregate_failures do
-        expect(response).to_not be_not_found
-        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
-        expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        aggregate_failures do
+          expect(response).to_not be_not_found
+          expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+          expect(response['Access-Control-Allow-Methods']).to eq('GET')
+        end
+      end
+    end
+
+    context 'origin is not included in ServiceProvider redirect_uris' do
+      it 'does not respond to request from origin' do
+        get api_openid_connect_userinfo_path, headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+
+        aggregate_failures do
+          expect(response['Access-Control-Allow-Origin']).to be_nil
+          expect(response['Access-Control-Allow-Methods']).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
**Why**: Due to enforcing basic auth in our lower envs, we need to set
`credentials: true` for the `/api/openid_connect/token` endpoint.
However, the combination of `credentials: true` and allowing all
origins via the wildcard setting poses a security risk, and the latest
version of the `rack-cors` gem will not allow that configuration.

Until we remove basic auth, the solution is to restrict origins to
those we trust. Since the CORS endpoints are specific to OIDC clients,
I've set the origins based on the domains in
`ServiceProvider#redirect_uris`.

Reference:
https://web-in-security.blogspot.de/2017/07/cors-misconfigurations-on-large-scale.html