### PR TITLE
Countdown timer varies based on user machine

### DIFF
--- a/app/assets/javascripts/app/utils/countdown-timer.js
+++ b/app/assets/javascripts/app/utils/countdown-timer.js
@@ -1,18 +1,23 @@
 import msFormatter from './ms-formatter';
 
-export default (el, timeLeft = 0, interval = 1000) => {
+export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
   let remaining = timeLeft;
+  let currentTime;
 
   if (!el || !('innerHTML' in el)) return;
 
   (function tick() {
     /* eslint-disable no-param-reassign */
+    if (endTime) {
+      currentTime = new Date().getTime();
+      remaining = endTime - currentTime;
+    }
+
     el.innerHTML = msFormatter(remaining);
 
     if (remaining <= 0) {
       return;
     }
-
     remaining -= interval;
     setTimeout(tick, interval);
   }());

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -32,15 +32,19 @@ function success(data) {
       show_warning = time_timeout < (time_cutoff + warning),
       time_remaining = time_timeout - time_cutoff;
 
+  if (!data.live || time_remaining <= 0) {
+    window.LoginGov.autoLogout();
+    return;
+  }
+
   if (show_warning && !modal.shown) {
     modal.show();
-    window.LoginGov.countdownTimer(document.getElementById('countdown'), time_remaining);
+    window.LoginGov.countdownTimer(
+      document.getElementById('countdown'), time_remaining, time_timeout
+    );
   }
 
   if (!show_warning && modal.shown) modal.hide();
-  if (!data.live) {
-    window.LoginGov.autoLogout();
-  }
 
   if (time_remaining < frequency){
     time_remaining = time_remaining < 0 ? 0 : time_remaining


### PR DESCRIPTION
**Why**:
Countdown timer ticks based on timer which
isn't accurate. Instead use the end time to
calculate exact time left in session. Multiple
tabs sync perfectly now

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
