### PR TITLE
Add encrypted recovery code digest to user

### DIFF
--- a/db/migrate/20180601145643_add_encrypted_recovery_code_digest_to_user.rb
+++ b/db/migrate/20180601145643_add_encrypted_recovery_code_digest_to_user.rb
@@ -1,0 +1,5 @@
+class AddEncryptedRecoveryCodeDigestToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :encrypted_recovery_code_digest, :string
+  end
+end

--- a/db/migrate/20180601145643_add_encrypted_recovery_code_digest_to_user.rb
+++ b/db/migrate/20180601145643_add_encrypted_recovery_code_digest_to_user.rb
@@ -1,5 +1,10 @@
 class AddEncryptedRecoveryCodeDigestToUser < ActiveRecord::Migration[5.1]
-  def change
+  def up
     add_column :users, :encrypted_recovery_code_digest, :string
+    change_column_default :users, :encrypted_recovery_code_digest, ""
+  end
+
+  def down
+    remove_column :users, :encrypted_recovery_code_digest
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521155700) do
+ActiveRecord::Schema.define(version: 20180601145643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 20180521155700) do
     t.integer "totp_timestamp"
     t.string "x509_dn_uuid"
     t.string "encrypted_password_digest", default: ""
+    t.string "encrypted_recovery_code_digest"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,7 +181,7 @@ ActiveRecord::Schema.define(version: 20180601145643) do
     t.integer "totp_timestamp"
     t.string "x509_dn_uuid"
     t.string "encrypted_password_digest", default: ""
-    t.string "encrypted_recovery_code_digest"
+    t.string "encrypted_recovery_code_digest", default: ""
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true


### PR DESCRIPTION
**Why**: So that we can start migrating the recovery code verification
logic the same way we are for passwords

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
