### PR TITLE
Only try to return a link to piv/cac if enabled

### DIFF
--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -58,6 +58,8 @@ module TwoFactorAuthCode
     end
 
     def piv_cac_link
+      return unless FeatureManagement.piv_cac_enabled?
+      return unless has_piv_cac_configured
       view.link_to(
         t('devise.two_factor_authentication.piv_cac_fallback.link'),
         login_two_factor_piv_cac_path(locale: LinkLocaleResolver.locale)

--- a/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/generic_delivery_presenter_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe TwoFactorAuthCode::GenericDeliveryPresenter do
+  include Rails.application.routes.url_helpers
+
   it 'is an abstract presenter with methods that should be implemented' do
     presenter = presenter_with
 
@@ -43,6 +45,27 @@ describe TwoFactorAuthCode::GenericDeliveryPresenter do
         expect(presenter.send(:piv_cac_option)).to eq t(
           'devise.two_factor_authentication.piv_cac_fallback.text_html',
           link: presenter.send(:piv_cac_link)
+        )
+      end
+    end
+  end
+
+  describe '#piv_cac_link' do
+    context 'for a user without a piv/cac enabled' do
+      let(:presenter) { presenter_with(has_piv_cac_configured: false) }
+
+      it 'returns nothing' do
+        expect(presenter.send(:piv_cac_link)).to be_nil
+      end
+    end
+
+    context 'for a user with a piv/cac enabled' do
+      let(:presenter) { presenter_with(has_piv_cac_configured: true) }
+
+      it 'returns a link to the piv/cac option' do
+        expect(presenter.send(:piv_cac_link)).to eq ActionController::Base.new.view_context.link_to(
+          t('devise.two_factor_authentication.piv_cac_fallback.link'),
+          login_two_factor_piv_cac_path(locale: LinkLocaleResolver.locale)
         )
       end
     end


### PR DESCRIPTION
**Why**:
The presenter uses the link form in the available alternative
options. When the piv/cac feature isn't enabled, this throws
an error.

**How**:
Guard the call so it doesn't try to construct a link if the
piv/cac feature isn't enabled.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
