### PR TITLE
Fix order of items in account history

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -8,6 +8,10 @@ EventDecorator = Struct.new(:event) do
   end
 
   def happened_at
-    EasternTimePresenter.new(event.created_at).to_s
+    event.created_at
+  end
+
+  def happened_at_in_words
+    EasternTimePresenter.new(happened_at).to_s
   end
 end

--- a/app/decorators/identity_decorator.rb
+++ b/app/decorators/identity_decorator.rb
@@ -11,6 +11,10 @@ IdentityDecorator = Struct.new(:identity) do
   end
 
   def happened_at
-    EasternTimePresenter.new(identity.last_authenticated_at).to_s
+    identity.last_authenticated_at
+  end
+
+  def happened_at_in_words
+    EasternTimePresenter.new(happened_at).to_s
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -116,9 +116,9 @@ class UserDecorator
   end
 
   def recent_events
-    events = user.events.order('updated_at DESC').limit(MAX_RECENT_EVENTS).map(&:decorate)
+    events = user.events.order('created_at DESC').limit(MAX_RECENT_EVENTS).map(&:decorate)
     identities = user.identities.order('last_authenticated_at DESC').map(&:decorate)
-    (events + identities).sort { |thing_a, thing_b| thing_b.happened_at <=> thing_a.happened_at }
+    (events + identities).sort_by(&:happened_at).reverse
   end
 
   def verified_account_partial

--- a/app/views/accounts/_event_item.html.slim
+++ b/app/views/accounts/_event_item.html.slim
@@ -3,4 +3,4 @@
     .sm-col.sm-col-6.px1
       .bold.truncate = event.event_type
     .sm-col.sm-col-6.px1.sm-right-align
-      = event.happened_at
+      = event.happened_at_in_words

--- a/app/views/accounts/_identity_item.html.slim
+++ b/app/views/accounts/_identity_item.html.slim
@@ -8,4 +8,4 @@
         - else
           = t('event_types.authenticated_at', service_provider: event.display_name)
     .sm-col.sm-col-6.px1.sm-right-align
-      = event.happened_at
+      = event.happened_at_in_words

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -319,17 +319,14 @@ describe UserDecorator do
   end
 
   describe '#recent_events' do
