### PR TITLE
Check phone presence in OtpDeliverySelectionForm

### DIFF
--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -4,6 +4,7 @@ class OtpDeliverySelectionForm
   attr_reader :otp_delivery_preference
 
   validates :otp_delivery_preference, inclusion: { in: %w[sms voice] }
+  validates :phone_to_deliver_to, presence: true
 
   def initialize(user, phone_to_deliver_to, context)
     @user = user

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -40,17 +40,25 @@ describe OtpDeliverySelectionForm do
 
     context 'when the form is invalid' do
       it 'returns false for success? and includes errors' do
-        errors = { otp_delivery_preference: ['is not included in the list'] }
+        errors = {
+          otp_delivery_preference: ['is not included in the list'],
+          phone_to_deliver_to: ['Please fill in this field.'],
+        }
 
         extra = {
           otp_delivery_preference: 'foo',
           resend: nil,
-          country_code: '1',
-          area_code: '202',
+          country_code: nil,
+          area_code: nil,
           context: 'authentication',
         }
 
         result = instance_double(FormResponse)
+        subject = OtpDeliverySelectionForm.new(
+          build_stubbed(:user),
+          nil,
+          'authentication'
+        )
 
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra).and_return(result)


### PR DESCRIPTION
**Why**: An OTP can't be sent to a null phone. Somehow, some users are
trying to access the `/otp/send` path before they have confirmed
their 2FA phone, either because their "stored location" was set to
that path and then they signed in, or somehow the
`user_session[:context]` got reset from "confirmation" to
"authentication" when they tried to set up 2FA, or perhaps it never got
set.

Those are the most likely reasons from looking at analytics events.
All users who are seeing this error had their session context set to
"authentication", in which case the app assumes the user already has a
phone number (as opposed to using `user_session[:unconfirmed_phone]`).
An interesting commonality between most users is that they are using
Chrome 62 on Windows 10.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
