### PR TITLE
Bold 'login.gov' on come back later screen

### DIFF
--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -99,7 +99,7 @@ en:
         this time you can continue later.
       come_back_later: Once your letter arrives, sign into %{app}, and enter your
         verification code when prompted.
-      come_back_later_no_sp_html: You can return to your %{app} <strong>account</strong>
+      come_back_later_no_sp_html: You can return to your <strong>%{app} account</strong>
         for now.
       come_back_later_sp_html: You can return to <strong>%{sp}</strong> for now.
       confirm: You have encrypted your verified data


### PR DESCRIPTION
**Why**:
When a user requests a letter, not
coming from an sp. login.gov, should be
bolded.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
