### PR TITLE
LG-166 Use proper rotation path suffix in SAML metadata

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -40,14 +40,22 @@ class SamlIdpController < ApplicationController
 
   def saml_metadata
     if SamlCertRotationManager.use_new_secrets_for_request?(request)
-      SamlIdp::MetadataBuilder.new(
-        SamlIdp.config,
-        SamlCertRotationManager.new_certificate,
-        SamlCertRotationManager.new_secret_key
-      )
+      cert_rotation_saml_metadata
     else
       SamlIdp.metadata
     end
+  end
+
+  def cert_rotation_saml_metadata
+    config = SamlIdp.config.dup
+    suffix = SamlCertRotationManager.rotation_path_suffix
+    config.single_service_post_location = config.single_service_post_location + suffix
+    config.single_logout_service_post_location = config.single_logout_service_post_location + suffix
+    SamlIdp::MetadataBuilder.new(
+      config,
+      SamlCertRotationManager.new_certificate,
+      SamlCertRotationManager.new_secret_key
+    )
   end
 
   def redirect_to_account_or_verify_profile_url

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -254,6 +254,16 @@ feature 'saml api' do
         cert_base64 = REXML::XPath.first(document, '//X509Certificate').text
         expect(cert_base64).to eq(Base64.strict_encode64(new_x509_cert.to_der))
       end
+
+      it 'includes the correct auth and logout urls' do
+        visit api_saml_metadata2018_path
+        document = REXML::Document.new(page.html)
+        auth_node = REXML::XPath.first(document, '//SingleSignOnService')
+        logout_node = REXML::XPath.first(document, '//SingleLogoutService')
+
+        expect(auth_node.attributes['Location']).to include(api_saml_auth2018_path)
+        expect(logout_node.attributes['Location']).to include(destroy_user_session2018_path)
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: So that the saml2018 metadata endpoint will show the saml2018
auth and logout paths instead of the auth and logout paths with the
expired certificate.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
