### PR TITLE
Rollback AAMVA integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,6 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v1.0.0'
   gem 'equifax', git: 'git@github.com:18F/identity-equifax-api-client-gem.git', tag: 'v1.1.0'
   gem 'mandrill_dm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: git@github.com:18F/identity-aamva-api-client-gem
-  revision: 2ede830efe106e8b1ec63d323dd14e681b1bca5a
-  tag: v1.0.0
-  specs:
-    aamva (0.1.0)
-      dotenv
-      hashie
-      httpi
-      xmldsig
-
-GIT
   remote: git@github.com:18F/identity-equifax-api-client-gem.git
   revision: de4258c7608997f72e119b16718eeead4d39db70
   tag: v1.1.0
@@ -657,8 +646,6 @@ GEM
     whenever (0.10.0)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
-    xmldsig (0.6.5)
-      nokogiri (>= 1.6.8, < 2.0.0)
     xmlenc (0.6.9)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -676,7 +663,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aamva!
   ahoy_matey
   american_date
   aws-sdk-core

--- a/app/services/idv/upcase_vendor_env_vars.rb
+++ b/app/services/idv/upcase_vendor_env_vars.rb
@@ -13,7 +13,6 @@ module Idv
       [
         env.profile_proofing_vendor,
         env.phone_proofing_vendor,
-        env.state_id_proofing_vendor,
       ]
     end
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -52,9 +52,6 @@ valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://id
 usps_mail_batch_hours: '24'
 
 development:
-  aamva_public_key: '123abc'
-  aamva_private_key: '123abc'
-  aamva_verification_url: 'https://example.org:12345/verification/url'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -126,9 +123,6 @@ development:
   enable_load_testing_mode: 'false'
 
 production:
-  aamva_public_key: '123abc'
-  aamva_private_key: '123abc'
-  aamva_verification_url: 'https://example.org:12345/verification/url'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -196,9 +190,6 @@ production:
   enable_load_testing_mode: 'false'
 
 test:
-  aamva_public_key: '123abc'
-  aamva_private_key: '123abc'
-  aamva_verification_url: 'https://example.org:12345/verification/url'
   async_job_refresh_interval_seconds: '1'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)

--- a/spec/services/idv/upcase_vendor_env_vars_spec.rb
+++ b/spec/services/idv/upcase_vendor_env_vars_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 describe Idv::UpcaseVendorEnvVars do
   describe '#call' do
     before do
-      allow(Figaro.env).to receive(:profile_proofing_vendor).and_return('equifax')
-      allow(Figaro.env).to receive(:state_id_proofing_vendor).and_return('aamva')
+      allow(Figaro.env).to receive(:profile_proofing_vendor).and_return('aamva')
       allow(Figaro.env).to receive(:phone_proofing_vendor).and_return('equifax')
       stub_const 'ENV', ENV.to_h.merge(
         'equifax_thing' => 'some value',


### PR DESCRIPTION
**Why**: The AAMVA gem is in a private repo which our production servers
do not have access to at this time. As a result, this commit prevents
the deps from installing which prevents the app from starting in
production.

The AAMVA gem can be re-added once 18F/identity-devops#728 is merged.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
