### PR TITLE
Group the conf token request since it has dynamic URLs

### DIFF
--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -35,7 +35,7 @@ class UserBehavior(locust.TaskSet):
         link = dom.find("a[href*='confirmation_token']")[0].attrib['href']
 
         # click email confirmation link and submit password
-        resp = self.client.get(link, auth=auth)
+        resp = self.client.get(link, auth=auth, name='/sign_up/email/confirm?confirmation_token=')
         resp.raise_for_status()
         dom = pyquery.PyQuery(resp.content)
         confirmation_token = dom.find('input[name="confirmation_token"]')[0].attrib['value']


### PR DESCRIPTION
__Why__

* The dynamic URLs used by the confirmation token do not work well with the locust.io results page.

__How__

* Use the name attribute to group the requests under one namespace.