### PR TITLE
Update initialization of Idv::Proofer@vendors

### DIFF
--- a/.reek
+++ b/.reek
@@ -93,6 +93,7 @@ TooManyStatements:
     - UserFlowExporter#self.run
     - Idv::Agent#proof
     - Idv::Proofer#configure_vendors
+    - Idv::VendorResult#initialize
 TooManyMethods:
   exclude:
     - Users::ConfirmationsController

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -11,10 +11,11 @@ module Idv
     end
 
     def proof(*stages)
-      results = { errors: {}, messages: [], exception: nil, success: false }
+      results = init_results
 
       stages.each do |stage|
         vendor = Idv::Proofer.get_vendor(stage).new
+        log_vendor(vendor, results, stage)
         proofer_result = vendor.proof(@applicant)
         results = merge_results(results, proofer_result)
         break unless proofer_result.success?
@@ -24,6 +25,23 @@ module Idv
     end
 
     private
+
+    def init_results
+      {
+        errors: {},
+        messages: [],
+        context: {
+          stages: [],
+        },
+        exception: nil,
+        success: false,
+      }
+    end
+
+    def log_vendor(vendor, results, stage)
+      v_class = vendor.class
+      results[:context][:stages].push(stage => v_class.vendor_name || v_class.inspect)
+    end
 
     def merge_results(results, proofer_result)
       results.merge(proofer_result.to_h) do |key, orig, current|

--- a/app/services/idv/proofer.rb
+++ b/app/services/idv/proofer.rb
@@ -13,11 +13,9 @@ module Idv
 
     STAGES = %i[resolution state_id address].freeze
 
+    @vendors = {}
+
     class << self
-      attr_accessor :configuration
-
-      @vendors = {}
-
       def attribute?(key)
         ATTRIBUTES.include?(key&.to_sym)
       end
@@ -31,8 +29,11 @@ module Idv
       end
 
       def configure
-        self.configuration ||= Configuration.new
         yield(configuration)
+      end
+
+      def configuration
+        @configuration ||= Configuration.new
       end
 
       class Configuration

--- a/app/services/idv/vendor_result.rb
+++ b/app/services/idv/vendor_result.rb
@@ -1,6 +1,12 @@
 module Idv
   class VendorResult
-    attr_reader :success, :errors, :messages, :normalized_applicant, :timed_out, :exception
+    attr_reader :success,
+                :errors,
+                :messages,
+                :context,
+                :normalized_applicant,
+                :timed_out,
+                :exception
 
     def self.new_from_json(json)
       parsed = JSON.parse(json, symbolize_names: true)
@@ -11,11 +17,12 @@ module Idv
       new(**parsed)
     end
 
-    def initialize(success: nil, errors: {}, messages: [],
+    def initialize(success: nil, errors: {}, messages: [], context: {},
                    normalized_applicant: nil, timed_out: nil, exception: nil)
       @success = success
       @errors = errors
       @messages = messages
+      @context = context
       @normalized_applicant = normalized_applicant
       @timed_out = timed_out
       @exception = exception

--- a/config/initializers/proofer.rb
+++ b/config/initializers/proofer.rb
@@ -1,9 +1,11 @@
+# rubocop:disable Metrics/LineLength
 if FeatureManagement.enable_identity_verification?
   Idv::Proofer.configure do |config|
     config.mock_fallback = Figaro.env.proofer_mock_fallback == 'true'
-    config.raise_on_missing_proofers = Figaro.env.proofer_raise_on_missing_proofers == 'false'
+    config.raise_on_missing_proofers = false if Figaro.env.proofer_raise_on_missing_proofers == 'false'
     config.vendors = JSON.parse(Figaro.env.proofer_vendors || '[]')
   end
 
   Idv::Proofer.init
 end
+# rubocop:enable Metrics/LineLength

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -82,7 +82,7 @@ describe Idv::Agent do
         let(:stages) { %i[resolution state_id] }
 
         it 'results from all stages are included' do
-          expect(subject.to_h).to eq(
+          expect(subject.to_h).to include(
             errors: {},
             messages: [resolution_message, state_id_message],
             success: true,
@@ -95,7 +95,7 @@ describe Idv::Agent do
         let(:stages) { %i[failed state_id] }
 
         it 'only the results from the first stage are included' do
-          expect(subject.to_h).to eq(
+          expect(subject.to_h).to include(
             errors: { bad: ['stuff'] },
             messages: [failed_message],
             success: false,


### PR DESCRIPTION
**WHY**
It appears that the class instance variable was being lost
in Sidekiq worker threads, perhaps it was being re initialized

**HOW**
Move it to the correct context and other fixes/enhancements

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
