### PR TITLE
Ensure user can view their new personal key

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,7 @@
 class AccountsController < ApplicationController
   before_action :confirm_two_factor_authenticated
+  before_action :confirm_personal_key_receipt
+
   layout 'card_wide'
 
   def show
@@ -11,5 +13,13 @@ class AccountsController < ApplicationController
       personal_key: flash[:personal_key],
       decorated_user: current_user.decorate
     )
+  end
+
+  private
+
+  def confirm_personal_key_receipt
+    return if user_session[:personal_key].blank?
+
+    redirect_to manage_personal_key_url
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -201,7 +201,7 @@ module TwoFactorAuthenticatable
   end
 
   def after_otp_action_url
-    if decorated_user.should_acknowledge_personal_key?(session)
+    if decorated_user.should_acknowledge_personal_key?(user_session)
       user_session[:first_time_personal_key_view] = 'true'
       sign_up_personal_key_url
     elsif @updating_existing_number

--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -7,7 +7,7 @@ module SignUp
 
     def show
       user_session.delete(:first_time_personal_key_view)
-      @code = new_code
+      @code = create_new_code
       analytics.track_event(Analytics::USER_REGISTRATION_PERSONAL_KEY_VISIT)
     end
 
@@ -16,14 +16,6 @@ module SignUp
     end
 
     private
-
-    def new_code
-      if session[:new_personal_key].present?
-        session.delete(:new_personal_key)
-      else
-        create_new_code
-      end
-    end
 
     def confirm_has_not_already_viewed_personal_key
       return if user_session[:first_time_personal_key_view].present?

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -1,11 +1,17 @@
 module Users
   class PersonalKeysController < ApplicationController
     include PersonalKeyConcern
+    include SecureHeadersConcern
 
     before_action :confirm_two_factor_authenticated
+    before_action :apply_secure_headers_override, only: :show
 
     def show
       personal_key = user_session[:personal_key]
+
+      analytics.track_event(
+        Analytics::PERSONAL_KEY_VIEWED, personal_key_present: personal_key.present?
+      )
 
       return redirect_to account_url if personal_key.blank?
 
@@ -27,13 +33,17 @@ module Users
     private
 
     def next_step
-      if session[:sp]
-        sign_up_completed_url
-      elsif current_user.decorate.password_reset_profile.present?
+      if current_user.decorate.password_reset_profile.present?
         reactivate_account_url
+      elsif session[:sp] && user_has_not_visited_any_sp_yet?
+        sign_up_completed_url
       else
-        account_url
+        after_sign_in_path_for(current_user)
       end
+    end
+
+    def user_has_not_visited_any_sp_yet?
+      current_user.identities.pluck(:last_authenticated_at).compact.empty?
     end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -108,7 +108,7 @@ class UserDecorator
   end
 
   def should_acknowledge_personal_key?(session)
-    return true if session[:new_personal_key]
+    return true if session[:personal_key]
 
     sp_session = session[:sp]
 

--- a/app/forms/personal_key_form.rb
+++ b/app/forms/personal_key_form.rb
@@ -14,11 +14,7 @@ class PersonalKeyForm
   def submit
     @success = valid?
 
-    if success
-      UpdateUser.new(user: user, attributes: { personal_key: nil }).call
-    else
-      reset_sensitive_fields
-    end
+    reset_sensitive_fields unless success
 
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -53,6 +53,7 @@ class Analytics
     @browser ||= DeviceDetector.new(request.user_agent)
   end
 
+  # rubocop:disable Metrics/LineLength
   ACCOUNT_DELETION = 'Account Deletion Requested'.freeze
   ACCOUNT_VISIT = 'Account Page Visited'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
@@ -75,6 +76,7 @@ class Analytics
   LOGOUT_INITIATED = 'Logout Initiated'.freeze
   MULTI_FACTOR_AUTH = 'Multi-Factor Authentication'.freeze
   MULTI_FACTOR_AUTH_ENTER_OTP_VISIT = 'Multi-Factor Authentication: enter OTP visited'.freeze
+  MULTI_FACTOR_AUTH_ENTER_PERSONAL_KEY_VISIT = 'Multi-Factor Authentication: enter personal key visited'.freeze
   MULTI_FACTOR_AUTH_MAX_ATTEMPTS = 'Multi-Factor Authentication: max attempts reached'.freeze
   MULTI_FACTOR_AUTH_PHONE_SETUP = 'Multi-Factor Authentication: phone setup'.freeze
   MULTI_FACTOR_AUTH_MAX_SENDS = 'Multi-Factor Authentication: max otp sends reached'.freeze
