### PR TITLE
Use simpler symmetric AES encryption for sessions

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,22 +1,16 @@
 class SessionEncryptor
-  def user_access_key
-    @user_access_key ||= begin
-      key = Figaro.env.session_encryption_key
-      uak = UserAccessKey.new(password: key, salt: key)
-      uak.random_r = OpenSSL::Digest::SHA256.digest(key)
-      uak
-    end
+  def cipher
+    @cipher ||= Gibberish::AES.new(Figaro.env.session_encryption_key)
   end
 
   def load(value)
-    decrypted = encryptor.decrypt(value, user_access_key)
-
+    decrypted = cipher.decrypt(value)
     JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
   end
 
   def dump(value)
     plain = JSON.generate(value, quirks_mode: true)
-    encryptor.encrypt(plain, user_access_key)
+    cipher.encrypt(plain)
   end
 
   private


### PR DESCRIPTION
**Why**: avoids side effects due to singleton UserAccessKey
for KMS encryption

--

note about specs, this relies on existing specs for encrypting/decrypting sessions as a drop-in replacement that has the same interface but a simpler implementatino