### PR TITLE
[LG-231] Allow PIV/CAC as 2FA during login

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -15,6 +15,7 @@ module TwoFactorAuthenticatable
     authenticator: 'authenticator',
     sms: 'phone',
     voice: 'phone',
+    piv_cac: 'piv_cac',
   }.freeze
 
   private
@@ -259,6 +260,7 @@ module TwoFactorAuthenticatable
   def generic_data
     {
       personal_key_unavailable: personal_key_unavailable?,
+      has_piv_cac_configured: current_user.piv_cac_enabled?,
       reauthn: reauthn?,
     }
   end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -1,0 +1,73 @@
+module TwoFactorAuthentication
+  class PivCacVerificationController < ApplicationController
+    include TwoFactorAuthenticatable
+
+    before_action :confirm_piv_cac_enabled
+    before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :show
+
+    def show
+      if params[:token]
+        process_token
+      else
+        @piv_cac_nonce = SecureRandom.base64(10)
+        user_session[:piv_cac_nonce] = @piv_cac_nonce
+        @presenter = presenter_for_two_factor_authentication_method
+      end
+    end
+
+    private
+
+    def process_token
+      result = piv_cac_verfication_form.submit
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.to_h.merge(analytics_properties))
+      if result.success?
+        handle_valid_piv_cac
+      else
+        handle_invalid_otp(type: 'piv_cac')
+      end
+    end
+
+    def handle_valid_piv_cac
+      handle_valid_otp_for_authentication_context
+
+      redirect_to after_otp_verification_confirmation_url
+      reset_otp_session_data
+    end
+
+    def piv_cac_view_data
+      {
+        two_factor_authentication_method: two_factor_authentication_method,
+        user_email: current_user.email,
+        remember_device_available: false,
+      }.merge(generic_data)
+    end
+
+    def piv_cac_verfication_form
+      @piv_cac_verification_form ||= UserPivCacVerificationForm.new(
+        user: current_user,
+        token: params[:token],
+        nonce: user_session[:piv_cac_nonce]
+      )
+    end
+
+    def confirm_piv_cac_enabled
+      return if current_user.piv_cac_enabled?
+
+      redirect_to user_two_factor_authentication_url
+    end
+
+    def presenter_for_two_factor_authentication_method
+      TwoFactorAuthCode::PivCacAuthenticationPresenter.new(
+        view: view_context,
+        data: piv_cac_view_data
+      )
+    end
+
+    def analytics_properties
+      {
+        context: context,
+        multi_factor_auth_method: 'piv_cac',
+      }
+    end
+  end
+end

--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -1,0 +1,69 @@
+class UserPivCacVerificationForm
+  include ActiveModel::Model
+
+  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user
+
+  validates :token, presence: true
+  validates :nonce, presence: true
+  validates :user, presence: true
+
+  def submit
+    success = valid? && valid_token?
+
+    FormResponse.new(success: success, errors: {})
+  end
+
+  private
+
+  def valid_token?
+    user_has_piv_cac &&
+      token_decoded &&
+      token_has_correct_nonce &&
+      not_error_token &&
+      x509_cert_matches
+  end
+
+  def x509_cert_matches
+    if user.confirm_piv_cac?(x509_dn_uuid)
+      true
+    else
+      self.error_type = 'user.piv_cac_mismatch'
+      false
+    end
+  end
+
+  def token_decoded
+    @data = PivCacService.decode_token(token)
+    true
+  end
+
+  def not_error_token
+    possible_error = @data['error']
+    if possible_error
+      self.error_type = possible_error
+      false
+    else
+      self.x509_dn_uuid = @data['uuid']
+      self.x509_dn = @data['dn']
+      true
+    end
+  end
+
+  def token_has_correct_nonce
+    if @data['nonce'] == nonce
+      true
+    else
+      self.error_type = 'token.invalid'
+      false
+    end
+  end
+
+  def user_has_piv_cac
+    if user.piv_cac_enabled?
+      true
+    else
+      self.error_type = 'user.no_piv_cac_associated'
+      false
+    end
+  end
+end

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -46,7 +46,7 @@ module TwoFactorAuthCode
 
     private
 
