### PR TITLE
Redirect to referer during most CSRF errors

### DIFF
--- a/.reek
+++ b/.reek
@@ -124,6 +124,7 @@ UtilityFunction:
   ControlParameter:
     exclude:
       - complete_idv_session
+      - visit_idp_from_sp_with_loa1
       - visit_idp_from_sp_with_loa3
   DuplicateMethodCall:
     enabled: false
@@ -149,6 +150,7 @@ UtilityFunction:
       - visit_idp_from_sp_with_loa1
       - visit_idp_from_sp_with_loa3
       - visit_idp_from_mobile_app_with_loa1
+      - visit_idp_from_oidc_sp_with_loa1
       - visit_idp_from_oidc_sp_with_loa3
   UncommunicativeParameterName:
     exclude:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,10 +109,13 @@ class ApplicationController < ActionController::Base
 
   def invalid_auth_token(_exception)
     controller_info = "#{controller_path}##{action_name}"
-    analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN, controller: controller_info)
-    sign_out
+    analytics.track_event(
+      Analytics::INVALID_AUTHENTICITY_TOKEN,
+      controller: controller_info,
+      user_signed_in: user_signed_in?
+    )
     flash[:error] = t('errors.invalid_authenticity_token')
-    redirect_to root_url
+    redirect_back fallback_location: new_user_session_url
   end
 
   def user_fully_authenticated?

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -1,6 +1,12 @@
 module PersonalKeyConcern
   delegate :active_profile, to: :current_user
 
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
+  end
+
   def create_new_code
     if active_profile.present?
       Pii::ReEncryptor.new(user: current_user, user_session: user_session).perform
@@ -8,5 +14,19 @@ module PersonalKeyConcern
     else
       PersonalKeyGenerator.new(current_user).create
     end
+  end
+
+  private
+
+  def redirect_to_signin
+    controller_info = "#{controller_path}##{action_name}"
+    analytics.track_event(
+      Analytics::INVALID_AUTHENTICITY_TOKEN,
+      controller: controller_info,
+      user_signed_in: user_signed_in?
+    )
+    sign_out
+    flash[:alert] = t('errors.invalid_authenticity_token')
+    redirect_to new_user_session_url
   end
 end

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -20,7 +20,7 @@ en:
       session_limited: Your login credentials were used in another browser. Please
         sign in again to continue in this browser.
       timeout: Your session has expired. Please sign in again to continue.
-      unauthenticated: ''
+      unauthenticated: Your session has expired. Please sign in again to continue.
       unconfirmed: You need to confirm your email address before continuing.
     mailer:
       account_locked:

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -20,7 +20,7 @@ es:
       session_limited: Sus credenciales para iniciar una sesión se utilizaron en otro
         navegador. Inicie una sesión nueva para continuar en este navegador.
       timeout: Su sesión ha caducado. Vuelva a iniciar la sesión para continuar.
-      unauthenticated: ''
+      unauthenticated: Su sesión ha caducado. Vuelva a iniciar la sesión para continuar.
       unconfirmed: Debe confirmar su email antes de continuar.
     mailer:
       account_locked:

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -21,7 +21,8 @@ fr:
         Veuillez vous connecter de nouveau pour continuer avec ce navigateur.
       timeout: Votre session est expirée. Veuillez vous connecter de nouveau pour
         continuer.
-      unauthenticated: ''
+      unauthenticated: Votre session est expirée. Veuillez vous connecter de nouveau
+        pour continuer.
       unconfirmed: Vous devez confirmer votre adresse courriel avant de continuer.
     mailer:
       account_locked:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -2,7 +2,7 @@
 en:
   errors:
     confirm_password_incorrect: Incorrect password.
-    invalid_authenticity_token: Oops, something went wrong. Please sign in again.
+    invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You've entered too many incorrect passwords. You
       can reset your password using the "Forgot your password?" link.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -2,7 +2,7 @@
 es:
   errors:
     confirm_password_incorrect: La contraseña es incorrecta.
-    invalid_authenticity_token: "¡Oops! Algo salió mal. Inicie la sesión de nuevo."
+    invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.
       Puede restablecer su contraseña usando el enlace "¿Olvidó su contraseña?".

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -2,7 +2,7 @@
 fr:
   errors:
     confirm_password_incorrect: Mot de passe incorrect.
