### PR TITLE
Use system libxml2, not nokogiri bundled version.

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -14,10 +14,15 @@ cd "$(dirname "$0")/.."
 
 set -x
 
+env
+
 id
 which bundle
 
 bundle_dir=/srv/idp/shared
+
+# use system libxml2, not the one vendored with nokogiri
+bundle config build.nokogiri --use-system-libraries
 
 bundle install --deployment --jobs 4 \
     --path "$bundle_dir/bundle" \


### PR DESCRIPTION
**Why**:

Nokogiri includes a vendored version of the libxml2 library that ships
with the gem. This is designed to ensure version compatibility in case
your system is running an older version of libxml2, and to facilitate
security updates by making it possible to take security updates just by
upgrading nokogiri.

However, on our systems this creates more problems than it solves. For
reasons that I have not been able to figure out, the nokogiri
compilation attempts to create temporary directories under
/etc/login.gov/repos/identity-devops/kitchen/local-mode-cache/cache/,
which it doesn't have permissions to do. This causes the bundle install
to fail.

In addition, we already get timely security updates of libxml2 from
security updates of the ubuntu package. The version included in Ubuntu
16.04 is libxml2 2.9.3, which is compatible with Nokogiri.

https://packages.ubuntu.com/source/xenial-updates/libxml2

Using the system libxml2 allows us to take security updates just with an
apt-get upgrade, which already happens automatically as part of
provisioning.

**How**:

Run `bundle config build.nokogiri --use-system-libraries` prior to
running `bundle install` during the build process.

Also run `env` as an aid to debugging to show what all of the
environment variables are during provisioning.