### PR TITLE
Let user know they don't have an account yet

### DIFF
--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -48,17 +48,25 @@ module Users
 
     protected
 
+    def email_params
+      params.require(:password_reset_email_form).permit(:email, :resend, :request_id)
+    end
+
     def email
-      params[:password_reset_email_form][:email]
+      email_params[:email]
+    end
+
+    def request_id
+      email_params[:request_id]
     end
 
     def handle_valid_email
-      RequestPasswordReset.new(email).perform
+      RequestPasswordReset.new(email, request_id).perform
 
       session[:email] = email
-      resend_confirmation = params[:password_reset_email_form][:resend]
+      resend_confirmation = email_params[:resend]
 
-      redirect_to forgot_password_url(resend: resend_confirmation)
+      redirect_to forgot_password_url(resend: resend_confirmation, request_id: request_id)
     end
 
     def handle_invalid_or_expired_token(result)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,4 +20,9 @@ class UserMailer < ActionMailer::Base
   def phone_changed(user)
     mail(to: user.email, subject: t('user_mailer.phone_changed.subject'))
   end
+
+  def account_does_not_exist(email, request_id)
+    @sign_up_email_url = sign_up_email_url(request_id: request_id, locale: locale_url_param)
+    mail(to: email, subject: t('user_mailer.account_does_not_exist.subject'))
+  end
 end

--- a/app/models/nonexistent_user.rb
+++ b/app/models/nonexistent_user.rb
@@ -14,4 +14,12 @@ class NonexistentUser
   def persisted?
     false
   end
+
+  def admin?
+    false
+  end
+
+  def tech?
+    false
+  end
 end

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -1,16 +1,20 @@
-RequestPasswordReset = Struct.new(:email) do
+RequestPasswordReset = Struct.new(:email, :request_id) do
   def perform
     # For security purposes, we don't want to allow password
     # recovery via email for admin and tech support users.
-    return if user_not_found? || user_found_but_is_an_admin_or_tech?
+    return if user_found_but_is_an_admin_or_tech?
 
-    user.send_reset_password_instructions
+    if user_not_found?
+      UserMailer.account_does_not_exist(email, request_id).deliver_later
+    else
+      user.send_reset_password_instructions
+    end
   end
 
   private
 
   def user_not_found?
-    user.nil?
+    user.is_a?(NonexistentUser)
   end
 
   def user_found_but_is_an_admin_or_tech?
@@ -18,6 +22,6 @@ RequestPasswordReset = Struct.new(:email) do
   end
 
   def user
-    @_user ||= User.find_with_email(email)
+    @_user ||= User.find_with_email(email) || NonexistentUser.new
   end
 end

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,4 +1,5 @@
 - title t('titles.passwords.forgot')
+- request_id = params[:request_id] || sp_session[:request_id]
 
 = render 'shared/sp_alert'
 
@@ -10,6 +11,7 @@ p.mt-tiny.mb0#email-description
                   html: { autocomplete: 'off', method: :post, role: 'form' }) do |f|
 
   = f.input :email, required: true, input_html: { 'aria-describedby': 'email-description' }
+  = f.input :request_id, as: :hidden, input_html: { value: request_id }
   = f.button :submit, t('forms.buttons.continue'), class: 'mt2'
 
 .mt2.pt1.border-top

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,5 @@
 - title t('titles.visitors.index')
+- request_id = params[:request_id] || sp_session[:request_id]
 
 = render 'shared/sp_alert'
 
@@ -9,7 +10,7 @@ h1.h3.my0 = decorated_session.new_session_heading
                   html: { autocomplete: 'off', role: 'form' }) do |f|
   = f.input :email, label: t('account.index.email'), required: true, input_html: { class: 'mb4' }
   = f.input :password, label: t('account.index.password'), required: true
-  = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] }
+  = f.input :request_id, as: :hidden, input_html: { value: request_id }
   = f.button :submit, t('links.next'), class: 'btn-wide'
 
 p.my3
@@ -18,6 +19,7 @@ p.my3
 .clearfix.pt1.border-top
   = render decorated_session.return_to_service_provider_partial
   .sm-col-right.mxn1
-    = link_to t('links.passwords.forgot'), new_password_path(resource_name), class: 'px1'
-    = link_to t('links.create_account'), sign_up_email_url(request_id: params[:request_id]), \
+    = link_to t('links.passwords.forgot'), new_user_password_url(request_id: request_id), \
+      class: 'px1'
+    = link_to t('links.create_account'), sign_up_email_url(request_id: request_id), \
       class: 'px1 border-left border-silver'

--- a/app/views/forgot_password/show.html.slim
+++ b/app/views/forgot_password/show.html.slim
@@ -1,4 +1,5 @@
 - title t('titles.verify_email')
+- request_id = params[:request_id] || sp_session[:request_id]
 
 .my2.p3.sm-px4.border.border-teal.rounded.rounded-xl.relative
   = image_tag(asset_url('check-email.svg'), size: '48x48', alt: '',\
@@ -13,8 +14,10 @@
     html: { autocomplete: 'off', method: :post, role: 'form', class: 'mb2' }) do |f|
     = f.input :email, as: :hidden, wrapper: false
     = f.input :resend, as: :hidden, wrapper: false
+    = f.input :request_id, as: :hidden, input_html: { value: request_id }
     | #{t('notices.forgot_password.no_email_sent_explanation_start')}
     = f.button :submit, t('links.resend'), class: 'btn-link ml-tiny'
