### PR TITLE
Capitalize Response in the TwiML XML

### DIFF
--- a/app/views/voice/otp/show.xml.slim
+++ b/app/views/voice/otp/show.xml.slim
@@ -1,5 +1,5 @@
 doctype xml
-response
+Response
   Say language="#{I18n.locale}"
     = @message
   - if @action_url

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Voice::OtpController do
         expect(say.text).to include('1, 2, 3, 4,')
       end
 
+      it 'includes a capitalized Response tag' do
+        action
+
+        doc = Nokogiri::XML(response.body)
+        response = doc.css('Response').first
+
+        expect(response).to be_present
+      end
+
       it 'sets the lang attribute to english' do
         action
 


### PR DESCRIPTION
**Why**: The Response tag is part of the tags Twilio expects to
be capitalized.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
