### PR TITLE
Prevent double submits by disabling form submit buttons after submit

### DIFF
--- a/app/assets/javascripts/app/form-validation.js
+++ b/app/assets/javascripts/app/form-validation.js
@@ -11,6 +11,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (forms.length !== 0) {
     [].forEach.call(forms, function(form) {
+      const buttons = form.querySelectorAll('[type="submit"]');
+      form.addEventListener('submit', function() {
+        if (buttons.length !== 0) {
+          [].forEach.call(buttons, function (button) {
+            button.disabled = true;
+          });
+        }
+      }, false);
+      const elements = form.querySelectorAll('input');
+      if (elements.length !== 0) {
+        [].forEach.call(elements, function(input) {
+          input.addEventListener('input', function () {
+            if (buttons.length !== 0) {
+              [].forEach.call(buttons, function(button) {
+                if (button.disabled) {
+                  button.disabled = false;
+                }
+              });
+            }
+          });
+        });
+      }
+
       const inputs = form.querySelectorAll('.field');
 
       if (inputs.length !== 0) {


### PR DESCRIPTION
**Why**: It will improve the user experience by preventing issues like CSRF errors

**How** Added javascript which hooks into submit and click events, disables submit button, and submits

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
