### PR TITLE
Move from SP-based UUIDs to agency-based UUIDs

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -48,7 +48,13 @@ module SamlIdpLogoutConcern
   end
 
   def sp_slo_identity
-    @_sp_slo_identity ||= Identity.includes(:user).find_by(uuid: name_id)
+    @_sp_slo_identity ||= begin
+      if FeatureManagement.enable_agency_based_uuids?
+        AgencyIdentityLinker.sp_identity_from_uuid(name_id)
+      else
+        Identity.includes(:user).find_by(uuid: name_id)
+      end
+    end
   end
 
   def name_id

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,0 +1,4 @@
+class Agency < ApplicationRecord
+  has_many :agency_identities, dependent: :destroy
+  validates :name, presence: true
+end

--- a/app/models/agency_identity.rb
+++ b/app/models/agency_identity.rb
@@ -1,0 +1,9 @@
+class AgencyIdentity < ApplicationRecord
+  belongs_to :user
+  belongs_to :agency
+  validates :uuid, presence: true
+
+  def agency_enabled?
+    !FeatureManagement.agencies_with_agency_based_uuids.index(agency_id).nil?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
 
   has_many :authorizations, dependent: :destroy
   has_many :identities, dependent: :destroy
+  has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
 

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -9,7 +9,7 @@ class OpenidConnectUserInfoPresenter
 
   def user_info
     info = {
-      sub: identity.uuid,
+      sub: uuid_from_sp_identity(identity),
       iss: root_url,
       email: identity.user.email,
       email_verified: true,
@@ -19,6 +19,14 @@ class OpenidConnectUserInfoPresenter
   end
 
   private
+
+  def uuid_from_sp_identity(identity)
+    if FeatureManagement.enable_agency_based_uuids?
+      AgencyIdentityLinker.new(identity).link_identity.uuid
+    else
+      identity.uuid
+    end
+  end
 
   # rubocop:disable Metrics/AbcSize
   def loa3_attributes

--- a/app/services/agency_identity_linker.rb
+++ b/app/services/agency_identity_linker.rb
@@ -1,0 +1,57 @@
+class AgencyIdentityLinker
+  def initialize(sp_identity)
+    @sp_identity = sp_identity
+    @agency_id = nil
+  end
+
+  def link_identity
+    ai = find_or_create_agency_identity
+    return ai if ai&.agency_enabled?
+    AgencyIdentity.new(user_id: @sp_identity.user_id, uuid: @sp_identity.uuid)
+  end
+
+  def self.sp_identity_from_uuid_and_sp(uuid, service_provider)
+    ai = AgencyIdentity.where(uuid: uuid).first
+    criteria = if ai&.agency_enabled?
+                 { user_id: ai.user_id, service_provider: service_provider }
+               else
+                 { uuid: uuid, service_provider: service_provider }
+               end
+    Identity.where(criteria).first
+  end
+
+  def self.sp_identity_from_uuid(uuid)
+    ai = AgencyIdentity.where(uuid: uuid).first
+    return Identity.where(uuid: uuid).first if ai.nil?
+    service_provider = ServiceProvider.where(agency_id: ai.agency_id).first
+    return unless service_provider
+    sp_identity_from_uuid_and_sp(ai.uuid, service_provider.issuer)
+  end
+
+  private
+
+  def find_or_create_agency_identity
+    ai = agency_identity
+    return ai if ai
+    create_agency_identity_for_sp
+  end
+
+  def create_agency_identity_for_sp
+    return unless agency_id
+    AgencyIdentity.create(agency_id: agency_id,
+                          user_id: @sp_identity.user_id,
+                          uuid: @sp_identity.uuid)
+  end
+
+  def agency_identity
+    ai = AgencyIdentity.where(uuid: @sp_identity.uuid).first
+    return ai if ai
+    sp = ServiceProvider.where(issuer: @sp_identity.service_provider).first
+    return unless agency_id(sp)
+    AgencyIdentity.where(agency_id: agency_id, user_id: @sp_identity.user_id).first
+  end
+
+  def agency_id(service_provider = nil)
+    @agency_id ||= service_provider&.agency_id
+  end
+end

--- a/app/services/agency_seeder.rb
+++ b/app/services/agency_seeder.rb
@@ -1,0 +1,27 @@
+# Update Agency from config/agencies.yml (all environments in rake db:seed)
+class AgencySeeder
+  def initialize(rails_env: Rails.env, deploy_env: LoginGov::Hostdata.env)
+    @rails_env = rails_env
+    @deploy_env = deploy_env
+  end
+
+  def run
+    agencies.each do |agency_id, config|
+      agency = Agency.find_by(id: agency_id)
+      if agency
+        agency.update!(config)
+      else
+        Agency.create!(config.merge(id: agency_id))
+      end
+    end
+  end
+
+  private
+
+  attr_reader :rails_env, :deploy_env
+
+  def agencies
+    content = ERB.new(Rails.root.join('config', 'agencies.yml').read).result
+    YAML.safe_load(content).fetch(rails_env, {})
+  end
+end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -51,7 +51,14 @@ class AttributeAsserter
   end
 
   def uuid_getter_function
-    ->(principal) { principal.decorate.active_identity_for(service_provider).uuid }
+    lambda do |principal|
+      identity = principal.decorate.active_identity_for(service_provider)
+      if FeatureManagement.enable_agency_based_uuids?
+        AgencyIdentityLinker.new(identity).link_identity.uuid
+      else
+        identity.uuid
+      end
+    end
   end
 
   def verified_at_getter_function

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -9,6 +9,7 @@ class IdentityLinker
   def link_identity(**extra_attrs)
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
+    AgencyIdentityLinker.new(identity).link_identity if FeatureManagement.enable_agency_based_uuids?
     identity
   end
 

--- a/app/services/link_agency_identities.rb
+++ b/app/services/link_agency_identities.rb
@@ -1,0 +1,55 @@
+class LinkAgencyIdentities
+  AGENCY_INFO = Struct.new(:issuer, :priority, :agency_id)
+
+  def link
+    sps = sps_to_link
+    sps.sort! { |spa, spb| spa.priority <=> spb.priority }
+    sps.each { |sp| link_service_provider(sp.agency_id, sp.issuer) }
+    self
+  end
+
+  def self.report
+    report_sql = <<~SQL
+      SELECT DISTINCT ag.name, id.uuid AS old_uuid, ai.uuid AS new_uuid
+      FROM agency_identities ai, service_providers sp, identities id, agencies ag
+      WHERE ag.id = ai.agency_id AND ag.id = sp.agency_id AND ai.user_id = id.user_id AND
+        sp.issuer = id.service_provider AND id.uuid != ai.uuid
+      ORDER BY ag.name ASC, id.uuid ASC
+    SQL
+    ActiveRecord::Base.connection.execute(report_sql)
+  end
+
+  private
+
+  def sps_to_link
+    sps = []
+    service_providers.each do |issuer, config|
+      priority, agency_id = agency_info(config)
+      sps << AGENCY_INFO.new(issuer, priority, agency_id) if priority && agency_id
+    end
+    sps
+  end
+
+  def agency_info(config)
+    priority = (config['uuid_priority'] || 1_000_000).to_i
+    [priority, config['agency_id'].to_i]
+  end
+
+  def link_service_provider(agency_id, service_provider)
+    linker_sql = <<~SQL
+      INSERT INTO agency_identities (user_id,agency_id,uuid)
+      SELECT user_id,%d,MAX(uuid)
+      FROM identities
+      WHERE service_provider='%s'
+      AND user_id NOT IN (SELECT user_id FROM agency_identities WHERE agency_id=%d)
+      GROUP BY user_id
+    SQL
+    sql = format(linker_sql, agency_id, service_provider, agency_id)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def service_providers
+    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
+    YAML.safe_load(content).fetch(Rails.env, {})
+  end
+end

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -13,7 +13,7 @@ class ServiceProviderSeeder
         sp.approved = true
         sp.active = true
         sp.native = true
-      end.update!(config.except('restrict_to_deploy_env'))
+      end.update!(config.except('restrict_to_deploy_env', 'uuid_priority'))
     end
   end
 

--- a/bin/link_agency_identities
+++ b/bin/link_agency_identities
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../../config/environment', __FILE__)
+
+LinkAgencyIdentities.new.link
+puts "agency, old_uuid, new_uuid"
+LinkAgencyIdentities.report.each do |row|
+  puts "#{row['name']}, #{row['old_uuid']}, #{row['new_uuid']}"
+end
+

--- a/config/agencies.yml
+++ b/config/agencies.yml
@@ -1,0 +1,35 @@
+test:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'
+  4:
+    name: 'RRB'
+  5:
+    name: 'NGA'
+
+development:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'
+  4:
+    name: 'RRB'
+  5:
+    name: 'NGA'
+
+production:
+  1:
+    name: 'CBP'
+  2:
+    name: 'OPM'
+  3:
+    name: 'EOP'
+  4:
+    name: 'RRB'
+  5:
+    name: 'NGA'

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -63,6 +63,7 @@ development:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
+  agencies_with_agency_based_uuids: ''
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -80,6 +81,7 @@ development:
   database_password: ''
   database_username: ''
   domain_name: 'localhost:3000'
+  enable_agency_based_uuids: 'false'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'false'
   enable_test_routes: 'true'
@@ -147,6 +149,7 @@ production:
   aamva_public_key: # Base64 encoded public key for AAMVA
   aamva_private_key: # Base64 encoded private key for AAMVA
   aamva_verification_url: # DLDV Verification URL
+  agencies_with_agency_based_uuids: ''
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -160,6 +163,7 @@ production:
   disable_email_sending: 'false'
   dashboard_api_token:
   domain_name: 'login.gov'
+  enable_agency_based_uuids: 'false'
   enable_identity_verification: 'false'
   enable_rate_limiting: 'true'
   enable_test_routes: 'false'
@@ -226,6 +230,7 @@ test:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
+  agencies_with_agency_based_uuids: ''
   async_job_refresh_interval_seconds: '1'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
@@ -242,6 +247,7 @@ test:
   database_password: ''
   database_username: ''
   dashboard_api_token: '123ABC'
+  enable_agency_based_uuids: 'false'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'true'
   enable_test_routes: 'true'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -4,6 +4,7 @@ Figaro.require_keys(
   'attribute_cost',
   'attribute_encryption_key',
   'domain_name',
+  'enable_agency_based_uuids',
   'enable_identity_verification',
   'enable_rate_limiting',
   'enable_test_routes',

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -6,6 +6,8 @@ test:
     block_encryption: 'none'
     cert: 'saml_test_sp'
     agency: 'Test Government Agency'
+    agency_id: 1
+    uuid_priority: 10
     friendly_name: 'Your friendly Government Agency'
     logo: 'generic.svg'
     return_to_sp_url: 'http://localhost:3000'
@@ -16,6 +18,7 @@ test:
       - phone
 
   'https://rp1.serviceprovider.com/auth/saml/metadata':
+    agency_id: 2
     acs_url: 'http://example.com/test/saml/decode_assertion'
     assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
     block_encryption: 'aes256-cbc'
@@ -47,9 +50,12 @@ test:
     cert: 'saml_test_sp'
     friendly_name: 'Example iOS App'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
     logo: 'generic.svg'
 
   'urn:gov:gsa:openidconnect:sp:server':
+    agency_id: 2
     redirect_uris:
       - 'http://localhost:7654/'
       - 'https://example.com'
@@ -59,6 +65,7 @@ test:
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':
+    agency_id: 2
     metadata_url: 'http://localhost:3000/test/saml/metadata'
     acs_url: 'http://localhost:3000/test/saml/decode_assertion'
     assertion_consumer_logout_service_url: 'http://localhost:3000/test/saml/decode_slo_request'
@@ -99,6 +106,8 @@ development:
     block_encryption: 'aes256-cbc'
     cert: 'sp_rails_demo'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 10
     friendly_name: '18F Test Service Provider'
     logo: 'generic.svg'
     return_to_sp_url: 'http://localhost:3003'
@@ -108,6 +117,8 @@ development:
   'https://dashboard.login.gov':
     friendly_name: 'Dashboard'
     agency: 'GSA'
+    agency_id: 2
+    uuid_priority: 30
     logo: '18f.svg'
     acs_url: 'http://localhost:3001/users/auth/saml/callback'
     assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
@@ -122,9 +133,12 @@ development:
       - 'gov.gsa.openidconnect.development://result'
     friendly_name: 'Example iOS App'
     agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
     logo: 'generic.svg'
 
   'urn:gov:gsa:openidconnect:sp:sinatra':
+    agency_id: 1
     redirect_uris:
       - 'http://localhost:9292/'
     cert: 'sp_sinatra_demo'
@@ -222,6 +236,8 @@ production:
 
   # CBP Jobs
   'urn:gov:dhs.cbp.jobs:openidconnect:cert':
+    agency_id: 1
+    uuid_priority: 30
     redirect_uris:
       - 'https://careers-cert.cbp.dhs.gov/hrm/app'
     friendly_name: 'CBP Jobs'
@@ -230,6 +246,8 @@ production:
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:cert:app':
+    agency_id: 1
+    uuid_priority: 30
     redirect_uris:
       - 'gov.dhs.cbp.jobs.applicant.cert://result'
     friendly_name: 'CBP Jobs'
@@ -238,6 +256,8 @@ production:
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod':
+    agency_id: 1
+    uuid_priority: 30
     redirect_uris:
       - 'https://careers.cbp.dhs.gov/hrm/app'
     friendly_name: 'CBP Jobs'
@@ -247,6 +267,8 @@ production:
     return_to_sp_url: 'https://careers.cbp.dhs.gov'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:prod:app':
+    agency_id: 1
+    uuid_priority: 30
     redirect_uris:
       - 'gov.dhs.cbp.jobs.applicant://result'
     friendly_name: 'CBP Jobs'
@@ -256,6 +278,7 @@ production:
 
   # RRB Online Retirement Application
   'urn:gov:gsa:SAML:2.0.profiles:sp:sso:RRB:BOS-Pre-Prod':
+    agency_id: 4
     friendly_name: 'Railroad Retirement Board'
     agency: 'RRB'
     logo: 'rrb.svg'
@@ -281,6 +304,7 @@ production:
 
   # RRB Benefit Connect
   'urn:gov:rrb:OIDC:V0.1:BenefitConnnect:app-stg':
+    agency_id: 4
     friendly_name: 'U.S. Railroad Retirement Board Benefit Connect'
     agency: 'RRB'
     logo: 'rrb.svg'
@@ -291,6 +315,8 @@ production:
 
   # CBP GOES
   'urn:gov:dhs.cbp.jobs:openidconnect:jenkins-pspd-credential-service':
+    agency_id: 1
+    uuid_priority: 15
     friendly_name: 'CBP PSPD Trusted Traveler Programs'
     agency: 'DHS'
     logo: 'cbp-ttp.png'
@@ -299,6 +325,8 @@ production:
       - 'http://10.156.152.27/login'
 
   'urn:gov:dhs.cbp.jobs:openidconnect:aws-cbp-ttp':
+    agency_id: 1
+    uuid_priority: 10
     agency: 'DHS'
     restrict_to_deploy_env: 'prod'
     block_encryption: 'aes256-cbc'
@@ -311,6 +339,8 @@ production:
 
   # CBP OARS
   'urn:gov:dhs.cbp.pspd.oars:openidconnect:prod:app':
+    agency_id: 1
+    uuid_priority: 20
     friendly_name: 'CBP OARS'
     agency: 'DHS'
     logo: 'cbp.png'
@@ -320,6 +350,8 @@ production:
 
   # CBP I'm Ready
   'urn:gov:gsa:openidconnect.profiles:sp:sso:cbp:imready':
+    agency_id: 1
+    uuid_priority: 40
     friendly_name: "CBP I'm Ready"
     agency: 'DHS'
     logo: 'cbp.png'
@@ -329,6 +361,7 @@ production:
 
   # USAJOBS
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS':
+    agency_id: 2
     friendly_name: 'USAJOBS'
     agency: 'OPM'
     logo: 'usajobs.svg'
@@ -339,6 +372,7 @@ production:
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:UAT':
+    agency_id: 2
     friendly_name: 'USAJOBS'
     agency: 'OPM'
     logo: 'usajobs.svg'
@@ -349,6 +383,7 @@ production:
     restrict_to_deploy_env: 'staging'
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:OPM:USAJOBS:PROD':
+    agency_id: 2
     friendly_name: 'USAJOBS'
     agency: 'OPM'
     logo: 'usajobs.svg'
@@ -360,6 +395,7 @@ production:
 
   # NGA NSG Open Mapping Enclave (NOME)
   'urn:gov:gsa:openidconnect.profiles:sp:sso:VGITeam:NOME':
+    agency_id: 5
     friendly_name: 'NSG Open Mapping Enclave (NOME)'
     agency: 'NGA'
     logo: 'nome.png'

--- a/db/migrate/20180124123749_create_agencies.rb
+++ b/db/migrate/20180124123749_create_agencies.rb
@@ -1,0 +1,8 @@
+class CreateAgencies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :agencies do |t|
+      t.string   "name", null: false
+    end
+    add_index :agencies, ["name"], name: "index_agencies_on_name", unique: true, using: :btree
+  end
+end

--- a/db/migrate/20180124123836_create_agency_identities.rb
+++ b/db/migrate/20180124123836_create_agency_identities.rb
@@ -1,0 +1,11 @@
+class CreateAgencyIdentities < ActiveRecord::Migration[5.1]
+  def change
+    create_table :agency_identities do |t|
+      t.integer  "user_id", null: false
+      t.integer  "agency_id", null: false
+      t.string   "uuid", null: false
+    end
+    add_index :agency_identities, ["user_id", "agency_id"], name: "index_agency_identities_on_user_id_and_agency_id", unique: true, using: :btree
+    add_index :agency_identities, ["uuid"], name: "index_agency_identities_on_uuid", unique: true, using: :btree
+  end
+end

--- a/db/migrate/20180125101934_add_agency_id_to_service_providers.rb
+++ b/db/migrate/20180125101934_add_agency_id_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddAgencyIdToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :agency_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,19 @@ ActiveRecord::Schema.define(version: 20180201161105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "agencies", force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_agencies_on_name", unique: true
+  end
+
+  create_table "agency_identities", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "agency_id", null: false
+    t.string "uuid", null: false
+    t.index ["user_id", "agency_id"], name: "index_agency_identities_on_user_id_and_agency_id", unique: true
+    t.index ["uuid"], name: "index_agency_identities_on_uuid", unique: true
+  end
+
   create_table "authorizations", force: :cascade do |t|
     t.string "provider", limit: 255
     t.string "uid", limit: 255
@@ -119,6 +132,7 @@ ActiveRecord::Schema.define(version: 20180201161105) do
     t.boolean "approved", default: false, null: false
     t.boolean "native", default: false, null: false
     t.string "redirect_uris", default: [], array: true
+    t.integer "agency_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,5 @@
 # add config/service_providers.yml
 ServiceProviderSeeder.new.run
+
+# add config/agencies.yml
+AgencySeeder.new.run

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -67,4 +67,12 @@ class FeatureManagement
   def self.no_pii_mode?
     enable_identity_verification? && Figaro.env.profile_proofing_vendor == :mock
   end
+
+  def self.enable_agency_based_uuids?
+    Figaro.env.enable_agency_based_uuids == 'true'
+  end
+
+  def self.agencies_with_agency_based_uuids
+    (Figaro.env.agencies_with_agency_based_uuids || '').split(',').map(&:to_i)
+  end
 end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -8,6 +8,11 @@ feature 'OpenID Connect' do
       oidc_end_client_secret_jwt(prompt: 'select_account')
     end
 
+    it 'succeeds with new agency based uuids' do
+      allow(FeatureManagement).to receive(:enable_agency_based_uuids?).and_return(true)
+      oidc_end_client_secret_jwt(prompt: 'select_account')
+    end
+
     it 'succeeds in returning back to sp with prompt select_account and prior session' do
       user = oidc_end_client_secret_jwt(prompt: 'select_account')
       oidc_end_client_secret_jwt(prompt: 'select_account', user: user, redirs_to: '/auth/result')

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -139,6 +139,19 @@ feature 'LOA1 Single Sign On' do
     end
   end
 
+  context 'fully signed up user is signed in with email/pwd and new agency based uuids' do
+    it 'prompts to enter OTP' do
+      allow(FeatureManagement).to receive(:enable_agency_based_uuids?).and_return(true)
+      user = create(:user, :signed_up)
+      sign_in_user(user)
+
+      saml_authn_request = auth_request.create(saml_settings)
+      visit saml_authn_request
+
+      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+    end
+  end
+
   context 'user that has not yet set up 2FA is signed in with email and password only' do
     it 'prompts to set up 2FA' do
       sign_in_user

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe OpenidConnectLogoutForm do
       it 'has a successful response' do
         expect(result).to be_success
       end
+
+      it 'has a successful response when agency based uuids are enabled' do
+        allow(FeatureManagement).to receive(:enable_agency_based_uuids?).and_return(true)
+        expect(result).to be_success
+      end
     end
 
     context 'with an invalid form' do
@@ -109,6 +114,13 @@ RSpec.describe OpenidConnectLogoutForm do
         end
 
         it 'is not valid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:id_token_hint]).
+            to include(t('openid_connect.logout.errors.id_token_hint'))
+        end
+
+        it 'is not valid when agency based uuids are enabled' do
+          allow(FeatureManagement).to receive(:enable_agency_based_uuids?).and_return(true)
           expect(valid?).to eq(false)
           expect(form.errors[:id_token_hint]).
             to include(t('openid_connect.logout.errors.id_token_hint'))

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -226,4 +226,58 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#enable_agency_based_uuids?' do
+    context 'when enabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('true')
+      end
+
+      it 'enables the feature' do
+        expect(FeatureManagement.enable_agency_based_uuids?).to eq(true)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('false')
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.enable_agency_based_uuids?).to eq(false)
+      end
+    end
+  end
+
+  describe 'agencies_with_agency_based_uuids' do
+    context 'when multiple agencies are enabled' do
+      before do
+        allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1,2,3')
+      end
+
+      it 'it returns an array of agencies' do
+        expect(FeatureManagement.agencies_with_agency_based_uuids).to eq([1, 2, 3])
+      end
+    end
+
+    context 'when one agency is enabled' do
+      before do
+        allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1')
+      end
+
+      it 'returns an array containing a single agency' do
+        expect(FeatureManagement.agencies_with_agency_based_uuids).to eq([1])
+      end
+    end
+
+    context 'when blank' do
+      before do
+        allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('')
+      end
+
+      it 'returns an empty array' do
+        expect(FeatureManagement.agencies_with_agency_based_uuids).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/agency_identity_spec.rb
+++ b/spec/models/agency_identity_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe AgencyIdentity do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:agency) }
+
+  describe 'validations' do
+    let(:agency_identity) { build_stubbed(:agency_identity) }
+
+    it { is_expected.to validate_presence_of(:uuid) }
+  end
+
+  describe '#agency_enabled?' do
+    it 'returns true if the agency is enabled' do
+      allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1')
+      ai = AgencyIdentity.new(agency_id:1,user_id:1,uuid:'UUID1')
+      expect(ai.agency_enabled?).to eq(true)
+    end
+
+    it 'returns false if the agency is disabled' do
+      allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('')
+      ai = AgencyIdentity.new(agency_id:1,user_id:1,uuid:'UUID1')
+      expect(ai.agency_enabled?).to eq(false)
+    end
+  end
+end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Agency do
+  describe 'Associations' do
+    it { is_expected.to have_many(:agency_identities) }
+  end
+  describe 'validations' do
+    let(:agency) { build_stubbed(:agency) }
+
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ describe User do
   describe 'Associations' do
     it { is_expected.to have_many(:authorizations) }
     it { is_expected.to have_many(:identities) }
