### PR TITLE
Move from SP-based UUIDs to agency-based UUIDs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,9 @@ read, not written.
 - [ ] For encryption changes, make sure it is compatible with data that was
 encrypted with the old code.
 
+- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
+new configs in **all** environments. 
+
 - [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
 they are false positives. If you're not sure how to fix the offense, please
 ask a teammate.

--- a/.reek
+++ b/.reek
@@ -111,6 +111,7 @@ UtilityFunction:
     - AnalyticsEventJob#perform
     - ApplicationController#default_url_options
     - ApplicationHelper#step_class
+    - NullTwilioClient#http_client
     - PersonalKeyFormatter#regexp
     - SessionTimeoutWarningHelper#frequency
     - SessionTimeoutWarningHelper#start

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem 'rails', '~> 5.1.3'
 
 gem 'ahoy_matey'
 gem 'american_date'
-gem 'aws-sdk-core'
+gem 'aws-sdk-kms', '~> 1.4'
+gem 'aws-sdk-ses', '~> 1.6'
 gem 'base32-crockford'
 gem 'browserify-rails'
 gem 'device_detector'
@@ -53,6 +54,7 @@ gem 'slim-rails'
 gem 'stringex'
 gem 'twilio-ruby'
 gem 'two_factor_authentication'
+gem 'typhoeus'
 gem 'uglifier', '>= 1.3.0'
 gem 'valid_email'
 gem 'whenever', require: false
@@ -116,7 +118,7 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v1.0.0'
+  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v1.0.2'
   gem 'equifax', git: 'git@github.com:18F/identity-equifax-api-client-gem.git', tag: 'v1.1.0'
   gem 'mandrill_dm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:18F/identity-aamva-api-client-gem
-  revision: 2ede830efe106e8b1ec63d323dd14e681b1bca5a
-  tag: v1.0.0
+  revision: 4239d0acb76637710e6f0cce8c1c32483fe01921
+  tag: v1.0.2
   specs:
     aamva (0.1.0)
       dotenv
@@ -24,11 +24,11 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-hostdata.git
-  revision: e8f7a1a571722c737b5372db9412639a5580313a
+  revision: 4340185470fdf07c5d06658c2aa5ce6c904bb898
   branch: master
   specs:
     identity-hostdata (0.3.2)
-      aws-sdk-core (~> 2.10.23)
+      aws-sdk-s3 (~> 1.8)
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
@@ -126,10 +126,22 @@ GEM
       nokogiri
     american_date (1.1.1)
     arel (8.0.0)
-    ast (2.3.0)
-    aws-sdk-core (2.10.52)
+    ast (2.4.0)
+    aws-partitions (1.56.0)
+    aws-sdk-core (3.14.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
+    aws-sdk-kms (1.4.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.8.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-ses (1.6.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
     axe-matchers (1.3.4)
       dumb_delegator (~> 0.8)
@@ -141,23 +153,23 @@ GEM
     base32-crockford (0.1.0)
     bcrypt (3.1.11)
     benchmark-ips (2.7.2)
-    better_errors (2.3.0)
+    better_errors (2.4.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bindata (2.4.0)
-    binding_of_caller (0.7.2)
+    bindata (2.4.2)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    brakeman (3.7.2)
+    brakeman (4.1.1)
     browser (2.4.0)
     browserify-rails (4.2.0)
       addressable (>= 2.4.0)
       railties (>= 4.0.0, < 5.2)
       sprockets (>= 3.6.0)
     builder (3.2.3)
-    bullet (5.6.1)
+    bullet (5.7.2)
       activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.10.0)
+      uniform_notifier (~> 1.11.0)
     bummr (0.2.1)
       rainbow
       thor
@@ -181,14 +193,14 @@ GEM
     capistrano-sidekiq (0.10.0)
       capistrano
       sidekiq (>= 3.4)
-    capybara (2.15.1)
+    capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    childprocess (0.7.1)
+      xpath (>= 2.0, < 4.0)
+    childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
     chronic (0.10.2)
@@ -210,11 +222,12 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.3)
     css_parser (1.6.0)
       addressable
     daemons (1.2.4)
-    database_cleaner (1.6.1)
-    debug_inspector (0.0.2)
+    database_cleaner (1.6.2)
+    debug_inspector (0.0.3)
     derailed (0.1.0)
       derailed_benchmarks
     derailed_benchmarks (1.3.2)
@@ -228,7 +241,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.0)
-    devise (4.3.0)
+    devise (4.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.2)
@@ -241,8 +254,7 @@ GEM
       actionpack (>= 4)
       i18n
     dumb_delegator (0.8.0)
-    easy_translate (0.5.0)
-      json
+    easy_translate (0.5.1)
       thread
       thread_safe
     email_spec (2.1.1)
@@ -252,7 +264,9 @@ GEM
     encryptor (3.0.0)
     equalizer (0.0.11)
     errbase (0.0.3)
-    erubi (1.6.1)
+    erubi (1.7.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.5)
     exception_notification (4.2.2)
       actionmailer (>= 4.0, < 6)
@@ -264,14 +278,14 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
-    fakefs (0.11.2)
-    faker (1.8.4)
-      i18n (~> 0.5)
-    faraday (0.13.1)
+    fakefs (0.13.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    fasterer (0.3.2)
+    fasterer (0.4.0)
       colorize (~> 0.7)
-      ruby_parser (~> 3.7)
+      ruby_parser (~> 3.9)
     ffi (1.9.18)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -303,7 +317,7 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (0.3.7)
-    hashie (3.5.6)
+    hashie (3.5.7)
     heapy (0.1.2)
     highline (1.7.10)
     hiredis (0.6.1)
@@ -314,12 +328,12 @@ GEM
     httpi (2.4.2)
       rack
       socksify
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.19)
+    i18n-tasks (0.9.20)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
-      easy_translate (>= 0.5.0)
+      easy_translate (>= 0.5.1)
       erubi
       highline (>= 1.7.3)
       i18n
@@ -330,7 +344,7 @@ GEM
     iniparse (1.4.4)
     jmespath (1.3.1)
     json (1.8.6)
-    json-jwt (1.8.0)
+    json-jwt (1.8.3)
       activesupport
       bindata
       securecompare
@@ -343,12 +357,13 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     logger (1.2.8)
-    lograge (0.7.1)
-      actionpack (>= 4, < 5.2)
-      activesupport (>= 4, < 5.2)
-      railties (>= 4, < 5.2)
+    lograge (0.9.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.11)
     macaddr (1.7.1)
@@ -363,9 +378,9 @@ GEM
       mandrill-api (~> 1.0.53)
     memory_profiler (0.9.8)
     method_source (0.9.0)
-    mini_mime (0.1.3)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.0)
@@ -375,28 +390,28 @@ GEM
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    newrelic_rpm (4.6.0.338)
+    newrelic_rpm (4.8.0.341)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    overcommit (0.41.0)
+    overcommit (0.42.0)
       childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
-    parallel (1.12.0)
+    parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
-    phonelib (0.6.17)
+    phonelib (0.6.18)
     phony (2.15.44)
     phony_rails (0.14.6)
       activesupport (>= 3.0)
       phony (> 2.15)
-    poltergeist (1.16.0)
+    poltergeist (1.17.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -415,7 +430,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.1)
-    rack (2.0.3)
+    rack (2.0.4)
     rack-attack (5.0.1)
       rack
     rack-cors (1.0.2)
@@ -424,7 +439,7 @@ GEM
       rack (>= 1.2.0)
     rack-protection (2.0.0)
       rack
-    rack-test (0.7.0)
+    rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rack-timeout (0.4.2)
     rack_session_access (0.1.1)
@@ -465,12 +480,12 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.1.0)
+    rake (12.3.0)
     randexp (0.1.7)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    readthis (2.1.0)
+    readthis (2.2.0)
       connection_pool (~> 2.1)
       redis (>= 3.0, < 5.0)
     redis (3.3.5)
@@ -479,7 +494,8 @@ GEM
       parser (>= 2.4.0.0, < 2.5)
       rainbow (~> 2.0)
     referer-parser (0.3.0)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -507,16 +523,16 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.51.0)
+    rubocop (0.52.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.9.0)
-    ruby-saml (1.6.0)
+    ruby-saml (1.6.1)
       nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
     ruby_parser (3.10.1)
@@ -535,12 +551,12 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    savon (2.11.2)
+    savon (2.12.0)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
       httpi (~> 2.3)
-      nokogiri (>= 1.4.0)
+      nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
     scrypt (3.0.5)
@@ -593,7 +609,7 @@ GEM
     sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stringex (2.7.1)
+    stringex (2.8.2)
     sysexits (1.2.0)
     systemu (2.6.5)
     teaspoon (1.1.5)
@@ -612,7 +628,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    twilio-ruby (5.5.0)
+    twilio-ruby (5.6.2)
       faraday (~> 0.9)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)
@@ -622,12 +638,14 @@ GEM
       rails (>= 3.1.1)
       randexp
       rotp (>= 3.2.0)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
-    uniform_notifier (1.10.0)
+    uniform_notifier (1.11.0)
     url_safe_base64 (0.2.2)
     user_agent_parser (2.3.1)
     useragent (0.16.8)
@@ -647,13 +665,13 @@ GEM
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
-    webmock (3.1.1)
+    webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
@@ -666,8 +684,8 @@ GEM
       xmlmapper (~> 0.6)
     xmlmapper (0.7.2)
       nokogiri (~> 1.5)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
     zonebie (0.6.1)
     zxcvbn-js (4.4.3)
       execjs
@@ -679,7 +697,8 @@ DEPENDENCIES
   aamva!
   ahoy_matey
   american_date
