### PR TITLE
[LG 240] piv/cac is only for certain agencies

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -9,7 +9,7 @@ class UserDecorator
   end
 
   delegate :email, to: :user
-  delegate :totp_enabled?, :piv_cac_enabled?, to: :user
+  delegate :totp_enabled?, :piv_cac_enabled?, :piv_cac_available?, to: :user
 
   def lockout_time_remaining_in_words
     current_time = Time.zone.now

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -23,4 +23,8 @@ class Identity < ApplicationRecord
   def decorate
     IdentityDecorator.new(self)
   end
+
+  def piv_cac_available?
+    PivCacService.piv_cac_available_for_agency?(sp_metadata[:agency])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,13 @@ class User < ApplicationRecord
     x509_dn_uuid.present?
   end
 
+  def piv_cac_available?
+    FeatureManagement.piv_cac_enabled? && (
+      piv_cac_enabled? ||
+      identities.any?(&:piv_cac_available?)
+    )
+  end
+
   def need_two_factor_authentication?(_request)
     two_factor_enabled?
   end

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -25,7 +25,23 @@ module PivCacService
       Figaro.env.piv_cac_verify_token_url
     end
 
+    def piv_cac_available_for_agency?(agency)
+      return if agency.blank?
+      return unless FeatureManagement.piv_cac_enabled?
+      @piv_cac_agencies ||= begin
+        piv_cac_agencies = Figaro.env.piv_cac_agencies || '[]'
+        JSON.parse(piv_cac_agencies)
+      end
+
+      @piv_cac_agencies.include?(agency)
+    end
+
     private
+
+    # Only used in tests
+    def reset_piv_cac_avaialable_agencies
+      @piv_cac_agencies = nil
+    end
 
     def token_present(token)
       raise ArgumentError, 'token missing' if token.blank?

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -45,7 +45,7 @@ h1.hide = t('titles.account')
     content: content_tag(:em, t(@view_model.totp_content)),
     action: @view_model.totp_partial
 
-  - if FeatureManagement.piv_cac_enabled?
+  - if current_user.piv_cac_available?
     = render 'account_item',
       name: t('account.index.piv_cac_card'),
       content: content_tag(:em, t(@view_model.piv_cac_content)),

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -237,6 +237,7 @@ production:
   participate_in_dap: 'false' # pair with google_analytics_key
   password_pepper: # generate via `rake secret`
   password_strength_enabled: 'true'
+  piv_cac_agencies: '["DOD"]'
   piv_cac_enabled: 'false'
   proofer_mock_fallback: 'true'
   reauthn_window: '120'

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -130,6 +130,34 @@ describe Identity do
     end
   end
 
+  describe '#piv_cac_available?' do
+    context 'when agency configured to support piv/cac' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
+          [service_provider.agency].to_json
+        )
+        PivCacService.send(:reset_piv_cac_avaialable_agencies)
+      end
+
+      it 'returns truthy' do
+        expect(identity_with_sp.piv_cac_available?).to be_truthy
+      end
+    end
+
+    context 'when agency is not configured to support piv/cac' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
+          [service_provider.agency + 'X'].to_json
+        )
+        PivCacService.send(:reset_piv_cac_avaialable_agencies)
+      end
+
+      it 'returns falsey' do
+        expect(identity_with_sp.piv_cac_available?).to be_falsey
+      end
+    end
+  end
+
   describe 'uniqueness validation for service provider per user' do
     it 'raises an error when uniqueness constraint is broken' do
       Identity.create(user_id: user.id, service_provider: 'externalapp')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,7 +84,7 @@ describe User do
     end
   end
 
-  context '#piv_cac_enabled?' do
+  describe '#piv_cac_enabled?' do
     it 'is true when the user has a confirmed piv/cac associated' do
       user = create(:user, :with_piv_or_cac)
 
@@ -98,7 +98,87 @@ describe User do
     end
   end
 
-  context '#confirm_piv_cac?' do
+  describe '#piv_cac_available?' do
+    before(:each) do
+      allow(Figaro.env).to receive(:piv_cac_enabled).and_return('true')
+    end
+
+    context 'when a user has no identities' do
+      let(:user) { create(:user) }
+
+      it 'does not allow piv/cac' do
+        expect(user.piv_cac_available?).to be_falsey
+      end
+    end
+
+    context 'when a user has an identity' do
+      let(:user) { create(:user) }
+
+      let(:service_provider) do
+        create(:service_provider)
+      end
+
+      let(:identity_with_sp) do
+        Identity.create(
+          user_id: user.id,
+          service_provider: service_provider.issuer
+        )
+      end
+
+      before(:each) do
+        user.identities << [identity_with_sp]
+      end
+
+      context 'not allowing it' do
+        it 'does not allow piv/cac' do
+          expect(user.piv_cac_available?).to be_falsey
+        end
+      end
+
+      context 'allowing it' do
+        before(:each) do
+          allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
+            [service_provider.agency].to_json
+          )
+          PivCacService.send(:reset_piv_cac_avaialable_agencies)
+        end
+
+        it 'does allows piv/cac' do
+          expect(user.piv_cac_available?).to be_truthy
+        end
+
+        context 'but piv/cac feature is not enabled' do
+          before(:each) do
+            allow(Figaro.env).to receive(:piv_cac_enabled).and_return('false')
+          end
+
+          it 'does not allow piv/cac' do
+            expect(user.piv_cac_available?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context 'when a user has a piv/cac associated' do
+      let(:user) { create(:user, :with_piv_or_cac) }
+
+      it 'allows piv/cac' do
+        expect(user.piv_cac_available?).to be_truthy
+      end
+
+      context 'but the piv/cac feature is disabled' do
+        before(:each) do
+          allow(Figaro.env).to receive(:piv_cac_enabled).and_return('false')
+        end
+
+        it 'does not allow piv/cac' do
+          expect(user.piv_cac_available?).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe '#confirm_piv_cac?' do
     context 'when the user has a piv/cac associated' do
       let(:user) { create(:user, :with_piv_or_cac) }
 


### PR DESCRIPTION
**Why**:
Piv/cac requires that we have a set of signing
certificates to validate presented certs. This
requires research. We don't have them for all
of the federal government, so we want to keep
from confusing almost everyone.

**How**:
Only show the piv/cac option if the user has
an identity tied to the right preconfigured
agencies.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
