### PR TITLE
Don't use Devise's stored location

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ Metrics/ClassLength:
   - app/controllers/application_controller.rb
   - app/controllers/openid_connect/authorization_controller.rb
   - app/controllers/users/confirmations_controller.rb
+  - app/controllers/users/sessions_controller.rb
   - app/controllers/devise/two_factor_authentication_controller.rb
   - app/decorators/user_decorator.rb
   - app/services/idv/session.rb

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,8 +95,8 @@ class ApplicationController < ActionController::Base
     @service_provider_request ||= ServiceProviderRequest.from_uuid(params[:request_id])
   end
 
-  def after_sign_in_path_for(user)
-    stored_location_for(user) || sp_session[:request_url] || signed_in_url
+  def after_sign_in_path_for(_user)
+    user_session[:stored_location] || sp_session[:request_url] || signed_in_url
   end
 
   def signed_in_url

--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -19,7 +19,7 @@ class ReauthnRequiredController < ApplicationController
   end
 
   def prompt_for_current_password
-    store_location_for(:user, request.url)
+    store_location(request.url)
     user_session[:context] = 'reauthentication'
     user_session[:factor_to_change] = factor_from_request_path(request.path)
     user_session[:current_password_required] = true
@@ -28,5 +28,9 @@ class ReauthnRequiredController < ApplicationController
 
   def factor_from_request_path(path)
     path.split('/')[-1]
+  end
+
+  def store_location(url)
+    user_session[:stored_location] = url
   end
 end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -15,8 +15,8 @@ class SamlIdpController < ApplicationController
   def auth
     return confirm_two_factor_authenticated(request_id) unless user_fully_authenticated?
     process_fully_authenticated_user do |needs_idv, needs_profile_finish|
-      return store_location_and_redirect_to(verify_url) if needs_idv && !needs_profile_finish
-      return store_location_and_redirect_to(account_or_verify_profile_url) if needs_profile_finish
+      return redirect_to(verify_url) if needs_idv && !needs_profile_finish
+      return redirect_to(account_or_verify_profile_url) if needs_profile_finish
     end
     delete_branded_experience
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
@@ -48,11 +48,6 @@ class SamlIdpController < ApplicationController
     analytics.track_event(Analytics::SAML_AUTH, analytics_payload)
 
     yield needs_idv, needs_profile_finish
-  end
-
-  def store_location_and_redirect_to(url)
-    store_location_for(:user, request.original_url)
-    redirect_to url
   end
 
   def render_template_for(message, action_url, type)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,11 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
 
     def new
-      analytics.track_event(Analytics::SIGN_IN_PAGE_VISIT, flash: flash[:alert])
+      analytics.track_event(
+        Analytics::SIGN_IN_PAGE_VISIT,
+        flash: flash[:alert],
+        stored_location: session['user_return_to']
+      )
       super
     end
 
@@ -90,6 +94,7 @@ module Users
         success: user_signed_in_and_not_locked_out?(user),
         user_id: user.uuid,
         user_locked_out: user_locked_out?(user),
+        stored_location: session['user_return_to'],
       }
 
       analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)


### PR DESCRIPTION
**Why**: When a user tries to access a page that requires
authentication (such as their account page) while they are signed out,
Devise automatically saves that URL as a "stored location", and when
the user signs in, it takes them to that page. From what I can tell,
this is only as a convenience to the user. For example, their session
might have timed out, but their browser still shows a form that
requires authentication. If they submit the form, they will be
prompted to sign in, and once they do, they will be taken back to the
form so they can continue what they were doing.

In our app, this Devise feature can cause more problems than it is
trying to solve. For example, if a user tries to visit their account
page while signed out, they will be prompted to sign in. If they then
visit a Service Provider and initiate login, after they sign in, they
will end up on their account page instead of back at the SP. This is
because in `after_sign_in_path_for(user)`, the order of lookup is the
stored location, then the SP request URL. The reason for this lookup
order is to support the reauthentication feature, where a user is
prompted to enter their current password and go through 2FA when they
are attempting to change their email, password, or phone (if enough
time has passed since they last authenticated). For example, if they
were trying to update their email, we store the location of the email
update page so that we can take them there after they go through the
reauthentication.

**How**: In our app, there aren't that many pages a user would need to
access while authenticated. The account page is basically the only one.
Moreover, we have callbacks on all controllers that will take the user
to where they need to be. In other words, if a user loses their place
during account creation and they sign out or their session times out,
they will always end up back where they left off. This feature doesn't
depend on Devise.

- Don't call `stored_location_for(user)`
- In `ReauthnRequiredController`, don't use Devise's method for
storing the location. Instead, use our own custom method and store
it in our own custom session key.
- Remove unnecessary location storage in `SamlIdpController`
- Add Devise's stored location to analytics in
`Users::SessionsController` to see how often people attempt to visit
pages before signing in. I have a theory that this is the cause of some
production errors I have seen.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.
