### PR TITLE
Capitalize TwiML tags; ignore slim-lint offense

### DIFF
--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -1,6 +1,11 @@
 exclude:
     - 'app/views/shared/_flashes.html.slim'
     - 'app/views/shared/_null.html.slim'
+    # The file below is ignored globally because for some reason,
+    # excluding it under the `TagCase` section below doesn't work.
+    # We need to exclude this file because slim-lint wants all XML
+    # tags to be lowercase, but Twilio requires them to be uppercase.
+    - 'app/views/voice/otp/show.xml.slim'
 linters:
   LineLength:
     max: 100
@@ -9,6 +14,6 @@ linters:
       - 'app/views/pages/privacy_policy.html.slim'
   TagCase:
     exclude:
-     - 'app/views/voice/otp/show.xml.slim'
+      - 'app/views/voice/otp/show.xml.slim'
   RuboCop:
     enabled: true

--- a/app/views/voice/otp/show.xml.slim
+++ b/app/views/voice/otp/show.xml.slim
@@ -1,9 +1,9 @@
 doctype xml
 response
-  say language="#{I18n.locale}"
+  Say language="#{I18n.locale}"
     = @message
   - if @action_url
-    gather numDigits="1" action=@action_url
-      say language="#{I18n.locale}"
+    Gather numDigits="1" action=@action_url
+      Say language="#{I18n.locale}"
         = t('voice.otp.repeat_instructions')
-  hangup /
+  Hangup /

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe Voice::OtpController do
       let(:code) { '1234' }
       let(:encrypted_code) { cipher.encrypt(code) }
 
-      it 'tells Twilio to <say> the code with pauses in between' do
+      it 'tells Twilio to <Say> the code with pauses in between' do
         action
 
         doc = Nokogiri::XML(response.body)
-        say = doc.css('say').first
+        say = doc.css('Say').first
         expect(say.text).to include('1, 2, 3, 4,')
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Voice::OtpController do
         action
 
         doc = Nokogiri::XML(response.body)
-        say = doc.css('say').first
+        say = doc.css('Say').first
 
         expect(say[:language]).to eq('en')
       end
@@ -52,16 +52,16 @@ RSpec.describe Voice::OtpController do
           action
 
           doc = Nokogiri::XML(response.body)
-          say = doc.css('say').first
+          say = doc.css('Say').first
 
           expect(say[:language]).to eq('es')
         end
 
-        it 'passes locale into the <gather> action URL' do
+        it 'passes locale into the <Gather> action URL' do
           action
 
           doc = Nokogiri::XML(response.body)
-          gather = doc.css('gather').first
+          gather = doc.css('Gather').first
 
           params = URIService.params(gather[:action])
           expect(params[:locale]).to eq('es')
@@ -75,36 +75,36 @@ RSpec.describe Voice::OtpController do
           action
 
           doc = Nokogiri::XML(response.body)
-          say = doc.css('say').first
+          say = doc.css('Say').first
 
           expect(say[:language]).to eq('fr')
         end
 
-        it 'passes locale into the <gather> action URL' do
+        it 'passes locale into the <Gather> action URL' do
           action
 
           doc = Nokogiri::XML(response.body)
-          gather = doc.css('gather').first
+          gather = doc.css('Gather').first
 
           params = URIService.params(gather[:action])
           expect(params[:locale]).to eq('fr')
         end
       end
 
-      it 'has a <gather> with instructions to repeat with a repeat_count' do
+      it 'has a <Gather> with instructions to repeat with a repeat_count' do
         action
 
         doc = Nokogiri::XML(response.body)
-        gather = doc.css('gather').first
+        gather = doc.css('Gather').first
 
         expect(gather[:action]).to include('repeat_count=4')
       end
 
-      it 'puts the encrypted code in the <gather> action' do
+      it 'puts the encrypted code in the <Gather> action' do
         action
 
         doc = Nokogiri::XML(response.body)
-        gather = doc.css('gather').first
+        gather = doc.css('Gather').first
         params = URIService.params(gather[:action])
 
         expect(cipher.decrypt(params[:encrypted_code])).to eq(code)
@@ -113,11 +113,11 @@ RSpec.describe Voice::OtpController do
       context 'when repeat_count counts down to 1' do
         let(:repeat_count) { 1 }
 
-        it 'does not have a <gather> in the response' do
+        it 'does not have a <Gather> in the response' do
           action
 
           doc = Nokogiri::XML(response.body)
-          expect(doc.css('gather')).to be_empty
+          expect(doc.css('Gather')).to be_empty
         end
       end
     end


### PR DESCRIPTION
**Why**: TwiML tags are case-sensitive according to Twilio
documentation, so we need to ignore the `TagCase` slim-lint offense
for `app/views/voice/otp/show.xml.slim`. For some reason, using the
exclude option under `TagCase` doesn't work, so I had to ignore the
file globally.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
