### PR TITLE
LG-209 Delete ahoy_visit cookie after sign out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,6 +70,11 @@ class ApplicationController < ActionController::Base
     { locale: locale_url_param, host: Figaro.env.domain_name }
   end
 
+  def sign_out
+    request.cookie_jar.delete('ahoy_visit')
+    super
+  end
+
   private
 
   # These attributes show up in New Relic traces for all requests.

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -36,7 +36,8 @@ module OpenidConnect
     end
 
     def track_authorize_analytics(result)
-      analytics_attributes = result.to_h.except(:redirect_uri)
+      analytics_attributes = result.to_h.except(:redirect_uri).
+                             merge(user_fully_authenticated: user_fully_authenticated?)
 
       analytics.track_event(
         Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION, analytics_attributes

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -255,4 +255,12 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#sign_out' do
+    it 'deletes the ahoy_visit cookie when signing out' do
+      expect(request.cookie_jar).to receive(:delete).with('ahoy_visit')
+
+      subject.sign_out
+    end
+  end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
                  success: true,
                  client_id: client_id,
-                 errors: {})
+                 errors: {},
+                 user_fully_authenticated: true)
 
           action
         end
@@ -128,7 +129,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
                  success: false,
                  client_id: client_id,
-                 errors: hash_including(:prompt))
+                 errors: hash_including(:prompt),
+                 user_fully_authenticated: true)
 
           action
         end
@@ -148,7 +150,8 @@ RSpec.describe OpenidConnect::AuthorizationController do
             with(Analytics::OPENID_CONNECT_REQUEST_AUTHORIZATION,
                  success: false,
                  client_id: nil,
-                 errors: hash_including(:client_id))
+                 errors: hash_including(:client_id),
+                 user_fully_authenticated: true)
 
           action
         end


### PR DESCRIPTION
**Why**: To tie each `visit_id` to a session. This will make it easier
to see what each user did during each session. Previously, the
`visit_id` would only change if the user was inactive for 8 minutes.
So, if the user signed in, then signed out, then signed back in, all of
those events in between would have the same `visit_id`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
