### PR TITLE
LG-227 Improve OIDC token code error message

### DIFF
--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -16,7 +16,8 @@ en:
         invalid_aud: Invalid audience claim, expected %{url}
         invalid_authentication: Client must authenticate via PKCE or private_key_jwt,
           missing either code_challenge or client_assertion
-        invalid_code: invalid code
+        invalid_code: is invalid either because it expired, or it doesn't match any
+          user. Please see our documentation at https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier did not match code_challenge
     user_info:
       errors:

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -16,7 +16,8 @@ es:
         invalid_aud: Solicitud de audiencia no válida, esperada %{url}
         invalid_authentication: El cliente debe autenticarse a través de PKCE o private_key_jwt,
           faltando code_challenge o client_assertion
-        invalid_code: código inválido
+        invalid_code: no es válido porque ha caducado o no coincide con ningún usuario.
+          Consulte nuestra documentación en https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier no coincide con code_challenge
     user_info:
       errors:

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -16,7 +16,9 @@ fr:
         invalid_aud: Affirmation liée à l'auditoire non valide, attendu %{url}
         invalid_authentication: Le client doit s'authentifier par PKCE ou private_key_jwt,
           code_challenge ou client_assertion manquant
-        invalid_code: code non valide
+        invalid_code: est non valide soit parce qu'il est périmé, soit parce qu'il
+          ne correspond à aucun utilisateur. Veuillez consulter notre documentation
+          à https://developers.login.gov/oidc/#token
         invalid_code_verifier: code_verifier ne correspondait pas à code_challenge
     user_info:
       errors:


### PR DESCRIPTION
**Why**: Some agency developers have been sending requests to our
OIDC token endpoint with an invalid code, and received a generic
"Code invalid code" error message.

**How**: Explain why the code is invalid and point developers to
our documentation.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
