### PR TITLE
Add useful info to exception notification emails

### DIFF
--- a/app/views/exception_notifier/_session.text.erb
+++ b/app/views/exception_notifier/_session.text.erb
@@ -1,0 +1,21 @@
+<% browser = Browser.new(@request.user_agent) %>
+Browser Name: <%= browser.name %>
+Browser Version: <%= browser.full_version %>
+Browser Platform: <%= browser.platform %> <%= browser.platform.version %>
+Browser Device: <%= browser.device.name %>
+Browser Bot?: <%= browser.bot? %>
+
+Referer: <%= @request.referer %>
+
+<% keys_to_keep = %w[session_expires_at pinged_at sp user_return_to] %>
+<% session = @request.session.to_hash.select { |k, _| keys_to_keep.include?(k) } %>
+<% if session['sp'] %>
+  <% session['sp'] = session['sp'].except('request_url') %>
+  <% session['sp']['request_id'] = 'FILTERED' if session['sp']['request_id'] %>
+<% end %>
+<% session['user_return_to'] = session['user_return_to']&.split('?')&.first %>
+Session: <%= session %>
+
+User UUID: <%= @kontroller.analytics_user.uuid %>
+
+Visitor ID: <%= @request.cookies['ahoy_visitor'] %>

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -10,6 +10,6 @@ ExceptionNotification.configure do |config|
     sender_address: %("Exception Notifier" <notifier@login.gov>),
     exception_recipients: EXCEPTION_RECIPIENTS,
     error_grouping: true,
-    sections: %w[request backtrace]
+    sections: %w[request backtrace session]
   )
 end


### PR DESCRIPTION
**Why**: To help us troubleshoot. Referer to know where a user came
from, SP-related info to know if the user came from an agency, or
if the SP info got dropped from the session, browser info to see if
certain errors affect certain devices/browsers more than others,
and user/visitor UUID to be able to look up the user.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.
