### PR TITLE
Don't retry failed IdV background jobs

### DIFF
--- a/.reek
+++ b/.reek
@@ -3,9 +3,11 @@ Attribute:
 ControlParameter:
   exclude:
     - OpenidConnectRedirector#initialize
+    - NoRetryJobs#call
 DuplicateMethodCall:
   exclude:
     - ApplicationController#disable_caching
+    - IdvFailureConcern#render_failure
     - ServiceProviderSessionDecorator#registration_heading
     - MfaConfirmationController#handle_invalid_password
     - needs_to_confirm_email_change?
@@ -66,6 +68,7 @@ TooManyInstanceVariables:
 TooManyStatements:
   max_statements: 6
   exclude:
+    - IdvFailureConcern#render_failure
     - OpenidConnect::AuthorizationController#index
     - OpenidConnect::AuthorizationController#store_request
     - SamlIdpAuthConcern#store_saml_request

--- a/app/controllers/concerns/idv_failure_concern.rb
+++ b/app/controllers/concerns/idv_failure_concern.rb
@@ -1,10 +1,14 @@
 module IdvFailureConcern
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/MethodLength
   def render_failure
     if step_attempts_exceeded?
       @view_model = view_model(error: 'fail')
       flash_message(type: :error)
+    elsif step.vendor_validator_job_failed?
+      @view_model = view_model(error: 'jobfail')
+      flash_message(type: :warning)
     elsif form_valid_but_vendor_validation_failed?
       @view_model = view_model(error: 'warning', timed_out: step.vendor_validation_timed_out?)
       flash_message(type: :warning)
@@ -12,6 +16,7 @@ module IdvFailureConcern
       @view_model = view_model
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def form_valid_but_vendor_validation_failed?
     idv_form.valid? && !step.vendor_validation_passed?

--- a/app/services/idv/step.rb
+++ b/app/services/idv/step.rb
@@ -8,11 +8,16 @@ module Idv
     end
 
     def vendor_validation_passed?
+      return false if vendor_validator_job_failed?
       vendor_validator_result.success?
     end
 
     def vendor_validation_timed_out?
       vendor_validator_result.timed_out?
+    end
+
+    def vendor_validator_job_failed?
+      vendor_validator_result&.job_failed?
     end
 
     private

--- a/app/services/idv/vendor_result.rb
+++ b/app/services/idv/vendor_result.rb
@@ -28,5 +28,9 @@ module Idv
     def timed_out?
       timed_out
     end
+
+    def job_failed?
+      errors.fetch(:job_failed, false)
+    end
   end
 end

--- a/app/view_models/verify/base.rb
+++ b/app/view_models/verify/base.rb
@@ -24,7 +24,7 @@ module Verify
     end
 
     def warning_partial
-      if error == 'warning'
+      if %w[warning jobfail].include?(error)
         'shared/modal_verification_warning'
       else
         'shared/null'
@@ -37,7 +37,7 @@ module Verify
     end
 
     def button
-      if error == 'warning'
+      if %w[warning jobfail].include?(error)
         helper.content_tag(
           :button, button_link_text, id: 'js-close-modal', class: button_css_classes
         )
@@ -52,6 +52,11 @@ module Verify
       )
       flash_body = message
       flash_heading + flash_body + attempts
+    end
+
+    def modal_class_name
+      return 'modal-warning' if %w[warning jobfail].include?(error)
+      "modal-#{error}"
     end
 
     private
@@ -69,7 +74,7 @@ module Verify
     end
 
     def attempts
-      if error == 'warning'
+      if %w[warning jobfail].include?(error)
         html_paragraph(text: I18n.t('idv.modal.attempts', count: remaining_attempts))
       else
         ''

--- a/app/views/shared/_modal_verification.slim
+++ b/app/views/shared/_modal_verification.slim
@@ -1,6 +1,6 @@
 #verification-modal.display-none
   = render layout: '/shared/modal_layout' do
-    .p3.sm-p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl(class="modal-#{view_model.error}")
+    .p3.sm-p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl(class="#{view_model.modal_class_name}")
       h2.my2.fs-20p.sans-serif.regular.center = t("idv.modal.#{view_model.step_name}.heading")
       hr.mb3.bw4.rounded
       .mb4

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,7 @@
 require 'encrypted_sidekiq_redis'
 require 'sidekiq_logger_formatter'
 require 'worker_health_checker'
+require 'no_retry_jobs'
 
 Sidekiq::Logging.logger.level = Logger::WARN
 Sidekiq::Logging.logger.formatter = SidekiqLoggerFormatter.new
@@ -18,6 +19,7 @@ Sidekiq.configure_server do |config|
   # middleware to spec/rails_helper.rb to run in tests as well
   config.server_middleware do |chain|
     chain.add WorkerHealthChecker::Middleware
