### PR TITLE
Add current SP issuer to analytics events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
   attr_writer :analytics
 
   def analytics
-    @analytics ||= Analytics.new(analytics_user, request)
+    @analytics ||= Analytics.new(user: analytics_user, request: request, sp: current_sp&.issuer)
   end
 
   def analytics_user

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,7 +1,8 @@
 class Analytics
-  def initialize(user, request)
+  def initialize(user:, request:, sp:)
     @user = user
     @request = request
+    @sp = sp
   end
 
   def track_event(event, attributes = {})
@@ -14,7 +15,7 @@ class Analytics
 
   private
 
-  attr_reader :user, :request
+  attr_reader :user, :request, :sp
 
   def ahoy
     @ahoy ||= Rails.env.test? ? FakeAhoyTracker.new : Ahoy::Tracker.new(request: request)
@@ -26,6 +27,7 @@ class Analytics
       user_agent: request.user_agent,
       host: request.host,
       pid: Process.pid,
+      service_provider: sp,
     }
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,11 +93,13 @@ describe ApplicationController do
 
   describe '#analytics' do
     context 'when a current_user is present' do
-      it 'calls the Analytics class by default with current_user and request parameters' do
+      it 'calls the Analytics class by default with current_user, request, and issuer' do
         user = build_stubbed(:user)
+        sp = ServiceProvider.new(issuer: 'http://localhost:3000')
         allow(controller).to receive(:current_user).and_return(user)
+        allow(controller).to receive(:current_sp).and_return(sp)
 
-        expect(Analytics).to receive(:new).with(user, request)
+        expect(Analytics).to receive(:new).with(user: user, request: request, sp: sp.issuer)
 
         controller.analytics
       end
@@ -110,7 +112,7 @@ describe ApplicationController do
         user = instance_double(AnonymousUser)
         allow(AnonymousUser).to receive(:new).and_return(user)
 
-        expect(Analytics).to receive(:new).with(user, request)
+        expect(Analytics).to receive(:new).with(user: user, request: request, sp: nil)
 
         controller.analytics
       end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -7,6 +7,7 @@ describe Analytics do
       user_agent: FakeRequest.new.user_agent,
       host: FakeRequest.new.host,
       pid: Process.pid,
+      service_provider: 'http://localhost:3000',
     }
   end
 
@@ -18,7 +19,7 @@ describe Analytics do
     it 'identifies the user and sends the event to the backend' do
       user = build_stubbed(:user, uuid: '123')
 
-      analytics = Analytics.new(user, FakeRequest.new)
+      analytics = Analytics.new(user: user, request: FakeRequest.new, sp: 'http://localhost:3000')
 
       analytics_hash = {
         event_properties: {},
@@ -35,7 +36,11 @@ describe Analytics do
       current_user = build_stubbed(:user, uuid: '123')
       tracked_user = build_stubbed(:user, uuid: '456')
 
-      analytics = Analytics.new(current_user, FakeRequest.new)
+      analytics = Analytics.new(
+        user: current_user,
+        request: FakeRequest.new,
+        sp: 'http://localhost:3000'
+      )
 
       analytics_hash = {
         event_properties: {},


### PR DESCRIPTION
**Why**: To be able to track a user end to end when they come from
a Service Provider, which will allow us to more easily measure return
rates (i.e. how many users who come from an SP return to that SP).