### PR TITLE
Allow OIDC requests with Accept header "*/*"

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -3,6 +3,7 @@ module OpenidConnect
     include FullyAuthenticatable
     include VerifyProfileConcern
 
+    skip_before_action :handle_two_factor_authentication
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :validate_authorize_form, only: [:index]
     before_action :store_request, only: [:index]

--- a/spec/requests/openid_connect_authorize_spec.rb
+++ b/spec/requests/openid_connect_authorize_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'user signs in partially and visits openid_connect/authorize' do
+  let(:user) { create(:user, :signed_up, phone: '+1 (202) 555-1213') }
+
+  it 'prompts the user to 2FA' do
+    client_id = 'urn:gov:gsa:openidconnect:sp:server'
+    state = SecureRandom.hex
+    nonce = SecureRandom.hex
+
+    post new_user_session_path, params: { user: { email: user.email, password: user.password } }
+    follow_redirect!
+    get(
+      openid_connect_authorize_path,
+      params: {
+        client_id: client_id,
+        response_type: 'code',
+        acr_values: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
+        scope: 'openid email profile:name social_security_number',
+        redirect_uri: 'http://localhost:7654/auth/result',
+        state: state,
+        prompt: 'select_account',
+        nonce: nonce,
+      },
+      headers: { 'Accept' => '*/*' }
+    )
+    follow_redirect!
+    expect(response).
+      to redirect_to login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
+  end
+end


### PR DESCRIPTION
**Why**: The `two_factor_authentication` gem includes a `before_action`
that calls `render nothing: true` if the Accept header is not set to
`html`. This means that if a user is partially signed in (i.e. with
email and password only), and then they visit a Service Provider and
make an OpenId Connect request to the IdP with an Accept header set to
`*/*`, the app will throw an `ActionView::MissingTemplate` error because
it's trying to render a view that does not exist.

It turns out we don't need the `handle_two_factor_authentication`
callback because we have our own `user_fully_authenticated?` method for
determining whether or not a user needs 2FA.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
