### PR TITLE
Confirm user is authed in completions controller

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -2,6 +2,7 @@ module SignUp
   class CompletionsController < ApplicationController
     include SecureHeadersConcern
 
+    before_action :confirm_two_factor_authenticated
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -41,13 +41,13 @@ describe SignUp::CompletionsController do
       subject.session[:sp] = { dog: 'max' }
       get :show
 
-      expect(response).to redirect_to(account_url)
+      expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'requires user with no session to be logged in' do
       get :show
 
-      expect(response).to redirect_to(account_url)
+      expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'requires service provider or identity info in session' do


### PR DESCRIPTION
**Why**: So that the user is redirected properly when visiting the
completions controller with an expired session instead of encountering a
CSRF error

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
