### PR TITLE
Don't allow users to modify international code

### DIFF
--- a/app/javascript/app/modules/international-phone-formatter.js
+++ b/app/javascript/app/modules/international-phone-formatter.js
@@ -1,6 +1,8 @@
 import { Formatter } from 'field-kit';
 import { asYouType as AsYouType } from 'libphonenumber-js';
 
+const INTERNATIONAL_CODE_REGEX = /^\+\d{1,3} /;
+
 const fixCountryCodeSpacing = (text, countryCode) => {
   // If the text is `+123456`, make it `+123 456`
   if (text[countryCode.length + 1] !== ' ') {
@@ -29,6 +31,15 @@ const getFormattedTextData = (text) => {
   };
 };
 
+const changeRemovesInternationalCode = (current, previous) => {
+  if (previous.text.match(INTERNATIONAL_CODE_REGEX) &&
+     !current.text.match(INTERNATIONAL_CODE_REGEX)
+  ) {
+    return true;
+  }
+  return false;
+};
+
 const cursorPosition = (formattedTextData) => {
   // If the text is `(23 )` the cursor goes after the 3
   const match = formattedTextData.text.match(/\d[^\d]*$/);
@@ -53,10 +64,7 @@ class InternationalPhoneFormatter extends Formatter {
     const formattedTextData = getFormattedTextData(change.proposed.text);
     const previousFormattedTextData = getFormattedTextData(change.current.text);
 
-    if (previousFormattedTextData.template &&
-      !formattedTextData.template &&
-      change.inserted.text.length === 1
-    ) {
+    if (changeRemovesInternationalCode(formattedTextData, previousFormattedTextData)) {
       return false;
     }
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -143,6 +143,26 @@ feature 'Two Factor Authentication' do
 
         expect(find('#user_phone_form_phone').value).to include '+81'
       end
+
+      scenario 'does not allow the user to remove the international code after entering it', :js do
+        sign_in_before_2fa
+        fill_in 'Phone', with: '+81 54 354 3643'
+
+        input = find('#user_phone_form_phone')
+        input.send_keys(*([:backspace] * input.value.length))
+
+        expect(input.value).to eq('+81 ')
+      end
+
+      scenario 'allows a user to continue typing even if a number is invalid', :js do
+        sign_in_before_2fa
+        select 'United States of America +1', from: 'International code'
+
+        input = find('#user_phone_form_phone')
+        input.send_keys('12345678901234567890')
+
+        expect(input.value).to eq('+1 2345678901234567890')
+      end
     end
   end
 


### PR DESCRIPTION
**Why**: So that user's will not accidentally change it while typing
their phone number

Also note that there is a change in here to allow users to continue
typing a phone number, even if libphonenumber thinks the number is
invalid. This is there to address reported issues where users could not
type their phone number into the phone number input.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
