### PR TITLE
Rollback change to session encryptor key caching

### DIFF
--- a/app/services/session_encryptor.rb
+++ b/app/services/session_encryptor.rb
@@ -1,48 +1,35 @@
 class SessionEncryptor
   def initialize
-    @initialized_user_access_key = nil
-    @encryption_user_access_key = nil
-    @decryption_user_access_key_map = {}
+    @user_access_key = reload_user_access_key
+  end
+
+  def duped_user_access_key
+    # Reload if UserAccessKey constant has been reloaded
+    @user_access_key = reload_user_access_key unless @user_access_key.is_a? UserAccessKey
+
+    # Return a clone since encryptor.decrypt mutates this key
+    @user_access_key.dup
   end
 
   def load(value)
-    user_access_key = decryption_user_access_key(value)
-    decrypted = encryptor.decrypt(value, user_access_key)
+    decrypted = encryptor.decrypt(value, duped_user_access_key)
+
     JSON.parse(decrypted, quirks_mode: true).with_indifferent_access
   end
 
   def dump(value)
     plain = JSON.generate(value, quirks_mode: true)
-    encryptor.encrypt(plain, encryption_user_access_key)
-  end
-
-  def initialized_user_access_key
-    # Initialize access key once and share it since scrypt hashes take a long time to calculate
-    # Return a dupe since encryption operations mutate this key
-    return @initialized_user_access_key.dup if @initialized_user_access_key.is_a?(UserAccessKey)
-
-    key = Figaro.env.session_encryption_key
-    @initialized_user_access_key = UserAccessKey.new(password: key, salt: key)
+    encryptor.encrypt(plain, duped_user_access_key)
   end
 
   private
 
-  attr_reader :decryption_user_access_key_map
-
-  def decryption_user_access_key(encrypted_value)
-    encryption_key = encrypted_value.split('.').first
-    existing_user_access_key = decryption_user_access_key_map[encryption_key]
-    return existing_user_access_key if existing_user_access_key.is_a?(UserAccessKey)
-
-    decryption_user_access_key_map[encryption_key] = initialized_user_access_key
-  end
-
-  def encryption_user_access_key
-    return @encryption_user_access_key if @encryption_user_access_key.is_a?(UserAccessKey)
-    @encryption_user_access_key ||= initialized_user_access_key
-  end
-
   def encryptor
     Pii::PasswordEncryptor.new
+  end
+
+  def reload_user_access_key
+    key = Figaro.env.session_encryption_key
+    UserAccessKey.new(password: key, salt: key)
   end
 end

--- a/app/services/usps_confirmation_entry.rb
+++ b/app/services/usps_confirmation_entry.rb
@@ -10,7 +10,7 @@ UspsConfirmationEntry = Struct.new(
   :issuer
 ) do
   def self.user_access_key
-    SessionEncryptor.new.initialized_user_access_key
+    SessionEncryptor.new.duped_user_access_key
   end
 
   def self.encryptor

--- a/spec/services/session_encryptor_spec.rb
+++ b/spec/services/session_encryptor_spec.rb
@@ -21,36 +21,18 @@ describe SessionEncryptor do
     expect(encryptor2.load(encrypted_text)).to eq(payload)
   end
 
-  it 'encrypts successive payloads with the same encryption key' do
-    first_encryptor = SessionEncryptor.new
-    first_payload = first_encryptor.dump('first' => 'payload 1')
+  it 'does not modify the user access key when decrypting a payload encrypted with an old key' do
+    old_encryptor = SessionEncryptor.new
+    old_payload = old_encryptor.dump('asdf' => '1234')
 
-    second_encryptor = SessionEncryptor.new
-    second_payload = second_encryptor.dump('second' => 'payload 2')
+    new_encryptor = SessionEncryptor.new
+    new_payload = new_encryptor.dump('1234' => 'asdf')
+    original_cek = new_encryptor.duped_user_access_key.cek
 
-    expect(second_encryptor.load(first_payload)).to eq('first' => 'payload 1')
+    expect(new_encryptor.load(old_payload)).to eq('asdf' => '1234')
+    expect(new_encryptor.duped_user_access_key.cek).to eq(original_cek)
 
-    third_payload = second_encryptor.dump('third' => 'payload 3')
-
-    expect(third_payload.split('.').first).to eq(second_payload.split('.').first)
-    expect(second_encryptor.load(second_payload)).to eq('second' => 'payload 2')
-    expect(second_encryptor.load(third_payload)).to eq('third' => 'payload 3')
-  end
-
-  it 'performs successive operations without remaking user access keys' do
-    encrypted_key_maker = EncryptedKeyMaker.new
-    allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker).at_least(1).times
-
-    expect(encrypted_key_maker).to receive(:make).and_call_original.exactly(2).times
-    expect(encrypted_key_maker).to receive(:unlock).and_call_original.exactly(2).times
-
-    encryptor1 = SessionEncryptor.new
-    encryptor2 = SessionEncryptor.new
-
-    encryptor1.load(encryptor1.dump('asdf' => '1234'))
-    encryptor2.load(encryptor2.dump('asdf' => '1234'))
-    encryptor1.load(encryptor1.dump('qwerty' => '1234'))
-    encryptor2.load(encryptor2.dump('qwerty' => '1234'))
+    expect(new_encryptor.load(new_payload)).to eq('1234' => 'asdf')
   end
 
   describe '#dump' do


### PR DESCRIPTION
**Why**: This appears to be causing CSRF issues in lower environments.
We should investigate before we roll this out.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
