### PR TITLE
Set Sidekiq log level to INFO

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,7 @@ require 'sidekiq_logger_formatter'
 require 'worker_health_checker'
 require 'no_retry_jobs'
 
-Sidekiq::Logging.logger.level = Logger::WARN
+Sidekiq::Logging.logger.level = Logger::INFO
 Sidekiq::Logging.logger.formatter = SidekiqLoggerFormatter.new
 
 redis_connection = proc do


### PR DESCRIPTION
**Why**: The WARN level doesn't log when Sidekiq starts, which makes
troubleshooting hard.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
