### PR TITLE
Don't log filepath in yaml normalizer spec

### DIFF
--- a/lib/yaml_normalizer.rb
+++ b/lib/yaml_normalizer.rb
@@ -5,7 +5,7 @@ class YamlNormalizer
   # Reads in YAML at a path, trims whitespace from each key, and writes it back to the file
   def self.run(argv)
     argv.each do |file|
-      $stderr.puts file
+      warn file
       data = YAML.load_file(file)
       handle_hash(data)
       dump(file, data)

--- a/spec/lib/yaml_normalizer_spec.rb
+++ b/spec/lib/yaml_normalizer_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe YamlNormalizer do
     after { tempfile.unlink }
 
     it 'normalizes a YAML files in-place' do
+      expect(YamlNormalizer).to receive(:warn).with(tempfile.path)
+
       YamlNormalizer.run([tempfile.path])
 
       expect(File.read(tempfile.path)).to eq <<~YAML


### PR DESCRIPTION
**Why**: So the file path doesn't create noise in the rspec output

**How**: This commit stubs out `YamlNormalizer.warn` with an expectation
that it receive the filepath as an argument. This stub has the
side-effect of preventing the method's original implementation from
being called which supresses the output.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
