### PR TITLE
LG-125 Select AWS SES region from a pool

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -72,7 +72,7 @@ development:
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
-  aws_ses_region:
+  aws_ses_region_pool: '{ "us-west-2": 5, "us-east-1": 95 }'
   basic_auth_user_name: 'user'
   basic_auth_password: 'secret'
   dashboard_api_token: 'test_token'
@@ -169,7 +169,7 @@ production:
   available_locales: 'en es fr'
   aws_kms_key_id:
   aws_region:
-  aws_ses_region:
+  aws_ses_region_pool:
   basic_auth_user_name:
   basic_auth_password:
   disable_email_sending: 'false'
@@ -256,7 +256,7 @@ test:
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-test-keymaker'
   aws_region: 'us-east-1'
-  aws_ses_region:
+  aws_ses_region_pool: '{ "us-west-2": 5, "us-east-1": 95 }'
   basic_auth_user_name: 'user'
   basic_auth_password: 'secret'
   domain_name: 'www.example.com'

--- a/spec/lib/aws/ses_spec.rb
+++ b/spec/lib/aws/ses_spec.rb
@@ -38,23 +38,49 @@ describe Aws::SES::Base do
       expect(mail.message_id).to eq('123abc@email.amazonses.com')
     end
 
-    context 'with an ses region in the configuration' do
+    context 'with an ses region pool in the configuration' do
       before do
-        allow(Figaro.env).to receive(:aws_ses_region).and_return('us-fake-1')
+        allow(Figaro.env).to receive(:aws_ses_region_pool).
+          and_return('{ "us-fake-1": 5, "us-phony-2": 95 }')
       end
 
-      it 'should initialize the AWS client with the configured region' do
+      it 'should build a region pool if the region pool does not exist' do
+        expected_pool = ['us-fake-1'] * 5 + ['us-phony-2'] * 95
+        described_class.region_pool = nil
         subject.deliver!(mail)
+
+        expect(described_class.region_pool).to eq(expected_pool)
+      end
+
+      it 'should not build a new region pool if one does exist' do
+        expected_pool = ['us-fake-1', 'us-phony-2']
+        described_class.region_pool = expected_pool
+        subject.deliver!(mail)
+
+        expect(described_class.region_pool).to eq(expected_pool)
+      end
+
+      it 'should initialize the AWS client with a region selected from the region pool' do
+        described_class.region_pool = []
+
+        allow(described_class.region_pool).to receive(:sample).and_return('us-fake-1')
+        described_class.new.deliver!(mail)
+
         expect(Aws::SES::Client).to have_received(:new).with(region: 'us-fake-1')
+
+        allow(described_class.region_pool).to receive(:sample).and_return('us-phony-2')
+        described_class.new.deliver!(mail)
+
+        expect(Aws::SES::Client).to have_received(:new).with(region: 'us-phony-2')
       end
     end
 
     context 'without an ses region in the configuration' do
       it 'should initialize the AWS client without a region argument' do
-        allow(Figaro.env).to receive(:aws_ses_region).and_return(nil)
+        allow(Figaro.env).to receive(:aws_ses_region_pool).and_return(nil)
         Aws::SES::Base.new.deliver!(mail)
 
-        allow(Figaro.env).to receive(:aws_ses_region).and_return('')
+        allow(Figaro.env).to receive(:aws_ses_region_pool).and_return('')
         Aws::SES::Base.new.deliver!(mail)
 
         expect(Aws::SES::Client).to have_received(:new).with(hash_excluding(:region)).twice


### PR DESCRIPTION
**Why**: We need to steadily increase our sending volume when moving
between AWS regions to keep from being block as spam. This commit allows
us to configure what percentage of mail gets sent from what region.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
