### PR TITLE
Allow wildcard whitelisting of domains for OTP/USPS prefilling

### DIFF
--- a/app/services/wildcard_pattern_matcher.rb
+++ b/app/services/wildcard_pattern_matcher.rb
@@ -1,0 +1,67 @@
+class WildcardPatternMatcher
+  PatAndStrPointers = Struct.new(:pat, :str, :pat_i, :str_i)
+
+  # pattern is a string or array of strings that can contain non-consecutive asterisks/wildcards
+  def self.match?(pat, str)
+    return false unless pat && str
+    return match_any?(pat, str) if pat.class == Array
+    ps = PatAndStrPointers.new(pat, str, 0, 0)
+    match_ps?(ps)
+  end
+
+  # private
+
+  def self.match_any?(pats, str)
+    pats.each do |pat|
+      return true if WildcardPatternMatcher.match?(pat, str)
+    end
+    false
+  end
+
+  def self.match_ps?(ps)
+    return true if nothing_left_to_compare(ps)
+    return false if char_after_wildcard_and_str_done(ps)
+    pat_ch = ps.pat[ps.pat_i]
+    return recursive_compare_next_chars(ps) if pat_ch == ps.str[ps.str_i]
+    return recursive_compare_next_char_from_pat_or_str(ps) if pat_ch == '*'
+    false
+  end
+
+  def self.nothing_left_to_compare(ps)
+    !ps.pat[ps.pat_i] && !ps.str[ps.str_i]
+  end
+
+  def self.char_after_wildcard_and_str_done(ps)
+    pat_i = ps.pat_i
+    pat = ps.pat
+    pat[pat_i] == '*' && pat[pat_i + 1] && !ps.str[ps.str_i]
+  end
+
+  def self.recursive_compare_next_chars(ps)
+    next_ps = ps.dup
+    next_ps.pat_i += 1
+    next_ps.str_i += 1
+    match_ps?(next_ps)
+  end
+
+  def self.recursive_compare_next_char_from_pat_or_str(ps)
+    pat_ps = ps.dup
+    str_ps = pat_ps.dup
+    pat_ps.pat_i += 1
+    return true if match_ps?(pat_ps)
+    str_ps.str_i += 1
+    match_ps?(str_ps)
+  end
+
+  private_class_method :match_ps?, :nothing_left_to_compare, :char_after_wildcard_and_str_done,
+                       :recursive_compare_next_chars, :recursive_compare_next_char_from_pat_or_str,
+                       :match_any?
+end
+
+# code above (rubocop/reek friendly) implements following 5 line alogrithm:
+# return true if !pat[pat_i] && !str[str_i]
+# return false if pat[pat_i] == '*' && pat[pat_i + 1] && !str[str_i]
+# return match?(pat, str, pat_i + 1, str_i + 1) if pat[pat_i] == str[str_i]
+# return match?(pat, pat_i + 1, str, str_i) ||
+#        match?(pat, pat_i, str, str_i + 1) if pat[pat_i] == '*'
+# false

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,12 +1,10 @@
 class FeatureManagement
   ENVS_WHERE_PREFILLING_OTP_ALLOWED = %w[
-    idp.dev.login.gov idp.pt.login.gov idp.dev.identitysandbox.gov idp.pt.identitysandbox.gov
+    idp.dev.login.gov idp.pt.login.gov idp.*.identitysandbox.gov
   ].freeze
 
   ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED = %w[
-    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov
-    idp.dev.identitysandbox.gov idp.qa.identitysandbox.gov idp.int.identitysandbox.gov
-    idp.pt.identitysandbox.gov
+    idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov idp.*.identitysandbox.gov
   ].freeze
 
   def self.telephony_disabled?
@@ -25,7 +23,8 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_production?
-    ENVS_WHERE_PREFILLING_OTP_ALLOWED.include?(Figaro.env.domain_name) && telephony_disabled?
+    WildcardPatternMatcher.match?(ENVS_WHERE_PREFILLING_OTP_ALLOWED, Figaro.env.domain_name) &&
+      telephony_disabled?
   end
 
   def self.enable_i18n_mode?
@@ -61,7 +60,7 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_usps_code?
-    ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED.include?(Figaro.env.domain_name)
+    WildcardPatternMatcher.match?(ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED, Figaro.env.domain_name)
   end
 
   def self.no_pii_mode?

--- a/spec/services/wildcard_pattern_matcher_spec.rb
+++ b/spec/services/wildcard_pattern_matcher_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe WildcardPatternMatcher do
+  describe '#match?' do
+    it 'matches with no wildcard' do
+      expect(match?("idp.dev.login.gov","idp.dev.login.gov")).to eq true
+    end
+    it 'does not match without a wildcard' do
+      expect(match?("idp.dev.login.gov","idp.int.login.gov")).to eq false
+    end
+    it 'matches wildcard at the beginning' do
+      expect(match?("*.login.gov","idp.dev.login.gov")).to eq true
+    end
+    it 'does not match wildcard at the beginning' do
+      expect(match?("*.login.gov","login.gov")).to eq false
+    end
+    it 'matches wildcard at the end' do
+      expect(match?("login.gov/*","login.gov/foo")).to eq true
+    end
+    it 'does not match with wildcard at the end' do
+      expect(match?("login.gov/*","login.gov.ru/foo")).to eq false
+    end
+    it 'matches blank for wildcard' do
+      expect(match?("login.gov/*","login.gov/")).to eq true
+    end
+    it 'matches array with wildcards' do
+      expect(match?(["idp.*.login.gov","idp.*.identitysandbox.gov"],"idp.qa.identitysandbox.gov")).to eq true
+    end
+    it 'does not match array with wildcards' do
+      expect(match?(["idp.*.login.gov","idp.*.identitysandbox.gov"],"gov")).to eq false
+    end
+    it 'matches array with no wildcards' do
+      expect(match?(["idp.qa.login.gov","idp.qa.identitysandbox.gov"],"idp.qa.identitysandbox.gov")).to eq true
+    end
+    it 'does not match array with no wildcards' do
+      expect(match?(["idp.qa.login.gov","idp.qa.identitysandbox.gov"],"idp")).to eq false
+    end
+    it 'does not match nil' do
+      expect(match?(["idp.*.login.gov","idp.*.identitysandbox.gov"],nil)).to eq false
+    end
+    it 'does not match blank' do
+      expect(match?(["idp.*.login.gov","idp.*.identitysandbox.gov"],"")).to eq false
+    end
+    it 'does not match blank array' do
+      expect(match?([],"idp.qa.login.ru")).to eq false
+    end
+    it 'does not match blank array to nil' do
+      expect(match?([],nil)).to eq false
+    end
+    it 'matches two wildcards' do
+      expect(match?("*.*.login.gov","idp.dev.login.gov")).to eq true
+    end
+    it 'does not match two wildcards' do
+      expect(match?("*.*.login.gov","idp.login.gov")).to eq false
+    end
+  end
+
+  def match?(pattern,str)
+    WildcardPatternMatcher.match?(pattern,str)
+  end
+end


### PR DESCRIPTION
**Why**: It is preferable to use a wildcard (*.identitysandbox.gov) when whitelisting domains for OTP/USPS

**How** Created a WildcardPatternMatcher service that can take a string and match them to an array of wildcarded patterns

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
