### PR TITLE
Put back button on left in the enter your personal key modal

### DIFF
--- a/app/views/shared/_personal_key_confirmation_modal.html.slim
+++ b/app/views/shared/_personal_key_confirmation_modal.html.slim
@@ -12,12 +12,12 @@
         = hidden_field_tag :authenticity_token, form_authenticity_token
 
         .clearfix.mxn2
-          .col.col-12.sm-col-6.px2.mb2.sm-mb0
-            button(type='submit' class='col-12 btn btn-primary personal-key-confirm')
-              = t('forms.buttons.continue')
           .col.col-12.sm-col-6.px2
             button.col-12.btn.btn-outline.blue.rounded-lg(
               type="button"
               data-dismiss="personal-key-confirm"
             )
               = t('forms.buttons.back')
+          .col.col-12.sm-col-6.px2.mb2.sm-mb0
+            button(type='submit' class='col-12 btn btn-primary personal-key-confirm')
+              = t('forms.buttons.continue')

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -72,7 +72,7 @@ feature 'View personal key' do
 
       press_shift_tab
 
-      expect_back_button_to_be_in_focus
+      expect_continue_button_to_be_in_focus
 
       click_back_button
 
@@ -127,9 +127,9 @@ def press_shift_tab
   body_element.send_keys %i[shift tab]
 end
 
-def expect_back_button_to_be_in_focus
+def expect_continue_button_to_be_in_focus
   expect(page.evaluate_script('document.activeElement.innerText')).to eq(
-    t('forms.buttons.back')
+    t('forms.buttons.continue')
   )
 end
 


### PR DESCRIPTION
**Why**: The back button should be on the left in the enter your personal key modal

**How** switched the cell contents of continue and back

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.