### PR TITLE
LG-163 Turn on agency based UUIDs

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -63,7 +63,7 @@ development:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
-  agencies_with_agency_based_uuids: ''
+  agencies_with_agency_based_uuids: '1,2,3,4,5'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -87,7 +87,7 @@ development:
   database_timeout: '5000'
   database_username: ''
   domain_name: 'localhost:3000'
-  enable_agency_based_uuids: 'false'
+  enable_agency_based_uuids: 'true'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'false'
   enable_test_routes: 'true'
@@ -160,7 +160,7 @@ production:
   aamva_public_key: # Base64 encoded public key for AAMVA
   aamva_private_key: # Base64 encoded private key for AAMVA
   aamva_verification_url: # DLDV Verification URL
-  agencies_with_agency_based_uuids: ''
+  agencies_with_agency_based_uuids: '1,2,3,4,5'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -175,7 +175,7 @@ production:
   disable_email_sending: 'false'
   dashboard_api_token:
   domain_name: 'login.gov'
-  enable_agency_based_uuids: 'false'
+  enable_agency_based_uuids: 'true'
   enable_identity_verification: 'false'
   enable_rate_limiting: 'true'
   enable_test_routes: 'false'
@@ -246,7 +246,7 @@ test:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
-  agencies_with_agency_based_uuids: ''
+  agencies_with_agency_based_uuids: '1,2,3,4,5'
   async_job_refresh_interval_seconds: '1'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
@@ -269,7 +269,7 @@ test:
   database_timeout: '5000'
   database_username: ''
   dashboard_api_token: '123ABC'
-  enable_agency_based_uuids: 'false'
+  enable_agency_based_uuids: 'true'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'true'
   enable_test_routes: 'true'


### PR DESCRIPTION
**Why**: We need to share agency-specific UUIDs as well as facilitate sharing of an agency’s UUID with other agencies. We also need a way to count the unique number of users for an agency for billing purposes

**How** Change the feature flags associated with agency based uuids.  Specifically we are changing the environment variables enable_agency_based_uuids and agencies_with_agency_based_uuids to include all agencies.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
