### PR TITLE
Unset phone confirmed when not verifying 2FA phone

### DIFF
--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -48,8 +48,7 @@ module Idv
       normalized_phone = phone.gsub(/\D/, '')[1..-1]
       idv_params[:phone] = normalized_phone
 
-      return if phone != user.phone
-
+      return idv_params[:phone_confirmed_at] = nil unless phone == user.phone
       idv_params[:phone_confirmed_at] = user.phone_confirmed_at
     end
   end

--- a/spec/controllers/verify/phone_controller_spec.rb
+++ b/spec/controllers/verify/phone_controller_spec.rb
@@ -142,6 +142,7 @@ describe Verify::PhoneController do
 
           expected_params = {
             phone: normalized_phone,
+            phone_confirmed_at: nil,
           }
           expect(subject.idv_session.params).to eq expected_params
         end

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -68,6 +68,41 @@ feature 'Verify phone' do
     end
   end
 
+  context 'failing to verify 2FA phone' do
+    scenario 'requires verifying and confirming a different phone', :idv_job do
+      phone_number_that_will_fail_verification = '+1 (555) 555-5555'
+
+      user = create(
+        :user, :signed_up,
+        phone: phone_number_that_will_fail_verification,
+        password: Features::SessionHelper::VALID_PASSWORD
+      )
+      sign_in_and_2fa_user(user)
+      visit verify_session_path
+      fill_out_idv_form_ok
+      click_idv_continue
+      fill_out_financial_form_ok
+      click_idv_continue
+      click_idv_address_choose_phone
+
+      fill_in 'Phone', with: user.phone
+      click_idv_continue
+
+      expect(page).to have_content(t('idv.modal.phone.heading'))
+
+      fill_in 'Phone', with: '+1 (555) 555-5000'
+      click_idv_continue
+
+      choose_idv_otp_delivery_method_sms
+      enter_correct_otp_code_for_user(user)
+      fill_in :user_password, with: user_password
+      click_submit_default
+      click_acknowledge_personal_key
+
+      expect(current_path).to eq account_path
+    end
+  end
+
   scenario 'phone field only allows numbers', js: true, idv_job: true do
     sign_in_and_2fa_user
     visit verify_session_path

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -23,6 +23,7 @@ describe Idv::PhoneForm do
 
         expected_params = {
           phone: '7035551212',
+          phone_confirmed_at: nil,
         }
 
         expect(subject.idv_params).to eq expected_params


### PR DESCRIPTION
**Why**: So that when a user fails to verify their 2FA phone, but then
verifies a new phone, the `phone_confirmed_at` flag set in the previous
verification transaction does not carry over to the current one. This
means that a user cannot enter their 2FA phone, fail verification, then
enter another phone, pass verification, and bypass the OTP
confirmation.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
