### PR TITLE
Remove vendor session id from idv session and proofing flow

### DIFF
--- a/app/jobs/idv/phone_job.rb
+++ b/app/jobs/idv/phone_job.rb
@@ -1,7 +1,7 @@
 module Idv
   class PhoneJob < ProoferJob
     def verify_identity_with_vendor
-      confirmation = agent.submit_phone(vendor_params, vendor_session_id)
+      confirmation = agent.submit_phone(vendor_params)
       result = extract_result(confirmation)
       store_result(result)
     end

--- a/app/jobs/idv/profile_job.rb
+++ b/app/jobs/idv/profile_job.rb
@@ -54,8 +54,7 @@ module Idv
         success: result_successful?,
         errors: result_errors,
         reasons: result_reasons,
-        normalized_applicant: resolution_vendor_resp.normalized_applicant,
-        session_id: resolution.session_id
+        normalized_applicant: resolution_vendor_resp.normalized_applicant
       )
       store_result(result)
     end

--- a/app/jobs/idv/proofer_job.rb
+++ b/app/jobs/idv/proofer_job.rb
@@ -2,13 +2,12 @@ module Idv
   class ProoferJob < ApplicationJob
     queue_as :idv
 
-    attr_reader :result_id, :applicant, :vendor_params, :vendor_session_id
+    attr_reader :result_id, :applicant, :vendor_params
 
-    def perform(result_id:, vendor_params:, applicant_json:, vendor_session_id: nil)
+    def perform(result_id:, vendor_params:, applicant_json:)
       @result_id = result_id
       @vendor_params = vendor_params
       @applicant = applicant_from_json(applicant_json)
-      @vendor_session_id = vendor_session_id
       perform_identity_proofing
     end
 

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -31,7 +31,6 @@ module Idv
 
     def update_idv_session
       idv_session.profile_confirmation = true
-      idv_session.vendor_session_id = vendor_validator_result.session_id
       idv_session.normalized_applicant_params = vendor_validator_result.normalized_applicant.to_hash
       idv_session.resolution_successful = true
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -18,7 +18,6 @@ module Idv
       personal_key
       resolution_successful
       step_attempts
-      vendor_session_id
     ].freeze
 
     attr_reader :current_user, :usps_otp

--- a/app/services/idv/submit_idv_job.rb
+++ b/app/services/idv/submit_idv_job.rb
@@ -23,7 +23,6 @@ module Idv
       {
         result_id: result_id,
         vendor_params: vendor_params,
-        vendor_session_id: idv_session.vendor_session_id,
         applicant_json: idv_session.applicant.to_json,
       }
     end

--- a/app/services/idv/vendor_result.rb
+++ b/app/services/idv/vendor_result.rb
@@ -1,6 +1,6 @@
 module Idv
   class VendorResult
-    attr_reader :success, :errors, :reasons, :session_id, :normalized_applicant, :timed_out
+    attr_reader :success, :errors, :reasons, :normalized_applicant, :timed_out
 
     def self.new_from_json(json)
       parsed = JSON.parse(json, symbolize_names: true)
@@ -11,12 +11,11 @@ module Idv
       new(**parsed)
     end
 
-    def initialize(success: nil, errors: {}, reasons: [], session_id: nil,
+    def initialize(success: nil, errors: {}, reasons: [],
                    normalized_applicant: nil, timed_out: nil)
       @success = success
       @errors = errors
       @reasons = reasons
-      @session_id = session_id
       @normalized_applicant = normalized_applicant
       @timed_out = timed_out
     end

--- a/spec/jobs/idv/phone_job_spec.rb
+++ b/spec/jobs/idv/phone_job_spec.rb
@@ -7,7 +7,6 @@ describe Idv::PhoneJob do
     let(:result_id) { SecureRandom.uuid }
     let(:applicant_json) { { first_name: 'Jean-Luc', last_name: 'Picard' }.to_json }
     let(:vendor_params) { '5555550000' }
-    let(:vendor_session_id) { SecureRandom.uuid }
 
     context 'when verification succeeds' do
       it 'should save a successful result' do
@@ -15,7 +14,6 @@ describe Idv::PhoneJob do
           result_id: result_id,
           vendor_params: vendor_params,
           applicant_json: applicant_json,
-          vendor_session_id: vendor_session_id
         )
         result = VendorValidatorResultStorage.new.load(result_id)
 
@@ -35,7 +33,6 @@ describe Idv::PhoneJob do
           result_id: result_id,
           vendor_params: vendor_params,
           applicant_json: applicant_json,
-          vendor_session_id: vendor_session_id
         )
         result = VendorValidatorResultStorage.new.load(result_id)
 
@@ -60,7 +57,6 @@ describe Idv::PhoneJob do
             result_id: result_id,
             vendor_params: vendor_params,
             applicant_json: applicant_json,
