### PR TITLE
Filter authenticity_token from params

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,6 +2,7 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[
+  authenticity_token
   code
   email
   idv_finance_form


### PR DESCRIPTION
**Why**: So it doesn't show up in logs or exception notification
emails.