+    it { is_expected.to have_many(:agency_identities) }
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
   end

--- a/spec/services/agency_identity_linker_spec.rb
+++ b/spec/services/agency_identity_linker_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe AgencyIdentityLinker do
+  let(:user) { create(:user) }
+  describe '#link_identity' do
+    before(:each) { init_env(user) }
+
+    it 'links identities from 2 sps' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      ai = AgencyIdentityLinker.new(sp1).link_identity
+      expect(ai.uuid).to eq('UUID1')
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'links identity with 1 sp' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      ai = AgencyIdentityLinker.new(sp1).link_identity
+      expect(ai.uuid).to eq('UUID1')
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'does not link identity without an agency_id' do
+      sp1 = create_identity(user, 'sp:with:no:agency_id', 'UUID1')
+      ai = AgencyIdentityLinker.new(sp1).link_identity
+      expect(ai.agency_id).to eq(nil)
+      expect(ai.uuid).to eq('UUID1')
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai).to eq(nil)
+    end
+
+    it 'returns the existing agency_identity if it exists' do
+      sp1 = create_identity(user, 'http://localhost:3000', 'UUID1')
+      ai = AgencyIdentityLinker.new(sp1).link_identity
+      expect(ai.uuid).to eq('UUID1')
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+  end
+
+  describe '#sp_identity_from_uuid_and_sp' do
+    before(:each) { init_env(user) }
+
+    it 'returns sp_identity if it exists' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentity.create(user_id: user.id, agency_id: 1, uuid: 'UUID2')
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid_and_sp('UUID2',
+                                                                      'http://localhost:3000')
+      expect(sp_identity.uuid).to eq('UUID1')
+      expect(sp_identity.service_provider).to eq('http://localhost:3000')
+    end
+
+    it 'returns nil if sp_identity does not exist' do
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid_and_sp('UUID1',
+                                                                      'http://localhost:3000')
+      expect(sp_identity).to eq(nil)
+    end
+  end
+
+  describe '#sp_identity_from_uuid' do
+    before(:each) { init_env(user) }
+
+    it 'returns sp_identity if it exists' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      AgencyIdentity.create(user_id: user.id, agency_id: 1, uuid: 'UUID2')
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid('UUID2')
+      expect(sp_identity.uuid).to eq('UUID1')
+      expect(sp_identity.service_provider).to eq('http://localhost:3000')
+    end
+
+    it 'returns nil if sp_identity does not exist' do
+      sp_identity = AgencyIdentityLinker.sp_identity_from_uuid('UUID1')
+      expect(sp_identity).to eq(nil)
+    end
+  end
+
+  def init_env(user)
+    allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('true')
+    allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1,2,3')
+    Identity.where(user_id: user.id).delete_all
+    AgencyIdentity.where(user_id: user.id).delete_all
+  end
+
+  def create_identity(user, service_provider, uuid)
+    Identity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
+  end
+end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe AgencySeeder do
+  subject(:instance) { AgencySeeder.new(rails_env: rails_env, deploy_env: deploy_env) }
+  let(:rails_env) { 'test' }
+  let(:deploy_env) { 'int' }
+
+  describe '#run' do
+    before { Agency.delete_all }
+
+    subject(:run) { instance.run }
+
+    it 'inserts agencies into the database from agencies.yml' do
+      expect { run }.to change(Agency, :count)
+    end
+
+    it 'inserts agencies in the proper order from agencies.yml' do
+      run
+      expect(Agency.find_by(id: 1).name).to eq('CBP')
+      expect(Agency.find_by(id: 2).name).to eq('OPM')
+      expect(Agency.find_by(id: 3).name).to eq('EOP')
+    end
+
+    context 'when an agency already exists in the database' do
+      before do
+        Agency.create(id: 1, name: 'FOO')
+      end
+
+      it 'updates the attributes based on the current value of the yml file' do
+        expect(Agency.find_by(id: 1).name).to eq('FOO')
+        run
+        expect(Agency.find_by(id: 1).name).to eq('CBP')
+      end
+    end
+  end
+end

