### PR TITLE
Allow cancel out of USPS confirm screen

### DIFF
--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -13,3 +13,5 @@ p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
   = link_to t('idv.messages.usps.resend'), verify_usps_path,
     class: 'block mb2'
 = link_to t('idv.messages.usps.bad_address'), verify_phone_path
+.mt2.pt1.border-top
+  = link_to t('idv.buttons.cancel'), account_path

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -19,6 +19,12 @@ feature 'verify profile with OTP' do
   context 'USPS letter' do
     let(:phone_confirmed) { false }
 
+
+    scenario 'profile phone not confirmed' do
+      sign_in_live_with_2fa(user)
+      expect(page).to have_link(t('idv.buttons.cancel'), account_path)
+    end
+
     scenario 'OTP has expired' do
       UspsConfirmationCode.first.update(code_sent_at: 11.days.ago)
 


### PR DESCRIPTION
**Why**: There is no option for the user to cancel or to go to their account

**How** Added a cancel link on the bottom of the form that pops up a modal which allows them to go back to their account or continue

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
