### PR TITLE
Consider Puerto Rico numbers to be like US numbers

### DIFF
--- a/app/javascript/app/phone-validation.js
+++ b/app/javascript/app/phone-validation.js
@@ -1,5 +1,13 @@
 import { isValidNumber } from 'libphonenumber-js';
 
+const isPhoneValid = (phone, countryCode) => {
+  let phoneValid = isValidNumber(phone, countryCode);
+  if (!phoneValid && countryCode === 'US') {
+    phoneValid = isValidNumber(`+1 ${phone}`, countryCode);
+  }
+  return phoneValid;
+};
+
 const checkPhoneValidity = () => {
   const sendCodeButton = document.querySelector('[data-international-phone-form] input[name=commit]');
   const phoneInput = document.querySelector('[data-international-phone-form] .phone');
@@ -9,13 +17,12 @@ const checkPhoneValidity = () => {
     const phone = phoneInput.value;
     const countryCode = countryCodeInput.value;
 
-    const phoneValid = isValidNumber(phone, countryCode);
+    const phoneValid = isPhoneValid(phone, countryCode);
 
-    if (phoneValid) {
-      sendCodeButton.disabled = false;
-    } else {
+    sendCodeButton.disabled = !phoneValid;
+
+    if (!phoneValid) {
       phoneInput.dispatchEvent(new Event('invalid'));
-      sendCodeButton.disabled = true;
     }
   }
 };

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -586,6 +586,10 @@ PL:
   name: Poland
   country_code: '48'
   sms_only: true
+PR:
+  name: Puerto Rico (U.S.)
+  country_code: '1'
+  sms_only: false
 PT:
   name: Portugal
   country_code: '351'

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -29,6 +29,13 @@ feature 'User edit' do
       expect(page).to have_button(t('forms.buttons.submit.confirm_change'), disabled: true)
     end
 
+    scenario 'user is able to submit with a Puerto Rico phone number as a US number', js: true do
+      fill_in 'Phone', with: '787 555-1234'
+      expect(page.find('#user_phone_form_international_code').value).to eq 'US'
+
+      expect(page).to have_button(t('forms.buttons.submit.confirm_change'), disabled: false)
+    end
+
     scenario 'updates international code as user types', :js do
       fill_in 'Phone', with: '+81 54 354 3643'
 


### PR DESCRIPTION
**Why**: When entering a PR number with US selected, the number
wouldn't validate.

**How**: Add PR as a country option for anyone looking for it, and
prepend `+1 ` to a number if it's not valid and the country is `US`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
