### PR TITLE
Skip handle_two_factor_authentication callback

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
   prepend_before_action :set_locale
   before_action :disable_caching
 
+  skip_before_action :handle_two_factor_authentication
+
   def session_expires_at
     now = Time.zone.now
     session[:session_expires_at] = now + Devise.timeout_in

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -4,7 +4,6 @@ module TwoFactorAuthenticatable
 
   included do
     before_action :authenticate_user
-    before_action :handle_two_factor_authentication
     before_action :require_current_password, if: :current_password_required?
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -3,7 +3,6 @@ module OpenidConnect
     include FullyAuthenticatable
     include VerifyProfileConcern
 
-    skip_before_action :handle_two_factor_authentication
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :validate_authorize_form, only: [:index]
     before_action :store_request, only: [:index]

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  skip_before_action :handle_two_factor_authentication
   before_action :skip_session_expiration
   skip_before_action :disable_caching
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -10,7 +10,6 @@ class SamlIdpController < ApplicationController
   include VerifyProfileConcern
 
   skip_before_action :verify_authenticity_token
-  skip_before_action :handle_two_factor_authentication, only: :logout
 
   def auth
     return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated?

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -1,8 +1,6 @@
 class SignOutController < ApplicationController
   include FullyAuthenticatable
 
-  skip_before_action :handle_two_factor_authentication
-
   def destroy
     url_after_cancellation = decorated_session.cancel_link_url
     sign_out

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -2,8 +2,6 @@ module SignUp
   class EmailConfirmationsController < ApplicationController
     include UnconfirmedUserConcern
 
-    skip_before_action :handle_two_factor_authentication
-
     def create
       validate_token
     end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -2,7 +2,6 @@ module TwoFactorAuthentication
   class OtpVerificationController < ApplicationController
     include TwoFactorAuthenticatable
 
-    skip_before_action :handle_two_factor_authentication
     before_action :confirm_two_factor_enabled
 
     def show

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -3,7 +3,6 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
 
     prepend_before_action :authenticate_user
-    skip_before_action :handle_two_factor_authentication
 
     def show
       @personal_key_form = PersonalKeyForm.new(current_user)

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -2,7 +2,6 @@ module TwoFactorAuthentication
   class TotpVerificationController < ApplicationController
     include TwoFactorAuthenticatable
 
-    skip_before_action :handle_two_factor_authentication
     before_action :confirm_totp_enabled
 
     def show

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,6 @@ module Users
 
     skip_before_action :session_expires_at, only: [:active]
     skip_before_action :require_no_authentication, only: [:new]
-    before_action :confirm_two_factor_authenticated, only: [:update]
     before_action :check_user_needs_redirect, only: [:new]
 
     def new

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -1,7 +1,6 @@
 module Users
   class TwoFactorAuthenticationController < ApplicationController
     include TwoFactorAuthenticatable
-    skip_before_action :handle_two_factor_authentication
 
     def show
       if current_user.totp_enabled?

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -5,7 +5,6 @@ module Users
 
     before_action :authorize_otp_setup
     before_action :authenticate_user
-    skip_before_action :handle_two_factor_authentication
 
     def index
       @user_phone_form = UserPhoneForm.new(current_user)


### PR DESCRIPTION
**Why**: We have our own `confirm_two_factor_authenticated` callback,
and don't need the one provided by the `two_factor_authentication` gem.
By having it, the app makes unnecessary additional logic checks.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
