### PR TITLE
Use nil for empty user/pass in basic auth

### DIFF
--- a/app/services/basic_auth_url.rb
+++ b/app/services/basic_auth_url.rb
@@ -3,8 +3,8 @@ module BasicAuthUrl
 
   def build(url, user: Figaro.env.basic_auth_user_name, password: Figaro.env.basic_auth_password)
     URI.parse(url).tap do |uri|
-      uri.user = user
-      uri.password = password
+      uri.user = user.present? ? user : nil
+      uri.password = password.present? ? password : nil
     end.to_s
   end
 end

--- a/spec/services/basic_auth_url_spec.rb
+++ b/spec/services/basic_auth_url_spec.rb
@@ -2,11 +2,22 @@ require 'rails_helper'
 
 RSpec.describe BasicAuthUrl do
   describe '.build' do
-    it 'is the URL as-is with no username or password' do
-      url = 'https://foo.example.com/bar'
-      external_url = BasicAuthUrl.build(url, user: nil, password: nil)
+    context 'with nil username and password' do
+      it 'is the URL as-is with no username or password' do
+        url = 'https://foo.example.com/bar'
+        external_url = BasicAuthUrl.build(url, user: nil, password: nil)
 
-      expect(external_url).to eq(url)
+        expect(external_url).to eq(url)
+      end
+    end
+
+    context 'with empty string for username and password' do
+      it 'is the URL as-is with no username or password' do
+        url = 'https://foo.example.com/bar'
+        external_url = BasicAuthUrl.build(url, user: '', password: '')
+
+        expect(external_url).to eq(url)
+      end
     end
 
     context 'with basic auth username and pass set in the config' do


### PR DESCRIPTION
**Why**: Building a URI with an empty string for the username or
password raises a URI::InvalidURIError

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
