### PR TITLE
Validate that config contains state id vendor

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -36,6 +36,7 @@ Figaro.require_keys(
   'secret_key_base',
   'session_encryption_key',
   'session_timeout_in_minutes',
+  'state_id_proofing_vendor',
   'twilio_accounts',
   'twilio_record_voice',
   'use_kms',

--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -3,6 +3,7 @@ class ConfigValidator
   NON_EMPTY_KEYS = %w[
     phone_proofing_vendor
     profile_proofing_vendor
+    state_id_proofing_vendor
   ].freeze
 
   def validate(env = ENV)

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -6,6 +6,7 @@ describe ConfigValidator do
       {
         'phone_proofing_vendor' => 'mock',
         'profile_proofing_vendor' => 'mock',
+        'state_id_proofing_vendor' => 'mock',
       }
     end
 


### PR DESCRIPTION
**Why**: So the app will raise an error if it tries to start without a
state id vendor configured

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
