### PR TITLE
Update screen when user verifies directly on login

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -7,21 +7,18 @@ module SignUp
 
     def show
       @view_model = view_model
-
-      if user_fully_authenticated? && session[:sp].present?
-        analytics.track_event(
-          Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
-          service_provider_attributes
+      if show_completions_page?
+        track_agency_handoff(
+          Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT
         )
       else
-        redirect_to new_user_session_url
+        redirect_to account_url
       end
     end
 
     def update
-      analytics.track_event(
-        Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
-        service_provider_attributes
+      track_agency_handoff(
+        Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE
       )
 
       if decider.go_back_to_mobile_app?
@@ -33,10 +30,16 @@ module SignUp
 
     private
 
+    def show_completions_page?
+      service_providers = session[:sp].present? || @view_model.user_has_identities?
+      user_fully_authenticated? && service_providers
+    end
+
     def view_model
       SignUpCompletionsShow.new(
         loa3_requested: loa3?,
-        decorated_session: decorated_session
+        decorated_session: decorated_session,
+        current_user: current_user
       )
     end
 
@@ -65,6 +68,13 @@ module SignUp
         friendly_name: view_model.decorated_session.sp_name
       )
       redirect_to new_user_session_url
+    end
+
+    def track_agency_handoff(analytic)
+      analytics.track_event(
+        analytic,
+        service_provider_attributes
+      )
     end
   end
 end

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -7,7 +7,6 @@ module Users
       usps_mail = Idv::UspsMail.new(current_user)
       @mail_spammed = usps_mail.mail_spammed?
       @verify_account_form = VerifyAccountForm.new(user: current_user)
-
       return unless FeatureManagement.reveal_usps_code?
       @code = session[:last_usps_confirmation_code]
     end

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -1,5 +1,6 @@
 IdentityDecorator = Struct.new(:identity) do
   delegate :display_name, to: :identity
+  delegate :agency_name, to: :identity
 
   def event_partial
     'accounts/identity_item'

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -16,6 +16,10 @@ class Identity < ApplicationRecord
     sp_metadata[:friendly_name] || sp_metadata[:agency] || service_provider
   end
 
+  def agency_name
+    sp_metadata[:agency] || sp_metadata[:friendly_name] || service_provider
+  end
+
   def decorate
     IdentityDecorator.new(self)
   end

--- a/app/views/sign_up/completions/_show_identities.html.slim
+++ b/app/views/sign_up/completions/_show_identities.html.slim
@@ -1,0 +1,11 @@
+- identities = @view_model.identities
+.mt2.mb3.p3.col-12.center.border-box.border.border-teal.rounded-xl
+  p
+    - if identities.length > 1
+      = t('idv.messages.agencies_login')
+    - else
+      = t('idv.messages.agency_login_html', sp: identities.first.display_name)
+  ul.list-reset
+    - identities.each do |identity|
+      li
+        = link_to identity.agency_name, identity.return_to_sp_url

--- a/app/views/sign_up/completions/_show_sp.html.slim
+++ b/app/views/sign_up/completions/_show_sp.html.slim
@@ -1,0 +1,12 @@
+.mt2.p3.col-12.center.border-box.border.border-teal.rounded-xl
+  p = t('idv.messages.return_to_sp_html', sp: decorated_session.sp_name)
+  p
+    = button_to t('forms.buttons.continue'), sign_up_completed_path, \
+              class: 'btn btn-primary btn-wide'
+p.mr5.ml5.mt3.mb3
+  = t('help_text.requested_attributes.intro_html', app_name: APP_NAME,
+    sp: content_tag(:strong, decorated_session.sp_agency))
+
+<div class='ml5 mr5' >
+  = render @view_model.requested_attributes_partial, view_model: @view_model
+</div>

--- a/app/views/sign_up/completions/show.html.slim
+++ b/app/views/sign_up/completions/show.html.slim
@@ -6,17 +6,6 @@
       = image_tag(asset_url(@view_model.image_name), width: 97, alt: '', class: 'mb2')
     h1.h3.mb3.my0.regular = @view_model.heading
 
-    .mt2.p3.col-12.center.border-box.border.border-teal.rounded-xl
-      p = t('idv.messages.return_to_sp_html', sp: decorated_session.sp_name)
-      p
-        = button_to t('forms.buttons.continue'), sign_up_completed_path, \
-                  class: 'btn btn-primary btn-wide'
-    p.mr5.ml5.mt3.mb3
-      = t('help_text.requested_attributes.intro_html', app_name: APP_NAME,
-        sp: content_tag(:strong, decorated_session.sp_agency))
-
-    <div class='ml5 mr5' >
-      = render @view_model.requested_attributes_partial, view_model: @view_model
-    </div>
+    = render @view_model.service_provider_partial
 
     = link_to t('idv.messages.return_to_profile'), profile_path

--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -2,7 +2,6 @@
 
 h1.h3.my0 = t('forms.verify_profile.title')
 p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
-
 = simple_form_for(@verify_account_form, url: verify_account_path,
   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
   = f.error :base

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -164,6 +164,8 @@ en:
           on file.
         resend: Send me another letter.
         success: It should arrive in 5 to 10 business days.
+      agencies_login: You can now continue to and log into these agencies.
+      agency_login_html: You can now continue to and into <br><strong>%{sp}</strong>.
     modal:
       attempts:
         one: You have <strong>1 attempt remaining.</strong>

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -166,6 +166,8 @@ es:
           verificada en el archivo.
         resend: Envíeme otra carta.
         success: Debe llegar en 5 a 10 días laborales.
+      agencies_login: NOT TRANSLATED YET
+      agency_login_html: NOT TRANSLATED YET
     modal:
       attempts:
         one: Tiene usted <strong> 1 intento restante.</ strong>

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -177,6 +177,8 @@ fr:
           Celle-ci contient un code de confirmation.
         resend: Envoyez-moi une autre lettre.
         success: Elle devrait arriver dans 5 à 10 jours ouvrables.
+      agencies_login: NOT TRANSLATED YET
+      agency_login_html: NOT TRANSLATED YET
     modal:
       attempts:
         one: Il ne vous reste qu' strongune tentative./strong

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -37,20 +37,44 @@ describe SignUp::CompletionsController do
       end
     end
 
-    it 'requires user to be logged in' do
+    it 'requires user with session to be logged in' do
       subject.session[:sp] = { dog: 'max' }
       get :show
 
-      expect(response).to redirect_to(new_user_session_url)
+      expect(response).to redirect_to(account_url)
     end
 
-    it 'requires service provider info in session' do
+    it 'requires user with no session to be logged in' do
+      get :show
+
+      expect(response).to redirect_to(account_url)
+    end
+
+    it 'requires service provider or identity info in session' do
       stub_sign_in
       subject.session[:sp] = {}
 
       get :show
 
-      expect(response).to redirect_to(new_user_session_url)
+      expect(response).to redirect_to(account_url)
+    end
+
+    it 'renders show if the user has an sp in the active session' do
+      stub_sign_in
+      subject.session[:sp] = { loa3: false }
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+
+    it 'renders show if the user has identities and no active session' do
+      user = create(:user)
+      create(:identity, user: user)
+      stub_sign_in(user)
+      subject.session[:sp] = {}
+      get :show
+
+      expect(response).to render_template(:show)
     end
   end
 

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -80,4 +80,53 @@ describe Identity do
       expect(identity.decorate).to be_a(IdentityDecorator)
     end
   end
+
+  let(:service_provider) do
+    create(:service_provider)
+  end
+
+  let(:identity_with_sp) do
+    Identity.create(
+      user_id: user.id,
+      service_provider: service_provider.issuer
+    )
+  end
+
+  describe '#display_name' do
+    it 'returns service provider friendly name first' do
+      expect(identity_with_sp.display_name).to eq(service_provider.friendly_name)
+    end
+
+    it 'returns service_provider agency if friendly_name is missing' do
+      service_provider.friendly_name = nil
+      service_provider.save
+      expect(identity_with_sp.display_name).to eq(service_provider.agency)
+    end
+
+    it 'returns service_provider issuer if friendly_name and agency are missing' do
+      service_provider.friendly_name = nil
+      service_provider.agency = nil
+      service_provider.save
+      expect(identity_with_sp.display_name).to eq(service_provider.issuer)
+    end
+  end
+
+  describe '#agency_name' do
+    it 'returns service provider agency first' do
+      expect(identity_with_sp.agency_name).to eq(service_provider.agency)
+    end
+
+    it 'returns service_provider friendly_name if agency is missing' do
+      service_provider.agency = nil
+      service_provider.save
+      expect(identity_with_sp.agency_name).to eq(service_provider.friendly_name)
+    end
+
+    it 'returns service_provider issuer if friendly_name and agency are missing' do
+      service_provider.friendly_name = nil
+      service_provider.agency = nil
+      service_provider.save
+      expect(identity_with_sp.agency_name).to eq(service_provider.issuer)
+    end
+  end
 end

--- a/spec/view_models/sign_up_completions_show_spec.rb
+++ b/spec/view_models/sign_up_completions_show_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe SignUpCompletionsShow do
+  before do
+    @user = create(:user)
+  end
+
+  subject do
+    SignUpCompletionsShow.new(
+      current_user: @user,
+      loa3_requested: false,
+      decorated_session: decorated_session
+    )
+  end
+
+  context 'with an sp session' do
+    let(:decorated_session) do
+      ServiceProviderSessionDecorator.new(
+        sp: build_stubbed(:service_provider),
+        view_context: ActionController::Base.new.view_context,
+        sp_session: {},
+        service_provider_request: ServiceProviderRequest.new
+      )
+    end
+
+    describe '#service_provider_partial' do
+      it 'returns show_sp path' do
+        expect(subject.service_provider_partial).to eq('sign_up/completions/show_sp')
+      end
+    end
+  end
+
+  context 'with no sp session' do
+    let(:decorated_session) do
+      SessionDecorator.new
+    end
+
+    let(:create_identity) do
+      create(:identity, user_id: @user.id)
+    end
+
+    describe '#service_provider_partial' do
+      it 'returns show_identities path' do
+        expect(subject.service_provider_partial).to eq('sign_up/completions/show_identities')
+      end
+    end
+
+    describe '#identities' do
+      it 'returns a users identities decorated' do
+        identity = create_identity
+        expect(subject.identities).to eq([identity.decorate])
+      end
+    end
+
+    describe '#user_has_identities?' do
+      it 'returns true if user has identities' do
+        create_identity
+        expect(subject.user_has_identities?).to eq(true)
+      end
+
+      it 'returns false if user has no identities' do
+        expect(subject.user_has_identities?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/views/sign_up/completions/show.html.slim_spec.rb
+++ b/spec/views/sign_up/completions/show.html.slim_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'sign_up/completions/show.html.slim' do
+  before do
+    @user = User.new
+    @view_model = SignUpCompletionsShow.new(
+      current_user: @user,
+      loa3_requested: false,
+      decorated_session: SessionDecorator.new
+    )
+  end
+
+  it 'lists the users multiple sps' do
+    identities = create_identities(@user, 3)
+    render
+    identities.each do |identity|
+      expect(rendered).to have_content(identity.agency_name)
+    end
+    expect(rendered).to have_content(t('idv.messages.agencies_login'))
+  end
+
+  it 'shows the users service_provider' do
+    identity = create_identities(@user).first
+    render
+    content = strip_tags(
+      t('idv.messages.agency_login_html', sp: identity.display_name)
+    )
+    expect(rendered).to have_content(content)
+  end
+
+  private
+
+  def create_identities(user, n = 0)
+    identities = []
+    (0..n).each do |i|
+      sp = create(
+        :service_provider,
+        friendly_name: "SP app #{i}",
+        agency: "Agency #{i}"
+      )
+      identities[i] = create(
+        :identity,
+        service_provider: sp.issuer,
+        user: user
+      )
+    end
+    identities
+  end
+end


### PR DESCRIPTION
**Why**:
If a user navigates directly to login.gov, they
will now see a screen after verifying, that displays
the different applications they have authenticated with