### PR TITLE
Changed password validation to check in range

### DIFF
--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -7,7 +7,7 @@ module FormPasswordValidator
 
     validates :password,
               presence: true,
-              length: { in: Devise.password_length }
+              length: Devise.password_length
 
     validate :strong_password, if: :password_strength_enabled?
   end

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -7,7 +7,7 @@ module FormPasswordValidator
 
     validates :password,
               presence: true,
-              length: Devise.password_length
+              length: { in: Devise.password_length }
 
     validate :strong_password, if: :password_strength_enabled?
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   config.mailer = 'CustomDeviseMailer'
   config.mailer_sender = email_with_name(Figaro.env.email_from, Figaro.env.email_from)
   config.paranoid = true
-  config.password_length = 8..128
+  config.password_length = 9..128
   config.reconfirmable = true
   config.reset_password_within = 6.hours
   config.secret_key = Figaro.env.secret_key_base

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -37,7 +37,7 @@ describe SignUp::PasswordsController do
 
       analytics_hash = {
         success: false,
-        errors: { password: ['is too short (minimum is 8 characters)'] },
+        errors: { password: ['is too short (minimum is 9 characters)'] },
         user_id: user.uuid,
         request_id_present: false,
       }

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -91,7 +91,7 @@ describe Users::ResetPasswordsController, devise: true do
         analytics_hash = {
           success: false,
           errors: {
-            password: ['is too short (minimum is 8 characters)'],
+            password: ['is too short (minimum is 9 characters)'],
             reset_password_token: ['token_expired'],
           },
           user_id: user.uuid,
@@ -122,7 +122,7 @@ describe Users::ResetPasswordsController, devise: true do
         form_params = { password: 'short', reset_password_token: raw_reset_token }
         analytics_hash = {
           success: false,
-          errors: { password: ['is too short (minimum is 8 characters)'] },
+          errors: { password: ['is too short (minimum is 9 characters)'] },
           user_id: user.uuid,
           active_profile: false,
           confirmed: true,

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -187,7 +187,7 @@ feature 'Password Recovery' do
         fill_in 'New password', with: '1234'
         click_button t('forms.passwords.edit.buttons.submit')
 
-        expect(page).to have_content 'is too short (minimum is 8 characters)'
+        expect(page).to have_content 'is too short (minimum is 9 characters)'
       end
 
       it "does not update the user's password when password is invalid" do

--- a/spec/features/visitors/set_password_spec.rb
+++ b/spec/features/visitors/set_password_spec.rb
@@ -54,7 +54,7 @@ feature 'Visitor sets password during signup' do
     it 'has dynamic password strength feedback' do
       expect(page).to have_content '...'
 
-      fill_in 'password_form_password', with: 'password'
+      fill_in 'password_form_password', with: '123456789'
       expect(page).to have_content t('zxcvbn.feedback.this_is_a_top_10_common_password')
     end
   end
@@ -88,7 +88,7 @@ feature 'Visitor sets password during signup' do
 
       create(:user, :unconfirmed)
       confirm_last_user
-      fill_in 'password_form_password', with: 'password'
+      fill_in 'password_form_password', with: '123456789'
 
       click_button t('forms.buttons.continue')
 

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -37,7 +37,7 @@ describe PasswordForm, type: :model do
         password = 'invalid'
 
         errors = {
-          password: ['is too short (minimum is 8 characters)'],
+          password: ['is too short (minimum is 9 characters)'],
         }
 
         extra = {

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -40,7 +40,7 @@ describe ResetPasswordForm, type: :model do
 
         password = 'invalid'
 
-        errors = { password: ['is too short (minimum is 8 characters)'] }
+        errors = { password: ['is too short (minimum is 9 characters)'] }
 
         extra = {
           user_id: '123',
@@ -89,7 +89,7 @@ describe ResetPasswordForm, type: :model do
         password = 'short'
 
         errors = {
-          password: ['is too short (minimum is 8 characters)'],
+          password: ['is too short (minimum is 9 characters)'],
           reset_password_token: ['token_expired'],
         }
 

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -7,7 +7,7 @@ shared_examples 'strong password' do |form_class|
     user = build_stubbed(:user, email: 'test@test.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
-    password = 'custom!@'
+    password = 'custom!@Z'
     errors = {
       password: ['Your password is not strong enough.' \
         ' This is similar to a commonly used password.' \

--- a/spec/support/shared_examples_for_password_validation.rb
+++ b/spec/support/shared_examples_for_password_validation.rb
@@ -5,12 +5,7 @@ shared_examples 'password validation' do
 
   it do
     is_expected.to validate_length_of(:password).
-      is_at_least(Devise.password_length.first)
-  end
-
-  it do
-    is_expected.to validate_length_of(:password).
-      is_at_most(Devise.password_length.last)
+      is_at_least(Devise.password_length.first).is_at_most(Devise.password_length.last)
   end
 
   it do


### PR DESCRIPTION
**Why**: To correct an off-by-one error.

Link:
Issue Description: We say the password only needs to be 8 characters long but no 8 character password no matter how complicated gets the green light.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
