### PR TITLE
Make production db pool size configurable

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -79,6 +79,10 @@ development:
   database_host: ''
   database_name: ''
   database_password: ''
+  database_pool_idp: '5'
+  database_pool_worker: '5'
+  database_readonly_password: ''
+  database_readonly_username: ''
   database_timeout: '5000'
   database_username: ''
   domain_name: 'localhost:3000'
@@ -256,6 +260,10 @@ test:
   database_host: ''
   database_name: ''
   database_password: ''
+  database_pool_idp:
+  database_pool_worker:
+  database_readonly_password: ''
+  database_readonly_username: ''
   database_timeout: '5000'
   database_username: ''
   dashboard_api_token: '123ABC'

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,3 +1,5 @@
+<% require 'production_database_configuration' %>
+
 postgresql: &postgresql
   adapter: postgresql
   encoding: utf8
@@ -33,6 +35,6 @@ production:
   username: <%= Figaro.env.database_username! %>
   host: <%= Figaro.env.database_host! %>
   password: <%= Figaro.env.database_password! %>
-  pool: <%= (File.exist?('/etc/login.gov/info') && File.read('/etc/login.gov/info/role').chomp == 'worker') ? 26 : 5 %>
+  pool: <%= ProductionDatabaseConfiguration.pool %>
   sslmode: 'verify-full'
   sslrootcert: '/usr/local/share/aws/rds-combined-ca-bundle.pem'

--- a/lib/production_database_configuration.rb
+++ b/lib/production_database_configuration.rb
@@ -1,0 +1,14 @@
+class ProductionDatabaseConfiguration
+  def self.pool
+    env = Figaro.env
+    role = File.read('/etc/login.gov/info') if File.exist?('/etc/login.gov/info')
+    case role
+    when 'idp'
+      env.database_pool_idp.presence || 5
+    when 'worker'
+      env.database_pool_worker.presence || 26
+    else
+      5
+    end
+  end
+end

--- a/spec/lib/production_database_configuration_spec.rb
+++ b/spec/lib/production_database_configuration_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe ProductionDatabaseConfiguration do
+  describe '.pool' do
+    context 'when the app is running on an idp host' do
+      before { stub_role_config('idp') }
+
+      it 'returns the idp pool size' do
+        allow(Figaro.env).to receive(:database_pool_idp).and_return(7)
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(7)
+      end
+
+      it 'defaults to 5' do
+        allow(Figaro.env).to receive(:database_pool_idp).and_return(nil)
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(5)
+
+        allow(Figaro.env).to receive(:database_pool_idp).and_return('')
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(5)
+      end
+    end
+
+    context 'when the app is running on a worker host' do
+      before { stub_role_config('worker') }
+
+      it 'returns the worker pool size' do
+        allow(Figaro.env).to receive(:database_pool_worker).and_return(8)
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(8)
+      end
+
+      it 'defaults to 26' do
+        allow(Figaro.env).to receive(:database_pool_worker).and_return(nil)
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(26)
+
+        allow(Figaro.env).to receive(:database_pool_worker).and_return('')
+
+        expect(ProductionDatabaseConfiguration.pool).to eq(26)
+      end
+    end
+
+    context 'when the app is running on an host with an ambigous role' do
+      before { stub_role_config('fake') }
+
+      it 'returns a default of 5' do
+        expect(ProductionDatabaseConfiguration.pool).to eq(5)
+      end
+    end
+
+    context 'when the app is running on a host without a role config file' do
+      before do
+        allow(File).to receive(:exist?).with('/etc/login.gov/info').and_return(false)
+      end
+
+      it 'returns 5 and does not read the role config' do
+        expect(File).to_not receive(:read)
+        expect(ProductionDatabaseConfiguration.pool).to eq(5)
+      end
+    end
+  end
+
+  def stub_role_config(role)
+    allow(File).to receive(:exist?).with('/etc/login.gov/info').and_return(true)
+    allow(File).to receive(:read).with('/etc/login.gov/info').and_return(role)
+  end
+end


### PR DESCRIPTION
**Why**: So that we can adjust the pool size without having to deploy a
new version of the code

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
