### PR TITLE
Ignore apdex score for health checks in NewRelic

### DIFF
--- a/app/controllers/health/abstract_health_controller.rb
+++ b/app/controllers/health/abstract_health_controller.rb
@@ -1,5 +1,7 @@
 module Health
   class AbstractHealthController < ApplicationController
+    newrelic_ignore_apdex
+
     def index
       summary = health_checker.check
 


### PR DESCRIPTION
**Why**: Health checks are not indicative of real user experience

**How**: Use the class method

Normally I would make sure we have a test for this, however
when we have NewRelic disabled in tests, the method is just a shim
with an empty implementation that has no observable side effects.

The behavior we want (a parent class having this method called)
is described by this spec in the NewRelic RPM gem so hopefully
we can take it on faith that this behaves as expected?

https://github.com/newrelic/rpm/blob/110fe199d638de10d28c2461f03c508e276040e6/test/multiverse/suites/rails/ignore_test.rb