### PR TITLE
Add message for Twilio/calling country not supported. Switch 21211 and 21614

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -28,24 +28,28 @@ module Users
     private
 
     def invalid_phone_number(exception)
-      analytics.track_event(Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: exception.message)
+      analytics.track_event(
+        Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: exception.message, code: exception.code
+      )
+      flash_error_for_exception(exception)
+      redirect_back(fallback_location: account_url)
+    end
+
+    def flash_error_for_exception(exception)
       flash[:error] = case exception.code
                       when TwilioService::SMS_ERROR_CODE
                         t('errors.messages.invalid_sms_number')
                       when TwilioService::INVALID_ERROR_CODE
                         t('errors.messages.invalid_phone_number')
+                      when TwilioService::INVALID_CALLING_AREA_ERROR_CODE
+                        t('errors.messages.invalid_calling_area')
                       else
                         t('errors.messages.otp_failed')
                       end
-      redirect_back(fallback_location: account_url)
     end
 
     def otp_delivery_selection_form
-      OtpDeliverySelectionForm.new(
-        current_user,
-        phone_to_deliver_to,
-        context
-      )
+      OtpDeliverySelectionForm.new(current_user, phone_to_deliver_to, context)
     end
 
     def reauthn_param
@@ -73,12 +77,10 @@ module Users
 
       job = "#{method.capitalize}OtpSenderJob".constantize
       job_priority = confirmation_context? ? :perform_now : :perform_later
-      job.send(
-        job_priority,
-        code: current_user.direct_otp,
-        phone: phone_to_deliver_to,
-        otp_created_at: current_user.direct_otp_sent_at.to_s
-      )
+      job.send(job_priority,
+               code: current_user.direct_otp,
+               phone: phone_to_deliver_to,
+               otp_created_at: current_user.direct_otp_sent_at.to_s)
     end
 
     def user_selected_otp_delivery_preference

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,6 +1,7 @@
 class TwilioService
-  SMS_ERROR_CODE = 21_211
-  INVALID_ERROR_CODE = 21_614
+  SMS_ERROR_CODE = 21_614
+  INVALID_ERROR_CODE = 21_211
+  INVALID_CALLING_AREA_ERROR_CODE = 21_215
 
   cattr_accessor :telephony_service do
     Twilio::REST::Client

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,6 +18,11 @@ en:
       format_mismatch: Please match the requested format.
       improbable_phone: Invalid phone number. Please make sure you enter a valid phone
         number.
+      invalid_calling_area: Calls to that phone number are not supported.  Please
+        try SMS if you have an SMS-capable phone.
+      invalid_phone_number: The phone number entered is not valid.
+      invalid_sms_number: The phone number entered doesn't support text messaging.
+        Try the Phone call option.
       missing_field: Please fill in this field.
       must_have_us_country_code: Invalid phone number. Please make sure you enter
         a phone number with a U.S. country code.
@@ -29,6 +34,7 @@ en:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      otp_failed: Your one time password failed to send.
       otp_incorrect: Incorrect code. Did you type it correctly?
       password_incorrect: Incorrect password
       personal_key_incorrect: Incorrect personal key
@@ -39,7 +45,4 @@ en:
       usps_otp_expired: Your confirmation code has expired. Please request another
         letter for a new code.
       weak_password: Your password is not strong enough. %{feedback}
-      invalid_phone_number: The phone number entered is not valid.
-      invalid_sms_number: The phone number entered doesn't support text messaging.
-      otp_failed: Your one time password failed to send.
     not_authorized: You are not authorized to perform this action.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -17,6 +17,10 @@ es:
       expired: ha caducado, por favor solicite uno nuevo
       format_mismatch: Por favor, use el formato solicitado.
       improbable_phone: NOT TRANSLATED YET
+      invalid_calling_area: NOT TRANSLATED YET
+      invalid_phone_number: NOT TRANSLATED YET
+      invalid_sms_number: El número de teléfono ingresado no admite mensajes de texto.
+        Pruebe la opción de llamada telefónica.
       missing_field: Por favor, rellene este campo.
       must_have_us_country_code: NOT TRANSLATED YET
       no_password_reset_profile: Ningún perfil ha sido desactivado recientemente por
