### PR TITLE
Clarify personal key message is for lost phone

### DIFF
--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -51,6 +51,6 @@ en:
         v: Great!
     personal_key_accent: Write it down or print it out.
     personal_key_html: This is the only way to regain access to your account if you
-      lose your password or phone. %{accent}
+      lose the phone where we send your security code. %{accent}
     registration:
       email: Pick an address you want to use for government communications.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -53,7 +53,7 @@ es:
         v: "¡Muy buena!"
     personal_key_accent: Anótelo o imprímalo.
     personal_key_html: Esta es la única manera de recuperar el acceso a su cuenta
-      si pierde su contraseña o teléfono. %{accent}
+      si pierde el teléfono donde enviamos su código de seguridad. %{accent}
     registration:
       email: Elija una dirección que desee usar para manejar las comunicaciones del
         Gobierno.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -59,7 +59,8 @@ fr:
         v: Excellente!
     personal_key_accent: Notez-la ou imprimez-la.
     personal_key_html: Il s'agit de la seule façon de récupérer l'accès à votre compte
-      si vous perdez votre mot de passe ou votre téléphone. %{accent}
+      si vous perdez le téléphone sur lequel nous envoyons votre code de sécurité.
+      %{accent}
     registration:
       email: Choisissez une adresse que vous souhaitez utiliser pour les communications
         avec le gouvernement.


### PR DESCRIPTION
**Why**:
Current message makes it seem like personal
key is the only way to recover password.
Personal key is for recovering 2 factor device.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
