### PR TITLE
Fix linter offenses

### DIFF
--- a/.reek
+++ b/.reek
@@ -132,9 +132,13 @@ UtilityFunction:
   InstanceVariableAssumption:
     enabled: false
 'spec':
+  BooleanParameter:
+    exclude:
+     - SamlAuthHelper#generate_saml_response
   ControlParameter:
     exclude:
       - complete_idv_session
+      - SamlAuthHelper#link_user_to_identity
       - visit_idp_from_sp_with_loa1
       - visit_idp_from_sp_with_loa3
   DuplicateMethodCall:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - 'spec/services/pii/nist_encryption_spec.rb'
     - 'lib/rspec/user_flow_formatter.rb'
     - 'lib/user_flow_exporter.rb'
+    - 'node_modules/**/*'
   TargetRubyVersion: 2.3
   TargetRailsVersion: 5.1
   UseCache: true

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
       context 'with valid params' do
         it 'redirects back to the client app with a code' do
           IdentityLinker.new(user, client_id).link_identity(ial: 1)
-          user.identities.last.update!(verified_attributes: ["given_name", "family_name", "birthdate"])
+          user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           action
 
           expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -57,7 +57,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
             it 'redirects to the redirect_uri immediately' do
               IdentityLinker.new(user, client_id).link_identity(ial: 3)
-              user.identities.last.update!(verified_attributes: ["given_name", "family_name", "birthdate"])
+              user.identities.last.update!(
+                verified_attributes: %w[given_name family_name birthdate]
+              )
               action
 
               expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
@@ -89,7 +91,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         context 'user has already approved this application' do
           before do
             IdentityLinker.new(user, client_id).link_identity
-            user.identities.last.update!(verified_attributes: ["given_name", "family_name", "birthdate"])
+            user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
           end
 
           it 'redirects back to the client app with a code' do

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -119,9 +119,9 @@ describe SignUp::CompletionsController do
         subject.session[:sp] = {
           loa3: false,
           request_url: 'http://example.com',
-          requested_attributes: ["email"]
+          requested_attributes: ['email'],
         }
-        expect(@linker).to receive(:link_identity).with(ial: 1 , verified_attributes: ["email"])
+        expect(@linker).to receive(:link_identity).with(ial: 1, verified_attributes: ['email'])
         patch :update
       end
     end
@@ -149,9 +149,10 @@ describe SignUp::CompletionsController do
         subject.session[:sp] = {
           loa3: true,
           request_url: 'http://example.com',
-          requested_attributes: ["email", "first_name"]
+          requested_attributes: %w[email first_name],
         }
-        expect(@linker).to receive(:link_identity).with(ial: 3 , verified_attributes: ["email", "first_name"])
+        expect(@linker).to receive(:link_identity).
+          with(ial: 3, verified_attributes: %w[email first_name])
         patch :update
       end
     end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -63,7 +63,7 @@ feature 'OpenID Connect' do
       user = user_with_2fa
 
       IdentityLinker.new(user, client_id).link_identity
-      user.identities.last.update!(verified_attributes: ["email"])
+      user.identities.last.update!(verified_attributes: ['email'])
 
       visit openid_connect_authorize_path(
         client_id: client_id,
@@ -93,7 +93,7 @@ feature 'OpenID Connect' do
       user = user_with_2fa
 
       IdentityLinker.new(user, client_id).link_identity
-      user.identities.last.update!(verified_attributes: ["email"])
+      user.identities.last.update!(verified_attributes: ['email'])
 
       visit openid_connect_authorize_path(
         client_id: client_id,
@@ -237,7 +237,7 @@ feature 'OpenID Connect' do
   context 'logging into an SP for the first time' do
     it 'displays shared attributes page once' do
       client_id = 'urn:gov:gsa:openidconnect:sp:server'
-      
+
       user = user_with_2fa
 
       oidc_path =  openid_connect_authorize_path(
@@ -251,13 +251,12 @@ feature 'OpenID Connect' do
         prompt: 'select_account'
       )
       visit oidc_path
-      
+
       sign_in_live_with_2fa(user)
-      
 
       expect(current_url).to eq(sign_up_completed_url)
       expect(page).to have_content(t('titles.sign_up.new_sp'))
-      
+
       click_continue
       expect(current_url).to start_with('http://localhost:7654/auth/result')
       visit sign_out_url
@@ -267,7 +266,6 @@ feature 'OpenID Connect' do
       redirect_uri = URI(current_url)
 
       expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-
     end
   end
 
@@ -428,7 +426,7 @@ feature 'OpenID Connect' do
     user = user_with_2fa
 
     link_identity(user, client_id)
-    user.identities.last.update!(verified_attributes: ["email"])
+    user.identities.last.update!(verified_attributes: ['email'])
 
     visit openid_connect_authorize_path(
       client_id: client_id,

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -130,9 +130,9 @@ feature 'LOA1 Single Sign On' do
   end
 
   context 'fully signed up user authenticates new sp' do
-    let(:user){ create(:user, :signed_up) }
-    let(:saml_authn_request){ auth_request.create(saml_settings) }
-    
+    let(:user) { create(:user, :signed_up) }
+    let(:saml_authn_request) { auth_request.create(saml_settings) }
+
     before do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)

--- a/spec/models/agency_identity_spec.rb
+++ b/spec/models/agency_identity_spec.rb
@@ -13,13 +13,13 @@ describe AgencyIdentity do
   describe '#agency_enabled?' do
     it 'returns true if the agency is enabled' do
       allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('1')
-      ai = AgencyIdentity.new(agency_id:1,user_id:1,uuid:'UUID1')
+      ai = AgencyIdentity.new(agency_id: 1, user_id: 1, uuid: 'UUID1')
       expect(ai.agency_enabled?).to eq(true)
     end
 
     it 'returns false if the agency is disabled' do
       allow(Figaro.env).to receive(:agencies_with_agency_based_uuids).and_return('')
-      ai = AgencyIdentity.new(agency_id:1,user_id:1,uuid:'UUID1')
+      ai = AgencyIdentity.new(agency_id: 1, user_id: 1, uuid: 'UUID1')
       expect(ai.agency_enabled?).to eq(false)
     end
   end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -41,7 +41,8 @@ describe TwilioService do
 
     it 'uses a real Twilio client' do
       client = instance_double(Twilio::REST::Client)
-      expect(Twilio::REST::Client).to receive(:new).with(/sid(1|2)/, /token(1|2)/).and_return(client)
+      expect(Twilio::REST::Client).
+        to receive(:new).with(/sid(1|2)/, /token(1|2)/).and_return(client)
       http_client = Struct.new(:adapter)
       expect(client).to receive(:http_client).and_return(http_client)
       expect(http_client).to receive(:adapter=).with(:typhoeus)

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -53,7 +53,7 @@ module ControllerHelper
   end
 
   def stub_identity(user, params)
-    Identity.new(params.merge({user: user})).save
+    Identity.new(params.merge(user: user)).save
   end
 end
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -178,15 +178,15 @@ module SamlAuthHelper
   private
 
   def link_user_to_identity(user, link, settings)
-    if link
-      IdentityLinker.new(
-        user,
-        settings.issuer
-      ).link_identity(
-        ial: loa3_requested?(settings) ? true : nil,
-        verified_attributes: ['email']
-      )
-    end
+    return unless link
+
+    IdentityLinker.new(
+      user,
+      settings.issuer
+    ).link_identity(
+      ial: loa3_requested?(settings) ? true : nil,
+      verified_attributes: ['email']
+    )
   end
 
   def loa3_requested?(settings)


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