@@ -27,6 +31,7 @@ es:
       not_saved:
         one: '1 error no permitió guardar este %{resource}:'
         other: "%{count} errores no permitieron guardar este %{resource}:"
+      otp_failed: NOT TRANSLATED YET
       otp_incorrect: El código es incorrecto. ¿Lo escribió correctamente?
       password_incorrect: La contraseña es incorrecta
       personal_key_incorrect: La clave personal es incorrecta
@@ -36,7 +41,4 @@ es:
       unauthorized_service_provider: Proveedor de servicio no autorizado
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
-      invalid_phone_number: NOT TRANSLATED YET
-      invalid_sms_number: NOT TRANSLATED YET
-      otp_failed: NOT TRANSLATED YET
     not_authorized: No está autorizado para realizar esta acción.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -20,6 +20,9 @@ fr:
       expired: est expiré, veuillez en demander un nouveau
       format_mismatch: Veuillez vous assurer de respecter le format requis.
       improbable_phone: NOT TRANSLATED YET
+      invalid_calling_area: NOT TRANSLATED YET
+      invalid_phone_number: NOT TRANSLATED YET
+      invalid_sms_number: NOT TRANSLATED YET
       missing_field: Veuillez remplir ce champ.
       must_have_us_country_code: NOT TRANSLATED YET
       no_password_reset_profile: Aucun profil récemment désactivé en raison d'une
@@ -30,6 +33,7 @@ fr:
       not_saved:
         one: '1 erreur a interdit la sauvegarde de cette %{resource} :'
         other: "%{count} des erreurs ont empêché la sauvegarde de cette %{resource} :"
+      otp_failed: NOT TRANSLATED YET
       otp_incorrect: Code non valide. L'avez-vous inscrit correctement?
       password_incorrect: Mot de passe incorrect
       personal_key_incorrect: Clé personnelle incorrecte
@@ -39,7 +43,4 @@ fr:
       unauthorized_service_provider: Fournisseur de service non autorisé
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
-      invalid_phone_number: NOT TRANSLATED YET
-      invalid_sms_number: NOT TRANSLATED YET
-      otp_failed: NOT TRANSLATED YET
     not_authorized: Vous n'êtes pas autorisé(e) à effectuer cette action.

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -262,6 +262,15 @@ describe Users::TwoFactorAuthenticationController do
         expect(flash[:error]).to eq(unsupported_phone_message)
       end
 
+      it 'flashes an invalid calling area error when twilio responds with an invalid calling area error' do
+        twilio_error = Twilio::REST::RestError.new('', TwilioService::INVALID_CALLING_AREA_ERROR_CODE, '400')
+
+        allow(VoiceOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)
+        get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'voice' } }
+
+        expect(flash[:error]).to eq(unsupported_calling_area)
+      end
+
       it 'flashes a failed to send error when twilio responds with an unknown error' do
         twilio_error = Twilio::REST::RestError.new('', '', '400')
 
@@ -289,7 +298,7 @@ describe Users::TwoFactorAuthenticationController do
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
 
         expect(@analytics).to receive(:track_event).
-          with(Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: 'error message')
+          with(Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: 'error message', code: '')
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end

--- a/spec/support/features/localization_helper.rb
+++ b/spec/support/features/localization_helper.rb
@@ -12,6 +12,10 @@ module Features
       t('errors.messages.invalid_sms_number')
     end
 
+    def unsupported_calling_area
+      t('errors.messages.invalid_calling_area')
+    end
+
     def failed_to_send_otp
       t('errors.messages.otp_failed')
     end


### PR DESCRIPTION
…11 and 21614

**Why**: We should add support for Twilio error 21215 to let the user know we don't actually support calling to that number. Also 21211 and 21614 are backwards in the code.

**How** Added translations to locale files and a new const error code INVALID_CALLING_AREA_ERROR_CODE for 21215 which we now catch

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
