### PR TITLE
Rescue errors parsing voice OTP encrypted code

### DIFF
--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -24,6 +24,8 @@ module Voice
       return if encrypted_code.blank?
 
       cipher.decrypt(encrypted_code)
+    rescue StandardError
+      nil
     end
 
     def message

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Voice::OtpController do
       end
     end
 
+    context 'with an invalid encrypted_code in the URL' do
+      let(:encrypted_code) { '%25' }
+
+      it 'renders a blank 400' do
+        action
+
+        expect(response).to be_bad_request
+        expect(response.body).to be_empty
+      end
+    end
+
     context 'with an encrypted_code in the URL' do
       render_views
 


### PR DESCRIPTION
**Why**: If someone tries to make a request with a bogus encrypted code,
it should not cause the app to blow up with a 500 error.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
