### PR TITLE
Make DB pool size configurable based on instance role

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,8 +5,8 @@ postgresql: &postgresql
   port: 5432
 
 defaults: &defaults
-  pool: 5
   host: localhost
+  pool: 5
   <<: *postgresql
   # timeout settings
   timeout: 5000
@@ -30,5 +30,6 @@ production:
   username: <%= Figaro.env.database_username! %>
   host: <%= Figaro.env.database_host! %>
   password: <%= Figaro.env.database_password! %>
+  pool: <%= (File.exist?('/etc/login.gov/info') && File.read('/etc/login.gov/info/role').chomp == 'worker') ? 26 : 5 %>
   sslmode: 'verify-full'
   sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'


### PR DESCRIPTION
__Why__

* Workers need a 5x larger pool than the IdP hosts hence we need a way to configure the pool size based on instance role.

__How__

* Use a conditional to set the pool size based on the instance role type.
