### PR TITLE
Add a NR method tracer to UserAccessKey#build

### DIFF
--- a/app/services/user_access_key.rb
+++ b/app/services/user_access_key.rb
@@ -9,6 +9,8 @@
 # Store F (User.encrypted_password) and D (User.encryption_key) in db
 
 class UserAccessKey
+  include ::NewRelic::Agent::MethodTracer
+
   attr_accessor :cost, :encrypted_d, :salt, :z1, :z2, :random_r
 
   def initialize(password:, salt:, cost: nil)
@@ -84,6 +86,7 @@ class UserAccessKey
     self.z1, self.z2 = build_segments(scrypted)
     self.random_r = Pii::Cipher.random_key
   end
+  add_method_tracer :build, 'Custom/UserAccessKey/build'
 
   def build_segments(scrypted)
     hashed = SCrypt::Password.new(scrypted).digest


### PR DESCRIPTION
**Why**: So that we can see calls to SCrypt in New Relic traces
and track down redundant SCrypt calls.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
