### PR TITLE
Fix nil error on completions page

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -31,6 +31,10 @@ module SignUp
     private
 
     def show_completions_page?
+      # error may be occurring here at user_has_identities?
+      
+      # session[:sp] is checked here
+      # in SignUpCompletionsShow partial conditional is on decorated_session class typ
       service_providers = session[:sp].present? || @view_model.user_has_identities?
       user_fully_authenticated? && service_providers
     end

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -65,6 +65,7 @@ class SignUpCompletionsShow
   end
 
   def service_provider_partial
+    # maybe @decorated_session is just a SessionDecorator, but session[:sp] is set
     if @decorated_session.is_a?(ServiceProviderSessionDecorator)
       'sign_up/completions/show_sp'
     else
@@ -83,6 +84,7 @@ class SignUpCompletionsShow
   end
 
   def user_has_identities?
+    # possible error source
     if identities
       identities.length.positive?
     else

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -154,7 +154,7 @@ en:
         resend: Send me another letter.
         success: It should arrive in 5 to 10 business days.
       agencies_login: You can now continue to and log into these agencies.
-      agency_login_html: You can now continue to and into <br><strong>%{sp}</strong>.
+      agency_login_html: You can now continue to and log into <br><strong>%{sp}</strong>.
     modal:
       attempts:
         one: You have <strong>1 attempt remaining.</strong>


### PR DESCRIPTION
**Why**:
When a user reaches the completions page without
an sp session and no linked identities,
a nil error occurs from a translation.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
