### PR TITLE
Don't set session[:sp] if no issuer is present

### DIFF
--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -2,6 +2,7 @@ class SignOutController < ApplicationController
   include FullyAuthenticatable
 
   def destroy
+    analytics.track_event(Analytics::LOGOUT_INITIATED, method: 'cancel link')
     url_after_cancellation = decorated_session.cancel_link_url
     sign_out
     flash[:success] = t('devise.sessions.signed_out')

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -31,7 +31,7 @@ module SignUp
     private
 
     def show_completions_page?
-      service_providers = session[:sp].present? || @view_model.user_has_identities?
+      service_providers = sp_session[:issuer].present? || @view_model.user_has_identities?
       user_fully_authenticated? && service_providers
     end
 

--- a/app/forms/password_form.rb
+++ b/app/forms/password_form.rb
@@ -8,6 +8,7 @@ class PasswordForm
 
   def submit(params)
     submitted_password = params[:password]
+    @request_id = params[:request_id]
 
     self.password = submitted_password
 
@@ -16,9 +17,12 @@ class PasswordForm
 
   private
 
+  attr_reader :request_id
+
   def extra_analytics_attributes
     {
       user_id: user.uuid,
+      request_id_present: request_id.present?,
     }
   end
 end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -5,6 +5,30 @@ class StoreSpMetadataInSession
   end
 
   def call
+    Rails.logger.info(event_attributes)
+
+    return if sp_request.is_a?(NullServiceProviderRequest)
+
+    update_session
+  end
+
+  private
+
+  attr_reader :session, :request_id
+
+  def event_attributes
+    {
+      event: 'StoreSpMetadataInSession',
+      request_id_present: request_id.present?,
+      sp_request_class: sp_request.class.to_s,
+    }.to_json
+  end
+
+  def sp_request
+    @sp_request ||= ServiceProviderRequest.from_uuid(request_id)
+  end
+
+  def update_session
     session[:sp] = {
       issuer: sp_request.issuer,
       loa3: loa3_requested?,
@@ -12,14 +36,6 @@ class StoreSpMetadataInSession
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
     }
-  end
-
-  private
-
-  attr_reader :session, :request_id
-
-  def sp_request
-    @sp_request ||= ServiceProviderRequest.from_uuid(request_id)
   end
 
   def loa3_requested?

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -18,5 +18,16 @@ describe SignOutController do
 
       get :destroy
     end
+
+    it 'tracks the event' do
+      stub_sign_in_before_2fa
+      stub_analytics
+      allow(controller.decorated_session).to receive(:cancel_link_url).and_return('foo')
+
+      expect(@analytics).
+        to receive(:track_event).with(Analytics::LOGOUT_INITIATED, method: 'cancel link')
+
+      get :destroy
+    end
   end
 end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -11,7 +11,7 @@ describe SignUp::CompletionsController do
       context 'LOA1' do
         it 'tracks page visit' do
           stub_sign_in
-          subject.session[:sp] = { loa3: false }
+          subject.session[:sp] = { issuer: 'awesome sp', loa3: false }
           get :show
 
           expect(@analytics).to have_received(:track_event).with(
@@ -25,7 +25,7 @@ describe SignUp::CompletionsController do
         it 'tracks page visit' do
           user = create(:user, profiles: [create(:profile, :verified, :active)])
           stub_sign_in(user)
-          subject.session[:sp] = { loa3: true }
+          subject.session[:sp] = { issuer: 'awesome sp', loa3: true }
 
           get :show
 
@@ -59,9 +59,18 @@ describe SignUp::CompletionsController do
       expect(response).to redirect_to(account_url)
     end
 
+    it 'requires service provider issuer in session' do
+      stub_sign_in
+      subject.session[:sp] = { issuer: nil }
+
+      get :show
+
+      expect(response).to redirect_to(account_url)
+    end
+
     it 'renders show if the user has an sp in the active session' do
       stub_sign_in
-      subject.session[:sp] = { loa3: false }
+      subject.session[:sp] = { issuer: 'awesome sp', loa3: false }
       get :show
 
       expect(response).to render_template(:show)

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -12,6 +12,7 @@ describe SignUp::PasswordsController do
         success: true,
         errors: {},
         user_id: user.uuid,
+        request_id_present: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -38,6 +39,7 @@ describe SignUp::PasswordsController do
         success: false,
         errors: { password: ['is too short (minimum is 8 characters)'] },
         user_id: user.uuid,
+        request_id_present: false,
       }
 
       expect(@analytics).to receive(:track_event).

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -16,6 +16,7 @@ describe PasswordForm, type: :model do
 
         extra = {
           user_id: user.uuid,
+          request_id_present: false,
         }
 
         result = instance_double(FormResponse)
