### PR TITLE
Validate Twilio requests to /api/voice/otp

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,5 +53,10 @@ module Upaya
     end
 
     config.middleware.use Rack::Attack if Figaro.env.enable_rate_limiting == 'true'
+
+    config.middleware.use(
+      Rack::TwilioWebhookAuthentication,
+      Figaro.env.twilio_auth_token, '/api/voice/otp'
+    )
   end
 end

--- a/spec/features/twilio/voice_spec.rb
+++ b/spec/features/twilio/voice_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'Twilio request validation' do
+  after do
+    page.driver.header 'X-Twilio-Signature', nil
+  end
+
+  it 'validates requests to the /api/voice/otp endpoint' do
+    cipher = Gibberish::AES.new(Figaro.env.attribute_encryption_key)
+    encrypted_code = cipher.encrypt('1234')
+
+    twilio_post_voice({ encrypted_code: encrypted_code }, false)
+
+    expect(page).to have_content 'Twilio Request Validation Failed.'
+  end
+
+  it 'renders the voice message text when the signature is valid' do
+    cipher = Gibberish::AES.new(Figaro.env.attribute_encryption_key)
+    encrypted_code = cipher.encrypt('1234')
+
+    twilio_post_voice(encrypted_code: encrypted_code)
+
+    expect(page).to have_content 'Hello! Your login.gov one time passcode is, 1, 2, 3, 4'
+  end
+end
+
+def twilio_post_voice(tw_params = {}, use_correct_signature = true)
+  post_path = '/api/voice/otp'
+  post_sig = use_correct_signature ? correct_signature(tw_params, post_path) : nil
+  twilio_post(tw_params, post_sig, post_path)
+end
+
+def twilio_post(tw_params, post_sig, post_url)
+  page.driver.header post_header_name, post_sig
+  page.driver.post post_url, tw_params
+end
+
+def correct_signature(tw_params, post_path = '')
+  Twilio::Security::RequestValidator.new(Figaro.env.twilio_auth_token).
+    build_signature_for("#{myhost}#{post_path}", tw_params)
+end
+
+def myhost
+  Capybara.current_host || Capybara.default_host
+end
+
+def post_header_name
+  'X-Twilio-Signature'
+end


### PR DESCRIPTION
**Why**: To make sure that only requests that contain Twilio's signature
are allowed.

Reference:
https://twilio-ruby.readthedocs.io/en/latest/usage/validation.html#rack-middleware

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
