### PR TITLE
Key confirmation button should be on top in mobile

### DIFF
--- a/app/views/shared/_personal_key_confirmation_modal.html.slim
+++ b/app/views/shared/_personal_key_confirmation_modal.html.slim
@@ -12,12 +12,15 @@
         = hidden_field_tag :authenticity_token, form_authenticity_token
 
         .clearfix.mxn2
+          .col.col-12.sm-col-6.px2.mb2.sm-mb0.sm-hide
+            button(type='submit' class='col-12 btn btn-primary personal-key-confirm')
+              = t('forms.buttons.continue')
           .col.col-12.sm-col-6.px2
             button.col-12.btn.btn-outline.blue.rounded-lg(
               type="button"
               data-dismiss="personal-key-confirm"
             )
               = t('forms.buttons.back')
-          .col.col-12.sm-col-6.px2.mb2.sm-mb0
+          .col.col-12.sm-col-6.px2.mb2.sm-mb0.sm-show
             button(type='submit' class='col-12 btn btn-primary personal-key-confirm')
               = t('forms.buttons.continue')

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -89,6 +89,34 @@ feature 'View personal key' do
 
       expect(current_path).to eq account_path
     end
+
+    it 'confirms personal key on mobile' do
+      Capybara.current_session.current_window.resize_to(414, 736)
+      sign_in_and_2fa_user
+      click_button t('account.links.regenerate_personal_key')
+
+      click_acknowledge_personal_key
+
+      expect_confirmation_modal_to_appear_with_first_code_field_in_focus
+
+      press_tab
+
+      expect_continue_button_to_be_in_focus
+
+      click_back_button
+
+      expect_to_be_back_on_manage_personal_key_page_with_continue_button_in_focus
+
+      click_acknowledge_personal_key
+      submit_form_without_entering_the_code
+
+      expect(current_path).not_to eq account_path
+
+      visit manage_personal_key_path
+      acknowledge_and_confirm_personal_key
+
+      expect(current_path).to eq account_path
+    end
   end
 
   it_behaves_like 'csrf error when asking for new personal key', :saml
@@ -129,6 +157,11 @@ end
 def press_shift_tab
   body_element = page.find('body')
   body_element.send_keys %i[shift tab]
+end
+
+def press_tab
+  body_element = page.find('body')
+  body_element.send_keys %i[tab]
 end
 
 def expect_continue_button_to_be_in_focus


### PR DESCRIPTION
**Why**:
On mobile, the continue button for the personal
key modal should be above the back button.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
