### PR TITLE
Turn off twilio proxy feature

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -9,8 +9,6 @@ class TwilioService
   def initialize
     @client = if FeatureManagement.telephony_disabled?
                 NullTwilioClient.new
-              elsif proxy_addr.present?
-                twilio_proxy_client
               else
                 twilio_client
               end
@@ -41,23 +39,6 @@ class TwilioService
   private
 
   attr_reader :client
-
-  def proxy_addr
-    Figaro.env.proxy_addr
-  end
-
-  def proxy_port
-    Figaro.env.proxy_port
-  end
-
-  def twilio_proxy_client
-    telephony_service.new(
-      account['sid'],
-      account['auth_token'],
-      proxy_addr: proxy_addr,
-      proxy_port: proxy_port
-    )
-  end
 
   def twilio_client
     telephony_service.new(

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -155,8 +155,6 @@ production:
   password_pepper: # generate via `rake secret`
   password_strength_enabled: 'true'
   proofing_vendors: 'mock'
-  proxy_addr:
-  proxy_port:
   reauthn_window: '120'
   redis_url: 'redis://redis.login.gov.internal:6379'
   requests_per_ip_limit: '300'

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -1,33 +1,6 @@
 require 'rails_helper'
 
 describe TwilioService do
-  describe 'proxy configuration' do
-    it 'ignores the proxy configuration if not set' do
-      TwilioService.telephony_service = Twilio::REST::Client
-
-      expect(Figaro.env).to receive(:proxy_addr).and_return(nil)
-      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/)
-
-      TwilioService.new
-    end
-
-    it 'passes the proxy configuration if set' do
-      TwilioService.telephony_service = Twilio::REST::Client
-
-      expect(Figaro.env).to receive(:proxy_addr).at_least(:once).and_return('123.456.789')
-      expect(Figaro.env).to receive(:proxy_port).and_return('6000')
-
-      expect(Twilio::REST::Client).to receive(:new).with(
-        /sid(1|2)/,
-        /token(1|2)/,
-        proxy_addr: '123.456.789',
-        proxy_port: '6000'
-      )
-
-      TwilioService.new
-    end
-  end
-
   context 'when telephony is disabled' do
     before do
       expect(FeatureManagement).to receive(:telephony_disabled?).at_least(:once).and_return(true)
@@ -35,17 +8,6 @@ describe TwilioService do
 
     it 'uses NullTwilioClient' do
       TwilioService.telephony_service = Twilio::REST::Client
-
-      expect(NullTwilioClient).to receive(:new)
-      expect(Twilio::REST::Client).to_not receive(:new)
-
-      TwilioService.new
-    end
-
-    it 'uses NullTwilioClient when proxy is set' do
-      TwilioService.telephony_service = Twilio::REST::Client
-
-      allow(Figaro.env).to receive(:proxy_addr).and_return('123.456.789')
 
       expect(NullTwilioClient).to receive(:new)
       expect(Twilio::REST::Client).to_not receive(:new)


### PR DESCRIPTION
__Why__

* We seem to be turning this on if we are trying to use an http proxy which is
  incorrect.  I believe that the proxy feature that is being turned on here is
  https://www.twilio.com/proxy, not http proxying.  If this is used, whenever
  we have http_proxy/https_proxy set, we get exceptions whenever we use
  twilio.

__How__

* remove it from initialize.