### PR TITLE
Verify user authed before assigning personal key

### DIFF
--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -2,9 +2,9 @@ module SignUp
   class PersonalKeysController < ApplicationController
     include PersonalKeyConcern
 
+    before_action :confirm_two_factor_authenticated
     before_action :confirm_user_needs_initial_personal_key, only: [:show]
     before_action :assign_initial_personal_key, only: [:show]
-    before_action :confirm_two_factor_authenticated
 
     def show
       @code = user_session[:personal_key]


### PR DESCRIPTION
**Why**: Because without an authed user there is nothing to assign a
personal key 2. Attempting to access this page while not authenticated
results in a 500. This page fixes that to have the expected behavior, a
redirect to the sign in page.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
