### PR TITLE
LG-309 Allow dynamic service provider updates in production

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ Metrics/ClassLength:
   - app/controllers/users/confirmations_controller.rb
   - app/controllers/users/sessions_controller.rb
   - app/controllers/devise/two_factor_authentication_controller.rb
+  - app/decorators/service_provider_session_decorator.rb
   - app/decorators/user_decorator.rb
   - app/services/analytics.rb
   - app/services/idv/session.rb

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -40,6 +40,15 @@ class ServiceProviderSessionDecorator
     sp.logo || DEFAULT_LOGO
   end
 
+  def sp_logo_url
+    logo = sp_logo
+    if RemoteSettingsService.remote?(logo)
+      logo
+    else
+      ActionController::Base.helpers.image_path("sp-logos/#{logo}")
+    end
+  end
+
   def return_to_service_provider_partial
     if sp_return_url.present?
       'devise/sessions/return_to_service_provider'

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -40,6 +40,8 @@ class SessionDecorator
 
   def sp_logo; end
 
+  def sp_logo_url; end
+
   def sp_redirect_uris; end
 
   def sp_return_url; end

--- a/app/models/remote_setting.rb
+++ b/app/models/remote_setting.rb
@@ -1,0 +1,6 @@
+class RemoteSetting < ApplicationRecord
+  validates :url, format: {
+    with:
+      %r{\A(https://raw.githubusercontent.com/18F/identity-idp/|https://login.gov).+\z},
+  }
+end

--- a/app/services/agency_seeder.rb
+++ b/app/services/agency_seeder.rb
@@ -21,7 +21,12 @@ class AgencySeeder
   attr_reader :rails_env, :deploy_env
 
   def agencies
-    content = ERB.new(Rails.root.join('config', 'agencies.yml').read).result
+    file = remote_setting || Rails.root.join('config', 'agencies.yml').read
+    content = ERB.new(file).result
     YAML.safe_load(content).fetch(rails_env, {})
+  end
+
+  def remote_setting
+    RemoteSetting.find_by(name: 'agencies.yml')&.contents
   end
 end

--- a/app/services/remote_settings_service.rb
+++ b/app/services/remote_settings_service.rb
@@ -1,0 +1,33 @@
+class RemoteSettingsService
+  def self.load_yml_erb(location)
+    result = ERB.new(load(location)).result
+    begin
+      YAML.safe_load(result.to_s)
+    rescue StandardError
+      raise "Error parsing yml file: #{location}"
+    end
+    result
+  end
+
+  def self.load(location)
+    raise "Location must begin with 'https://': #{location}" unless remote?(location)
+    response = HTTParty.get(
+      location, headers:
+      { 'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1' }
+    )
+    raise "Error retrieving: #{location}" unless response.code == 200
+    response.body
+  end
+
+  def self.update_setting(name, url)
+    remote_setting = RemoteSetting.where(name: name).first_or_initialize
+    remote_setting.url = url
+    raise "url not whitelisted: #{url}" unless remote_setting.valid?
+    remote_setting.contents = RemoteSettingsService.load(remote_setting.url)
+    remote_setting.save
+  end
+
+  def self.remote?(location)
+    location.to_s.starts_with?('https://')
+  end
+end

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -22,8 +22,13 @@ class ServiceProviderSeeder
   attr_reader :rails_env, :deploy_env
 
   def service_providers
-    content = ERB.new(Rails.root.join('config', 'service_providers.yml').read).result
+    file = remote_setting || Rails.root.join('config', 'service_providers.yml').read
+    content = ERB.new(file).result
     YAML.safe_load(content).fetch(rails_env, {})
+  end
+
+  def remote_setting
+    RemoteSetting.find_by(name: 'service_providers.yml')&.contents
   end
 
   def write_service_provider?(config)

--- a/app/views/shared/_nav_branded.html.slim
+++ b/app/views/shared/_nav_branded.html.slim
@@ -3,5 +3,5 @@ nav.nav-branded.vertical-align.bg-light-blue.center.relative
     alt: APP_NAME, class: 'inline-block align-middle')
   .px-12p.inline-block
     span.absolute.top-0.bottom-0.border-right.my1.sm-my2
-  = image_tag(asset_url("sp-logos/#{decorated_session.sp_logo}"), height: 40,
+  = image_tag(decorated_session.sp_logo_url, height: 40,
     alt: decorated_session.sp_name, class: 'inline-block align-middle')

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -19,7 +19,7 @@ SecureHeaders::Configuration.default do |config|
       '*.google-analytics.com',
     ],
     font_src: ["'self'", 'data:'],
-    img_src: ["'self'", 'data:'],
+    img_src: ["'self'", 'data:', 'login.gov'],
     media_src: ["'self'"],
     object_src: ["'none'"],
     script_src: [

--- a/db/migrate/20180607144007_create_remote_settings.rb
+++ b/db/migrate/20180607144007_create_remote_settings.rb
@@ -1,0 +1,11 @@
+class CreateRemoteSettings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :remote_settings do |t|
+      t.string   "name", null: false
+      t.string   "url", null: false
+      t.text     "contents", null: false
+      t.timestamps
+    end
+    add_index :remote_settings, ["name"], name: "index_remote_settings_on_name", unique: true, using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180601145643) do
+ActiveRecord::Schema.define(version: 20180607144007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,15 @@ ActiveRecord::Schema.define(version: 20180601145643) do
     t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"
     t.index ["user_id", "ssn_signature", "active"], name: "index_profiles_on_user_id_and_ssn_signature_and_active", unique: true, where: "(active = true)"
     t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
+  create_table "remote_settings", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "url", null: false
+    t.text "contents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_remote_settings_on_name", unique: true
   end
 
   create_table "service_provider_requests", force: :cascade do |t|

--- a/lib/tasks/remote_settings.rake
+++ b/lib/tasks/remote_settings.rake
@@ -1,0 +1,26 @@
+namespace :remote_settings do
+  task :update, [:name, :url] => [:environment] do |task, args|
+    RemoteSettingsService.update_setting(args[:name], args[:url])
+    Kernel.puts "Update successful"
+  end
+
+  task :view, [:name] => [:environment] do |task, args|
+    Kernel.puts  RemoteSetting.find_by(name: args[:name])&.contents
+  end
+
+  task list: :environment do
+    RemoteSetting.all.each do |rec|
+      Kernel.puts "name=#{rec.name} url=#{rec.url}"
+    end
+  end
+
+  task :delete, [:name] => [:environment] do |task, args|
+    RemoteSetting.where(name: args[:name]).delete_all
+    Kernel.puts "Delete successful"
+  end
+end
+
+# example invocations:
+# rake "remote_settings:update[agencies.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml]"
+# rake "remote_settings:update[agencies.yml,https://login.gov/assets/idp/config/agencies.yml"
+# rake "remote_settings:update[service_providers.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/service_providers.yml]"

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -126,6 +126,55 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
+  describe '#sp_logo_url' do
+    context 'service provider has a logo' do
+      it 'returns the logo' do
+        sp_logo = 'real_logo.svg'
+        sp = build_stubbed(:service_provider, logo: sp_logo)
+
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequest.new
+        )
+
+        expect(subject.sp_logo_url).to end_with("/sp-logos/#{sp_logo}")
+      end
+    end
+
+    context 'service provider does not have a logo' do
+      it 'returns the default logo' do
+        sp = build_stubbed(:service_provider, logo: nil)
+
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequest.new
+        )
+
+        expect(subject.sp_logo_url).to match(%r{/sp-logos/generic-.+\.svg})
+      end
+    end
+
+    context 'service provider has a remote logo' do
+      it 'returns the remote logo' do
+        logo = 'https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/generic.svg'
+        sp = build_stubbed(:service_provider, logo: logo)
+
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequest.new
+        )
+
+        expect(subject.sp_logo_url).to eq(logo)
+      end
+    end
+  end
+
   describe '#cancel_link_url' do
     subject(:decorator) do
       ServiceProviderSessionDecorator.new(

--- a/spec/models/remote_setting_spec.rb
+++ b/spec/models/remote_setting_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe RemoteSetting do
+  describe 'validations' do
+    it 'validates that our github repo is white listed' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      expect(valid_setting).to be_valid
+    end
+
+    it 'validates that the login.gov static site is white listed' do
+      location = 'https://login.gov/agencies.yml'
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      expect(valid_setting).to be_valid
+    end
+
+    it 'does not accept http' do
+      location = 'http://login.gov/agencies.yml'
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      expect(valid_setting).to_not be_valid
+    end
+  end
+end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -155,4 +155,17 @@ describe ServiceProvider do
       end
     end
   end
+
+  describe '#ssl_cert' do
+    it 'returns the remote setting cert' do
+      WebMock.allow_net_connect!
+      sp = create(:service_provider, issuer: 'foo', cert: 'https://raw.githubusercontent.com/18F/identity-idp/master/certs/sp/saml_test_sp.crt')
+      expect(sp.ssl_cert.class).to be(OpenSSL::X509::Certificate)
+    end
+
+    it 'returns the local cert' do
+      sp = create(:service_provider, issuer: 'foo', cert: 'saml_test_sp')
+      expect(sp.ssl_cert.class).to be(OpenSSL::X509::Certificate)
+    end
+  end
 end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -32,5 +32,25 @@ RSpec.describe AgencySeeder do
         expect(Agency.find_by(id: 1).name).to eq('CBP')
       end
     end
+
+    context 'when agencies.yml has a remote setting' do
+      before do
+        location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+        RemoteSetting.create(name: 'agencies.yml', url:location, contents: "test:\n  1:\n    name: 'CBP'")
+      end
+
+      it 'updates the attributes based on the current value of the yml file' do
+        Agency.create(id: 1, name: 'FOO')
+        expect(Agency.find_by(id: 1).name).to eq('FOO')
+        run
+        expect(Agency.find_by(id: 1).name).to eq('CBP')
+      end
+
+      it 'insert the attributes based on the contents of the remote setting' do
+        run
+        expect(Agency.find_by(id: 1).name).to eq('CBP')
+        expect(Agency.count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/services/remote_settings_service_spec.rb
+++ b/spec/services/remote_settings_service_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe RemoteSettingsService do
+  subject(:service) { RemoteSettingsService }
+  before {
+    WebMock.allow_net_connect!
+  }
+
+  describe '.load_yml_erb' do
+    it 'loads the remote location' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      expect { service.load_yml_erb(location) }.to_not raise_error
+    end
+
+    it 'raises an error if the location is not https://' do
+      location = 'agencies.yml'
+      expect do
+        RemoteSettingsService.load_yml_erb(location)
+      end.to raise_error(RuntimeError, "Location must begin with 'https://': #{location}")
+    end
+
+    it 'raises an error if the file is not found' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies'
+      expect do
+        service.load_yml_erb(location)
+      end.to raise_error(RuntimeError, "Error retrieving: #{location}")
+    end
+
+    it 'raises an error if the file is not a yml file' do
+      location = 'https://github.com/18F/identity-idp/blob/master/public/images/logo.svg'
+      expect do
+        service.load_yml_erb(location)
+      end.to raise_error(RuntimeError, "Error parsing yml file: #{location}")
+    end
+  end
+
+
+  describe '.load' do
+    it 'loads the remote location' do
+      expect do
+        service.load('https://github.com/18F/identity-idp/blob/master/public/images/logo.svg')
+      end.to_not raise_error
+
+    end
+
+    it 'raises an error if the location is not https://' do
+      location = 'agencies.yml'
+      expect do
+        RemoteSettingsService.load(location)
+      end.to raise_error(RuntimeError, "Location must begin with 'https://': #{location}")
+    end
+
+    it 'raises an error if the file is not found' do
+      location = 'https://github.com/18F/identity-idp/blob/master/public/images/logo'
+      expect do
+        service.load(location)
+      end.to raise_error(RuntimeError, "Error retrieving: #{location}")
+    end
+  end
+
+  describe '.update_setting' do
+    it 'it creates a setting if it does not exist' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      service.update_setting('agencies.yml', location)
+      expect(RemoteSetting.find_by(name: 'agencies.yml').url).to eq(location)
+    end
+
+    it 'it updates the setting if it exists' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      agencies = 'agencies.yml'
+      service.update_setting(agencies, location)
+      location2 = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      service.update_setting(agencies, location2)
+      expect(RemoteSetting.find_by(name: agencies).url).to eq(location2)
+    end
+  end
+
+  describe '.remote?' do
+    it 'returns true if it is a remote location' do
+      location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
+      expect(subject.remote?(location)).to eq(true)
+    end
+
+    it 'returns false if it is not a remote location' do
+      location = 'agencies.yml'
+      expect(subject.remote?(location)).to eq(false)
+    end
+  end
+end

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -112,5 +112,25 @@ RSpec.describe ServiceProviderSeeder do
         end
       end
     end
+
+    context 'when service_providers.yml has a remote setting' do
+      before do
+        location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/service_providers.yml'
+        RemoteSetting.create(name: 'service_providers.yml', url:location,
+                             contents: "test:\n  'issuer1':\n    friendly_name: 'name1'")
+      end
+
+      it 'updates the attributes based on the current value of the yml file' do
+        ServiceProvider.create(issuer: 'issuer1', friendly_name: 'FOO')
+        expect(ServiceProvider.find_by(issuer: 'issuer1').friendly_name).to eq('FOO')
+        run
+        expect(ServiceProvider.find_by(issuer: 'issuer1').friendly_name).to eq('name1')
+      end
+
+      it 'insert the service_provider based on the contents of the remote setting' do
+        run
+        expect(ServiceProvider.find_by(issuer: 'issuer1').friendly_name).to eq('name1')
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**: So we can make changes to existing SP's or add new ones at anytime and not have it coupled to the release process.

**How**: Treat our SP configurations and assets as data. Allow urls for public certs and logos and whitelist the static site or our github repo as a CMS. Create a remote settings table that caches the current version of agencies.yml and service_providers.yml seeder files and update the seeders to conditionally use the remote content.  Provide a rake task that allows us to update, delete, list, and view the current remote settings.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
