### PR TITLE
Add return_to_sp url to USAJobs configuration

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -376,6 +376,7 @@ production:
     redirect_uris:
       - 'https://login.test.usajobs.gov/openid'
       - 'https://login.test.usajobs.gov/externalloggedout'
+    return_to_sp_url: 'https://www.test.usajobs.gov/'
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:UAT':
@@ -385,6 +386,7 @@ production:
     redirect_uris:
       - 'https://login.uat.usajobs.gov/openid'
       - 'https://login.uat.usajobs.gov/externalloggedout'
+    return_to_sp_url: 'https://www.uat.usajobs.gov/'
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:PROD':
@@ -394,6 +396,7 @@ production:
     redirect_uris:
       - 'https://login.usajobs.gov/openid'
       - 'https://login.usajobs.gov/externalloggedout'
+    return_to_sp_url:  'https://www.usajobs.gov/'
     restrict_to_deploy_env: 'prod'
 
   # NGA NSG Open Mapping Enclave (NOME)


### PR DESCRIPTION
**Why**: So that we have a url to point users to when they are visiting
the SP for reasons outside of auth (e.g. clicking a link in their event
history).

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
