### PR TITLE
Improve invalid authentication error message

### DIFF
--- a/.reek
+++ b/.reek
@@ -2,6 +2,7 @@ Attribute:
   enabled: false
 ControlParameter:
   exclude:
+    - CustomDeviseFailureApp#i18n_message
     - OpenidConnectRedirector#initialize
     - NoRetryJobs#call
 DuplicateMethodCall:
@@ -20,6 +21,8 @@ FeatureEnvy:
   exclude:
     - ActiveJob::Logging::LogSubscriber#json_for
     - Aws::SES::Base#deliver
+    - CustomDeviseFailureApp#build_options
+    - CustomDeviseFailureApp#keys
     - track_registration
     - append_info_to_payload
     - generate_slo_request

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,5 @@
 require 'saml_idp_constants'
+require 'custom_devise_failure_app'
 
 Devise.setup do |config|
   include Mailable
@@ -27,4 +28,8 @@ Devise.setup do |config|
   config.direct_otp_valid_for = Figaro.env.otp_valid_for.to_i.minutes
   config.max_login_attempts = 3 # max OTP login attempts, not devise strategies (e.g. pw auth)
   config.otp_length = 6
+
+  config.warden do |manager|
+    manager.failure_app = CustomDeviseFailureApp
+  end
 end

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -13,10 +13,13 @@ en:
     failure:
       already_authenticated: ''
       inactive: Your account hasn't been activated.
-      invalid: Invalid email or password.
+      invalid_link_text: resetting your password
+      invalid_html: The email or password you've entered is wrong. Try %{link}.
       last_attempt: You have one more attempt before your account is locked.
       locked: Your account has been locked.
-      not_found_in_database: Invalid email or password.
+      not_found_in_database_link_text: resetting your password
+      not_found_in_database_html: The email or password you've entered is wrong. Try
+        %{link}.
       session_limited: Your login credentials were used in another browser. Please
         sign in again to continue in this browser.
       timeout: Your session has expired. Please sign in again to continue.

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -13,10 +13,14 @@ es:
     failure:
       already_authenticated: ''
       inactive: Su cuenta aún no está activada.
-      invalid: Email o contraseña no válido.
+      invalid_link_text: restablecer su contraseña
+      invalid_html: El email o la contraseña que ingresó son incorrectos. Intente
+        %{link}.
       last_attempt: Tiene un intento más antes de que su cuenta esté bloqueada.
       locked: Su cuenta está bloqueada.
-      not_found_in_database: Email o contraseña no válido.
+      not_found_in_database_link_text: restablecer su contraseña
+      not_found_in_database_html: El email o la contraseña que ingresó son incorrectos.
+        Intente %{link}.
       session_limited: Sus credenciales para iniciar una sesión se utilizaron en otro
         navegador. Inicie una sesión nueva para continuar en este navegador.
       timeout: Su sesión ha caducado. Vuelva a iniciar la sesión para continuar.

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -13,10 +13,14 @@ fr:
     failure:
       already_authenticated: ''
       inactive: Votre compte n'est pas encore activé.
-      invalid: Adresse courriel ou mot de passe non valide.
+      invalid_link_text: réinitialiser votre mot de passe
+      invalid_html: L'adresse courriel ou le mot de passe que vous avez entré est
+        erroné. Essayez de %{link}.
       last_attempt: Il vous reste un essai avant que votre compte ne soit verrouillé.
       locked: Votre compte est maintenant verrouillé.
-      not_found_in_database: Adresse courriel ou mot de passe non valide.
+      not_found_in_database_link_text: réinitialiser votre mot de passe
+      not_found_in_database_html: L'adresse courriel ou le mot de passe que vous avez
+        entré est erroné. Essayez de %{link}.
       session_limited: Vos authentifiants ont été utilisés dans un autre navigateur.
         Veuillez vous connecter de nouveau pour continuer avec ce navigateur.
       timeout: Votre session est expirée. Veuillez vous connecter de nouveau pour

--- a/lib/custom_devise_failure_app.rb
+++ b/lib/custom_devise_failure_app.rb
@@ -1,0 +1,53 @@
+# This class overrides the default `i18n_message` defined by Devise
+# in order to allow customizing the `devise.failure.invalid` and
+# 'devise.failure.not_found_in_database' error messages with a link
+# that preserves the locale and request_id.
+class CustomDeviseFailureApp < Devise::FailureApp
+  def i18n_message(default = nil)
+    message = warden_message || default || :unauthenticated
+
+    message.is_a?(Symbol) ? build_message(message) : message.to_s
+  end
+
+  private
+
+  def build_message(message)
+    options = build_options(message)
+
+    if %i[invalid not_found_in_database].include?(message)
+      customized_message(message)
+    else
+      I18n.t(:"#{scope}.#{message}", options)
+    end
+  end
+
+  def build_options(message)
+    options = {}
+    options[:resource_name] = scope
+    options[:scope] = 'devise.failure'
+    options[:default] = [message]
+    i18n_options(options)
+  end
+
+  def customized_message(message)
+    prefix = "devise.failure.#{message}"
+    link = helper.link_to(
+      I18n.t("#{prefix}_link_text"),
+      new_user_password_url(locale: locale_url_param, request_id: sp_session[:request_id])
+    )
+    I18n.t("#{prefix}_html", link: link)
+  end
+
+  def helper
+    ActionController::Base.helpers
+  end
+
+  def locale_url_param
+    active_locale = I18n.locale
+    active_locale == I18n.default_locale ? nil : active_locale
+  end
+
+  def sp_session
+    session.fetch(:sp, {})
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -10,7 +10,10 @@ feature 'Sign in' do
 
   scenario 'user cannot sign in if not registered' do
     signin('test@example.com', 'Please123!')
