### PR TITLE
LG-290 Move attribute encryption away from KMS

### DIFF
--- a/app/services/encryption/encryptors/attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/attribute_encryptor.rb
@@ -1,65 +1,71 @@
 module Encryption
   module Encryptors
     class AttributeEncryptor
+      include Encodable
+
+      def initialize
+        @aes_cipher = AesCipher.new
+        @stale = false
+      end
+
       def encrypt(plaintext)
-        user_access_key = self.class.load_or_init_user_access_key(
-          key: current_key, cost: current_cost
-        )
-        UserAccessKeyEncryptor.new(user_access_key).encrypt(plaintext)
+        unless Figaro.env.attribute_encryption_without_kms == 'true'
+          return deprecated_encryptor.encrypt(plaintext)
+        end
+
+        aes_encrypted_ciphertext = aes_cipher.encrypt(plaintext, current_key)
+        encode(aes_encrypted_ciphertext)
       end
 
       def decrypt(ciphertext)
-        encryption_keys_with_cost.each do |key_with_cost|
-          key = key_with_cost.fetch(:key)
-          cost = key_with_cost.fetch(:cost)
-          result = try_decrypt(ciphertext, key: key, cost: cost)
+        return deprecated_encryptor.decrypt(ciphertext) if legacy?(ciphertext)
+        raise EncryptionError, 'ciphertext invalid' unless valid_base64_encoding?(ciphertext)
+        decoded_ciphertext = decode(ciphertext)
+        try_decrypt(decoded_ciphertext)
+      end
+
+      def stale?
+        deprecated_encryptor&.stale? || stale
+      end
+
+      private
+
+      attr_reader :aes_cipher
+      attr_accessor :stale
+
+      def try_decrypt(decoded_ciphertext)
+        all_keys.each do |key|
+          result = try_decrypt_with_key(decoded_ciphertext, key)
           return result unless result.nil?
         end
         raise EncryptionError, 'unable to decrypt attribute with any key'
       end
 
-      def stale?
-        stale
+      def try_decrypt_with_key(decoded_ciphertext, key)
+        self.stale = key != current_key
+        aes_cipher.decrypt(decoded_ciphertext, key)
+      rescue EncryptionError
+        nil
       end
 
-      def self.load_or_init_user_access_key(key:, cost:)
-        @_scypt_hashes_by_key ||= {}
-        scrypt_hash = @_scypt_hashes_by_key["#{key}:#{cost}"]
-        return UserAccessKey.new(scrypt_hash: scrypt_hash) if scrypt_hash.present?
-        uak = UserAccessKey.new(password: key, salt: key, cost: cost)
-        @_scypt_hashes_by_key["#{key}:#{cost}"] = uak.as_scrypt_hash
-        uak
-      end
-
-      private
-
-      attr_accessor :stale
-
-      def try_decrypt(ciphertext, key:, cost:)
-        user_access_key = self.class.load_or_init_user_access_key(key: key, cost: cost)
-        begin
-          result = UserAccessKeyEncryptor.new(user_access_key).decrypt(ciphertext)
-          self.stale = key != current_key
-          result
-        rescue EncryptionError
-          nil
-        end
-      end
-
-      def encryption_keys_with_cost
-        @encryption_keys_with_cost ||= [{ key: current_key, cost: current_cost }] + old_keys
+      def legacy?(ciphertext)
+        Encryption::KmsClient.looks_like_kms?(ciphertext) || ciphertext.index('.')
       end
 
       def current_key
         Figaro.env.attribute_encryption_key
       end
 
-      def current_cost
-        Figaro.env.attribute_cost
+      def all_keys
+        [current_key].concat(old_keys.collect { |hash| hash['key'] })
       end
 
       def old_keys
-        JSON.parse(Figaro.env.attribute_encryption_key_queue, symbolize_names: true)
+        JSON.parse(Figaro.env.attribute_encryption_key_queue)
+      end
+
+      def deprecated_encryptor
+        @_deprecated_encryptor ||= DeprecatedAttributeEncryptor.new
       end
     end
   end