-    attr_reader :personal_key_unavailable, :view, :reauthn
+    attr_reader :personal_key_unavailable, :has_piv_cac_configured, :view, :reauthn
 
     def personal_key_tag
       view.link_to(t("#{personal_key}.link"),
@@ -55,6 +55,22 @@ module TwoFactorAuthCode
 
     def personal_key
       'devise.two_factor_authentication.personal_key_fallback'
+    end
+
+    def piv_cac_link
+      view.link_to(
+        t('devise.two_factor_authentication.piv_cac_fallback.link'),
+        login_two_factor_piv_cac_path(locale: LinkLocaleResolver.locale)
+      )
+    end
+
+    def piv_cac_option
+      return unless FeatureManagement.piv_cac_enabled?
+      return unless has_piv_cac_configured
+      t(
+        'devise.two_factor_authentication.piv_cac_fallback.text_html',
+        link: piv_cac_link
+      )
     end
   end
 end

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -19,6 +19,7 @@ module TwoFactorAuthCode
       [
         otp_fallback_options,
         update_phone_link,
+        piv_cac_option,
         personal_key_link,
       ].compact
     end

--- a/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
@@ -1,20 +1,25 @@
 module TwoFactorAuthCode
-  class AuthenticatorDeliveryPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
+  class PivCacAuthenticationPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::TranslationHelper
+
     def header
-      t('devise.two_factor_authentication.totp_header_text')
+      t('devise.two_factor_authentication.piv_cac_header_text')
     end
 
     def help_text
-      t("instructions.mfa.#{two_factor_authentication_method}.confirm_code_html",
+      t('instructions.mfa.piv_cac.confirm_piv_cac_html',
         email: content_tag(:strong, user_email),
-        app: content_tag(:strong, APP_NAME),
-        tooltip: view.tooltip(t('tooltips.authentication_app')))
+        app: content_tag(:strong, APP_NAME))
+    end
+
+    def piv_cac_capture_text
+      t('forms.piv_cac_mfa.submit')
     end
 
     def fallback_links
       [
         otp_fallback_options,
-        piv_cac_link,
         personal_key_link,
       ].compact
     end

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -1,14 +1,24 @@
+require 'cgi'
 require 'net/https'
 
 module PivCacService
   class << self
+    include Rails.application.routes.url_helpers
+
     def decode_token(token)
       token_present(token) &&
         token_decoded(token)
     end
 
-    def piv_cac_service_link
-      Figaro.env.piv_cac_service_url
+    def piv_cac_service_link(nonce)
+      if FeatureManagement.development_and_piv_cac_entry_enabled?
+        test_piv_cac_entry_url
+      else
+        uri = URI(Figaro.env.piv_cac_service_url)
+        # add the nonce
+        uri.query = "nonce=#{CGI.escape(nonce)}"
+        uri.to_s
+      end
     end
 
     def piv_cac_verify_token_link

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.slim
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.slim
@@ -1,0 +1,11 @@
+- title t('titles.present_piv_cac')
+
+h1.h3.my0 = @presenter.header
+p.mt-tiny.mb3 = @presenter.help_text
+
+= link_to @presenter.piv_cac_capture_text,
+              PivCacService.piv_cac_service_link(@piv_cac_nonce),
+              class: 'btn btn-primary'
+
+= render 'shared/fallback_links', presenter: @presenter
+= render 'shared/cancel', link: @presenter.cancel_link

--- a/app/views/users/piv_cac_authentication_setup/error.html.slim
+++ b/app/views/users/piv_cac_authentication_setup/error.html.slim
@@ -13,7 +13,7 @@ p.mt-tiny.mb3 = @presenter.description
 .mt2.pt1.border-top
   - if @presenter.may_select_another_certificate?
     = link_to t('forms.piv_cac_setup.choose_different_certificate'),
-              test_piv_cac_entry_url, class: 'h5'
+              setup_piv_cac_url, class: 'h5'
     br
   - if user_signing_up? || user_verifying_identity?
     - method = user_signing_up? ? :delete : :get

--- a/app/views/users/piv_cac_authentication_setup/new.html.slim
+++ b/app/views/users/piv_cac_authentication_setup/new.html.slim
@@ -3,12 +3,9 @@
 h1.h3.my0 = t('headings.piv_cac_setup.new')
 p.mt-tiny.mb3 = t('forms.piv_cac_setup.piv_cac_intro_html')
 
-- if FeatureManagement.development_and_piv_cac_entry_enabled?
-  = link_to t('forms.piv_cac_setup.submit'), test_piv_cac_entry_url, class: 'btn btn-primary'
-- else
-  = link_to t('forms.piv_cac_setup.submit'),
-                PivCacService.piv_cac_service_link,
-                class: 'btn btn-primary'
+= link_to t('forms.piv_cac_setup.submit'),
+              PivCacService.piv_cac_service_link(@piv_cac_nonce),
+              class: 'btn btn-primary'
 = render 'shared/cancel', link: account_path
 
 == javascript_pack_tag 'clipboard'

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -102,6 +102,7 @@ en:
       invalid_otp: That security code is invalid. You can try entering it again or
         request a new one-time security code.
       invalid_personal_key: That personal key is invalid.
+      invalid_piv_cac: That PIV/CAC is incorrect.
       max_generic_login_attempts_reached: Your account is temporarily locked.
       max_otp_login_attempts_reached: Your account is temporarily locked because you
         have entered the one-time security code incorrectly too many times.
@@ -133,6 +134,10 @@ en:
       personal_key_header_text: Enter your personal key
       personal_key_prompt: You can use this personal key once. If you still need a
         code after signing in, go to your account settings page to get a new one.
+      piv_cac_fallback:
+        link: Use your PIV/CAC instead
+        text_html: Do you have your PIV/CAC? %{link}
+      piv_cac_header_text: Present your PIV/CAC
       please_confirm: Your phone number has been set. Confirm it by entering the security
         code below.
       please_try_again_html: Please try again in %{time_remaining}.

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -107,6 +107,7 @@ es:
       invalid_otp: Ese código de seguridad no es válido. Puede intentar ingresarlo
         de nuevo o solicitar un nuevo código de seguridad de sólo un uso.
       invalid_personal_key: Esa clave personal no es válida.
+      invalid_piv_cac: NOT TRANSLATED YET
       max_generic_login_attempts_reached: Su cuenta está bloqueada temporalmente.
       max_otp_login_attempts_reached: Su cuenta ha sido bloqueada temporalmente porque
         ha ingresado incorrectamente el código de seguridad de sólo un uso demasiadas
@@ -136,6 +137,10 @@ es:
       personal_key_prompt: Puede usar esta clave personal una vez. Si todavía necesita
         un código después de iniciar una sesión, vaya a la página de configuración
         de su cuenta para obtener una clave nueva.
+      piv_cac_fallback:
+        link: Use su PIV/CAC en su lugar
+        text_html: "¿Tiene usted PIV/CAC? %{link}"
+      piv_cac_header_text: NOT TRANSLATED YET
       please_confirm: Su número de teléfono ha sido establecido. Confírmelo ingresando
         el código de seguridad a continuación.
       please_try_again_html: Inténtelo de nuevo en %{time_remaining}.

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -113,6 +113,7 @@ fr:
       invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l'entrer
         de nouveau ou demander un nouveau code de sécurité à utilisation unique.
       invalid_personal_key: Cette clé personnelle est non valide.
+      invalid_piv_cac: NOT TRANSLATED YET
       max_generic_login_attempts_reached: Votre compte est temporairement verrouillé.
       max_otp_login_attempts_reached: Votre compte est temporairement verrouillé,
         car vous avez entré le code de sécurité à utilisation unique de façon erronée
@@ -144,6 +145,10 @@ fr:
       personal_key_prompt: Vous pouvez utiliser cette clé personnelle une fois seulement.
         Si vous avez toujours besoin d'un code après votre connexion, allez à la page
         des réglages de votre compte pour en obtenir un nouveau.
+      piv_cac_fallback:
+        link: Utilisez plutôt votre PIV/CAC
+        text_html: Avez-vous votre PIV/CAC? %{link}
+      piv_cac_header_text: NOT TRANSLATED YET
       please_confirm: Votre numéro de téléphone a été entré. Confirmez-le en entrant
         le code de sécurité ci-dessous.
       please_try_again_html: Veuillez essayer de nouveau dans %{time_remaining}.

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -31,6 +31,8 @@ en:
       instructions: Please confirm you have a copy of your personal key by entering
         it below.
       title: Enter your personal key
+    piv_cac_mfa:
+      submit: Present PIV/CAC card
     piv_cac_setup:
       certificate:
         bad_html: Please choose a different certificate from your PIV/CAC or contact

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -31,6 +31,8 @@ es:
       instructions: Confirme que tiene una copia de su clave personal ingresándola
         a continuación.
       title: Ingrese su clave personal
+    piv_cac_mfa:
+      submit: NOT TRANSLATED YET
     piv_cac_setup:
       certificate:
         bad_html: Elija un certificado diferente de su PIV/CAC o póngase en contacto

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -32,6 +32,8 @@ fr:
       instructions: Veuillez confirmer que vous avez une copie de votre clé personnelle
         en l'entrant ci-dessous.
       title: Entrez votre clé personnelle
+    piv_cac_mfa:
+      submit: NOT TRANSLATED YET
     piv_cac_setup:
       certificate:
         bad_html: Veuillez choisir un certificat différent de votre PIV/CAC ou contactez

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -30,6 +30,8 @@ en:
         fallback_html: If you can't get text messages right now, you can %{link}
         number_message: We sent a security code to %{number}. This code will expire
           in %{expiration} minutes.
+      piv_cac:
+        confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
       voice:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         fallback_html: If you can't take a phone call right now, you can %{link}

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -25,6 +25,8 @@ es:
           varias cuentas configuradas en su app, ingrese el código correspondiente
           a %{email} en %{app}.%{tooltip}
         or: o
+      piv_cac:
+        confirm_piv_cac_html: NOT TRANSLATED YET
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar
           sujeto a cargos de mensajería y datos."

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -27,6 +27,8 @@ fr:
           Si vous avez plusieurs comptes configurés dans votre application, entrez
           le code correspondant à %{email} à %{app}.%{tooltip}
         or: or
+      piv_cac:
+        confirm_piv_cac_html: NOT TRANSLATED YET
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.
           Les frais liés aux messages texte peuvent s'appliquer.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -31,6 +31,7 @@ en:
         bad: Internal error
         missing: Internal error
         invalid: PIV/CAC certificate error
+    present_piv_cac: Present your PIV/CAC
     reactivate_account: Reactivate your account
     registrations:
       new: Sign up for a account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -31,6 +31,7 @@ es:
         bad: NOT TRANSLATED YET
         invalid: NOT TRANSLATED YET
         missing: NOT TRANSLATED YET
+    present_piv_cac: NOT TRANSLATED YET
     reactivate_account: Reactive su cuenta
     registrations:
       new: Regístrese para una cuenta

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -31,6 +31,7 @@ fr:
         bad: NOT TRANSLATED YET
         invalid: NOT TRANSLATED YET
         missing: NOT TRANSLATED YET
+    present_piv_cac: NOT TRANSLATED YET
     reactivate_account: Réactiver le profil
     registrations:
       new: S'inscrire et créer un compte

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
       post '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#create'
       get '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#show'
       post '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#create'
+      if FeatureManagement.piv_cac_enabled?
+        get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
+      end
       get  '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#show',
            as: :login_two_factor
       post '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#create',

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -1,0 +1,187 @@
+require 'rails_helper'
+
+describe TwoFactorAuthentication::PivCacVerificationController do
+  let(:user) do
+    create(:user, :signed_up, :with_piv_or_cac,
+      phone: '+1 (555) 555-0000'
+    )
+  end
+
+  let(:nonce) { 'once' }
+
+  before(:each) do
+    allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
+    allow(PivCacService).to receive(:decode_token).with('good-token').and_return(
+      'uuid' => user.x509_dn_uuid,
+      'dn' => 'bar',
+      'nonce' => nonce,
+    )
+    allow(PivCacService).to receive(:decode_token).with('bad-token').and_return(
+      'uuid' => 'bad-uuid',
+      'dn' => 'bad-dn',
+      'nonce' => nonce
+    )
+    allow(PivCacService).to receive(:decode_token).with('bad-nonce').and_return(
+      'uuid' => user.x509_dn_uuid,
+      'dn' => 'bar',
+      'nonce' => 'bad-' + nonce
+    )
+  end
+
+  describe '#show' do
+    context 'before the user presents a valid PIV/CAC' do
+      before(:each) do
+        sign_in_before_2fa(user)
+      end
+
+      it 'renders a page with a submit button to capture the cert' do
+        get :show
+
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when the user presents a valid PIV/CAC' do
+      before(:each) do
+        sign_in_before_2fa(user)
+      end
+
+      it 'redirects to the profile' do
+        expect(subject.current_user).to receive(:confirm_piv_cac?).and_return(true)
+        expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
+
+        get :show, params: { token:  'good-token' }
+
+        expect(response).to redirect_to account_path
+      end
+
+      it 'resets the second_factor_attempts_count' do
+        UpdateUser.new(
+          user: subject.current_user,
+          attributes: { second_factor_attempts_count: 1 }
+        ).call
+
+        get :show, params: { token:  'good-token' }
+
+        expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
+      end
+
+      it 'tracks the valid authentication event' do
+        stub_analytics
+        attributes = {
+          success: true,
+          errors: {},
+          context: 'authentication',
+          multi_factor_auth_method: 'piv_cac',
+        }
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, attributes)
+
+        get :show, params: { token:  'good-token' }
+      end
+    end
+
+    context 'when the user presents an invalid piv/cac' do
+      before do
+        sign_in_before_2fa(user)
+
+        get :show, params: { token: 'bad-token' }
+      end
+
+      it 'increments second_factor_attempts_count' do
+        expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
+      end
+
+      it 're-renders the piv/cac entry screen' do
+        expect(response).to render_template(:show)
+      end
+
+      it 'displays flash error message' do
+        expect(flash[:error]).to eq t('devise.two_factor_authentication.invalid_piv_cac')
+      end
+    end
+
+    context 'when the user has reached the max number of piv/cac attempts' do
+      it 'tracks the event' do
+        allow_any_instance_of(User).to receive(:max_login_attempts?).and_return(true)
+        sign_in_before_2fa(user)
+
+        stub_analytics
+
+        attributes = {
+          success: false,
+          errors: {},
+          context: 'authentication',
+          multi_factor_auth_method: 'piv_cac',
+        }
+
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, attributes)
+        expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH_MAX_ATTEMPTS)
+
+        get :show, params: { token: 'bad-token' }
+      end
+    end
+
+    context 'when the user lockout period expires' do
+      before(:each) do
+        sign_in_before_2fa(user)
+      end
+
+      let(:lockout_period) { Figaro.env.lockout_period_in_minutes.to_i.minutes }
+
+      let(:user) do
+        create(:user, :signed_up, :with_piv_or_cac,
+          second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
+          second_factor_attempts_count: 3
+        )
+      end
+
+      describe 'when user submits an incorrect piv/cac' do
+        before(:each) do
+          get :show, params: { token: 'bad-token' }
+        end
+
+        it 'resets attempts count' do
+          expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
+        end
+
+        it 'resets second_factor_locked_at' do
+          expect(subject.current_user.reload.second_factor_locked_at).to eq nil
+        end
+      end
+
+      describe 'when user submits a valid piv/cac' do
+        before do
+          get :show, params: { token: 'good-token' }
+        end
+
+        it 'resets attempts count' do
+          expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
+        end
+
+        it 'resets second_factor_locked_at' do
+          expect(subject.current_user.reload.second_factor_locked_at).to eq nil
+        end
+      end
+    end
+
+    context 'when the user does not have a piv/cac associated' do
+      context 'and a token is provided' do
+        it 'redirects to user_two_factor_authentication_path' do
+          stub_sign_in_before_2fa
+          get :show, params: { token: '123456' }
+
+          expect(response).to redirect_to user_two_factor_authentication_path
+        end
+      end
+
+      context 'and no token is provided' do
+        it 'redirects to user_two_factor_authentication_path' do
+          stub_sign_in_before_2fa
+          get :show
+
+          expect(response).to redirect_to user_two_factor_authentication_path
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe UserPivCacVerificationForm do
+  let(:form) { described_class.new(user: user, token: token, nonce: nonce) }
+  let(:user) { create(:user, :with_piv_or_cac) }
+  let(:nonce) { 'once' }
+
+  describe '#submit' do
+    before(:each) do
+      allow(PivCacService).to receive(:decode_token).with(token) { token_response }
+    end
+
+    context 'when token is valid' do
+      let(:token) { 'good-token' }
+      let(:x509_dn_uuid) { 'some-random-uuid' }
+
+      let(:token_response) do
+        {
+          'uuid' => x509_dn_uuid,
+          'subject' => 'x509-subject',
+          'nonce' => nonce
+        }
+      end
+
+      context 'and a user has no piv/cac associated' do
+        let(:user) { create(:user) }
+
+        it 'returns FormResponse with success: false' do
+          result = instance_double(FormResponse)
+
+          expect(FormResponse).to receive(:new).
+            with(success: false, errors: {}).and_return(result)
+          expect(form.submit).to eq result
+          expect(form.error_type).to eq 'user.no_piv_cac_associated'
+        end
+      end
+
+      context 'and a user has a different piv/cac associated' do
+        let(:user) { create(:user, :with_piv_or_cac) }
+
+        it 'returns FormResponse with success: false' do
+          result = instance_double(FormResponse)
+
+          expect(FormResponse).to receive(:new).
+            with(success: false, errors: {}).and_return(result)
+          expect(form.submit).to eq result
+          expect(form.error_type).to eq 'user.piv_cac_mismatch'
+        end
+      end
+
+      context 'and the correct piv/cac is presented' do
+        let(:user) { create(:user, :with_piv_or_cac) }
+        let(:x509_dn_uuid) { user.x509_dn_uuid }
+
+        it 'returns FormResponse with success: true' do
+          result = instance_double(FormResponse)
+
+          expect(FormResponse).to receive(:new).
+            with(success: true, errors: {}).and_return(result)
+          expect(form.submit).to eq result
+        end
+
+        context 'when nonce is bad' do
+          before(:each) do
+            form.nonce = form.nonce + 'X'
+          end
+
+          it 'returns FormResponse with success: false' do
+            result = instance_double(FormResponse)
+
+            expect(FormResponse).to receive(:new).
+              with(success: false, errors: {}).and_return(result)
+            expect(Event).to_not receive(:create)
+            expect(form.submit).to eq result
+            expect(form.error_type).to eq 'token.invalid'
+          end
+        end
+      end
+    end
+
+    context 'when token is invalid' do
+      let(:token) { 'bad-token' }
+      let(:token_response) do
+        { 'error' => 'token.bad', 'nonce' => nonce }
+      end
+
+      it 'returns FormResponse with success: false' do
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: {}).and_return(result)
+        expect(Event).to_not receive(:create)
+        expect(form.submit).to eq result
+        expect(form.error_type).to eq 'token.bad'
+      end
+    end
+
+    context 'when token is missing' do
+      let(:token) { }
+
+      it 'returns FormResponse with success: false' do
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: {}).and_return(result)
+        expect(Event).to_not receive(:create)
+        expect(form.submit).to eq result
+      end
+    end
+  end
+end

