### PR TITLE
Update service provider seeding

### DIFF
--- a/.reek
+++ b/.reek
@@ -28,6 +28,7 @@ FeatureEnvy:
     - Idv::ProfileMaker#pii_from_applicant
     - Idv::Step#vendor_validator_result
     - IdvSession#vendor_result_timed_out?
+    - ServiceProviderSeeder#run
 InstanceVariableAssumption:
   exclude:
     - User
@@ -41,6 +42,7 @@ NestedIterators:
     - FileEncryptor#encrypt
     - UserFlowExporter#self.massage_html
     - TwilioService#sanitize_phone_number
+    - ServiceProviderSeeder#run
 NilCheck:
   enabled: false
 LongParameterList:

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -1,0 +1,26 @@
+# Update ServiceProvider from config/service_providers.yml (all environments in rake db:seed)
+class ServiceProviderSeeder
+  def initialize(rails_env: Rails.env, deploy_env: LoginGov::Hostdata.env)
+    @rails_env = rails_env
+    @deploy_env = deploy_env
+  end
+
+  def run
+    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
+    service_providers = YAML.load(content).fetch(rails_env, {})
+
+    service_providers.each do |issuer, config|
+      next if Figaro.env.chef_env == 'prod' && config['allow_on_prod_chef_env'] != 'true'
+      ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
+        sp.approved = true
+        sp.active = true
+        sp.native = true
+        sp.attributes = config.except('allow_on_prod_chef_env')
+      end
+    end
+  end
+
+  private
+
+  attr_reader :rails_env, :deploy_env
+end

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -6,21 +6,33 @@ class ServiceProviderSeeder
   end
 
   def run
-    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
-    service_providers = YAML.load(content).fetch(rails_env, {})
-
     service_providers.each do |issuer, config|
-      next if Figaro.env.chef_env == 'prod' && config['allow_on_prod_chef_env'] != 'true'
+      next unless write_service_provider?(config)
+
       ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
         sp.approved = true
         sp.active = true
         sp.native = true
-        sp.attributes = config.except('allow_on_prod_chef_env')
-      end
+      end.update(config.except('restrict_to_deploy_env'))
     end
   end
 
   private
 
   attr_reader :rails_env, :deploy_env
+
+  def service_providers
+    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
+    YAML.safe_load(content).fetch(rails_env, {})
+  end
+
+  def write_service_provider?(config)
+    return true if rails_env != 'production'
+
+    restrict_env = config['restrict_to_deploy_env']
+
+    is_production_or_has_a_restriction = (deploy_env == 'prod' || restrict_env.present?)
+
+    !is_production_or_has_a_restriction || (restrict_env == deploy_env)
+  end
 end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,3 +1,4 @@
