### PR TITLE
Add GitHub Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+Hi! Before submitting your PR for review, and/or before merging it, please
+go through the following checklist:
+
+- [ ] For DB changes, check for missing indexes, check to see if the changes
+affect other apps (such as the dashboard), make sure the DB columns in the
+various environments are properly populated, coordinate with devops, plan
+migrations in separate steps.
+
+- [ ] For route changes, make sure GET requests don't change state or result in
+destructive behavior. GET requests should only result in information being
+read, not written.
+
+- [ ] For encryption changes, make sure it is compatible with data that was
+encrypted with the old code.
+
+- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
+they are false positives. If you're not sure how to fix the offense, please
+ask a teammate.
+
+- [ ] When reading data, write tests for nil values, empty strings,
+and invalid formats.
+
+- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.


### PR DESCRIPTION
**Why**: To remind the team to follow a checklist when opening or
before merging a PR. We've had a few mistakes slip through the cracks,
and a checklist can help remind us what we need to verify.