+    chain.add NoRetryJobs
   end
 end
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -169,12 +169,15 @@ en:
         other: You have <strong>%{count} attempts remaining.</strong>
       button:
         fail: Okay
+        jobfail: Try again tomorrow
         warning: Try again
       financials:
         fail: Your account is <strong>locked for 24 hours</strong> before you can
           try to verify again. Check our Help section for more information about identity
           verification.
         heading: We could not find records matching your financial information.
+        jobfail: Something went wrong and we cannot process your request at this time.
+          Please try again tomorrow.
         timeout: Our request to verify your information timed out.
         warning: Please check the information you entered.
       phone:
@@ -182,12 +185,16 @@ en:
           try to verify again. Check our Help section for more information about identity
           verification.
         heading: We could not find records matching your phone information.
+        jobfail: Something went wrong and we cannot process your request at this time.
+          Please try again tomorrow.
         timeout: Our request to verify your information timed out.
         warning: Please check the information you entered.
       sessions:
         fail: Your account is <strong>locked for 24 hours</strong> before you can
           try to verify again.
         heading: We could not find records matching your personal information.
+        jobfail: Something went wrong and we cannot process your request at this time.
+          Please try again tomorrow.
         timeout: Our request to verify your information timed out.
         warning: Please check the information you entered. Common mistakes are an
           incorrect Social Security Number, ZIP Code, or date of birth.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -171,6 +171,7 @@ es:
         other: Tiene usted <strong>%{count} intentos restantes.</strong>
       button:
         fail: Bueno
+        jobfail: Inténtelo de nuevo mañana
         warning: Inténtelo de nuevo
       financials:
         fail: Su cuenta está <strong>bloqueada por 24 horas</ strong> antes de intentar
@@ -178,6 +179,7 @@ es:
           información sobre la verificación de identidad.
         heading: No hemos podido encontrar registros que coincidan con su información
           financiera.
+        jobfail: NOT TRANSLATED YET
         timeout: NOT TRANSLATED YET
         warning: Compruebe la información que ingresó.
       phone:
@@ -186,11 +188,13 @@ es:
           información sobre la verificación de identidad.
         heading: No hemos podido encontrar registros que coincidan con la información
           de su teléfono.
+        jobfail: NOT TRANSLATED YET
         timeout: NOT TRANSLATED YET
         warning: Compruebe la información que ingresó.
       sessions:
         fail: Su cuenta está <strong>bloqueada por 24 horas</ strong> antes de que
           pueda intentar verificarla de nuevo.
+        jobfail: NOT TRANSLATED YET
         heading: No hemos podido encontrar registros que coincidan con su información
           personal.
         timeout: NOT TRANSLATED YET

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -182,12 +182,14 @@ fr:
         other: Il ne vous reste que strong%{count} tentatives./strong
       button:
         fail: OK
+        jobfail: Essayez à nouveau demain
         warning: Essayez à nouveau
       financials:
         fail: Votre compte est strongverrouillé pour 24 heures/strong au cours desquelles
           vous ne pourrez pas y accéder. Consultez notre Centre d'aide pour plus d'information
           sur la vérification de votre identité.
         heading: Nous ne trouvons pas de données qui correspondent à vos données financières.
+        jobfail: NOT TRANSLATED YET
         timeout: NOT TRANSLATED YET
         warning: Veuillez vérifier l'information que vous avez fournie.
       phone:
@@ -196,6 +198,7 @@ fr:
           sur la vérification de votre identité.
         heading: Nous ne trouvons pas de données qui correspondent à vos informations
           téléphoniques.
+        jobfail: NOT TRANSLATED YET
         timeout: NOT TRANSLATED YET
         warning: Veuillez vérifier l'information que vous avez fournie.
       sessions:
@@ -203,6 +206,7 @@ fr:
           vous ne pourrez pas y accéder.
         heading: Nous ne trouvons pas de données qui correspondent à vos informations
           téléphoniques.
+        jobfail: NOT TRANSLATED YET
         timeout: NOT TRANSLATED YET
         warning: Veuillez vérifier l'information que vous avez fournie. Un numéro
           de sécurité sociale, un code ZIP ou une date de naissance mal écrits sont

--- a/lib/no_retry_jobs.rb
+++ b/lib/no_retry_jobs.rb
@@ -1,0 +1,8 @@
+class NoRetryJobs
+  def call(_worker, msg, queue)
+    yield
+  rescue StandardError => _e
+    msg['retry'] = false if queue == 'idv'
+    raise
+  end
+end

