### PR TITLE
Add uniqueness index to identities table

### DIFF
--- a/db/migrate/20171122194214_add_unique_index_to_identities_and_users.rb
+++ b/db/migrate/20171122194214_add_unique_index_to_identities_and_users.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToIdentitiesAndUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :identities, %i[user_id service_provider]
+    add_index :identities, %i[user_id service_provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171016185939) do
+ActiveRecord::Schema.define(version: 20171122194214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 20171016185939) do
     t.string "rails_session_id"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
-    t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider"
+    t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true
     t.index ["user_id"], name: "index_identities_on_user_id"
     t.index ["uuid"], name: "index_identities_on_uuid", unique: true
   end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -129,4 +129,18 @@ describe Identity do
       expect(identity_with_sp.agency_name).to eq(service_provider.issuer)
     end
   end
+
+  describe 'uniqueness validation for service provider per user' do
+    it 'raises an error when uniqueness constraint is broken' do
+      Identity.create(user_id: user.id, service_provider: 'externalapp')
+      expect { Identity.create(user_id: user.id, service_provider: 'externalapp') }.
+        to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does not raise an error for a different service provider' do
+      Identity.create(user_id: user.id, service_provider: 'externalapp')
+      expect { Identity.create(user_id: user.id, service_provider: 'externalapp2') }.
+        to_not raise_error
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,7 +139,7 @@ describe User do
       Identity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
     end
     let(:inactive_identity) do
-      Identity.create(service_provider: 'entity_id', session_uuid: nil)
+      Identity.create(service_provider: 'entity_id2', session_uuid: nil)
     end
 
     describe '#active_identities' do


### PR DESCRIPTION
__Why__

* because each user should only have one identity per service provider

__How__

* remove existing index and re-add it with uniqueness constraint

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
