### PR TITLE
Prepend set_locale before action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   helper_method :decorated_session, :reauthn?, :user_fully_authenticated?
 
   prepend_before_action :session_expires_at
-  before_action :set_locale
+  prepend_before_action :set_locale
   before_action :disable_caching
 
   def session_expires_at

--- a/spec/requests/i18n_spec.rb
+++ b/spec/requests/i18n_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'i18n requests' do
+  context 'with CSRF errors' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it 'renders the page in the language of the current request despite CSRF errors' do
+      get root_path(locale: :es)
+
+      post root_path(
+        locale: :en,
+        params: { user: { email: 'asdf@gmail.com', passowrd: '123abcdef' } }
+      )
+      get response.headers['Location']
+
+      expect(response.body).to include(t('errors.invalid_authenticity_token', locale: :en))
+      expect(response.body).to_not include(t('errors.invalid_authenticity_token', locale: :es))
+    end
+  end
+end


### PR DESCRIPTION
**Why**: The set_locale before action sets the `I18n.locale` variable.
Since that is part of the global state, it needs to be set before
rendering any pages or pages will be rendered with the locale of the
previous request. Prepending the `set_locale` action means it comes
before actions that break the callback chain for things like CSRF errors
and timeouts, assuring those pages are rendered in the correct language.