### PR TITLE
Set a timeout for MX validation

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -21,6 +21,9 @@ max_mail_events_window_in_days: '30'
 # https://github.com/dropbox/zxcvbn#usage
 min_password_score: '3'
 
+# How long to wait for the MX validator to get a response from the DNS server
+mx_timeout: '3'
+
 password_max_attempts: '3'
 
 # If a queue does not have a healthy job after this many seconds, report it as unhealthy

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -21,6 +21,7 @@ Figaro.require_keys(
   'max_mail_events',
   'max_mail_events_window_in_days',
   'min_password_score',
+  'mx_timeout',
   'otp_delivery_blocklist_findtime',
   'otp_delivery_blocklist_maxretry',
   'otp_valid_for',

--- a/config/initializers/valid_email.rb
+++ b/config/initializers/valid_email.rb
@@ -1,3 +1,5 @@
 config = Rails.root.join('config', 'valid_email.yml')
 
 BanDisposableEmailValidator.config = YAML.load_file(config)['disposable_email_services']
+
+MxValidator.config[:timeouts] = [Figaro.env.mx_timeout.to_i]


### PR DESCRIPTION
**Why**: It's a best practice in general to always set timeouts for any
external connection. Without a timeout for MX validation, the app will
sit waiting for a response for more than a minute by default, which can
queue up requests and bring the server down. We use Rack::Timeout to
stop any long-running requests (currently set to 30 seconds, but I have
a PR to halve that), but that's not meant as a solution for
long-running requests. Rack::Timeout is only supposed to be used as a
debugging tool to see where we have long-running requests,
and then our goal is to make them faster or introduce timeouts.

If MX validation takes more than 2 or 3 seconds, we should stop it
immediately and let the user try again later if the domain name was
indeed valid.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
