### PR TITLE
CORS: handle bad URIs in the database

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,12 @@ module Upaya
       allow do
         origins do |source, _env|
           ServiceProvider.pluck(:redirect_uris).flatten.map do |uri|
-            URI.join(uri, '/').to_s[0..-2]
+            begin
+              URI.join(uri, '/').to_s[0..-2]
+            rescue URI::BadURIError => err
+              Rails.logger.warn({ warning: err.class.to_s, source: 'Rack::Cors', uri: uri }.to_json)
+              ''
+            end
           end.include?(source)
         end
         resource '/.well-known/openid-configuration', headers: :any, methods: [:get]

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
         end
       end
     end
+
+    context 'with a bad URI in the database' do
+      before { create(:service_provider, redirect_uris: %w[/foobar]) }
+
+      it 'does not blow up' do
+        get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+
+        expect(response).to be_ok
+      end
+    end
   end
 
   describe 'certs endpoint' do


### PR DESCRIPTION
**Why**: One bad URI should not mess up all requests