### PR TITLE
Don't allow email as password

### DIFF
--- a/app/assets/javascripts/misc/pw-strength.js
+++ b/app/assets/javascripts/misc/pw-strength.js
@@ -55,6 +55,8 @@ function analyzePw() {
   const pwStrength = document.getElementById('pw-strength-txt');
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const submit = document.querySelector('input[type="submit"]');
+  const forbiddenPasswordsElement = document.querySelector('[data-forbidden-passwords]');
+  const forbiddenPasswords = forbiddenPasswordsElement.dataset.forbiddenPasswords;
 
   disableSubmit(submit);
 
@@ -64,7 +66,7 @@ function analyzePw() {
   pwCntnr.className = '';
 
   function checkPasswordStrength(e) {
-    const z = zxcvbn(e.target.value);
+    const z = zxcvbn(e.target.value, JSON.parse(forbiddenPasswords));
     const [cls, strength] = getStrength(z);
     const feedback = getFeedback(z);
     pwCntnr.className = cls;

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -24,6 +24,7 @@ module UnconfirmedUserConcern
 
   def process_valid_confirmation_token
     @confirmation_token = params[:confirmation_token]
+    @forbidden_passwords = ForbiddenPasswords.new(@user.email).call
     flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password')
     session[:user_confirmation_token] = @confirmation_token
   end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -4,6 +4,7 @@ module Users
 
     def edit
       @update_user_password_form = UpdateUserPasswordForm.new(current_user)
+      @forbidden_passwords = ForbiddenPasswords.new(current_user.email).call
     end
 
     def update

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -18,12 +18,13 @@ module Users
     end
 
     def edit
-      result = PasswordResetTokenValidator.new(token_user(params)).submit
+      result = PasswordResetTokenValidator.new(token_user).submit
 
       analytics.track_event(Analytics::PASSWORD_RESET_TOKEN, result.to_h)
 
       if result.success?
         @reset_password_form = ResetPasswordForm.new(build_user)
+        @forbidden_passwords = ForbiddenPasswords.new(token_user.email).call
       else
         handle_invalid_or_expired_token(result)
       end
@@ -82,7 +83,7 @@ module Users
       user
     end
 
-    def token_user(params)
+    def token_user
       @_token_user ||= User.with_reset_password_token(params[:reset_password_token])
     end
 

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -18,7 +18,7 @@ class UpdateUserPasswordForm
 
   private
 
-  attr_reader :user, :user_session, :password
+  attr_reader :user, :user_session
 
   def process_valid_submission
     update_user_password

--- a/app/services/forbidden_passwords.rb
+++ b/app/services/forbidden_passwords.rb
@@ -1,0 +1,17 @@
+class ForbiddenPasswords
+  def initialize(email)
+    @email = email
+  end
+
+  def call
+    [email, split_email(email), APP_NAME].flatten unless email.nil?
+  end
+
+  private
+
+  attr_reader :email
+
+  def split_email(email_address)
+    email_address.split(/[[:^word:]_]/)
+  end
+end

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -23,7 +23,7 @@ module FormPasswordValidator
   end
 
   def password_score
-    @pass_score ||= ZXCVBN_TESTER.test(password)
+    @password_score = ZXCVBN_TESTER.test(password, ForbiddenPasswords.new(user.email).call)
   end
 
   def min_password_score
@@ -37,7 +37,7 @@ module FormPasswordValidator
   end
 
   def zxcvbn_feedback
-    feedback = @pass_score.feedback.values.flatten.reject(&:empty?)
+    feedback = @password_score.feedback.values.flatten.reject(&:empty?)
 
     feedback.map do |error|
       I18n.t("zxcvbn.feedback.#{i18n_key(error)}")

--- a/app/views/devise/shared/_password_strength.html.slim
+++ b/app/views/devise/shared/_password_strength.html.slim
@@ -7,6 +7,6 @@
       .pw-bar
     .h5
       span.h6 = t('instructions.password.strength.intro')
-      span#pw-strength-txt.bold = '...'
+      span#pw-strength-txt.bold*{ 'data-forbidden-passwords' => @forbidden_passwords } = '...'
     .h6
       #pw-strength-feedback.italic

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -55,6 +55,11 @@ describe Users::ResetPasswordsController, devise: true do
         user = instance_double('User', uuid: '123')
         allow(User).to receive(:with_reset_password_token).with('foo').and_return(user)
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+        expect(user).to receive(:email).twice
+
+        forbidden = instance_double(ForbiddenPasswords)
+        allow(ForbiddenPasswords).to receive(:new).with(user.email).and_return(forbidden)
+        expect(forbidden).to receive(:call)
 
         get :edit, params: { reset_password_token: 'foo' }
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -93,6 +93,19 @@ feature 'Sign Up' do
         expect(page).to have_xpath("//input[@value=\"#{t('sign_up.buttons.cancel')}\"]")
       end
     end
+
+    context 'user enters their email as their password', email: true do
+      it 'treats it as a weak password' do
+        email = 'test@test.com'
+
+        visit sign_up_email_path
+        submit_form_with_valid_email(email)
+        click_confirmation_link_in_email(email)
+
+        fill_in 'Password', with: email
+        expect(page).to have_content('Very weak')
+      end
+    end
   end
 
   context 'user accesses password screen with already confirmed token', email: true do

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -4,6 +4,7 @@ describe PasswordForm, type: :model do
   subject { PasswordForm.new(build_stubbed(:user)) }
 
   it_behaves_like 'password validation'
+  it_behaves_like 'strong password', 'PasswordForm'
 
   describe '#submit' do
     context 'when the form is valid' do
@@ -49,37 +50,6 @@ describe PasswordForm, type: :model do
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
-      end
-    end
-
-    context 'when the password is not strong enough' do
-      it 'returns false and adds user errors to the form errors' do
-        allow(Figaro.env).to receive(:password_strength_enabled).and_return('true')
-
-        user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
-
-        form = PasswordForm.new(user)
-
-        passwords = ['custom!@', 'benevolent', 'custom benevolent comcast']
-
-        errors = {
-          password: ['Your password is not strong enough.' \
-            ' This is similar to a commonly used password.' \
-            ' Add another word or two.' \
-            ' Uncommon words are better'],
-        }
-
-        passwords.each do |password|
-          extra = {
-            user_id: '123',
-            request_id_present: false,
-          }
-          result = instance_double(FormResponse)
-
-          expect(FormResponse).to receive(:new).
-            with(success: false, errors: errors, extra: extra).and_return(result)
-          expect(form.submit(password: password)).to eq result
-        end
       end
     end
 

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -107,38 +107,6 @@ describe ResetPasswordForm, type: :model do
       end
     end
 
-    context 'when the password is not strong enough' do
-      it 'returns false and adds user errors to the form errors' do
-        allow(Figaro.env).to receive(:password_strength_enabled).and_return('true')
-
-        user = build_stubbed(:user, email: 'custom@benevolent.com')
-        allow(user).to receive(:reset_password_period_valid?).and_return(true)
-
-        form = ResetPasswordForm.new(user)
-
-        passwords = ['custom!@', 'benevolent', 'custom benevolent comcast']
-
-        passwords.each do |password|
-          errors = {
-            password: ['Your password is not strong enough.' \
-              ' This is similar to a commonly used password.' \
-              ' Add another word or two.' \
-              ' Uncommon words are better'],
-          }
-
-          extra = {
-            user_id: nil,
-            active_profile: false,
-            confirmed: true,
-          }
-
-          result = instance_double(FormResponse)
-          expect(FormResponse).to receive(:new).
-            with(success: false, errors: errors, extra: extra).and_return(result)
-          expect(form.submit(password: password)).
-            to eq result
-        end
-      end
-    end
+    it_behaves_like 'strong password', 'ResetPasswordForm'
   end
 end

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe UpdateUserPasswordForm do
+describe UpdateUserPasswordForm, type: :model do
   let(:user) { User.new(password: 'old strong password') }
   let(:user_session) { {} }
   let(:password) { 'salty new password' }
@@ -8,6 +8,9 @@ describe UpdateUserPasswordForm do
   let(:subject) do
     UpdateUserPasswordForm.new(user, user_session)
   end
+
+  it_behaves_like 'password validation'
+  it_behaves_like 'strong password', 'UpdateUserPasswordForm'
 
   describe '#submit' do
     context 'when the password is invalid' do

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -1,0 +1,142 @@
+shared_examples 'strong password' do |form_class|
+  before(:each) do
+    allow(Figaro.env).to receive(:password_strength_enabled).and_return('true')
+  end
+
+  it 'does not allow a password that is common and/or needs more words' do
+    user = build_stubbed(:user, email: 'test@test.com', uuid: '123')
+    allow(user).to receive(:reset_password_period_valid?).and_return(true)
+    form = form_class.constantize.new(user)
+    password = 'custom!@'
+    errors = {
+      password: ['Your password is not strong enough.' \
+        ' This is similar to a commonly used password.' \
+        ' Add another word or two.' \
+        ' Uncommon words are better'],
+    }
+    if form_class == 'PasswordForm'
+      extra = {
+        user_id: '123',
+        request_id_present: false,
+      }
+    elsif form_class == 'ResetPasswordForm'
+      extra = {
+        user_id: '123',
+        active_profile: false,
+        confirmed: true,
+      }
+    end
+    result = instance_double(FormResponse)
+
+    if %w[PasswordForm ResetPasswordForm].include?(form_class)
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+    else
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors).and_return(result)
+    end
+    expect(form.submit(password: password)).to eq result
+  end
+
+  it 'does not allow a password that needs more words' do
+    user = build_stubbed(:user, email: 'test@test.com', uuid: '123')
+    allow(user).to receive(:reset_password_period_valid?).and_return(true)
+    form = form_class.constantize.new(user)
+    password = 'benevolent'
+    errors = {
+      password: ['Your password is not strong enough.' \
+        ' Add another word or two.' \
+        ' Uncommon words are better'],
+    }
+    if form_class == 'PasswordForm'
+      extra = {
+        user_id: '123',
+        request_id_present: false,
+      }
+    elsif form_class == 'ResetPasswordForm'
+      extra = {
+        user_id: '123',
+        active_profile: false,
+        confirmed: true,
+      }
+    end
+    result = instance_double(FormResponse)
+
+    if %w[PasswordForm ResetPasswordForm].include?(form_class)
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+    else
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors).and_return(result)
+    end
+    expect(form.submit(password: password)).to eq result
+  end
+
+  it 'does not allow a password containing words from the user email' do
+    user = build_stubbed(:user, email: 'joe@gmail.com', uuid: '123')
+    allow(user).to receive(:reset_password_period_valid?).and_return(true)
+    form = form_class.constantize.new(user)
+    password = 'joe gmail'
+    errors = {
+      password: ['Your password is not strong enough.' \
+        ' Add another word or two.' \
+        ' Uncommon words are better'],
+    }
+    if form_class == 'PasswordForm'
+      extra = {
+        user_id: '123',
+        request_id_present: false,
+      }
+    elsif form_class == 'ResetPasswordForm'
+      extra = {
+        user_id: '123',
+        active_profile: false,
+        confirmed: true,
+      }
+    end
+    result = instance_double(FormResponse)
+
+    if %w[PasswordForm ResetPasswordForm].include?(form_class)
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+    else
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors).and_return(result)
+    end
+    expect(form.submit(password: password)).to eq result
+  end
+
+  it 'does not allow a password that is the user email' do
+    user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
+    allow(user).to receive(:reset_password_period_valid?).and_return(true)
+    form = form_class.constantize.new(user)
+    password = 'custom@benevolent.com'
+    errors = {
+      password: ['Your password is not strong enough.' \
+        ' Add another word or two.' \
+        ' Uncommon words are better'],
+    }
+    if form_class == 'PasswordForm'
+      extra = {
+        user_id: '123',
+        request_id_present: false,
+      }
+    elsif form_class == 'ResetPasswordForm'
+      extra = {
+        user_id: '123',
+        active_profile: false,
+        confirmed: true,
+      }
+    end
+    result = instance_double(FormResponse)
+
+    if %w[PasswordForm ResetPasswordForm].include?(form_class)
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors, extra: extra).and_return(result)
+    else
+      expect(FormResponse).to receive(:new).
+        with(success: false, errors: errors).and_return(result)
+    end
+    expect(form.submit(password: password)).to eq result
+  end
+end


### PR DESCRIPTION
**Why**: Allowing someone to use their email as their password (which
the zxcvbn algorithm will not flag as a weak password by default)
reduces the security of their account.

**How**: Add a small dictionary of words that the password strength
meter can look up to adjust the calculated strength. The words are
the user's email, the different word components of the user's email,
and "login.gov". Note that the Dropbox algorithm does not outright ban
a password just because it contains a combination of those words. It
just can't be exactly one of those words, and that word only. In other
words, if the user's email is "test@test.com", you can set a password
that is "test@test.com login.gov", but you can't use a password that
is "test@testcom" or "login.gov".

Note that the ability to set a password that contains both the user's
email and "login.gov" is due to our minimum password strength being set
to 3. If we increase it to 4, a user won't be able to set such a
password.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
