### PR TITLE
Fix scope of present_with method

### DIFF
--- a/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-def presenter_with(arguments = {}, view = ActionController::Base.new.view_context)
-  TwoFactorAuthCode::GenericDeliveryPresenter.new(data: arguments, view: view)
-end
-
 describe TwoFactorAuthCode::GenericDeliveryPresenter do
   it 'is an abstract presenter with methods that should be implemented' do
     presenter = presenter_with
@@ -15,7 +11,7 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
 
   describe '#personal_key_link' do
     context 'with unconfirmed user' do
-      presenter = presenter_with(personal_key_unavailable: true)
+      let(:presenter) { presenter_with(personal_key_unavailable: true) }
 
       it 'returns without providing the option to use a personal key' do
         expect(presenter.personal_key_link).to be_nil
@@ -23,7 +19,7 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
     end
 
     context 'with confirmed user' do
-      presenter = presenter_with(personal_key_unavailable: false)
+      let(:presenter) { presenter_with(personal_key_unavailable: false) }
 
       it 'returns a personal key link' do
         expect(presenter.personal_key_link).not_to be_nil
@@ -50,5 +46,9 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
         )
       end
     end
+  end
+
+  def presenter_with(arguments = {}, view = ActionController::Base.new.view_context)
+    TwoFactorAuthCode::GenericDeliveryPresenter.new(data: arguments, view: view)
   end
 end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-def presenter_with(arguments = {}, view = ActionController::Base.new.view_context)
-  TwoFactorAuthCode::PivCacAuthenticationPresenter.new(data: arguments, view: view)
-end
-
 describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::TagHelper
@@ -58,5 +54,9 @@ describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
         expect(presenter.cancel_link).to eq sign_out_path(locale: locale)
       end
     end
+  end
+
+  def presenter_with(arguments = {}, view = ActionController::Base.new.view_context)
+    TwoFactorAuthCode::PivCacAuthenticationPresenter.new(data: arguments, view: view)
   end
 end


### PR DESCRIPTION
**Why**: Defining the method at the global scope means that when another
presenter spec redefines it overrides the original implementation
causing the tests to fail.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
