### PR TITLE
[LG-190] share certificate subject with SPs

### DIFF
--- a/.reek
+++ b/.reek
@@ -117,6 +117,12 @@ UncommunicativeMethodName:
     - render_401
     - SessionDecorator#registration_bullet_1
     - ServiceProviderSessionDecorator#registration_bullet_1
+UncommunicativeModuleName:
+  exclude:
+    - X509
+    - X509::Attribute
+    - X509::Attributes
+    - X509::SessionStore
 UnusedPrivateMethod:
   exclude:
     - ApplicationController

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Metrics/BlockLength:
     - 'app/services/omniauth_authorizer.rb'
     - 'app/services/single_logout_handler.rb'
     - 'app/services/pii/attributes.rb'
+    - 'app/services/x509/attributes.rb'
     - 'config/environments/*.rb'
     - 'config/initializers/secure_headers.rb'
     - 'config/routes.rb'

--- a/app/controllers/concerns/piv_cac_concern.rb
+++ b/app/controllers/concerns/piv_cac_concern.rb
@@ -10,6 +10,14 @@ module PivCacConcern
   end
 
   def clear_piv_cac_nonce
-    user_session[:piv_cac_nonce] = nil
+    user_session.delete(:piv_cac_nonce)
+  end
+
+  def save_piv_cac_information(data)
+    user_session[:decrypted_x509] = data.to_json
+  end
+
+  def clear_piv_cac_information
+    user_session.delete(:decrypted_x509)
   end
 end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -21,20 +21,29 @@ module TwoFactorAuthentication
       result = piv_cac_verfication_form.submit
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.to_h.merge(analytics_properties))
       if result.success?
-        clear_piv_cac_nonce
         handle_valid_piv_cac
       else
-        # create new nonce for retry
-        create_piv_cac_nonce
-        handle_invalid_otp(type: 'piv_cac')
+        handle_invalid_piv_cac
       end
     end
 
     def handle_valid_piv_cac
-      handle_valid_otp_for_authentication_context
+      clear_piv_cac_nonce
+      save_piv_cac_information(
+        subject: piv_cac_verfication_form.x509_dn,
+        presented: true
+      )
 
+      handle_valid_otp_for_authentication_context
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
+    end
+
+    def handle_invalid_piv_cac
+      clear_piv_cac_information
+      # create new nonce for retry
+      create_piv_cac_nonce
+      handle_invalid_otp(type: 'piv_cac')
     end
 
     def piv_cac_view_data

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -22,6 +22,7 @@ module Users
     def delete
       analytics.track_event(Analytics::USER_REGISTRATION_PIV_CAC_DISABLED)
       current_user.update!(x509_dn_uuid: nil)
+      clear_piv_cac_information
       Event.create(user_id: current_user.id, event_type: :piv_cac_disabled)
       flash[:success] = t('notices.piv_cac_disabled')
       redirect_to account_url
@@ -49,12 +50,17 @@ module Users
 
     def process_valid_submission
       flash[:success] = t('notices.piv_cac_configured')
+      save_piv_cac_information(
+        subject: user_piv_cac_form.x509_dn,
+        presented: true
+      )
       redirect_to account_url
     end
 
     def process_invalid_submission
       create_piv_cac_nonce
       @presenter = PivCacAuthenticationSetupErrorPresenter.new(user_piv_cac_form)
+      clear_piv_cac_information
       render :error
     end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -20,6 +20,10 @@ class Identity < ApplicationRecord
     sp_metadata[:agency] || sp_metadata[:friendly_name] || service_provider
   end
 
+  def piv_cac_enabled?
+    user&.piv_cac_enabled?
+  end
+
   def decorate
     IdentityDecorator.new(self)
   end

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -8,6 +8,9 @@ class OpenidConnectAttributeScoper
     profile:birthdate
     profile:name
     social_security_number
+    x509
+    x509:subject
+    x509:presented
   ].freeze
 
   ATTRIBUTE_SCOPES_MAP = {
@@ -20,6 +23,8 @@ class OpenidConnectAttributeScoper
     family_name: %w[profile profile:name],
     birthdate: %w[profile profile:birthdate],
     social_security_number: %w[social_security_number],
+    x509_subject: %w[x509 x509:subject],
+    x509_presented: %w[x509 x509:presented],
   }.with_indifferent_access.freeze
 
   SCOPE_ATTRIBUTE_MAP = {}.tap do |scope_attribute_map|

--- a/app/services/reactivate_account_session.rb
+++ b/app/services/reactivate_account_session.rb
@@ -46,6 +46,7 @@ class ReactivateAccountSession
       active: false,
       personal_key: false,
       pii: nil,
+      x509: nil,
     }
   end
 

--- a/app/services/x509/attribute.rb
+++ b/app/services/x509/attribute.rb
@@ -1,0 +1,16 @@
+require 'stringex/unidecoder'
+require 'stringex/core_ext'
+
+module X509
+  class Attribute
+    attr_accessor :raw, :norm
+
+    def initialize(raw: nil, norm: nil)
+      @raw = raw
+      @norm = norm
+    end
+
+    delegate :blank?, :present?, :to_s, :to_date, :==, :eql?, to: :raw
+    alias to_str to_s
+  end
+end

