### PR TITLE
LG-243 Disallow indexing of certain pages

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,8 @@ html lang="#{I18n.locale}" class='no-js'
     meta name="format-detection" content="telephone=no"
     - if content_for?(:meta_refresh)
       meta http-equiv="refresh" content="#{yield(:meta_refresh)}"
+    - if session_with_trust? || FeatureManagement.disallow_all_web_crawlers?
+      meta name='robots' content='noindex,nofollow'
 
     title
       = APP_NAME

--- a/bin/copy_robots_file
+++ b/bin/copy_robots_file
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'login_gov/hostdata'
+
+if LoginGov::Hostdata.in_datacenter? && LoginGov::Hostdata.env != 'prod'
+  FileUtils.cp('public/ban-robots.txt', 'public/robots.txt')
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -90,6 +90,7 @@ development:
   database_statement_timeout: '2500'
   database_timeout: '5000'
   database_username: ''
+  disallow_all_web_crawlers: 'true'
   domain_name: 'localhost:3000'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'false'
@@ -183,6 +184,7 @@ production:
   disable_email_sending: 'false'
   dashboard_api_token:
   database_statement_timeout: '2500'
+  disallow_all_web_crawlers: 'false'
   domain_name: 'login.gov'
   enable_identity_verification: 'false'
   enable_rate_limiting: 'true'
@@ -281,6 +283,7 @@ test:
   database_timeout: '5000'
   database_username: ''
   dashboard_api_token: '123ABC'
+  disallow_all_web_crawlers: 'true'
   enable_identity_verification: 'true'
   enable_rate_limiting: 'true'
   enable_test_routes: 'true'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -4,6 +4,7 @@ Figaro.require_keys(
   'attribute_cost',
   'attribute_encryption_key',
   'database_statement_timeout',
+  'disallow_all_web_crawlers',
   'domain_name',
   'enable_identity_verification',
   'enable_rate_limiting',

--- a/deploy/build-post-config
+++ b/deploy/build-post-config
@@ -20,6 +20,8 @@ export NODE_ENV=production
 
 bundle exec rake assets:precompile
 
+bundle exec bin/copy_robots_file
+
 set +x
 
 echo "deploy/build-post-config finished"

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -93,4 +93,8 @@ class FeatureManagement
     AbTest.new(:ab_test_recaptcha_enabled, Figaro.env.recaptcha_enabled_percent).
       enabled?(session, reset)
   end
+
+  def self.disallow_all_web_crawlers?
+    Figaro.env.disallow_all_web_crawlers == 'true'
+  end
 end

--- a/public/ban-robots.txt
+++ b/public/ban-robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /users/password/edit
+Disallow: /sign_up/enter_password
+Disallow: /sign_up/email/confirm

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -48,4 +48,15 @@ describe SignUp::PasswordsController do
       post :create, params: { password_form: { password: 'NewVal' }, confirmation_token: token }
     end
   end
+
+  describe '#new' do
+    render_views
+    it 'instructs crawlers to not index this page' do
+      token = 'foo token'
+      user = create(:user, :unconfirmed, confirmation_token: token, confirmation_sent_at: Time.zone.now)
+      get :new, params: { confirmation_token: token }
+
+      expect(response.body).to match('<meta content="noindex,nofollow" name="robots" />')
+    end
+  end
 end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -49,7 +49,9 @@ describe Users::ResetPasswordsController, devise: true do
     end
 
     context 'token is valid' do
-      it 'displays the form to enter a new password' do
+      render_views
+
+      it 'displays the form to enter a new password and disallows indexing' do
         stub_analytics
 
         user = instance_double('User', uuid: '123')
@@ -65,6 +67,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         expect(response).to render_template :edit
         expect(flash.keys).to be_empty
+        expect(response.body).to match('<meta content="noindex,nofollow" name="robots" />')
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,7 +22,7 @@ describe ApplicationHelper do
   end
 
   describe '#session_with_trust?' do
-    context 'no user present' do
+    context 'no user present and page is not one with trust' do
       before do
         allow(controller).to receive(:current_user).and_return(nil)
       end
@@ -52,6 +52,14 @@ describe ApplicationHelper do
 
           expect(helper.session_with_trust?).to eq true
         end
+      end
+    end
+
+    context 'curent user is present' do
+      it 'returns true' do
+        allow(controller).to receive(:current_user).and_return(true)
+
+        expect(helper.session_with_trust?).to eq true
       end
     end
   end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -395,4 +395,18 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
+
+  describe '#disallow_all_web_crawlers?' do
+    it 'returns true when Figaro setting is true' do
+      allow(Figaro.env).to receive(:disallow_all_web_crawlers) { 'true' }
+
+      expect(FeatureManagement.disallow_all_web_crawlers?).to eq(true)
+    end
+
+    it 'returns false when Figaro setting is false' do
+      allow(Figaro.env).to receive(:disallow_all_web_crawlers) { 'false' }
+
+      expect(FeatureManagement.disallow_all_web_crawlers?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
**Why**: A couple of our unauthenticated pages can contain sensitive
parameters in the URL, which can be indexed by some search engines.
Although these parameters are only valid for a short period of time,
we want to be cautious and prevent search engines from indexing them.

In addition, we want to disallow indexing and crawling altogether on
our lower environments in order to avoid being dinged by search engines
for having duplicate content across different domains.

**How**:
- During app deploy, copy a different `robots.txt` that disallows all
- Use our existing `session_with_trust?` helper method, along with a new
Figaro config to disallow indexing of pages that can contain sensitive
parameters.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
