### PR TITLE
Validate phone for Voice OTP delivery preference

### DIFF
--- a/.reek
+++ b/.reek
@@ -32,6 +32,7 @@ FeatureEnvy:
     - Idv::Step#vendor_validator_result
     - IdvSession#vendor_result_timed_out?
     - ServiceProviderSeeder#run
+    - OtpDeliverySelectionForm#unsupported_phone?
 InstanceVariableAssumption:
   exclude:
     - User

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -3,6 +3,7 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
 
     before_action :confirm_two_factor_enabled
+    before_action :confirm_voice_capability, only: [:show]
 
     def show
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH_ENTER_OTP_VISIT, analytics_properties)
@@ -28,6 +29,21 @@ module TwoFactorAuthentication
       return if confirmation_context? || current_user.two_factor_enabled?
 
       redirect_to phone_setup_url
+    end
+
+    def confirm_voice_capability
+      return if two_factor_authentication_method == 'sms'
+
+      phone = current_user&.phone || user_session[:unconfirmed_phone]
+      capabilities = PhoneNumberCapabilities.new(phone)
+
+      return unless capabilities.sms_only?
+
+      flash[:error] = t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: capabilities.unsupported_location
+      )
+      redirect_to login_two_factor_url(otp_delivery_preference: 'sms', reauthn: reauthn?)
     end
 
     def form_params

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -6,7 +6,7 @@ module Users
       if current_user.totp_enabled?
         redirect_to login_two_factor_authenticator_url
       elsif current_user.two_factor_enabled?
-        handle_valid_otp_delivery_preference(current_user.otp_delivery_preference)
+        validate_otp_delivery_preference_and_send_code
       else
         redirect_to phone_setup_url
       end
@@ -19,13 +19,32 @@ module Users
       if result.success?
         handle_valid_otp_delivery_preference(user_selected_otp_delivery_preference)
       else
-        redirect_to user_two_factor_authentication_url(reauthn: reauthn?)
+        handle_invalid_otp_delivery_preference(result)
       end
     rescue Twilio::REST::RestError => exception
       invalid_phone_number(exception)
     end
 
     private
+
+    def validate_otp_delivery_preference_and_send_code
+      delivery_preference = current_user.otp_delivery_preference
+      result = otp_delivery_selection_form.submit(otp_delivery_preference: delivery_preference)
+      analytics.track_event(Analytics::OTP_DELIVERY_SELECTION, result.to_h)
+
+      if result.success?
+        handle_valid_otp_delivery_preference(delivery_preference)
+      else
+        handle_valid_otp_delivery_preference('sms')
+        flash[:error] = result.errors[:phone].first
+      end
+    end
+
+    def handle_invalid_otp_delivery_preference(result)
+      flash[:error] = result.errors[:phone].first
+      preference = current_user.otp_delivery_preference
+      redirect_to login_two_factor_url(otp_delivery_preference: preference)
+    end
 
     def invalid_phone_number(exception)
       analytics.track_event(
@@ -67,7 +86,6 @@ module Users
       end
 
       send_user_otp(method)
-      session[:code_sent] = 'true'
       redirect_to login_two_factor_url(otp_delivery_preference: method, reauthn: reauthn?)
     end
 

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -111,7 +111,10 @@ en:
       otp_delivery_preference:
         instruction: You can change your choice the next time you sign in
         phone_unsupported: We're unable to make phone calls to people in %{location}
-          at this time. You will receive your security code via text message
+          at this time. We have sent your security code via text message. If you don't
+          receive the message in a few minutes, click "get another text message" to
+          try again. If that doesn't work, check that your phone or cellular operator
+          is not blocking messages from US phone numbers.
         sms: Text message (SMS)
         title: How would you like to receive your security code?
         voice: Phone call

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -315,7 +315,7 @@ describe Users::TwoFactorAuthenticationController do
           otp_delivery_selection_form: { otp_delivery_preference: 'pigeon' },
         }
 
-        expect(response).to redirect_to user_two_factor_authentication_path(reauthn: false)
+        expect(response).to redirect_to login_two_factor_url(otp_delivery_preference: 'sms')
       end
     end
   end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -243,49 +243,6 @@ feature 'OpenID Connect' do
     end
   end
 
-  context 'LOA3 continuation' do
-    let(:user) { profile.user }
-    let(:otp) { 'abc123' }
-    let(:profile) do
-      create(
-        :profile,
-        deactivation_reason: :verification_pending,
-        phone_confirmed: phone_confirmed,
-        pii: { ssn: '6666', dob: '1920-01-01' }
-      )
-    end
-    let(:oidc_auth_url) do
-      client_id = 'urn:gov:gsa:openidconnect:sp:server'
-      state = SecureRandom.hex
-      nonce = SecureRandom.hex
-
-      openid_connect_authorize_path(
-        client_id: client_id,
-        response_type: 'code',
-        acr_values: Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF,
-        scope: 'openid email profile:name social_security_number',
-        redirect_uri: 'http://localhost:7654/auth/result',
-        state: state,
-        prompt: 'select_account',
-        nonce: nonce
-      )
-    end
-
-    context 'phone verification' do
-      let(:phone_confirmed) { true }
-
-      it 'prompts to finish verifying profile, then redirects to SP' do
-        visit oidc_auth_url
-
-        sign_in_live_with_2fa(user)
-        enter_correct_otp_code_for_user(user)
-
-        redirect_uri = URI(current_url)
-        expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-      end
-    end
-  end
-
   context 'visiting IdP via SP, then going back to SP and visiting IdP again' do
     it 'displays the branded page' do
       visit_idp_from_sp_with_loa1

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -171,22 +171,6 @@ feature 'LOA3 Single Sign On', idv_job: true do
       end
     end
 
