### PR TITLE
Add link to service provider to account history

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,5 +1,9 @@
 EventDecorator = Struct.new(:event) do
-  def pretty_event_type
+  def event_partial
+    'accounts/event_item'
+  end
+
+  def event_type
     I18n.t("event_types.#{event.event_type}")
   end
 

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -1,6 +1,12 @@
 IdentityDecorator = Struct.new(:identity) do
-  def pretty_event_type
-    I18n.t('event_types.authenticated_at', service_provider: identity.display_name)
+  delegate :display_name, to: :identity
+
+  def event_partial
+    'accounts/identity_item'
+  end
+
+  def return_to_sp_url
+    identity.sp_metadata[:return_to_sp_url]
   end
 
   def happened_at

--- a/app/views/accounts/_event_item.html.slim
+++ b/app/views/accounts/_event_item.html.slim
@@ -1,6 +1,6 @@
 .p2.clearfix.border-top
- .clearfix.mxn1
-   .sm-col.sm-col-6.px1
-     .bold.truncate = event.pretty_event_type
-   .sm-col.sm-col-6.px1.sm-right-align
-     = event.happened_at
+  .clearfix.mxn1
+    .sm-col.sm-col-6.px1
+      .bold.truncate = event.event_type
+    .sm-col.sm-col-6.px1.sm-right-align
+      = event.happened_at

--- a/app/views/accounts/_identity_item.html.slim
+++ b/app/views/accounts/_identity_item.html.slim
@@ -1,0 +1,11 @@
+.p2.clearfix.border-top
+  .clearfix.mxn1
+    .sm-col.sm-col-6.px1
+      .bold.truncate
+        - if event.return_to_sp_url.present?
+          = t('event_types.authenticated_at_html',
+          service_provider_link: link_to(event.display_name, event.return_to_sp_url))
+        - else
+          = t('event_types.authenticated_at', service_provider: event.display_name)
+    .sm-col.sm-col-6.px1.sm-right-align
+      = event.happened_at

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -57,4 +57,4 @@ h1.hide = t('titles.account')
     = t('headings.account.account_history')
     = image_tag asset_url('history.svg'), width: 12, class: 'ml1'
   - @view_model.recent_events.each do |event|
-    = render @view_model.recent_event_partial, event: event
+    = render event.event_partial, event: event

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -4,6 +4,7 @@ en:
     account_created: Account created
     account_verified: Account verified
     authenticated_at: Signed in at %{service_provider}
+    authenticated_at_html: Signed in at %{service_provider_link}
     authenticator_disabled: Authenticator app disabled
     authenticator_enabled: Authenticator app enabled
     eastern_timestamp: "%{timestamp} (Eastern)"

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -4,6 +4,7 @@ es:
     account_created: Cuenta creada
     account_verified: Cuenta verificada
     authenticated_at: Sesión iniciada en %{service_provider}
+    authenticated_at_html: Sesión iniciada en %{service_provider_link}
     authenticator_disabled: La app de autenticación fue suspendida
     authenticator_enabled: App de autenticación permitido
     eastern_timestamp: "%{timestamp} (hora del Este)"

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -4,6 +4,7 @@ fr:
     account_created: Compte créé
     account_verified: Compte vérifié
     authenticated_at: Connecté à %{service_provider}
+    authenticated_at_html: Connecté à %{service_provider_link}
     authenticator_disabled: Application d'authentification désactivée
     authenticator_enabled: Application d'authentification activée
     eastern_timestamp: "%{timestamp} (Eastern)"

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe EventDecorator do
-  describe '#pretty_event_type' do
-    it 'returns the localized text corresponding to the event type' do
+  describe '#event_type' do
+    it 'returns the localized event_type' do
       event = build_stubbed(:event, event_type: :email_changed)
       decorator = EventDecorator.new(event)
 
-      expect(decorator.pretty_event_type).to eq t('event_types.email_changed')
+      expect(decorator.event_type).to eq t('event_types.email_changed')
     end
   end
 end

--- a/spec/decorators/identity_decorator_spec.rb
+++ b/spec/decorators/identity_decorator_spec.rb
@@ -1,16 +1,28 @@
 require 'rails_helper'
 
 describe IdentityDecorator do
+  include ActionView::Helpers::TagHelper
+
   let(:user) { create(:user) }
-  let(:identity) { create(:identity, :active, user: user) }
+  let(:service_provider) { 'http://localhost:3000' }
+  let(:identity) { create(:identity, :active, user: user, service_provider: service_provider) }
 
   subject { IdentityDecorator.new(identity) }
 
-  describe '#pretty_event_type' do
-    it 'returns the localized text corresponding to the identity event' do
-      expect(subject.pretty_event_type).to eq(
-        t('event_types.authenticated_at', service_provider: identity.display_name)
-      )
+  describe '#return_to_sp_url' do
+    context 'for an sp without a return URL' do
+      context 'for an sp with a return URL' do
+        it 'returns the return url for the sp' do
+          return_to_sp_url = ServiceProvider.from_issuer(service_provider).return_to_sp_url
+          expect(subject.return_to_sp_url).to eq(return_to_sp_url)
+        end
+      end
+
+      let(:service_provider) { 'https://rp2.serviceprovider.com/auth/saml/metadata' }
+
+      it 'returns nil' do
+        expect(subject.return_to_sp_url).to eq(nil)
+      end
     end
   end
 end

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Account history' do
+  let(:user) { create(:user, :signed_up) }
+  let(:account_created_event) { create(:event, user: user) }
+  let(:identity_with_link) do
+    create(
+      :identity,
+      :active,
+      user: user,
+      service_provider: 'http://localhost:3000'
+    )
+  end
+  let(:identity_without_link) do
+    create(
+      :identity,
+      :active,
+      user: user,
+      service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata'
+    )
+  end
+
+  before do
+    sign_in_and_2fa_user(user)
+    build_account_history
+    visit account_path
+  end
+
+  scenario 'viewing account history' do
+    expect(page).to have_content(t('event_types.account_created'))
+
+    expect(page).to have_content(
+      t('event_types.authenticated_at', service_provider: identity_without_link.display_name)
+    )
+    expect(page).to_not have_link(identity_without_link.display_name)
+
+    expect(page).to have_content(
+      t('event_types.authenticated_at_html', service_provider_link: identity_with_link.display_name)
+    )
+    expect(page).to have_link(
+      identity_with_link.display_name, href: 'http://localhost:3000'
+    )
+  end
+
+  def build_account_history
+    account_created_event
+    identity_with_link
+    identity_without_link
+  end
+end


### PR DESCRIPTION
**Why**: So that user's can navigate to an SP from their account history
page. Note that this only applies to SP's that have a
`return_to_sp_url`. SP's without do not have a link.

Screenshot:

![image](https://user-images.githubusercontent.com/963654/31509554-8d6cc39e-af47-11e7-8e1c-8b3a726e1d27.png)
