### PR TITLE
Improve ServiceProvider redirect_uri validation

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -61,7 +61,7 @@ class ServiceProvider < ApplicationRecord
 
   def redirect_uri_valid?(redirect_uri)
     parsed_uri = URI.parse(redirect_uri)
-    parsed_uri.scheme.present? || parsed_uri.host.present?
+    parsed_uri.scheme.present? && parsed_uri.host.present?
   rescue URI::BadURIError, URI::InvalidURIError
     false
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,7 @@ module Upaya
           ServiceProvider.pluck(:redirect_uris).flatten.compact.find do |uri|
             split_uri = uri.split('//')
             protocol = split_uri[0]
-            domain = split_uri[1].split('/')[0]
+            domain = split_uri[1].split('/')[0] if split_uri.size > 1
             source == "#{protocol}//#{domain}"
           end.present?
         end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -8,12 +8,16 @@ describe ServiceProvider do
       empty_uri_sp = build(:service_provider, redirect_uris: [''])
       relative_uri_sp = build(:service_provider, redirect_uris: ['/asdf/hjkl'])
       bad_uri_sp = build(:service_provider, redirect_uris: [' http://foo.com'])
+      missing_host_sp = build(:service_provider, redirect_uris: ['hipchat://'])
+      hipchat_sp = build(:service_provider, redirect_uris: ['hipchat://return'])
 
       expect(valid_sp).to be_valid
       expect(missing_protocol_sp).to_not be_valid
       expect(empty_uri_sp).to_not be_valid
       expect(relative_uri_sp).to_not be_valid
       expect(bad_uri_sp).to_not be_valid
+      expect(missing_host_sp).to_not be_valid
+      expect(hipchat_sp).to be_valid
     end
 
     it 'allows redirect_uris to be blank' do

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
     end
   end
 
-  describe 'nil redirect_uris' do
+  describe 'bad redirect_uris' do
     it 'handles a nil value gracefully' do
       ServiceProvider.create(issuer: 'foo', redirect_uris: nil)
 
@@ -143,6 +143,17 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
         expect(response['Access-Control-Allow-Credentials']).to eq('true')
         expect(response['Access-Control-Allow-Methods']).to eq('POST, OPTIONS')
         expect(response['Access-Control-Allow-Origin']).to eq('https://example.com')
+      end
+    end
+
+    it 'gracefully handles a uri that only includes the protocol' do
+      ServiceProvider.create(issuer: 'foo', redirect_uris: ['hipchat://'])
+
+      post api_openid_connect_token_path, headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+
+      aggregate_failures do
+        expect(response).to_not be_not_found
+        expect(response['Access-Control-Allow-Origin']).to be_nil
       end
     end
   end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -7,7 +7,7 @@ describe ServiceProviderUpdater do
   let(:dashboard_sp_issuer) { 'some-dashboard-service-provider' }
   let(:inactive_dashboard_sp_issuer) { 'old-dashboard-service-provider' }
   let(:openid_connect_issuer) { 'sp:test:foo:bar' }
-  let(:openid_connect_redirect_uris) { %w[http://localhost:1234 my-app:/result] }
+  let(:openid_connect_redirect_uris) { %w[http://localhost:1234 my-app://result] }
   let(:dashboard_service_providers) do
     [
       {


### PR DESCRIPTION
**Why**: Someone added "hipchat://" as a redirect URI in the prod DB,
which caused the app to return 500 errors.

**How**:
- Allow the CORS config to handle this scenario gracefully
- Update the URI validation to require both a scheme and a host.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
