### PR TITLE
Include remaining session time in /active response

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -30,7 +30,7 @@ module Users
       response.headers['Etag'] = '' # clear etags to prevent caching
       session[:pinged_at] = now
       Rails.logger.debug(alive?: alive?, expires_at: expires_at)
-      render json: { live: alive?, timeout: expires_at }
+      render json: { live: alive?, timeout: expires_at, remaining: remaining_session_time }
     end
 
     def timeout
@@ -88,6 +88,10 @@ module Users
 
     def expires_at
       @_expires_at ||= (session[:session_expires_at]&.to_datetime || (now - 1))
+    end
+
+    def remaining_session_time
+      expires_at.to_i - Time.zone.now.to_i
     end
 
     def alive?

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -27,12 +27,11 @@ function success(data) {
   var el = document.getElementById('session-timeout-msg'),
       cntnr = document.getElementById('session-timeout-cntnr');
 
-  var time_timeout = new Date(data.timeout).getTime(),
-      time_cutoff = new Date().getTime(),
-      show_warning = time_timeout < (time_cutoff + warning),
-      time_remaining = time_timeout - time_cutoff;
+  var time_remaining = data.remaining * 1000,
+      time_timeout = new Date().getTime() + time_remaining,
+      show_warning = time_remaining < warning
 
-  if (!data.live || time_remaining <= 0) {
+  if (!data.live) {
     window.LoginGov.autoLogout();
     return;
   }


### PR DESCRIPTION
**Why**: So we can use that on the frontend instead of the timestamp to
determine when to show the popup and when to timeout the session. This
is necessary because some users's system clocks may be way out of sync
with our server clock which leads to buggy behavior when comparing the
timestamp served by us against the time in the user's browser.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