+# Update ServiceProvider table by pulling from the Dashboard app API (lower environments only)
 class ServiceProviderUpdater
   PROTECTED_ATTRIBUTES = %i[
     created_at

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -209,7 +209,7 @@ production:
     cert: 'sp_micropurchase'
     agency: 'TTS Acquisition'
     logo: '18f.svg'
-    allow_on_prod_chef_env: 'true'
+    restrict_to_deploy_env: 'prod'
     friendly_name: 'Micro-purchase'
     return_to_sp_url: 'https://micropurchase.18f.gov'
     attribute_bundle:
@@ -248,6 +248,7 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    restrict_to_deploy_env: 'staging'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:cert:app':
     redirect_uris:
@@ -255,6 +256,7 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
+    restrict_to_deploy_env: 'staging'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod':
     redirect_uris:
@@ -262,7 +264,7 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
-    allow_on_prod_chef_env: 'true'
+    restrict_to_deploy_env: 'prod'
     return_to_sp_url: 'https://careers.cbp.dhs.gov'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod:app':
@@ -271,7 +273,7 @@ production:
     friendly_name: 'CBP Jobs'
     agency: 'DHS'
     logo: 'cbp.png'
-    allow_on_prod_chef_env: 'true'
+    restrict_to_deploy_env: 'prod'
 
   # RRB
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:RRB:BOS-Pre-Prod':
@@ -309,7 +311,7 @@ production:
 
   'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp':
     agency: 'DHS'
-    allow_on_prod_chef_env: 'true'
+    restrict_to_deploy_env: 'prod'
     block_encryption: 'aes256-cbc'
     cert: 'cbp_goes_prod'
     friendly_name: 'CBP Trusted Traveler Programs'
@@ -325,4 +327,4 @@ production:
     logo: 'cbp.png'
     redirect_uris:
       - 'gov.dhs.cbp.pspd.oars.user.prod://result'
-    allow_on_prod_chef_env: 'true'
+    restrict_to_deploy_env: 'prod'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,15 +4,4 @@ AppSetting.find_or_create_by!(name: 'RegistrationsEnabled') do |setting|
 end
 
 # add config/service_providers.yml
-content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
-service_providers = YAML.load(content).fetch(Rails.env, {})
-
-service_providers.each do |issuer, config|
-  next if Figaro.env.chef_env == 'prod' && config['allow_on_prod_chef_env'] != 'true'
-  ServiceProvider.find_or_create_by!(issuer: issuer) do |sp|
-    sp.approved = true
-    sp.active = true
-    sp.native = true
-    sp.attributes = config.except('allow_on_prod_chef_env')
-  end
-end
+ServiceProviderSeeder.new.run

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe ServiceProviderSeeder do
       expect { run }.to change { ServiceProvider.count }
     end
 
+    context 'with other existing service providers in the database' do
+      let!(:existing_provider) { create(:service_provider) }
+
+      it 'sets approved, active and native on service providers from the yaml' do
+        run
+
+        config_sp = ServiceProvider.from_issuer('http://test.host')
+        expect(config_sp.approved).to eq(true)
+        expect(config_sp.active).to eq(true)
+        expect(config_sp.native).to eq(true)
+      end
+
+      it 'does not change approve, active and native on the other existing service providers' do
+        run
+
+        existing_provider.reload
+        expect(existing_provider.approved).to_not eq(true)
+        expect(existing_provider.active).to_not eq(true)
+        expect(existing_provider.native).to_not eq(true)
+      end
+    end
+
     context 'when a service provider already exists in the database' do
       before do
         create(
@@ -33,14 +55,44 @@ RSpec.describe ServiceProviderSeeder do
     context 'when running in a production environment' do
       let(:rails_env) { 'production' }
 
-      it 'only adds/updates configs for that environment' do
-        run
+      context 'in prod' do
+        let(:deploy_env) { 'prod' }
 
-        expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp')).
-          to be
+        it 'only writes configs with restrict_to_deploy_env for prod' do
+          run
 
-        expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:cert')).
-          to eq(nil)
+          # restrict_to_deploy_env: prod
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp')).
+            to be_present
+
+          # restrict_to_deploy_env: staging
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:cert')).
+            to eq(nil)
+
+          # restrict_to_deploy_env: nil
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:sp:sinatra')).
+            to eq(nil)
+        end
+      end
+
+      context 'in another environment' do
+        let(:deploy_env) { 'staging' }
+
+        it 'only writes configs with restrict_to_deploy_env for that env, or no restrictions' do
+          run
+
+          # restrict_to_deploy_env: prod
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp')).
+            to eq(nil)
+
+          # restrict_to_deploy_env: staging
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:cert')).
+            to be_present
+
+          # restrict_to_deploy_env: nil
+          expect(ServiceProvider.find_by(issuer: 'urn:gov:gsa:openidconnect:sp:sinatra')).
+            to be_present
+        end
       end
     end
   end

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ServiceProviderSeeder do
+  subject(:instance) { ServiceProviderSeeder.new(rails_env: rails_env, deploy_env: deploy_env) }
+  let(:rails_env) { 'test' }
+  let(:deploy_env) { 'int' }
+
+  describe '#run' do
+    before { ServiceProvider.delete_all }
+
+    subject(:run) { instance.run }
+
+    it 'inserts service providers into the database from service_providers.yml' do
+      expect { run }.to change { ServiceProvider.count }
+    end
+
+    context 'when a service provider already exists in the database' do
+      before do
+        create(
+          :service_provider,
+          issuer: 'http://test.host',
+          acs_url: 'http://test.host/test/saml/decode_assertion_old'
+        )
+      end
+
+      it 'updates the attributes based on the current value of the yml file' do
+        expect { run }.
+          to change { ServiceProvider.from_issuer('http://test.host').acs_url }.
+          to('http://test.host/test/saml/decode_assertion')
+      end
+    end
+
+    context 'when running in a production environment' do
+      let(:rails_env) { 'production' }
+
+      it 'only adds/updates configs for that environment' do
+        run
+
+        expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp')).
+          to be
+
+        expect(ServiceProvider.find_by(issuer: 'urn:gov:dhs.cbp.jobs:openidconnect:cert')).
+          to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracts code and adds tests to make sure we do the following:

- Update database with current values in `service_providers.yml` each time
- Correctly restrict production SPs to production
- Allow all SPs in lower envs
