### PR TITLE
Add staging to allowed prefill envs

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,10 +1,10 @@
 class FeatureManagement
   ENVS_WHERE_PREFILLING_OTP_ALLOWED = %w[
-    idp.dev.login.gov idp.pt.login.gov
+    idp.dev.login.gov idp.pt.login.gov idp.staging.login.gov
   ].freeze
 
   ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED = %w[
-    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov
+    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov idp.staging.login.gov
   ].freeze
 
   def self.telephony_disabled?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -41,8 +41,8 @@ describe 'FeatureManagement', type: :feature do
         end
       end
 
-      context 'when the server is idp.staging.login.gov' do
-        let(:domain_name) { 'idp.staging.login.gov' }
+      context 'when the server is secure.login.gov' do
+        let(:domain_name) { 'secure.login.gov' }
 
         it 'does not prefill codes' do
           expect(FeatureManagement.prefill_otp_codes?).to eq(false)


### PR DESCRIPTION
__Why__

* We need to use staging to do some load testing however the code restricts that functionality to only certain envs.

__How__

* Add idp.staging.login.gov to the list of exceptions.

I am PRing to `stages/staging` since I consider this a temporary change. We can revert this change later and use the `pt` env once it's ready.