-            vendor_session_id: vendor_session_id
           )
         end.to raise_error(RuntimeError, '🔥🔥🔥')
         result = VendorValidatorResultStorage.new.load(result_id)
@@ -78,7 +74,6 @@ describe Idv::PhoneJob do
         result_id: result_id,
         vendor_params: vendor_params,
         applicant_json: applicant_json,
-        vendor_session_id: vendor_session_id
       )
       result = VendorValidatorResultStorage.new.load(result_id)
 

--- a/spec/jobs/idv/profile_job_spec.rb
+++ b/spec/jobs/idv/profile_job_spec.rb
@@ -50,7 +50,6 @@ describe Idv::ProfileJob do
         expect(result.normalized_applicant.last_name).to eq('PICARD')
         expect(result.reasons).to eq(['Everything looks good', 'valid state ID'])
         expect(result.errors).to eq({})
-        expect(result.session_id).to be_present
       end
     end
 
@@ -74,7 +73,6 @@ describe Idv::ProfileJob do
         expect(result.job_failed?).to eq(false)
         expect(result.reasons).to eq(['The name was suspicious'])
         expect(result.errors).to eq(first_name: 'Unverified first name.')
-        expect(result.session_id).to be_present
         expect(agent).to have_received(:start)
         expect(agent).to_not have_received(:submit_state_id)
       end
@@ -96,7 +94,6 @@ describe Idv::ProfileJob do
         expect(result.job_failed?).to eq(false)
         expect(result.reasons).to eq(['Everything looks good', 'invalid state id number'])
         expect(result.errors).to eq(state_id_number: 'The state ID number could not be verified')
-        expect(result.session_id).to be_present
       end
     end
 

--- a/spec/services/idv/submit_idv_job_spec.rb
+++ b/spec/services/idv/submit_idv_job_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Idv::SubmitIdvJob do
       user_session: {
         idv: {
           applicant: applicant,
-          vendor_session_id: vendor_session_id,
         },
       }
     )
@@ -23,7 +22,6 @@ RSpec.describe Idv::SubmitIdvJob do
 
   let(:user) { build(:user) }
   let(:applicant) { Proofer::Applicant.new(first_name: 'Greatest') }
-  let(:vendor_session_id) { '12345' }
   let(:result_id) { 'abcdef' }
   let(:vendor_params) { { dob: '01/01/1985' } }
 
@@ -33,7 +31,6 @@ RSpec.describe Idv::SubmitIdvJob do
         with(
           result_id: result_id,
           vendor_params: vendor_params,
-          vendor_session_id: vendor_session_id,
           applicant_json: applicant.to_json
         )
 
@@ -57,7 +54,6 @@ RSpec.describe Idv::SubmitIdvJob do
         with(
           result_id: result_id,
           vendor_params: vendor_params,
-          vendor_session_id: vendor_session_id,
           applicant_json: applicant.to_json
         )
 

--- a/spec/services/idv/vendor_result_spec.rb
+++ b/spec/services/idv/vendor_result_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Idv::VendorResult do
   let(:success) { true }
   let(:errors) { { foo: ['is not valid'] } }
   let(:reasons) { %w[foo bar baz] }
-  let(:session_id) { SecureRandom.uuid }
   let(:normalized_applicant) do
     Proofer::Applicant.new(
       last_name: 'Ever',
@@ -18,7 +17,6 @@ RSpec.describe Idv::VendorResult do
       success: success,
       errors: errors,
       reasons: reasons,
-      session_id: session_id,
       normalized_applicant: normalized_applicant,
       timed_out: timed_out
     )
@@ -52,7 +50,6 @@ RSpec.describe Idv::VendorResult do
       expect(new_from_json.success?).to eq(vendor_result.success?)
       expect(new_from_json.errors).to eq(vendor_result.errors)
       expect(new_from_json.reasons).to eq(vendor_result.reasons)
-      expect(new_from_json.session_id).to eq(vendor_result.session_id)
     end
 
     it 'turns applicant into a full object' do

--- a/spec/services/vendor_validator_result_storage_spec.rb
+++ b/spec/services/vendor_validator_result_storage_spec.rb
@@ -3,12 +3,10 @@ require 'rails_helper'
 RSpec.describe VendorValidatorResultStorage do
   subject(:service) { VendorValidatorResultStorage.new }
 
-  let(:session_id) { SecureRandom.uuid }
   let(:result_id) { SecureRandom.uuid }
   let(:original_result) do
     Idv::VendorResult.new(
       success: false,
-      session_id: session_id,
       normalized_applicant: Proofer::Applicant.new(first_name: 'First')
     )
   end


### PR DESCRIPTION
**WHY**
We no longer need to track a vendor session across multiple
proofing requests, each request will be handled independently

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
