### PR TITLE
Timeouts behave inconsistantly between tabs

### DIFF
--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -6,6 +6,7 @@ var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);
 
 var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
+var ping_timeout;
 
 function ping() {
   var request = new XMLHttpRequest();
@@ -19,7 +20,7 @@ function ping() {
   };
 
   request.send();
-  setTimeout(ping, frequency);
+  ping_timeout = setTimeout(ping, frequency)
 }
 
 function success(data) {
@@ -27,17 +28,23 @@ function success(data) {
       cntnr = document.getElementById('session-timeout-cntnr');
 
   var time_timeout = new Date(data.timeout).getTime(),
-      time_cutoff = new Date().getTime() + warning,
-      show_warning = time_timeout < time_cutoff;
+      time_cutoff = new Date().getTime(),
+      show_warning = time_timeout < (time_cutoff + warning),
+      time_remaining = time_timeout - time_cutoff;
 
   if (show_warning && !modal.shown) {
     modal.show();
-    window.LoginGov.countdownTimer(document.getElementById('countdown'), warning);
+    window.LoginGov.countdownTimer(document.getElementById('countdown'), time_remaining);
   }
 
   if (!show_warning && modal.shown) modal.hide();
   if (!data.live) {
     window.LoginGov.autoLogout();
+  }
+
+  if (time_remaining < frequency){
+    time_remaining = time_remaining < 0 ? 0 : time_remaining
+    ping_timeout = setTimeout(ping, time_remaining)
   }
 }
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -88,8 +88,11 @@ feature 'Sign in' do
       ajax_headers = { 'name' => 'X-Requested-With', 'value' => 'XMLHttpRequest' }
 
       expect(request_headers).to include ajax_headers
-      expect(page).to have_content('7:59')
-      expect(page).to have_content('7:58')
+      time1 = page.text[/7:5[0-9]/]
+      expect(page).to have_content(time1)
+      sleep(1)
+      time2 = page.text[/7:5[0-9]/]
+      expect(time2).to be < time1
     end
 
     scenario 'user can continue browsing' do


### PR DESCRIPTION
**Why**:
Timeouts triggered based on timers set
at specific intervals. This would cause
certain tabs to count down to 0 and hold
before being cleared if the session was
refreshed on another page.

Set the timer based on actual time remaining
in the session.

Ping active_path again based on time remaining
to clear modal once it times to 0.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
