### PR TITLE
Don't check worker health if we have no workers.

### DIFF
--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -3,10 +3,17 @@ module Health
     private
 
     def health_checker
-      MultiHealthChecker.new(
+      checkers = {
         database: DatabaseHealthChecker,
-        workers: WorkerHealthChecker
-      )
+        workers: WorkerHealthChecker,
+      }
+      # Don't run worker health checks if we're not using workers (i.e. if the
+      # queue adapter is inline or async)
+      case Rails.application.config.active_job.queue_adapter
+      when :async, :inline
+        checkers.delete(:workers)
+      end
+      MultiHealthChecker.new(**checkers)
     end
   end
 end

--- a/app/services/multi_health_checker.rb
+++ b/app/services/multi_health_checker.rb
@@ -5,7 +5,8 @@ class MultiHealthChecker
     end
 
     def to_h
-      super.merge(healthy: healthy?)
+      result = healthy?
+      super.merge(healthy: result, all_checks_healthy: result)
     end
 
     def as_json(*args)


### PR DESCRIPTION
**Why**:

If we switch the activejob queue adapter to inline or async, then it
doesn't make sense for the top level health check to test redis queue
health because they won't be used.

**How**:

If the activejob queue adapter is set to inline or async, remove the
worker check from the multi health checker that serves the `/api/health`
endpoint so that health checks will still pass if sidekiq is not in use.

Also add an "all_checks_healthy" key to the multi checker output, which
makes it easier to grep for success in clients like New Relic that don't
really speak JSON.