### PR TITLE
LG-273 Sanitize Ahoy headers and cookies

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -52,6 +52,7 @@ module Ahoy
       # we probably want to ignore the Rails definition and use Ruby's.
       # To do that, we'll need to set `config.active_support.bare = true`,
       # and then only require the extensions we use.
+      token = token.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
       uuid_regex = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
       !uuid_regex.match?(token)
     end

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,3 +1,5 @@
+require 'utf8_cleaner'
+
 Ahoy.api = false
 # Period of inactivity before a new visit is created
 Ahoy.visit_duration = Figaro.env.session_timeout_in_minutes.to_i.minutes
@@ -52,7 +54,7 @@ module Ahoy
       # we probably want to ignore the Rails definition and use Ruby's.
       # To do that, we'll need to set `config.active_support.bare = true`,
       # and then only require the extensions we use.
-      token = token.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      token = Utf8Cleaner.new(token).remove_invalid_utf8_bytes
       uuid_regex = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
       !uuid_regex.match?(token)
     end

--- a/lib/rack_request_parser.rb
+++ b/lib/rack_request_parser.rb
@@ -1,0 +1,49 @@
+class RackRequestParser
+  attr_reader :env
+
+  def initialize(env)
+    @env = env
+  end
+
+  def values_to_check
+    param_values + ahoy_headers + ahoy_cookies
+  end
+
+  def request
+    @request ||= Rack::Request.new(env)
+  end
+
+  private
+
+  def param_values
+    all_values(request.params)
+  end
+
+  def all_values(hash)
+    hash.values.flat_map { |value| value.is_a?(Hash) ? all_values(value) : [value] }
+  end
+
+  def ahoy_headers
+    [ahoy_visit_header, ahoy_visitor_header]
+  end
+
+  def ahoy_visit_header
+    request.fetch_header('HTTP_AHOY_VISIT') { '' }
+  end
+
+  def ahoy_visitor_header
+    request.fetch_header('HTTP_AHOY_VISITOR') { '' }
+  end
+
+  def ahoy_cookies
+    [ahoy_visit_cookie, ahoy_visitor_cookie]
+  end
+
+  def ahoy_visit_cookie
+    request.cookies['ahoy_visit']
+  end
+
+  def ahoy_visitor_cookie
+    request.cookies['ahoy_visitor']
+  end
+end

--- a/lib/rack_request_parser.rb
+++ b/lib/rack_request_parser.rb
@@ -1,16 +1,12 @@
 class RackRequestParser
-  attr_reader :env
+  attr_reader :request
 
-  def initialize(env)
-    @env = env
+  def initialize(request)
+    @request = request
   end
 
   def values_to_check
     param_values + ahoy_headers + ahoy_cookies
-  end
-
-  def request
-    @request ||= Rack::Request.new(env)
   end
 
   private

--- a/lib/utf8_cleaner.rb
+++ b/lib/utf8_cleaner.rb
@@ -1,0 +1,11 @@
+class Utf8Cleaner
+  attr_reader :string
+
+  def initialize(string)
+    @string = string
+  end
+
+  def remove_invalid_utf8_bytes
+    string&.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+  end
+end

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -1,4 +1,5 @@
 require 'rack_request_parser'
+require 'utf8_cleaner'
 
 class Utf8Sanitizer
   def initialize(app)
@@ -6,7 +7,8 @@ class Utf8Sanitizer
   end
 
   def call(env)
-    parser = RackRequestParser.new(env)
+    request = Rack::Request.new(env)
+    parser = RackRequestParser.new(request)
     values_to_check = parser.values_to_check
 
     if invalid_strings(values_to_check)
@@ -50,7 +52,7 @@ class Utf8Sanitizer
   end
 
   def sanitized_visitor_id(request)
-    request.cookies['ahoy_visitor']&.
-      encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    string_to_clean = request.cookies['ahoy_visitor']
+    Utf8Cleaner.new(string_to_clean).remove_invalid_utf8_bytes
   end
 end

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -1,14 +1,16 @@
+require 'rack_request_parser'
+
 class Utf8Sanitizer
   def initialize(app)
     @app = app
   end
 
   def call(env)
-    request = Rack::Request.new(env)
-    values = all_values(request.params)
+    parser = RackRequestParser.new(env)
+    values_to_check = parser.values_to_check
 
-    if invalid_strings(values)
-      Rails.logger.info(event_attributes(env, request))
+    if invalid_strings(values_to_check)
+      Rails.logger.info(event_attributes(env, parser.request))
 
       return [400, {}, ['Bad request']]
     end
@@ -17,10 +19,6 @@ class Utf8Sanitizer
   end
 
   private
-
-  def all_values(hash)
-    hash.values.flat_map { |value| value.is_a?(Hash) ? all_values(value) : [value] }
-  end
 
   def invalid_strings(values)
     string_values(values).any? { |string| invalid_string?(string) }
@@ -42,12 +40,17 @@ class Utf8Sanitizer
       user_agent: request.user_agent,
       timestamp: Time.zone.now,
       host: request.host,
-      visitor_id: request.cookies['ahoy_visitor'],
+      visitor_id: sanitized_visitor_id(request),
       content_type: env['CONTENT_TYPE'],
     }.to_json
   end
 
   def remote_ip(request)
     @remote_ip ||= (request.env['action_dispatch.remote_ip'] || request.ip).to_s
