### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
     - 'lib/rspec/user_flow_formatter.rb'
     - 'lib/user_flow_exporter.rb'
   TargetRubyVersion: 2.3
-  TargetRailsVersion: 4.0
+  TargetRailsVersion: 5.0
   UseCache: true
 
 Rails:
@@ -105,6 +105,11 @@ Rails/HttpPositionalArguments:
   Include:
     - 'spec/**/*'
     - 'test/**/*'
+
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/concerns/saml_idp_auth_concern.rb'
+    - 'app/controllers/concerns/two_factor_authenticatable.rb'
 
 Rails/OutputSafety:
   Exclude:
@@ -204,7 +209,6 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: true
-  MaxLineLength: 80
 
 # Checks the indentation of the first element in an array literal.
 Layout/IndentArray:
@@ -236,6 +240,9 @@ Layout/MultilineOperationIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+
+Style/FormatStringToken:
+  Enabled: false
 
 Style/PercentLiteralDelimiters:
   # Specify the default preferred delimiter for all types with the 'default' key

--- a/app/controllers/service_provider_controller.rb
+++ b/app/controllers/service_provider_controller.rb
@@ -3,9 +3,7 @@ class ServiceProviderController < ApplicationController
 
   def update
     authorize do
-      if FeatureManagement.use_dashboard_service_providers?
-        ServiceProviderUpdater.new.run
-      end
+      ServiceProviderUpdater.new.run if FeatureManagement.use_dashboard_service_providers?
 
       render json: { status: 'If the feature is enabled, service providers have been updated.' }
     end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -32,6 +32,8 @@ module SignUp
       end
     end
 
+    def destroy_confirm; end
+
     protected
 
     def require_no_authentication

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -29,7 +29,7 @@ module Users
     def authorize_otp_setup
       if user_fully_authenticated?
         redirect_to(request.referer || root_url)
-      elsif current_user && current_user.two_factor_enabled?
+      elsif current_user&.two_factor_enabled?
         redirect_to user_two_factor_authentication_url
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
 
   def destroy_user
     user = current_user || User.find_by(confirmation_token: session[:user_confirmation_token])
-    user && user.destroy!
+    user&.destroy!
     sign_out if user
   end
 end

--- a/app/controllers/verify/sessions_controller.rb
+++ b/app/controllers/verify/sessions_controller.rb
@@ -44,7 +44,7 @@ module Verify
 
     def destroy
       idv_session = user_session[:idv]
-      idv_session && idv_session.clear
+      idv_session&.clear
       handle_idv_redirect
     end
 

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -22,6 +22,8 @@ class VerifyController < ApplicationController
     idv_session.clear
   end
 
+  def cancel; end
+
   def fail
     redirect_to verify_url unless ok_to_fail?
   end

--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -21,7 +21,7 @@ module Voice
     end
 
     def code
-      return unless encrypted_code.present?
+      return if encrypted_code.blank?
 
       cipher.decrypt(encrypted_code)
     end

--- a/app/decorators/openid_connect_authorize_decorator.rb
+++ b/app/decorators/openid_connect_authorize_decorator.rb
@@ -1,6 +1,4 @@
 class OpenidConnectAuthorizeDecorator
-  attr_reader :requested_attributes
-
   def initialize(scopes:)
     @scopes = scopes
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,6 +1,6 @@
-include ActionView::Helpers::DateHelper
-
 class UserDecorator
+  include ActionView::Helpers::DateHelper
+
   MAX_RECENT_EVENTS = 5
   DEFAULT_LOCKOUT_PERIOD = 10.minutes
 

--- a/app/forms/personal_key_form.rb
+++ b/app/forms/personal_key_form.rb
@@ -3,7 +3,6 @@ class PersonalKeyForm
   include PersonalKeyValidator
 
   attr_accessor :personal_key
-  attr_reader :user
 
   validate :check_personal_key
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,6 @@
 class Profile < ApplicationRecord
   belongs_to :user
-  has_many :usps_confirmation_codes
+  has_many :usps_confirmation_codes, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
   validates :ssn_signature, uniqueness: { scope: :active, if: :active? }

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -6,7 +6,7 @@ class ServiceProvider < ApplicationRecord
   validate :redirect_uris_are_parsable
 
   def self.from_issuer(issuer)
