### PR TITLE
Use Typhoeus adapter instead of Net::HTTP

### DIFF
--- a/.reek
+++ b/.reek
@@ -111,6 +111,7 @@ UtilityFunction:
     - AnalyticsEventJob#perform
     - ApplicationController#default_url_options
     - ApplicationHelper#step_class
+    - NullTwilioClient#http_client
     - PersonalKeyFormatter#regexp
     - SessionTimeoutWarningHelper#frequency
     - SessionTimeoutWarningHelper#start

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'slim-rails'
 gem 'stringex'
 gem 'twilio-ruby'
 gem 'two_factor_authentication'
+gem 'typhoeus'
 gem 'uglifier', '>= 1.3.0'
 gem 'valid_email'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,8 @@ GEM
     equalizer (0.0.11)
     errbase (0.0.3)
     erubi (1.7.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.5)
     exception_notification (4.2.2)
       actionmailer (>= 4.0, < 6)
@@ -636,6 +638,8 @@ GEM
       rails (>= 3.1.1)
       randexp
       rotp (>= 3.2.0)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -784,6 +788,7 @@ DEPENDENCIES
   timecop
   twilio-ruby
   two_factor_authentication
+  typhoeus
   uglifier (>= 1.3.0)
   valid_email
   webmock

--- a/app/services/null_twilio_client.rb
+++ b/app/services/null_twilio_client.rb
@@ -1,4 +1,6 @@
 class NullTwilioClient
+  HttpClient = Struct.new(:adapter)
+
   def messages
     self
   end
@@ -9,5 +11,9 @@ class NullTwilioClient
 
   def create(_params)
     # noop
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,3 +1,5 @@
+require 'typhoeus/adapters/faraday'
+
 class TwilioService
   INVALID_VOICE_NUMBER_ERROR_CODE = 13_224
   SMS_ERROR_CODE = 21_614
@@ -14,6 +16,7 @@ class TwilioService
               else
                 twilio_client
               end
+    @client.http_client.adapter = :typhoeus
   end
 
   def place_call(params = {})

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -9,7 +9,11 @@ describe TwilioService do
     it 'uses NullTwilioClient' do
       TwilioService.telephony_service = Twilio::REST::Client
 
-      expect(NullTwilioClient).to receive(:new)
+      client = instance_double(NullTwilioClient)
+      expect(NullTwilioClient).to receive(:new).and_return(client)
+      http_client = Struct.new(:adapter)
+      expect(client).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:adapter=).with(:typhoeus)
       expect(Twilio::REST::Client).to_not receive(:new)
 
       TwilioService.new
@@ -36,7 +40,11 @@ describe TwilioService do
     end
 
     it 'uses a real Twilio client' do
-      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/)
+      client = instance_double(Twilio::REST::Client)
+      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/).and_return(client)
+      http_client = Struct.new(:adapter)
+      expect(client).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:adapter=).with(:typhoeus)
       TwilioService.new
     end
   end

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -1,5 +1,6 @@
 class FakeSms
   Message = Struct.new(:to, :body, :messaging_service_sid)
+  HttpClient = Struct.new(:adapter)
 
   cattr_accessor :messages
   self.messages = []
@@ -16,5 +17,9 @@ class FakeSms
       opts[:body],
       opts[:messaging_service_sid]
     )
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end

--- a/spec/support/fake_voice_call.rb
+++ b/spec/support/fake_voice_call.rb
@@ -1,4 +1,6 @@
 class FakeVoiceCall
+  HttpClient = Struct.new(:adapter)
+
   cattr_accessor :calls
   self.calls = []
 
@@ -10,5 +12,9 @@ class FakeVoiceCall
 
   def create(opts = {})
     self.class.calls << OpenStruct.new(opts)
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end


### PR DESCRIPTION
**Why**:
- It's more than 4 times faster than Net::HTTP
- Net::HTTP in Ruby < 2.5 has a bug where it doubles the timeout
- We've been seeing occasional timeouts when making Twilio calls.
We'd like to see if Typhoeus will reduce those incidents.

Reference:
https://engineering.wework.com/ruby-users-be-wary-of-net-http-f284747288b2

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
