### PR TITLE
LG-203 Make MFA event properties consistent

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -53,7 +53,7 @@ module TwoFactorAuthentication
     def analytics_properties
       {
         context: context,
-        method: params[:otp_delivery_preference],
+        multi_factor_auth_method: params[:otp_delivery_preference],
         confirmation_for_phone_change: confirmation_for_phone_change?,
       }
     end

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -6,7 +6,7 @@ module TwoFactorAuthentication
 
     def show
       analytics.track_event(
-        Analytics::MULTI_FACTOR_AUTH_ENTER_PERSONAL_KEY_VISIT, analytics_properties
+        Analytics::MULTI_FACTOR_AUTH_ENTER_PERSONAL_KEY_VISIT, context: context
       )
 
       @personal_key_form = PersonalKeyForm.new(current_user)
@@ -65,13 +65,6 @@ module TwoFactorAuthentication
       handle_valid_otp_for_authentication_context
       redirect_to manage_personal_key_url
       reset_otp_session_data
-    end
-
-    def analytics_properties
-      {
-        context: context,
-        method: 'personal key',
-      }
     end
   end
 end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -39,7 +39,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
       stub_analytics
       analytics_hash = {
         context: 'authentication',
-        method: 'sms',
+        multi_factor_auth_method: 'sms',
         confirmation_for_phone_change: false,
       }
 
@@ -79,7 +79,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           errors: {},
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms',
+          multi_factor_auth_method: 'sms',
         }
 
         stub_analytics
@@ -125,7 +125,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           errors: {},
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms',
+          multi_factor_auth_method: 'sms',
         }
 
         stub_analytics
@@ -169,7 +169,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           errors: {},
           confirmation_for_phone_change: false,
           context: 'authentication',
-          method: 'sms',
+          multi_factor_auth_method: 'sms',
         }
 
         stub_analytics
@@ -298,7 +298,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               errors: {},
               confirmation_for_phone_change: true,
               context: 'confirmation',
-              method: 'sms',
+              multi_factor_auth_method: 'sms',
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -340,7 +340,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               errors: {},
               confirmation_for_phone_change: true,
               context: 'confirmation',
-              method: 'sms',
+              multi_factor_auth_method: 'sms',
             }
 
             expect(@analytics).to have_received(:track_event).
@@ -376,7 +376,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               success: true,
               errors: {},
               context: 'confirmation',
-              method: 'sms',
+              multi_factor_auth_method: 'sms',
               confirmation_for_phone_change: false,
             }
 
@@ -467,7 +467,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             errors: {},
             confirmation_for_phone_change: false,
             context: 'idv',
-            method: 'sms',
+            multi_factor_auth_method: 'sms',
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -533,7 +533,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             errors: {},
             confirmation_for_phone_change: false,
             context: 'idv',
-            method: 'sms',
+            multi_factor_auth_method: 'sms',
           }
 
           expect(@analytics).to have_received(:track_event).

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -18,7 +18,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
     it 'tracks the page visit' do
       stub_sign_in_before_2fa
       stub_analytics
-      analytics_hash = { context: 'authentication', method: 'personal key' }
+      analytics_hash = { context: 'authentication' }
 
       expect(@analytics).to receive(:track_event).
         with(Analytics::MULTI_FACTOR_AUTH_ENTER_PERSONAL_KEY_VISIT, analytics_hash)


### PR DESCRIPTION
**Why**: The name of the property used to track the type of multi-factor
authentication used (SMS, Voice, TOTP, Personal Key) was inconsistent.
For Voice and SMS, it was `method`, and `multi_factor_auth_method` for
the other two.

**How**: Use `multi_factor_auth_method` for all four.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
