### PR TITLE
Remove Twilio configs from production config

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -209,10 +209,10 @@ production:
   session_encryption_key: # generate via `rake secret`
   session_timeout_in_minutes: '8'
   state_id_proofing_vendor: 'mock'
-  twilio_numbers: '["9999999999","2222222222"]'
-  twilio_sid: 'sid1'
-  twilio_auth_token: 'token1'
-  twilio_messaging_service_sid: '123abc'
+  twilio_numbers: # Add JSON encoded array of phone numbers
+  twilio_sid: # Twilio SID
+  twilio_auth_token: # Twilio auth token
+  twilio_messaging_service_sid: # Twilio CoPilot SID
   twilio_record_voice: 'false'
   use_kms: 'true'
   usps_confirmation_max_days: '30'


### PR DESCRIPTION
**Why**: So that when the configs in the applicaiton.yml.example are
merged with the live production config, the app will fail to start with
a helpful message when the Twilio configs are not present.

Failure message looks like this:

```
Missing required configuration keys: ["twilio_numbers", "twilio_sid",
"twilio_auth_token", "twilio_messaging_service_sid"]
```

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
