### PR TITLE
Reload uak if UserAccessKey constant was reloaded

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,12 +1,12 @@
 class SessionEncryptor
   def initialize
-    @user_access_key ||= begin
-      key = Figaro.env.session_encryption_key
-      UserAccessKey.new(password: key, salt: key)
-    end
+    reload_user_access_key
   end
 
   def duped_user_access_key
+    # Reload if UserAccessKey constant has been reloaded
+    reload_user_access_key unless @user_access_key.is_a? UserAccessKey
+
     # Return a clone since encryptor.decrypt mutates this key
     @user_access_key.dup
   end
@@ -26,5 +26,10 @@ class SessionEncryptor
 
   def encryptor
     Pii::PasswordEncryptor.new
+  end
+
+  def reload_user_access_key
+    key = Figaro.env.session_encryption_key
+    @user_access_key = UserAccessKey.new(password: key, salt: key)
   end
 end

--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,11 +1,11 @@
 class SessionEncryptor
   def initialize
-    reload_user_access_key
+    @user_access_key = reload_user_access_key
   end
 
   def duped_user_access_key
     # Reload if UserAccessKey constant has been reloaded
-    reload_user_access_key unless @user_access_key.is_a? UserAccessKey
+    @user_access_key = reload_user_access_key unless @user_access_key.is_a? UserAccessKey
 
     # Return a clone since encryptor.decrypt mutates this key
     @user_access_key.dup
@@ -30,6 +30,6 @@ class SessionEncryptor
 
   def reload_user_access_key
     key = Figaro.env.session_encryption_key
-    @user_access_key = UserAccessKey.new(password: key, salt: key)
+    UserAccessKey.new(password: key, salt: key)
   end
 end


### PR DESCRIPTION
**Why**: Autoloader reloads the UserAccessKey constant which creates
issues with the encrypted key maker. The encrypted key maker checks that
an access key is part of the UserAccessKey class. When the UserAccessKey
constant is reloaded, this check fails and starts raising an error.