-    invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez vous connecter
+    invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.
     max_password_attempts_reached: Vous avez inscrit des mots de passe incorrects

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -55,6 +55,24 @@ describe Users::PersonalKeysController do
 
       expect(controller.user_session[:personal_key]).to be_nil
     end
+
+    it 'tracks CSRF errors' do
+      stub_sign_in
+      stub_analytics
+      analytics_hash = {
+        controller: 'users/personal_keys#update',
+        user_signed_in: true,
+      }
+      allow(controller).to receive(:update).and_raise(ActionController::InvalidAuthenticityToken)
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::INVALID_AUTHENTICITY_TOKEN, analytics_hash)
+
+      post :update
+
+      expect(response).to redirect_to new_user_session_url
+      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
+    end
   end
 
   describe '#create' do
@@ -80,6 +98,24 @@ describe Users::PersonalKeysController do
 
       post :create, params: { resend: true }
       expect(flash[:success]).to eq t('notices.send_code.personal_key')
+    end
+
+    it 'tracks CSRF errors' do
+      stub_sign_in
+      stub_analytics
+      analytics_hash = {
+        controller: 'users/personal_keys#create',
+        user_signed_in: true,
+      }
+      allow(controller).to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::INVALID_AUTHENTICITY_TOKEN, analytics_hash)
+
+      post :create
+
+      expect(response).to redirect_to new_user_session_url
+      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
     end
   end
 end

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'View personal key' do
   include XPathHelper
   include PersonalKeyHelper
+  include SamlAuthHelper
 
   context 'during sign up' do
     scenario 'user refreshes personal key page' do
@@ -89,6 +90,9 @@ feature 'View personal key' do
       expect(current_path).to eq account_path
     end
   end
+
+  it_behaves_like 'csrf error when asking for new personal key', :saml
+  it_behaves_like 'csrf error when asking for new personal key', :oidc
 end
 
 def sign_up_and_view_personal_key

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Sign Up' do
+  include SamlAuthHelper
+
   context 'confirmation token error message does not persist on success' do
     scenario 'with no or invalid token' do
       visit sign_up_create_email_confirmation_url(confirmation_token: '')
@@ -128,4 +130,7 @@ feature 'Sign Up' do
       expect(page).to_not have_content 'userb@test.com'
     end
   end
+
+  it_behaves_like 'csrf error when acknowledging personal key', :saml
+  it_behaves_like 'csrf error when acknowledging personal key', :oidc
 end

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -1,0 +1,25 @@
+shared_examples 'csrf error when asking for new personal key' do |sp|
+  it 'redirects to sign in page', email: true do
+    visit_idp_from_sp_with_loa1(sp)
+    register_user
+    allow_any_instance_of(Users::PersonalKeysController).
+      to receive(:create).and_raise(ActionController::InvalidAuthenticityToken)
+    click_on t('users.personal_key.get_another')
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content t('errors.invalid_authenticity_token')
+  end
+end
+
+shared_examples 'csrf error when acknowledging personal key' do |sp|
+  it 'redirects to sign in page', email: true do
+    visit_idp_from_sp_with_loa1(sp)
+    register_user
+    allow_any_instance_of(SignUp::PersonalKeysController).
+      to receive(:update).and_raise(ActionController::InvalidAuthenticityToken)
+    click_acknowledge_personal_key
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content t('errors.invalid_authenticity_token')
+  end
+end


### PR DESCRIPTION
**Why**: Signing the user out and redirecting them to the sign in
page is not helpful when they encounter a CSRF error. For example,
if they get a CSRF error while creating their password for the first
time during account creation, they might not know what they should
do to get back to the password creation screen.

Instead, we should try to redirect back to where they were so they can
try again. One exception is on the personal key screen. Due to the way
the feature works, we can't take the user back to the personal key
screen without modifying the session and regenerating a new key for
them. We don't want to make any state changes as a result of a CSRF
error for security reasons. Instead, we sign them out and redirect
to the sign in screen.

`Users::SessionsController` also has its own way of rescuing the
CSRF error because the only way I could get the flash message to
appear was to call `sign_out`, and we don't want to call `sign_out`
in `ApplicationController`. Also, in order to preserve the `request_id`
(so that users can go back to the SP), we need to use `redirect_back`,
whereas in the Personal Keys controllers, we don't want to redirect
back.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