-  aws-sdk-core
+  aws-sdk-kms (~> 1.4)
+  aws-sdk-ses (~> 1.6)
   axe-matchers
   base32-crockford
   better_errors
@@ -769,6 +788,7 @@ DEPENDENCIES
   timecop
   twilio-ruby
   two_factor_authentication
+  typhoeus
   uglifier (>= 1.3.0)
   valid_email
   webmock

--- a/app/assets/images/get-started/ID.svg
+++ b/app/assets/images/get-started/ID.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>ID number</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="90.59375%" y1="91%" x2="32.684375%" y2="32.51375%" id="linearGradient-1">
+            <stop stop-color="#00BFE7" offset="0%"></stop>
+            <stop stop-color="#99D7F4" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="55.3860784%" y1="54.9103149%" x2="100%" y2="113.713732%" id="linearGradient-2">
+            <stop stop-color="#4398BF" offset="0%"></stop>
+            <stop stop-color="#D8D8D8" stop-opacity="0" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Element/ID-number" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="ID-number">
+            <g id="Doc_2">
+                <g id="Background" fill-rule="nonzero">
+                    <rect id="Rectangle-path" fill="url(#linearGradient-1)" x="0" y="0" width="40" height="40" rx="3.33333333"></rect>
+                    <path d="M40,14.4888316 L40,36.6666667 C40,38.5076158 38.5076158,40 36.6666667,40 L14.3877883,40 L6.55009138,32.3376925 L34.7583232,7.63032779 L40,14.4888316 Z" id="Combined-Shape" fill="url(#linearGradient-2)"></path>
+                    <circle id="Oval" fill="#112E51" cx="36.25" cy="36.25" r="1.25"></circle>
+                    <circle id="Oval" fill="#112E51" cx="3.75" cy="36.25" r="1.25"></circle>
+                    <circle id="Oval" fill="#112E51" cx="36.25" cy="3.75" r="1.25"></circle>
+                    <circle id="Oval" fill="#112E51" cx="3.75" cy="3.75" r="1.25"></circle>
+                </g>
+                <rect id="Rectangle" stroke="#112E51" stroke-width="1.66666667" fill="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" x="6.25" y="7.5" width="28.3333333" height="24.5833333" rx="1.66666667"></rect>
+                <g id="Text-lines" transform="translate(19.166667, 14.166667)" fill="#112E51" fill-rule="nonzero">
+                    <rect id="Rectangle-path" x="0.395833333" y="0.0708333333" width="7.91666667" height="1" rx="0.208333333"></rect>
+                    <rect id="Rectangle-path" x="0.395833333" y="1.65833333" width="9.16666667" height="1" rx="0.208333333"></rect>
+                    <rect id="Rectangle-path" x="0.395833333" y="3.24583333" width="4.58333333" height="1" rx="0.208333333"></rect>
+                </g>
+                <g id="Text-lines-Copy" transform="translate(19.166667, 20.000000)" fill="#112E51" fill-rule="nonzero">
+                    <rect id="Rectangle-path" x="0.395833333" y="0.0708333333" width="9.58333333" height="1" rx="0.208333333"></rect>
+                    <rect id="Rectangle-path" x="0.395833333" y="1.65833333" width="11.2708333" height="1" rx="0.208333333"></rect>
+                    <rect id="Rectangle-path" x="0.395833333" y="3.24583333" width="4.58333333" height="1" rx="0.208333333"></rect>
+                </g>
+                <path d="M8.54166667,10 L32.2916667,10 C32.406726,10 32.5,10.093274 32.5,10.2083333 L32.5,11.4583333 C32.5,11.5733927 32.406726,11.6666667 32.2916667,11.6666667 L8.54166667,11.6666667 C8.42660734,11.6666667 8.33333333,11.5733927 8.33333333,11.4583333 L8.33333333,10.2083333 C8.33333333,10.093274 8.42660734,10 8.54166667,10 Z" id="Rectangle-path-Copy" fill="#112E51" fill-rule="nonzero"></path>
+                <path d="M8.54166667,26.6666667 L32.2916667,26.6666667 C32.406726,26.6666667 32.5,26.7599407 32.5,26.875 L32.5,27.2916667 C32.5,27.406726 32.406726,27.5 32.2916667,27.5 L8.54166667,27.5 C8.42660734,27.5 8.33333333,27.406726 8.33333333,27.2916667 L8.33333333,26.875 C8.33333333,26.7599407 8.42660734,26.6666667 8.54166667,26.6666667 Z" id="Rectangle-path-Copy-2" fill="#112E51" fill-rule="nonzero"></path>
+                <circle id="Oval-Copy" fill="#00BFE7" fill-rule="nonzero" cx="28.3333333" cy="27.0833333" r="2.91666667"></circle>
+                <path d="M16.9129391,21.8791667 C15.4296058,21.25 13.7879391,20.4666667 13.6462725,19.9791667 L13.6462725,19.4666667 C13.9838396,19.06255 14.2208675,18.5842105 14.3379391,18.0708333 C14.6954886,17.77193 14.7593216,17.2466757 14.4837725,16.8708333 L14.4837725,15.7416667 C14.4837725,14.5583333 13.8837725,13.75 12.5171058,13.75 C11.1504391,13.75 10.5546058,14.5416667 10.5546058,15.7416667 L10.5546058,16.8875 C10.2790567,17.2633424 10.3428897,17.7885967 10.7004391,18.0875 C10.8175107,18.6008772 11.0545386,19.0792166 11.3921058,19.4833333 L11.3921058,19.9958333 C11.2546058,20.4833333 9.60877246,21.2458333 8.12543912,21.8958333 C7.99448966,21.9584476 7.91280252,22.0924145 7.91710579,22.2375 L7.91710579,23.5166667 C7.90762952,23.7062042 8.05266199,23.8679712 8.24210579,23.8791667 L16.7962725,23.8791667 C16.9857163,23.8679712 17.1307487,23.7062042 17.1212725,23.5166667 L17.1212725,22.2208333 C17.1255757,22.0757479 17.0438886,21.941781 16.9129391,21.8791667 Z" id="Shape" fill="#112E51" fill-rule="nonzero"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -48,7 +48,12 @@ module SamlIdpLogoutConcern
   end
 
   def sp_slo_identity
-    @_sp_slo_identity ||= Identity.includes(:user).find_by(uuid: name_id)
+    identity = if FeatureManagement.enable_agency_based_uuids?
+                 AgencyIdentityLinker.sp_identity_from_uuid(name_id)
+               else
+                 Identity.includes(:user).find_by(uuid: name_id)
+               end
+    @_sp_slo_identity ||= identity
   end
 
   def name_id

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -202,7 +202,6 @@ module TwoFactorAuthenticatable
 
   def after_otp_action_url
     if decorated_user.should_acknowledge_personal_key?(user_session)
-      user_session[:first_time_personal_key_view] = 'true'
       sign_up_personal_key_url
     elsif @updating_existing_number
       account_url

--- a/app/controllers/health/abstract_health_controller.rb
+++ b/app/controllers/health/abstract_health_controller.rb
@@ -5,6 +5,11 @@ module Health
     def index
       summary = health_checker.check
 
+      # Add health check summary data to New Relic traces.
+      ::NewRelic::Agent.add_custom_attributes(
+        health_check_summary: summary.as_json
+      )
+
       render json: summary, status: (summary.healthy? ? :ok : :internal_error)
     end
   end

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -38,7 +38,7 @@ module SignUp
 
     def require_no_authentication
       return unless current_user
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to signed_in_url
     end
 
     def permitted_params

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,0 +1,3 @@
+class Agency < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/models/agency_identity.rb
+++ b/app/models/agency_identity.rb
@@ -1,0 +1,5 @@
+class AgencyIdentity < ApplicationRecord
+  belongs_to :user
+  belongs_to :agency
+  validates :uuid, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   end
 
   def confirmation_period_expired?
