### PR TITLE
Remove references to `yarn build`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
           name: Test Setup
           command: |
             yarn install
-            yarn build
             cp config/application.yml.example config/application.yml
             cp certs/saml.crt.example certs/saml.crt
             cp certs/saml2018.crt.example certs/saml2018.crt

--- a/bin/setup
+++ b/bin/setup
@@ -39,7 +39,6 @@ Dir.chdir APP_ROOT do
     run 'docker-compose build'
     run 'docker-compose run --rm web bin/generate-example-keys'
     run 'docker-compose run --rm web yarn install'
-    run 'docker-compose run --rm web yarn build'
     run 'docker-compose run --rm web rake db:reset RAILS_ENV=development'
     run 'docker-compose run --rm web rake db:reset RAILS_ENV=test'
     run 'docker-compose run --rm web rake dev:prime'
@@ -57,7 +56,6 @@ Dir.chdir APP_ROOT do
   run 'gem install foreman --conservative && gem update foreman'
   run "bundle check || bundle install --without deploy production"
   run "yarn install"
-  run "yarn build"
   run "gem install mailcatcher"
 
   puts "\n== Preparing database =="

--- a/deploy/build
+++ b/deploy/build
@@ -25,7 +25,6 @@ bundle install --deployment --jobs 4 \
     --without 'deploy development doc test'
 
 bundle exec yarn install
-bundle exec yarn build
 
 set +x
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "npm": "~5.x.x"
   },
   "scripts": {
-    "build": "true",
     "test": "NODE_ENV=test mocha --require babel-core/register --require spec/javascripts/spec_helper.js spec/javascripts/**/*.js"
   },
   "dependencies": {


### PR DESCRIPTION
**Why**: Literally, all it does is run the `true` command. The `scripts`
section of `package.json` is meant to specify certain scripts that can
be run. Each script has a name, which is the key of the hash, and the
value is meant to contain an actual script that can be run on the
command line.

Reference: https://yarnpkg.com/en/docs/cli/run

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
