### PR TITLE
Add ServiceProvider#redirect_uris to the CSP header

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -59,7 +59,9 @@ class SamlIdpController < ApplicationController
   def render_template_for(message, action_url, type)
     domain = SecureHeadersWhitelister.extract_domain(action_url)
     csp_uris = ["'self'", domain]
-    csp_uris |= decorated_session.sp_redirect_uris.compact unless decorated_session.sp_redirect_uris.empty?
+
+    additional_csp_uris = decorated_session.sp_redirect_uris.compact
+    csp_uris |= additional_csp_uris unless additional_csp_uris.empty?
 
     override_content_security_policy_directives(form_action: csp_uris)
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -60,8 +60,8 @@ class SamlIdpController < ApplicationController
     domain = SecureHeadersWhitelister.extract_domain(action_url)
     csp_uris = ["'self'", domain]
 
-    additional_csp_uris = decorated_session.sp_redirect_uris.compact
-    csp_uris |= additional_csp_uris unless additional_csp_uris.empty?
+    additional_csp_uris = decorated_session.sp_redirect_uris || []
+    csp_uris |= additional_csp_uris.compact unless additional_csp_uris.empty?
 
     override_content_security_policy_directives(form_action: csp_uris)
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -20,7 +20,7 @@ class SamlIdpController < ApplicationController
     end
     delete_branded_experience
 
-    render_template_for(saml_response, saml_request.response_url, 'SAMLResponse', decorated_session.sp_redirect_uris)
+    render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
   end
 
   def metadata
@@ -56,10 +56,10 @@ class SamlIdpController < ApplicationController
     redirect_to url
   end
 
-  def render_template_for(message, action_url, type, additional_csp_uris)
+  def render_template_for(message, action_url, type)
     domain = SecureHeadersWhitelister.extract_domain(action_url)
     csp_uris = ["'self'", domain]
-    csp_uris = csp_uris | additional_csp_uris.compact unless additional_csp_uris.empty?
+    csp_uris |= decorated_session.sp_redirect_uris.compact unless decorated_session.sp_redirect_uris.empty?
 
     override_content_security_policy_directives(form_action: csp_uris)
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -58,11 +58,11 @@ class SamlIdpController < ApplicationController
 
   def render_template_for(message, action_url, type)
     domain = SecureHeadersWhitelister.extract_domain(action_url)
-    csp_uris = ["'self'", domain]
 
