### PR TITLE
Make OTP expiration in messages match config

### DIFF
--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -27,7 +27,8 @@ module Voice
     end
 
     def message
-      t('voice.otp.message', code: code_with_pauses)
+      expiration = Devise.direct_otp_valid_for.to_i / 60
+      t('voice.otp.message', code: code_with_pauses, expiration: expiration)
     end
 
     def code_with_pauses

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -15,7 +15,14 @@ class SmsOtpSenderJob < ApplicationJob
   def send_otp(twilio_service, code, phone)
     twilio_service.send_sms(
       to: phone,
-      body: I18n.t('jobs.sms_otp_sender_job.message', code: code, app: APP_NAME)
+      body: I18n.t(
+        'jobs.sms_otp_sender_job.message',
+        code: code, app: APP_NAME, expiration: otp_valid_for_minutes
+      )
     )
+  end
+
+  def otp_valid_for_minutes
+    Devise.direct_otp_valid_for.to_i / 60
   end
 end

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -3,4 +3,4 @@ en:
   jobs:
     sms_otp_sender_job:
       message: "%{code} is your %{app} one-time security code. This code will expire
-        in five minutes."
+        in %{expiration} minutes."

--- a/config/locales/jobs/es.yml
+++ b/config/locales/jobs/es.yml
@@ -3,4 +3,4 @@ es:
   jobs:
     sms_otp_sender_job:
       message: "%{code} es su %{app} código de seguridad de sólo un uso. Este código
-        caducará en cinco minutos."
+        caducará en %{expiration} minutos."

--- a/config/locales/jobs/fr.yml
+++ b/config/locales/jobs/fr.yml
@@ -3,4 +3,4 @@ fr:
   jobs:
     sms_otp_sender_job:
       message: "%{code} est votre %{app} code de sécurité à utilisation unique. Ce
-        code expirera dans cinq minutes."
+        code expirera dans %{expiration} minutes."

--- a/config/locales/voice/en.yml
+++ b/config/locales/voice/en.yml
@@ -3,5 +3,5 @@ en:
   voice:
     otp:
       message: Hello! Your login.gov one time passcode is, %{code}, again, your passcode
-        is, %{code}. This code expires in five minutes.
+        is, %{code}. This code expires in %{expiration} minutes.
       repeat_instructions: Press 1 to repeat this message.

--- a/config/locales/voice/es.yml
+++ b/config/locales/voice/es.yml
@@ -3,5 +3,5 @@ es:
   voice:
     otp:
       message: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su
-        código de acceso es %{code}. Este código caducará en cinco minutos."
+        código de acceso es %{code}. Este código caducará en %{expiration} minutos."
       repeat_instructions: Presione 1 para repetir este mensaje.

--- a/config/locales/voice/fr.yml
+++ b/config/locales/voice/fr.yml
@@ -4,5 +4,5 @@ fr:
     otp:
       message: Bonjour! Votre code de sécurité à utilisation unique de login.gov est,
         %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera
-        dans cinq minutes.
+        dans %{expiration} minutes.
       repeat_instructions: Appuyez sur 1 pour répéter votre code.

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe Voice::OtpController do
           expect(doc.css('Gather')).to be_empty
         end
       end
+
+      it 'includes the otp expiration in the message' do
+        locale = :en # rubocop:disable Lint/UselessAssignment
+        allow(Devise).to receive(:direct_otp_valid_for).and_return(4.minutes)
+
+        action
+        expect(response.body).to include('4 minutes')
+      end
     end
   end
 end

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -35,7 +35,22 @@ describe SmsOtpSenderJob do
 
       expect(msg.messaging_service_sid).to eq('fake_sid')
       expect(msg.to).to eq('+1 (888) 555-5555')
-      expect(msg.body).to eq(I18n.t('jobs.sms_otp_sender_job.message', code: '1234', app: APP_NAME))
+      expect(msg.body).to eq(
+        I18n.t('jobs.sms_otp_sender_job.message', code: '1234', app: APP_NAME, expiration: '5')
+      )
+    end
+
+    it 'includes the expiration period in the message body' do
+      allow(I18n).to receive(:locale).and_return(:en).at_least(:once)
+      allow(Devise).to receive(:direct_otp_valid_for).and_return(4.minutes)
+
+      TwilioService.telephony_service = FakeSms
+
+      perform
+
+      message = FakeSms.messages.first
+
+      expect(message.body).to include('4 minutes')
     end
 
     context 'if the OTP code is expired' do


### PR DESCRIPTION
**Why**: So that the period of time in which messages say they will
expire matches how long they're configured to expire in the config

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
