### PR TITLE
Add controller info to CSRF analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,13 +107,12 @@ class ApplicationController < ActionController::Base
     params[:reauthn]
   end
 
-  def invalid_auth_token(exception)
-    analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN)
+  def invalid_auth_token(_exception)
+    controller_info = "#{controller_path}##{action_name}"
+    analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN, controller: controller_info)
     sign_out
     flash[:error] = t('errors.invalid_authenticity_token')
     redirect_to root_url
-
-    ExceptionNotifier.notify_exception(exception, env: request.env)
   end
 
   def user_fully_authenticated?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -28,7 +28,9 @@ describe ApplicationController do
       expect(subject.current_user).to be_present
 
       stub_analytics
-      expect(@analytics).to receive(:track_event).with(Analytics::INVALID_AUTHENTICITY_TOKEN)
+      event_properties = { controller: 'anonymous#index' }
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::INVALID_AUTHENTICITY_TOKEN, event_properties)
 
       get :index
 


### PR DESCRIPTION
**Why**: It's helpful to know what the user was trying to do that
resulted in a CSRF error, and it will show us which controllers
get this error the most. With this information, we can exclude these
errors from the Exception Notification emails. We can continue
troubleshooting and monitoring via our analytics.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
