### PR TITLE
LG-246 Create attribute encryptor

### DIFF
--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -1,8 +1,6 @@
 module EncryptableAttribute
   extend ActiveSupport::Concern
 
-  attr_accessor :attribute_user_access_key
-
   module ClassMethods
     cattr_accessor :encryptable_attributes do
       []
@@ -67,12 +65,7 @@ module EncryptableAttribute
   end
 
   def build_encrypted_attribute(name, encrypted_string)
-    encrypted_attribute = EncryptedAttribute.new(
-      encrypted_string,
-      cost: attribute_cost,
-      user_access_key: attribute_user_access_key
-    )
-    self.attribute_user_access_key ||= encrypted_attribute.user_access_key
+    encrypted_attribute = EncryptedAttribute.new(encrypted_string)
     encrypted_attributes[name] = encrypted_attribute
   end
 
@@ -87,18 +80,10 @@ module EncryptableAttribute
   end
 
   def build_encrypted_attribute_from_plain(name, plain_value)
-    self.attribute_user_access_key ||= new_attribute_user_access_key
-    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(
-      plain_value.downcase.strip,
-      attribute_user_access_key
-    )
+    encrypted_attributes[name] = EncryptedAttribute.new_from_decrypted(plain_value.downcase.strip)
   end
 
   def encrypted_attribute_name(name)
     "encrypted_#{name}".to_sym
-  end
-
-  def new_attribute_user_access_key
-    EncryptedAttribute.new_user_access_key(cost: attribute_cost)
   end
 end

--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -1,4 +1,6 @@
 class EncryptedAttribute
+  extend Forwardable
+
   attr_reader :encrypted, :decrypted
 
   def self.new_from_decrypted(decrypted)
@@ -15,9 +17,7 @@ class EncryptedAttribute
     Pii::Fingerprinter.fingerprint(decrypted)
   end
 
-  def stale?
-    encryptor.stale?
-  end
+  def_delegators :encryptor, :stale?
 
   private
 

--- a/app/services/encrypted_attribute.rb
+++ b/app/services/encrypted_attribute.rb
@@ -1,25 +1,14 @@
 class EncryptedAttribute
-  attr_accessor :user_access_key
   attr_reader :encrypted, :decrypted
 
-  def self.new_user_access_key(cost: nil, key: nil)
-    env = Figaro.env
-    key ||= env.attribute_encryption_key
-    cost ||= env.attribute_cost
-    new_key = load_or_build_user_access_key(cost: cost, key: key).dup
-    new_key
+  def self.new_from_decrypted(decrypted)
+    encrypted = Encryption::Encryptors::AttributeEncryptor.new.encrypt(decrypted)
+    new(encrypted, decrypted: decrypted)
   end
 
-  def self.new_from_decrypted(decrypted, user_access_key = new_user_access_key)
-    encryptor = Pii::PasswordEncryptor.new
-    encrypted = encryptor.encrypt(decrypted, user_access_key)
-    new(encrypted, decrypted: decrypted, user_access_key: user_access_key)
-  end
-
-  def initialize(encrypted, decrypted: nil, cost: nil, user_access_key: nil)
+  def initialize(encrypted, decrypted: nil)
     self.encrypted = encrypted
-    self.user_access_key = user_access_key
-    self.decrypted = decrypted.presence || decrypt(cost)
+    self.decrypted = decrypted.presence || encryptor.decrypt(encrypted)
   end
 
   def fingerprint
@@ -27,59 +16,14 @@ class EncryptedAttribute
   end
 
   def stale?
-    user_access_key.salt != current_salt
+    encryptor.stale?
   end
 
   private
 
   attr_writer :encrypted, :decrypted
 