--- a/spec/features/idv/failed_job_spec.rb
+++ b/spec/features/idv/failed_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature 'IdV session' do
+  include IdvHelper
+
+  context 'VendorValidatorJob raises an error', idv_job: true do
+    it 'displays a warning that something went wrong' do
+      sign_in_and_2fa_user
+
+      step = instance_double(
+        Idv::ProfileStep, attempts_exceeded?: false, vendor_validator_job_failed?: true
+      )
+      allow(Idv::ProfileStep).to receive(:new).and_return(step)
+      allow(step).to receive(:submit).
+        and_return(FormResponse.new(success: false, errors: {}, extra: {}))
+
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_idv_continue
+
+      expect(page).to have_current_path(verify_session_result_path)
+      expect(page).to have_content t('idv.modal.sessions.jobfail')
+    end
+  end
+end

--- a/spec/jobs/vendor_validator_job_spec.rb
+++ b/spec/jobs/vendor_validator_job_spec.rb
@@ -63,5 +63,20 @@ RSpec.describe VendorValidatorJob do
         expect(result.reasons).to eq([exception_msg])
       end
     end
+
+    context 'when parsing the vendor response throws an exception' do
+      it 'rescues the error and stores the job failed result' do
+        allow(Idv::PhoneValidator).to receive(:new).and_raise(StandardError)
+
+        storage = instance_double(VendorValidatorResultStorage)
+        result =  instance_double(Idv::VendorResult, errors: { job_failed: true })
+        allow(Idv::VendorResult).to receive(:new).and_return(result)
+
+        expect(VendorValidatorResultStorage).to receive(:new).and_return(storage)
+        expect(storage).to receive(:store).with(result_id: result_id, result: result)
+
+        expect { perform }.to raise_error StandardError
+      end
+    end
   end
 end

--- a/spec/lib/no_retry_jobs_spec.rb
+++ b/spec/lib/no_retry_jobs_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe NoRetryJobs do
+  describe '#call' do
+    context 'when the queue is idv' do
+      it 'runs' do
+        count = 0
+        NoRetryJobs.new.call(nil, nil, 'idv') { count += 1 }
+
+        expect(count).to eq 1
+      end
+
+      it 'sets retry to false when rescuing StandardError then raises the error' do
+        msg = {}
+        expect { NoRetryJobs.new.call(nil, msg, 'idv') { raise StandardError } }.
+          to change { msg }.from({}).to('retry' => false).and raise_error(StandardError)
+      end
+    end
+
+    context 'when the queue is not idv' do
+      it 'does not set retry to false and raises StandardError' do
+        msg = {}
+        expect { NoRetryJobs.new.call(nil, msg, 'sms') { raise StandardError } }.
+          to change(msg, :keys).by([]).and raise_error(StandardError)
+      end
+    end
+  end
+end

--- a/spec/view_models/verify/base_spec.rb
+++ b/spec/view_models/verify/base_spec.rb
@@ -32,4 +32,41 @@ RSpec.describe Verify::Base do
       end
     end
   end
+
+  describe '#modal_class_name' do
+    let(:view_model) do
+      Verify::Base.new(
+        error: error,
+        remaining_attempts: 1,
+        idv_form: nil,
+        timed_out: false
+      )
+    end
+
+    subject(:modal_class_name) { view_model.modal_class_name }
+
+    context 'when error is warning' do
+      let(:error) { 'warning' }
+
+      it 'returns modal_warning' do
+        expect(modal_class_name).to eq 'modal-warning'
+      end
+    end
+
+    context 'when error is jobfail' do
+      let(:error) { 'jobfail' }
+
+      it 'returns modal_warning' do
+        expect(modal_class_name).to eq 'modal-warning'
+      end
+    end
+
+    context 'when error is fail' do
+      let(:error) { 'fail' }
+
+      it 'returns modal_fail' do
+        expect(modal_class_name).to eq 'modal-fail'
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: While testing IdV in staging, we noticed the Sidekiq jobs
were failing due to bugs in the equifax gem. The requests to Equifax
were successfully sent, as were the responses back from Equifax, but
the parsing of the XML response was broken, leading to an exception
in the Sidekiq job.

Each time a request is sent to Equifax, it increments the user's
attempts count, which is limited to a certain number per day.
Since the exception in the job happened after the attempt was already
made, and since Sidekiq is configured to retry failed jobs
automatically, attempt counts kept getting incremented each time the
job retried, unnecessarily penalizing the user. Moreover, exceeding
the allowable limit on Equifax means being locked out of other services
that use Equifax for identity verification.

**How**:
- To disable retries, add a custom Sidekiq middleware to rescue the
exception, then set retries to `false`, then raise the exception so
that we can be notified and see it in the logs.
- To improve the UX, create a new error message for this scenario by
rescuing the exception in the VendorValidatorJob and return an instance
of `Idv::VendorResult` with `job_failed: true` as the error.