### PR TITLE
LG-226 Fix Double Render Error with Bad Saml Packet on Logout

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -85,7 +85,6 @@ module SamlIdpLogoutConcern
   end
 
   def prepare_saml_logout_request
-    validate_saml_request
     return if slo_session[:logout_response]
     # store originating SP's logout response in the user session
     # for final step in SLO


### PR DESCRIPTION
**Why**: This error and a stack trace appear in the logs and make it difficult to diagnose saml logout issues with agency integration.  Moreover we throw a 500 error when the saml idp gem is trying to return a 403 / forbidden error.

**How**: Check the return value of the gem's validation of the saml packet and return from the concern.  Then check if there was a valid render in the controller.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