-  private_class_method def self.load_or_build_user_access_key(cost:, key:)
-    @_uaks_by_key ||= {}
-    uak_lookup = "#{key}:#{cost}"
-    @_uaks_by_key[uak_lookup] ||= Encryption::UserAccessKey.new(
-      password: key, salt: key, cost: cost
-    )
-  end
-
-  def current_salt
-    OpenSSL::Digest::SHA256.hexdigest(Figaro.env.attribute_encryption_key)
-  end
-
-  def decrypt(cost)
-    encryptor = Pii::PasswordEncryptor.new
-    decrypted = try_decrypt_with_uak(encryptor) if user_access_key.present?
-    return decrypted if decrypted
-    try_decrypt_with_all_keys(encryptor, cost)
-  end
-
-  def try_decrypt(encryptor, key, cost)
-    self.user_access_key = self.class.new_user_access_key(cost: cost, key: key)
-    encryptor.decrypt(encrypted, user_access_key)
-  rescue Pii::EncryptionError => _err
-    nil
-  end
-
-  def try_decrypt_with_all_keys(encryptor, cost)
-    encryption_keys.each do |key|
-      decrypted = try_decrypt(encryptor, key, cost) or next
-      return decrypted
-    end
-
-    raise Pii::EncryptionError, 'unable to decrypt attribute with any key'
-  end
-
-  def try_decrypt_with_uak(encryptor)
-    encryptor.decrypt(encrypted, user_access_key)
-  rescue Pii::EncryptionError => _err
-    nil
-  end
-
-  def encryption_keys
-    [Figaro.env.attribute_encryption_key] + old_keys
-  end
-
-  def old_keys
-    KeyRotator::Utils.old_keys(:attribute_encryption_key_queue)
+  def encryptor
+    @encryptor ||= Encryption::Encryptors::AttributeEncryptor.new
   end
 end

--- a/app/services/encryption/encryptors/attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/attribute_encryptor.rb
@@ -1,0 +1,67 @@
+module Encryption
+  module Encryptors
+    class AttributeEncryptor
+      def encrypt(plaintext)
+        user_access_key = self.class.load_or_init_user_access_key(
+          key: current_key, cost: current_cost
+        )
+        UserAccessKeyEncryptor.new(user_access_key).encrypt(plaintext)
+      end
+
+      def decrypt(ciphertext)
+        encryption_keys_with_cost.each do |key_with_cost|
+          key = key_with_cost.fetch(:key)
+          cost = key_with_cost.fetch(:cost)
+          result = try_decrypt(ciphertext, key: key, cost: cost)
+          return result unless result.nil?
+        end
+        raise Pii::EncryptionError, 'unable to decrypt attribute with any key'
+      end
+
+      def stale?
+        return false if stale.nil?
+        stale
+      end
+
+      def self.load_or_init_user_access_key(key:, cost:)
+        @_scypt_hashes_by_key ||= {}
+        scrypt_hash = @_scypt_hashes_by_key["#{key}:#{cost}"]
+        return UserAccessKey.new(scrypt_hash: scrypt_hash) if scrypt_hash.present?
+        uak = UserAccessKey.new(password: key, salt: key, cost: cost)
+        @_scypt_hashes_by_key["#{key}:#{cost}"] = uak.as_scrypt_hash
+        uak
+      end
+
+      private
+
+      attr_accessor :stale
+
+      def try_decrypt(ciphertext, key:, cost:)
+        user_access_key = self.class.load_or_init_user_access_key(key: key, cost: cost)
+        begin
+          result = UserAccessKeyEncryptor.new(user_access_key).decrypt(ciphertext)
+          self.stale = true if key != current_key
+          result
+        rescue Pii::EncryptionError
+          nil
+        end
+      end
+
+      def encryption_keys_with_cost
+        @encryption_keys_with_cost ||= [{ key: current_key, cost: current_cost }] + old_keys
+      end
+
+      def current_key
+        Figaro.env.attribute_encryption_key
+      end
+
+      def current_cost
+        Figaro.env.attribute_cost
+      end
+
+      def old_keys
+        JSON.parse(Figaro.env.attribute_encryption_key_queue, symbolize_names: true)
+      end
+    end
+  end
+end

--- a/app/services/encryption/encryptors/attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/attribute_encryptor.rb
@@ -19,7 +19,6 @@ module Encryption
       end
 
       def stale?
-        return false if stale.nil?
         stale
       end
 
@@ -40,7 +39,7 @@ module Encryption
         user_access_key = self.class.load_or_init_user_access_key(key: key, cost: cost)
         begin
           result = UserAccessKeyEncryptor.new(user_access_key).decrypt(ciphertext)
-          self.stale = true if key != current_key
+          self.stale = key != current_key
           result
         rescue Pii::EncryptionError
           nil

