### PR TITLE
Read Pii encryption salt/cost from ciphertext

### DIFF
--- a/.reek
+++ b/.reek
@@ -69,7 +69,6 @@ LongParameterList:
     - Idv::ProoferJob#perform
     - Idv::VendorResult#initialize
     - JWT
-    - Pii::Attributes#self.new_from_encrypted
 RepeatedConditional:
   exclude:
     - Users::ResetPasswordsController

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,39 +33,27 @@ class Profile < ApplicationRecord
   def decrypt_pii(password)
     Pii::Attributes.new_from_encrypted(
       encrypted_pii,
-      password: password,
-      salt: user.password_salt,
-      cost: user.password_cost
+      password: password
     )
   end
 
   def recover_pii(personal_key)
     Pii::Attributes.new_from_encrypted(
       encrypted_pii_recovery,
-      password: personal_key,
-      salt: user.recovery_salt,
-      cost: user.recovery_cost
+      password: personal_key
     )
   end
 
   def encrypt_pii(pii, password)
     ssn = pii.ssn
     self.ssn_signature = Pii::Fingerprinter.fingerprint(ssn) if ssn
-    self.encrypted_pii = pii.encrypted(
-      password: password,
-      salt: user.password_salt,
-      cost: user.password_cost
-    )
+    self.encrypted_pii = pii.encrypted(password)
     encrypt_recovery_pii(pii)
   end
 
   def encrypt_recovery_pii(pii)
     personal_key = personal_key_generator.create
-    self.encrypted_pii_recovery = pii.encrypted(
-      password: personal_key_generator.normalize(personal_key),
-      salt: user.recovery_salt,
-      cost: user.recovery_cost
-    )
+    self.encrypted_pii_recovery = pii.encrypted(personal_key_generator.normalize(personal_key))
     @personal_key = personal_key
   end
 

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -1,39 +1,62 @@
 module Encryption
   module Encryptors
     class PiiEncryptor
-      include Pii::Encodable
+      Ciphertext = Struct.new(:encrypted_data, :salt, :cost) do
+        include Pii::Encodable
+        class << self
+          include Pii::Encodable
+        end
 
-      def initialize(password:, salt:, cost: nil)
-        cost ||= Figaro.env.scrypt_cost
+        def self.parse_from_string(ciphertext_string)
+          parsed_json = JSON.parse(ciphertext_string)
+          encoded_encrypted_data = parsed_json['encrypted_data']
+          raise Pii::EncryptionError, 'ciphertext invalid' unless valid_base64_encoding?(
+            encoded_encrypted_data
+          )
+          new(decode(encoded_encrypted_data), parsed_json['salt'], parsed_json['cost'])
+        rescue JSON::ParserError
+          raise Pii::EncryptionError, 'ciphertext is not valid JSON'
+        end
+
+        def to_s
+          {
+            encrypted_data: encode(encrypted_data),
+            salt: salt,
+            cost: cost,
+          }.to_json
+        end
+      end
+
+      def initialize(password)
+        @password = password
         @aes_cipher = Pii::Cipher.new
         @kms_client = KmsClient.new
-        @scrypt_password_digest = build_scrypt_password(password, salt, cost).digest
       end
 
       def encrypt(plaintext)
+        salt = Devise.friendly_token[0, 20]
+        cost = Figaro.env.scrypt_cost
+        aes_encryption_key = scrypt_password_digest(salt: salt, cost: cost)
         aes_encrypted_ciphertext = aes_cipher.encrypt(plaintext, aes_encryption_key)
         kms_encrypted_ciphertext = kms_client.encrypt(aes_encrypted_ciphertext)
-        encode(kms_encrypted_ciphertext)
+        Ciphertext.new(kms_encrypted_ciphertext, salt, cost).to_s
       end
 
-      def decrypt(ciphertext)
-        raise Pii::EncryptionError, 'ciphertext invalid' unless valid_base64_encoding?(ciphertext)
-        decoded_ciphertext = decode(ciphertext)
-        aes_encrypted_ciphertext = kms_client.decrypt(decoded_ciphertext)
+      def decrypt(ciphertext_string)
+        ciphertext = Ciphertext.parse_from_string(ciphertext_string)
+        aes_encrypted_ciphertext = kms_client.decrypt(ciphertext.encrypted_data)
+        aes_encryption_key = scrypt_password_digest(salt: ciphertext.salt, cost: ciphertext.cost)
         aes_cipher.decrypt(aes_encrypted_ciphertext, aes_encryption_key)
       end
 
       private
 
