### PR TITLE
Drop AppSettings table

### DIFF
--- a/db/migrate/20171130190756_remove_app_setting.rb
+++ b/db/migrate/20171130190756_remove_app_setting.rb
@@ -1,0 +1,5 @@
+class RemoveAppSetting < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :app_settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129194911) do
+ActiveRecord::Schema.define(version: 20171130190756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "app_settings", force: :cascade do |t|
-    t.string "name", limit: 255
-    t.string "value", limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["name"], name: "index_app_settings_on_name"
-  end
 
   create_table "authorizations", force: :cascade do |t|
     t.string "provider", limit: 255


### PR DESCRIPTION
**Why**: It's no longer used. We removed the code earlier in #1805, and
now we are removing the table. This should be merged only after
PR #1805 has been deployed.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