--- a/app/services/encryption/encryptors/user_access_key_encryptor.rb
+++ b/app/services/encryption/encryptors/user_access_key_encryptor.rb
@@ -1,0 +1,55 @@
+module Encryption
+  module Encryptors
+    class UserAccessKeyEncryptor
+      include Pii::Encodable
+
+      DELIMITER = '.'.freeze
+
+      def initialize(user_access_key)
+        @user_access_key = user_access_key
+        @encryptor = Pii::Encryptor.new
+      end
+
+      def encrypt(plaintext)
+        user_access_key.build unless user_access_key.built?
+        encrypted_contents = encryptor.encrypt(plaintext, user_access_key.cek)
+        build_ciphertext(user_access_key.encryption_key, encrypted_contents)
+      end
+
+      def decrypt(ciphertext)
+        encryption_key = encryption_key_from_ciphertext(ciphertext)
+        encrypted_contents = encrypted_contents_from_ciphertext(ciphertext)
+        unlock_user_access_key(encryption_key)
+        encryptor.decrypt(encrypted_contents, user_access_key.cek)
+      end
+
+      private
+
+      attr_reader :encryptor, :user_access_key
+
+      def build_ciphertext(encryption_key, encrypted_contents)
+        [
+          encode(encryption_key),
+          encrypted_contents,
+        ].join(DELIMITER)
+      end
+
+      def encryption_key_from_ciphertext(ciphertext)
+        encoded_encryption_key = ciphertext.split(DELIMITER).first
+        raise Pii::EncryptionError, 'ciphertext is invalid' unless valid_base64_encoding?(
+          encoded_encryption_key
+        )
+        decode(encoded_encryption_key)
+      end
+
+      def encrypted_contents_from_ciphertext(ciphertext)
+        ciphertext.split(DELIMITER).second
+      end
+
+      def unlock_user_access_key(encryption_key)
+        return if user_access_key.unlocked? && user_access_key.encryption_key == encryption_key
+        user_access_key.unlock(encryption_key)
+      end
+    end
+  end
+end

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -2,8 +2,7 @@ module KeyRotator
   class AttributeEncryption
     def initialize(user)
       @user = user
-      self.new_cost = Figaro.env.attribute_cost
-      self.encryptor = Pii::PasswordEncryptor.new
+      @encryptor = Encryption::Encryptors::AttributeEncryptor.new
     end
 
     # rubocop:disable Rails/SkipsModelValidations
@@ -14,12 +13,7 @@ module KeyRotator
 
     private
 
-    attr_accessor :encryptor, :new_cost
-    attr_reader :user
-
-    def uak
-      @_uak ||= EncryptedAttribute.new_user_access_key(cost: new_cost)
-    end
+    attr_reader :user, :encryptor
 
     def encrypted_attributes
       User.encryptable_attributes.each_with_object({}) do |attribute, result|
@@ -27,8 +21,7 @@ module KeyRotator
         next unless plain_attribute
 
         result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(
-          plain_attribute,
-          uak
+          plain_attribute
         ).encrypted
       end
     end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -71,7 +71,7 @@ development:
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   attribute_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
-  attribute_encryption_key_queue: '["old-key-one", "old-key-two"]'
+  attribute_encryption_key_queue: '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
@@ -173,7 +173,7 @@ production:
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   attribute_encryption_key: # generate via `rake secret`
-  attribute_encryption_key_queue: # '["old-key-one", "old-key-two"]'
+  attribute_encryption_key_queue: # '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
   available_locales: 'en es fr'
   aws_kms_key_id:
   aws_region:
@@ -262,7 +262,7 @@ test:
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
   attribute_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
-  attribute_encryption_key_queue: '["old-key-one", "old-key-two"]'
+  attribute_encryption_key_queue: '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-test-keymaker'
   aws_region: 'us-east-1'

--- a/spec/services/encrypted_attribute_spec.rb
+++ b/spec/services/encrypted_attribute_spec.rb
@@ -4,28 +4,8 @@ describe EncryptedAttribute do
   let(:email) { 'someone@example.com' }
   let(:fingerprint) { Pii::Fingerprinter.fingerprint(email) }
   let(:encrypted_email) do
-    encryptor = Pii::PasswordEncryptor.new
-    encryptor.encrypt(email, EncryptedAttribute.new_user_access_key)
-  end
-
-  describe '.new_user_access_key' do
-    it 'does not return the same key twice' do
-      key1 = EncryptedAttribute.new_user_access_key
-      key2 = EncryptedAttribute.new_user_access_key
-
-      expect(key1).to_not eq(key2)
-    end
-
-    it 'does not return successive keys that are unlocked or have the same random_r value' do
-      key1 = EncryptedAttribute.new_user_access_key.build
-
-      key2 = EncryptedAttribute.new_user_access_key
-
-      expect(key2.unlocked?).to eq(false)
-      key2.build
-
-      expect(key1.random_r).to_not eq(key2.random_r)
-    end
+    encryptor = Encryption::Encryptors::AttributeEncryptor.new
+    encryptor.encrypt(email)
   end
 
   describe '#new' do