--- a/app/services/x509/attributes.rb
+++ b/app/services/x509/attributes.rb
@@ -1,0 +1,38 @@
+module X509
+  Attributes = Struct.new(
+    :subject, :presented
+  ) do
+    def self.new_from_hash(hash)
+      attrs = new
+      hash.each { |key, val| attrs[key] = val }
+      attrs
+    end
+
+    def self.new_from_json(piv_cert_json)
+      return new if piv_cert_json.blank?
+      piv_cert_info = JSON.parse(piv_cert_json, symbolize_names: true)
+      new_from_hash(piv_cert_info)
+    end
+
+    def initialize(*args)
+      super
+      assign_all_members
+    end
+
+    def []=(key, value)
+      if value.is_a?(Hash)
+        super(key, X509::Attribute.new(value))
+      else
+        super(key, X509::Attribute.new(raw: value))
+      end
+    end
+
+    private
+
+    def assign_all_members
+      self.class.members.each do |member|
+        self[member] = self[member]
+      end
+    end
+  end
+end

--- a/app/services/x509/session_store.rb
+++ b/app/services/x509/session_store.rb
@@ -1,0 +1,45 @@
+# Provides a way to access already-decrypted and cached PII from the redis
+# in an out-of-band fashion (using only the session UUID) instead of having access
+# to the user_session from Devise/Warden
+# Should only be used outside of a normal browser session (such as the OpenID Connect API)
+# See X509::Cacher for accessing PII inside of a normal browser session
+module X509
+  class SessionStore
+    attr_reader :session_uuid
+
+    def initialize(session_uuid)
+      @session_uuid = session_uuid
+    end
+
+    def ttl
+      uuid = session_uuid
+      session_store.instance_eval { redis.ttl(prefixed(uuid)) }
+    end
+
+    def load
+      session = session_store.send(:load_session_from_redis, session_uuid) || {}
+      X509::Attributes.new_from_json(session.dig('warden.user.user.session', :decrypted_x509))
+    end
+
+    # @api private
+    # Only used for convenience in tests
+    # @param [X509::Attributes] x509
+    def put(piv_cert_info, expiration = 5.minutes)
+      session_data = {
+        'warden.user.user.session' => {
+          decrypted_x509: piv_cert_info.to_h.to_json,
+        },
+      }
+
+      session_store.
+        send(:set_session, {}, session_uuid, session_data, expire_after: expiration.to_i)
+    end
+
+    private
+
+    def session_store
+      config = Rails.application.config
+      config.session_store.new({}, config.session_options)
+    end
+  end
+end

--- a/spec/services/x509/attribute_spec.rb
+++ b/spec/services/x509/attribute_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe X509::Attribute do
+  let(:x509_subject) { 'O=US, OU=DoD, CN=John.Doe.1234' }
+
+  subject { described_class.new(raw: x509_subject) }
+
+  # rubocop:disable UnneededInterpolation
+  describe 'delegation' do
+    it 'delegates to raw' do
+      expect(subject.blank?).to eq false
+      expect(subject.present?).to eq true
+      expect(subject.to_s).to eq x509_subject
+      expect(subject.to_str).to eq x509_subject
+      expect(subject).to eq x509_subject
+    end
+  end
+  # rubocop:enable UnneededInterpolation
+end

--- a/spec/services/x509/attributes_spec.rb
+++ b/spec/services/x509/attributes_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe X509::Attributes do
+  let(:user_access_key) { UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
+
+  describe '#new_from_hash' do
+    it 'initializes from plain Hash' do
+      x509 = described_class.new_from_hash(subject: 'O=US, OU=DoD, CN=John.Doe.1234')
+
+      expect(x509.subject).to eq 'O=US, OU=DoD, CN=John.Doe.1234'
+    end
+
+    it 'initializes from complex Hash' do
+      x509 = described_class.new_from_hash(
+        subject: { raw: 'O=US, OU=DoD, CN=José', norm: 'O=US, OU=DoD, CN=Jose' },
+      )
+
+      expect(x509.subject.to_s).to eq 'O=US, OU=DoD, CN=José'
+      expect(x509.subject).to be_a X509::Attribute
+    end
+
+    it 'assigns to all members' do
+      x509 = described_class.new_from_hash({})
+
+      expect(x509.subject).to be_a X509::Attribute
+      expect(x509.subject.raw).to eq nil
+      expect(x509.subject).to eq nil
+      expect(x509.presented).to eq nil
+    end
+  end
+
+  describe '#new_from_json' do
+    it 'inflates from JSON string' do
+      x509_json = { subject: 'O=US, OU=DoD, CN=John.Doe.1234' }.to_json
+      x509_attrs = described_class.new_from_json(x509_json)
+
+      expect(x509_attrs.subject.to_s).to eq 'O=US, OU=DoD, CN=John.Doe.1234'
+    end
+
+    it 'returns all-nil object when passed blank JSON' do
+      expect(described_class.new_from_json(nil)).to be_a X509::Attributes
+      expect(described_class.new_from_json('')).to be_a X509::Attributes
+    end
+  end
+end

--- a/spec/services/x509/session_store_spec.rb
+++ b/spec/services/x509/session_store_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe X509::SessionStore do
+  let(:session_uuid) { SecureRandom.uuid }
+
+  subject(:store) { X509::SessionStore.new(session_uuid) }
+
+  describe '#ttl' do
+    it 'returns the remaining time-to-live of the session data in redis' do
+      store.put({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.to_i)
+
+      expect(store.ttl).to eq(5.minutes.to_i)
+    end
+  end
+
+  describe '#load' do
+    it 'loads X509 data from the session' do
+      store.put({ subject: 'O=US, OU=DoD, CN=John.Doe.1234' }, 5.minutes.to_i)
+
+      x509 = store.load
+      expect(x509).to be_kind_of(X509::Attributes)
+      expect(x509.subject).to eq('O=US, OU=DoD, CN=John.Doe.1234')
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
Some SPs need to know the proofed identity of the user as
attested by their PIV/CAC certificate.

**How**:
We save the certificate subject to the encrypted user
session so it's available for the OIDC callback
from the SP. We're delaying SAML support so we can
get this out the door for an SP using OIDC.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