-  - link = link_to t('notices.forgot_password.use_diff_email.link'), sign_up_email_path
+  - link = link_to t('notices.forgot_password.use_diff_email.link'), \
+      sign_up_email_path(request_id: request_id)
   p = t('notices.forgot_password.use_diff_email.text_html', link: link)
   p = t('instructions.forgot_password.close_window')

--- a/app/views/user_mailer/account_does_not_exist.html.slim
+++ b/app/views/user_mailer/account_does_not_exist.html.slim
@@ -1,0 +1,27 @@
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
+
+table.button.expanded.large.radius
+  tbody
+    tr
+      td
+        table
+          tbody
+            tr
+              td
+                center
+                  = link_to t('.link_text', app: APP_NAME),
+                    @sign_up_email_url, target: '_blank',
+                    class: 'float-center', align: 'center'
+      td.expander
+
+p = link_to @sign_up_email_url, @sign_up_email_url, target: '_blank'
+
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -1,6 +1,13 @@
 ---
 en:
   user_mailer:
+    account_does_not_exist:
+      intro: This email address is not yet associated with a %{app} account. If you’d
+        like to create a login.gov account using this email address, please click
+        the link below or copy and paste the entire link into your browser. If you
+        didn't request a password reset, you can ignore this message.
+      link_text: Create your account
+      subject: Your login.gov password reset request
     contact_link_text: contact us
     email_changed:
       help: If you did not want to change your email address, please visit the %{app}

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   user_mailer:
+    account_does_not_exist:
+      intro: NOT TRANSLATED YET
+      link_text: NOT TRANSLATED YET
+      subject: NOT TRANSLATED YET
     contact_link_text: Contáctenos
     email_changed:
       help: Si no desea cambiar su email, visite el %{app} %{help_link} o el %{contact_link}.

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -1,6 +1,10 @@
 ---
 fr:
   user_mailer:
+    account_does_not_exist:
+      intro: NOT TRANSLATED YET
+      link_text: NOT TRANSLATED YET
+      subject: NOT TRANSLATED YET
     contact_link_text: communiquez avec nous
     email_changed:
       help: Si vous préférez ne pas changer votre adresse courriel, veuillez visiter

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -255,8 +255,7 @@ describe Users::ResetPasswordsController, devise: true do
 
   describe '#create' do
     context 'no user matches email' do
-      it 'redirects to forgot_password_path to prevent revealing account existence ' \
-        'and tracks event using nonexistent user' do
+      it 'send an email to tell the user they do not have an account yet' do
         stub_analytics
 
         analytics_hash = {
@@ -274,7 +273,7 @@ describe Users::ResetPasswordsController, devise: true do
           put :create, params: {
             password_reset_email_form: { email: 'nonexistent@example.com' },
           }
-        end.to_not(change { ActionMailer::Base.deliveries.count })
+        end.to(change { ActionMailer::Base.deliveries.count }.by(1))
 
         expect(response).to redirect_to forgot_password_path
       end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -98,6 +98,30 @@ describe UserMailer, type: :mailer do
     end
   end
 
+  describe 'account_does_not_exist' do
+    let(:mail) { UserMailer.account_does_not_exist('test@test.com', 'request_id') }
+
+    it_behaves_like 'a system email'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq ['test@test.com']
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_does_not_exist.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).to have_content(
+        t('user_mailer.account_does_not_exist.intro', app: APP_NAME)
+      )
+      expect(mail.html_part.body).to have_link(
+        t('user_mailer.account_does_not_exist.link_text', app: APP_NAME),
+        href: sign_up_email_url(request_id: 'request_id')
+      )
+    end
+  end
+
   def expect_email_body_to_have_help_and_contact_links
     expect(mail.html_part.body).to have_link(
       t('user_mailer.help_link_text'), href: MarketingSite.help_url

--- a/spec/models/nonexistent_user_spec.rb
+++ b/spec/models/nonexistent_user_spec.rb
@@ -14,4 +14,20 @@ describe NonexistentUser do
       expect(nonexistent_user.role).to eq 'nonexistent'
     end
   end
+
+  describe 'admin?' do
+    it 'returns false' do
+      nonexistent_user = NonexistentUser.new
+
+      expect(nonexistent_user.admin?).to eq false
+    end
+  end
+
+  describe 'tech?' do
+    it 'returns false' do
+      nonexistent_user = NonexistentUser.new
+
+      expect(nonexistent_user.tech?).to eq false
+    end
+  end
 end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 describe RequestPasswordReset do
   describe '#perform' do
     context 'when the user is not found' do
-      it 'does not send any emails' do
-        user = build_stubbed(:user)
+      it 'sends the account does not exist email' do
+        email = 'nonexistent@example.com'
 
-        expect(user).to_not receive(:send_reset_password_instructions)
+        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(UserMailer).to receive(:account_does_not_exist).
+          with(email, 'request_id').and_return(mailer)
+        expect(mailer).to receive(:deliver_later)
 
-        RequestPasswordReset.new('nonexistent@example.com').perform
+        RequestPasswordReset.new(email, 'request_id').perform
       end
     end
 


### PR DESCRIPTION
**Why**: Despite the instructions on our site and the TTP site, many
people still think they already have a login.gov account with their
old TTP email, and keep requesting password reset emails.

**How**: If someone requests a password reset to an email that is not
in our database, send them an email letting them know they don't have
an account yet.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