--- a/spec/services/link_agency_identities_spec.rb
+++ b/spec/services/link_agency_identities_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe LinkAgencyIdentities do
+  describe '#link' do
+    let(:user) { create(:user) }
+    before(:each) { init_env(user) }
+
+    it 'migrates a user with two sps' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'migrates a user with two sps in uuid_priority order' do
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'links identity with 1 sp' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai.uuid).to eq('UUID1')
+    end
+
+    it 'does not link identity without an agency_id' do
+      create_identity(user, 'sp:with:no:agent_id', 'UUID1')
+      LinkAgencyIdentities.new.link
+      ai = AgencyIdentity.where(user_id: user.id).first
+      expect(ai).to eq(nil)
+    end
+  end
+
+  describe '#report' do
+    let(:user) { create(:user) }
+    before(:each) { init_env(user) }
+
+    it 'migrates a user with two sps and reports' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      LinkAgencyIdentities.new.link
+      report = LinkAgencyIdentities.report
+      expect(report[0]['name']).to eq('CBP')
+      expect(report[0]['old_uuid']).to eq('UUID2')
+      expect(report[0]['new_uuid']).to eq('UUID1')
+      expect(report.cmd_tuples).to eq(1)
+    end
+
+    it 'migrates a user with two sps in uuid_priority order and reports' do
+      create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      report = LinkAgencyIdentities.report
+      expect(report[0]['name']).to eq('CBP')
+      expect(report[0]['old_uuid']).to eq('UUID2')
+      expect(report[0]['new_uuid']).to eq('UUID1')
+      expect(report.cmd_tuples).to eq(1)
+    end
+
+    it 'links identity with 1 sp and reports no change' do
+      create_identity(user, 'http://localhost:3000', 'UUID1')
+      LinkAgencyIdentities.new.link
+      report = LinkAgencyIdentities.report
+      expect(report.cmd_tuples).to eq(0)
+    end
+
+    it 'does not link identity without an agency_id' do
+      create_identity(user, 'sp:with:no:agent_id', 'UUID1')
+      LinkAgencyIdentities.new.link
+      report = LinkAgencyIdentities.report
+      expect(report.cmd_tuples).to eq(0)
+    end
+  end
+
+  def init_env(user)
+    allow(Figaro.env).to receive(:enable_agency_based_uuids).and_return('true')
+    allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1,2,3')
+    AgencySeeder.new(rails_env: Rails.env, deploy_env: Rails.env).run
+    Identity.where(user_id: user.id).delete_all
+    AgencyIdentity.where(user_id: user.id).delete_all
+  end
+
+  def create_identity(user, service_provider, uuid)
+    Identity.create(user_id: user.id, service_provider: service_provider, uuid: uuid)
+  end
+end

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -239,6 +239,13 @@ class SamlResponseDoc
     )
   end
 
