### PR TITLE
Add help text for TTP users

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,5 +1,15 @@
 - title t('titles.passwords.forgot')
 
+- if decorated_session.sp_name == 'CBP Trusted Traveler Programs'
+  .alert.alert-notice
+    .bold = 'Coming from Trusted Traveler Programs?'
+    p
+      = 'Your old GOES userID and password won’t work. Please '
+      = link_to 'create a login.gov account.', sign_up_email_url(request_id: params[:request_id])
+    p.mb1
+      = link_to 'Learn more.',
+                'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/'
+
 h1.h3.my0 = t('headings.passwords.forgot')
 p.mt-tiny.mb0#email-description
   = t('instructions.password.forgot')

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,5 +1,15 @@
 - title t('titles.visitors.index')
 
+- if decorated_session.sp_name == 'CBP Trusted Traveler Programs'
+  .alert.alert-notice
+    .bold = 'Coming from Trusted Traveler Programs?'
+    p
+      = 'Your old GOES userID and password won’t work. Please '
+      = link_to 'create a login.gov account.', sign_up_email_url(request_id: params[:request_id])
+    p.mb1
+      = link_to 'Learn more.',
+                'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/'
+
 h1.h3.my0 = decorated_session.new_session_heading
 = simple_form_for(resource,
                   as: resource_name,

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -5,6 +5,15 @@
 
   = render decorated_session.registration_heading
 
+  - if decorated_session.sp_name == 'CBP Trusted Traveler Programs'
+    .alert.alert-notice.sm-left-align
+      .bold = 'Coming from Trusted Traveler Programs?'
+      p
+        = 'Your old GOES userID and password won’t work. Please create a login.gov account below.'
+      p.mb1
+        = link_to 'Learn more.',
+          'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/'
+
   = link_to t('sign_up.registrations.create_account'),
     sign_up_email_path(request_id: params[:request_id]),
     class: 'sm-col-10 col-12 btn btn-primary btn-wide mb2 fs-20p'


### PR DESCRIPTION
**Why**: Many users don't realize they need to create a new login.gov
account and that they can't use their old GOES credentials