### PR TITLE
Stop reading old singular redirect_uri column

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -43,8 +43,4 @@ class ServiceProvider < ApplicationRecord
   def live?
     active? && approved?
   end
-
-  def redirect_uris
-    super.presence || Array(redirect_uri)
-  end
 end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -140,8 +140,8 @@ describe ServiceProvider do
         )
       end
 
-      it 'is an array of the legacy redirect_uri' do
-        expect(service_provider.redirect_uris).to eq(%w[http://a.example.com])
+      it 'ignores the old singular column and just uses the new plural one' do
+        expect(service_provider.redirect_uris).to eq([])
       end
     end
 


### PR DESCRIPTION
**Why**: We've migrated to the new plural redirect_uris

--

Going to follow up with a migration in a separate PR so we can run the migration out-of-band of the code deploy