### PR TITLE
Preserve locale in presenter links

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -283,12 +283,13 @@ module TwoFactorAuthenticatable
   end
 
   def reenter_phone_number_path
+    locale = LinkLocaleResolver.locale
     if idv_context?
-      verify_phone_path
+      verify_phone_path(locale: locale)
     elsif current_user.phone.present?
-      manage_phone_path
+      manage_phone_path(locale: locale)
     else
-      phone_setup_path
+      phone_setup_path(locale: locale)
     end
   end
 

--- a/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
@@ -19,10 +19,11 @@ module TwoFactorAuthCode
     end
 
     def cancel_link
+      locale = LinkLocaleResolver.locale
       if reauthn
-        account_path
+        account_path(locale: locale)
       else
-        sign_out_path
+        sign_out_path(locale: locale)
       end
     end
 
@@ -41,14 +42,16 @@ module TwoFactorAuthCode
     def sms_link
       view.link_to(
         t('devise.two_factor_authentication.totp_fallback.sms_link_text'),
-        otp_send_path(otp_delivery_selection_form: { otp_delivery_preference: 'sms' })
+        otp_send_path(locale: LinkLocaleResolver.locale, otp_delivery_selection_form:
+          { otp_delivery_preference: 'sms' })
       )
     end
 
     def voice_link
       view.link_to(
         t('devise.two_factor_authentication.totp_fallback.voice_link_text'),
-        otp_send_path(otp_delivery_selection_form: { otp_delivery_preference: 'voice' })
+        otp_send_path(locale: LinkLocaleResolver.locale, otp_delivery_selection_form:
+          { otp_delivery_preference: 'voice' })
       )
     end
   end

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -45,7 +45,8 @@ module TwoFactorAuthCode
     attr_reader :personal_key_unavailable, :view, :reauthn
 
     def personal_key_tag
-      view.link_to(t("#{personal_key}.link"), login_two_factor_personal_key_path)
+      view.link_to(t("#{personal_key}.link"),
+                   login_two_factor_personal_key_path(locale: LinkLocaleResolver.locale))
     end
 
     def personal_key

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -19,12 +19,13 @@ module TwoFactorAuthCode
     end
 
     def cancel_link
+      locale = LinkLocaleResolver.locale
       if confirmation_for_phone_change || reauthn
-        account_path
+        account_path(locale: locale)
       elsif confirmation_for_idv
-        verify_cancel_path
+        verify_cancel_path(locale: locale)
       else
-        sign_out_path
+        sign_out_path(locale: locale)
       end
     end
 
@@ -75,7 +76,8 @@ module TwoFactorAuthCode
     def phone_link_tag
       view.link_to(
         t("links.two_factor_authentication.#{fallback_method}"),
-        otp_send_path(otp_delivery_selection_form: { otp_delivery_preference: fallback_method })
+        otp_send_path(locale: LinkLocaleResolver.locale, otp_delivery_selection_form:
+          { otp_delivery_preference: fallback_method })
       )
     end
 
@@ -86,7 +88,7 @@ module TwoFactorAuthCode
     def auth_app_fallback_tag
       view.link_to(
         t('links.two_factor_authentication.app'),
-        login_two_factor_authenticator_path
+        login_two_factor_authenticator_path(locale: LinkLocaleResolver.locale)
       )
     end
 
@@ -105,12 +107,9 @@ module TwoFactorAuthCode
     def resend_code_link
       view.link_to(
         t("links.two_factor_authentication.resend_code.#{otp_delivery_preference}"),
-        otp_send_path(
-          otp_delivery_selection_form: {
-            otp_delivery_preference: otp_delivery_preference,
-            resend: true,
-          }
-        )
+        otp_send_path(locale: LinkLocaleResolver.locale,
+                      otp_delivery_selection_form:
+                        { otp_delivery_preference: otp_delivery_preference, resend: true })
       )
     end
   end

--- a/app/services/link_locale_resolver.rb
+++ b/app/services/link_locale_resolver.rb
@@ -1,0 +1,6 @@
+class LinkLocaleResolver
+  def self.locale
+    locale = I18n.locale
+    locale == I18n.default_locale ? nil : locale
+  end
+end

--- a/spec/presenters/two_factor_auth_code/authenticator_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/authenticator_delivery_presenter_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe TwoFactorAuthCode::AuthenticatorDeliveryPresenter do
+
+  it 'handles multiple locales' do
+    I18n.available_locales.each do |locale|
+      I18n.locale = locale
+      presenter.fallback_links.each do |html|
+        if locale == :en
+          expect(html).not_to match(%r{href="/en/})
+        else
+          expect(html).to match(%r{href="/#{locale}/})
+        end
+      end
+      if locale == :en
+        expect(presenter.cancel_link).not_to match(%r{/en/})
+      else
+        expect(presenter.cancel_link).to match(%r{/#{locale}/})
+      end
+    end
+  end
+
+  def presenter
+    TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(data: {}, view: ActionController::Base.new.view_context)
+  end
+
+end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -49,6 +49,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         code_link = link_to(
           t('links.two_factor_authentication.resend_code.sms'),
           otp_send_path(
+            locale: LinkLocaleResolver.locale,
             otp_delivery_selection_form: {
               otp_delivery_preference: 'sms',
               resend: true,


### PR DESCRIPTION
**Why**: Links generated by presenters should preserve the current users locale

**How** Fixed internationalized links throughout the application by adding a LinkLocaleResolver and using it on path helpers.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
