### PR TITLE
Move call to SamlAuthHelper out of support file

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-include SessionTimeoutWarningHelper
-include ActionView::Helpers::DateHelper
-
 feature 'Sign in' do
+  include SessionTimeoutWarningHelper
+  include ActionView::Helpers::DateHelper
+  include SamlAuthHelper
+
   scenario 'user cannot sign in if not registered' do
     signin('test@example.com', 'Please123!')
     expect(page).to have_content t('devise.failure.not_found_in_database')

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -1,5 +1,3 @@
-include SamlAuthHelper
-
 shared_examples 'signing in with the site in Spanish' do |sp|
   it 'redirects to the SP' do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)


### PR DESCRIPTION
**Why**: By default, files in the `spec/support` directory don't get
loaded in the same order each time you run the tests. Calling
`include SamlAuthHelper` in `sign_in.rb` without requiring the
`saml_auth_helper` file can cause an `uninitialized constant` error
if the `sign_in.rb` is loaded before `saml_auth_helper`.

**How**: Move the call to `include SamlAuthHelper` into the feature
spec, which gets called after all support files have been loaded and
required.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
