### PR TITLE
LG-246 Create purpose-built encryptor for encrypting PII

### DIFF
--- a/.reek
+++ b/.reek
@@ -65,6 +65,7 @@ LongParameterList:
     - IdentityLinker#optional_attributes
     - Idv::ProoferJob#perform
     - Idv::VendorResult#initialize
+    - Pii::Attributes#self.new_from_encrypted
 RepeatedConditional:
   exclude:
     - Users::ResetPasswordsController

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -73,8 +73,8 @@ module Idv
     end
 
     def init_profile
-      idv_session.cache_applicant_profile_id
-      idv_session.cache_encrypted_pii(current_user.user_access_key)
+      idv_session.create_profile_from_applicant_with_password(password)
+      idv_session.cache_encrypted_pii(password)
       idv_session.complete_session
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -119,7 +119,7 @@ module Users
       cacher = Pii::Cacher.new(current_user, user_session)
       profile = current_user.decorate.active_or_pending_profile
       begin
-        cacher.save(current_user.user_access_key, profile)
+        cacher.save(auth_params[:password], profile)
       rescue Pii::EncryptionError => err
         profile.deactivate(:encryption_error)
         analytics.track_event(Analytics::PROFILE_ENCRYPTION_INVALID, error: err.message)

--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -33,7 +33,7 @@ class VerifyPasswordForm
   end
 
   def reencrypt_pii
-    personal_key = profile.encrypt_pii(user_access_key, decrypted_pii)
+    personal_key = profile.encrypt_pii(decrypted_pii, password)
     profile.update(deactivation_reason: nil, active: true)
     profile.save!
     personal_key

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -30,29 +30,42 @@ class Profile < ApplicationRecord
     update!(active: false, deactivation_reason: reason)
   end
 
-  def decrypt_pii(user_access_key)
-    Pii::Attributes.new_from_encrypted(encrypted_pii, user_access_key)
+  def decrypt_pii(password)
+    Pii::Attributes.new_from_encrypted(
+      encrypted_pii,
+      password: password,
+      salt: user.password_salt,
+      cost: user.password_cost
+    )
   end
 
   def recover_pii(personal_key)
-    rc_user_access_key = Encryption::UserAccessKey.new(
+    Pii::Attributes.new_from_encrypted(
+      encrypted_pii_recovery,
       password: personal_key,
       salt: user.recovery_salt,
       cost: user.recovery_cost
     )
-    Pii::Attributes.new_from_encrypted(encrypted_pii_recovery, rc_user_access_key)
   end
 
-  def encrypt_pii(user_access_key, pii)
+  def encrypt_pii(pii, password)
     ssn = pii.ssn
     self.ssn_signature = Pii::Fingerprinter.fingerprint(ssn) if ssn
-    self.encrypted_pii = pii.encrypted(user_access_key)
+    self.encrypted_pii = pii.encrypted(
+      password: password,
+      salt: user.password_salt,
+      cost: user.password_cost
+    )
     encrypt_recovery_pii(pii)
   end
 
   def encrypt_recovery_pii(pii)
-    personal_key, rc_user_access_key = generate_personal_key
-    self.encrypted_pii_recovery = pii.encrypted(rc_user_access_key)
+    personal_key = personal_key_generator.create
+    self.encrypted_pii_recovery = pii.encrypted(
+      password: personal_key_generator.normalize(personal_key),
+      salt: user.recovery_salt,
+      cost: user.recovery_cost
+    )
     @personal_key = personal_key
   end
 
@@ -60,10 +73,5 @@ class Profile < ApplicationRecord
 
   def personal_key_generator
     @_personal_key_generator ||= PersonalKeyGenerator.new(user)
-  end
-
-  def generate_personal_key
-    personal_key = personal_key_generator.create
-    [personal_key, personal_key_generator.user_access_key]
   end
 end

--- a/app/services/active_profile_encryptor.rb
+++ b/app/services/active_profile_encryptor.rb
@@ -9,8 +9,7 @@ class ActiveProfileEncryptor
 
   def call
     active_profile = @user.active_profile
-    user_access_key = @user.unlock_user_access_key(@password)
-    @personal_key = active_profile.encrypt_pii(user_access_key, current_pii)
+    @personal_key = active_profile.encrypt_pii(current_pii, @password)
     active_profile.save!
   end
 

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -1,0 +1,22 @@
+module Encryption
+  module Encryptors
+    class PiiEncryptor
+      extend Forwardable
+
+      def initialize(password:, salt:, cost: nil)
+        user_access_key = UserAccessKey.new(
+          password: password,
+          cost: cost,
+          salt: salt
+        )
+        @encryptor = UserAccessKeyEncryptor.new(user_access_key)
+      end
+
+      def_delegators :encryptor, :encrypt, :decrypt
+
+      private
+
+      attr_reader :encryptor
+    end
+  end
+end

--- a/app/services/encryption/encryptors/user_access_key_encryptor.rb
+++ b/app/services/encryption/encryptors/user_access_key_encryptor.rb
@@ -43,7 +43,9 @@ module Encryption
       end
 
       def encrypted_contents_from_ciphertext(ciphertext)
-        ciphertext.split(DELIMITER).second
+        contents = ciphertext.split(DELIMITER).second
+        raise Pii::EncryptionError, 'ciphertext is missing encrypted contents' if contents.nil?
+        contents
       end
 
       def unlock_user_access_key(encryption_key)

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -2,12 +2,13 @@ module Idv
   class ProfileMaker
     attr_reader :pii_attributes
 
-    def initialize(applicant:, user:, normalized_applicant:, phone_confirmed:)
+    def initialize(applicant:, user:, normalized_applicant:, phone_confirmed:, user_password:)
       self.pii_attributes = pii_from_applicant(
         OpenStruct.new(applicant),
         OpenStruct.new(normalized_applicant)
       )
       self.user = user
+      self.user_password = user_password
       self.phone_confirmed = phone_confirmed
     end
 
@@ -17,14 +18,14 @@ module Idv
         phone_confirmed: phone_confirmed,
         user: user
       )
