### PR TITLE
Fallback to english for untranslated text

### DIFF
--- a/config/initializers/i18n_english_fallback.rb
+++ b/config/initializers/i18n_english_fallback.rb
@@ -1,0 +1,21 @@
+I18n.module_eval do
+  class << self
+    def translate(*args)
+      original_translation = super(*args)
+      return original_translation unless original_translation == 'NOT TRANSLATED YET'
+      fallback_to_english(*args)
+    end
+
+    alias_method :t, :translate
+
+    private
+
+    def fallback_to_english(*args)
+      key = args.shift
+      options = args.last.is_a?(Hash) ? args.last : {}
+      options.delete(:locale)
+
+      config.backend.translate(:en, key, options)
+    end
+  end
+end

--- a/spec/config/initializers/i18n_english_fallback.rb
+++ b/spec/config/initializers/i18n_english_fallback.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe I18n do
+  let(:translation_key) { 'asdf.qwert.1234' }
+  let(:english_translation) { 'this is some text' }
+  let(:spanish_translation) { 'NOT TRANSLATED YET' }
+  let(:local_argument) { :en }
+
+  before do
+    allow(I18n.config.backend).to receive(:translate).
+      with(:es, translation_key, {}).
+      and_return(spanish_translation)
+    allow(I18n.config.backend).to receive(:translate).
+      with(:en, translation_key, {}).
+      and_return(english_translation)
+  end
+
+  after do
+    I18n.locale = :en
+  end
+
+  describe '#translate' do
+    context 'with non-english locale' do
+      context 'when the requested string is untranslated' do
+        it 'should return the english translation with a locale argument' do
+          expect(I18n.t('asdf.qwert.1234', locale: :es)).to eq(english_translation)
+        end
+
+        it 'should return the english translation with a global locale' do
+          I18n.locale = :es
+
+          expect(I18n.t('asdf.qwert.1234')).to eq(english_translation)
+        end
+      end
+
+      context 'when the requested string is translated' do
+        let(:spanish_translation) { 'esto es un texto' }
+
+        it 'should return the non-english translation with a locale argument' do
+          expect(I18n.t('asdf.qwert.1234', locale: :es)).to eq(spanish_translation)
+        end
+
+        it 'should return the non-english translation with a global locale' do
+          I18n.locale = :es
+
+          expect(I18n.t('asdf.qwert.1234')).to eq(spanish_translation)
+        end
+      end
+    end
+
+    context 'with english locale' do
+      it 'should return the english translation with a locale argument' do
+        expect(I18n.t('asdf.qwert.1234', locale: :en)).to eq(english_translation)
+      end
+
+      it 'should return the english translation with a global locale' do
+        expect(I18n.t('asdf.qwert.1234')).to eq(english_translation)
+      end
+    end
+
+    context 'when english translation is "NOT TRANSLATED YET"' do
+      let(:english_translation) { 'NOT TRANSLATED YET' }
+
+      it 'does not recurse with a locale argument' do
+        expect(I18n.t('asdf.qwert.1234', locale: :en)).to eq('NOT TRANSLATED YET')
+      end
+
+      it 'does not recurse without a locale argument' do
+        expect(I18n.t('asdf.qwert.1234')).to eq('NOT TRANSLATED YET')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that users using the site in other languages will not see
NOT TRANSLATED AT.

**How**: Patch `I18n.translate` and `I18n.t` such that when it is about
to return "NOT TRANSLATED AT", it instead calls back to the I18n
backend for the same translation in english.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