+  def uuid
+    response_doc.at(
+      '//ds:Attribute[@Name="uuid"]',
+      ds: Saml::XML::Namespaces::ASSERTION
+    ).children.children.to_s
+  end
+
   def attribute_node_for(name)
     response_doc.at(
       %(//ds:Attribute[@Name="#{name}"]),


### PR DESCRIPTION
**Why**: We need to share agency-specific UUIDs as well as facilitate sharing of an agency’s UUID with other agencies. We also need a way to count the unique number of users for an agency for billing purposes

**How** Create new tables to store agencies and agency identity relationships (user identity per agency). Add an agency_id to service providers. Add agency_id and uuid priority to the service providers.yml file to specify the priority as defined in the requirements doc (selectively allowing our largest sps to use their original uuids). Create a migration script called link_agency_identities which prepopulates the relationships in priority order and creates definitive uuids per user per agency.  This script can be run as needed and ideally right before launch so that agencies can get the complete list of their user uuids.  Once the code is live new relationships are added on the fly via AgencyIdentityLinker. Finally a feature flag environment variable called enable_agency_based_uuids is added through FeatureManagement/Figaro so we can go live at anytime. Since this solution does not modify any existing data in the db we can disable the feature at anytime and the system will behave as before. Moreover the migration script and schema changes can all be done and run before go live and before the feature is turned on. The additional tables that are added leave the db normalized with the exception of the uuids column in identities.  This is necessary to ensure a successful go live or rollback with zero downtime.  After a successful transition is confirmed by all the agencies we can eventually remove this column and update the code accordingly.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
