### PR TITLE
Store generated user data in local sqlite db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,6 @@ group :development do
   gem 'rails_layout'
   gem 'reek'
   gem 'rubocop', require: false
-  gem 'sqlite3'
 end
 
 group :development, :test do
@@ -91,6 +90,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5.2'
   gem 'slim_lint'
+  gem 'sqlite3'
   gem 'teaspoon-mocha'
   gem 'thin'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :development do
   gem 'rails_layout'
   gem 'reek'
   gem 'rubocop', require: false
+  gem 'sqlite3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,6 +593,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -756,6 +757,7 @@ DEPENDENCIES
   sinatra
   slim-rails
   slim_lint
+  sqlite3
   stringex
   teaspoon-mocha
   thin

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -70,7 +70,6 @@ namespace :dev do
         User.find_or_create_by!(email_fingerprint: ee.fingerprint) do |user|
           setup_user(user, ee: ee, pw: pw, num: num_created)
         end
-
         if ENV['VERIFIED']
           user = User.find_by(email_fingerprint: ee.fingerprint)
           user.unlock_user_access_key(pw)
@@ -85,13 +84,12 @@ namespace :dev do
           profile.verified_at = Time.zone.now
           profile.activate
 
-          unless ENV['DB'] == 'no'
-            db.execute("INSERT INTO users (email, personal_key) VALUES (?, ?)", [email_addr, personal_key])
-          end
-
           Rails.logger.warn "email=#{email_addr} personal_key=#{personal_key}"
         end
 
+        unless ENV['DB'] == 'no'
+          db.execute("INSERT INTO users (email, personal_key) VALUES (?, ?)", [email_addr, personal_key])
+        end
         num_created += 1
         progress&.increment
       end


### PR DESCRIPTION
__Why__

* We need to generate users and reuse those credentials for load testing. This modifies the existing user generator script to also store the data to the db.

__How__

* Add sqlite and write users to db as they are generated.
