### PR TITLE
Log Pii::EncryptionError during sign in

### DIFF
--- a/app/services/encrypted_key_maker.rb
+++ b/app/services/encrypted_key_maker.rb
@@ -62,7 +62,7 @@ class EncryptedKeyMaker
     ciphertext = user_access_key.xor(decode(encryption_key)).sub(KEY_TYPE[:KMS], '')
     user_access_key.unlock(aws_client.decrypt(ciphertext_blob: ciphertext).plaintext)
   rescue Aws::KMS::Errors::InvalidCiphertextException
-    raise Pii::EncryptionError
+    raise Pii::EncryptionError, 'Aws::KMS::Errors::InvalidCiphertextException'
   end
 
   def make_local(user_access_key)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -308,6 +308,21 @@ describe Users::SessionsController, devise: true do
 
       expect(response).to render_template(:new)
     end
+
+    it 'logs Pii::EncryptionError' do
+      user = create(:user, :signed_up)
+      allow(user).to receive(:unlock_user_access_key).and_raise Pii::EncryptionError, 'foo'
+
+      expect(Rails.logger).to receive(:info) do |attributes|
+        attributes = JSON.parse(attributes)
+        expect(attributes['event']).to eq 'Pii::EncryptionError when validating password'
+        expect(attributes['error']).to eq 'foo'
+        expect(attributes['uuid']).to eq user.uuid
+        expect(attributes).to have_key('timestamp')
+      end
+
+      post :create, params: { user: { email: user.email, password: user.password } }
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
**Why**: We've had reports of people who were not able to sign in
with their email and password, even after resetting their password
multiple times. If the app raises `Pii::EncryptionError`, then
`valid_password?` will be false and the user will see the "invalid email
or password" message. Encryption errors are expected when the password
is indeed wrong, but we'd like to know if there are other errors being
raised. To help troubleshoot this, we will log the error messages.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
