### PR TITLE
Skip handle_two_factor_authentication

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -2,6 +2,8 @@ module SignUp
   class EmailConfirmationsController < ApplicationController
     include UnconfirmedUserConcern
 
+    skip_before_action :handle_two_factor_authentication
+
     def create
       validate_token
     end


### PR DESCRIPTION
**Why**: This is a callback that is included by default in all
non-Devise controllers by the `two_factor_authentication` gem.
We don't have a need for this callback at all since in the
controllers where we do need to enforce that the user is fully
authenticated, we have our own `confirm_two_factor_authenticated`
callback.

As we've seen previously in #1799, allowing this callback to run
prevents requests with the `*/*` Accept header from succeeding.

Unfortunately, we can't skip this callback in ApplicationController
because I think it gets defined later in the chain. I am working
on a PR that will disable this callback everywhere we don't need it,
but for now, I wanted to keep this simple and disable in a controller
that shows up in our error logs.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
