### PR TITLE
Don't retry SMS and Voice background jobs

### DIFF
--- a/lib/no_retry_jobs.rb
+++ b/lib/no_retry_jobs.rb
@@ -2,7 +2,7 @@ class NoRetryJobs
   def call(_worker, msg, queue)
     yield
   rescue StandardError => _e
-    msg['retry'] = false if queue == 'idv'
+    msg['retry'] = false if %w[idv sms voice].include?(queue)
     raise
   end
 end

--- a/spec/lib/no_retry_jobs_spec.rb
+++ b/spec/lib/no_retry_jobs_spec.rb
@@ -2,25 +2,30 @@ require 'rails_helper'
 
 RSpec.describe NoRetryJobs do
   describe '#call' do
-    context 'when the queue is idv' do
+    context 'when the queue is idv, sms, or voice' do
       it 'runs' do
-        count = 0
-        NoRetryJobs.new.call(nil, nil, 'idv') { count += 1 }
+        %w[idv sms voice].each do |queue|
+          count = 0
+          NoRetryJobs.new.call(nil, nil, queue) { count += 1 }
 
-        expect(count).to eq 1
+          expect(count).to eq 1
+        end
       end
 
       it 'sets retry to false when rescuing StandardError then raises the error' do
-        msg = {}
-        expect { NoRetryJobs.new.call(nil, msg, 'idv') { raise StandardError } }.
-          to change { msg }.from({}).to('retry' => false).and raise_error(StandardError)
+        %w[idv sms voice].each do |queue|
+          msg = {}
+
+          expect { NoRetryJobs.new.call(nil, msg, queue) { raise StandardError } }.
+            to change { msg }.from({}).to('retry' => false).and raise_error(StandardError)
+        end
       end
     end
 
-    context 'when the queue is not idv' do
+    context 'when the queue is not idv, sms, or voice' do
       it 'does not set retry to false and raises StandardError' do
         msg = {}
-        expect { NoRetryJobs.new.call(nil, msg, 'sms') { raise StandardError } }.
+        expect { NoRetryJobs.new.call(nil, msg, 'mailers') { raise StandardError } }.
           to change(msg, :keys).by([]).and raise_error(StandardError)
       end
     end


### PR DESCRIPTION
**Why**:
By default, Sidekiq automatically retries any failed job, but sometimes,
the job might fail after the OTP was already sent, and retrying the job
will send the OTP again, costing us money, and potentially the user
too, as well as resulting in a confusing and annoying user experience.

Moreover, OTPs are only valid for 5 minutes. It doesn't make sense to
keep sending the same OTP over and over once it is no longer valid.