### PR TITLE
Populate state with prior value after idv failure

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -92,7 +92,7 @@ module FormHelper
   end
 
   def state_name_for_abbrev(abbrev)
-    us_states_territories.find { |state| state.second == abbrev }.first
+    us_states_territories.find([]) { |state| state.second == abbrev }.first
   end
 
   private

--- a/app/views/idv/jurisdiction/show.html.slim
+++ b/app/views/idv/jurisdiction/show.html.slim
@@ -1,9 +1,11 @@
-- state_name = state_name_for_abbrev(@state)
-- title t("idv.titles.#{@reason}", state: state_name)
+- i18n_args = @state ? { state: state_name_for_abbrev(@state) } : {}
 
-h1.h3.mb2.my0 = t("idv.titles.#{@reason}", state: state_name)
+- title t("idv.titles.#{@reason}", **i18n_args)
 
-p.mb1 = t("idv.messages.jurisdiction.#{@reason}", state: state_name)
+h1.h3.mb2.my0 = t("idv.titles.#{@reason}", **i18n_args)
+
+- if @state
+  p.mb1 = t("idv.messages.jurisdiction.#{@reason}", **i18n_args)
 
 .col-2
   hr.mt5.mb2.bw4.border-blue.rounded

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -31,9 +31,10 @@ p.mb2 = link_to t('links.access_help'),
           "data-error-message": t('idv.errors.unsupported_jurisdiction'),
           "data-error-message-sp": sp_error,\
         }
+        - selected_state = @view_model.idv_form.state || @view_model.selected_state
         = f.input :state, collection: us_states_territories,
           label: t('idv.form.state'), required: true,
-          input_html: data_attrs, selected: @view_model.selected_state,
+          input_html: data_attrs, selected: selected_state,
           prompt: '- Select -'
 
       .sm-col.sm-col-4.px1

--- a/spec/features/idv/steps/jurisdiction_step_spec.rb
+++ b/spec/features/idv/steps/jurisdiction_step_spec.rb
@@ -33,6 +33,15 @@ feature 'idv jurisdiction step' do
         expect(page).to have_content(t('idv.titles.unsupported_jurisdiction', state: 'Alabama'))
       end
     end
+
+    context 'when the user does not have a state-issued ID' do
+      it 'renders the `no_id` fail page' do
+        click_on t('idv.messages.jurisdiction.no_id')
+
+        expect(page).to have_current_path(idv_jurisdiction_fail_path(reason: :no_id))
+        expect(page).to have_content(t('idv.titles.no_id'))
+      end
+    end
   end
 
   context 'cancelling idv' do

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -24,12 +24,12 @@ module IdvHelper
     fill_in 'profile_state_id_number', with: '123456789'
   end
 
-  def fill_out_idv_form_fail
+  def fill_out_idv_form_fail(state: 'Virginia')
     fill_in 'profile_first_name', with: 'Bad'
     fill_in 'profile_last_name', with: 'User'
     fill_in 'profile_address1', with: '123 Main St'
     fill_in 'profile_city', with: 'Nowhere'
-    select 'Virginia', from: 'profile_state'
+    select state, from: 'profile_state'
     fill_in 'profile_zipcode', with: '00000'
     fill_in 'profile_dob', with: '01/02/1900'
     fill_in 'profile_ssn', with: '666-66-6666'


### PR DESCRIPTION
**WHY**
After an idv failure, the state was not pre-populated on the form so the user would have to re-enter it.

**HOW**
Populate the state from the form if it exists, then from the view model.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
