### PR TITLE
Update onboarding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,31 @@ Testing dependencies:
   to set up a development environment is by running our [Laptop]
   script. The script will install all of this project's dependencies.
 
-1. Make sure Postgres and Redis are running.
+  If using rbenv, you may need to alias your specific installed ruby version to the more generic version found in the `.ruby-version` file. To do this, use [`rbenv-aliases`](https://github.com/tpope/rbenv-aliases):
+
+  ```
+  git clone git://github.com/tpope/rbenv-aliases.git "$(rbenv root)/plugins/rbenv-aliases" # install rbenv-aliases per its documentation
+
+  rbenv alias 2.3 2.3.5 # create the version alias
+  ```
+
+2. Make sure Postgres and Redis are running.
 
   For example, if you've installed the laptop script on OS X, you can start the services like this:
 
   ```
   $ brew services start redis
-  $ brew services start postgres
+  $ brew services start postgresql
   ```
 
-1. Run the following command to set up the environment:
+3. Create the development and test databases:
+
+  ```
+  $ psql -c "CREATE DATABASE upaya_development;"
+  $ psql -c "CREATE DATABASE upaya_test;"
+  ```
+
+4. Run the following command to set up the environment:
 
   ```
   $ make setup
@@ -46,7 +61,7 @@ Testing dependencies:
   This command copies sample configuration files, installs required gems
   and sets up the database.
 
-1. Run the app server with:
+5. Run the app server with:
 
   ```
   $ make run
@@ -60,7 +75,7 @@ performed in the setup script, will necessitate a new signature.
 For more information, see [overcommit](https://github.com/brigade/overcommit)
 
 
-If you want to develop without and internet connection, you can set
+If you want to develop without an internet connection, you can set
 `RAILS_OFFLINE=1` in your environment. This disables the `mx` record
 check on email addresses.
 
@@ -255,7 +270,7 @@ login.gov team for credentials and other values.
 
 ### Managing translation files
 
-To help us handle extra newlines and make sure we wrap lines consistently, we have a script called `./script/normalize-yaml` that helps format YAML consistently. After importing translations (or making changes to the *.yml files with strings, run this for the IDP app: 
+To help us handle extra newlines and make sure we wrap lines consistently, we have a script called `./script/normalize-yaml` that helps format YAML consistently. After importing translations (or making changes to the *.yml files with strings, run this for the IDP app:
 
 ```
 $ make normalize_yaml


### PR DESCRIPTION
As a new contributor, I was setting up my development environment and found it helpful to update the documentation based on my experience. 

Notes: 

  + The ruby version got bumped as a result of running a command, perhaps when I set a ruby version using `rbenv`. I'm happy to revert this change if desired, for example if it breaks CI builds.
  + I installed PG via `homebrew install postgresql` and didn't see a formula named "postgres", so I updated the README instructions to reference the official formula name. If running `brew services start postgres` works for other people and is preferable to keep, then I'm happy to revert this change. 
  + When running `make setup` I encountered an error: `rake aborted! ... ActiveRecord::NoDatabaseError: FATAL:  database "upaya_development" does not exist ... PG::ConnectionBad: FATAL:  database "upaya_development" does not exist`. So I added a prerequisite step to the README which instructs the developer to first create these databases. I then ran the setup script at least two times in a row to ensure it is idempotent. My inclination was to add these commands to `bin/setup` but it would require an idempotent approach like the MySQL-style `CREATE DATABASE IF NOT EXISTS` and I wasn't sure how to implement that in PG. Here is a relevant [SO post](https://stackoverflow.com/questions/18389124/simulate-create-database-if-not-exists-for-postgresql) if someone wants to try incorporating the proposed solution. Otherwise I think the README step is reasonable.

