### PR TITLE
Update secure_headers from 3.7.3 to 6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'saml_idp', git: 'https://github.com/18F/saml_idp.git', tag: 'v0.7.0-18f'
 gem 'sass-rails', '~> 5.0'
 gem 'savon'
 gem 'scrypt'
-gem 'secure_headers', '~> 3.0'
+gem 'secure_headers', '~> 6.0'
 gem 'sidekiq'
 gem 'simple_form'
 gem 'sinatra', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,8 +543,7 @@ GEM
       wasabi (~> 3.4)
     scrypt (3.0.5)
       ffi-compiler (>= 1.0, < 2.0)
-    secure_headers (3.7.3)
-      useragent
+    secure_headers (6.0.0)
     selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -626,7 +625,6 @@ GEM
     unicode-display_width (1.3.0)
     uniform_notifier (1.11.0)
     user_agent_parser (2.4.1)
-    useragent (0.16.8)
     uuid (2.3.9)
       macaddr (~> 1.0)
     valid_email (0.1.0)
@@ -754,7 +752,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   savon
   scrypt
-  secure_headers (~> 3.0)
+  secure_headers (~> 6.0)
   shoulda-matchers (~> 3.0)
   sidekiq
   simple_form

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,7 +1,4 @@
 class ServiceProviderSessionDecorator
-  include Rails.application.routes.url_helpers
-  include LocaleHelper
-
   DEFAULT_LOGO = 'generic.svg'.freeze
 
   SP_ALERTS = {
@@ -97,7 +94,7 @@ class ServiceProviderSessionDecorator
   end
 
   def cancel_link_url
-    sign_up_start_url(request_id: sp_session[:request_id], locale: locale_url_param)
+    view_context.sign_up_start_url(request_id: sp_session[:request_id])
   end
 
   def sp_alert?

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -1,6 +1,7 @@
 class SessionDecorator
-  include Rails.application.routes.url_helpers
-  include LocaleHelper
+  def initialize(view_context: nil)
+    @view_context = view_context
+  end
 
   def return_to_service_provider_partial
     'shared/null'
@@ -31,7 +32,7 @@ class SessionDecorator
   end
 
   def cancel_link_url
-    root_url(locale: locale_url_param)
+    view_context.root_url
   end
 
   def sp_name; end
@@ -51,4 +52,8 @@ class SessionDecorator
   def sp_alert_name; end
 
   def sp_alert_learn_more; end
+
+  private
+
+  attr_reader :view_context
 end

--- a/app/services/decorated_session.rb
+++ b/app/services/decorated_session.rb
@@ -15,7 +15,7 @@ class DecoratedSession
         service_provider_request: service_provider_request
       )
     else
-      SessionDecorator.new
+      SessionDecorator.new(view_context: view_context)
     end
   end
 

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -136,18 +136,14 @@ RSpec.describe ServiceProviderSessionDecorator do
       )
     end
 
-    it 'returns sign_up_start_url with the request_id as a param' do
-      expect(decorator.cancel_link_url).
-        to eq 'http://www.example.com/sign_up/start?request_id=foo'
+    before do
+      allow(view_context).to receive(:sign_up_start_url).
+        and_return('https://www.example.com/sign_up/start')
     end
 
-    context 'in another language' do
-      before { I18n.locale = :fr }
-
-      it 'keeps the language' do
-        expect(decorator.cancel_link_url).
-          to eq 'http://www.example.com/fr/sign_up/start?request_id=foo'
-      end
+    it 'returns view_context.sign_up_start_url' do
+      expect(decorator.cancel_link_url).
+        to eq 'https://www.example.com/sign_up/start'
     end
   end
 end

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -62,8 +62,12 @@ RSpec.describe SessionDecorator do
   end
 
   describe '#cancel_link_url' do
-    it 'returns root url' do
-      expect(subject.cancel_link_url).to eq 'http://www.example.com/'
+    it 'returns view_context.root url' do
+      view_context = ActionController::Base.new.view_context
+      allow(view_context).to receive(:root_url).and_return('http://www.example.com')
+      decorator = SessionDecorator.new(view_context: view_context)
+
+      expect(decorator.cancel_link_url).to eq 'http://www.example.com'
     end
   end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -82,7 +82,7 @@ feature 'Sign Up' do
         click_on t('links.cancel')
         click_on t('sign_up.buttons.cancel')
 
-        expect(page).to have_current_path(sign_up_start_path)
+        expect(page).to have_current_path(sign_up_start_path(request_id: '123'))
         expect { User.find(user.id) }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -50,7 +50,7 @@ module Features
       Warden.on_next_request do |proxy|
         session = proxy.env['rack.session']
         sp = ServiceProvider.from_issuer('http://localhost:3000')
-        session[:sp] = { loa3: loa3, issuer: sp.issuer }
+        session[:sp] = { loa3: loa3, issuer: sp.issuer, request_id: '123' }
       end
 
       visit account_path

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -9,6 +9,9 @@ describe 'devise/passwords/new.html.slim' do
       return_to_sp_url: 'www.awesomeness.com'
     )
     view_context = ActionController::Base.new.view_context
+    allow(view_context).to receive(:sign_up_start_url).
+      and_return('https://www.example.com/sign_up/start')
+
     @decorated_session = DecoratedSession.new(
       sp: @sp,
       view_context: view_context,

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -12,6 +12,7 @@ describe 'sign_up/registrations/new.html.slim' do
       sp: nil, view_context: view_context, sp_session: {}, service_provider_request: nil
     ).call
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
+    allow(view_context).to receive(:root_url).and_return('http://www.example.com')
   end
 
   it 'has a localized title' do


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
