### PR TITLE
Fix uncommunicative parameter name in view test

### DIFF
--- a/spec/views/sign_up/completions/show.html.slim_spec.rb
+++ b/spec/views/sign_up/completions/show.html.slim_spec.rb
@@ -30,20 +30,14 @@ describe 'sign_up/completions/show.html.slim' do
 
   private
 
-  def create_identities(user, n = 0)
-    identities = []
-    (0..n).each do |i|
+  def create_identities(user, count = 0)
+    (0..count).map do |index|
       sp = create(
         :service_provider,
-        friendly_name: "SP app #{i}",
-        agency: "Agency #{i}"
+        friendly_name: "SP app #{index}",
+        agency: "Agency #{index}"
       )
-      identities[i] = create(
-        :identity,
-        service_provider: sp.issuer,
-        user: user
-      )
+      create(:identity, service_provider: sp.issuer, user: user)
     end
-    identities
   end
 end


### PR DESCRIPTION
**Why**: So reek will stop finding UncommunicativeParameterName issues
when running locally

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