--- a/app/services/encryption/encryptors/deprecated_attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/deprecated_attribute_encryptor.rb
@@ -1,0 +1,66 @@
+module Encryption
+  module Encryptors
+    class DeprecatedAttributeEncryptor
+      def encrypt(plaintext)
+        user_access_key = self.class.load_or_init_user_access_key(
+          key: current_key, cost: current_cost
+        )
+        UserAccessKeyEncryptor.new(user_access_key).encrypt(plaintext)
+      end
+
+      def decrypt(ciphertext)
+        encryption_keys_with_cost.each do |key_with_cost|
+          key = key_with_cost.fetch(:key)
+          cost = key_with_cost.fetch(:cost)
+          result = try_decrypt(ciphertext, key: key, cost: cost)
+          return result unless result.nil?
+        end
+        raise Encryption::EncryptionError, 'unable to decrypt attribute with any key'
+      end
+
+      def stale?
+        stale
+      end
+
+      def self.load_or_init_user_access_key(key:, cost:)
+        @_scypt_hashes_by_key ||= {}
+        scrypt_hash = @_scypt_hashes_by_key["#{key}:#{cost}"]
+        return UserAccessKey.new(scrypt_hash: scrypt_hash) if scrypt_hash.present?
+        uak = UserAccessKey.new(password: key, salt: key, cost: cost)
+        @_scypt_hashes_by_key["#{key}:#{cost}"] = uak.as_scrypt_hash
+        uak
+      end
+
+      private
+
+      attr_accessor :stale
+
+      def try_decrypt(ciphertext, key:, cost:)
+        user_access_key = self.class.load_or_init_user_access_key(key: key, cost: cost)
+        begin
+          result = UserAccessKeyEncryptor.new(user_access_key).decrypt(ciphertext)
+          self.stale = key != current_key
+          result
+        rescue Encryption::EncryptionError
+          nil
+        end
+      end
+
+      def encryption_keys_with_cost
+        @encryption_keys_with_cost ||= [{ key: current_key, cost: current_cost }] + old_keys
+      end
+
+      def current_key
+        Figaro.env.attribute_encryption_key
+      end
+
+      def current_cost
+        Figaro.env.attribute_cost
+      end
+
+      def old_keys
+        JSON.parse(Figaro.env.attribute_encryption_key_queue, symbolize_names: true)
+      end
+    end
+  end
+end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -12,11 +12,19 @@ module Encryption
     end
 
     def decrypt(ciphertext)
-      return decrypt_kms(ciphertext) if FeatureManagement.use_kms? && looks_like_kms?(ciphertext)
+      return decrypt_kms(ciphertext) if use_kms?(ciphertext)
       decrypt_local(ciphertext)
     end
 
+    def self.looks_like_kms?(ciphertext)
+      ciphertext.start_with?(KEY_TYPE[:KMS])
+    end
+
     private