--- a/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+describe Encryption::Encryptors::AttributeEncryptor do
+  let(:plaintext) { 'some secret text' }
+  let(:current_key) { '1' * 32 }
+  let(:current_cost) { '400$8$1$' }
+  let(:retired_key) { '2' * 32 }
+  let(:retired_cost) { '2000$8$1$' }
+
+  before do
+    described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
+
+    allow(Figaro.env).to receive(:attribute_encryption_key).and_return(current_key)
+    allow(Figaro.env).to receive(:attribute_cost).and_return(current_cost)
+    allow(Figaro.env).to receive(:attribute_encryption_key_queue).and_return(
+      [{ key: retired_key, cost: retired_cost }].to_json
+    )
+  end
+
+  describe '#encrypt' do
+    it 'returns encrypted text' do
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to_not eq(plaintext)
+    end
+
+    it 'only computes an scrypt hash the first time a key is used' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      subject.encrypt(plaintext)
+
+      expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+      subject.encrypt(plaintext)
+    end
+  end
+
+  describe '#decrypt' do
+    let(:ciphertext) do
+      result = subject.encrypt(plaintext)
+      described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
+      result
+    end
+
+    before do
+      # Memoize the ciphertext and purge the key pool so that encryption does not
+      # affect expected call counts
+      ciphertext
+    end
+
+    context 'with a ciphertext made with the current key' do
+      it 'decrypts the ciphertext' do
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
+
+      it 'only computes an scrypt hash the first time a keys is used' do
+        expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+        subject.decrypt(ciphertext)
+
+        expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+        subject.decrypt(ciphertext)
+      end
+    end
+
+    context 'after rotating keys' do
+      before do
+        rotate_attribute_encryption_key
+      end
+
+      it 'tries to decrypt with successive keys until it is successful' do
+        expect(Encryption::UserAccessKey).to receive(:new).twice.and_call_original
+
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
+    end
+
+    context 'with a ciphertext made with a key that does not exist' do
+      before do
+        rotate_attribute_encryption_key_with_invalid_queue
+      end
+
+      it 'raises and encryption error' do
+        expect { subject.decrypt(ciphertext) }.to raise_error(
+          Pii::EncryptionError, 'unable to decrypt attribute with any key'
+        )
+      end
+    end
+  end
+
+  describe '#stale?' do
+    it 'returns false if the current key last was used to decrypt something' do
+      ciphertext = subject.encrypt(plaintext)
+      subject.decrypt(ciphertext)
+
+      expect(subject.stale?).to eq(false)
+    end
+
+    it 'returns true if an old key was last used to decrypt something' do
+      ciphertext = subject.encrypt(plaintext)
+      rotate_attribute_encryption_key
+      subject.decrypt(ciphertext)
+
+      expect(subject.stale?).to eq(true)
+    end
+  end
+
+  describe '.load_or_init_user_access_key' do
+    it 'does not return the same key object for the same salt and cost' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      key1 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
+      key2 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
+
+      expect(key1.as_scrypt_hash).to eq(key2.as_scrypt_hash)
+      expect(key1).to_not eq(key2)
+    end
+  end
+end

