### PR TITLE
Don't redirect to SP when already signed in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,9 @@ class ApplicationController < ActionController::Base
   def redirect_on_timeout
     return unless params[:timeout]
 
-    flash[:notice] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+    unless current_user
+      flash[:notice] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+    end
     redirect_to url_for(permitted_timeout_params)
   end
 

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -38,7 +38,7 @@ module SignUp
 
     def require_no_authentication
       return unless current_user
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to signed_in_url
     end
 
     def permitted_params

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -16,6 +16,8 @@ describe SignUp::RegistrationsController, devise: true do
     it 'cannot be viewed by signed in users' do
       stub_sign_in
 
+      subject.session[:sp] = { request_url: 'http://test.com' }
+
       get :new
 
       expect(response).to redirect_to account_path


### PR DESCRIPTION
**Why**:
Consider the following scenario:
1. Visit IdP via SP
2. Start account creation in tab 1 up until you enter your email address
3. Click the confirmation link in your email, which will most likely
open a new tab in your browser. Tab 2 is where you will continue your
account creation
4. Go all the way through until the agency handoff page but don't click
Continue just yet
5. Go back to tab 1 and refresh the page. This will call
`SignUp::EmailsController#show`, which will redirect to
`sign_up_email_url` because `session[:email]` is blank. In turn,
the `/sign_up/enter_email` page calls the `require_no_authentication`
callback because we restrict access to that page to users who are not
signed in. If a user who is already signed in tries to visit the
email registration page, we were redirecting them to
`after_sign_in_path_for`, which in this case will be
`sp_session[:request_url]`
6. Go back to tab 2 and click "Continue" on the agency handoff page.
In the case of USAJOBS, this will result in an error because they don't
allow the same request to be made if you're already signed in.

Or this scenario:
1. Visit IdP via SP
2. Right-click on the "Sign in" button and open it in a new tab
3. In the new tab, sign in and 2FA, which will redirect you back to the
SP.
4. Go back to the old tab (which should be on the `sign_up/start` page)
and refresh it. Before the fix in this PR, this would have taken you
back to the SP with an error if the SP is USAJOBS.

**How**:
- Redirect to `signed_in_url` if already signed in and trying to access
pages that are meant for signed out users. This is consistent with
`check_user_needs_redirect` in `Users::SessionsController`.
- To prevent the "For your security, we clear what you entered" flash
message from appearing on the account page, we only display it if a
current user is not present, since that message is only meant for
signed out users due to the automatic page refresh via JS (to prevent
a CSRF error when they try to submit the form after the session has
timed out).

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
