### PR TITLE
Change OTP timestamp column to integer

### DIFF
--- a/db/migrate/20180125230905_change_totp_timestamp_to_integer.rb
+++ b/db/migrate/20180125230905_change_totp_timestamp_to_integer.rb
@@ -1,0 +1,6 @@
+class ChangeTotpTimestampToInteger < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :totp_timestamp, :timestamp
+    add_column :users, :totp_timestamp, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219042656) do
+ActiveRecord::Schema.define(version: 20180125230905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define(version: 20171219042656) do
     t.string "attribute_cost"
     t.text "encrypted_phone"
     t.integer "otp_delivery_preference", default: 0, null: false
-    t.datetime "totp_timestamp"
+    t.integer "totp_timestamp"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true


### PR DESCRIPTION
**Why**: In the `User#authenticate_totp` method in the two factor
authentication gem, the value assigned to `User#totp_timestamp` is an
integer, but the column type was datetime. This meant that the value was
saved as nil, preventing the logic to prevent TOTP re-use from working.

This commit also adds a test to verify that TOTP re-use is not possible.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
