### PR TITLE
Break phone input tests into their own spec

### DIFF
--- a/spec/features/idv/phone_input_spec.rb
+++ b/spec/features/idv/phone_input_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+feature 'IdV phone number input', :idv_job, :js do
+  include IdvStepHelper
+
+  before do
+    complete_idv_steps_before_phone_step
+  end
+
+  scenario 'phone input only allows numbers' do
+    fill_in 'Phone', with: ''
+    find('#idv_phone_form_phone').native.send_keys('abcd1234')
+
+    expect(find('#idv_phone_form_phone').value).to eq '1 (234) '
+  end
+
+  scenario 'phone input does not format international numbers' do
+    fill_in 'Phone', with: ''
+    find('#idv_phone_form_phone').native.send_keys('+81543543643')
+
+    expect(find('#idv_phone_form_phone').value).to eq '+1 (815) 435-4364'
+  end
+end

--- a/spec/features/idv/phone_spec.rb
+++ b/spec/features/idv/phone_spec.rb
@@ -99,32 +99,6 @@ feature 'Verify phone' do
     end
   end
 
-  scenario 'phone field only allows numbers', js: true, idv_job: true do
-    sign_in_and_2fa_user
-    visit verify_session_path
-    fill_out_idv_form_ok
-    click_idv_continue
-
-    visit verify_phone_path
-    fill_in 'Phone', with: ''
-    find('#idv_phone_form_phone').native.send_keys('abcd1234')
-
-    expect(find('#idv_phone_form_phone').value).to eq '1 (234) '
-  end
-
-  scenario 'phone field does not format international numbers', :js, idv_job: true do
-    sign_in_and_2fa_user
-    visit verify_session_path
-    fill_out_idv_form_ok
-    click_idv_continue
-
-    visit verify_phone_path
-    fill_in 'Phone', with: ''
-    find('#idv_phone_form_phone').native.send_keys('+81543543643')
-
-    expect(find('#idv_phone_form_phone').value).to eq '+1 (815) 435-4364'
-  end
-
   def complete_idv_profile_with_phone(phone)
     fill_out_idv_form_ok
     click_idv_continue

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -1,0 +1,22 @@
+module IdvStepHelper
+  def self.included(base)
+    base.class_eval { include IdvHelper }
+  end
+
+  def start_idv_at_profile_step(user = user_with_2fa)
+    sign_in_and_2fa_user(user)
+    visit verify_path unless current_path == verify_path
+    click_idv_begin
+  end
+
+  def complete_idv_steps_before_address_step(user = user_with_2fa)
+    start_idv_at_profile_step(user)
+    fill_out_idv_form_ok
+    click_idv_continue
+  end
+
+  def complete_idv_steps_before_phone_step(user = user_with_2fa)
+    complete_idv_steps_before_address_step(user)
+    click_idv_address_choose_phone
+  end
+end


### PR DESCRIPTION
**Why**: To draw a boundary between code that tests the behavior at the
phone step from the code that tests the form

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
