### PR TITLE
Deprecate attributes in PII instead of removing

### DIFF
--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -1,9 +1,14 @@
 module Pii
+  DEPRECATED_PII_ATTRIBUTES = [
+    :otp, # https://github.com/18F/identity-idp/pull/1661
+  ].freeze
+
   Attributes = Struct.new(
     :first_name, :middle_name, :last_name,
     :address1, :address2, :city, :state, :zipcode,
     :ssn, :dob, :phone,
-    :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
+    :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode,
+    *DEPRECATED_PII_ATTRIBUTES
   ) do
     def self.new_from_hash(hash)
       attrs = new

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -38,6 +38,14 @@ describe Pii::Attributes do
 
       expect(pii_attrs.first_name).to eq 'Jane'
     end
+
+    it 'allows deprecated attributes that are no longer added to the hash schema' do
+      deprecated_atts = described_class.new_from_hash(otp: '123abc')
+      encrypted_pii = deprecated_atts.encrypted(user_access_key)
+      pii_attrs = described_class.new_from_encrypted(encrypted_pii, user_access_key)
+
+      expect(pii_attrs[:otp]).to eq('123abc')
+    end
   end
 
   describe '#new_from_json' do


### PR DESCRIPTION
**Why**: Since we can't modify the PII blob without decrypting, we need
to make sure the blog stays backwards compatible or we'll start running
into errors decrypting old PII blobs.