### PR TITLE
Rescue from URI:Error instead of URI::BadURIError

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module Upaya
           ServiceProvider.pluck(:redirect_uris).flatten.compact.map do |uri|
             begin
               URI.join(uri, '/').to_s[0..-2]
-            rescue URI::BadURIError => err
+            rescue URI::Error => err
               Rails.logger.warn({ warning: err.class.to_s, source: 'Rack::Cors', uri: uri }.to_json)
               ''
             end

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
         expect(response).to be_ok
       end
     end
+
+    context 'with an invalid URI in the database' do
+      before { create(:service_provider, redirect_uris: [' https://foo.com']) }
+
+      it 'does not blow up' do
+        get api_openid_connect_certs_path, headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+
+        expect(response).to be_ok
+      end
+    end
   end
 
   describe 'certs endpoint' do


### PR DESCRIPTION
**Why**: So that the app will not break if there is a URI error adding
the SP's url to the allowed origins in our CORS headers. Previously we
were rescuing from `URI::InvalidURIError`, but the URI module has a
number of URI error subclasses it can raise if there is an issue with
the URI.

ref: https://docs.ruby-lang.org/en/2.4.0/URI.html