### PR TITLE
Add phone otp verification step spec

### DIFF
--- a/spec/features/idv/cancel_idv_step_spec.rb
+++ b/spec/features/idv/cancel_idv_step_spec.rb
@@ -15,12 +15,6 @@ feature 'cancel at IdV step', :idv_job do
     it_behaves_like 'cancel at idv step', :profile, :saml
   end
 
-  context 'phone otp verification step' do
-    it_behaves_like 'cancel at idv step', :phone_otp_verification
-    it_behaves_like 'cancel at idv step', :phone_otp_verification, :oidc
-    it_behaves_like 'cancel at idv step', :phone_otp_verification, :saml
-  end
-
   xcontext 'usps step' do
     # USPS step does not have a cancel button :(
   end

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'phone otp verification step spec', :idv_job do
+  include IdvStepHelper
+
+  it 'requires the user to enter the correct otp before continuing' do
+    user = user_with_2fa
+
+    start_idv_from_sp
+    complete_idv_steps_before_phone_otp_verification_step(user)
+
+    # Attempt to bypass the step
+    visit verify_review_path
+    expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+
+    # Enter an incorrect otp
+    fill_in 'code', with: '000000'
+    click_submit_default
+
+    expect(page).to have_content(t('devise.two_factor_authentication.invalid_otp'))
+    expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+
+    # Enter the correct code
+    enter_correct_otp_code_for_user(user)
+
+    expect(page).to have_content(t('idv.titles.session.review'))
+    expect(page).to have_current_path(verify_review_path)
+  end
+
+  it_behaves_like 'cancel at idv step', :phone_otp_verification
+  it_behaves_like 'cancel at idv step', :phone_otp_verification, :oidc
+  it_behaves_like 'cancel at idv step', :phone_otp_verification, :saml
+end


### PR DESCRIPTION
**Why**: So we can collect the things we want to test with regards to
the phone OTP verification

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
