### PR TITLE
Allow user to refresh personal key page

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -202,7 +202,6 @@ module TwoFactorAuthenticatable
 
   def after_otp_action_url
     if decorated_user.should_acknowledge_personal_key?(user_session)
-      user_session[:first_time_personal_key_view] = 'true'
       sign_up_personal_key_url
     elsif @updating_existing_number
       account_url

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -233,7 +233,6 @@ feature 'LOA1 Single Sign On' do
       session = proxy.env['rack.session']
       session['warden.user.user.session'] = {
         'need_two_factor_authentication' => true,
-        first_time_personal_key_view: true,
       }
     end
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -9,7 +9,14 @@ feature 'View personal key' do
     scenario 'user refreshes personal key page' do
       sign_up_and_view_personal_key
 
+      personal_key = scrape_personal_key
+
       visit sign_up_personal_key_path
+
+      expect(current_path).to eq(sign_up_personal_key_path)
+      expect(scrape_personal_key).to eq(personal_key)
+
+      click_acknowledge_personal_key
 
       expect(current_path).to eq(account_path)
     end
@@ -50,6 +57,20 @@ feature 'View personal key' do
       end
 
       it_behaves_like 'personal key page'
+    end
+
+    context 'visitting the personal key path' do
+      scenario 'does not regenerate the personal and redirects to account' do
+        user = sign_in_and_2fa_user
+        old_code = user.personal_key
+
+        visit sign_up_personal_key_path
+
+        user.reload
+
+        expect(user.personal_key).to eq(old_code)
+        expect(current_path).to eq(account_path)
+      end
     end
   end
 


### PR DESCRIPTION
**Why**: So that if a user refreshes the personal key page, they still
have to confirm their personal key, and can still see their initial
personal key.

**How**: This commit writes the personal key to the session when it is
created. If the user refreshes, they are shown the personal key that is
saved in the session.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
