### PR TITLE
Add deploy/build scripts to decouple build process from identity-devops.

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -8,9 +8,14 @@
 
 set -euo pipefail
 
+echo "deploy/build starting"
+echo "HOME: ${HOME-}"
+cd "$(dirname "$0")/.."
+
 set -x
 
-cd "$(dirname "$0")/.."
+id
+which bundle
 
 bundle_dir=/srv/idp/shared
 
@@ -22,4 +27,6 @@ bundle install --deployment --jobs 4 \
 bundle exec yarn install
 bundle exec yarn build
 
-bundle exec rake assets:precompile
+set +x
+
+echo "deploy/build finished"

--- a/deploy/build
+++ b/deploy/build
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is called by identity-devops cookbooks as part of the deployment
+# process. It runs build steps needed to complete building the application,
+# such as vendoring ruby/nodejs libraries and compiling static assets.
+# Then the deploy/activate script is called to instantiate live configuration
+# and take steps at runtime.
+
+set -euo pipefail
+
+set -x
+
+cd "$(dirname "$0")/.."
+
+bundle_dir=/srv/idp/shared
+
+bundle install --deployment --jobs 4 \
+    --path "$bundle_dir/bundle" \
+    --binstubs "$bundle_dir/bin" \
+    --without 'deploy development doc test'
+
+bundle exec yarn install
+bundle exec yarn build
+
+bundle exec rake assets:precompile

--- a/deploy/build-post-config
+++ b/deploy/build-post-config
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is called by identity-devops cookbooks as part of the deployment
+# process. It runs build steps needed to complete building the application. It
+# runs *after* deploy/activate is called to download secrets. This allows us to
+# rely on the full configuration being available.
+
+set -euo pipefail
+
+echo "deploy/build-post-config starting"
+echo "HOME: ${HOME-}"
+cd "$(dirname "$0")/.."
+
+set -x
+
+id
+which bundle
+
+export NODE_ENV=production
+
+bundle exec rake assets:precompile
+
+set +x
+
+echo "deploy/build-post-config finished"


### PR DESCRIPTION
Previously these deploy steps were performed by chef cookbooks in the identity-devops repo. This made it more difficult to make changes like moving from npm to yarn or switching to webpacker because we had to tightly coordinate rolling out changes in sync between identity-idp and identity-devops.

With these changes, move build bootstrapping steps into the identity-idp repo so that the idp repo knows how to bootstrap itself.