### PR TITLE
Switch queuing from sidekiq to inline by default.

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -42,7 +42,7 @@ queue_health_check_frequency_seconds: '30'
 
 # Configuration to probabilistically select the config.active_job.queue_adapter
 # Currently known options are: sidekiq, async, inline
-queue_adapter_weights: '{"sidekiq": 1}'
+queue_adapter_weights: '{"inline": 1}'
 
 # The number of words in the personal key phrase
 recovery_code_length: '4'


### PR DESCRIPTION
**Why**: We no longer use sidekiq because it does not guarantee timely
delivery, even in the sidekiq enterprise reliable delivery mode.

**How**: Make the default queue_adapter_weights 100% inline. This means
that ActiveJob jobs will run inside rails during the request.

See also: https://github.com/18F/identity-devops-private/issues/629