@@ -40,6 +41,7 @@ describe PasswordForm, type: :model do
 
         extra = {
           user_id: '123',
+          request_id_present: false,
         }
 
         result = instance_double(FormResponse)
@@ -70,6 +72,7 @@ describe PasswordForm, type: :model do
         passwords.each do |password|
           extra = {
             user_id: '123',
+            request_id_present: false,
           }
           result = instance_double(FormResponse)
 
@@ -77,6 +80,23 @@ describe PasswordForm, type: :model do
             with(success: false, errors: errors, extra: extra).and_return(result)
           expect(form.submit(password: password)).to eq result
         end
+      end
+    end
+
+    context 'when the request_id is passed in the params' do
+      it 'tracks that it is present' do
+        user = build_stubbed(:user)
+        form = PasswordForm.new(user)
+        password = 'valid password'
+        extra = {
+          user_id: user.uuid,
+          request_id_present: true,
+        }
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
+        expect(form.submit(password: password, request_id: 'foo')).to eq result
       end
     end
   end

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe StoreSpMetadataInSession do
+  describe '#call' do
+    context 'when a ServiceProviderRequest is not found' do
+      it 'does not set the session[:sp] hash' do
+        allow(Rails.logger).to receive(:info)
+        app_session = {}
+        instance = StoreSpMetadataInSession.new(session: app_session, request_id: 'foo')
+        info_hash = {
+          event: 'StoreSpMetadataInSession',
+          request_id_present: true,
+          sp_request_class: 'NullServiceProviderRequest',
+        }.to_json
+
+        expect { instance.call }.to_not change(app_session, :keys)
+        expect(Rails.logger).to have_received(:info).with(info_hash)
+      end
+    end
+
+    context 'when a ServiceProviderRequest is found' do
+      it 'sets the session[:sp] hash' do
+        allow(Rails.logger).to receive(:info)
+
+        app_session = {}
+        request_id = SecureRandom.uuid
+        ServiceProviderRequest.find_or_create_by(uuid: request_id) do |sp_request|
+          sp_request.issuer = 'issuer'
+          sp_request.loa = 'loa1'
+          sp_request.url = 'http://issuer.gov'
+          sp_request.requested_attributes = %w[email]
+        end
+        instance = StoreSpMetadataInSession.new(session: app_session, request_id: request_id)
+
+        info_hash = {
+          event: 'StoreSpMetadataInSession',
+          request_id_present: true,
+          sp_request_class: 'ServiceProviderRequest',
+        }.to_json
+
+        app_session_hash = {
+          issuer: 'issuer',
+          loa3: false,
+          request_url: 'http://issuer.gov',
+          request_id: request_id,
+          requested_attributes: %w[email],
+        }
+
+        instance.call
+        expect(Rails.logger).to have_received(:info).with(info_hash)
+        expect(app_session[:sp]).to eq app_session_hash
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: For some yet unknown reason, some people are getting in a
state where they have an `sp` key in the session, but with nil values
for issuer and other attributes. The only place we set `session[:sp]`
is in `StoreSpMetadataInSession`, which means that somehow, the
service is being called either with a nil `request_id`, or a
`request_id` that no longer matches one in the DB.

This was causing an exception when the user viewed the agency handoff
page because the view was determining whether or not the user is allowed
to view the page based only on the presence of `session[:sp]`, which is
true in this case, which then calls
`@view_model.service_provider_partial`, which has this logic:

```ruby
def service_provider_partial
  if @decorated_session.is_a?(ServiceProviderSessionDecorator)
    'sign_up/completions/show_sp'
  else
    'sign_up/completions/show_identities'
  end
end
```

Because there is no issuer in the `sp` hash, the decorated session is a
regular `SessionDecorator`, and so the app tries to render
`sign_up/completions/show_identities`, which has a bug because it's
trying to call a method on the user's `identities` even if the user does
not have any identities:

```slim
- if identities.length > 1
  = t('idv.messages.agencies_login')
- else
  = t('idv.messages.agency_login_html', sp: identities.first.display_name)
```

**How**:
- Don't set `session[:sp]` if a ServiceProviderRequest cannot be found
- Check for the presence of the issuer in the agency handoff page
- Add logging to help determine where and if the `request_id` is being
dropped or changed.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
