### PR TITLE
Remove session & environment from exception email

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -9,6 +9,7 @@ ExceptionNotification.configure do |config|
     email_prefix: "[#{APP_NAME} EXCEPTION - #{LoginGov::Hostdata.env}] ",
     sender_address: %("Exception Notifier" <notifier@login.gov>),
     exception_recipients: EXCEPTION_RECIPIENTS,
-    error_grouping: true
+    error_grouping: true,
+    sections: %w[request backtrace]
   )
 end


### PR DESCRIPTION
**Why**: They contain sensitive information, such as the session
id and token. We can create a custom section later that includes
some of the useful information from the environment section.