-      profile.encrypt_pii(user.user_access_key, pii_attributes)
+      profile.encrypt_pii(pii_attributes, user_password)
       profile.save!
       profile
     end
 
     private
 
-    attr_accessor :user, :phone_confirmed
+    attr_accessor :user, :user_password, :phone_confirmed
     attr_writer :pii_attributes
 
     # rubocop:disable MethodLength, AbcSize

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -48,7 +48,8 @@ module Idv
       applicant.present? && resolution_successful
     end
 
-    def cache_applicant_profile_id
+    def create_profile_from_applicant_with_password(user_password)
+      profile_maker = build_profile_maker(user_password)
       profile = profile_maker.save_profile
       self.pii = profile_maker.pii_attributes
       self.profile_id = profile.id
@@ -133,12 +134,13 @@ module Idv
       Hash[applicant_params.map { |key, value| [key, value.to_ascii] }]
     end
 
-    def profile_maker
-      @_profile_maker ||= Idv::ProfileMaker.new(
+    def build_profile_maker(user_password)
+      Idv::ProfileMaker.new(
         applicant: applicant_params,
         normalized_applicant: normalized_applicant_params,
         phone_confirmed: vendor_phone_confirmation || false,
-        user: current_user
+        user: current_user,
+        user_password: user_password
       )
     end
   end

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -16,9 +16,13 @@ module Pii
       attrs
     end
 
-    def self.new_from_encrypted(encrypted, user_access_key)
-      encryptor = Pii::PasswordEncryptor.new
-      decrypted = encryptor.decrypt(encrypted, user_access_key)
+    def self.new_from_encrypted(encrypted, password:, salt:, cost:)
+      encryptor = Encryption::Encryptors::PiiEncryptor.new(
+        password: password,
+        salt: salt,
+        cost: cost
+      )
+      decrypted = encryptor.decrypt(encrypted)
       new_from_json(decrypted)
     end
 
@@ -33,9 +37,13 @@ module Pii
       assign_all_members
     end
 
-    def encrypted(user_access_key)
-      encryptor = Pii::PasswordEncryptor.new
-      encryptor.encrypt(to_json, user_access_key)
+    def encrypted(password:, salt:, cost:)
+      encryptor = Encryption::Encryptors::PiiEncryptor.new(
+        password: password,
+        salt: salt,
+        cost: cost
+      )
+      encryptor.encrypt(to_json)
     end
 
     def eql?(other)

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -11,8 +11,8 @@ module Pii
       @user_session = user_session
     end
 
-    def save(user_access_key, profile = user.active_profile)
-      user_session[:decrypted_pii] = profile.decrypt_pii(user_access_key).to_json if profile
+    def save(user_password, profile = user.active_profile)
+      user_session[:decrypted_pii] = profile.decrypt_pii(user_password).to_json if profile
       rotate_fingerprints(profile) if stale_fingerprints?(profile)
       rotate_encrypted_attributes if stale_attributes?
       user_session[:decrypted_pii]

--- a/lib/tasks/create_test_accounts.rb
+++ b/lib/tasks/create_test_accounts.rb
@@ -22,7 +22,6 @@ def create_account(email: 'joe.smith@email.com', password: 'salty pickles', mfa_
 
   if verified
     user = User.find_by(email_fingerprint: ee.fingerprint)
-    user.unlock_user_access_key(password)
     profile = Profile.new(user: user)
     pii = Pii::Attributes.new_from_hash(
       first_name: first_name,
@@ -37,7 +36,7 @@ def create_account(email: 'joe.smith@email.com', password: 'salty pickles', mfa_
       zipcode: zipcode,
       phone: phone
     )
-    personal_key = profile.encrypt_pii(user.user_access_key, pii)
+    personal_key = profile.encrypt_pii(pii, password)
     profile.verified_at = Time.zone.now
     profile.activate
   end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -10,7 +10,6 @@ namespace :dev do
     end
 
     loa3_user = User.find_by(email_fingerprint: fingerprint('test2@test.com'))
-    loa3_user.unlock_user_access_key(pw)
     profile = Profile.new(user: loa3_user)
     pii = Pii::Attributes.new_from_hash(
       ssn: '660-00-1234',
@@ -18,7 +17,7 @@ namespace :dev do
       first_name: 'Some',
       last_name: 'One'
     )
-    personal_key = profile.encrypt_pii(loa3_user.user_access_key, pii)
+    personal_key = profile.encrypt_pii(pii, pw)
     profile.verified_at = Time.zone.now
     profile.activate
 
@@ -60,7 +59,6 @@ namespace :dev do
 
         if ENV['VERIFIED']
           user = User.find_by(email_fingerprint: ee.fingerprint)
-          user.unlock_user_access_key(pw)
           profile = Profile.new(user: user)
           pii = Pii::Attributes.new_from_hash(
             first_name: 'Test',
@@ -68,7 +66,7 @@ namespace :dev do
             dob: '1970-05-01',
             ssn: "666-#{num_created}" # doesn't need to be legit 9 digits, just unique
           )
-          personal_key = profile.encrypt_pii(user.user_access_key, pii)
+          personal_key = profile.encrypt_pii(pii, pw)
           profile.verified_at = Time.zone.now
           profile.activate
 

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -14,12 +14,12 @@ describe Idv::ConfirmationsController do
     idv_session.applicant = idv_session.vendor_params
     idv_session.normalized_applicant_params = { first_name: 'Somebody' }
     idv_session.resolution_successful = true
-    user.unlock_user_access_key(password)
     profile_maker = Idv::ProfileMaker.new(
       applicant: applicant,
       user: user,
       normalized_applicant: normalized_applicant,
-      phone_confirmed: true
+      phone_confirmed: true,
+      user_password: password
     )
     profile = profile_maker.save_profile
     idv_session.pii = profile_maker.pii_attributes
@@ -95,7 +95,7 @@ describe Idv::ConfirmationsController do
     end
 
     it 'sets code instance variable' do
-      subject.idv_session.cache_applicant_profile_id
+      subject.idv_session.create_profile_from_applicant_with_password(password)
       code = subject.idv_session.personal_key
 
       get :show

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -305,8 +305,7 @@ describe Idv::ReviewController do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
         profile = idv_session.profile
-        uak = user.unlock_user_access_key(ControllerHelper::VALID_PASSWORD)
-        pii = profile.decrypt_pii(uak)
+        pii = profile.decrypt_pii(ControllerHelper::VALID_PASSWORD)
 
         expect(pii.zipcode.raw).to eq raw_zipcode
         expect(pii.zipcode.norm).to eq norm_zipcode

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -223,9 +223,8 @@ describe Users::SessionsController, devise: true do
     end
 
     context 'LOA1 user' do
-      it 'computes only one SCrypt hash for the user password' do
+      it 'computes one SCrypt hash for the user password' do
         user = create(:user, :signed_up)
-        create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
 
         expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
 
@@ -238,11 +237,11 @@ describe Users::SessionsController, devise: true do
         allow(FeatureManagement).to receive(:use_kms?).and_return(false)
       end
 
-      it 'computes only one SCrypt hash for the user password' do
+      it 'computes one SCrypt hash for the user password and one for the PII' do
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
 
-        expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+        expect(SCrypt::Engine).to receive(:hash_secret).twice.and_call_original
 
         post :create, params: { user: { email: user.email.upcase, password: user.password } }
       end
@@ -286,8 +285,7 @@ describe Users::SessionsController, devise: true do
           with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
         profile_encryption_error = {
-          error: 'Unable to parse encrypted payload. ' \
-                 '#<TypeError: no implicit conversion of nil into String>',
+          error: 'ciphertext is missing encrypted contents',
         }
         expect(@analytics).to receive(:track_event).
           with(Analytics::PROFILE_ENCRYPTION_INVALID, profile_encryption_error)

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -17,8 +17,7 @@ FactoryBot.define do
     after(:build) do |profile, evaluator|
       if evaluator.pii
         pii_attrs = Pii::Attributes.new_from_hash(evaluator.pii)
-        user_access_key = profile.user.unlock_user_access_key(profile.user.password)
-        profile.encrypt_pii(user_access_key, pii_attrs)
+        profile.encrypt_pii(pii_attrs, profile.user.password)
       end
     end
   end

--- a/spec/services/active_profile_encryptor_spec.rb
+++ b/spec/services/active_profile_encryptor_spec.rb
@@ -18,7 +18,7 @@ describe ActiveProfileEncryptor do
 
       ActiveProfileEncryptor.new(user, user_session, password).call
 
-      expect(profile).to have_received(:encrypt_pii).with(user.user_access_key, current_pii)
+      expect(profile).to have_received(:encrypt_pii).with(current_pii, password)
       expect(profile).to have_received(:save!)
     end
   end

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe Encryption::Encryptors::PiiEncryptor do
+  let(:password) { 'password' }
+  let(:salt) { 'n-pepa' }
+  let(:plaintext) { 'Oooh baby baby' }
+
+  subject { described_class.new(password: password, salt: salt) }
+
+  describe '#encrypt' do
+    it 'returns encrypted text' do
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to_not match plaintext
+    end
+
+    it 'uses the user access key encryptor to encrypt the plaintext' do
+      user_access_key = double(Encryption::UserAccessKey)
+      expect(Encryption::UserAccessKey).to receive(:new).
+        with(password: password, salt: salt, cost: nil).
+        and_return(user_access_key)
+      encryptor = double(Encryption::Encryptors::UserAccessKeyEncryptor)
+      expect(Encryption::Encryptors::UserAccessKeyEncryptor).to receive(:new).
+        with(user_access_key).
+        and_return(encryptor)
+      expect(encryptor).to receive(:encrypt).with(plaintext).and_return('ciphertext')
+
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to eq('ciphertext')
+    end
+  end
+
+  describe '#decrypt' do
+    it 'returns the original text' do
+      ciphertext = subject.encrypt(plaintext)
+      decrypted_ciphertext = subject.decrypt(ciphertext)
+
+      expect(decrypted_ciphertext).to eq(plaintext)
+    end
+
+    it 'requires the same password used for encrypt' do
+      ciphertext = subject.encrypt(plaintext)
+      new_encryptor = described_class.new(password: 'This is not the passowrd', salt: salt)
+
+      expect { new_encryptor.decrypt(ciphertext) }.to raise_error Pii::EncryptionError
+    end
+
+    it 'uses the user access key to decrypt the contents' do
+      user_access_key = double(Encryption::UserAccessKey)
+      expect(Encryption::UserAccessKey).to receive(:new).
+        with(password: password, salt: salt, cost: nil).
+        and_return(user_access_key)
+      encryptor = double(Encryption::Encryptors::UserAccessKeyEncryptor)
+      expect(Encryption::Encryptors::UserAccessKeyEncryptor).to receive(:new).
+        with(user_access_key).
+        and_return(encryptor)
+      expect(encryptor).to receive(:decrypt).with('ciphertext').and_return(plaintext)
+
+      result = subject.decrypt('ciphertext')
+
+      expect(result).to eq(plaintext)
+    end
+  end
+end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -2,21 +2,25 @@ require 'rails_helper'
 
 describe Idv::ProfileMaker do
   describe '#save_profile' do
-    it 'creates Profile with encrypted PII' do
-      applicant = { first_name: 'Some', last_name: 'One' }
-      normalized_applicant = { first_name: 'Somebody', last_name: 'Oneatatime' }
-      user = create(:user, :signed_up)
-      user.unlock_user_access_key(user.password)
+    let(:applicant) { { first_name: 'Some', last_name: 'One' } }
+    let(:normalized_applicant) { { first_name: 'Somebody', last_name: 'Oneatatime' } }
+    let(:user) { create(:user, :signed_up) }
+    let(:user_password) { user.password }
+    let(:phone_confirmed) { false }
 
-      profile_maker = described_class.new(
+    subject do
+      described_class.new(
         applicant: applicant,
-        user: user,
         normalized_applicant: normalized_applicant,
-        phone_confirmed: false
+        user: user,
+        user_password: user_password,
+        phone_confirmed: phone_confirmed
       )
+    end
 
-      profile = profile_maker.save_profile
-      pii = profile_maker.pii_attributes
+    it 'creates a Profile with encrypted PII' do
+      profile = subject.save_profile
+      pii = subject.pii_attributes
 
       expect(profile).to be_a Profile
       expect(profile.id).to_not be_nil
@@ -26,6 +30,16 @@ describe Idv::ProfileMaker do
       expect(pii).to be_a Pii::Attributes
       expect(pii.first_name.raw).to eq 'Some'
       expect(pii.first_name.norm).to eq 'Somebody'
+    end
+
+    context 'when phone_confirmed is true' do
+      let(:phone_confirmed) { true }
+      it { expect(subject.save_profile.phone_confirmed).to eq(true) }
+    end
+
+    context 'when phone_confirmed is false' do
+      let(:phone_confirmed) { false }
+      it { expect(subject.save_profile.phone_confirmed).to eq(false) }
     end
   end
 end

--- a/spec/services/key_rotator/hmac_fingerprinter_spec.rb
+++ b/spec/services/key_rotator/hmac_fingerprinter_spec.rb
@@ -6,8 +6,7 @@ describe KeyRotator::HmacFingerprinter do
       rotator = described_class.new
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
-      user_access_key = user.user_access_key
-      pii_attributes = profile.decrypt_pii(user_access_key)
+      pii_attributes = profile.decrypt_pii(user.password)
 
       old_ssn_signature = profile.ssn_signature
       old_email_fingerprint = user.email_fingerprint
@@ -23,7 +22,7 @@ describe KeyRotator::HmacFingerprinter do
     it 'does not change the `updated_at` timestamp' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
-      pii_attributes = profile.decrypt_pii(user.user_access_key)
+      pii_attributes = profile.decrypt_pii(user.password)
 
       old_updated_timestamp = user.updated_at
 

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 describe Pii::Attributes do
-  let(:user_access_key) { Encryption::UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
+  # let(:user_access_key) { Encryption::UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
+  let(:password) { 'I am the password' }
+  let(:salt) { 'I am the salt' }
+  let(:cost) { '800$8$1$' }
 
   describe '#new_from_hash' do
     it 'initializes from plain Hash' do
@@ -33,16 +36,20 @@ describe Pii::Attributes do
   describe '#new_from_encrypted' do
     it 'inflates from encrypted string' do
       orig_attrs = described_class.new_from_hash(first_name: 'Jane')
-      encrypted_pii = orig_attrs.encrypted(user_access_key)
-      pii_attrs = described_class.new_from_encrypted(encrypted_pii, user_access_key)
+      encrypted_pii = orig_attrs.encrypted(password: password, salt: salt, cost: cost)
+      pii_attrs = described_class.new_from_encrypted(
+        encrypted_pii, password: password, salt: salt, cost: cost
+      )
 
       expect(pii_attrs.first_name).to eq 'Jane'
     end
 
     it 'allows deprecated attributes that are no longer added to the hash schema' do
       deprecated_atts = described_class.new_from_hash(otp: '123abc')
-      encrypted_pii = deprecated_atts.encrypted(user_access_key)
-      pii_attrs = described_class.new_from_encrypted(encrypted_pii, user_access_key)
+      encrypted_pii = deprecated_atts.encrypted(password: password, salt: salt, cost: cost)
+      pii_attrs = described_class.new_from_encrypted(
+        encrypted_pii, password: password, salt: salt, cost: cost
+      )
 
       expect(pii_attrs[:otp]).to eq('123abc')
     end
@@ -66,7 +73,8 @@ describe Pii::Attributes do
     it 'returns the object as encrypted string' do
       pii_attrs = described_class.new_from_hash(first_name: 'Jane')
 
-      expect(pii_attrs.encrypted(user_access_key)).to_not match 'Jane'
+      encrypted = pii_attrs.encrypted(password: password, salt: salt, cost: cost)
+      expect(encrypted).to_not match 'Jane'
     end
   end
 

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Pii::Cacher do
   let(:password) { 'salty peanuts are best' }
-  let(:user_access_key) { user.unlock_user_access_key(password) }
   let(:user) { create(:user, :with_phone, password: password, otp_secret_key: 'abc123') }
   let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
   let(:diff_profile) { build(:profile, :verified, user: user, pii: { ssn: '5678' }) }
@@ -17,7 +16,7 @@ describe Pii::Cacher do
     end
 
     it 'writes decrypted PII to user_session' do
-      decrypted_pii_json = subject.save(user_access_key)
+      decrypted_pii_json = subject.save(password)
       decrypted_pii = JSON.parse(decrypted_pii_json, symbolize_names: true)
 
       expect(decrypted_pii[:ssn][:raw]).to eq '1234'
@@ -26,7 +25,7 @@ describe Pii::Cacher do
 
     it 'allows specific profile to be decrypted' do
       diff_profile.save!
-      decrypted_pii_json = subject.save(user_access_key, diff_profile)
+      decrypted_pii_json = subject.save(password, diff_profile)
       decrypted_pii = JSON.parse(decrypted_pii_json, symbolize_names: true)
 
       expect(decrypted_pii[:ssn][:raw]).to_not eq '1234'
@@ -48,7 +47,7 @@ describe Pii::Cacher do
       reloaded_user = User.find(user_id)
       reloaded_profile = user.profiles.first
 
-      described_class.new(reloaded_user, user_session).save(user_access_key)
+      described_class.new(reloaded_user, user_session).save(password)
 
       user.reload
       profile.reload
@@ -62,11 +61,10 @@ describe Pii::Cacher do
 
     it 'does not attempt to rotate nil attributes' do
       user = create(:user, password: password)
-      user_access_key = user.unlock_user_access_key(password)
       cacher = described_class.new(user, user_session)
       rotate_all_keys
 
-      expect { cacher.save(user_access_key) }.to_not raise_error
+      expect { cacher.save(password) }.to_not raise_error
     end
   end
 
@@ -77,7 +75,7 @@ describe Pii::Cacher do
     end
 
     it 'fetches decrypted PII from user_session' do
-      subject.save(user_access_key)
+      subject.save(password)
       decrypted_pii = subject.fetch
 
       expect(decrypted_pii).to be_a Pii::Attributes
@@ -86,7 +84,7 @@ describe Pii::Cacher do
 
     it 'allows specific profile to be decrypted' do
       diff_profile.save!
-      subject.save(user_access_key, diff_profile)
+      subject.save(password, diff_profile)
       decrypted_pii = subject.fetch
 
       expect(decrypted_pii).to be_a Pii::Attributes

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -8,8 +8,7 @@ module PersonalKeyHelper
   def personal_key_from_pii(user, pii)
     profile = create(:profile, :active, :verified, user: user)
     pii_attrs = Pii::Attributes.new_from_hash(pii)
-    user_access_key = user.unlock_user_access_key(user.password)
-    personal_key = profile.encrypt_pii(user_access_key, pii_attrs)
+    personal_key = profile.encrypt_pii(pii_attrs, user.password)
     profile.save!
 
     personal_key

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -189,8 +189,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_successful_saml_handoff
-    user_access_key = user.unlock_user_access_key(Features::SessionHelper::VALID_PASSWORD)
-    profile_phone = user.active_profile.decrypt_pii(user_access_key).phone
+    profile_phone = user.active_profile.decrypt_pii(Features::SessionHelper::VALID_PASSWORD).phone
     xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -179,9 +179,8 @@ end
 
 def personal_key_for_loa3_user(user, pii)
   pii_attrs = Pii::Attributes.new_from_hash(pii)
-  user_access_key = user.unlock_user_access_key(user.password)
   profile = user.profiles.last
-  personal_key = profile.encrypt_pii(user_access_key, pii_attrs)
+  personal_key = profile.encrypt_pii(pii_attrs, user.password)
   profile.save!
 
   personal_key


### PR DESCRIPTION
**Why**: To consolidate the logic that is used to encrypt PII and to
prevent code that invokes the encryption logic from having to manage
user access keys. This consolidates things into a simpler encryption API
that makes things like migrating to a new algorithm easier.

Note that there is a performance hit when encrypting / decrypting PII
since we have to calculate 2 SCrypt hashes now, one to verify the
password and one to encrypt/decrypt the data. This is an intentional
tradeoff to make the API for the encryption module simpler with the
understanding that it is very likely that the logic used to verify the
password and encrypt PII will diverge in the future.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
