### PR TITLE
LG-320 Account History should log when their personal key is changed

### DIFF
--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -26,6 +26,7 @@ module Users
     def create
       user_session[:personal_key] = create_new_code
       analytics.track_event(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      Event.create(user_id: current_user.id, event_type: :new_personal_key)
       flash[:success] = t('notices.send_code.personal_key') if params[:resend].present?
       redirect_to manage_personal_key_url
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,6 +13,7 @@ class Event < ApplicationRecord
     usps_mail_sent: 9,
     piv_cac_enabled: 10,
     piv_cac_disabled: 11,
+    new_personal_key: 12,
   }
 
   validates :event_type, presence: true

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -9,6 +9,7 @@ en:
     authenticator_enabled: Authenticator app enabled
     eastern_timestamp: "%{timestamp} (Eastern)"
     email_changed: Email address changed
+    new_personal_key: Personal key changed
     password_changed: Password changed
     phone_changed: Phone number changed
     phone_confirmed: Phone confirmed

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -9,6 +9,7 @@ es:
     authenticator_enabled: App de autenticación permitido
     eastern_timestamp: "%{timestamp} (hora del Este)"
     email_changed: Email cambiado
+    new_personal_key: Clave personal cambiado
     password_changed: Contraseña cambiada
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -9,6 +9,7 @@ fr:
     authenticator_enabled: Application d'authentification activée
     eastern_timestamp: "%{timestamp} (Eastern)"
     email_changed: Adresse courriel modifiée
+    new_personal_key: Clé personnelle modifié
     password_changed: Mot de passe modifié
     phone_changed: Numéro de téléphone modifié
     phone_confirmed: Numéro de téléphone confirmé

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -121,6 +121,8 @@ describe Users::PersonalKeysController do
 
       expect(generator).to receive(:create)
       expect(@analytics).to receive(:track_event).with(Analytics::PROFILE_PERSONAL_KEY_CREATE)
+      expect(Event).to receive(:create).
+        with(user_id: subject.current_user.id, event_type: :new_personal_key)
 
       post :create
 

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -32,6 +32,8 @@ describe 'Account history' do
   let(:identity_with_link_timestamp) { identity_with_link.decorate.happened_at_in_words }
   let(:usps_mail_sent_again_timestamp) { usps_mail_sent_again_event.decorate.happened_at_in_words }
   let(:identity_without_link_timestamp) { identity_without_link.decorate.happened_at_in_words }
+  let(:new_personal_key_event) { create(:event, event_type: :new_personal_key,
+                                        user: user, created_at: Time.zone.now - 40.days) }
 
   before do
     sign_in_and_2fa_user(user)
@@ -40,7 +42,7 @@ describe 'Account history' do
   end
 
   scenario 'viewing account history' do
-    [account_created_event, usps_mail_sent_event, usps_mail_sent_again_event].each do |event|
+    [account_created_event, usps_mail_sent_event, usps_mail_sent_again_event, new_personal_key_event].each do |event|
       decorated_event = event.decorate
       expect(page).to have_content(decorated_event.event_type)
       expect(page).to have_content(decorated_event.happened_at_in_words)
@@ -70,5 +72,6 @@ describe 'Account history' do
     usps_mail_sent_again_event
     identity_with_link
     identity_without_link
+    new_personal_key_event
   end
 end


### PR DESCRIPTION
**Why**: A user should be aware of sensitive account changes

**How**: Create a new new_personal_key event when a user changes their personal key.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