@@ -88,6 +90,7 @@ class Analytics
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
+  PERSONAL_KEY_VIEWED = 'Personal Key Viewed'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
   PROFILE_PERSONAL_KEY_CREATE = 'Profile: Created new personal key'.freeze
@@ -104,4 +107,5 @@ class Analytics
   USER_REGISTRATION_INTRO_VISIT = 'User Registration: intro visited'.freeze
   USER_REGISTRATION_PHONE_SETUP_VISIT = 'User Registration: phone setup visited'.freeze
   USER_REGISTRATION_PERSONAL_KEY_VISIT = 'User Registration: personal key visited'.freeze
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -53,5 +53,16 @@ describe AccountsController do
         expect(response).to_not be_redirect
       end
     end
+
+    context 'user has not acknowledged new personal key' do
+      it 'redirects to manage_personal_key_url' do
+        stub_sign_in
+        allow(subject).to receive(:user_session).and_return(personal_key: 'new key')
+
+        get :show
+
+        expect(response).to redirect_to(manage_personal_key_url)
+      end
+    end
   end
 end

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -6,6 +6,7 @@ describe PersonalKeyForm do
       it 'returns FormResponse with success: true' do
         user = create(:user)
         raw_code = PersonalKeyGenerator.new(user).create
+        old_key = user.reload.personal_key
 
         form = PersonalKeyForm.new(user, raw_code)
         result = instance_double(FormResponse)
@@ -14,7 +15,7 @@ describe PersonalKeyForm do
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.personal_key).to be_nil
+        expect(user.reload.personal_key).to eq old_key
       end
     end
 

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -22,4 +22,12 @@ module PersonalKeyHelper
     open_last_email
     click_email_link_matching(/reset_password_token/)
   end
+
+  def scrape_personal_key
+    new_personal_key_words = []
+    page.all(:css, '[data-personal-key]').each do |node|
+      new_personal_key_words << node.text
+    end
+    new_personal_key_words.join('-')
+  end
 end

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -24,3 +24,132 @@ shared_examples 'signing in with the site in Spanish' do |sp|
     end
   end
 end
