### PR TITLE
Use string key for Norway country dialing code

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -542,7 +542,7 @@ NG:
   name: Nigeria
   country_code: '234'
   sms_only: true
-NO:
+'NO':
   name: Norway
   country_code: '47'
   sms_only: true

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -89,6 +89,17 @@ describe UserPhoneForm do
         expect(result.success?).to eq(false)
       end
     end
+
+    it 'does not raise inclusion errors for Norwegian phone numbers' do
+      # ref: https://github.com/18F/identity-private/issues/2392
+      params[:phone] = '21 11 11 11'
+      params[:international_code] = 'NO'
+      result = subject.submit(params)
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(true)
+      expect(result.errors).to be_empty
+    end
   end
 
   describe '#phone_changed?' do


### PR DESCRIPTION
**Why**: Because in yaml, `NO` without quotation marks means `false`. This meant the country dialing code information for Norway was being stored under the key `false` which caused bugs when submitted in phone form.