### PR TITLE
Drop redirect uri column

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -43,8 +43,4 @@ class ServiceProvider < ApplicationRecord
   def live?
     active? && approved?
   end
-
-  def redirect_uris
-    super.presence || Array(redirect_uri)
-  end
 end

--- a/db/migrate/20171016185939_drop_redirect_uri_from_service_providers.rb
+++ b/db/migrate/20171016185939_drop_redirect_uri_from_service_providers.rb
@@ -1,0 +1,5 @@
+class DropRedirectUriFromServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :service_providers, :redirect_uri, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170905144239) do
+ActiveRecord::Schema.define(version: 20171016185939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,7 +121,6 @@ ActiveRecord::Schema.define(version: 20170905144239) do
     t.text "return_to_sp_url"
     t.string "agency"
     t.json "attribute_bundle"
-    t.string "redirect_uri"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "active", default: false, null: false

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -130,29 +130,4 @@ describe ServiceProvider do
       end
     end
   end
-
-  describe '#redirect_uris' do
-    context 'when a legacy single redirect_uri is set but not redirect_uris' do
-      let(:service_provider) do
-        ServiceProvider.new(
-          redirect_uri: 'http://a.example.com',
-          redirect_uris: []
-        )
-      end
-
-      it 'ignores the old singular column and just uses the new plural one' do
-        expect(service_provider.redirect_uris).to eq([])
-      end
-    end
-
-    context 'when there are new-style multiple redirect_uris' do
-      let(:service_provider) do
-        ServiceProvider.new(redirect_uris: %w[http://b.example.com my-app://result])
-      end
-
-      it 'is the new-style multiple redirect_uris' do
-        expect(service_provider.redirect_uris).to eq(%w[http://b.example.com my-app://result])
-      end
-    end
-  end
 end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -140,8 +140,8 @@ describe ServiceProvider do
         )
       end
 
-      it 'is an array of the legacy redirect_uri' do
-        expect(service_provider.redirect_uris).to eq(%w[http://a.example.com])
+      it 'ignores the old singular column and just uses the new plural one' do
+        expect(service_provider.redirect_uris).to eq([])
       end
     end
 


### PR DESCRIPTION
Follow-up to https://github.com/18F/identity-idp/pull/1743

This is the migration that can be run out-of-band from the previous PR. We should not merge this until the previous PR has been merged and deployed