### PR TITLE
Redirect back to SP regardless of locale

### DIFF
--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -2,7 +2,7 @@ module SecureHeadersConcern
   extend ActiveSupport::Concern
 
   def apply_secure_headers_override
-    return unless stored_url_for_user&.start_with?(openid_connect_authorize_url)
+    return if stored_url_for_user.blank?
 
     authorize_params = URIService.params(stored_url_for_user)
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -283,4 +283,7 @@ feature 'Sign in' do
       expect(page).to have_content(t('devise.failure.unauthenticated'))
     end
   end
+
+  it_behaves_like 'signing in with the site in Spanish', :saml
+  it_behaves_like 'signing in with the site in Spanish', :oidc
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -133,4 +133,6 @@ feature 'Sign Up' do
 
   it_behaves_like 'csrf error when acknowledging personal key', :saml
   it_behaves_like 'csrf error when acknowledging personal key', :oidc
+  it_behaves_like 'creating an account with the site in Spanish', :saml
+  it_behaves_like 'creating an account with the site in Spanish', :oidc
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -346,7 +346,7 @@ module Features
     end
 
     def set_up_2fa_with_valid_phone
-      fill_in 'Phone', with: '202-555-1212'
+      fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
     end
 

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -23,3 +23,30 @@ shared_examples 'csrf error when acknowledging personal key' do |sp|
     expect(page).to have_content t('errors.invalid_authenticity_token')
   end
 end
+
+shared_examples 'creating an account with the site in Spanish' do |sp|
+  it 'redirects to the SP', email: true do
+    Capybara.current_session.driver.header('Accept-Language', 'es')
+    visit_idp_from_sp_with_loa1(sp)
+    register_user
+    click_acknowledge_personal_key
+
+    if sp == :oidc
+      expect(page.response_headers['Content-Security-Policy']).
+        to(include('form-action \'self\' http://localhost:7654'))
+    end
+
+    click_on t('forms.buttons.continue')
+
+    if sp == :saml
+      expect(current_url).to eq @saml_authn_request
+    end
+
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+      redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -1,0 +1,31 @@
+include SamlAuthHelper
+
+shared_examples 'signing in with the site in Spanish' do |sp|
+  it 'redirects to the SP' do
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    Capybara.current_session.driver.header('Accept-Language', 'es')
+
+    user = create(:user, :signed_up)
+    visit_idp_from_sp_with_loa1(sp)
+    click_link t('links.sign_in')
+    fill_in_credentials_and_submit(user.email, user.password)
+
+    if sp == :oidc
+      expect(page.response_headers['Content-Security-Policy']).
+        to(include('form-action \'self\' http://localhost:7654'))
+    end
+
+    click_submit_default
+
+    if sp == :saml
+      expect(current_url).to eq @saml_authn_request
+    end
+
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+      redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Andrew found a bug where selecting Spanish during account
creation or authentication would not redirect you back to the SP.

The bug was in `SecureHeadersConcern`, which only allowed the redirect
to happen if the redirect URI started with the OIDC endpoint. The
problem is the URL of the OIDC endpoint is dynamic depending on the
language. When the language is not English, the SP's redirect URI no
longer starts with the same set of characters as the OIDC endpoint,
therefore the condition will always be false, and the redirect will
not be allowed.

**How**: Instead of determining whether or not to return early based on
whether or not the SP request URL is an OIDC URL, base it only on the
presence of the request URL.

I believe the original intent of the conditional in the first return
statement was for performance reasons, since SAML URLs do not need to
be added to CSP headers in the CompletionsController. The reason is
that CSP headers only matter on the last POST request before a redirect
to an external URL. In the case of OIDC, clicking Continue on the
Completions page, or after 2FA authentication, is the last form that
is submitted before the redirect back to the SP. However, for SAML,
there is an additional hidden form that is rendered and automatically
submitted via JS. This happens in SamlIdpController, which is why it
has its own CSP override.

Thanks to our use of the Null Object pattern, passing in a SAML URL
in `SecureHeadersConcern` allows the app to work as expected because
`authorize_form.valid?` will return `false`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
