### PR TITLE
LG-135 User should be able to see entire delete account modal on small screens

### DIFF
--- a/app/views/users/delete/show.html.slim
+++ b/app/views/users/delete/show.html.slim
@@ -1,21 +1,17 @@
-= content_for :body_class do
-  ' modal-open
+.p0.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
+  h2.my2.fs-20p.sans-serif.regular.center
+    = t('users.delete.heading')
+  hr.mb3.bw4.rounded
+  .mb1.bold
+    = t('users.delete.subheading')
 
-= render layout: '/shared/modal_layout' do
-  .p4.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
-    h2.my2.fs-20p.sans-serif.regular.center
-      = t('users.delete.heading')
-    hr.mb3.bw4.rounded
-    .mb1.bold
-      = t('users.delete.subheading')
+  ul.px2.yellow-dots
+    li.mb1 = t('users.delete.bullet_1', app: APP_NAME)
+    li.mb1 = t(current_user.decorate.delete_account_bullet_key, app: APP_NAME)
+    li.mb1 = t('users.delete.bullet_3', app: APP_NAME)
+  .center
+    = button_to t('users.delete.actions.delete'), account_delete_path,
+            class: 'btn btn-primary col-12 mb2 p2 rounded-lg', method: 'delete'
 
-    ul.px2.yellow-dots
-      li.mb1 = t('users.delete.bullet_1', app: APP_NAME)
-      li.mb1 = t(current_user.decorate.delete_account_bullet_key, app: APP_NAME)
-      li.mb1 = t('users.delete.bullet_3', app: APP_NAME)
-    .center
-      = button_to t('users.delete.actions.delete'), account_delete_path,
-                  class: 'btn btn-primary col-12 mb2 p2 rounded-lg', method: 'delete'
-
-      = link_to t('users.delete.actions.cancel'), account_path,
-              class: 'btn col-12 p2 rounded-lg border border-blue blue border-box'
+    = link_to t('users.delete.actions.cancel'), account_path,
+            class: 'btn col-12 p2 rounded-lg border border-blue blue border-box'


### PR DESCRIPTION
**Why**: The modal window is obscured at the bottom depending on screen size.

**How**: Removed deprecated styles for the modal.

An LOA1 user that has lost access to their 2FA device can no longer login to their account

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
