### PR TITLE
LG-311 Prevent bypassing account lockout when sending SMS verification codes

### DIFF
--- a/app/services/otp_rate_limiter.rb
+++ b/app/services/otp_rate_limiter.rb
@@ -16,7 +16,7 @@ class OtpRateLimiter
   end
 
   def max_requests_reached?
-    entry_for_current_phone.otp_send_count >= otp_maxretry_times
+    entry_for_current_phone.otp_send_count > otp_maxretry_times
   end
 
   def rate_limit_period_expired?
@@ -32,9 +32,8 @@ class OtpRateLimiter
   end
 
   def increment
-    entry_for_current_phone.otp_send_count += 1
-    entry_for_current_phone.otp_last_sent_at = Time.zone.now
-    entry_for_current_phone.save!
+    # DO NOT MEMOIZE
+    @entry = OtpRequestsTracker.atomic_increment(entry_for_current_phone.id)
   end
 
   private

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -158,7 +158,7 @@ describe Users::TwoFactorAuthenticationController do
         allow(OtpRateLimiter).to receive(:new).with(phone: @user.phone, user: @user).
           and_return(otp_rate_limiter)
 
-        expect(otp_rate_limiter).to receive(:exceeded_otp_send_limit?)
+        expect(otp_rate_limiter).to receive(:exceeded_otp_send_limit?).twice
         expect(otp_rate_limiter).to receive(:increment)
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -387,7 +387,7 @@ feature 'Two Factor Authentication' do
         rate_limited_phone = OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint)
 
         expect(current_path).to eq otp_send_path
-        expect(rate_limited_phone.otp_send_count).to eq max_attempts
+        expect(rate_limited_phone.otp_send_count).to eq max_attempts + 1
 
         visit account_path
 

--- a/spec/services/otp_rate_limiter_spec.rb
+++ b/spec/services/otp_rate_limiter_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe OtpRateLimiter do
       expect(otp_rate_limiter.exceeded_otp_send_limit?).to eq(false)
     end
 
-    it 'is true after maxretry_times attemps in findtime minutes' do
+    it 'is true after maxretry_times attemps +1 in findtime minutes' do
       expect(otp_rate_limiter.exceeded_otp_send_limit?).to eq(false)
 
-      Figaro.env.otp_delivery_blocklist_maxretry.to_i.times do
+      (Figaro.env.otp_delivery_blocklist_maxretry.to_i + 1).times do
         otp_rate_limiter.increment
       end
 


### PR DESCRIPTION
**Why**: An attacker can abuse the SMS system and spam users

**How**: Create an atomic increment on OtpRequestsTracker.  Increment count before checking rate limit. Don't memoize the OtpRequestsTracker returned from the update.  (3 fixes total).  Testing will need to be done with Burp's repeater to hit idp with parallel requests.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
