### PR TITLE
Redirect to phone setup if 2FA isn't setup yet

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -3,6 +3,7 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
 
     skip_before_action :handle_two_factor_authentication
+    before_action :confirm_two_factor_enabled
 
     def show
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH_ENTER_OTP_VISIT, analytics_properties)
@@ -23,6 +24,12 @@ module TwoFactorAuthentication
     end
 
     private
+
+    def confirm_two_factor_enabled
+      return if confirmation_context? || current_user.two_factor_enabled?
+
+      redirect_to phone_setup_url
+    end
 
     def form_params
       params.permit(:code)

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -58,6 +58,15 @@ describe TwoFactorAuthentication::OtpVerificationController do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    it 'redirects to phone setup page if user does not have a phone yet' do
+      user = build_stubbed(:user)
+      stub_sign_in_before_2fa(user)
+
+      get :show, params: { otp_delivery_preference: 'sms' }
+
+      expect(response).to redirect_to(phone_setup_url)
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
**Why**: If you try to visit `login/two_factor/sms|voice` directly
before you set up 2FA, the app will raise an error due to `user.phone`
being `nil` (because the view tries to display the user's masked phone
number). This handles that scenario more gracefully by redirecting
to the phone setup page.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
