### PR TITLE
LG-126 - Validate the appearance of phone numbers before allowing OTP submission

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (elements.length !== 0) {
         [].forEach.call(elements, function(input) {
           input.addEventListener('input', function () {
-            if (buttons.length !== 0) {
+            if (buttons.length !== 0 && input.valid) {
               [].forEach.call(buttons, function(button) {
                 if (button.disabled) {
                   button.disabled = false;

--- a/app/javascript/app/phone-validation.js
+++ b/app/javascript/app/phone-validation.js
@@ -1,0 +1,33 @@
+import { isValidNumber } from 'libphonenumber-js';
+
+const checkPhoneValidity = () => {
+  const sendCodeButton = document.querySelector('[data-international-phone-form] input[name=commit]');
+  const phoneInput = document.querySelector('[data-international-phone-form] .phone');
+  const countryCodeInput = document.querySelector('[data-international-phone-form] .international-code');
+
+  if (phoneInput && countryCodeInput && sendCodeButton) {
+    const phone = phoneInput.value;
+    const countryCode = countryCodeInput.value;
+
+    const phoneValid = isValidNumber(phone, countryCode);
+
+    if (phoneValid) {
+      sendCodeButton.disabled = false;
+    } else {
+      phoneInput.dispatchEvent(new Event('invalid'));
+      sendCodeButton.disabled = true;
+    }
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const intlPhoneInput = document.querySelector('[data-international-phone-form] .phone');
+  const codeInput = document.querySelector('[data-international-phone-form] .international-code');
+  if (intlPhoneInput) {
+    intlPhoneInput.addEventListener('keyup', checkPhoneValidity);
+  }
+  if (codeInput) {
+    codeInput.addEventListener('change', checkPhoneValidity);
+  }
+  checkPhoneValidity();
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,5 +5,6 @@ require('../app/form-validation');
 require('../app/form-field-format');
 require('../app/radio-btn');
 require('../app/phone-internationalization');
+require('../app/phone-validation');
 require('../app/print-personal-key');
 require('../app/i18n-dropdown');

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -25,9 +25,8 @@ feature 'User edit' do
 
     scenario 'user sees error message if form is submitted without phone number', js: true do
       fill_in 'Phone', with: ''
-      click_button t('forms.buttons.submit.confirm_change')
 
-      expect(page).to have_content t('errors.messages.improbable_phone')
+      expect(page).to have_button(t('forms.buttons.submit.confirm_change'), disabled: true)
     end
 
     scenario 'updates international code as user types', :js do


### PR DESCRIPTION
**Why**: We want to be able to leverage several phone validation options,
so we are (1) moving the validation to the backend, (2) giving feedback
to the user when the phone number is considered valid, (3) enabling
"Send Code" only when the phone number is considered valid.

**How**: Originally, we were going to send a POST to an endpoint, but since we
already have libphonenumber-js in our browser-side environment, we're using that
until we need to do validation that can't be done in the browser. Since this isn't the
final validation, we do this just for the benefit of the UX.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
