### PR TITLE
Add faster setup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ all: check
 setup $(CONFIG): config/application.yml.example
 	bin/setup
 
+fast_setup:
+	bin/fast_setup
+
 check: lint test
 
 lint:
@@ -38,10 +41,10 @@ brakeman:
 test: $(CONFIG)
 	bundle exec rspec && RAILS_ENV=test bundle exec teaspoon
 
-fast_test: $(CONFIG)
+fast_test:
 	bundle exec rspec --exclude-pattern "**/features/accessibility/*_spec.rb"
 
-run: $(CONFIG)
+run:
 	foreman start -p $(PORT)
 
 load_test: $(CONFIG)

--- a/bin/fast_setup
+++ b/bin/fast_setup
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
+
+def run(command)
+  abort "command failed (#{$?}): #{command}" unless system command
+end
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts %q[
+   _             _
+  | |           (_)
+  | | ___   __ _ _ _ __    __ _  _____   __
+  | |/ _ \ / _` | | '_ \  / _` |/ _ \ \ / /
+  | | (_) | (_| | | | | || (_| | (_) \ V /
+  |_|\___/ \__, |_|_| |_(_)__, |\___/ \_/
+            __/ |          __/ |
+           |___/          |___/
+  ]
+
+  puts "== Copying application.yml =="
+  run "cp config/application.yml.example config/application.yml"
+
+  puts "\n== Installing dependencies =="
+  run "bundle check || bundle install --without deploy production"
+
+  puts "\n== Removing old logs and tempfiles =="
+  run "rm -f log/*"
+  run "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  run "mkdir -p tmp"
+  run "touch tmp/restart.txt"
+end


### PR DESCRIPTION
**Why**: When developing locally, it's rare that you want to recreate
the DB and set up the assets from scratch every time you switch
branches or make changes. Having to wait for the entire setup script,
then 30 seconds for the assets to load is a waste of time.

**How**: Introduce a new `fast_setup` script that only copies over the
latest `application.yml` and installs any missing gems, which is 99%
of the time all you wanted to do. Also, don't run `bin/setup` during
`make run`. `make run` means all I want is to start the server. If I
wanted to run the setup script, I would explicitly run `make setup`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