-      attr_reader :aes_cipher, :kms_client, :scrypt_password_digest
+      attr_reader :password, :aes_cipher, :kms_client
 
-      def build_scrypt_password(password, salt, cost)
+      def scrypt_password_digest(salt:, cost:)
         scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
         scrypted = SCrypt::Engine.hash_secret password, scrypt_salt, 32
-        SCrypt::Password.new(scrypted)
-      end
-
-      def aes_encryption_key
+        scrypt_password_digest = SCrypt::Password.new(scrypted).digest
         scrypt_password_digest[0...32]
       end
     end

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -18,12 +18,8 @@ module Pii
       attrs
     end
 
-    def self.new_from_encrypted(encrypted, password:, salt:, cost:)
-      encryptor = Encryption::Encryptors::PiiEncryptor.new(
-        password: password,
-        salt: salt,
-        cost: cost
-      )
+    def self.new_from_encrypted(encrypted, password:)
+      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
       decrypted = encryptor.decrypt(encrypted)
       new_from_json(decrypted)
     end
@@ -39,12 +35,8 @@ module Pii
       assign_all_members
     end
 
-    def encrypted(password:, salt:, cost:)
-      encryptor = Encryption::Encryptors::PiiEncryptor.new(
-        password: password,
-        salt: salt,
-        cost: cost
-      )
+    def encrypted(password)
+      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
       encryptor.encrypt(to_json)
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -271,7 +271,9 @@ describe Users::SessionsController, devise: true do
       it 'deactivates profile if not de-cryptable' do
         user = create(:user, :signed_up)
         profile = create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
-        profile.update!(encrypted_pii: Base64.strict_encode64('nonsense'))
+        profile.update!(
+          encrypted_pii: { encrypted_data: Base64.strict_encode64('nonsense') }.to_json
+        )
 
         stub_analytics
         analytics_hash = {

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 describe Pii::Attributes do
   # let(:user_access_key) { Encryption::UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
   let(:password) { 'I am the password' }
-  let(:salt) { 'I am the salt' }
-  let(:cost) { '800$8$1$' }
 
   describe '#new_from_hash' do
     it 'initializes from plain Hash' do
@@ -34,20 +32,16 @@ describe Pii::Attributes do
   describe '#new_from_encrypted' do
     it 'inflates from encrypted string' do
       orig_attrs = described_class.new_from_hash(first_name: 'Jane')
-      encrypted_pii = orig_attrs.encrypted(password: password, salt: salt, cost: cost)
-      pii_attrs = described_class.new_from_encrypted(
-        encrypted_pii, password: password, salt: salt, cost: cost
-      )
+      encrypted_pii = orig_attrs.encrypted(password)
+      pii_attrs = described_class.new_from_encrypted(encrypted_pii, password: password)
 
       expect(pii_attrs.first_name).to eq 'Jane'
     end
 
     it 'allows deprecated attributes that are no longer added to the hash schema' do
       deprecated_atts = described_class.new_from_hash(otp: '123abc')
-      encrypted_pii = deprecated_atts.encrypted(password: password, salt: salt, cost: cost)
-      pii_attrs = described_class.new_from_encrypted(
-        encrypted_pii, password: password, salt: salt, cost: cost
-      )
+      encrypted_pii = deprecated_atts.encrypted(password)
+      pii_attrs = described_class.new_from_encrypted(encrypted_pii, password: password)
 
       expect(pii_attrs[:otp]).to eq('123abc')
     end
@@ -71,7 +65,7 @@ describe Pii::Attributes do
     it 'returns the object as encrypted string' do
       pii_attrs = described_class.new_from_hash(first_name: 'Jane')
 
-      encrypted = pii_attrs.encrypted(password: password, salt: salt, cost: cost)
+      encrypted = pii_attrs.encrypted(password)
       expect(encrypted).to_not match 'Jane'
     end
   end


### PR DESCRIPTION
**Why**: We are moving the salt/cost attributes into the ciphertexts for
pii encryption and password and decoupling password verification from Pii
encryption. This is the first step in this process. Up next is moving
these into the password digest. Then we can drop these columns.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] ~~For encryption changes, make sure it is compatible with data that was
encrypted with the old code.~~

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