-    it 'interleaves identities and events' do
-      user = build(:user)
-      user_decorator = UserDecorator.new(user)
-      identity = create(
-        :identity,
-        last_authenticated_at: Time.zone.now - 1,
-        user: user
-      )
-      event = create(:event, event_type: :email_changed, user: user)
+    let!(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+    let(:decorated_user) { user.decorate }
+    let!(:event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
+    let!(:identity) { create(:identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days) }
+    let!(:another_event) { create(:event, user: user, event_type: :email_changed, created_at: Time.zone.now - 30.days) }
 
-      expect(user_decorator.recent_events).to eq [event.decorate, identity.decorate]
+    it 'interleaves identities and events, decorates them, and sorts them in descending order' do
+      expect(decorated_user.recent_events).to eq [another_event.decorate, identity.decorate, event.decorate]
     end
   end
 

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -1,24 +1,33 @@
 require 'rails_helper'
 
 describe 'Account history' do
-  let(:user) { create(:user, :signed_up) }
-  let(:account_created_event) { create(:event, user: user) }
+  let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+  let(:account_created_event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
+  let(:usps_mail_sent_event) { create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 90.days) }
   let(:identity_with_link) do
     create(
       :identity,
       :active,
       user: user,
+      last_authenticated_at: Time.zone.now - 80.days,
       service_provider: 'http://localhost:3000'
     )
   end
+  let(:usps_mail_sent_again_event) { create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 60.days) }
   let(:identity_without_link) do
     create(
       :identity,
       :active,
       user: user,
+      last_authenticated_at: Time.zone.now - 50.days,
       service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata'
     )
   end
+  let(:account_created_timestamp) { account_created_event.decorate.happened_at_in_words }
+  let(:usps_mail_sent_timestamp) { usps_mail_sent_event.decorate.happened_at_in_words }
+  let(:identity_with_link_timestamp) { identity_with_link.decorate.happened_at_in_words }
+  let(:usps_mail_sent_again_timestamp) { usps_mail_sent_again_event.decorate.happened_at_in_words }
+  let(:identity_without_link_timestamp) { identity_without_link.decorate.happened_at_in_words }
 
   before do
     sign_in_and_2fa_user(user)
@@ -27,7 +36,11 @@ describe 'Account history' do
   end
 
   scenario 'viewing account history' do
-    expect(page).to have_content(t('event_types.account_created'))
+    [account_created_event, usps_mail_sent_event, usps_mail_sent_again_event].each do |event|
+      decorated_event = event.decorate
+      expect(page).to have_content(decorated_event.event_type)
+      expect(page).to have_content(decorated_event.happened_at_in_words)
+    end
 
     expect(page).to have_content(
       t('event_types.authenticated_at', service_provider: identity_without_link.display_name)
@@ -40,10 +53,17 @@ describe 'Account history' do
     expect(page).to have_link(
       identity_with_link.display_name, href: 'http://localhost:3000'
     )
+
+    expect(identity_without_link_timestamp).to appear_before(usps_mail_sent_again_timestamp)
+    expect(usps_mail_sent_again_timestamp).to appear_before(identity_with_link_timestamp)
+    expect(identity_with_link_timestamp).to appear_before(usps_mail_sent_timestamp)
+    expect(usps_mail_sent_timestamp).to appear_before(account_created_timestamp)
   end
 
   def build_account_history
     account_created_event
+    usps_mail_sent_event
+    usps_mail_sent_again_event
     identity_with_link
     identity_without_link
   end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -147,6 +147,7 @@ feature 'LOA3 Single Sign On', idv_job: true do
 
           click_button(t('idv.buttons.mail.resend'))
 
+          expect(user.events.usps_mail_sent.size).to eq 2
           expect(current_path).to eq(verify_come_back_later_path)
         end
 

--- a/spec/support/matchers/appear_before.rb
+++ b/spec/support/matchers/appear_before.rb
@@ -1,0 +1,19 @@
+#
+# Use this matcher in any test that has access to a Capybara page object (a.k.a. Capybara::Session)
+# ... to test whether some content appears before some other content on the page.
+# ... source: https://stackoverflow.com/a/14769902
+#
+# @param [String] earlier_content some text on the page expected to appear first
+# @param [String] later_content some text on the page expected to appear last
+#
+# @example
+#
+# it "ensures proper order of page contents" do
+#   expect("Hello").to appear_before("World")
+# end
+#
+RSpec::Matchers.define :appear_before do |later_content|
+  match do |earlier_content|
+    page.body.index(earlier_content) < page.body.index(later_content)
+  end
+end


### PR DESCRIPTION
I was working on a fix for [this issue](https://github.com/18F/identity-private/issues/2036) (*Add USPS confirmation letter to user's event history*), but I think the desired behavior is already happening, so I added a test to confirm (screenshot below).

<img width="587" alt="screen shot 2017-11-18 at 1 46 31 pm" src="https://user-images.githubusercontent.com/1328807/32984189-a1bd11f6-cc6f-11e7-802d-c9cd9c14410a.png">

So I'm not sure whether the issue is erroneous (maybe a subsequent fix got pushed since May, when the issue was created), or if I didn't choose the right test case.

I was able to recreate the USPS confirmation event in the test using a factory, but not via a separate test scenario or development environment scenario. I'd benefit from more information about a user's workflow/scenario that would produce the unexpected behavior. And after learning more, I would be happy to implement a different test and corresponding fix, as necessary.

UPDATE: reading more about "signing in with pending USPS verification" spec now...

UPDATE: I am thinking maybe the following line of code might be a relevant place to test for presence of the event in the account history. Right now only a "Account verified" event shows up there. But I would hope to get confirmation/clarification before progressing further.

https://github.com/18F/identity-idp/blob/dd4dd898990ac69fa03fe6071cc286351ac206e5/spec/support/idv_examples/usps_verification.rb#L46