### PR TITLE
Memoize UAKs on EncryptedAttribute class

### DIFF
--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -6,7 +6,9 @@ class EncryptedAttribute
     env = Figaro.env
     key ||= env.attribute_encryption_key
     cost ||= env.attribute_cost
-    UserAccessKey.new(password: key, salt: key, cost: cost)
+    @_uaks_by_key ||= {}
+    uak_lookup = "#{key}:#{cost}"
+    (@_uaks_by_key[uak_lookup] ||= UserAccessKey.new(password: key, salt: key, cost: cost)).dup
   end
 
   def self.new_from_decrypted(decrypted, user_access_key = new_user_access_key)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -204,13 +204,17 @@ describe Users::SessionsController, devise: true do
     end
 
     context 'LOA1 user' do
-      it 'hashes password exactly once, hashes attribute access key exactly once' do
+      it 'hashes and unlocks password once, unlocks attribute access key once' do
+        # Memoize encrypted attribute key to keep UserAccessKey#new calls from
+        # exceeding expected call count
+        EncryptedAttribute.new_user_access_key
+
         allow(FeatureManagement).to receive(:use_kms?).and_return(false)
         encrypted_key_maker = EncryptedKeyMaker.new
         allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker)
         user = create(:user, :signed_up)
 
-        expect(UserAccessKey).to receive(:new).exactly(:twice).and_call_original
+        expect(UserAccessKey).to receive(:new).exactly(:once).and_call_original
         expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
         expect(EncryptedAttribute).to receive(:new_user_access_key).exactly(:once).and_call_original
 
@@ -223,13 +227,17 @@ describe Users::SessionsController, devise: true do
         allow(FeatureManagement).to receive(:use_kms?).and_return(false)
       end
 
-      it 'hashes password exactly once, hashes attribute access key exactly once' do
+      it 'hashes and unlocks password once, unlocks attribute access key once' do
+        # Memoize encrypted attribute key to keep UserAccessKey#new calls from
+        # exceeding expected call count
+        EncryptedAttribute.new_user_access_key
+
         encrypted_key_maker = EncryptedKeyMaker.new
         allow(EncryptedKeyMaker).to receive(:new).and_return(encrypted_key_maker)
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
 
-        expect(UserAccessKey).to receive(:new).exactly(:twice).and_call_original
+        expect(UserAccessKey).to receive(:new).exactly(:once).and_call_original
         expect(encrypted_key_maker).to receive(:unlock).exactly(:twice).and_call_original
         expect(EncryptedAttribute).to receive(:new_user_access_key).exactly(:once).and_call_original
 

--- a/spec/services/encrypted_attribute_spec.rb
+++ b/spec/services/encrypted_attribute_spec.rb
@@ -8,6 +8,22 @@ describe EncryptedAttribute do
     encryptor.encrypt(email, EncryptedAttribute.new_user_access_key)
   end
 
+  describe '.new_user_access_key' do
+    it 'does not return the same key twice' do
+      key1 = EncryptedAttribute.new_user_access_key
+      key2 = EncryptedAttribute.new_user_access_key
+
+      expect(key1).to_not eq(key2)
+    end
+
+    it 'does not return successive keys with the same random_r value' do
+      key1 = EncryptedAttribute.new_user_access_key
+      key2 = EncryptedAttribute.new_user_access_key
+
+      expect(key1.random_r).to_not eq(key2.random_r)
+    end
+  end
+
   describe '#new' do
     it 'automatically decrypts' do
       ee = EncryptedAttribute.new(encrypted_email)


### PR DESCRIPTION
**Why**: Initializing a user access key means calculating a SCrypt hash
which is expensive. If we've already calculated the SCrypt hash for a
given key/cost, we shouldn't have to again. The EncryptedAttribute class
was initializing a UAK with a shared key each time it was called for a
new model. This commit memoizes a UAK when we initialize it for a key so
we are not constantly re-initializing it.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