-    context 'having previously cancelled phone verification' do
-      let(:phone_confirmed) { true }
-
-      it 'prompts for OTP at sign in, then continues' do
-        saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
-
-        visit saml_authn_request
-
-        sign_in_live_with_2fa(user)
-
-        enter_correct_otp_code_for_user(user)
-
-        expect(current_url).to eq saml_authn_request
-      end
-    end
-
     context 'returning to verify after canceling during the same session' do
       it 'allows the user to verify' do
         user = create(:user, :signed_up)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -287,4 +287,87 @@ feature 'Sign in' do
 
   it_behaves_like 'signing in with the site in Spanish', :saml
   it_behaves_like 'signing in with the site in Spanish', :oidc
+
+  context 'user signs in with Voice OTP delivery preference to an unsupported country' do
+    it 'falls back to SMS with an error message' do
+      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(VoiceOtpSenderJob).to receive(:perform_later)
+      user = create(:user, :signed_up, phone: '+91 1234567890', otp_delivery_preference: 'voice')
+      signin(user.email, user.password)
+
+      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
+      expect(SmsOtpSenderJob).to have_received(:perform_later)
+      expect(page).
+        to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
+      expect(page).to have_content t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: 'India'
+      )
+      expect(user.reload.otp_delivery_preference).to eq 'sms'
+    end
+  end
+
+  context 'user tries to visit /login/two_factor/voice with an unsupported phone' do
+    it 'displays an error message but does not send an SMS' do
+      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(VoiceOtpSenderJob).to receive(:perform_later)
+      user = create(:user, :signed_up, phone: '+91 1234567890', otp_delivery_preference: 'sms')
+      signin(user.email, user.password)
+      visit login_two_factor_path(otp_delivery_preference: 'voice', reauthn: false)
+
+      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
+      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(page).
+        to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
+      expect(page).to have_content t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: 'India'
+      )
+      expect(user.reload.otp_delivery_preference).to eq 'sms'
+    end
+  end
+
+  context 'user tries to visit /otp/send with voice delivery to an unsupported phone' do
+    it 'displays an error message but does not send an SMS' do
+      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(VoiceOtpSenderJob).to receive(:perform_later)
+      user = create(:user, :signed_up, phone: '+91 1234567890', otp_delivery_preference: 'sms')
+      signin(user.email, user.password)
+      visit otp_send_path(
+        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true }
+      )
+
+      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
+      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(page).
+        to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
+      expect(page).to have_content t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: 'India'
+      )
+      expect(user.reload.otp_delivery_preference).to eq 'sms'
+    end
+  end
+
+  context 'user with voice delivery preference visits /otp/send' do
+    it 'displays an error message but does not send an SMS' do
+      allow(SmsOtpSenderJob).to receive(:perform_later)
+      allow(VoiceOtpSenderJob).to receive(:perform_later)
+      user = create(:user, :signed_up, phone: '+91 1234567890', otp_delivery_preference: 'voice')
+      signin(user.email, user.password)
+      visit otp_send_path(
+        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true }
+      )
+
+      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
+      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(page).
+        to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
+      expect(page).to have_content t(
+        'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
+        location: 'India'
+      )
+      expect(user.reload.otp_delivery_preference).to eq 'sms'
+    end
+  end
 end

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -42,7 +42,7 @@ describe OtpDeliverySelectionForm do
       it 'returns false for success? and includes errors' do
         errors = {
           otp_delivery_preference: ['is not included in the list'],
-          phone_to_deliver_to: ['Please fill in this field.'],
+          phone: ['Please fill in this field.'],
         }
 
         extra = {


### PR DESCRIPTION
**Why**: We noticed Twilio errors due to people attempting to make
phone calls to India, a country that we currently don't support.
While using the app normally, it is not possible to make phone calls
to unsupported countries or area codes. For example, when setting up
your 2FA phone for the first time, we have both client and server
validation that prevents making phone calls to unsupported countries
and area codes. In addition, once you confirm your 2FA number via SMS,
and then sign in, if your phone number is from an unsupported country
or area code, the link to get a phone call does not appear.

However, given that many of our SMS messages to India are being blocked,
it's not surprising that people are trying other means. Some clever
folks noticed that the OTP delivery method is part of the URL on the
page that prompts for your OTP (`/login/two_factor/sms`), and they
changed `sms` to `voice`, at which point the link to get a phone call
was visible, and they clicked it hoping to get a phone call. This also
resulted in their default OTP delivery preference being set to Voice,
and every time they sign in, we try to send them a phone call, which
increases the amount of Twilio errors we get.

**How**:
- Instead of automatically sending an OTP using the user's current
otp_delivery_preference, first validate the preference. If the
preference is voice, but the number is unsupported, then we send the
OTP via SMS and redirect to `login/two_factor/sms`. Additionally,
if the current preference is voice, we make sure to reset it to 'sms'.

- If a user tries to manipulate the URL to access the voice page,
we check to see if they are allowed to access the voice page, and if
not, we redirect to the SMS page

- If a user tries to manipulate the URL to send an OTP via voice,
we validate the preference, and if it fails we redirect to the SMS page

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