+
+    def use_kms?(ciphertext)
+      FeatureManagement.use_kms? && self.class.looks_like_kms?(ciphertext)
+    end
 
     def encrypt_kms(plaintext)
       ciphertext_blob = aws_client.encrypt(
@@ -39,10 +47,6 @@ module Encryption
 
     def decrypt_local(ciphertext)
       encryptor.decrypt(ciphertext, Figaro.env.password_pepper)
-    end
-
-    def looks_like_kms?(ciphertext)
-      ciphertext.start_with?(KEY_TYPE[:KMS])
     end
 
     def aws_client

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -82,7 +82,8 @@ development:
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   attribute_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
-  attribute_encryption_key_queue: '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
+  attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111", "cost": "4000$8$4$" }, { "key": "key": "22222222222222222222222222222222", "cost": "4000$8$4$" }]'
+  attribute_encryption_without_kms: 'false'
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-development-keymaker'
   aws_region: 'us-east-1'
@@ -123,7 +124,7 @@ development:
   equifax_ssh_passphrase: 'sekret'
   exception_recipients: 'test1@test.com'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
-  hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
+  hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   identity_pki_disabled: 'true'
   issuers_with_email_nameid_format: ''
   lexisnexis_account_id: 'test_account'
@@ -216,6 +217,7 @@ production:
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
   attribute_encryption_key: # generate via `rake secret`
   attribute_encryption_key_queue: # '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
+  attribute_encryption_without_kms: 'false'
   available_locales: 'en es fr'
   aws_kms_key_id:
   aws_region:
@@ -328,7 +330,8 @@ test:
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
   attribute_encryption_key: '2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25'
-  attribute_encryption_key_queue: '[{ "key": "old-key-one", "cost": "4000$8$4$" }, { "key": "old-key-one", "cost": "4000$8$4$" }]'
+  attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111", "cost": "4000$8$4$" }, { "key": "22222222222222222222222222222222", "cost": "4000$8$4$" }]'
+  attribute_encryption_without_kms: 'false'
   available_locales: 'en es fr'
   aws_kms_key_id: 'alias/login-dot-gov-test-keymaker'
   aws_region: 'us-east-1'

--- a/spec/services/encrypted_attribute_spec.rb
+++ b/spec/services/encrypted_attribute_spec.rb
@@ -48,8 +48,17 @@ describe EncryptedAttribute do
 
   describe '#stale?' do
     it 'returns true when email was encrypted with old key' do
+      allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('false')
       encrypted_with_old_key = encrypted_email
       rotate_attribute_encryption_key
+
+      expect(EncryptedAttribute.new(encrypted_with_old_key).stale?).to eq true
+    end
+
+    it 'returns true with legacy encryption and old key now switched to encryption without kms' do
+      encrypted_with_old_key = encrypted_email
+      rotate_attribute_encryption_key
+      allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('true')
 
       expect(EncryptedAttribute.new(encrypted_with_old_key).stale?).to eq true
     end

--- a/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
@@ -8,8 +8,6 @@ describe Encryption::Encryptors::AttributeEncryptor do
   let(:retired_cost) { '2000$8$1$' }
 
   before do
-    described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
-
     allow(Figaro.env).to receive(:attribute_encryption_key).and_return(current_key)
     allow(Figaro.env).to receive(:attribute_cost).and_return(current_cost)
     allow(Figaro.env).to receive(:attribute_encryption_key_queue).and_return(
@@ -18,73 +16,129 @@ describe Encryption::Encryptors::AttributeEncryptor do
   end
 
   describe '#encrypt' do
-    it 'returns encrypted text' do
-      ciphertext = subject.encrypt(plaintext)
+    context 'with old kms based encryption' do
+      before do
+        allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('false')
+      end
 
-      expect(ciphertext).to_not eq(plaintext)
+      it 'returns encrypted text' do
+        ciphertext = subject.encrypt(plaintext)
+
+        expect(ciphertext).to_not eq(plaintext)
+      end
     end
 
-    it 'only computes an scrypt hash the first time a key is used' do
-      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+    context 'with new non kms based encrytpion' do
+      before do
+        allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('true')
+      end
 
-      subject.encrypt(plaintext)
+      it 'returns encrypted text' do
+        ciphertext = subject.encrypt(plaintext)
 
-      expect(SCrypt::Engine).to_not receive(:hash_secret)
-
-      subject.encrypt(plaintext)
+        expect(ciphertext).to_not eq(plaintext)
+      end
     end
   end
 
   describe '#decrypt' do
-    let(:ciphertext) do
-      result = subject.encrypt(plaintext)
-      described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
-      result
-    end
-
-    before do
-      # Memoize the ciphertext and purge the key pool so that encryption does not
-      # affect expected call counts
-      ciphertext
-    end
-
-    context 'with a ciphertext made with the current key' do
-      it 'decrypts the ciphertext' do
-        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+    context 'with old kms based encryption' do
+      let(:ciphertext) do
+        subject.encrypt(plaintext)
       end
 
-      it 'only computes an scrypt hash the first time a keys is used' do
-        expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-
-        subject.decrypt(ciphertext)
-
-        expect(SCrypt::Engine).to_not receive(:hash_secret)
-
-        subject.decrypt(ciphertext)
-      end
-    end
-
-    context 'after rotating keys' do
       before do
-        rotate_attribute_encryption_key
+        allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('false')
+        # Memoize the ciphertext and purge the key pool so that encryption does not
+        # affect expected call counts
+        ciphertext
       end
 
-      it 'tries to decrypt with successive keys until it is successful' do
-        expect(Encryption::UserAccessKey).to receive(:new).twice.and_call_original
+      context 'with a ciphertext made with the current key' do
+        it 'decrypts the ciphertext' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
 
-        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      context 'after rotating keys' do
+        before do
+          rotate_attribute_encryption_key
+        end
+
+        it 'tries to decrypt with successive keys until it is successful' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
+
+      context 'it migrates legacy encrypted data after rotating keys' do
+        before do
+          rotate_attribute_encryption_key
+        end
+
+        it 'tries to decrypt with successive keys until it is successful' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
+
+      context 'with a ciphertext made with a key that does not exist' do
+        before do
+          rotate_attribute_encryption_key_with_invalid_queue
+        end
+
+        it 'raises and encryption error' do
+          expect { subject.decrypt(ciphertext) }.to \
+            raise_error(Encryption::EncryptionError, 'unable to decrypt attribute with any key')
+        end
       end
     end
 
-    context 'with a ciphertext made with a key that does not exist' do
-      before do
-        rotate_attribute_encryption_key_with_invalid_queue
+    context 'with new new non kms based encryption' do
+      let(:ciphertext) do
+        subject.encrypt(plaintext)
       end
 
-      it 'raises and encryption error' do
-        expect { subject.decrypt(ciphertext) }.to raise_error(
-          Encryption::EncryptionError, 'unable to decrypt attribute with any key'
-        )
+      before do
+        # Memoize the ciphertext and purge the key pool so that encryption does not
+        # affect expected call counts
+        allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('true')
+        ciphertext
+      end
+
+      context 'with a ciphertext made with the current key' do
+        it 'decrypts the ciphertext' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
+
+      context 'after rotating keys' do
+        before do
+          rotate_attribute_encryption_key
+        end
+
+        it 'tries to decrypt with successive keys until it is successful' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
+
+      context 'it migrates legacy encrypted data after rotating keys' do
+        before do
+          rotate_attribute_encryption_key
+        end
+
+        it 'tries to decrypt with successive keys until it is successful' do
+          expect(subject.decrypt(ciphertext)).to eq(plaintext)
+        end
+      end
+
+      context 'with a ciphertext made with a key that does not exist' do
+        before do
+          rotate_attribute_encryption_key_with_invalid_queue
+        end
+
+        it 'raises and encryption error' do
+          expect { subject.decrypt(ciphertext) }.to \
+            raise_error(Encryption::EncryptionError, 'unable to decrypt attribute with any key')
+        end
       end
     end
   end
@@ -98,23 +152,21 @@ describe Encryption::Encryptors::AttributeEncryptor do
     end
 
     it 'returns true if an old key was last used to decrypt something' do
+      allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('false')
       ciphertext = subject.encrypt(plaintext)
       rotate_attribute_encryption_key
       subject.decrypt(ciphertext)
 
       expect(subject.stale?).to eq(true)
     end
-  end
 
-  describe '.load_or_init_user_access_key' do
-    it 'does not return the same key object for the same salt and cost' do
-      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+    it 'returns true if old key used to decrypt and we turn on new encryption' do
+      ciphertext = subject.encrypt(plaintext)
+      rotate_attribute_encryption_key
+      allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('true')
+      subject.decrypt(ciphertext)
 
-      key1 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
-      key2 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
-
-      expect(key1.as_scrypt_hash).to eq(key2.as_scrypt_hash)
-      expect(key1).to_not eq(key2)
+      expect(subject.stale?).to eq(true)
     end
   end
 end

--- a/spec/services/encryption/encryptors/deprecated_attribute_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/deprecated_attribute_encryptor_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+describe Encryption::Encryptors::DeprecatedAttributeEncryptor do
+  let(:plaintext) { 'some secret text' }
+  let(:current_key) { '1' * 32 }
+  let(:current_cost) { '400$8$1$' }
+  let(:retired_key) { '2' * 32 }
+  let(:retired_cost) { '2000$8$1$' }
+
+  before do
+    described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
+
+    allow(Figaro.env).to receive(:attribute_encryption_key).and_return(current_key)
+    allow(Figaro.env).to receive(:attribute_cost).and_return(current_cost)
+    allow(Figaro.env).to receive(:attribute_encryption_key_queue).and_return(
+      [{ key: retired_key, cost: retired_cost }].to_json
+    )
+  end
+
+  describe '#encrypt' do
+    it 'returns encrypted text' do
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to_not eq(plaintext)
+    end
+
+    it 'only computes an scrypt hash the first time a key is used' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      subject.encrypt(plaintext)
+
+      expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+      subject.encrypt(plaintext)
+    end
+  end
+
+  describe '#decrypt' do
+    let(:ciphertext) do
+      result = subject.encrypt(plaintext)
+      described_class.instance_variable_set(:@_scypt_hashes_by_key, nil)
+      result
+    end
+
+    before do
+      # Memoize the ciphertext and purge the key pool so that encryption does not
+      # affect expected call counts
+      ciphertext
+    end
+
+    context 'with a ciphertext made with the current key' do
+      it 'decrypts the ciphertext' do
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
+
+      it 'only computes an scrypt hash the first time a keys is used' do
+        expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+        subject.decrypt(ciphertext)
+
+        expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+        subject.decrypt(ciphertext)
+      end
+    end
+
+    context 'after rotating keys' do
+      before do
+        rotate_attribute_encryption_key
+      end
+
+      it 'tries to decrypt with successive keys until it is successful' do
+        expect(Encryption::UserAccessKey).to receive(:new).twice.and_call_original
+
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
+    end
+
+    context 'with a ciphertext made with a key that does not exist' do
+      before do
+        rotate_attribute_encryption_key_with_invalid_queue
+      end
+
+      it 'raises and encryption error' do
+        expect { subject.decrypt(ciphertext) }.to raise_error(
+          Encryption::EncryptionError, 'unable to decrypt attribute with any key'
+        )
+      end
+    end
+  end
+
+  describe '#stale?' do
+    it 'returns false if the current key last was used to decrypt something' do
+      ciphertext = subject.encrypt(plaintext)
+      subject.decrypt(ciphertext)
+
+      expect(subject.stale?).to eq(false)
+    end
+
+    it 'returns true if an old key was last used to decrypt something' do
+      ciphertext = subject.encrypt(plaintext)
+      rotate_attribute_encryption_key
+      subject.decrypt(ciphertext)
+
+      expect(subject.stale?).to eq(true)
+    end
+  end
+
+  describe '.load_or_init_user_access_key' do
+    it 'does not return the same key object for the same salt and cost' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      key1 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
+      key2 = described_class.load_or_init_user_access_key(key: current_key, cost: current_cost)
+
+      expect(key1.as_scrypt_hash).to eq(key2.as_scrypt_hash)
+      expect(key1).to_not eq(key2)
+    end
+  end
+end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -69,4 +69,14 @@ describe Encryption::KmsClient do
       end
     end
   end
+
+  describe '#looks_like_kms?' do
+    it 'returns true for kms encrypted data' do
+      expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
+    end
+
+    it 'returns false for non kms encrypted data' do
+      expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+    end
+  end
 end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -11,6 +11,7 @@ describe Pii::Cacher do
 
   describe '#save' do
     before do
+      allow(Figaro.env).to receive(:attribute_encryption_without_kms).and_return('false')
       allow(FeatureManagement).to receive(:use_kms?).and_return(false)
       profile.save!
     end

--- a/spec/support/key_rotation_helper.rb
+++ b/spec/support/key_rotation_helper.rb
@@ -5,10 +5,10 @@ module KeyRotationHelper
     allow(env).to receive(:hmac_fingerprinter_key_queue).and_return(
       "[\"#{old_hmac_key}\"]"
     )
-    allow(env).to receive(:hmac_fingerprinter_key).and_return('a-new-key')
+    allow(env).to receive(:hmac_fingerprinter_key).and_return('4' * 32)
   end
 
-  def rotate_attribute_encryption_key(new_key = 'a-new-key', new_cost = '4000$8$2$')
+  def rotate_attribute_encryption_key(new_key = '4' * 32, new_cost = '4000$8$2$')
     env = Figaro.env
     old_key = env.attribute_encryption_key
     old_cost = env.attribute_cost
@@ -33,6 +33,6 @@ module KeyRotationHelper
     allow(env).to receive(:attribute_encryption_key_queue).and_return(
       [{ key: 'key-that-was-never-used-in-the-past', cost: '4000$8$2$' }].to_json
     )
-    allow(env).to receive(:attribute_encryption_key).and_return('a-new-key')
+    allow(env).to receive(:attribute_encryption_key).and_return('4' * 32)
   end
 end


### PR DESCRIPTION
**Why**: KMS is not multi-region and KMS does not allow importing or exporting keys which ties us to AWS.

**How**: Perform an in place migration via two steps: a deployment and a subsequent feature flag change.  

Performing an in place migration in one deployment would cause destructive changes in the database that could not be rolled back upon failure and would also cause 500 errors while servers scaled in and scaled out.  This PR deploys code that supports decryption for old and new formats but continues encrypting in the old format. The ability to encrypt in old and new format will be controlled via a feature flag.  Upon this PR's successful deployment the next step is to enable the new encryption via the new feature flag.  Shortly thereafter the rake task rotate.rake can be run to convert all the attributes to the new encryption scheme.

To accomplish this in the code we move AttributeEncryptor to DeprecatedAttributeEncryptor.  Depending on the state of the feature flag the new AttributeEncryptor encrypts in old or new format.  The new AttributeEncryptor decrypts in old format if it detects an old cipher text otherwise it decrypts in the new format.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.  Use rotate.rake to migrate the attributes.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
