### PR TITLE
Add normalize yaml command to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ load_test: $(CONFIG)
 	bin/load_test $(type)
 
 .PHONY: setup all lint run test check brakeman
+
+normalize_yaml:
+	find ./config/locales -type f | xargs ./scripts/normalize-yaml

--- a/README.md
+++ b/README.md
@@ -252,3 +252,11 @@ login.gov team for credentials and other values.
 ### Why 'Upaya'?
 
 "skill in means" https://en.wikipedia.org/wiki/Upaya
+
+### Managing translation files
+
+To help us handle extra newlines and make sure we wrap lines consistently, we have a script called `./script/normalize-yaml` that helps format YAML consistently. After importing translations (or making changes to the *.yml files with strings, run this for the IDP app: 
+
+```
+$ make normalize_yaml
+```


### PR DESCRIPTION
**Why**:
The script for normalizing YAML requires
some configuration. Having that in make
will make this faster in the future