### PR TITLE
Log email domain name during registration

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -50,6 +50,7 @@ class RegisterUserEmailForm
     {
       email_already_exists: email_taken?,
       user_id: existing_user.uuid,
+      domain_name: email&.split('@')&.last,
     }
   end
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -46,6 +46,7 @@ describe SignUp::RegistrationsController, devise: true do
           errors: {},
           email_already_exists: false,
           user_id: user.uuid,
+          domain_name: 'example.com',
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -81,6 +82,7 @@ describe SignUp::RegistrationsController, devise: true do
         errors: {},
         email_already_exists: true,
         user_id: existing_user.uuid,
+        domain_name: 'example.com',
       }
 
       expect(@analytics).to receive(:track_event).
@@ -98,6 +100,7 @@ describe SignUp::RegistrationsController, devise: true do
         errors: { email: [t('valid_email.validations.email.invalid')] },
         email_already_exists: false,
         user_id: 'anonymous-uuid',
+        domain_name: 'invalid',
       }
 
       expect(@analytics).to receive(:track_event).

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -18,6 +18,7 @@ describe RegisterUserEmailForm do
         extra = {
           email_already_exists: true,
           user_id: existing_user.uuid,
+          domain_name: 'gmail.com',
         }
 
         result = instance_double(FormResponse)
@@ -40,6 +41,7 @@ describe RegisterUserEmailForm do
         extra = {
           email_already_exists: true,
           user_id: user.uuid,
+          domain_name: 'test.com',
         }
 
         result = instance_double(FormResponse)
@@ -58,6 +60,7 @@ describe RegisterUserEmailForm do
         extra = {
           email_already_exists: false,
           user_id: User.find_with_email('not_taken@gmail.com').uuid,
+          domain_name: 'gmail.com',
         }
 
         expect(FormResponse).to have_received(:new).
@@ -73,6 +76,7 @@ describe RegisterUserEmailForm do
         extra = {
           email_already_exists: false,
           user_id: 'anonymous-uuid',
+          domain_name: 'invalid_email',
         }
 
         result = instance_double(FormResponse)


### PR DESCRIPTION
**Why**: I noticed a few thousand errors over the past month due
to people entering invalid emails when registering. Since most modern
browsers have built-in validations for the email format (i.e. it has to
have some characters, then an @ character, then a domain name), the
error is most likely an invalid domain name, which we validate using
the valid_email gem, which performs MX validation.

We have also noticed that the MX validation has been timing out for
some users, and we suggested disabling it. However, before we do that,
I'd like to get some data on these errors to determine whether or not
they are due to MX validation failing, and to see if MX validation is
worth keeping.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
