### PR TITLE
Don't discard user access keys in SessionEncryptor

### DIFF
--- a/app/services/usps_confirmation_entry.rb
+++ b/app/services/usps_confirmation_entry.rb
@@ -10,7 +10,7 @@ UspsConfirmationEntry = Struct.new(
   :issuer
 ) do
   def self.user_access_key
-    SessionEncryptor.new.duped_user_access_key
+    SessionEncryptor.new.initialized_user_access_key
   end
 
   def self.encryptor

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -21,18 +21,36 @@ describe SessionEncryptor do
     expect(encryptor2.load(encrypted_text)).to eq(payload)
   end
 
-  it 'does not modify the user access key when decrypting a payload encrypted with an old key' do
-    old_encryptor = SessionEncryptor.new
-    old_payload = old_encryptor.dump('asdf' => '1234')
+  it 'encrypts successive payloads with the same encryption key' do
+    first_encryptor = SessionEncryptor.new
+    first_payload = first_encryptor.dump('first' => 'payload 1')
 
-    new_encryptor = SessionEncryptor.new
-    new_payload = new_encryptor.dump('1234' => 'asdf')
-    original_cek = new_encryptor.duped_user_access_key.cek
+    second_encryptor = SessionEncryptor.new
+    second_payload = second_encryptor.dump('second' => 'payload 2')
 
-    expect(new_encryptor.load(old_payload)).to eq('asdf' => '1234')
-    expect(new_encryptor.duped_user_access_key.cek).to eq(original_cek)
+    expect(second_encryptor.load(first_payload)).to eq('first' => 'payload 1')
 
-    expect(new_encryptor.load(new_payload)).to eq('1234' => 'asdf')
+    third_payload = second_encryptor.dump('third' => 'payload 3')
+
+    expect(third_payload.split('.').first).to eq(second_payload.split('.').first)
+    expect(second_encryptor.load(second_payload)).to eq('second' => 'payload 2')
+    expect(second_encryptor.load(third_payload)).to eq('third' => 'payload 3')
+  end
+
+  it 'performs successive operations without remaking user access keys' do
+    encrypted_key_maker = EncryptedKeyMaker.new
+    allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker).at_least(1).times
+
+    expect(encrypted_key_maker).to receive(:make).and_call_original.exactly(2).times
+    expect(encrypted_key_maker).to receive(:unlock).and_call_original.exactly(2).times
+
+    encryptor1 = SessionEncryptor.new
+    encryptor2 = SessionEncryptor.new
+
+    encryptor1.load(encryptor1.dump('asdf' => '1234'))
+    encryptor2.load(encryptor2.dump('asdf' => '1234'))
+    encryptor1.load(encryptor1.dump('qwerty' => '1234'))
+    encryptor2.load(encryptor2.dump('qwerty' => '1234'))
   end
 
   describe '#dump' do


### PR DESCRIPTION
**Why**: The SessionEncryptor memoized an initialized UserAccessKey to
keep from recomputing scrypt hashes, but did not memoize a made or
unlocked access key. The reason for this is that different instances
share user access keys with different encryption keys, and locking
/ unlocking saves a read-only access key. This meant that every time a
session was loaded or saved a KMS operation needed to be invoked to
compute the CEK from the encryption key.

This commit changes the session encryptor to memoize an encryption key,
and memoize a map of decryption keys for encrypting sessions saved by
other instances. This means that the instance only has to call KMS to
compute the CEK for a user access key the first time it encrypts a
session with its key, and the first times it decrypts a session
encrypted with a different instances keys.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
