### PR TITLE
LG-208 Create user Event when password is changed

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -28,6 +28,7 @@ module Users
     end
 
     def handle_success
+      create_user_event(:password_changed)
       bypass_sign_in current_user
 
       flash[:personal_key] = @update_user_password_form.personal_key

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -32,6 +32,7 @@ describe Users::PasswordsController do
         allow(updater).to receive(:submit).and_return(response)
         personal_key = 'five random words for test'
         allow(updater).to receive(:personal_key).and_return(personal_key)
+        allow(controller).to receive(:create_user_event)
 
         params = { password: password }
         patch :update, params: { update_user_password_form: params }
@@ -39,6 +40,15 @@ describe Users::PasswordsController do
         expect(flash[:personal_key]).to eq personal_key
         expect(updater).to have_received(:submit)
         expect(updater).to have_received(:personal_key)
+      end
+
+      it 'creates a user Event for the password change' do
+        stub_sign_in
+
+        expect(controller).to receive(:create_user_event)
+
+        params = { password: 'salty new password' }
+        patch :update, params: { update_user_password_form: params }
       end
     end
 
@@ -61,6 +71,15 @@ describe Users::PasswordsController do
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PASSWORD_CHANGED, success: false, errors: errors)
         expect(response).to render_template(:edit)
+      end
+
+      it 'does not create a password_changed user Event' do
+        stub_sign_in
+
+        expect(controller).to_not receive(:create_user_event)
+
+        params = { password: 'new' }
+        patch :update, params: { update_user_password_form: params }
       end
     end
   end


### PR DESCRIPTION
**Why**: To make it easier to troubleshoot and determine if the user
ever changed their password via the account page.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
