### PR TITLE
Add href option to USPS verify spec

### DIFF
--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -21,7 +21,7 @@ feature 'verify profile with OTP' do
 
     scenario 'profile phone not confirmed' do
       sign_in_live_with_2fa(user)
-      expect(page).to have_link(t('idv.buttons.cancel'), account_path)
+      expect(page).to have_link(t('idv.buttons.cancel'), href: account_path)
     end
 
     scenario 'OTP has expired' do


### PR DESCRIPTION
**Why**: So it will stop warning us about unused parameters every time we
run the test suite. Specifically, this cleans up this message:

```
Unused parameters passed to Capybara::Queries::SelectorQuery : ["/account"]
```

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