-    return NullServiceProvider.new(issuer: nil) unless issuer.present?
+    return NullServiceProvider.new(issuer: nil) if issuer.blank?
     find_by(issuer: issuer) || NullServiceProvider.new(issuer: issuer)
   end
 

--- a/app/services/basic_auth_url.rb
+++ b/app/services/basic_auth_url.rb
@@ -3,8 +3,8 @@ module BasicAuthUrl
 
   def build(url, user: Figaro.env.basic_auth_user_name, password: Figaro.env.basic_auth_password)
     URI.parse(url).tap do |uri|
-      uri.user = user.present? ? user : nil
-      uri.password = password.present? ? password : nil
+      uri.user = user.presence
+      uri.password = password.presence
     end.to_s
   end
 end

--- a/app/services/database_health_checker.rb
+++ b/app/services/database_health_checker.rb
@@ -12,7 +12,7 @@ module DatabaseHealthChecker
   # @return [Summary]
   def check
     Summary.new(true, simple_query)
-  rescue => err
+  rescue StandardError => err
     NewRelic::Agent.notice_error(err)
     Summary.new(false, err.message)
   end

--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -18,7 +18,7 @@ class EncryptedAttribute
   def initialize(encrypted, decrypted: nil, cost: nil, user_access_key: nil)
     self.encrypted = encrypted
     self.user_access_key = user_access_key
-    self.decrypted = decrypted.present? ? decrypted : decrypt(cost)
+    self.decrypted = decrypted.presence || decrypt(cost)
   end
 
   def fingerprint

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -86,9 +86,7 @@ module Idv
 
     def create_usps_entry
       move_pii_to_user_session
-      if pii.is_a?(String)
-        self.pii = Pii::Attributes.new_from_json(user_session[:decrypted_pii])
-      end
+      self.pii = Pii::Attributes.new_from_json(user_session[:decrypted_pii]) if pii.is_a?(String)
       confirmation_maker = UspsConfirmationMaker.new(pii: pii, issuer: issuer, profile: profile)
       confirmation_maker.perform
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -12,9 +12,7 @@ module Pii
     end
 
     def save(user_access_key, profile = user.active_profile)
-      if profile
-        user_session[:decrypted_pii] = profile.decrypt_pii(user_access_key).to_json
-      end
+      user_session[:decrypted_pii] = profile.decrypt_pii(user_access_key).to_json if profile
       rotate_fingerprints(profile) if stale_fingerprints?(profile)
       rotate_encrypted_attributes if stale_attributes?
       user_session[:decrypted_pii]

--- a/app/services/pii/cipher.rb
+++ b/app/services/pii/cipher.rb
@@ -48,7 +48,7 @@ module Pii
 
     def unpack_payload(payload)
       JSON.parse(payload, symbolize_names: true)
-    rescue => err
+    rescue StandardError => err
       raise Pii::EncryptionError, "Unable to parse encrypted payload. #{err.inspect}"
     end
 

--- a/app/services/pii/encodable.rb
+++ b/app/services/pii/encodable.rb
@@ -6,7 +6,7 @@ module Pii
 
     def valid_base64_encoding?(text)
       Base64.strict_decode64(text)
-    rescue
+    rescue StandardError
       false
     end
 

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -56,7 +56,7 @@ class ServiceProviderUpdater
     return parse_service_providers(body) if dashboard_response.code == 200
     log_error "Failed to parse response from #{url}: #{body}"
     []
-  rescue
+  rescue StandardError
     log_error "Failed to contact #{url}"
     []
   end

--- a/app/services/usps_uploader.rb
+++ b/app/services/usps_uploader.rb
@@ -3,7 +3,7 @@ class UspsUploader
     build_file
     upload_file
     clear_file
-  rescue => error
+  rescue StandardError => error
     NewRelic::Agent.notice_error(error)
   end
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,5 @@
 # if we're on a server, always default to production
-if File.exist?('/etc/login.gov/info/domain')
-  ENV['RAILS_ENV'] ||= 'production'.freeze
-end
+ENV['RAILS_ENV'] ||= 'production'.freeze if File.exist?('/etc/login.gov/info/domain')
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,11 +19,11 @@ Rails.application.configure do
 
   config.assets.debug = true
 
