### PR TITLE
Use readonly production database config in console

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -32,9 +32,9 @@ test:
 production:
   <<: *defaults
   database: <%= Figaro.env.database_name! %>
-  username: <%= Figaro.env.database_username! %>
+  username: <%= ProductionDatabaseConfiguration.username %>
   host: <%= Figaro.env.database_host! %>
-  password: <%= Figaro.env.database_password! %>
+  password: <%= ProductionDatabaseConfiguration.password %>
   pool: <%= ProductionDatabaseConfiguration.pool %>
   sslmode: 'verify-full'
   sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'

--- a/lib/production_database_configuration.rb
+++ b/lib/production_database_configuration.rb
@@ -1,4 +1,22 @@
 class ProductionDatabaseConfiguration
+  READONLY_WARNING_MESSAGE = '
+    WARNING: Loading database a configuration with the readonly database user.
+    If you wish to make changes to records in the database set
+    ALLOW_CONSOLE_DB_WRITE_ACCESS to "true" in the environment
+  '.freeze.gsub(/^\s+/, '')
+
+  def self.username
+    env = Figaro.env
+    return env.database_username! unless readonly_mode?
+    env.database_readonly_username!
+  end
+
+  def self.password
+    env = Figaro.env
+    return env.database_password! unless readonly_mode?
+    env.database_readonly_password!
+  end
+
   def self.pool
     env = Figaro.env
     role = File.read('/etc/login.gov/info/role') if File.exist?('/etc/login.gov/info/role')
@@ -10,5 +28,24 @@ class ProductionDatabaseConfiguration
     else
       5
     end
+  end
+
+  private_class_method def self.readonly_mode?
+    return false unless defined?(Rails::Console)
+    return false unless readonly_credentials_present?
+    return false if ENV['ALLOW_CONSOLE_DB_WRITE_ACCESS'] == 'true'
+    print_readonly_warning
+    true
+  end
+
+  private_class_method def self.readonly_credentials_present?
+    env = Figaro.env
+    env.database_readonly_username.present? &&
+    env.database_readonly_password.present?
+  end
+
+  private_class_method def self.print_readonly_warning
+    return if @readonly_warning.present?
+    warn @readonly_warning ||= READONLY_WARNING_MESSAGE
   end
 end

--- a/lib/tasks/readonly_database_user.rake
+++ b/lib/tasks/readonly_database_user.rake
@@ -1,0 +1,14 @@
+namespace :db do
+  desc 'Create a readonly database user'
+  task create_readonly_user: :environment do
+    username = Figaro.env.database_readonly_username
+    password = Figaro.env.database_readonly_password
+
+    sql_statements = [
+      "CREATE USER #{username} WITH ENCRYPTED PASSWORD '#{password}'",
+      "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}",
+    ]
+
+    sql_statements.each { |sql| ActiveRecord::Base.connection.execute(sql) }
+  end
+end

--- a/spec/lib/production_database_configuration_spec.rb
+++ b/spec/lib/production_database_configuration_spec.rb
@@ -1,6 +1,101 @@
 require 'rails_helper'
 
 describe ProductionDatabaseConfiguration do
+  let(:database_username) { 'db_user' }
+  let(:database_password) { 'db_pass' }
+  let(:database_readonly_username) { 'db_readonly_user' }
+  let(:database_readonly_password) { 'db_readonly_pass' }
+
+  before do
+    allow(Figaro.env).to receive(:database_username).and_return(database_username)
+    allow(Figaro.env).to receive(:database_password).and_return(database_password)
+    allow(Figaro.env).to receive(:database_readonly_username).and_return(database_readonly_username)
+    allow(Figaro.env).to receive(:database_readonly_password).and_return(database_readonly_password)
+    allow(ProductionDatabaseConfiguration).to receive(:warn)
+  end
+
+  describe '.username' do
+    context 'when app is running in a console' do
+      before { stub_rails_console }
+
+      it 'returns the readonly username' do
+        expect(ProductionDatabaseConfiguration.username).to eq(database_readonly_username)
+      end
+    end
+
+    context 'when the app is running in a console without readonly user credentials' do
+      it 'returns the read/write username' do
+        allow(Figaro.env).to receive(:database_readonly_username).and_return(nil)
+        allow(Figaro.env).to receive(:database_readonly_password).and_return(nil)
+
+        expect(ProductionDatabaseConfiguration.username).to eq(database_username)
+
+        allow(Figaro.env).to receive(:database_readonly_username).and_return('')
+        allow(Figaro.env).to receive(:database_readonly_password).and_return('')
+
+        expect(ProductionDatabaseConfiguration.username).to eq(database_username)
+      end
+    end
+
+    context 'when the app is running in a console with the write access flag' do
+      before do
+        stub_rails_console
+        stub_environment_write_access_flag
+      end
+
+      it 'returns the read/write username' do
+        expect(ProductionDatabaseConfiguration.username).to eq(database_username)
+      end
+    end
+
+    context 'when the app is not running in a console' do
+      it 'returns the read/write username' do
+        expect(ProductionDatabaseConfiguration.username).to eq(database_username)
+      end
+    end
+  end
+
+  describe '.password' do
+    context 'when app is running in a console' do
+      before { stub_rails_console }
+
+      it 'returns the readonly password' do
+        expect(ProductionDatabaseConfiguration.password).to eq(database_readonly_password)
+      end
+    end
+
+    context 'when the app is running in a console without readonly user credentials' do
+      it 'returns the read/write username' do
+        allow(Figaro.env).to receive(:database_readonly_username).and_return(nil)
+        allow(Figaro.env).to receive(:database_readonly_password).and_return(nil)
+
+        expect(ProductionDatabaseConfiguration.password).to eq(database_password)
+
+        allow(Figaro.env).to receive(:database_readonly_username).and_return('')
+        allow(Figaro.env).to receive(:database_readonly_password).and_return('')
+
+        expect(ProductionDatabaseConfiguration.password).to eq(database_password)
+      end
+    end
+
+    context 'when the app is running in a console with the write access flag' do
+      before do
+        stub_rails_console
+        stub_environment_write_access_flag
+      end
+
+      it 'returns the read/write password' do
+        expect(ProductionDatabaseConfiguration.password).to eq(database_password)
+      end
+    end
+
+    context 'when the app is not running in a console' do
+      it 'returns the read/write password' do
+        expect(ProductionDatabaseConfiguration.password).to eq(database_password)
+      end
+    end
+  end
+
   describe '.pool' do
     context 'when the app is running on an idp host' do
       before { stub_role_config('idp') }
@@ -60,6 +155,14 @@ describe ProductionDatabaseConfiguration do
         expect(ProductionDatabaseConfiguration.pool).to eq(5)
       end
     end
+  end
+
+  def stub_rails_console
+    stub_const('Rails::Console', Object)
+  end
+
+  def stub_environment_write_access_flag
+    allow(ENV).to receive(:[]).with('ALLOW_CONSOLE_DB_WRITE_ACCESS').and_return('true')
   end
 
   def stub_role_config(role)


### PR DESCRIPTION
**Why**: So that console users in deployed environments will not be able
to modify records without explicitly enabling write access. Enabling
write access is done by setting ALLOW_CONSOLE_DB_WRITE_ACCESS=true.

**How**: This commit adds a class called ProductionDatabaseConfiguration
which is loaded in database.yml and used to determine the value of
configs such as the username, password, and pool size. When the rails
console is defined, it uses 2 new configs for user name and password
that should correspond to a read only user.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
