### PR TITLE
Add OIDC dashboard config

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -128,6 +128,17 @@ development:
     attribute_bundle:
       - email
 
+  'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
+    friendly_name: 'Dashboard'
+    agency: 'GSA'
+    agency_id: 2
+    uuid_priority: 30
+    logo: '18f.svg'
+    cert: 'identity_dashboard_cert'
+    return_to_sp_url: 'http://localhost:3001'
+    redirect_uris:
+      - 'http://localhost:3001/users/result'
+
   'urn:gov:gsa:openidconnect:development':
     redirect_uris:
       - 'gov.gsa.openidconnect.development://result'
@@ -212,6 +223,17 @@ production:
     cert: 'identity_dashboard_cert'
     attribute_bundle:
       - email
+
+  'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
+    friendly_name: 'Dashboard'
+    agency: 'GSA'
+    agency_id: 2
+    uuid_priority: 30
+    logo: '18f.svg'
+    cert: 'identity_dashboard_cert'
+    return_to_sp_url: 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>'
+    redirect_uris:
+      - 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/users/result'
   <% end %>
 
   'urn:gov:gsa:openidconnect:sp:sinatra':


### PR DESCRIPTION
**Why**: We're updating the dashboard to use OpenID Connect, so this adds the new config, while keeping the old SAML config in place during the transition.