### PR TITLE
LG-142 Password reset should count as email confirmation

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -16,12 +16,12 @@ class RegisterUserEmailForm
     'true'
   end
 
-  def submit(params)
+  def submit(params, instructions = nil)
     user.email = params[:email]
     request_id = params[:request_id]
 
     if valid_form?
-      process_successful_submission(request_id)
+      process_successful_submission(request_id, instructions)
     else
       @success = process_errors(request_id)
     end
@@ -38,10 +38,10 @@ class RegisterUserEmailForm
     valid? && !email_taken?
   end
 
-  def process_successful_submission(request_id)
+  def process_successful_submission(request_id, instructions)
     @success = true
     user.save!
-    user.send_custom_confirmation_instructions(request_id)
+    user.send_custom_confirmation_instructions(request_id, instructions)
   end
 
   def extra_analytics_attributes

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -12,7 +12,7 @@ class CustomDeviseMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, options = {})
     presenter = ConfirmationEmailPresenter.new(record, view_context)
-    @first_sentence = presenter.first_sentence
+    @first_sentence = options[:first_sentence] || presenter.first_sentence
     @confirmation_period = presenter.confirmation_period
     @request_id = options[:request_id]
     @locale = locale_url_param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,11 +142,13 @@ class User < ApplicationRecord
     # no-op
   end
 
-  def send_custom_confirmation_instructions(id = nil)
+  def send_custom_confirmation_instructions(id = nil, instructions = nil)
     generate_confirmation_token! unless @raw_confirmation_token
 
     opts = pending_reconfirmation? ? { to: unconfirmed_email, request_id: id } : { request_id: id }
-    send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+    opts[:first_sentence] = instructions if instructions
+    send_devise_notification(:confirmation_instructions,
+                             @raw_confirmation_token, opts)
   end
 end
 # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -5,13 +5,20 @@ RequestPasswordReset = Struct.new(:email, :request_id) do
     return if user_found_but_is_an_admin_or_tech?
 
     if user_not_found?
-      UserMailer.account_does_not_exist(email, request_id).deliver_later
+      form = RegisterUserEmailForm.new
+      result = form.submit({ email: email }, instructions)
+      [form.user, result]
     else
       user.send_reset_password_instructions
+      nil
     end
   end
 
   private
+
+  def instructions
+    I18n.t('mailer.confirmation_instructions.first_sentence.forgot_password')
+  end
 
   def user_not_found?
     user.is_a?(NonexistentUser)

--- a/config/locales/mailer/en.yml
+++ b/config/locales/mailer/en.yml
@@ -5,6 +5,9 @@ en:
     confirmation_instructions:
       first_sentence:
         confirmed: Trying to change your email address?
+        forgot_password: You tried to reset your login.gov password but we don't have
+          an account linked to this  email address. If you'd like to set up a new
+          account linked to this email, confirm your email address below.
         reset_requested: Your %{app} account has been reset by a tech support representative.
           To continue, you must confirm your email address.
         unconfirmed: Thanks for creating an account.

--- a/config/locales/mailer/es.yml
+++ b/config/locales/mailer/es.yml
@@ -5,6 +5,10 @@ es:
     confirmation_instructions:
       first_sentence:
         confirmed: "¿Desea cambiar su email?"
+        forgot_password: Intentó restablecer su contraseña de login.gov pero no tenemos
+          una cuenta vinculada a esta dirección de correo electrónico. Si desea configurar
+          una nueva cuenta vinculada a este correo electrónico, confirme su dirección
+          de correo electrónico a continuación.
         reset_requested: Su cuenta de %{app} ha sido restablecida por un representante
           de soporte técnico. Para continuar, debe confirmar su email.
         unconfirmed: Gracias por crear una cuenta.

--- a/config/locales/mailer/fr.yml
+++ b/config/locales/mailer/fr.yml
@@ -5,6 +5,10 @@ fr:
     confirmation_instructions:
       first_sentence:
         confirmed: Vous tentez de changer votre adresse courriel?
+        forgot_password: Vous avez essayé de réinitialiser le mot de passe de votre
+          compte login.gov, mais nous ne possédons pas de compte associé à cette adresse
+          courriel. Si vous souhaitez créer un nouveau compte associé à cette adresse
+          courriel, confirmez votre adresse courriel ci-dessous.
         reset_requested: Votre compte %{app} a été réinitialisé par un représentant
           du soutien technique. Pour continuer, vous devez confirmer votre adresse
           courriel.

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -3,15 +3,12 @@ require 'rails_helper'
 describe RequestPasswordReset do
   describe '#perform' do
     context 'when the user is not found' do
-      it 'sends the account does not exist email' do
+      it 'sends the account registration email' do
         email = 'nonexistent@example.com'
-
-        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(UserMailer).to receive(:account_does_not_exist).
-          with(email, 'request_id').and_return(mailer)
-        expect(mailer).to receive(:deliver_later)
-
-        RequestPasswordReset.new(email, 'request_id').perform
+        expect_any_instance_of(User).to receive(:send_custom_confirmation_instructions).
+          with(nil, I18n.t('mailer.confirmation_instructions.first_sentence.forgot_password'))
+        RequestPasswordReset.new(email).perform
+        expect(User.find_with_email(email)).to be_present
       end
     end
 


### PR DESCRIPTION
**Why**: When you don't have an account and request a password reset and click through to that email that says create your account now, users are taken to the very first step of having to confirm their email address again.

**How**: Override the functionality of reset password when the user is not found to behave like create account.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
