### PR TITLE
Catch timeout exceptions and return 503

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -95,6 +95,7 @@ class Analytics
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze
   PROFILE_PERSONAL_KEY_CREATE = 'Profile: Created new personal key'.freeze
   RATE_LIMIT_TRIGGERED = 'Rate Limit Triggered'.freeze
+  RESPONSE_TIMED_OUT = 'Response Timed Out'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze

--- a/app/views/pages/page_took_too_long.html.slim
+++ b/app/views/pages/page_took_too_long.html.slim
@@ -1,0 +1,21 @@
+doctype html
+html lang="#{I18n.locale}"
+
+  head
+    meta[name='viewport' content='width=device-width, initial-scale=1.0']
+    title
+      = 'The server took too long to process your request. (503)'
+
+    == stylesheet_link_tag '/css/static.css'
+
+  body
+    .site-wrapper
+      .site-wrapper-inner
+        .cover-container
+          .masthead.clearfix
+            .inner
+              = image_tag asset_url('logo-white.svg'), width: 150, alt: APP_NAME,
+                class: 'masthead-brand'
+          .inner.cover
+            h1 = t('pages.page_took_too_long.header')
+            p = t('pages.page_took_too_long.body')

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,11 +12,13 @@ defaults: &defaults
   timeout: 5000
   reconnect: true
   connect_timeout: 2
-  keepalives_idle: 30
+  keepalives_idle: 10
   keepalives_interval: 10
   keepalives_count: 2
   checkout_timeout: 5
   reaping_frequency: 10
+  variables:
+    statement_timeout: 2500 # ms
 
 development:
   <<: *defaults

--- a/config/locales/pages/en.yml
+++ b/config/locales/pages/en.yml
@@ -4,3 +4,6 @@ en:
     page_not_found:
       body: You might want to double-check your link and try again. (404)
       header: The page you were looking for doesn’t exist.
+    page_took_too_long:
+      body: You might want to wait a few minutes and try again. (503)
+      header: The server took too long to process your request.

--- a/config/locales/pages/es.yml
+++ b/config/locales/pages/es.yml
@@ -4,3 +4,7 @@ es:
     page_not_found:
       body: Es posible que desee comprobar su enlace e intentar nuevamente. (404)
       header: La página que buscaba no existe.
+    page_took_too_long:
+      body: Por favor, es posible que desee esperar unos minutos y vuelva a intentarlo.
+        (503)
+      header: El sistema de información tomó demasiado tiempo procesar su solicitud.

--- a/config/locales/pages/fr.yml
+++ b/config/locales/pages/fr.yml
@@ -4,3 +4,6 @@ fr:
     page_not_found:
       body: Vous pouvez revérifier votre lien et essayer de nouveau. (404)
       header: La page que vous recherchez n'existe pas.
+    page_took_too_long:
+      body: Veuillez réessayer dans quelques minutes. (503)
+      header: Le système d'information a pris trop de temps à traiter votre demande.

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,31 @@ describe ApplicationController do
     end
   end
 
+  #
+  # We don't test *every* exception we try to capture since we handle all such exceptions the same
+  # way. This test doesn't ensure we have the right set of exceptions caught, but that, if caught,
+  # we handle the exception with the proper response.
+  #
+  describe 'handling RequestTimeoutException exceptions' do
+    controller do
+      def index
+        raise Rack::Timeout::RequestTimeoutException, {}
+      end
+    end
+
+    it 'returns a proper status' do
+      get :index
+
+      expect(response.status).to eq 503
+    end
+
+    it 'returns an html page' do
+      get :index
+
+      expect(response.content_type).to eq 'text/html'
+    end
+  end
+
   describe 'handling InvalidAuthenticityToken exceptions' do
     controller do
       def index


### PR DESCRIPTION
**Why**:
- Even with the database timeout settings, there are edge cases that cause the connection to RDS to hang around too long after RDS has gone away (e.g., when the master changes).
- When a request does time out, we want to handle it gracefully rather than the default content returned by an ALB/ELB.

**How**:
- We decrease the time to first keepalive so that we can (hopefully) catch dead connections before the web request times out. This timeout is at the ALB/ELB and the Rack::Timeout level.
- We catch timeout errors so we can return a useful page letting the user know that the request was taking too long.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [X] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [X] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [X] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [X] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [X] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [X] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [X] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [X] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