-  if ENV.key?('RAILS_ASSET_HOST')
-    config.action_controller.asset_host = ENV['RAILS_ASSET_HOST']
-  else
-    config.action_controller.asset_host = '//'
-  end
+  config.action_controller.asset_host = if ENV.key?('RAILS_ASSET_HOST')
+                                          ENV['RAILS_ASSET_HOST']
+                                        else
+                                          '//'
+                                        end
 
   config.assets.digest = ENV.key?('RAILS_DISABLE_ASSET_DIGEST') ? false : true
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,6 +12,4 @@ Rails.application.config.assets.precompile += %w[
   misc/*.js email.css ie*.css es5-shim.min.js html5shiv.js respond.min.js
 ]
 
-if Rails.env.test?
-  Rails.application.config.assets.precompile += %w[spec_helper.js]
-end
+Rails.application.config.assets.precompile += %w[spec_helper.js] if Rails.env.test?

--- a/config/initializers/devise_mailer_helpers.rb
+++ b/config/initializers/devise_mailer_helpers.rb
@@ -20,9 +20,7 @@ module Devise
       private
 
       def recipient
-        unconfirmed_email = resource.unconfirmed_email
-
-        unconfirmed_email.present? ? unconfirmed_email : resource.email
+        resource.unconfirmed_email.presence || resource.email
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   post '/api/service_provider' => 'service_provider#update'
   match '/api/voice/otp' => 'voice/otp#show',
-        via: [:get, :post],
+        via: %i[get post],
         as: :voice_otp,
         defaults: { format: :xml }
 

--- a/lib/encrypted_sidekiq_redis.rb
+++ b/lib/encrypted_sidekiq_redis.rb
@@ -68,7 +68,7 @@ class EncryptedSidekiqRedis
     # if job is JSON, possibly ActiveJob format, possibly Gibberish format.
     begin
       job = JSON.parse(job_json)
-    rescue
+    rescue StandardError
       return job_json
     end
     if encrypted?(job)

--- a/lib/sidekiq_logger_formatter.rb
+++ b/lib/sidekiq_logger_formatter.rb
@@ -15,7 +15,7 @@ class SidekiqLoggerFormatter < Logger::Formatter
   def filter_msg_string(msg)
     parsed = JSON.parse(msg)
     filter_msg_hash(parsed)
-  rescue
+  rescue StandardError
     msg
   end
 

--- a/lib/worker_health_checker.rb
+++ b/lib/worker_health_checker.rb
@@ -14,7 +14,7 @@ module WorkerHealthChecker
 
   # Empty job that we put in each background queue to make sure the queue is running
   # Relies on the Middleware to mark the queue as healthy
-  class DummyJob < ActiveJob::Base
+  class DummyJob < ApplicationJob
     def perform; end
   end
 

--- a/lib/yaml_normalizer.rb
+++ b/lib/yaml_normalizer.rb
@@ -17,9 +17,7 @@ class YamlNormalizer
   end
 
   def self.handle_hash(hash)
-    hash.each do |_key, value|
-      handle_value(value)
-    end
+    hash.each_value { |value| handle_value(value) }
   end
 
   def self.handle_array(array)
@@ -31,7 +29,7 @@ class YamlNormalizer
       trim(value)
     elsif value.is_a?(Array)
       handle_array(value)
-    elsif value.kind_of?(Hash)
+    elsif value.is_a?(Hash)
       handle_hash(value)
     elsif value
       raise ArgumentError, "unknown YAML value #{value}"

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -145,7 +145,7 @@ describe SamlIdpController do
         )
       end
       let(:this_authn_request) do
-        raw_req = URI.decode loa3_authnrequest.split('SAMLRequest').last
+        raw_req = CGI.unescape loa3_authnrequest.split('SAMLRequest').last
         SamlIdp::Request.from_deflated_request(raw_req)
       end
       let(:asserter) do

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include Features::LocalizationHelper
-include Features::MailerHelper
-
 describe Users::EmailsController do
+  include Features::LocalizationHelper
+  include Features::MailerHelper
+
   describe '#update' do
     let(:user) { create(:user, :signed_up, email: 'old_email@example.com') }
     let(:second_user) { create(:user, :signed_up, email: 'another@example.com') }

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include Features::LocalizationHelper
-include Features::MailerHelper
-
 describe Users::PasswordsController do
+  include Features::LocalizationHelper
+  include Features::MailerHelper
+
   describe '#update' do
     context 'form returns success' do
       it 'redirects to profile and sends a password change email' do

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include Features::MailerHelper
-include Features::LocalizationHelper
-
 describe Users::PhonesController do
+  include Features::MailerHelper
+  include Features::LocalizationHelper
+
   describe '#phone' do
     let(:user) { create(:user, :signed_up, phone: '+1 (202) 555-1234') }
     let(:second_user) { create(:user, :signed_up, phone: '+1 (202) 555-5678') }

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-include ActionView::Helpers::DateHelper
-
 describe Users::SessionsController, devise: true do
+  include ActionView::Helpers::DateHelper
+
   describe 'GET /users/sign_in' do
     it 'clears the session when user is not yet 2fa-ed' do
       sign_in_before_2fa

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-include Features::LocalizationHelper
 
 describe Users::TwoFactorAuthenticationController do
+  include Features::LocalizationHelper
+
   describe 'before_actions' do
     it 'includes the appropriate before_actions' do
       expect(subject).to have_actions(

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -322,11 +322,16 @@ describe UserDecorator do
     let!(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
     let(:decorated_user) { user.decorate }
     let!(:event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
-    let!(:identity) { create(:identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days) }
-    let!(:another_event) { create(:event, user: user, event_type: :email_changed, created_at: Time.zone.now - 30.days) }
+    let!(:identity) do
+      create(:identity, :active, user: user, last_authenticated_at: Time.zone.now - 60.days)
+    end
+    let!(:another_event) do
+      create(:event, user: user, event_type: :email_changed, created_at: Time.zone.now - 30.days)
+    end
 
     it 'interleaves identities and events, decorates them, and sorts them in descending order' do
-      expect(decorated_user.recent_events).to eq [another_event.decorate, identity.decorate, event.decorate]
+      expect(decorated_user.recent_events).
+        to eq [another_event.decorate, identity.decorate, event.decorate]
     end
   end
 

--- a/spec/deploy/activate_spec.rb
+++ b/spec/deploy/activate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'deploy/activate' do
 
   let(:logger) { @logger }
   let(:s3_client) { LoginGov::Hostdata::FakeS3Client.new }
-  let(:set_up_files!) {}
+  let(:set_up_files!){}
 
   describe '#run' do
     context 'in a deployed production environment' do

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 describe 'Account history' do
   let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
   let(:account_created_event) { create(:event, user: user, created_at: Time.zone.now - 98.days) }
-  let(:usps_mail_sent_event) { create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 90.days) }
+  let(:usps_mail_sent_event) do
+    create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 90.days)
+  end
   let(:identity_with_link) do
     create(
       :identity,
@@ -13,7 +15,9 @@ describe 'Account history' do
       service_provider: 'http://localhost:3000'
     )
   end
-  let(:usps_mail_sent_again_event) { create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 60.days) }
+  let(:usps_mail_sent_again_event) do
+    create(:event, user: user, event_type: :usps_mail_sent, created_at: Time.zone.now - 60.days)
+  end
   let(:identity_without_link) do
     create(
       :identity,

--- a/spec/features/saml/idp_initiated_slo_spec.rb
+++ b/spec/features/saml/idp_initiated_slo_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include SamlAuthHelper
-include IdvHelper
-
 feature 'IDP-initiated logout' do
+  include SamlAuthHelper
+  include IdvHelper
+
   let(:user) { create(:user, :signed_up) }
 
   context 'when logged in to single SP' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include SamlAuthHelper
-include IdvHelper
-
 feature 'saml api' do
+  include SamlAuthHelper
+  include IdvHelper
+
   let(:user) { create(:user, :signed_up) }
 
   context 'SAML Assertions' do

--- a/spec/features/saml/sp_initiated_slo_spec.rb
+++ b/spec/features/saml/sp_initiated_slo_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include SamlAuthHelper
-include IdvHelper
-
 feature 'SP-initiated logout' do
+  include SamlAuthHelper
+  include IdvHelper
+
   let(:user) { create(:user, :signed_up) }
 
   context 'when SP uses embed_sign:false' do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-include Features::ActiveJobHelper
-
 feature 'Two Factor Authentication' do
+  include Features::ActiveJobHelper
+
   describe 'When the user has not set up 2FA' do
     scenario 'user is prompted to set up two factor authentication at account creation' do
       user = sign_in_before_2fa

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -19,7 +19,6 @@ feature 'verify profile with OTP' do
   context 'USPS letter' do
     let(:phone_confirmed) { false }
 
-
     scenario 'profile phone not confirmed' do
       sign_in_live_with_2fa(user)
       expect(page).to have_link(t('idv.buttons.cancel'), account_path)

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-include Features::ActiveJobHelper
 
 describe SmsOtpSenderJob do
+  include Features::ActiveJobHelper
+
   describe '.perform' do
     before do
       reset_job_queues

--- a/spec/jobs/voice_otp_sender_job_spec.rb
+++ b/spec/jobs/voice_otp_sender_job_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-include Features::ActiveJobHelper
 
 describe VoiceOtpSenderJob do
+  include Features::ActiveJobHelper
+
   describe '.perform' do
     before do
       TwilioService.telephony_service = FakeVoiceCall

--- a/spec/lib/i18n_override_spec.rb
+++ b/spec/lib/i18n_override_spec.rb
@@ -12,7 +12,7 @@ describe 'i18n override' do
       file_path = '/18F/identity-idp/blob/master/config/locales/shared/en.yml'
 
       expect(localized_str).to match regex
-      expect(localized_str.scan(URI.regexp).flatten).to include(file_path)
+      expect(localized_str.scan(URI::DEFAULT_PARSER.make_regexp).flatten).to include(file_path)
     end
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -15,6 +15,7 @@ describe Profile do
   let(:user_access_key) { user.unlock_user_access_key(user.password) }
 
   it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:usps_confirmation_codes).dependent(:destroy) }
 
   describe '#encrypt_pii' do
     it 'encrypts PII' do

--- a/spec/presenters/two_factor_auth_code/authenticator_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/authenticator_delivery_presenter_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe TwoFactorAuthCode::AuthenticatorDeliveryPresenter do
-
   it 'handles multiple locales' do
     I18n.available_locales.each do |locale|
       I18n.locale = locale
@@ -21,7 +20,7 @@ describe TwoFactorAuthCode::AuthenticatorDeliveryPresenter do
   end
 
   def presenter
-    TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(data: {}, view: ActionController::Base.new.view_context)
+    TwoFactorAuthCode::AuthenticatorDeliveryPresenter.
+      new(data: {}, view: ActionController::Base.new.view_context)
   end
-
 end

--- a/spec/requests/edit_user_spec.rb
+++ b/spec/requests/edit_user_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-include Features::MailerHelper
-include Features::ActiveJobHelper
-
 describe 'user edits their account', email: true do
+  include Features::MailerHelper
+  include Features::ActiveJobHelper
+
   let(:user) { create(:user, :signed_up, phone: '+1 (202) 555-1213') }
 
   def user_session

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -19,8 +19,8 @@ describe AttributeAsserter do
       metadata: {}
     )
   end
-  let(:raw_loa1_authn_request) { URI.decode sp1_authnrequest.split('SAMLRequest').last }
-  let(:raw_loa3_authn_request) { URI.decode loa3_authnrequest.split('SAMLRequest').last }
+  let(:raw_loa1_authn_request) { CGI.unescape sp1_authnrequest.split('SAMLRequest').last }
+  let(:raw_loa3_authn_request) { CGI.unescape loa3_authnrequest.split('SAMLRequest').last }
   let(:loa1_authn_request) do
     SamlIdp::Request.from_deflated_request(raw_loa1_authn_request)
   end
@@ -96,7 +96,9 @@ describe AttributeAsserter do
 
         context 'authn request specifies bundle' do
           let(:raw_loa3_authn_request) do
-            URI.decode auth_request.create(loa3_with_bundle_saml_settings).split('SAMLRequest').last
+            CGI.unescape(
+              auth_request.create(loa3_with_bundle_saml_settings).split('SAMLRequest').last
+            )
           end
 
           it 'uses authn request bundle' do
@@ -179,7 +181,9 @@ describe AttributeAsserter do
 
         context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
           let(:raw_loa1_authn_request) do
-            URI.decode auth_request.create(loa1_with_bundle_saml_settings).split('SAMLRequest').last
+            CGI.unescape(
+              auth_request.create(loa1_with_bundle_saml_settings).split('SAMLRequest').last
+            )
           end
 
           it 'only returns uuid + email' do

--- a/spec/services/parse_controller_from_referer_spec.rb
+++ b/spec/services/parse_controller_from_referer_spec.rb
@@ -6,15 +6,15 @@ describe ParseControllerFromReferer do
       it 'returns "no referer" string' do
         parser = ParseControllerFromReferer.new(nil)
 
-        expect(parser.call).to eq "no referer"
+        expect(parser.call).to eq 'no referer'
       end
     end
 
     context 'when the referer is present' do
       it 'returns the corresponding controller and action' do
-        parser = ParseControllerFromReferer.new("http://example.com/")
+        parser = ParseControllerFromReferer.new('http://example.com/')
 
-        expect(parser.call).to eq "users/sessions#new"
+        expect(parser.call).to eq 'users/sessions#new'
       end
     end
   end

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ServiceProviderSeeder do
     subject(:run) { instance.run }
 
     it 'inserts service providers into the database from service_providers.yml' do
-      expect { run }.to change { ServiceProvider.count }
+      expect { run }.to change(ServiceProvider, :count)
     end
 
     context 'with other existing service providers in the database' do
@@ -96,8 +96,8 @@ RSpec.describe ServiceProviderSeeder do
       end
 
       context 'when a service provider is invalid' do
-        let(:invalid_service_providers) do
-          {
+        it 'raises an error' do
+          invalid_service_providers = {
             'https://rp2.serviceprovider.com/auth/saml/metadata' => {
               acs_url: 'http://example.com/test/saml/decode_assertion',
               assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request',
@@ -106,9 +106,7 @@ RSpec.describe ServiceProviderSeeder do
               redirect_uris: [''],
             },
           }
-        end
 
-        it 'raises an error' do
           expect(instance).to receive(:service_providers).and_return(invalid_service_providers)
           expect { run }.to raise_error(ActiveRecord::RecordInvalid)
         end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -171,7 +171,7 @@ module SamlAuthHelper
 
   def saml_get_auth(settings)
     # GET redirect binding Authn Request
-    get :auth, params: { SAMLRequest: URI.decode(saml_request(settings)) }
+    get :auth, params: { SAMLRequest: CGI.unescape(saml_request(settings)) }
   end
 
   private

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -38,13 +38,10 @@ shared_examples 'creating an account with the site in Spanish' do |sp|
 
     click_on t('forms.buttons.continue')
 
-    if sp == :saml
-      expect(current_url).to eq @saml_authn_request
-    end
+    expect(current_url).to eq @saml_authn_request if sp == :saml
 
     if sp == :oidc
       redirect_uri = URI(current_url)
-      redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
 
       expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
     end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -15,13 +15,10 @@ shared_examples 'signing in with the site in Spanish' do |sp|
 
     click_submit_default
 
-    if sp == :saml
-      expect(current_url).to eq @saml_authn_request
-    end
+    expect(current_url).to eq @saml_authn_request if sp == :saml
 
     if sp == :oidc
       redirect_uri = URI(current_url)
-      redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
 
       expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
     end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -85,7 +85,7 @@ describe 'devise/sessions/new.html.slim' do
 
       expect(rendered).to have_selector('.alert')
     end
-    
+
     it 'does not have an sp alert for service providers without alert messages' do
       render
 

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -73,7 +73,7 @@ describe 'sign_up/registrations/show.html.slim' do
 
       expect(rendered).to have_selector('.alert')
     end
-    
+
     it 'does not have an sp alert for service providers without alert messages' do
       render
 


### PR DESCRIPTION
**Why**: To keep the code clean and consistent.

The main offenses that were fixed are:
- URI.decode is obsolete
- URI.regexp is obsolete
- includes should be placed inside the class definition
- line is too long
- put conditionals on one line if they fit within the max line length
- use `each_value` when all you care about in a hash are the values
- don't rescue with specifying an error

Most of these were autocorrected by running `rubocop -R -a`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