--- a/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
@@ -30,4 +30,25 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
       end
     end
   end
+
+  describe '#piv_cac_option' do
+    context 'for a user without a piv/cac enabled' do
+      let(:presenter) { presenter_with(has_piv_cac_configured: false) }
+
+      it 'returns nothing' do
+        expect(presenter.send(:piv_cac_option)).to be_nil
+      end
+    end
+
+    context 'for a user with a piv/cac enabled' do
+      let(:presenter) { presenter_with(has_piv_cac_configured: true) }
+
+      it 'returns a link to the piv/cac option' do
+        expect(presenter.send(:piv_cac_option)).to eq t(
+          'devise.two_factor_authentication.piv_cac_fallback.text_html',
+          link: presenter.send(:piv_cac_link)
+        )
+      end
+    end
+  end
 end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+def presenter_with(arguments = {}, view = ActionController::Base.new.view_context)
+  TwoFactorAuthCode::PivCacAuthenticationPresenter.new(data: arguments, view: view)
+end
+
+describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::TagHelper
+
+  let(:user_email) { 'user@example.com' }
+  let(:reauthn) { }
+  let(:presenter) { presenter_with(reauthn: reauthn, user_email: user_email) }
+
+  describe '#header' do
+    let(:expected_header) { t('devise.two_factor_authentication.piv_cac_header_text') }
+
+    it { expect(presenter.header).to eq expected_header }
+  end
+
+  describe '#help_text' do
+    let(:expected_help_text) do
+      t('instructions.mfa.piv_cac.confirm_piv_cac_html',
+        email: content_tag(:strong, user_email),
+        app: content_tag(:strong, APP_NAME))
+    end
+
+    it { expect(presenter.help_text).to eq expected_help_text }
+  end
+
+  describe '#piv_cac_capture_text' do
+    let(:expected_text) { t('forms.piv_cac_mfa.submit') }
+
+    it { expect(presenter.piv_cac_capture_text).to eq expected_text }
+  end
+
+  describe '#fallback_links' do
+    it 'has two options' do
+      expect(presenter.fallback_links.count).to eq 2
+    end
+  end
+
+  describe '#cancel_link' do
+    let(:locale) { LinkLocaleResolver.locale }
+
+    context 'reauthn' do
+      let(:reauthn) { true }
+
+      it 'returns the account path' do
+        expect(presenter.cancel_link).to eq account_path(locale: locale)
+      end
+    end
+
+    context 'not reauthn' do
+      let(:reauthn) { false }
+
+      it 'returns the sign out path' do
+        expect(presenter.cancel_link).to eq sign_out_path(locale: locale)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
We want someone able to use their PIV/CAC as their second factor
if they've associated it with their account.
    
**How**:
See if the PIV/CAC identity is the same as configured for the 
user account.

**N.B.**: This builds off of #2128 

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
