### PR TITLE
LG-228 Make migrations safer and more resilient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5.2'
   gem 'slim_lint'
+  gem 'strong_migrations'
   gem 'thin'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,6 +579,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stringex (2.8.4)
+    strong_migrations (0.2.2)
+      activerecord (>= 3.2.0)
     sysexits (1.2.0)
     systemu (2.6.5)
     temple (0.8.0)
@@ -744,6 +746,7 @@ DEPENDENCIES
   slim-rails
   slim_lint
   stringex
+  strong_migrations
   thin
   timecop
   twilio-ruby

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -84,6 +84,7 @@ development:
   database_pool_worker: '5'
   database_readonly_password: ''
   database_readonly_username: ''
+  database_statement_timeout: '2500'
   database_timeout: '5000'
   database_username: ''
   domain_name: 'localhost:3000'
@@ -175,6 +176,7 @@ production:
   basic_auth_password:
   disable_email_sending: 'false'
   dashboard_api_token:
+  database_statement_timeout: '2500'
   domain_name: 'login.gov'
   enable_agency_based_uuids: 'true'
   enable_identity_verification: 'false'
@@ -268,6 +270,7 @@ test:
   database_pool_worker:
   database_readonly_password: ''
   database_readonly_username: ''
+  database_statement_timeout: '2500'
   database_timeout: '5000'
   database_username: ''
   dashboard_api_token: '123ABC'

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ defaults: &defaults
   checkout_timeout: 5
   reaping_frequency: 10
   variables:
-    statement_timeout: 2500 # ms
+    statement_timeout: <%= Figaro.env.database_statement_timeout.to_i %>
 
 development:
   <<: *defaults

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,6 +3,7 @@ require Rails.root.join('lib', 'config_validator.rb')
 Figaro.require_keys(
   'attribute_cost',
   'attribute_encryption_key',
+  'database_statement_timeout',
   'domain_name',
   'enable_agency_based_uuids',
   'enable_identity_verification',

--- a/config/initializers/safe_migrations.rb
+++ b/config/initializers/safe_migrations.rb
@@ -1,0 +1,5 @@
+require 'deploy/migration_statement_timeout'
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Migration.prepend(Deploy::MigrationStatementTimeout)
+end

--- a/deploy/migrate
+++ b/deploy/migrate
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script is called by identity-devops cookbooks as part of the deployment
+# process. It runs any pending migrations.
+
+set -euo pipefail
+
+echo "deploy/migrate starting"
+echo "HOME: ${HOME-}"
+cd "$(dirname "$0")/.."
+
+set -x
+
+id
+which bundle
+
+export RAILS_ENV=production
+export MIGRATION_STATEMENT_TIMEOUT=60000
+
+bundle exec rake db:create db:migrate db:seed --trace
+
+set +x
+
+echo "deploy/migrate finished"

--- a/lib/deploy/migration_statement_timeout.rb
+++ b/lib/deploy/migration_statement_timeout.rb
@@ -1,0 +1,13 @@
+module Deploy
+  module MigrationStatementTimeout
+    def connection
+      connection = super
+      new_statement_timeout = ENV['MIGRATION_STATEMENT_TIMEOUT']
+      if new_statement_timeout && !@migration_statement_timeout_set
+        connection.execute("SET statement_timeout = #{new_statement_timeout.to_i}")
+        @migration_statement_timeout_set = true
+      end
+      connection
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ if ENV['COVERAGE']
     add_filter '/config/'
     add_filter '/lib/rspec/formatters/user_flow_formatter.rb'
     add_filter '/lib/user_flow_exporter.rb'
+    add_filter '/lib/deploy/migration_statement_timeout.rb'
   end
 end
 


### PR DESCRIPTION
**Why**: We recently ran into an issue while deploying RC 56 to
production due to a migration needing more time than allowed by our
`statement_timeout`.

**How**:
- Add the `strong_migrations` gem, which will check your migrations
for unsafe usage and best practices. Read more here:
https://github.com/ankane/strong_migrations
- Allow configuring the statement_timeout in `database.yml` via Figaro
- Allow overriding the statement_timeout via an ENV var for migrations.
Code shamelessly copied from the Slowpoke gem:
https://github.com/ankane/slowpoke
- Add a `deploy/migrate` script so that it is maintained in this repo
as opposed to the devops repo.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
