### PR TITLE
LG-351 Rate limiting does not work as expected in all cases of an email address

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -111,7 +111,7 @@ module Rack
         # increments the count), so requests below the limit are not blocked until
         # they hit the limit. At that point, `filter` will return true and block.
         user = req.params.fetch('user', {})
-        email = user['email'].to_s
+        email = user['email'].to_s.downcase.strip
         email_fingerprint = Pii::Fingerprinter.fingerprint(email) if email.present?
         email_and_ip = "#{email_fingerprint}-#{req.remote_ip}"
         maxretry = Figaro.env.logins_per_email_and_ip_limit.to_i

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -205,15 +205,15 @@ describe 'throttling requests' do
       end
     end
 
-    context 'when the number of logins per email and ip is higher than the limit per period' do
+    context 'when number of logins per stripped/downcased email + ip is higher than limit per period' do
       it 'throttles with a custom response' do
         analytics = instance_double(Analytics)
         allow(Analytics).to receive(:new).and_return(analytics)
         allow(analytics).to receive(:track_event)
 
-        (logins_per_email_and_ip_limit + 1).times do
+        (logins_per_email_and_ip_limit + 1).times do |index|
           post '/', params: {
-            user: { email: 'test@example.com' },
+            user: { email: index % 2 == 0 ? 'test@example.com' : ' test@EXAMPLE.com   ' },
           }, headers: { REMOTE_ADDR: '1.2.3.4' }
         end
 


### PR DESCRIPTION
**Why**: We strip and downcase emails upon account creation but we do not do the same when passing emails to the rate limiter (rack attack).

**How**: Strip and downcase all emails before passing it to rack attack.  Write a spec that tests for padding and mixed case.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
