### PR TITLE
Remove app npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build": "true"
   },
   "dependencies": {
-    "app": "^0.1.0",
     "basscss-sass": "^3.0.0",
     "classlist.js": "^1.1.20150312",
     "clipboard": "^1.6.1",


### PR DESCRIPTION
**Why**: It is a heavy dependency and it does not look like we use it.

This should allow us to close [this PR](https://github.com/18F/identity-idp/pull/1695) confidently.