-    confirmation_sent_at && confirmation_sent_at.utc <= self.class.confirm_within.ago
+    confirmation_sent_at.present? && confirmation_sent_at.utc <= self.class.confirm_within.ago
   end
 
   def first_identity

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -9,7 +9,7 @@ class OpenidConnectUserInfoPresenter
 
   def user_info
     info = {
-      sub: identity.uuid,
+      sub: uuid_from_sp_identity(identity),
       iss: root_url,
       email: identity.user.email,
       email_verified: true,
@@ -19,6 +19,14 @@ class OpenidConnectUserInfoPresenter
   end
 
   private
+
+  def uuid_from_sp_identity(identity)
+    if FeatureManagement.enable_agency_based_uuids?
+      AgencyIdentityLinker.new(identity).link_identity.uuid
+    else
+      identity.uuid
+    end
+  end
 
   # rubocop:disable Metrics/AbcSize
   def loa3_attributes

--- a/app/services/agency_identity_linker.rb
+++ b/app/services/agency_identity_linker.rb
@@ -1,0 +1,49 @@
+class AgencyIdentityLinker
+  def initialize(sp_identity)
+    @sp_identity = sp_identity
+    @agency_id = nil
+  end
+
+  def link_identity
+    ai = agency_identity_from_sp_identity
+    return ai if ai
+    create_agency_identity_for_sp || AgencyIdentity.new(user_id: @sp_identity.user_id,
+                                                        uuid: @sp_identity.uuid)
+  end
+
+  def self.sp_identity_from_uuid_and_sp(uuid, service_provider)
+    agency_identity = AgencyIdentity.where(uuid: uuid).first
+    criteria = if agency_identity
+                 { user_id: agency_identity.user_id, service_provider: service_provider }
+               else
+                 { uuid: uuid, service_provider: service_provider }
+               end
+    Identity.where(criteria).first
+  end
+
+  def self.sp_identity_from_uuid(uuid)
+    agency_identity = AgencyIdentity.where(uuid: uuid).first
+    return Identity.where(uuid: uuid).first if agency_identity.nil?
+    service_provider = ServiceProvider.where(agency_id: agency_identity.agency_id).first
+    return unless service_provider
+    sp_identity_from_uuid_and_sp(agency_identity.uuid, service_provider.issuer)
+  end
+
+  private
+
+  def create_agency_identity_for_sp
+    return unless @agency_id
+    AgencyIdentity.create(agency_id: @agency_id,
+                          user_id: @sp_identity.user_id,
+                          uuid: @sp_identity.uuid)
+  end
+
+  def agency_identity_from_sp_identity
+    agency_identity = AgencyIdentity.where(uuid: @sp_identity.uuid).first
+    return agency_identity unless agency_identity.nil?
+    sp = ServiceProvider.where(issuer: @sp_identity.service_provider).first
+    @agency_id = sp&.agency_id
+    return unless @agency_id
+    AgencyIdentity.where(agency_id: @agency_id, user_id: @sp_identity.user_id).first
+  end
+end

--- a/app/services/agency_seeder.rb
+++ b/app/services/agency_seeder.rb
@@ -1,0 +1,27 @@
+# Update Agency from config/agencies.yml (all environments in rake db:seed)
+class AgencySeeder
+  def initialize(rails_env: Rails.env, deploy_env: LoginGov::Hostdata.env)
+    @rails_env = rails_env
+    @deploy_env = deploy_env
+  end
+
+  def run
+    agencies.each do |agency_id, config|
+      agency = Agency.find_by(id: agency_id)
+      if agency
+        agency.update!(config)
+      else
+        Agency.create!(config.merge(id: agency_id))
+      end
+    end
+  end
+
+  private
+
+  attr_reader :rails_env, :deploy_env
+
+  def agencies
+    content = ERB.new(Rails.root.join('config', 'agencies.yml').read).result
+    YAML.safe_load(content).fetch(rails_env, {})
+  end
+end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -51,7 +51,14 @@ class AttributeAsserter
   end
 
   def uuid_getter_function
-    ->(principal) { principal.decorate.active_identity_for(service_provider).uuid }
+    lambda do |principal|
+      identity = principal.decorate.active_identity_for(service_provider)
+      if FeatureManagement.enable_agency_based_uuids?
+        AgencyIdentityLinker.new(identity).link_identity.uuid
+      else
+        identity.uuid
+      end
+    end
   end
 
   def verified_at_getter_function

--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -84,9 +84,8 @@ class EncryptedKeyMaker
 
   def aws_client
     @_aws_client ||= Aws::KMS::Client.new(
-      region: Figaro.env.aws_region,
       instance_profile_credentials_timeout: 1, # defaults to 1 second
-      instance_profile_credentials_retries: 5 # defaults to 0 retries
+      instance_profile_credentials_retries: 5, # defaults to 0 retries
     )
   end
 

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -9,6 +9,7 @@ class IdentityLinker
   def link_identity(**extra_attrs)
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
+    AgencyIdentityLinker.new(identity).link_identity if FeatureManagement.enable_agency_based_uuids?
     identity
   end
 

--- a/app/services/link_agency_identities.rb
+++ b/app/services/link_agency_identities.rb
@@ -1,0 +1,42 @@
+class LinkAgencyIdentities
+  AGENCY_INFO = Struct.new(:issuer, :priority, :agency_id)
+
+  def link
+    sps = sps_to_link
+    sps.sort! { |spa, spb| spa.priority <=> spb.priority }
+    sps.each { |sp| link_service_provider(sp.agency_id, sp.issuer) }
+  end
+
+  private
+
+  def sps_to_link
+    sps = []
+    service_providers.each do |issuer, config|
+      priority, agency_id = agency_info(config)
+      sps << AGENCY_INFO.new(issuer, priority, agency_id) if priority && agency_id
+    end
+    sps
+  end
+
+  def agency_info(config)
+    [config['uuid_priority'], config['agency_id']]
+  end
+
+  def link_service_provider(agency_id, service_provider)
+    linker_sql = <<~SQL
+      INSERT INTO agency_identities (user_id,agency_id,uuid)
+      SELECT user_id,%d,max(uuid)
+      FROM identities
+      WHERE service_provider='%s'
+      AND user_id NOT IN (SELECT user_id FROM agency_identities WHERE agency_id=%d)
+      GROUP BY user_id
+    SQL
+    sql = format(linker_sql, agency_id, service_provider, agency_id)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def service_providers
+    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
+    YAML.safe_load(content).fetch(Rails.env, {})
+  end
+end

--- a/app/services/null_twilio_client.rb
+++ b/app/services/null_twilio_client.rb
@@ -1,4 +1,6 @@
 class NullTwilioClient
+  HttpClient = Struct.new(:adapter)
+
   def messages
     self
   end
@@ -9,5 +11,9 @@ class NullTwilioClient
 
   def create(_params)
     # noop
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -1,25 +1,22 @@
 class PhoneNumberCapabilities
   VOICE_UNSUPPORTED_US_AREA_CODES = {
-    '648' => 'American Samoa',
     '264' => 'Anguilla',
     '268' => 'Antigua and Barbuda',
+    '242' => 'Bahamas',
     '246' => 'Barbados',
     '441' => 'Bermuda',
+    '284' => 'British Virgin Islands',
     '345' => 'Cayman Islands',
     '767' => 'Dominica',
     '809' => 'Dominican Republic',
     '473' => 'Grenada',
-    '671' => 'Guam',
     '876' => 'Jamaica',
     '664' => 'Montserrat',
-    '670' => 'Northern Mariana Islands',
     '869' => 'Saint Kitts and Nevis',
     '758' => 'Saint Lucia',
     '784' => 'Saint Vincent Grenadines',
     '868' => 'Trinidad and Tobago',
     '649' => 'Turks and Caicos Islands',
-    '284' => 'British Virgin Islands',
-    '340' => 'United States Virgin Islands',
   }.freeze
 
   INTERNATIONAL_CODES = YAML.load_file(

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -13,7 +13,7 @@ class ServiceProviderSeeder
         sp.approved = true
         sp.active = true
         sp.native = true
-      end.update!(config.except('restrict_to_deploy_env'))
+      end.update!(config.except('restrict_to_deploy_env', 'uuid_priority'))
     end
   end
 

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,3 +1,5 @@
+require 'typhoeus/adapters/faraday'
+
 class TwilioService
   INVALID_VOICE_NUMBER_ERROR_CODE = 13_224
   SMS_ERROR_CODE = 21_614
@@ -14,6 +16,7 @@ class TwilioService
               else
                 twilio_client
               end
+    @client.http_client.adapter = :typhoeus
   end
 
   def place_call(params = {})
@@ -30,12 +33,12 @@ class TwilioService
     end
   end
 
-  def account
-    @account ||= random_account
+  def phone_number
+    @phone_number ||= random_phone_number
   end
 
   def from_number
-    "+1#{account['number']}"
+    "+1#{phone_number}"
   end
 
   private
@@ -44,13 +47,13 @@ class TwilioService
 
   def twilio_client
     telephony_service.new(
-      account['sid'],
-      account['auth_token']
+      TWILIO_SID,
+      TWILIO_AUTH_TOKEN
     )
   end
 
-  def random_account
-    TWILIO_ACCOUNTS.sample
+  def random_phone_number
+    TWILIO_NUMBERS.sample
   end
 
   def sanitize_errors

--- a/app/views/sign_up/registrations/_required_pii_accordion.html.slim
+++ b/app/views/sign_up/registrations/_required_pii_accordion.html.slim
@@ -1,31 +1,33 @@
-.mt4
+p.clearfix
+  = image_tag(asset_url('get-started/ID.svg'),
+          size: '40', alt: '', class: 'mt-tiny col col-1')
+  span.col.col-11.pl2 = t('idv.index.id.need_html')
+
+.mt2
   = accordion('you-will-need', t('devise.registrations.start.accordion')) do
-    .clearfix
-      .col.col-1.center
-        = image_tag(asset_url('get-started/email-password.svg'),
-          size: '40', alt: '', class: 'mt1')
-      .col.col-11.pl2
-        p.mb3 = t('devise.registrations.start.bullet_1_html')
-    .clearfix
-      .col.col-1.center
-        = image_tag(asset_url('get-started/2FA.svg'), size: '40', alt: '', class: 'mt1')
-      .col.col-11.pl2
-        p.mb3 = t('devise.registrations.start.bullet_2_html')
-    .clearfix
-      .col.col-1.center
-        = image_tag(asset_url('get-started/personal-details.svg'),
-          size: '40', alt: '', class: 'mt1')
-      .col.col-11.pl2
-        p.mb3 = t('devise.registrations.start.bullet_3_html')
-    .clearfix
-      .col.col-1.center
-        = image_tag(asset_url('get-started/financial.svg'), size: '40', alt: '', class: 'mt1')
-      .col.col-11.pl2
-        p.mb3 = t('devise.registrations.start.bullet_4_html')
-    .clearfix
-      .col.col-1.center
-        = image_tag(asset_url('p-key.svg'), size: '40', alt: '', class: 'mt1')
-      .col.col-11.pl2
-        p.mb2 = t('devise.registrations.start.bullet_5_html')
-        p.mb3 = link_to \
-          t('devise.registrations.start.learn_more'), MarketingSite.help_url, target: '_blank'
+    p.clearfix
+      = image_tag(asset_url('get-started/email-password.svg'),
+          size: '40', alt: '', class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_1_html')
+    p.clearfix
+      = image_tag(asset_url('get-started/2FA.svg'), size: '40', alt: '',
+        class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_2_html')
+    p.clearfix
+      = image_tag(asset_url('get-started/personal-details.svg'),
+          size: '40', alt: '', class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_3_html')
+    p.clearfix
+      = image_tag(asset_url('get-started/personal-details.svg'),
+          size: '40', alt: '', class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_4_html')
+    p.clearfix
+      = image_tag(asset_url('get-started/financial.svg'),
+        size: '40', alt: '', class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_5_html')
+    p.clearfix
+      = image_tag(asset_url('p-key.svg'), size: '40', alt: '', class: 'mt-tiny col col-1')
+      span.col.col-11.pl2 = t('devise.registrations.start.bullet_6_html')
+    p.mb3 = link_to t('devise.registrations.start.learn_more'),
+      MarketingSite.help_url,
+      target: '_blank'

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -1,14 +1,13 @@
 - title t('titles.registrations.new')
 
 h1.h3.my0 = t('headings.registrations.enter_email')
-p.mt-tiny.mb0#email-description = t('instructions.registration.email')
+
 = simple_form_for(@register_user_email_form,
     html: { autocomplete: 'off', role: 'form' },
     url: sign_up_register_path) do |f|
-  = f.input :email, label: t('forms.registration.labels.email'), required: true,
-            input_html: { 'aria-describedby' => 'email-description' }
+  = f.input :email, label: t('forms.registration.labels.email'), required: true
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }
-  p.mb-40p.mt1
+  p.mt1
     = link_to t('notices.terms_of_service.link'), MarketingSite.privacy_url, target: '_blank'
 
   = f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide'

--- a/app/views/sign_up/registrations/show.html.slim
+++ b/app/views/sign_up/registrations/show.html.slim
@@ -1,19 +1,20 @@
 - title t('titles.registrations.start')
 
-.sm-px3.mb0.center
-  = image_tag(asset_url('user-access.svg'), width: '352', alt: '')
+.center
+  = image_tag(asset_url('user-access.svg'), width: '280', alt: '')
 
   = render decorated_session.registration_heading
 
   = render 'shared/sp_alert'
 
-  = link_to t('sign_up.registrations.create_account'),
-    sign_up_email_path(request_id: params[:request_id]),
-    class: 'sm-col-10 col-12 btn btn-primary btn-wide mb2 fs-20p'
+  .sm-px4
+    = link_to t('sign_up.registrations.create_account'),
+      sign_up_email_path(request_id: params[:request_id]),
+      class: 'sm-col-10 col-12 btn btn-primary btn-wide mb2 fs-20p'
 
-  = link_to t('links.sign_in'),
-    new_user_session_path(request_id: params[:request_id]),
-    class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb1 fs-20p'
+    = link_to t('links.sign_in'),
+      new_user_session_path(request_id: params[:request_id]),
+      class: 'sm-col-10 col-12 btn btn-secondary btn-wide mb1 fs-20p'
 
   = render decorated_session.return_to_sp_from_start_page_partial
 

--- a/app/views/users/verify_password/new.html.slim
+++ b/app/views/users/verify_password/new.html.slim
@@ -1,6 +1,6 @@
 - title t('idv.titles.review')
 
-h1.h3.my0 = t('idv.titles.session.review')
+h1.h3 = t('idv.titles.session.review')
 
 = render 'shared/user_verify_password', update_path: update_verify_password_path
 

--- a/app/views/verify/phone/new.html.slim
+++ b/app/views/verify/phone/new.html.slim
@@ -3,7 +3,7 @@
 h1.h2.my0 = t('idv.titles.session.phone')
 p.mt-tiny.mb2 = t('idv.messages.phone.intro')
 
-.alert.alert-warning
+.alert.alert-warning.mb1
   strong
     = t('idv.messages.phone.alert')
   ul.py1.m0.px0
@@ -14,8 +14,7 @@ p.mt-tiny.mb2 = t('idv.messages.phone.intro')
     li
       = t('idv.messages.phone.us_country_code')
 
-em
-  = t('idv.messages.phone.same_as_2fa')
+p = t('idv.messages.phone.same_as_2fa')
 
 = simple_form_for(@view_model.idv_form, url: verify_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form', class: 'mt2' }) do |f|

--- a/app/views/verify/review/new.html.slim
+++ b/app/views/verify/review/new.html.slim
@@ -1,6 +1,6 @@
 - title t('idv.titles.review')
 
-h1.h3.my0 = t('idv.titles.session.review')
+h1.h3 = t('idv.titles.session.review')
 
 = render 'shared/user_verify_password', update_path: verify_review_path
 

--- a/bin/link_agency_identities
+++ b/bin/link_agency_identities
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../../config/environment', __FILE__)
+
+LinkAgencyIdentities.new.link
+

--- a/bin/setup
+++ b/bin/setup
@@ -24,14 +24,14 @@ Dir.chdir APP_ROOT do
   ]
 
   puts "== Copying application.yml =="
-  run "cp config/application.yml.example config/application.yml"
+  run "test -L config/application.yml || cp config/application.yml.example config/application.yml"
 
   puts "== Copying logstash.conf =="
   run "cat logstash.conf.example | sed 's/path_to_repo/#{APP_ROOT.to_s.gsub('/', '\/')}/g' > logstash.conf"
 
   puts "== Copying sample certs and keys =="
-  run "cp keys/saml.key.enc.example keys/saml.key.enc"
-  run "cp certs/saml.crt.example certs/saml.crt"
+  run "test -L keys/saml.key.enc || cp keys/saml.key.enc.example keys/saml.key.enc"
+  run "test -L certs/saml.crt || cp certs/saml.crt.example certs/saml.crt"
 
   if ARGV.shift == "--docker" then
     run 'docker-compose build'

--- a/config/agencies.yml
+++ b/config/agencies.yml
@@ -1,0 +1,23 @@
+test:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'
+
+development:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'
+
+production:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -14,6 +14,7 @@ idv_attempt_window_in_hours: '24'
 mailer_domain_name: 'http://localhost:3000'
 max_mail_events: '4'
 max_mail_events_window_in_days: '30'
+aws_http_timeout: '5'
 
 # The scores 0, 1, 2, 3 or 4 are given when the number of guesses to crack the
 # password are less than 10^3, 10^6, 10^8, 10^10, and >= 10^10 respectively.
@@ -58,6 +59,7 @@ valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://id
 usps_mail_batch_hours: '24'
 
 development:
+  aamva_cert_enabled: 'true'
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
@@ -78,6 +80,7 @@ development:
   database_password: ''
   database_username: ''
   domain_name: 'localhost:3000'
+  enable_agency_based_uuids: 'false'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'false'
   enable_test_routes: 'true'
@@ -129,7 +132,9 @@ development:
   session_timeout_in_minutes: '15'
   state_id_proofing_vendor: 'mock'
   telephony_disabled: 'true'
-  twilio_accounts: '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
+  twilio_numbers: '["9999999999","2222222222"]'
+  twilio_sid: 'sid1'
+  twilio_auth_token: 'token1'
   twilio_messaging_service_sid: '123abc'
   twilio_record_voice: 'true'
   use_dashboard_service_providers: 'true'
@@ -139,9 +144,10 @@ development:
   enable_load_testing_mode: 'false'
 
 production:
-  aamva_public_key: '123abc'
-  aamva_private_key: '123abc'
-  aamva_verification_url: 'https://example.org:12345/verification/url'
+  aamva_cert_enabled: 'true'
+  aamva_public_key: # Base64 encoded public key for AAMVA
+  aamva_private_key: # Base64 encoded private key for AAMVA
+  aamva_verification_url: # DLDV Verification URL
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -155,6 +161,7 @@ production:
   disable_email_sending: 'false'
   dashboard_api_token:
   domain_name: 'login.gov'
+  enable_agency_based_uuids: 'false'
   enable_identity_verification: 'false'
   enable_rate_limiting: 'true'
   enable_test_routes: 'false'
@@ -206,8 +213,10 @@ production:
   session_encryption_key: # generate via `rake secret`
   session_timeout_in_minutes: '8'
   state_id_proofing_vendor: 'mock'
-  twilio_accounts: # '[{"sid":"sid", "auth_token":"token", "number":"9999999999"}]'
-  twilio_messaging_service_sid: '123abc'
+  twilio_numbers: # Add JSON encoded array of phone numbers
+  twilio_sid: # Twilio SID
+  twilio_auth_token: # Twilio auth token
+  twilio_messaging_service_sid: # Twilio CoPilot SID
   twilio_record_voice: 'false'
   use_kms: 'true'
   usps_confirmation_max_days: '30'
@@ -215,6 +224,7 @@ production:
   enable_load_testing_mode: 'false'
 
 test:
+  aamva_cert_enabled: 'true'
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
@@ -234,6 +244,7 @@ test:
   database_password: ''
   database_username: ''
   dashboard_api_token: '123ABC'
+  enable_agency_based_uuids: 'true'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'true'
   enable_test_routes: 'true'
@@ -280,7 +291,9 @@ test:
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
   session_timeout_in_minutes: '8'
   state_id_proofing_vendor: 'mock'
-  twilio_accounts: '[{"sid":"sid1", "auth_token":"token1", "number":"9999999999"}, {"sid":"sid2", "auth_token":"token2", "number":"2222222222"}]'
+  twilio_numbers: '["9999999999","2222222222"]'
+  twilio_sid: 'sid1'
+  twilio_auth_token: 'token1'
   twilio_messaging_service_sid: '123abc'
   twilio_record_voice: 'true'
   use_kms: 'false'

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -785,7 +785,7 @@ VN:
 VG:
   name: Virgin Islands (British)
   country_code: '1'
-  sms_only: false
+  sms_only: true
 VI:
   name: Virgin Islands (U.S.)
   country_code: '1'

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,5 @@
+Aws.config.update(
+  region: Figaro.env.aws_region,
+  http_open_timeout: Figaro.env.aws_http_timeout.to_i,
+  http_read_timeout: Figaro.env.aws_http_timeout.to_i
+)

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -12,4 +12,15 @@ ExceptionNotification.configure do |config|
     error_grouping: true,
     sections: %w[request backtrace session]
   )
+
+  config.ignored_exceptions << 'ActionController::BadRequest'
+  config.ignore_if do |exception, _options|
+    exception.message.start_with?('string contains null byte')
+  end
+  config.ignore_if do |exception, _options|
+    exception.message.start_with?('invalid byte sequence in UTF-8')
+  end
+  config.ignore_if do |exception, _options|
+    exception.code == 21_614 if exception.respond_to?(:code)
+  end
 end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -4,6 +4,7 @@ Figaro.require_keys(
   'attribute_cost',
   'attribute_encryption_key',
   'domain_name',
+  'enable_agency_based_uuids',
   'enable_identity_verification',
   'enable_rate_limiting',
   'enable_test_routes',
@@ -45,8 +46,11 @@ Figaro.require_keys(
   'session_encryption_key',
   'session_timeout_in_minutes',
   'state_id_proofing_vendor',
-  'twilio_accounts',
+  'twilio_numbers',
+  'twilio_sid',
+  'twilio_auth_token',
   'twilio_record_voice',
+  'twilio_messaging_service_sid',
   'use_kms',
   'valid_authn_contexts'
 )

--- a/config/initializers/twilio_accounts.rb
+++ b/config/initializers/twilio_accounts.rb
@@ -1,1 +1,3 @@
-TWILIO_ACCOUNTS = JSON.parse(Figaro.env.twilio_accounts).freeze
+TWILIO_NUMBERS = JSON.parse(Figaro.env.twilio_numbers).freeze
+TWILIO_SID = Figaro.env.twilio_sid.freeze
+TWILIO_AUTH_TOKEN = Figaro.env.twilio_auth_token.freeze

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -68,18 +68,16 @@ en:
       signed_up_but_locked: You have created an account. However, we could not sign
         you in because your account is locked.
       start:
-        accordion: You will need
-        bullet_1_html: Provide your <strong>email address</strong> and create a <strong>strong
-          password</strong>.
-        bullet_2_html: Enable <strong>two-step authentication</strong>. This adds
-          a second layer of security to your account by requiring you to enter a new
-          code that’s sent to your phone every time you log in.
-        bullet_3_html: Provide <strong>basic information</strong>, such as your name,
-          address, phone number, and social security number.
-        bullet_4_html: Provide a <strong>financial account number</strong>, such as
-          your  credit card number. This number will only be used to verify your identity.
-        bullet_5_html: When you are finished with this process we’ll give you a personal
-          key. <strong>Write it down and store it in a safe place; it’s important.</strong>
+        accordion: You will also need
+        bullet_1_html: An <strong>email address</strong>.
+        bullet_2_html: Enable <strong>two-step authentication</strong>.
+        bullet_3_html: To provide <strong>basic information</strong>, such as your
+          name, address and phone number.
+        bullet_4_html: Your <strong>Social Security number</strong>.
+        bullet_5_html: To verify your address by providing a <strong>phone number
+          or mailing address where you receive mail</strong>.
+        bullet_6_html: When you are finished with this process we’ll give you a <strong>personal
+          key</strong>. Write it down and store it in a safe place; it’s important.
           You’ll be asked for the personal key every time you make changes to your
           account.
         learn_more: Learn more about verifying your identity

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -72,20 +72,16 @@ es:
       signed_up_but_locked: Usted ha creado una cuenta. No hemos podido iniciar su
         sesión porque su cuenta está bloqueada.
       start:
-        accordion: Usted necesitará
-        bullet_1_html: Proporcione su <strong> dirección de email </strong> y establezca
-          una <strong>contraseña segura</strong>.
+        accordion: También necesitarás
+        bullet_1_html: Una <strong>dirección de correo electrónico</strong>.
         bullet_2_html: Permita <strong>la autenticación de dos factores</strong>.
-          Esto agrega una segunda capa de seguridad a su cuenta al requerirle que
-          ingrese un nuevo código que recibirá en su teléfono cada vez que inicie
-          una sesión.
-        bullet_3_html: Proporcione <strong>información básica</strong> como su nombre,
-          dirección, número de teléfono y número de Seguro Social.
-        bullet_4_html: Proporcione <strong>un número de cuenta financiera</strong>
-          como su número de tarjeta de crédito. Este número solamente será usado para
-          verificar su identidad.
-        bullet_5_html: Cuando haya terminado con este proceso, le daremos una clave
-          personal. <strong>Escríbala y guárdela en un lugar seguro; es importante.</strong>
+        bullet_3_html: Para proporcionar <strong>información básica</strong>, como
+          su nombre, dirección y número de teléfono.
+        bullet_4_html: Su <strong>número de Seguridad Social</strong>.
+        bullet_5_html: para verificar su dirección, proporcione un <strong>número
+          de teléfono o dirección postal donde recibe el correo</strong>.
+        bullet_6_html: Cuando haya terminado con este proceso, le daremos <strong>una
+          clave personal</strong>. Escríbala y guárdela en un lugar seguro; es importante.
           Se le pedirá la clave personal cada vez que realice cambios en su cuenta.
         learn_more: Obtenga más información sobre la verificación de su identidad.
       updated: "¡Su cuenta ha sido actualizada!"

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -78,21 +78,18 @@ fr:
       signed_up_but_locked: Vous avez créé un compte. Cependant, nous n'avons pu vous
         connecter, car votre compte est verrouillé.
       start:
-        accordion: Vous devrez
-        bullet_1_html: fournir votre <strong>adresse courriel</strong> et créer un
-          <strong> mot de passe fort</strong>.
+        accordion: Vous aurez aussi besoin
+        bullet_1_html: Une <strong>adresse e-mail</strong>.
         bullet_2_html: Activez <strong>l'authentification à deux facteurs</strong>.
-          Cela permet d'ajouter un degré de sécurité à votre compte, car vous devez
-          entrer un nouveau code envoyé à votre téléphone chaque fois que vous vous
-          connectez.
-        bullet_3_html: Fournissez <strong>de l'information de base</strong>, comme
-          votre nom, adresse et numéro de sécurité sociale.
-        bullet_4_html: Fournissez un <strong>numéro de compte bancaire</strong>, comme
-          votre numéro de carte de crédit.
-        bullet_5_html: 'Lorsque vous aurez terminé ce processus, nous vous donnerons
-          une clé personnelle. <strong>Notez-la et placez-la en lieu sûr : c''est
-          important.</strong> On vous demandera la clé personnelle chaque fois que
-          vous apporterez des changements à votre compte.'
+        bullet_3_html: Pour fournir des <strong>informations de base</strong>, telles
+          que votre nom, adresse et numéro de téléphone.
+        bullet_4_html: Votre <strong>numéro de Sécurité Sociale</strong>.
+        bullet_5_html: Pour vérifier votre adresse en fournissant un <strong>numéro
+          de téléphone ou adresse postale où vous recevez du courrier électronique</strong>.
+        bullet_6_html: Lorsque vous avez terminé ce processus, nous allons vous donner
+          un <strong>clé personnelle</strong>. Ecrivez-le et rangez-le dans un endroit
+          sûr. C'est important. La clé personnelle vous sera demandée chaque fois
+          que vous apportez des modifications à votre compte.
         learn_more: En savoir plus sur la vérification de votre identité
       updated: Votre compte a été mis à jour!
     sessions:

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -60,6 +60,9 @@ en:
       zipcode: ZIP Code
     index:
       continue_link: Yes, continue
+      id:
+        need_html: If you're creating an account, you'll need a <strong>current state-issued
+          ID</strong>.
       paragraph_1: We have partnered with a trusted third party company to verify
         this information and your identity.
       prompt: Do you have all of this information available right now?

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -59,6 +59,9 @@ es:
       zipcode: Código postal
     index:
       continue_link: Sí, continuar
+      id:
+        need_html: Si está creando una cuenta, necesitará una <strong>identificación
+          emitida por el estado actual</strong>.
       paragraph_1: Nos hemos asociado con una empresa externa confiable para verificar
         esta información y su identidad.
       prompt: "¿Tiene toda esta información disponible ahora mismo?"

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -63,6 +63,9 @@ fr:
       zipcode: Code ZIP
     index:
       continue_link: Oui, continuer
+      id:
+        need_html: Si vous créez un compte, vous aurez besoin d'un <strong>identifiant
+          actuel émis par l'état</strong>.
       paragraph_1: Nous avons un partenariat avec une entreprise de confiance afin
         de vérifier cette information ainsi que votre identité.
       prompt: Est-ce que vous avez accès à toute cette information en ce moment?

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -51,6 +51,4 @@ en:
         v: Great!
     personal_key_accent: Write it down or print it out.
     personal_key_html: This is the only way to regain access to your account if you
-      lose your password or phone. %{accent}
-    registration:
-      email: Pick an address you want to use for government communications.
+      lose the phone where we send your security code. %{accent}

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -53,7 +53,4 @@ es:
         v: "¡Muy buena!"
     personal_key_accent: Anótelo o imprímalo.
     personal_key_html: Esta es la única manera de recuperar el acceso a su cuenta
-      si pierde su contraseña o teléfono. %{accent}
-    registration:
-      email: Elija una dirección que desee usar para manejar las comunicaciones del
-        Gobierno.
+      si pierde el teléfono donde enviamos su código de seguridad. %{accent}

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -59,7 +59,5 @@ fr:
         v: Excellente!
     personal_key_accent: Notez-la ou imprimez-la.
     personal_key_html: Il s'agit de la seule façon de récupérer l'accès à votre compte
-      si vous perdez votre mot de passe ou votre téléphone. %{accent}
-    registration:
-      email: Choisissez une adresse que vous souhaitez utiliser pour les communications
-        avec le gouvernement.
+      si vous perdez le téléphone sur lequel nous envoyons votre code de sécurité.
+      %{accent}

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -6,6 +6,8 @@ test:
     block_encryption: 'none'
     cert: 'saml_test_sp'
     agency: 'Test Government Agency'
+    agency_id: 1
+    uuid_priority: 10
     friendly_name: 'Your friendly Government Agency'
     logo: 'generic.svg'
     return_to_sp_url: 'http://localhost:3000'
@@ -47,6 +49,8 @@ test:
     cert: 'saml_test_sp'
     friendly_name: 'Example iOS App'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
     logo: 'generic.svg'
 
   'urn:gov:gsa:openidconnect:sp:server':
@@ -99,6 +103,8 @@ development:
     block_encryption: 'aes256-cbc'
     cert: 'sp_rails_demo'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 10
     friendly_name: '18F Test Service Provider'
     logo: 'generic.svg'
     return_to_sp_url: 'http://localhost:3003'
@@ -108,6 +114,8 @@ development:
   'https://dashboard.login.gov':
     friendly_name: 'Dashboard'
     agency: 'GSA'
+    agency_id: 2
+    uuid_priority: 30
     logo: '18f.svg'
     acs_url: 'http://localhost:3001/users/auth/saml/callback'
     assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
@@ -122,6 +130,8 @@ development:
       - 'gov.gsa.openidconnect.development://result'
     friendly_name: 'Example iOS App'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
     logo: 'generic.svg'
 
   'urn:gov:gsa:openidconnect:sp:sinatra':
@@ -185,47 +195,6 @@ production:
       - email
   <% end %>
 
-# Micro-purchase
-  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase':
-    acs_url: 'http://localhost:3000/auth/saml/callback'
-    assertion_consumer_logout_service_url: 'http://localhost:3000/auth/saml/logout'
-    sp_initiated_login_url: 'http://localhost:3000/admin/sign_in'
-    block_encryption: 'aes256-cbc'
-    cert: 'sp_micropurchase'
-    logo: '18f.svg'
-    agency: 'TTS Acquisition'
-    friendly_name: 'Micro-purchase Dev'
-    return_to_sp_url: 'http://localhost:3000'
-    attribute_bundle:
-      - email
-
-  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:micropurchase-staging':
-    acs_url: 'https://micropurchase-staging.18f.gov/auth/saml/callback'
-    assertion_consumer_logout_service_url: 'https://micropurchase-staging.18f.gov/auth/saml/logout'
-    sp_initiated_login_url: 'https://micropurchase-staging.18f.gov/admin/sign_in'
-    block_encryption: 'aes256-cbc'
-    cert: 'sp_micropurchase'
-    logo: '18f.svg'
-    agency: 'TTS Acquisition'
-    friendly_name: 'Micro-purchase Staging'
-    return_to_sp_url: 'https://micropurchase-staging.18f.gov'
-    attribute_bundle:
-      - email
-
-  'urn:gov:gsa:SAML:2.0.profiles:sp:sso:micropurchase-production':
-    acs_url: 'https://micropurchase.18f.gov/auth/saml/callback'
-    assertion_consumer_logout_service_url: 'https://micropurchase.18f.gov/auth/saml/logout'
-    sp_initiated_login_url: 'https://micropurchase.18f.gov/admin/sign_in'
-    block_encryption: 'aes256-cbc'
-    cert: 'sp_micropurchase'
-    agency: 'TTS Acquisition'
-    logo: '18f.svg'
-    restrict_to_deploy_env: 'prod'
-    friendly_name: 'Micro-purchase'
-    return_to_sp_url: 'https://micropurchase.18f.gov'
-    attribute_bundle:
-      - email
-
   # Dashboard
   <% if LoginGov::Hostdata.in_datacenter? %>
   'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>':
@@ -266,6 +235,7 @@ production:
     redirect_uris:
       - 'https://careers-cert.cbp.dhs.gov/hrm/app'
     friendly_name: 'CBP Jobs'
+    agency_id: 1
     agency: 'DHS'
     logo: 'cbp.png'
     restrict_to_deploy_env: 'staging'
@@ -274,6 +244,7 @@ production:
     redirect_uris:
       - 'gov.dhs.cbp.jobs.applicant.cert://result'
     friendly_name: 'CBP Jobs'
+    agency_id: 1
     agency: 'DHS'
     logo: 'cbp.png'
     restrict_to_deploy_env: 'staging'
@@ -282,6 +253,7 @@ production:
     redirect_uris:
       - 'https://careers.cbp.dhs.gov/hrm/app'
     friendly_name: 'CBP Jobs'
+    agency_id: 1
     agency: 'DHS'
     logo: 'cbp.png'
     restrict_to_deploy_env: 'prod'
@@ -291,6 +263,7 @@ production:
     redirect_uris:
       - 'gov.dhs.cbp.jobs.applicant://result'
     friendly_name: 'CBP Jobs'
+    agency_id: 1
     agency: 'DHS'
     logo: 'cbp.png'
     restrict_to_deploy_env: 'prod'
@@ -333,6 +306,7 @@ production:
   # CBP GOES
   'urn:gov:dhs.cbp.jobs:openidconnect:jenkins-pspd-credential-service':
     friendly_name: 'CBP PSPD Trusted Traveler Programs'
+    agency_id: 1
     agency: 'DHS'
     logo: 'cbp-ttp.png'
     cert: 'cbp_goes_pre_prod'
@@ -340,6 +314,8 @@ production:
       - 'http://10.156.152.27/login'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp':
+    agency_id: 1
+    uuid_priority: 40
     agency: 'DHS'
     restrict_to_deploy_env: 'prod'
     block_encryption: 'aes256-cbc'
@@ -353,6 +329,8 @@ production:
   # CBP OARS
   'urn:gov:dhs.cbp.pspd.oars:openidconnect:prod:app':
     friendly_name: 'CBP OARS'
+    agency_id: 1
+    uuid_priority: 40
     agency: 'DHS'
     logo: 'cbp.png'
     redirect_uris:
@@ -363,6 +341,7 @@ production:
   'urn:gov:gsa:openidconnect.profiles:sp:sso:cbp:imready':
     friendly_name: "CBP I'm Ready"
     agency: 'DHS'
+    uuid_priority: 40
     logo: 'cbp.png'
     redirect_uris:
       - 'gov.dhs.cbp.pspd.imready.user.prod://result'
@@ -371,6 +350,8 @@ production:
   # USAJOBS
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS':
     friendly_name: 'USAJOBS'
+    agency_id: 2
+    uuid_priority: 40
     agency: 'OPM'
     logo: 'usajobs.svg'
     redirect_uris:
@@ -381,6 +362,8 @@ production:
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:UAT':
     friendly_name: 'USAJOBS'
+    agency_id: 2
+    uuid_priority: 40
     agency: 'OPM'
     logo: 'usajobs.svg'
     redirect_uris:
@@ -391,6 +374,8 @@ production:
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:PROD':
     friendly_name: 'USAJOBS'
+    agency_id: 2
+    uuid_priority: 40
     agency: 'OPM'
     logo: 'usajobs.svg'
     redirect_uris:
@@ -406,5 +391,35 @@ production:
     logo: 'nome.png'
     cert: 'nome_prod'
     redirect_uris:
+      - 'https://blog.vgihub.geointservices.io/op_redirect'
+      - 'https://certgen.vgihub.geointservices.io/op_redirect'
+      - 'https://compare.vgihub.geointservices.io/op_redirect'
+      - 'https://download.vgihub.geointservices.io/op_redirect'
+      - 'https://geojson.vgihub.geointservices.io/op_redirect'
+      - 'https://geonode.vgihub.geointservices.io/op_redirect'
+      - 'https://geonode-old.vgihub.geointservices.io/op_redirect'
+      - 'https://hootenanny.vgihub.geointservices.io/op_redirect'
+      - 'https://hotnightly.vgihub.geointservices.io/op_redirect'
+      - 'https://testing.vgihub.geointservices.io/op_redirect'
+      - 'https://metest.vgihub.geointservices.io/op_redirect'
+      - 'https://nomtest.vgihub.geointservices.io/op_redirect'
+      - 'https://tmtest.vgihub.geointservices.io/op_redirect'
+      - 'https://maproulette.vgihub.geointservices.io/op_redirect'
       - 'https://nome.vgihub.geointservices.io/op_redirect'
+      - 'https://nome-vector.vgihub.geointservices.io/op_redirect'
+      - 'https://nominatim.vgihub.geointservices.io/op_redirect'
+      - 'https://onion.vgihub.geointservices.io/op_redirect'
+      - 'https://osqa.vgihub.geointservices.io/op_redirect'
+      - 'https://overpassapi.vgihub.geointservices.io/op_redirect'
+      - 'https://overpass.vgihub.geointservices.io/op_redirect'
+      - 'https://piwik.vgihub.geointservices.io/op_redirect'
+      - 'https://rocketchat.vgihub.geointservices.io/op_redirect'
+      - 'https://saadmin.vgihub.geointservices.io/op_redirect'
+      - 'https://saserver.vgihub.geointservices.io/op_redirect'
+      - 'https://stats.vgihub.geointservices.io/op_redirect'
+      - 'https://status.vgihub.geointservices.io/op_redirect'
+      - 'https://taginfo.vgihub.geointservices.io/op_redirect'
+      - 'https://tasks.vgihub.geointservices.io/op_redirect'
+      - 'https://training.vgihub.geointservices.io/op_redirect'
+      - 'https://wiki.vgihub.geointservices.io/op_redirect'
     restrict_to_deploy_env: 'prod'

--- a/db/migrate/20180124123749_create_agencies.rb
+++ b/db/migrate/20180124123749_create_agencies.rb
@@ -1,0 +1,8 @@
+class CreateAgencies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :agencies do |t|
+      t.string   "name", null: false
+    end
+    add_index :agencies, ["name"], name: "index_agencies_on_name", unique: true, using: :btree
+  end
+end

--- a/db/migrate/20180124123836_create_agency_identities.rb
+++ b/db/migrate/20180124123836_create_agency_identities.rb
@@ -1,0 +1,11 @@
+class CreateAgencyIdentities < ActiveRecord::Migration[5.1]
+  def change
+    create_table :agency_identities do |t|
+      t.integer  "user_id", null: false
+      t.integer  "agency_id", null: false
+      t.string   "uuid", null: false
+    end
+    add_index :agency_identities, ["user_id", "agency_id"], name: "index_agency_identities_on_user_id_and_agency_id", unique: true, using: :btree
+    add_index :agency_identities, ["uuid"], name: "index_agency_identities_on_uuid", unique: true, using: :btree
+  end
+end

--- a/db/migrate/20180125101934_add_agency_id_to_service_providers.rb
+++ b/db/migrate/20180125101934_add_agency_id_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddAgencyIdToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :agency_id, :integer
+  end
+end

--- a/db/migrate/20180125230905_change_totp_timestamp_to_integer.rb
+++ b/db/migrate/20180125230905_change_totp_timestamp_to_integer.rb
@@ -1,0 +1,6 @@
+class ChangeTotpTimestampToInteger < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :totp_timestamp, :timestamp
+    add_column :users, :totp_timestamp, :integer
+  end
+end

--- a/db/migrate/20180201161105_add_verified_attributes_to_identities.rb
+++ b/db/migrate/20180201161105_add_verified_attributes_to_identities.rb
@@ -1,0 +1,9 @@
+class AddVerifiedAttributesToIdentities < ActiveRecord::Migration[5.1]
+  def up
+    add_column :identities, :verified_attributes, :json
+  end
+
+  def down
+    remove_column :identities, :verified_attributes, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219042656) do
+ActiveRecord::Schema.define(version: 20180201161105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "agencies", force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_agencies_on_name", unique: true
+  end
+
+  create_table "agency_identities", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "agency_id", null: false
+    t.string "uuid", null: false
+    t.index ["user_id", "agency_id"], name: "index_agency_identities_on_user_id_and_agency_id", unique: true
+    t.index ["uuid"], name: "index_agency_identities_on_uuid", unique: true
+  end
 
   create_table "authorizations", force: :cascade do |t|
     t.string "provider", limit: 255
@@ -48,6 +61,7 @@ ActiveRecord::Schema.define(version: 20171219042656) do
     t.string "scope"
     t.string "code_challenge"
     t.string "rails_session_id"
+    t.json "verified_attributes"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true
@@ -118,6 +132,7 @@ ActiveRecord::Schema.define(version: 20171219042656) do
     t.boolean "approved", default: false, null: false
     t.boolean "native", default: false, null: false
     t.string "redirect_uris", default: [], array: true
+    t.integer "agency_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 
@@ -163,7 +178,7 @@ ActiveRecord::Schema.define(version: 20171219042656) do
     t.string "attribute_cost"
     t.text "encrypted_phone"
     t.integer "otp_delivery_preference", default: 0, null: false
-    t.datetime "totp_timestamp"
+    t.integer "totp_timestamp"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,5 @@
 # add config/service_providers.yml
 ServiceProviderSeeder.new.run
+
+# add config/agencies.yml
+AgencySeeder.new.run

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -17,7 +17,7 @@ module Aws
       private
 
       def ses_client
-        @ses_client ||= Aws::SES::Client.new(region: Figaro.env.aws_region)
+        @ses_client ||= Aws::SES::Client.new
       end
     end
   end

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -67,4 +67,8 @@ class FeatureManagement
   def self.no_pii_mode?
     enable_identity_verification? && Figaro.env.profile_proofing_vendor == :mock
   end
+
+  def self.enable_agency_based_uuids?
+    Figaro.env.enable_agency_based_uuids == 'true'
+  end
 end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -16,6 +16,8 @@ describe SignUp::RegistrationsController, devise: true do
     it 'cannot be viewed by signed in users' do
       stub_sign_in
 
+      subject.session[:sp] = { request_url: 'http://test.com' }
+
       get :new
 
       expect(response).to redirect_to account_path

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -28,7 +28,7 @@ feature 'Verify phone' do
     end
 
     scenario 'phone number with no voice otp support only allows sms delivery' do
-      guam_phone = '671-555-5000'
+      unsupported_phone = '242-555-5000'
       user = create(
         :user, :signed_up,
         otp_delivery_preference: 'voice',
@@ -41,7 +41,7 @@ feature 'Verify phone' do
       allow(VoiceOtpSenderJob).to receive(:perform_later)
       allow(SmsOtpSenderJob).to receive(:perform_later)
 
-      complete_idv_profile_with_phone(guam_phone)
+      complete_idv_profile_with_phone(unsupported_phone)
 
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -233,7 +233,6 @@ feature 'LOA1 Single Sign On' do
       session = proxy.env['rack.session']
       session['warden.user.user.session'] = {
         'need_two_factor_authentication' => true,
-        first_time_personal_key_view: true,
       }
     end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -56,7 +56,7 @@ feature 'Changing authentication factor' do
 
     scenario 'editing phone number with no voice otp support only allows sms delivery' do
       user.update(otp_delivery_preference: 'voice')
-      guam_phone = '671-555-5000'
+      unsupported_phone = '242-555-5000'
 
       visit manage_phone_path
       complete_2fa_confirmation
@@ -64,7 +64,7 @@ feature 'Changing authentication factor' do
       allow(VoiceOtpSenderJob).to receive(:perform_later)
       allow(SmsOtpSenderJob).to receive(:perform_now)
 
-      update_phone_number(guam_phone)
+      update_phone_number(unsupported_phone)
 
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -9,7 +9,14 @@ feature 'View personal key' do
     scenario 'user refreshes personal key page' do
       sign_up_and_view_personal_key
 
+      personal_key = scrape_personal_key
+
       visit sign_up_personal_key_path
+
+      expect(current_path).to eq(sign_up_personal_key_path)
+      expect(scrape_personal_key).to eq(personal_key)
+
+      click_acknowledge_personal_key
 
       expect(current_path).to eq(account_path)
     end
@@ -50,6 +57,20 @@ feature 'View personal key' do
       end
 
       it_behaves_like 'personal key page'
+    end
+
+    context 'visitting the personal key path' do
+      scenario 'does not regenerate the personal and redirects to account' do
+        user = sign_in_and_2fa_user
+        old_code = user.personal_key
+
+        visit sign_up_personal_key_path
+
+        user.reload
+
+        expect(user.personal_key).to eq(old_code)
+        expect(current_path).to eq(account_path)
+      end
     end
   end
 

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -74,10 +74,10 @@ describe UserPhoneForm do
     end
 
     context 'when otp_delivery_preference is voice and phone number does not support voice' do
-      let(:guam_phone) { '671-555-5000' }
+      let(:unsupported_phone) { '242-555-5000' }
       let(:params) do
         {
-          phone: guam_phone,
+          phone: unsupported_phone,
           international_code: 'US',
           otp_delivery_preference: 'voice',
         }

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -226,4 +226,26 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#enable_agency_based_uuids?' do
+    context 'when enabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('true')
+      end
+
+      it 'enables the feature' do
+        expect(FeatureManagement.enable_agency_based_uuids?).to eq(true)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('false')
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.enable_agency_based_uuids?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/agency_identity_spec.rb
+++ b/spec/models/agency_identity_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe AgencyIdentity do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:agency) }
+
+  describe 'validations' do
+    let(:agency_identity) { build_stubbed(:agency_identity) }
+
+    it { is_expected.to validate_presence_of(:uuid) }
+  end
+end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Agency do
+  describe 'validations' do
+    let(:agency) { build_stubbed(:agency) }
+
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/requests/openid_connect_authorize_spec.rb
+++ b/spec/requests/openid_connect_authorize_spec.rb
@@ -23,7 +23,7 @@ describe 'user signs in partially and visits openid_connect/authorize' do
       to redirect_to login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
   end
 
-  def openid_test(prompt=nil)
+  def openid_test(prompt = nil)
     client_id = 'urn:gov:gsa:openidconnect:sp:server'
     state = SecureRandom.hex
     nonce = SecureRandom.hex

--- a/spec/services/agency_identity_linker_spec.rb
+++ b/spec/services/agency_identity_linker_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+describe AgencyIdentityLinker do
+  let(:user) { create(:user) }
+  describe '#link_identity' do
+    before(:each) { init_db(user) }
+
+    it 'links identities from 2 sps' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      AgencyIdentityLinker.new(sp1).link_identity
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'links identity with 1 sp' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentityLinker.new(sp1).link_identity
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'does not link identity without an agency_id' do
+      sp1 = create_identity(user, 'sp:with:no:agency_id', 'UUID1')
+      AgencyIdentityLinker.new(sp1).link_identity
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai).to eq(nil)
+    end
+
+    it 'returns the existing agency_identity if it exists' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentityLinker.new(sp1).link_identity
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+  end
+
+  describe '#sp_identity_from_uuid_and_sp' do
+    before(:each) { init_db(user) }
+
+    it 'returns sp_identity if it exists' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentity.create(user_id: user.id, agency_id: 1, uuid: 'UUID2')
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid_and_sp('UUID2',
+                                                                      'http://localhost:3000')
+      expect(sp_identity.uuid).to eq('UUID1')
+      expect(sp_identity.service_provider).to eq('http://localhost:3000')
+    end
+
+    it 'returns nil if sp_identity does not exist' do
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid_and_sp('UUID1',
+                                                                      'http://localhost:3000')
+      expect(sp_identity).to eq(nil)
+    end
+  end
+
+  describe '#sp_identity_from_uuid' do
+    before(:each) { init_db(user) }
+
+    it 'returns sp_identity if it exists' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentity.create(user_id: user.id, agency_id: 1, uuid: 'UUID2')
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid('UUID2')
+      expect(sp_identity.uuid).to eq('UUID1')
+      expect(sp_identity.service_provider).to eq('http://localhost:3000')
+    end
+
+    it 'returns nil if sp_identity does not exist' do
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid('UUID1')
+      expect(sp_identity).to eq(nil)
+    end
+  end
+
+  def init_db(user)
+    Identity.where(user_id: user.id).delete_all
+    AgencyIdentity.where(user_id: user.id).delete_all
+  end
+
+  def create_identity(user, service_provider, uuid)
+    Identity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
+  end
+end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe AgencySeeder do
+  subject(:instance) { AgencySeeder.new(rails_env: rails_env, deploy_env: deploy_env) }
+  let(:rails_env) { 'test' }
+  let(:deploy_env) { 'int' }
+
+  describe '#run' do
+    before { Agency.delete_all }
+
+    subject(:run) { instance.run }
+
+    it 'inserts agencies into the database from agencies.yml' do
+      expect { run }.to change(Agency, :count)
+    end
+
+    it 'inserts agencies in the proper order from agencies.yml' do
+      run
+      expect(Agency.find_by(id: 1).name).to eq('CBP')
+      expect(Agency.find_by(id: 2).name).to eq('OPM')
+      expect(Agency.find_by(id: 3).name).to eq('EOP')
+    end
+
+    context 'when an agency already exists in the database' do
+      before do
+        Agency.create(id: 1, name: 'FOO')
+      end
+
+      it 'updates the attributes based on the current value of the yml file' do
+        expect(Agency.find_by(id: 1).name).to eq('FOO')
+        run
+        expect(Agency.find_by(id: 1).name).to eq('CBP')
+      end
+    end
+  end
+end

--- a/spec/services/link_agency_identities_spec.rb
+++ b/spec/services/link_agency_identities_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe LinkAgencyIdentities do
+  describe '#link' do
+    let(:user) { create(:user) }
+    before(:each) { init_db(user) }
+
+    it 'migrates a user with two sps' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'migrates a user with two sps in uuid_priority order' do
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'links identity with 1 sp' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'does not link identity without an agency_id' do
+      create_identity(user, 'sp:with:no:agent_id', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai).to eq(nil)
+    end
+  end
+
+  def init_db(user)
+    Identity.where(user_id: user.id).delete_all
+    AgencyIdentity.where(user_id: user.id).delete_all
+  end
+
+  def create_identity(user, service_provider, uuid)
+    Identity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
+  end
+end

--- a/spec/services/phone_number_capabilities_spec.rb
+++ b/spec/services/phone_number_capabilities_spec.rb
@@ -10,7 +10,7 @@ describe PhoneNumberCapabilities do
     end
 
     context 'voice is not supported for the area code' do
-      let(:phone) { '+1 (671) 555-5000' }
+      let(:phone) { '+1 (242) 555-5000' }
       it { expect(subject.sms_only?).to eq(true) }
     end
 
@@ -28,8 +28,8 @@ describe PhoneNumberCapabilities do
 
   describe '#unsupported_location' do
     it 'returns the name of the unsupported area code location' do
-      locality = PhoneNumberCapabilities.new('+1 (671) 555-5000').unsupported_location
-      expect(locality).to eq('Guam')
+      locality = PhoneNumberCapabilities.new('+1 (242) 555-5000').unsupported_location
+      expect(locality).to eq('Bahamas')
     end
 
     it 'returns the name of the unsupported international code location' do
@@ -41,26 +41,23 @@ describe PhoneNumberCapabilities do
   describe 'list of unsupported area codes' do
     it 'is up to date' do
       unsupported_area_codes = {
-        '648' => 'American Samoa',
         '264' => 'Anguilla',
         '268' => 'Antigua and Barbuda',
+        '242' => 'Bahamas',
         '246' => 'Barbados',
         '441' => 'Bermuda',
+        '284' => 'British Virgin Islands',
         '345' => 'Cayman Islands',
         '767' => 'Dominica',
         '809' => 'Dominican Republic',
         '473' => 'Grenada',
-        '671' => 'Guam',
         '876' => 'Jamaica',
         '664' => 'Montserrat',
-        '670' => 'Northern Mariana Islands',
         '869' => 'Saint Kitts and Nevis',
         '758' => 'Saint Lucia',
         '784' => 'Saint Vincent Grenadines',
         '868' => 'Trinidad and Tobago',
         '649' => 'Turks and Caicos Islands',
-        '284' => 'British Virgin Islands',
-        '340' => 'United States Virgin Islands',
       }
       expect(PhoneNumberCapabilities::VOICE_UNSUPPORTED_US_AREA_CODES).to eq unsupported_area_codes
     end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -9,7 +9,11 @@ describe TwilioService do
     it 'uses NullTwilioClient' do
       TwilioService.telephony_service = Twilio::REST::Client
 
-      expect(NullTwilioClient).to receive(:new)
+      client = instance_double(NullTwilioClient)
+      expect(NullTwilioClient).to receive(:new).and_return(client)
+      http_client = Struct.new(:adapter)
+      expect(client).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:adapter=).with(:typhoeus)
       expect(Twilio::REST::Client).to_not receive(:new)
 
       TwilioService.new
@@ -36,14 +40,18 @@ describe TwilioService do
     end
 
     it 'uses a real Twilio client' do
-      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/)
+      client = instance_double(Twilio::REST::Client)
+      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/).and_return(client)
+      http_client = Struct.new(:adapter)
+      expect(client).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:adapter=).with(:typhoeus)
       TwilioService.new
     end
   end
 
