### PR TITLE
Redirect to SP after new personal key request

### DIFF
--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -27,7 +27,9 @@ module Users
     private
 
     def next_step
-      if current_user.decorate.password_reset_profile.present?
+      if session[:sp]
+        sign_up_completed_url
+      elsif current_user.decorate.password_reset_profile.present?
         reactivate_account_url
       else
         account_url

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -94,6 +94,22 @@ feature 'LOA1 Single Sign On' do
       expect(current_path).to eq sign_up_completed_path
     end
 
+    it 'redirects user to SP after asking for new personal key during sign up' do
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+
+      saml_authn_request = auth_request.create(saml_settings)
+      visit saml_authn_request
+      register_user
+      click_on t('users.personal_key.get_another')
+      click_acknowledge_personal_key
+
+      expect(current_path).to eq sign_up_completed_path
+
+      click_on t('forms.buttons.continue')
+
+      expect(current_url).to eq saml_authn_request
+    end
+
     it 'after session timeout, signing in takes user back to SP' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
 


### PR DESCRIPTION
**Why**: Requesting a new personal key during account creation
should not prevent a user from going back to the SP.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
