### PR TITLE
LG-136 - Fall back to A record if MX record doesn't exist

### DIFF
--- a/app/validators/form_email_validator.rb
+++ b/app/validators/form_email_validator.rb
@@ -10,7 +10,7 @@ module FormEmailValidator
 
     validates :email,
               email: {
-                mx: !ENV['RAILS_OFFLINE'],
+                mx_with_fallback: !ENV['RAILS_OFFLINE'],
                 ban_disposable_email: true,
               }
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -62,7 +62,7 @@ describe Users::SessionsController, devise: true do
 
         json ||= JSON.parse(response.body)
 
-        expect(json['remaining']).to eq(10)
+        expect(json['remaining']).to be_within(1).of(10)
       end
     end
 

--- a/spec/support/shared_examples_for_email_validation.rb
+++ b/spec/support/shared_examples_for_email_validation.rb
@@ -4,6 +4,6 @@ shared_examples 'email validation' do
                       detect { |v| v.class == EmailValidator }
 
     expect(email_validator.options).
-      to eq(mx: true, ban_disposable_email: true)
+      to eq(mx_with_fallback: true, ban_disposable_email: true)
   end
 end


### PR DESCRIPTION
**Why**: Some email servers don't configure an MX record and rely on
senders falling back to the A record, as recommended by the RFC.

**How**: The email validation gem takes a parameter to do a check of
the MX record and fall back to an A record if there is no MX record.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