-  describe '#account' do
-    it 'randomly samples one of the accounts' do
-      expect(TWILIO_ACCOUNTS).to include(TwilioService.new.account)
+  describe '#phone_number' do
+    it 'randomly samples one of the numbers' do
+      expect(TWILIO_NUMBERS).to include(TwilioService.new.phone_number)
     end
   end
 

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -1,5 +1,6 @@
 class FakeSms
   Message = Struct.new(:to, :body, :messaging_service_sid)
+  HttpClient = Struct.new(:adapter)
 
   cattr_accessor :messages
   self.messages = []
@@ -16,5 +17,9 @@ class FakeSms
       opts[:body],
       opts[:messaging_service_sid]
     )
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end

--- a/spec/support/fake_voice_call.rb
+++ b/spec/support/fake_voice_call.rb
@@ -1,4 +1,6 @@
 class FakeVoiceCall
+  HttpClient = Struct.new(:adapter)
+
   cattr_accessor :calls
   self.calls = []
 
@@ -10,5 +12,9 @@ class FakeVoiceCall
 
   def create(opts = {})
     self.class.calls << OpenStruct.new(opts)
+  end
+
+  def http_client
+    HttpClient.new(adapter: 'foo')
   end
 end

--- a/spec/support/idv_examples/otp_delivery_method.rb
+++ b/spec/support/idv_examples/otp_delivery_method.rb
@@ -47,7 +47,7 @@ shared_examples 'idv otp delivery method selection' do |sp|
   end
 
   context 'with a phone number that does not support voice calling' do
