### PR TITLE
Don't send confirmation for same email

### DIFF
--- a/app/forms/update_user_email_form.rb
+++ b/app/forms/update_user_email_form.rb
@@ -18,8 +18,7 @@ class UpdateUserEmailForm
 
     if valid_form?
       @success = true
-      UpdateUser.new(user: @user, attributes: { email: email }).call
-      @user.send_custom_confirmation_instructions
+      update_user_email if email_changed?
     else
       @success = process_errors
     end
@@ -53,5 +52,10 @@ class UpdateUserEmailForm
       email_already_exists: email_taken?,
       email_changed: email_changed?,
     }
+  end
+
+  def update_user_email
+    UpdateUser.new(user: @user, attributes: { email: email }).call
+    @user.send_custom_confirmation_instructions
   end
 end

--- a/spec/forms/update_user_email_form_spec.rb
+++ b/spec/forms/update_user_email_form_spec.rb
@@ -97,5 +97,24 @@ describe UpdateUserEmailForm do
         expect(subject.submit(email: 'invalid_email')).to eq result
       end
     end
+
+    context 'when email is same as current email' do
+      it 'it does not send an email' do
+        user = create(:user, :signed_up, email: 'taken@gmail.com')
+        form = UpdateUserEmailForm.new(user)
+
+        result = instance_double(FormResponse)
+        extra = {
+          email_already_exists: false,
+          email_changed: false,
+        }
+
+        expect(user).to_not receive(:send_custom_confirmation_instructions)
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}, extra: extra).and_return(result)
+        expect(form.submit(email: 'taken@gmail.com')).to eq result
+        expect(form.email).to eq 'taken@gmail.com'
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**:
When a user attempts to change their email
and uses the same address, no confirmation
email should be sent.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