-    expect(page).to have_content t('devise.failure.not_found_in_database')
+    link_url = new_user_password_url
+
+    expect(page).
+      to have_link t('devise.failure.not_found_in_database_link_text', href: link_url)
   end
 
   it 'does not throw an exception if the email contains invalid bytes' do
@@ -21,25 +24,37 @@ feature 'Sign in' do
   scenario 'user cannot sign in with wrong email' do
     user = create(:user)
     signin('invalid@email.com', user.password)
-    expect(page).to have_content t('devise.failure.not_found_in_database')
+    link_url = new_user_password_url
+
+    expect(page).
+      to have_link t('devise.failure.invalid_link_text', href: link_url)
   end
 
   scenario 'user cannot sign in with empty email' do
     signin('', 'foo')
 
-    expect(page).to have_content t('devise.failure.invalid')
+    link_url = new_user_password_url
+
+    expect(page).
+      to have_link t('devise.failure.not_found_in_database_link_text', href: link_url)
   end
 
   scenario 'user cannot sign in with empty password' do
     signin('test@example.com', '')
 
-    expect(page).to have_content t('devise.failure.invalid')
+    link_url = new_user_password_url
+
+    expect(page).
+      to have_link t('devise.failure.not_found_in_database_link_text', href: link_url)
   end
 
   scenario 'user cannot sign in with wrong password' do
     user = create(:user)
     signin(user.email, 'invalidpass')
-    expect(page).to have_content t('devise.failure.invalid')
+    link_url = new_user_password_url
+
+    expect(page).
+      to have_link t('devise.failure.invalid_link_text', href: link_url)
   end
 
   scenario 'user can see and use password visibility toggle', js: true do
@@ -252,8 +267,12 @@ feature 'Sign in' do
 
       user = create(:user)
       signin(user.email, 'invalid')
+
+      link_url = new_user_password_url
+
+      expect(page).
+        to have_link t('devise.failure.invalid_link_text', href: link_url)
       expect(current_path).to eq root_path
-      expect(page).to have_content t('devise.failure.invalid')
     end
   end
 
@@ -383,6 +402,8 @@ feature 'Sign in' do
   it_behaves_like 'signing in as LOA1 with personal key', :oidc
   it_behaves_like 'signing in as LOA3 with personal key', :saml
   it_behaves_like 'signing in as LOA3 with personal key', :oidc
+  it_behaves_like 'signing in with wrong credentials', :saml
+  it_behaves_like 'signing in with wrong credentials', :oidc
 
   context 'user signs in with personal key, visits account page before viewing new key' do
     # this can happen if you submit the personal key form multiple times quickly

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'I18n' do
         expect(bad_keys).to be_empty
       end
 
-      it 'is formatted as normalized YAML (run scripts/normalize-yaml)' do
+      it 'is formatted as normalized YAML (run make normalize-yaml)' do
         normalized_yaml = YAML.dump(YamlNormalizer.handle_hash(YAML.load_file(full_path)))
 
         expect(File.read(full_path)).to eq(normalized_yaml)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -143,6 +143,40 @@ shared_examples 'signing in as LOA3 with personal key after resetting password' 
   end
 end
 
+shared_examples 'signing in with wrong credentials' do |sp|
+  # This tests the custom Devise error message defined in lib/custom_devise_failure_app.rb
+  context 'when the user does not exist' do
+    it 'links to forgot password page with locale and request_id' do
+      Capybara.current_session.driver.header('Accept-Language', 'es')
+
+      visit_idp_from_sp_with_loa1(sp)
+      sp_request_id = ServiceProviderRequest.last.uuid
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit('test@test.com', 'foo')
+
+      link_url = new_user_password_url(locale: 'es', request_id: sp_request_id)
+      expect(page).
+        to have_link t('devise.failure.not_found_in_database_link_text', href: link_url)
+    end
+  end
+
+  context 'when the user exists' do
+    it 'links to forgot password page with locale and request_id' do
+      Capybara.current_session.driver.header('Accept-Language', 'es')
+
+      user = create(:user, :signed_up)
+      visit_idp_from_sp_with_loa1(sp)
+      sp_request_id = ServiceProviderRequest.last.uuid
+      click_link t('links.sign_in')
+      fill_in_credentials_and_submit(user.email, 'password')
+
+      link_url = new_user_password_url(locale: 'es', request_id: sp_request_id)
+      expect(page).
+        to have_link t('devise.failure.invalid_link_text', href: link_url)
+    end
+  end
+end
+
 def personal_key_for_loa3_user(user, pii)
   pii_attrs = Pii::Attributes.new_from_hash(pii)
   user_access_key = user.unlock_user_access_key(user.password)


### PR DESCRIPTION
**Why**: A fair number of users don't realize they don't already have a
login.gov account and they try to sign in with credentials from an
account at one of our SPs. By adding a link to the password reset page,
we hope users will click the link and submit their email, at which
point they will receive an email letting them know they don't have an
account yet.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
