### PR TITLE
Make rack timeout setting configurable

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -32,6 +32,9 @@ queue_health_check_frequency_seconds: '30'
 # The number of words in the personal key phrase
 recovery_code_length: '4'
 
+# How long (in seconds) to wait for requests before dropping them (via the rack_timeout gem).
+service_timeout: '15'
+
 # Set the number of seconds before the session times out that the timeout
 # warning should appear.
 # NOTE: session_timeout_warning_seconds + session_check_delay % 60 should == 0
@@ -113,6 +116,7 @@ development:
   saml_passphrase: 'trust-but-verify'
   scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   secret_key_base: 'development_secret_key_base'
+  service_timeout: '30'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
   session_timeout_in_minutes: '15'
   state_id_proofing_vendor: 'mock'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -35,6 +35,7 @@ Figaro.require_keys(
   'saml_passphrase',
   'scrypt_cost',
   'secret_key_base',
+  'service_timeout',
   'session_encryption_key',
   'session_timeout_in_minutes',
   'state_id_proofing_vendor',

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,1 @@
-Rack::Timeout.service_timeout = 30 # seconds
+Rack::Timeout.service_timeout = Figaro.env.service_timeout.to_i # seconds


### PR DESCRIPTION
**Why**: To make it easier to change values without requiring code
changes. 30 seconds is way too high. The default rack timeout setting
is 15 seconds, and even that is arguably a very long time to make the
user wait for anything.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
