### PR TITLE
LG-259 Password reset tokens should not leak to 3rd party sites (GA and NR)

### DIFF
--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -33,6 +33,7 @@ describe Users::ResetPasswordsController, devise: true do
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
 
         get :edit, params: { reset_password_token: 'foo' }
+        get :edit
 
         analytics_hash = {
           success: false,
@@ -65,6 +66,9 @@ describe Users::ResetPasswordsController, devise: true do
 
         get :edit, params: { reset_password_token: 'foo' }
 
+        expect(response).to redirect_to edit_user_password_url
+
+        get :edit
         expect(response).to render_template :edit
         expect(flash.keys).to be_empty
         expect(response.body).to match('<meta content="noindex,nofollow" name="robots" />')
@@ -87,8 +91,9 @@ describe Users::ResetPasswordsController, devise: true do
           reset_password_token: db_confirmation_token
         )
 
-        params = { password: 'short', reset_password_token: raw_reset_token }
+        params = { password: 'short' }
 
+        get :edit, params: { reset_password_token: raw_reset_token }
         put :update, params: { reset_password_form: params }
 
         analytics_hash = {
@@ -122,7 +127,7 @@ describe Users::ResetPasswordsController, devise: true do
           reset_password_token: db_confirmation_token,
           reset_password_sent_at: Time.zone.now
         )
-        form_params = { password: 'short', reset_password_token: raw_reset_token }
+        form_params = { password: 'short' }
         analytics_hash = {
           success: false,
           errors: { password: ['is too short (minimum is 9 characters)'] },
@@ -134,6 +139,7 @@ describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to receive(:track_event).
           with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
+        get :edit, params: { reset_password_token: raw_reset_token }
         put :update, params: { reset_password_form: form_params }
 
         expect(response).to render_template(:edit)
@@ -161,8 +167,9 @@ describe Users::ResetPasswordsController, devise: true do
           stub_email_notifier(user)
 
           password = 'a really long passw0rd'
-          params = { password: password, reset_password_token: raw_reset_token }
+          params = { password: password }
 
+          get :edit, params: { reset_password_token: raw_reset_token }
           put :update, params: { reset_password_form: params }
 
           analytics_hash = {
@@ -199,8 +206,9 @@ describe Users::ResetPasswordsController, devise: true do
 
         stub_email_notifier(user)
 
+        get :edit, params: { reset_password_token: raw_reset_token }
         password = 'a really long passw0rd'
-        params = { password: password, reset_password_token: raw_reset_token }
+        params = { password: password }
 
         put :update, params: { reset_password_form: params }
 
@@ -239,8 +247,9 @@ describe Users::ResetPasswordsController, devise: true do
         stub_email_notifier(user)
 
         password = 'a really long passw0rd'
-        params = { password: password, reset_password_token: raw_reset_token }
+        params = { password: password }
 
+        get :edit, params: { reset_password_token: raw_reset_token }
         put :update, params: { reset_password_form: params }
 
         analytics_hash = {


### PR DESCRIPTION
**Why**: Password reset tokens on the url for the password reset page are leaked to third party sites google analytics and new relic.

**How**: After validating the token, implement redirection from the url with the token to the url without it while saving the token in session.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