+
+shared_examples 'signing in as LOA1 with personal key' do |sp|
+  it 'redirects to the SP after acknowledging new personal key', email: true do
+    user = create_loa1_account_go_back_to_sp_and_sign_out(sp)
+    old_personal_key = PersonalKeyGenerator.new(user).create
+    visit_idp_from_sp_with_loa1(sp)
+    click_link t('links.sign_in')
+    fill_in_credentials_and_submit(user.email, 'Val!d Pass w0rd')
+    click_link t('devise.two_factor_authentication.personal_key_fallback.link')
+    enter_personal_key(personal_key: old_personal_key)
+    click_submit_default
+
+    expect(page).to have_current_path(manage_personal_key_path)
+    if sp == :oidc
+      expect(page.response_headers['Content-Security-Policy']).
+        to(include('form-action \'self\' http://localhost:7654'))
+    end
+
+    new_personal_key = scrape_personal_key
+    click_acknowledge_personal_key
+
+    expect(current_url).to eq @saml_authn_request if sp == :saml
+
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end
+
+shared_examples 'signing in as LOA3 with personal key' do |sp|
+  it 'redirects to the SP after acknowledging new personal key', :email, :idv_job do
+    user = create_loa3_account_go_back_to_sp_and_sign_out(sp)
+    pii = { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' }
+
+    visit_idp_from_sp_with_loa3(sp)
+    click_link t('links.sign_in')
+    fill_in_credentials_and_submit(user.email, user.password)
+    click_link t('devise.two_factor_authentication.personal_key_fallback.link')
+    enter_personal_key(personal_key: personal_key_for_loa3_user(user, pii))
+    click_submit_default
+
+    expect(page).to have_current_path(manage_personal_key_path)
+
+    new_personal_key = scrape_personal_key
+    click_acknowledge_personal_key
+
+    expect(current_url).to eq @saml_authn_request if sp == :saml
+
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end
+
+shared_examples 'signing in as LOA1 with personal key after resetting password' do |sp|
+  it 'redirects to SP', email: true do
+    user = create_loa1_account_go_back_to_sp_and_sign_out(sp)
+    old_personal_key = PersonalKeyGenerator.new(user).create
+    visit_idp_from_sp_with_loa1(sp)
+    trigger_reset_password_and_click_email_link(user.email)
+    reset_password_and_sign_back_in(user, new_password)
+    click_link t('devise.two_factor_authentication.personal_key_fallback.link')
+    enter_personal_key(personal_key: old_personal_key)
+    click_submit_default
+
+    expect(current_path).to eq manage_personal_key_path
+    if sp == :oidc
+      expect(page.response_headers['Content-Security-Policy']).
+        to(include('form-action \'self\' http://localhost:7654'))
+    end
+
+    new_personal_key = scrape_personal_key
+    click_acknowledge_personal_key
+
+    expect(current_url).to eq @saml_authn_request if sp == :saml
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end
+
+shared_examples 'signing in as LOA3 with personal key after resetting password' do |sp|
+  xit 'redirects to SP after reactivating account', :email, :idv_job do
+    user = create_loa3_account_go_back_to_sp_and_sign_out(sp)
+    visit_idp_from_sp_with_loa3(sp)
+    trigger_reset_password_and_click_email_link(user.email)
+    reset_password_and_sign_back_in(user, new_password)
+    click_link t('devise.two_factor_authentication.personal_key_fallback.link')
+    enter_personal_key(personal_key: personal_key_for_loa3_user(user, pii))
+    click_submit_default
+
+    expect(current_path).to eq manage_personal_key_path
+
+    new_personal_key = scrape_personal_key
+    click_acknowledge_personal_key
+
+    expect(current_path).to eq reactivate_account_path
+
+    reactivate_profile(new_password, new_personal_key)
+
+    expect(current_path).to eq manage_personal_key_path
+
+    new_personal_key = scrape_personal_key
+    click_acknowledge_personal_key
+
+    expect(current_url).to eq @saml_authn_request if sp == :saml
+    if sp == :oidc
+      redirect_uri = URI(current_url)
+
+      expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end
+
+def personal_key_for_loa3_user(user, pii)
+  pii_attrs = Pii::Attributes.new_from_hash(pii)
+  user_access_key = user.unlock_user_access_key(user.password)
+  profile = user.profiles.last
+  personal_key = profile.encrypt_pii(user_access_key, pii_attrs)
+  profile.save!
+
+  personal_key
+end

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -1,0 +1,39 @@
+module SpAuthHelper
+  def create_loa1_account_go_back_to_sp_and_sign_out(sp)
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    email = 'test@test.com'
+    visit_idp_from_sp_with_loa1(sp)
+    click_link t('sign_up.registrations.create_account')
+    submit_form_with_valid_email
+    click_confirmation_link_in_email(email)
+    submit_form_with_valid_password
+    set_up_2fa_with_valid_phone
+    click_submit_default
+    click_acknowledge_personal_key
+    click_on t('forms.buttons.continue')
+    visit sign_out_url
+    User.find_with_email(email)
+  end
+
+  def create_loa3_account_go_back_to_sp_and_sign_out(sp)
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    user = create(:user, :signed_up)
+    visit_idp_from_sp_with_loa3(sp)
+    click_link t('links.sign_in')
+    fill_in_credentials_and_submit(user.email, user.password)
+    click_submit_default
+    click_idv_begin
+    fill_out_idv_form_ok
+    click_idv_continue
+    click_idv_address_choose_phone
+    fill_out_phone_form_ok(user.phone)
+    click_idv_continue
+    fill_in :user_password, with: user.password
+    click_submit_default
+    click_acknowledge_personal_key
+    expect(page).to have_current_path(sign_up_completed_path)
+    click_on t('forms.buttons.continue')
+    visit sign_out_url
+    user.reload
+  end
+end


### PR DESCRIPTION
**Why**: We have received reports from users who were no longer able to
sign in with their personal key because they no longer had one. This
was very easy to reproduce as follows:
1. Sign in with your email and password
2. On the 2FA prompt page, click the link to sign in with your personal
key
3. After you type in your personal key, press the return button on your
keyboard or click the Submit button multiple times really fast

The result was that the user was redirected somewhere other than the
personal key page, and because the PersonalKeyForm reset the personal
key to `nil` as soon as the user entered the correct key in step 3, and
because the new key does not get generated until the personal key view
is rendered, the user ended up with a nil personal key and was no
longer able to sign back in with their key (because the link to sign in
with a personal key does not appear if you don't have a personal key).

**How**:
- Never set a user's personal key to nil
- Generate the new key in `PersonalKeyVerificationController` and store
it in the session, so that if the user double-submits a form by mistake,
we still have access to their key and can redirect them to the
PersonalKey page if they get redirected to the account page and have not
yet acknowledged their new key.
- Store the key in the `user_session`, not global `session`.
- Track visits to `PersonalKeyVerificationController` and
`PersonalKeysController` to make it easier to see step by step what
happened to the user.
- Write tests for both SAML and OIDC using real-life scenarios for
better end-to-end tests.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
