### PR TITLE
SAML auth should set loa level on identity

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -48,7 +48,12 @@ module SamlIdpAuthConcern
   end
 
   def link_identity_from_session_data
-    IdentityLinker.new(current_user, current_issuer).link_identity
+    IdentityLinker.new(
+      current_user,
+      current_issuer
+    ).link_identity(
+      ial: loa3_requested? ? 3 : 1
+    )
   end
 
   def identity_needs_verification?

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -168,6 +168,11 @@ describe SamlIdpController do
         saml_get_auth(loa3_saml_settings)
       end
 
+      it 'sets identity loa to 3' do
+        saml_get_auth(loa3_saml_settings)
+        expect(user.identities.last.ial).to eq(3)
+      end
+
       it 'does not redirect the user to the IdV URL' do
         saml_get_auth(loa3_saml_settings)
 
@@ -327,14 +332,23 @@ describe SamlIdpController do
         )
       end
 
-      context 'after successful assertion' do
+      context 'after successful assertion of loa1' do
         before do
           sign_in(@user)
           saml_get_auth(saml_settings)
+          @user_identity = @user.identities.find_by(service_provider: saml_settings.issuer)
         end
 
         it 'does not delete SP metadata from session' do
           expect(session.key?(:sp)).to eq(true)
+        end
+
+        it 'links the user to the service provider' do
+          expect(@user_identity).to_not be_nil
+        end
+
+        it 'sets user identity loa value to 1' do
+          expect(@user_identity.ial).to eq(1)
         end
       end
     end


### PR DESCRIPTION
**Why**:

Currently when authorizing with SAML
an Identity is linked between the SP
and the user. The LOA is not currently
being set on the identity and is always
set to nil

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