-    additional_csp_uris = decorated_session.sp_redirect_uris || []
-    csp_uris |= additional_csp_uris.compact unless additional_csp_uris.empty?
-
+    # Returns fully formed CSP array w/"'self'", domain, and ServiceProvider#redirect_uris
+    csp_uris = SecureHeadersWhitelister.csp_with_sp_redirect_uris(
+      domain, decorated_session.sp_redirect_uris
+    )
     override_content_security_policy_directives(form_action: csp_uris)
 
     render(

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -82,6 +82,10 @@ class ServiceProviderSessionDecorator
     end
   end
 
+  def sp_redirect_uris
+    sp.redirect_uris
+  end
+
   def cancel_link_url
     sign_up_start_url(request_id: sp_session[:request_id], locale: locale_url_param)
   end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -22,6 +22,8 @@ class ServiceProviderSessionDecorator
     @service_provider_request = service_provider_request
   end
 
+  delegate :redirect_uris, to: :sp, :prefix => true
+
   def sp_logo
     sp.logo || DEFAULT_LOGO
   end
@@ -80,10 +82,6 @@ class ServiceProviderSessionDecorator
     else
       sp.return_to_sp_url
     end
-  end
-
-  def sp_redirect_uris
-    sp.redirect_uris
   end
 
   def cancel_link_url

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -22,7 +22,7 @@ class ServiceProviderSessionDecorator
     @service_provider_request = service_provider_request
   end
 
-  delegate :redirect_uris, to: :sp, :prefix => true
+  delegate :redirect_uris, to: :sp, prefix: true
 
   def sp_logo
     sp.logo || DEFAULT_LOGO

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -40,6 +40,8 @@ class SessionDecorator
 
   def sp_logo; end
 
+  def sp_redirect_uris; end
+
   def sp_return_url; end
 
   def requested_attributes; end

--- a/app/services/secure_headers_whitelister.rb
+++ b/app/services/secure_headers_whitelister.rb
@@ -2,4 +2,12 @@ class SecureHeadersWhitelister
   def self.extract_domain(url)
     url.split('//')[1].split('/')[0]
   end
+
+  def self.csp_with_sp_redirect_uris(action_url_domain, sp_redirect_uris)
+    csp_uris = ["'self'", action_url_domain]
+
+    csp_uris |= sp_redirect_uris.compact if sp_redirect_uris.present?
+
+    csp_uris
+  end
 end

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -9,6 +9,8 @@ test:
     friendly_name: 'Your friendly Government Agency'
     logo: 'generic.svg'
     return_to_sp_url: 'http://localhost:3000'
+    redirect_uris:
+      - 'x-example-app://idp_return'
     attribute_bundle:
       - email
       - phone

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -491,7 +491,9 @@ describe SamlIdpController do
       end
 
       it 'sets correct CSP config that includes any custom app scheme uri from SP redirect_uris' do
-        expect(response.request.headers.env['secure_headers_request_config'].csp.form_action).to match_array(["'self'", "localhost:3000", "x-example-app://idp_return"])
+        form_action = response.request.headers.env['secure_headers_request_config'].csp.form_action
+        csp_array = ["'self'", 'localhost:3000', 'x-example-app://idp_return']
+        expect(form_action).to match_array(csp_array)
       end
 
       # http://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Assertions

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -490,6 +490,10 @@ describe SamlIdpController do
         expect(status_code['Value']).to eq(Saml::XML::Namespaces::Statuses::SUCCESS)
       end
 
+      it 'sets correct CSP config that includes any custom app scheme uri from SP redirect_uris' do
+        expect(response.request.headers.env['secure_headers_request_config'].csp.form_action).to match_array(["'self'", "localhost:3000", "x-example-app://idp_return"])
+      end
+
       # http://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Assertions
       context 'Assertion' do
         let(:assertion) { xmldoc.response_assertion_nodeset[0] }

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -18,7 +18,7 @@ feature 'Session Timeout' do
     it 'displays the branded experience' do
       issuer = 'http://localhost:3000'
       sp = ServiceProvider.from_issuer(issuer)
-      sp_session = { issuer: issuer }
+      sp_session = { issuer: issuer, request_url: 'http://localhost:3000/api/saml/auth' }
       page.set_rack_session(sp: sp_session)
       visit root_path
 

--- a/spec/services/secure_headers_whitelister_spec.rb
+++ b/spec/services/secure_headers_whitelister_spec.rb
@@ -15,4 +15,25 @@ RSpec.describe SecureHeadersWhitelister do
       end
     end
   end
+
+  describe '.csp_with_sp_redirect_uris' do
+    def csp_with_sp_redirect_uris(domain, sp_redirect_uris)
+      SecureHeadersWhitelister.csp_with_sp_redirect_uris(domain, sp_redirect_uris)
+    end
+
+    it 'generates the proper CSP array from action_url domain and ServiceProvider#redirect_uris' do
+      aggregate_failures do
+        domain = 'example1.com'
+        test_sp_uris = ['x-example-app://test', 'https://example2.com']
+        full_return = ["'self'", 'example1.com', 'x-example-app://test', 'https://example2.com']
+
+        expect(csp_with_sp_redirect_uris(domain, test_sp_uris)).to eq(full_return)
+
+        expect(csp_with_sp_redirect_uris(domain, test_sp_uris[0..0])).to eq(full_return[0...3])
+
+        expect(csp_with_sp_redirect_uris(domain, [])).to eq(full_return[0...2])
+        expect(csp_with_sp_redirect_uris(domain, nil)).to eq(full_return[0...2])
+      end
+    end
+  end
 end

--- a/spec/services/secure_headers_whitelister_spec.rb
+++ b/spec/services/secure_headers_whitelister_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe SecureHeadersWhitelister do
 
         expect(csp_with_sp_redirect_uris(domain, test_sp_uris)).to eq(full_return)
 
-        expect(csp_with_sp_redirect_uris(domain, test_sp_uris[0..0])).to eq(full_return[0...3])
+        expect(csp_with_sp_redirect_uris(domain, test_sp_uris[0..0])).to eq(full_return[0..2])
 
-        expect(csp_with_sp_redirect_uris(domain, [])).to eq(full_return[0...2])
-        expect(csp_with_sp_redirect_uris(domain, nil)).to eq(full_return[0...2])
+        expect(csp_with_sp_redirect_uris(domain, [])).to eq(full_return[0..1])
+        expect(csp_with_sp_redirect_uris(domain, nil)).to eq(full_return[0..1])
       end
     end
   end


### PR DESCRIPTION
**Why**:
- USDS's HipChat SSO process doesn't work on iOS devices because
the RelayState on the iOS app has a custom scheme/form of
hipchat://idp_return, which isn't a uri currently included in
the Content-Security-Policy headers

**How**:
- Add ability to include custom app scheme URIs in
ServiceProvider#redirect_uris, and whitelist them in the CSP form-action directive

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
