### PR TITLE
Handle nil redirect_uris gracefully

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module Upaya
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins do |source, _env|
-          ServiceProvider.pluck(:redirect_uris).flatten.map do |uri|
+          ServiceProvider.pluck(:redirect_uris).flatten.compact.map do |uri|
             begin
               URI.join(uri, '/').to_s[0..-2]
             rescue URI::BadURIError => err

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -141,4 +141,19 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
       end
     end
   end
+
+  describe 'nil redirect_uris' do
+    it 'handles a nil value gracefully' do
+      ServiceProvider.create(issuer: 'foo', redirect_uris: nil)
+
+      post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+
+      aggregate_failures do
+        expect(response).to_not be_not_found
+        expect(response['Access-Control-Allow-Credentials']).to eq('true')
+        expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
+        expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**: The IdP app expects the `redirect_uris` column in the
ServiceProvider table to be an array and to have a default value
of an empty array, but the dashboard app saves an empty value as
`null`, and Rails does not have a built-in mechanism for converting
the `nil` value into an empty array.

**How**: Call `#compact` on the array before iterating through the
URIs to get rid of any `nil` values since we don't care about them.