### PR TITLE
Make AWS SES region configurable

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -72,6 +72,7 @@ development:
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
+  aws_ses_region:
   basic_auth_user_name: 'user'
   basic_auth_password: 'secret'
   dashboard_api_token: 'test_token'
@@ -168,6 +169,7 @@ production:
   available_locales: 'en es fr'
   aws_kms_key_id:
   aws_region:
+  aws_ses_region:
   basic_auth_user_name:
   basic_auth_password:
   disable_email_sending: 'false'
@@ -254,6 +256,7 @@ test:
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-test-keymaker'
   aws_region: 'us-east-1'
+  aws_ses_region:
   basic_auth_user_name: 'user'
   basic_auth_password: 'secret'
   domain_name: 'www.example.com'

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -17,7 +17,14 @@ module Aws
       private
 
       def ses_client
-        @ses_client ||= Aws::SES::Client.new
+        @ses_client ||= Aws::SES::Client.new(ses_client_options)
+      end
+
+      def ses_client_options
+        region = Figaro.env.aws_ses_region
+        opts = {}
+        opts[:region] = region if region.present?
+        opts
       end
     end
   end


### PR DESCRIPTION
**Why**: So we can configure which region the app uses to send emails

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
