### PR TITLE
Don't load entire stringex gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'sidekiq'
 gem 'simple_form'
 gem 'sinatra', require: false
 gem 'slim-rails'
-gem 'stringex'
+gem 'stringex', require: false
 gem 'twilio-ruby'
 gem 'two_factor_authentication'
 gem 'typhoeus'

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,3 +1,6 @@
+require 'stringex/unidecoder'
+require 'stringex/core_ext'
+
 module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = %i[

--- a/app/services/pii/attribute.rb
+++ b/app/services/pii/attribute.rb
@@ -1,3 +1,6 @@
+require 'stringex/unidecoder'
+require 'stringex/core_ext'
+
 module Pii
   class Attribute
     attr_accessor :raw, :norm

--- a/app/views/verify/_hardfail4.html.slim
+++ b/app/views/verify/_hardfail4.html.slim
@@ -6,6 +6,6 @@ p.mb1 = t('idv.messages.hardfail', hours: Figaro.env.idv_attempt_window_in_hours
       decorated_session.sp_return_url,
       class: 'btn btn-primary btn-wide'
 hr.mt2
-.mt2 = link_to t('idv.messages.help_center_html').strip_html_tags, MarketingSite.help_url
+.mt2 = link_to t('idv.messages.help_center_html'), MarketingSite.help_url
 .mt2
   = link_to t('idv.messages.return_to_profile', app: APP_NAME), profile_path

--- a/spec/views/verify/come_back_later/show.html.slim_spec.rb
+++ b/spec/views/verify/come_back_later/show.html.slim_spec.rb
@@ -23,10 +23,10 @@ describe 'verify/come_back_later/show.html.slim' do
     it 'renders return to SP message' do
       render
       expect(rendered).to have_content(
-        t(
+        strip_tags(t(
           'idv.messages.come_back_later_sp_html',
           sp: @decorated_session.sp_name
-        ).strip_html_tags
+        ))
       )
     end
   end
@@ -58,10 +58,10 @@ describe 'verify/come_back_later/show.html.slim' do
     it 'renders return to account message' do
       render
       expect(rendered).to have_content(
-        t(
+        strip_tags(t(
           'idv.messages.come_back_later_no_sp_html',
           app: APP_NAME
-        ).strip_html_tags
+        ))
       )
     end
   end


### PR DESCRIPTION
**Why**: We only use it for the `#to_ascii` method.

**How**:
- Don't require the gem in Gemfile
- Require only the necessary modules where needed
- Use the Rails `strip_tags` method instead of Stringex's
`strip_html_tags`

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
