### PR TITLE
LG-274 Remove ascii vendor_params

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,6 +1,3 @@
-require 'stringex/unidecoder'
-require 'stringex/core_ext'
-
 module Idv
   class Session
     VALID_SESSION_ATTRIBUTES = %i[
@@ -61,7 +58,7 @@ module Idv
     end
 
     def vendor_params
-      applicant_params_ascii.merge('uuid' => current_user.uuid)
+      applicant_params.merge('uuid' => current_user.uuid)
     end
 
     def profile
@@ -127,10 +124,6 @@ module Idv
 
     def applicant_params
       params.select { |key, _value| Idv::Agent.proofer_attribute?(key) }
-    end
-
-    def applicant_params_ascii
-      Hash[applicant_params.map { |key, value| [key, value.to_ascii] }]
     end
 
     def build_profile_maker(user_password)

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -303,7 +303,7 @@ describe Idv::ReviewController do
 
         expect(pii.zipcode).to eq zipcode
 
-        expect(idv_session.applicant[:first_name]).to eq 'Jose'
+        expect(idv_session.applicant[:first_name]).to eq 'José'
         expect(pii.first_name).to eq 'José'
       end
 


### PR DESCRIPTION
Removes ascii version of applicant_params from Idv, leaves ascii stuff in handling SAML.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