--- a/spec/services/encryption/encryptors/user_access_key_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/user_access_key_encryptor_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe Encryption::Encryptors::UserAccessKeyEncryptor do
+  let(:password) { 'password' }
+  let(:salt) { 'n-pepa' }
+  let(:plaintext) { 'Oooh baby baby' }
+  let(:user_access_key) { Encryption::UserAccessKey.new(password: password, salt: salt) }
+
+  subject { described_class.new(user_access_key) }
+
+  describe '#encrypt' do
+    it 'returns encrypted text' do
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to_not match plaintext
+    end
+
+    it 'only builds the user access key once' do
+      expect(user_access_key).to receive(:build).once.and_call_original
+      expect(user_access_key).to_not receive(:unlock)
+
+      subject.encrypt(plaintext)
+      subject.encrypt(plaintext)
+    end
+  end
+
+  describe '#decrypt' do
+    it 'returns the original text' do
+      ciphertext = subject.encrypt(plaintext)
+      decrypted_ciphertext = subject.decrypt(ciphertext)
+
+      expect(decrypted_ciphertext).to eq(plaintext)
+    end
+
+    it 'requires the same user access key used for encrypt' do
+      ciphertext = subject.encrypt(plaintext)
+      wrong_key = Encryption::UserAccessKey.new(password: 'This is not the password', salt: salt)
+      new_encryptor = described_class.new(wrong_key)
+
+      expect { new_encryptor.decrypt(ciphertext) }.to raise_error Pii::EncryptionError
+    end
+
+    it 'raises an error if the ciphertext is not base64 encoded' do
+      expect { subject.decrypt('@@@@@@@') }.to raise_error Pii::EncryptionError
+    end
+
+    it 'only unlocks the user access key once' do
+      # Encrypt the plaintext so that user access key is not built by encrypt
+      # but encryption instead of being unlocked
+      ciphertext = described_class.new(user_access_key.dup).encrypt(plaintext)
+
+      expect(user_access_key).to receive(:unlock).once.and_call_original
+      expect(user_access_key).to_not receive(:build)
+
+      subject.decrypt(ciphertext)
+      subject.decrypt(ciphertext)
+    end
+
+    it 'can decrypt contents created by different user access keys if the password is the same' do
+      uak_1 = Encryption::UserAccessKey.new(password: password, salt: salt)
+      uak_2 = Encryption::UserAccessKey.new(password: password, salt: salt)
+      payload_1 = described_class.new(uak_1).encrypt(plaintext)
+      payload_2 = described_class.new(uak_2).encrypt(plaintext)
+
+      expect(payload_1).to_not eq(payload_2)
+
+      expect(user_access_key).to receive(:unlock).twice.and_call_original
+
+      result_1 = subject.decrypt(payload_1)
+      result_2 = subject.decrypt(payload_2)
+
+      expect(result_1).to eq(plaintext)
+      expect(result_2).to eq(plaintext)
+    end
+  end
+end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -43,7 +43,14 @@ describe Pii::Cacher do
 
       rotate_all_keys
 
-      subject.save(user_access_key)
+      # Create a new user object to drop the memoized encrypted attributes
+      user_id = user.id
+      reloaded_user = User.find(user_id)
+      reloaded_profile = user.profiles.first
+
+      described_class.new(reloaded_user, user_session).save(user_access_key)
+
+      user.reload
       profile.reload
 
       expect(user.email_fingerprint).to_not eq old_email_fingerprint

--- a/spec/support/key_rotation_helper.rb
+++ b/spec/support/key_rotation_helper.rb
@@ -8,13 +8,19 @@ module KeyRotationHelper
     allow(env).to receive(:hmac_fingerprinter_key).and_return('a-new-key')
   end
 
-  def rotate_attribute_encryption_key
+  def rotate_attribute_encryption_key(new_key = 'a-new-key', new_cost = '4000$8$2$')
     env = Figaro.env
     old_key = env.attribute_encryption_key
-    allow(env).to receive(:attribute_encryption_key_queue).and_return(
-      "[\"a-new-key\", \"#{old_key}\"]"
-    )
-    allow(env).to receive(:attribute_encryption_key).and_return('a-new-key')
+    old_cost = env.attribute_cost
+
+    allow(Figaro.env).to receive(:attribute_encryption_key).and_return(new_key)
+    allow(Figaro.env).to receive(:attribute_cost).and_return(new_cost)
+
+    current_queue = JSON.parse(Figaro.env.attribute_encryption_key_queue)
+    current_queue = [{ key: old_key, cost: old_cost }] + current_queue
+
+    allow(Figaro.env).to receive(:attribute_encryption_key_queue).
+      and_return(current_queue.to_json)
   end
 
   def rotate_all_keys
@@ -25,7 +31,7 @@ module KeyRotationHelper
   def rotate_attribute_encryption_key_with_invalid_queue
     env = Figaro.env
     allow(env).to receive(:attribute_encryption_key_queue).and_return(
-      '["key-that-was-never-used-in-the-past"]'
+      [{ key: 'key-that-was-never-used-in-the-past', cost: '4000$8$2$' }].to_json
     )
     allow(env).to receive(:attribute_encryption_key).and_return('a-new-key')
   end


### PR DESCRIPTION
**Why**: To prevent the models with encrypted attributes from having to
worry about managing user access keys or key rotation. This commit
starts the move to a place where user access key management is handled
by encryptors and not by the clients using those encryptors. This will
make it easier to migrate to a different encryption solution if/when
that becomes necessary.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
