### PR TITLE
Instrument New Relic traces with more useful info.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :decorated_session, :reauthn?, :user_fully_authenticated?
 
+  prepend_before_action :add_new_relic_trace_attributes
   prepend_before_action :session_expires_at
   prepend_before_action :set_locale
   before_action :disable_caching
@@ -62,6 +63,14 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  # These attributes show up in New Relic traces for all requests.
+  # https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes
+  def add_new_relic_trace_attributes
+    ::NewRelic::Agent.add_custom_attributes(
+      amzn_trace_id: request.headers['X-Amzn-Trace-Id']
+    )
+  end
 
   def disable_caching
     response.headers['Cache-Control'] = 'no-store'

--- a/app/controllers/health/abstract_health_controller.rb
+++ b/app/controllers/health/abstract_health_controller.rb
@@ -5,6 +5,11 @@ module Health
     def index
       summary = health_checker.check
 
+      # Add health check summary data to New Relic traces.
+      ::NewRelic::Agent.add_custom_attributes(
+        health_check_summary: summary.as_json
+      )
+
       render json: summary, status: (summary.healthy? ? :ok : :internal_error)
     end
   end

--- a/bin/setup
+++ b/bin/setup
@@ -24,14 +24,14 @@ Dir.chdir APP_ROOT do
   ]
 
   puts "== Copying application.yml =="
-  run "cp config/application.yml.example config/application.yml"
+  run "test -L config/application.yml || cp config/application.yml.example config/application.yml"
 
   puts "== Copying logstash.conf =="
   run "cat logstash.conf.example | sed 's/path_to_repo/#{APP_ROOT.to_s.gsub('/', '\/')}/g' > logstash.conf"
 
   puts "== Copying sample certs and keys =="
-  run "cp keys/saml.key.enc.example keys/saml.key.enc"
-  run "cp certs/saml.crt.example certs/saml.crt"
+  run "test -L keys/saml.key.enc || cp keys/saml.key.enc.example keys/saml.key.enc"
+  run "test -L certs/saml.crt || cp certs/saml.crt.example certs/saml.crt"
 
   if ARGV.shift == "--docker" then
     run 'docker-compose build'


### PR DESCRIPTION
- For all requests, save the request ID generated by the Amazon ALB.
- For health check requests, send the full JSON of the health check
  response to New Relic.

**Why**:

This makes it much easier to correlate requests in New Relic with
requests in the nginx and ALB access logs. It also makes it easier for
us to troubleshoot what happened in any given health check failure.