### PR TITLE
Register return_to_sp_urls for CBP apps

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -263,6 +263,7 @@ production:
     agency: 'DHS'
     logo: 'cbp.png'
     allow_on_prod_chef_env: 'true'
+    return_to_sp_url: 'https://careers.cbp.dhs.gov'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod:app':
     redirect_uris:
@@ -315,6 +316,7 @@ production:
     logo: 'cbp-ttp.png'
     redirect_uris:
       - 'https://ttp.cbp.dhs.gov'
+    return_to_sp_url: https://ttp.cbp.dhs.gov/
 
   # CBP OARS
   'urn:gov:dhs.cbp.pspd.oars:openidconnect:prod:app':


### PR DESCRIPTION
**Why**: So we can link to SPs in production (see #1736)