### PR TITLE
Clarify help text for choosing mobile or landline

### DIFF
--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -116,7 +116,8 @@ en:
         title: How would you like to receive your security code?
         voice: Phone call
       otp_phone_label: Phone number
-      otp_phone_label_info: Mobile phone or landline
+      otp_phone_label_info: Mobile phone or landline. If you enter a landline, please
+        select “Phone call” below.
       otp_phone_label_info_modile_only: Mobile phone
       otp_setup_html: "<strong>Every time you log in,</strong> we will send you a
         one-time security code via text message or phone call. This helps safeguard

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -122,7 +122,8 @@ es:
         title: "¿Cómo le gustaría recibir su código de seguridad?"
         voice: Llamada telefónica
       otp_phone_label: Número de teléfono
-      otp_phone_label_info: El móvil o teléfono fijo está bien.
+      otp_phone_label_info: El móvil o teléfono fijo. Si tiene un teléfono fijo, seleccione
+        "Llamada telefónica" en la siguiente pregunta.
       otp_phone_label_info_modile_only: NOT TRANSLATED YET
       otp_setup_html: "<strong>Cada vez que inicie una sesión,</ strong> le enviaremos
         un código de seguridad de sólo un uso por mensaje de texto o llamada telefónica.

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -129,7 +129,8 @@ fr:
         title: Comment souhaitez-vous recevoir votre code de sécurité?
         voice: Appel téléphonique
       otp_phone_label: Numéro de téléphone
-      otp_phone_label_info: Cellulaire ou ligne fixe est acceptable
+      otp_phone_label_info: Cellulaire ou ligne fixe. Si vous entrez une ligne fixe,
+        veuillez choisir l'option "Appel téléphonique" ci-dessous.
       otp_phone_label_info_modile_only: NOT TRANSLATED YET
       otp_setup_html: "<strong>Chaque fois que vous vous connecterez,</strong> nous
         vous enverrons un code de sécurité à utilisation unique par message texte


### PR DESCRIPTION
**Why**: We are getting many Twilio errors from people in Mexico
who are requesting an OTP via SMS to landlines. We think this might
be due to the help text saying "Mobile phone or landline" with the
default radio button set to SMS.

**How**: Add text that asks the user to choose the "Phone call" option
if they enter a landline.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
