### PR TITLE
Use SecureRandom.urlsafe_base64 for request ids

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -26,7 +26,7 @@ module SamlIdpAuthConcern
   end
 
   def store_saml_request
-    @request_id = SecureRandom.uuid
+    @request_id = SecureRandom.urlsafe_base64
     ServiceProviderRequest.find_or_create_by(uuid: @request_id) do |sp_request|
       sp_request.issuer = current_issuer
       sp_request.loa = requested_authn_context

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -95,7 +95,7 @@ module OpenidConnect
     def store_request
       client_id = @authorize_form.client_id
 
-      @request_id = SecureRandom.uuid
+      @request_id = SecureRandom.urlsafe_base64
       ServiceProviderRequest.find_or_create_by(uuid: @request_id) do |sp_request|
         sp_request.issuer = client_id
         sp_request.loa = @authorize_form.acr_values.sort.max

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -23,7 +23,7 @@ describe StoreSpMetadataInSession do
         allow(Rails.logger).to receive(:info)
 
         app_session = {}
-        request_id = SecureRandom.uuid
+        request_id = SecureRandom.urlsafe_base64
         ServiceProviderRequest.find_or_create_by(uuid: request_id) do |sp_request|
           sp_request.issuer = 'issuer'
           sp_request.loa = 'loa1'


### PR DESCRIPTION
**Why**: So that URLs are more compact and request IDs are not
guessable. The UUID spec specifies that UUIDs should not be assumed to
be unguessable.

Currently, if someone guesses a UUID, they can hijack a user's service
provider request. That means they can break the sign in flow
for that user, but can't sign in as that user. It would be a concern
if in the future a user sets some kind of state at an SP and then signs
in. Someone guessing a UUID would be able to sign into the SP
with the state the user initiated there. We should correct for this
since we cannot directly control whether service providers do
this.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
