### PR TITLE
Read instance role from correct file in db config

### DIFF
--- a/lib/production_database_configuration.rb
+++ b/lib/production_database_configuration.rb
@@ -1,7 +1,7 @@
 class ProductionDatabaseConfiguration
   def self.pool
     env = Figaro.env
-    role = File.read('/etc/login.gov/info') if File.exist?('/etc/login.gov/info')
+    role = File.read('/etc/login.gov/info/role') if File.exist?('/etc/login.gov/info/role')
     case role
     when 'idp'
       env.database_pool_idp.presence || 5

--- a/spec/lib/production_database_configuration_spec.rb
+++ b/spec/lib/production_database_configuration_spec.rb
@@ -52,7 +52,7 @@ describe ProductionDatabaseConfiguration do
 
     context 'when the app is running on a host without a role config file' do
       before do
-        allow(File).to receive(:exist?).with('/etc/login.gov/info').and_return(false)
+        allow(File).to receive(:exist?).with('/etc/login.gov/info/role').and_return(false)
       end
 
       it 'returns 5 and does not read the role config' do
@@ -63,7 +63,7 @@ describe ProductionDatabaseConfiguration do
   end
 
   def stub_role_config(role)
-    allow(File).to receive(:exist?).with('/etc/login.gov/info').and_return(true)
-    allow(File).to receive(:read).with('/etc/login.gov/info').and_return(role)
+    allow(File).to receive(:exist?).with('/etc/login.gov/info/role').and_return(true)
+    allow(File).to receive(:read).with('/etc/login.gov/info/role').and_return(role)
   end
 end


### PR DESCRIPTION
**Why**: On the instances, `/etc/login.gov/info` is a folder and the
file is named `/etc/login.gov/info/role`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
