### PR TITLE
Use duped user access key in session_encryptor

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -6,7 +6,7 @@ class SessionEncryptor
     end
   end
 
-  def user_access_key
+  def duped_user_access_key
     # Return a clone since encryptor.decrypt mutates this key
     @user_access_key.dup
   end

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -2,11 +2,11 @@ class SessionEncryptor
   def user_access_key
     @user_access_key ||= begin
       key = Figaro.env.session_encryption_key
-      user_access_key = UserAccessKey.new(password: key, salt: key)
-      random_r = OpenSSL::Digest::SHA256.digest(key)
-      user_access_key.unlock(random_r)
-      user_access_key
+      UserAccessKey.new(password: key, salt: key)
     end
+
+    # Return a clone since encryptor.decrypt mutates this key
+    @user_access_key.dup
   end
 
   def load(value)

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,23 +1,25 @@
 class SessionEncryptor
-  def user_access_key
+  def initialize
     @user_access_key ||= begin
       key = Figaro.env.session_encryption_key
       UserAccessKey.new(password: key, salt: key)
     end
+  end
 
+  def user_access_key
     # Return a clone since encryptor.decrypt mutates this key
     @user_access_key.dup
   end
 
   def load(value)
-    decrypted = encryptor.decrypt(value, user_access_key)
+    decrypted = encryptor.decrypt(value, duped_user_access_key)
 
     JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
   end
 
   def dump(value)
     plain = JSON.generate(value, quirks_mode: true)
-    encryptor.encrypt(plain, user_access_key)
+    encryptor.encrypt(plain, duped_user_access_key)
   end
 
   private

--- a/app/services/usps_confirmation_entry.rb
+++ b/app/services/usps_confirmation_entry.rb
@@ -10,7 +10,7 @@ UspsConfirmationEntry = Struct.new(
   :issuer
 ) do
   def self.user_access_key
-    SessionEncryptor.new.user_access_key
+    SessionEncryptor.new.duped_user_access_key
   end
 
   def self.encryptor

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -23,15 +23,14 @@ describe SessionEncryptor do
 
   it 'does not modify the user access key when decrypting a payload encrypted with an old key' do
     old_encryptor = SessionEncryptor.new
-    old_encryptor.user_access_key.unlock(Pii::Cipher.random_key)
     old_payload = old_encryptor.dump('asdf' => '1234')
 
     new_encryptor = SessionEncryptor.new
-    new_payload = old_encryptor.dump('1234' => 'asdf')
-    original_cek = new_encryptor.user_access_key.cek
+    new_payload = new_encryptor.dump('1234' => 'asdf')
+    original_cek = new_encryptor.duped_user_access_key.cek
 
     expect(new_encryptor.load(old_payload)).to eq('asdf' => '1234')
-    expect(new_encryptor.user_access_key.cek).to eq(original_cek)
+    expect(new_encryptor.duped_user_access_key.cek).to eq(original_cek)
 
     expect(new_encryptor.load(new_payload)).to eq('1234' => 'asdf')
   end

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -21,16 +21,19 @@ describe SessionEncryptor do
     expect(encryptor2.load(encrypted_text)).to eq(payload)
   end
 
-  it 'does not modify the cek when failing to decrypt a payload encrypted with an old key' do
+  it 'does not modify the user access key when decrypting a payload encrypted with an old key' do
     old_encryptor = SessionEncryptor.new
     old_encryptor.user_access_key.unlock(Pii::Cipher.random_key)
     old_payload = old_encryptor.dump('asdf' => '1234')
 
     new_encryptor = SessionEncryptor.new
+    new_payload = old_encryptor.dump('1234' => 'asdf')
     original_cek = new_encryptor.user_access_key.cek
 
-    expect { new_encryptor.load(old_payload) }.to raise_error(Pii::EncryptionError)
+    expect(new_encryptor.load(old_payload)).to eq('asdf' => '1234')
     expect(new_encryptor.user_access_key.cek).to eq(original_cek)
+
+    expect(new_encryptor.load(new_payload)).to eq('1234' => 'asdf')
   end
 
   describe '#dump' do


### PR DESCRIPTION
**Why**: Duping the key means that when encrypting, the key will use
it's randomly generated random_r, and when decrypting, it will derive
random_r from the ciphertext. This means the session encryptor can use
non-deterministic user access keys to encrypt and decrypt session data.