### PR TITLE
Ignore exceptions we don't care about

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -12,4 +12,15 @@ ExceptionNotification.configure do |config|
     error_grouping: true,
     sections: %w[request backtrace session]
   )
+
+  config.ignored_exceptions << 'ActionController::BadRequest'
+  config.ignore_if do |exception, _options|
+    exception.message.start_with?('string contains null byte')
+  end
+  config.ignore_if do |exception, _options|
+    exception.message.start_with?('invalid byte sequence in UTF-8')
+  end
+  config.ignore_if do |exception, _options|
+    exception.code == 21_614 if exception.respond_to?(:code)
+  end
 end


### PR DESCRIPTION
**Why**: To reduce the noise in our exception logs

The last one in the list is the error code that Twilio returns
when someone tries to send an SMS to a landline, or other number
that does not support SMS.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
