### PR TITLE
Add the uuid for a x509 subject to the users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
 
+  validates :x509_dn_uuid, uniqueness: true, allow_nil: true
+
   attr_accessor :asserted_attributes
 
   def personal_key

--- a/db/migrate/20180409193120_add_x509_dn_uuid_to_users_table.rb
+++ b/db/migrate/20180409193120_add_x509_dn_uuid_to_users_table.rb
@@ -1,0 +1,11 @@
+class AddX509DnUuidToUsersTable < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :x509_dn_uuid, :string
+    add_index :users, :x509_dn_uuid, unique: true
+  end
+
+  def down
+    remove_index :users, :x509_dn_uuid
+    remove_column :users, :x509_dn_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180201161105) do
+ActiveRecord::Schema.define(version: 20180409193120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 20180201161105) do
     t.text "encrypted_phone"
     t.integer "otp_delivery_preference", default: 0, null: false
     t.integer "totp_timestamp"
+    t.string "x509_dn_uuid"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
@@ -186,6 +187,7 @@ ActiveRecord::Schema.define(version: 20180201161105) do
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
     t.index ["unlock_token"], name: "index_users_on_unlock_token"
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
+    t.index ["x509_dn_uuid"], name: "index_users_on_x509_dn_uuid", unique: true
   end
 
   create_table "usps_confirmation_codes", force: :cascade do |t|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       phone_confirmed_at Time.zone.now
     end
 
+    trait :with_piv_or_cac do
+      x509_dn_uuid { SecureRandom.uuid }
+    end
+
     trait :admin do
       role :admin
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -270,4 +270,12 @@ describe User do
       expect(User.find_with_email(foo: 'bar')).to eq(nil)
     end
   end
+
+  describe 'x509_dn_uuid' do
+    it 'validates uniqueness' do
+      user = create(:user, :with_piv_or_cac, email: 'test1@test.com')
+
+      expect(user).to validate_uniqueness_of(:x509_dn_uuid).allow_nil
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
- We want to track which PIV/CAC a user associates with their account.
- We don't want to record PII -- the PIV/CAC public certificates have a
DN which contains the user's name.

**How**:
- We use a UUID created by the identity piv/cac management micro-
service. This will be randomly generated the first time the system
encounters a given PIV/CAC, assuming the certificate is valid.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
