### PR TITLE
LG-315 Can't submit personal key after typo

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (elements.length !== 0) {
         [].forEach.call(elements, function(input) {
           input.addEventListener('input', function () {
-            if (buttons.length !== 0 && input.valid) {
+            if (buttons.length !== 0 && input.checkValidity()) {
               [].forEach.call(buttons, function(button) {
                 if (button.disabled) {
                   button.disabled = false;


### PR DESCRIPTION
**Why**: When a user attempts to confirm a personal key and mistypes the key, they receive an error and the continue button is disabled.

**How**: Fix the logic for enabling/disabling the button and checking form validation upon user input. Rspec and Capybara are insufficient to test the javascript disabling/enabling of the submit button.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