-    let(:phone) { '671-555-5000' }
+    let(:phone) { '242-555-5000' }
 
     scenario 'voice call option is disabled', :email do
       voice_radio_button = page.find(
@@ -58,7 +58,7 @@ shared_examples 'idv otp delivery method selection' do |sp|
       expect(voice_radio_button.disabled?).to eq(true)
       expect(page).to have_content t(
         'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'Guam'
+        location: 'Bahamas'
       )
     end
   end


### PR DESCRIPTION
**Why**: We need to share agency-specific UUIDs as well as facilitate sharing of an agency’s UUID with other agencies. We also need a way to count the unique number of users for an agency for billing purposes

**How** Create new tables to store agencies and agency identity relationships (user identity per agency). Add an agency_id to service providers. Add agency_id and uuid priority to the service providers.yml file to specify the priority as defined in the requirements doc (selectively allowing our largest sps to use their original uuids). Create a migration script called link_agency_identities which prepopulates the relationships in priority order and creates definitive uuids per user per agency.  This script can be run as needed and ideally right before launch so that agencies can get the complete list of their user uuids.  Once the code is live new relationships are added on the fly via AgencyIdentityLinker. Finally a feature flag environment variable called enable_agency_based_uuids is added through FeatureManagement/Figaro so we can go live at anytime. Since this solution does not modify any existing data in the db we can disable the feature at anytime and the system will behave as before. Moreover the migration script and schema changes can all be done and run before go live and before the feature is turned on. The additional tables that are added leave the db normalized with the exception of the uuids column in identities.  This is necessary to ensure a successful go live or rollback with zero downtime.  After a successful transition is confirmed by all the agencies we can eventually remove this column and update the code accordingly.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
