### PR TITLE
Unlock access key in session encryptor

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -2,9 +2,10 @@ class SessionEncryptor
   def user_access_key
     @user_access_key ||= begin
       key = Figaro.env.session_encryption_key
-      uak = UserAccessKey.new(password: key, salt: key)
-      uak.random_r = OpenSSL::Digest::SHA256.digest(key)
-      uak
+      user_access_key = UserAccessKey.new(password: key, salt: key)
+      random_r = OpenSSL::Digest::SHA256.digest(key)
+      user_access_key.unlock(random_r)
+      user_access_key
     end
   end
 

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -21,6 +21,18 @@ describe SessionEncryptor do
     expect(encryptor2.load(encrypted_text)).to eq(payload)
   end
 
+  it 'does not modify the cek when failing to decrypt a payload encrypted with an old key' do
+    old_encryptor = SessionEncryptor.new
+    old_encryptor.user_access_key.unlock(Pii::Cipher.random_key)
+    old_payload = old_encryptor.dump('asdf' => '1234')
+
+    new_encryptor = SessionEncryptor.new
+    original_cek = new_encryptor.user_access_key.cek
+
+    expect { new_encryptor.load(old_payload) }.to raise_error(Pii::EncryptionError)
+    expect(new_encryptor.user_access_key.cek).to eq(original_cek)
+  end
+
   describe '#dump' do
     it 'encrypts session' do
       session = SessionEncryptor.new.dump(foo: 'bar')


### PR DESCRIPTION
**Why**: The session encryptor was not unlocking the user access keys
when it was initializing. This meant that if an old session that was
created with the old non-deterministic access key was decrypted, that
key would be used to unlock the session encryptor's user access key,
setting the random_r to the value of the random_r for the
non-deterministic key.