### PR TITLE
LG-244 Exclude events with invalid tokens

### DIFF
--- a/app/views/exception_notifier/_data.text.erb
+++ b/app/views/exception_notifier/_data.text.erb
@@ -1,4 +1,4 @@
-<% job = @data[:sidekiq][:job] %>
+<% job = @data.dig(:sidekiq, :job) || {} %>
 
 Job class: <%= job['wrapped'] %>
 Queue: <%= job['queue'] %>

--- a/spec/config/initializers/ahoy_spec.rb
+++ b/spec/config/initializers/ahoy_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe Ahoy::Store do
+  context 'visit_token is an invalid UUID' do
+    it 'excludes the event' do
+      MockAhoy = Struct.new(:visit_token, :visitor_token)
+      mock_ahoy = MockAhoy.new('foo', '1056d484-194c-4b8c-978d-0c0f57958f04')
+      store = Ahoy::Store.new(ahoy: mock_ahoy)
+
+
+      expect(store.exclude?).to eq true
+    end
+  end
+
+  context 'visitor_token is an invalid UUID' do
+    it 'excludes the event' do
+      MockAhoy = Struct.new(:visit_token, :visitor_token)
+      mock_ahoy = MockAhoy.new('1056d484-194c-4b8c-978d-0c0f57958f04', 'foo')
+      store = Ahoy::Store.new(ahoy: mock_ahoy)
+
+
+      expect(store.exclude?).to eq true
+    end
+  end
+
+  context 'both visitor_token and visit_token are a valid UUID' do
+    it 'does not exclude the event' do
+      MockAhoy = Struct.new(:visit_token, :visitor_token)
+      mock_ahoy = MockAhoy.new(
+        '1056d484-194c-4b8c-978d-0c0f57958f04', '1056d484-194c-4b8c-978d-0c0f57958f04'
+      )
+      store = Ahoy::Store.new(ahoy: mock_ahoy)
+
+
+      expect(store.exclude?).to eq false
+    end
+  end
+
+  context 'FeatureManagement.enable_load_testing_mode? is true' do
+    it 'does not exclude the event' do
+      allow(FeatureManagement).to receive(:enable_load_testing_mode?).and_return(true)
+      store = Ahoy::Store.new({})
+
+      expect(store.exclude?).to be_nil
+    end
+  end
+
+  context 'FeatureManagement.use_dashboard_service_providers? is true' do
+    it 'does not exclude the event' do
+      allow(FeatureManagement).to receive(:use_dashboard_service_providers?).
+        and_return(true)
+      store = Ahoy::Store.new({})
+
+      expect(store.exclude?).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
Ahoy uses UUIDs to track visits and visitors. To determine the
value of `visit_id` and `visitor_id`, Ahoy first checks the request's
headers, then cookies, and if neither are present, it generates a new
random UUID.

In version 1.x of the Ahoy gem, if a request was made with headers
and/or cookies containing non-UUID bogus values, Ahoy would
automatically convert them to a valid UUID. This masked the fact that we
get events that should actually be ignored, such as when pentesters make
those fake requests.

In version 2.x of the gem (which we upgraded to recently), the tokens
are still altered (by removing anything that's not an alphanumeric
character or a dash, and limiting the length to 64 characters) but not
converted to a UUID, which then exposed the fact that some people are
passing in non-UUID values in headers and/or cookies. We want to ignore
these invalid visits so they don't clutter our analytics logs.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
