### PR TITLE
LG-134 Update delete account message

### DIFF
--- a/app/controllers/reauthn_required_controller.rb
+++ b/app/controllers/reauthn_required_controller.rb
@@ -21,13 +21,20 @@ class ReauthnRequiredController < ApplicationController
   def prompt_for_current_password
     store_location(request.url)
     user_session[:context] = 'reauthentication'
-    user_session[:factor_to_change] = factor_from_request_path(request.path)
+    user_session[:factor_to_change], user_session[:no_factor_message] =
+      factor_or_message_from_path(request.path)
     user_session[:current_password_required] = true
     redirect_to user_password_confirm_url
   end
 
-  def factor_from_request_path(path)
-    path.split('/')[-1]
+  def factor_or_message_from_path(path)
+    factor = path.split('/')[-1]
+    message = nil
+    if factor == 'delete'
+      factor = nil
+      message = I18n.t('help_text.no_factor.delete_account')
+    end
+    [factor, message]
   end
 
   def store_location(url)

--- a/app/views/mfa_confirmation/new.html.slim
+++ b/app/views/mfa_confirmation/new.html.slim
@@ -1,7 +1,8 @@
 - title t('titles.passwords.confirm')
 
 h1.h3.my0 = t('headings.passwords.confirm')
-p.mt-tiny.mb0 = t('help_text.change_factor', factor: user_session[:factor_to_change])
+p.mt-tiny.mb0 = user_session[:no_factor_message] || t('help_text.change_factor',
+        factor: user_session[:factor_to_change])
 = simple_form_for(current_user,
                   url: reauthn_user_password_path,
                   html: { autocomplete: 'off', role: 'form', method: 'post' }) do |f|

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -11,3 +11,6 @@ en:
       intro_html: 'This is the only information %{app_name} will share with %{sp}:'
       phone: Phone number
       social_security_number: Social Security number
+    no_factor:
+      delete_account: To delete your account, please confirm your password and security
+        code.

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -11,3 +11,6 @@ es:
       intro_html: 'Esta es la única información que %{app_name} compartirá con %{sp}:'
       phone: Teléfono
       social_security_number: Número de Seguro Social
+    no_factor:
+      delete_account: Para eliminar su cuenta, confirme su contraseña y código de
+        seguridad.

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -12,3 +12,6 @@ fr:
         %{sp}:'
       phone: Numéro de téléphone
       social_security_number: Numéro de sécurité sociale
+    no_factor:
+      delete_account: Pour supprimer votre compte, veuillez confirmer votre mot de
+        passe et votre code de sécurité.

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -129,6 +129,15 @@ feature 'Changing authentication factor' do
 
       expect(current_path).to eq manage_email_path
     end
+
+    scenario 'deleting account' do
+      visit account_delete_path
+
+      expect(page).to have_content t('help_text.no_factor.delete_account')
+      complete_2fa_confirmation
+
+      expect(current_path).to eq account_delete_path
+    end
   end
 
   context 'user has authenticator app enabled' do


### PR DESCRIPTION
**Why**: The reauthenticate process reuses edit screen verbiage which forces the text to include a factor that is changing (ie phone number).

**How**: We expanded the reauthenticate code to allow for full text messages that don't have a specific factor that is changing. This new feature allows us to give full verbiage for delete account while reusing the reauthenticate code.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
