### PR TITLE
Allow load test script to take ENV vars for config

### DIFF
--- a/bin/load_test
+++ b/bin/load_test
@@ -35,14 +35,20 @@ if [ $1 ]
 then
   test_to_run="$1"
   target="${TARGET_HOST:-http://localhost:3000}"
+  num_clients=${NUM_CLIENTS:-3}
+  num_requests=${NUM_REQUESTS:-100}
+  hatch_rate=${HATCH_RATE:-1}
 
   brew_install_or_upgrade 'libevent'
   source /usr/local/bin/virtualenvwrapper.sh
   mkvirtualenv locust && \
     workon locust &&  \
     pip install -r scripts/load_testing/requirements.txt && \
-    locust -f scripts/load_testing/$test_to_run.py -H "$target" --no-web -c 3 -n 27 -r 1
+    echo "running locust with concurrency of $num_clients, new user hatch rate"\
+    "of $hatch_rate, and a total number of $num_requests requests" && \
+    locust -f scripts/load_testing/$test_to_run.py -H "$target" --no-web \
+    -c $num_clients -n $hatch_rate -r $num_requests
   deactivate
 else
-  echo "Usage: load_test [name_of_file]"
+  echo "Usage: NUM_CLIENTS=3 NUM_REQUESTS=100 HATCH_RATE=1 load_test [name_of_file]"
 fi

--- a/bin/load_test
+++ b/bin/load_test
@@ -47,8 +47,12 @@ then
     echo "running locust with concurrency of $num_clients, new user hatch rate"\
     "of $hatch_rate, and a total number of $num_requests requests" && \
     locust -f scripts/load_testing/$test_to_run.py -H "$target" --no-web \
-    -c $num_clients -n $hatch_rate -r $num_requests
+    -c $num_clients -n $num_requests -r $hatch_rate
   deactivate
 else
   echo "Usage: NUM_CLIENTS=3 NUM_REQUESTS=100 HATCH_RATE=1 load_test [name_of_file]"
+  echo "Usage:"
+  echo "load_test [name_of_file]"
+  echo "or, if you'd like to set the arguments"
+  echo "NUM_CLIENTS=3 NUM_REQUESTS=100 HATCH_RATE=1 load_test [name_of_file]"
 fi


### PR DESCRIPTION
__Why__

* There was no easy way to change the basic settings without editing the script in the /bin folder.

__How__

* Allow the wrapper script to take ENV variables to further config the locust command.