+  end
+
+  def sanitized_visitor_id(request)
+    request.cookies['ahoy_visitor']&.
+      encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
   end
 end

--- a/spec/config/initializers/ahoy_spec.rb
+++ b/spec/config/initializers/ahoy_spec.rb
@@ -7,7 +7,6 @@ describe Ahoy::Store do
       mock_ahoy = MockAhoy.new('foo', '1056d484-194c-4b8c-978d-0c0f57958f04')
       store = Ahoy::Store.new(ahoy: mock_ahoy)
 
-
       expect(store.exclude?).to eq true
     end
   end
@@ -18,6 +17,15 @@ describe Ahoy::Store do
       mock_ahoy = MockAhoy.new('1056d484-194c-4b8c-978d-0c0f57958f04', 'foo')
       store = Ahoy::Store.new(ahoy: mock_ahoy)
 
+      expect(store.exclude?).to eq true
+    end
+  end
+
+  context 'visitor_token is a string with invalid UTF-8 bytes' do
+    it 'excludes the event' do
+      MockAhoy = Struct.new(:visit_token, :visitor_token)
+      mock_ahoy = MockAhoy.new("foo\255", "bar\255")
+      store = Ahoy::Store.new(ahoy: mock_ahoy)
 
       expect(store.exclude?).to eq true
     end
@@ -30,7 +38,6 @@ describe Ahoy::Store do
         '1056d484-194c-4b8c-978d-0c0f57958f04', '1056d484-194c-4b8c-978d-0c0f57958f04'
       )
       store = Ahoy::Store.new(ahoy: mock_ahoy)
-
 
       expect(store.exclude?).to eq false
     end

--- a/spec/config/initializers/ahoy_spec.rb
+++ b/spec/config/initializers/ahoy_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
+MockAhoy = Struct.new(:visit_token, :visitor_token)
+
 describe Ahoy::Store do
   context 'visit_token is an invalid UUID' do
     it 'excludes the event' do
-      MockAhoy = Struct.new(:visit_token, :visitor_token)
       mock_ahoy = MockAhoy.new('foo', '1056d484-194c-4b8c-978d-0c0f57958f04')
       store = Ahoy::Store.new(ahoy: mock_ahoy)
 
@@ -13,7 +14,6 @@ describe Ahoy::Store do
 
   context 'visitor_token is an invalid UUID' do
     it 'excludes the event' do
-      MockAhoy = Struct.new(:visit_token, :visitor_token)
       mock_ahoy = MockAhoy.new('1056d484-194c-4b8c-978d-0c0f57958f04', 'foo')
       store = Ahoy::Store.new(ahoy: mock_ahoy)
 
@@ -23,7 +23,6 @@ describe Ahoy::Store do
 
   context 'visitor_token is a string with invalid UTF-8 bytes' do
     it 'excludes the event' do
-      MockAhoy = Struct.new(:visit_token, :visitor_token)
       mock_ahoy = MockAhoy.new("foo\255", "bar\255")
       store = Ahoy::Store.new(ahoy: mock_ahoy)
 
@@ -33,7 +32,6 @@ describe Ahoy::Store do
 
   context 'both visitor_token and visit_token are a valid UUID' do
     it 'does not exclude the event' do
-      MockAhoy = Struct.new(:visit_token, :visitor_token)
       mock_ahoy = MockAhoy.new(
         '1056d484-194c-4b8c-978d-0c0f57958f04', '1056d484-194c-4b8c-978d-0c0f57958f04'
       )

--- a/spec/requests/invalid_encoding_spec.rb
+++ b/spec/requests/invalid_encoding_spec.rb
@@ -49,4 +49,30 @@ RSpec.describe 'Invalid UTF-8 encoding in form input' do
 
     expect(response.status).to eq 400
   end
+
+  it 'returns 400 when Ahoy-Visitor header contains invalid UTF-8 bytes' do
+    get '/', headers: { 'Ahoy-Visitor' => "foo\255" }
+
+    expect(response.status).to eq 400
+  end
+
+  it 'returns 400 when Ahoy-Visit header contains invalid UTF-8 bytes' do
+    get '/', headers: { 'Ahoy-Visit' => "foo\255" }
+
+    expect(response.status).to eq 400
+  end
+
+  it 'returns 400 when ahoy_visit cookie contains invalid UTF-8 bytes' do
+    cookies['ahoy_visit'] = "foo\255"
+    get '/'
+
+    expect(response.status).to eq 400
+  end
+
+  it 'returns 400 when ahoy_visitor cookie contains invalid UTF-8 bytes' do
+    cookies['ahoy_visitor'] = "foo\255"
+    get '/'
+
+    expect(response.status).to eq 400
+  end
 end


### PR DESCRIPTION
**Why**: Ahoy headers and cookies with invalid UTF-8 bytes should not
cause the app to throw a 500 error. The root cause of the exception is
in the Ahoy gem's code, which manipulates the header/cookie value to
remove certain strings using `gsub`.

**How**: Capture invalid headers and cookies in our utf8_sanitizer class
before they get to the Ahoy gem. Ideally, the Ahoy gem would remove the
token manipulation and instead, allow clients to validate tokens
however they please. I proposed this to the gem maintainer and am
waiting to hear back.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
