### PR TITLE
LG-123 Show OTP expiration to user on web page

### DIFF
--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -6,7 +6,8 @@ module TwoFactorAuthCode
 
     def phone_number_message
       t("instructions.mfa.#{otp_delivery_preference}.number_message",
-        number: content_tag(:strong, phone_number))
+        number: content_tag(:strong, phone_number),
+        expiration: Figaro.env.otp_valid_for)
     end
 
     def help_text

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -28,7 +28,8 @@ en:
         confirm_code_html: Need another code? %{resend_code_link}. Message rates may
           apply.
         fallback_html: If you can't get text messages right now, you can %{link}
-        number_message: We sent a security code to %{number}.
+        number_message: We sent a security code to %{number}. This code will expire
+          in %{expiration} minutes.
       voice:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         fallback_html: If you can't take a phone call right now, you can %{link}

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -29,7 +29,8 @@ es:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar
           sujeto a cargos de mensajería y datos."
         fallback_html: Si no puede recibir mensajes de texto ahora, puede %{link}
-        number_message: Enviamos un código de seguridad al %{number}.
+        number_message: Enviamos un código de seguridad al %{number}. Este código
+          caducará en %{expiration} minutos.
       voice:
         confirm_code_html: "¿Desea que le llamemos de nuevo? %{resend_code_link}"
         fallback_html: Si no puede recibir una llamada de teléfono ahora, puede %{link}

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -32,7 +32,8 @@ fr:
           Les frais liés aux messages texte peuvent s'appliquer.
         fallback_html: Si vous ne pouvez recevoir de messages texte pour le moment,
           vous pouvez %{link}
-        number_message: Nous avons envoyé un code de sécurité au %{number}.
+        number_message: Nous avons envoyé un code de sécurité au %{number}. Ce code
+          expirera dans %{expiration} minutes.
       voice:
         confirm_code_html: Vous voulez que nous vous appelions de nouveau? %{resend_code_link}
         fallback_html: Si vous ne pouvez recevoir d'appels pour le moment, vous pouvez

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -145,6 +145,17 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
     end
   end
 
+  describe '#phone_number_message' do
+    it 'specifies when the code will expire' do
+      text = t(
+        'instructions.mfa.sms.number_message',
+        number: "<strong>#{data[:phone_number]}</strong>",
+        expiration: Figaro.env.otp_valid_for
+      )
+      expect(presenter.phone_number_message).to eq text
+    end
+  end
+
   def presenter_with_locale(locale)
     TwoFactorAuthCode::PhoneDeliveryPresenter.new(
       data: data.clone.merge(reenter_phone_number_path:


### PR DESCRIPTION
**Why**: So they know up front when it will expire.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
