### PR TITLE
Check content before path in flickering test

### DIFF
--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -48,8 +48,8 @@ feature 'Password recovery via personal key', idv_job: true do
     complete_idv_profile_ok(user, new_password)
     acknowledge_and_confirm_personal_key
 
-    expect(current_path).to eq(account_path)
     expect(page).to have_content(t('headings.account.verified_account'))
+    expect(current_path).to eq(account_path)
   end
 
   scenario 'resets password, uses personal key as 2fa', email: true do


### PR DESCRIPTION
**Why**: The test was occasionally failing because Capybara's web driver
was not making it to the URL before checking the path, occasionally
causing a false negative in the testing suite. Checking the content
first means the spec will wait for the driver to visit the page and load
the content.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
