### PR TITLE
Use random valid phone numbers in load test

### DIFF
--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -1,13 +1,17 @@
 import os
 
 from faker import Factory
+import foney
 import locust
 import pyquery
+import random
 
 fake = Factory.create()
 
 username, password = os.getenv('AUTH_USER'), os.getenv('AUTH_PASS')
 auth = (username, password) if username and password else ()
+
+phone_numbers = foney.phone_numbers()
 
 def authenticity_token(dom):
     return dom.find('input[name="authenticity_token"]')[0].attrib['value']
@@ -53,7 +57,7 @@ class UserBehavior(locust.TaskSet):
         data = {
             '_method': 'patch',
             'user_phone_form[international_code]': 'US',
-            'user_phone_form[phone]': '7035550001',
+            'user_phone_form[phone]': phone_numbers[random.randint(1,1000)],
             'user_phone_form[otp_delivery_preference]': 'sms',
             'authenticity_token': authenticity_token(dom),
             'commit': 'Send security code',

--- a/scripts/load_testing/create_account.py
+++ b/scripts/load_testing/create_account.py
@@ -1,10 +1,11 @@
 import os
+import random
 
 from faker import Factory
-import foney
 import locust
 import pyquery
-import random
+
+import foney
 
 fake = Factory.create()
 

--- a/scripts/load_testing/foney.py
+++ b/scripts/load_testing/foney.py
@@ -1,0 +1,63 @@
+# thanks to https://gist.github.com/ifnull/a32fcc90cd60f6e85b57
+
+def area_codes(count_start=200, count=1000):
+    """
+    NPA (Area Code) Rules:
+    http://www.nanpa.com/area_codes/index.html
+    * Starts with [2-9].
+    * Does not end in 11 (N11).
+    * Does not end in 9* (N9X).
+    * Does not start with 37 (37X).
+    * Does not start with 96 (96X).
+    * Does not contain ERC (Easily Recognizable
+      Codes) AKA last two digits aren't the same.
+    """
+    npa = []
+
+    for x in range(count_start, count):
+        s = str(x)
+        # N11
+        if s[1:] == '11':
+            continue
+        # N9X
+        if s[1:-1] == '9':
+            continue
+        # 37X/96X
+        if s[:2] == '37' or s[:2] == '96':
+            continue
+        # ERC
+        if s[1:2] == s[2:3]:
+            continue
+        npa.append(x)
+
+    return npa
+
+
+def prefixes(count_start=200, count=1000):
+    """
+    CO (Prefix) Rules:
+    * Starts with [2-9].
+    * Does not end with 11 (N11).
+    """
+    co = []
+
+    for x in range(count_start, count):
+        s = str(x)
+        # N11
+        if s[1:] == '11':
+            continue
+        co.append(x)
+
+    return co
+
+
+def phone_numbers(npa=206, count_start=1, count=1000):
+    pns = []
+
+    for co in prefixes():
+        for sub in range(count_start, count):
+            sub = "%04d" % sub
+            pn = '{0}{1}{2}'.format(npa, co, sub)
+            pns.append(pn)
+
+    return pns


### PR DESCRIPTION
__Why__

* When the phone number is fixed it causes rate limiting errors since the same phone number is being used. When using purely random 10 digit numbers it also fails since the web app validates phone numbers.

__How__

* Generate valid phone numbers and use a random one for each user.