### PR TITLE
Update .rubocop.yml and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,16 +10,14 @@ AllCops:
     - '**/Rakefile'
     - '**/Capfile'
   Exclude:
-    - 'db/schema.rb'
-    - 'node_modules/**/*'
-    - 'lib/rspec/user_flow_formatter.rb'
-    - 'lib/user_flow_exporter.rb'
-    - 'scripts/load_testing/*'
-    - 'spec/**/*'
-    - 'tmp/**/*'
     - 'bin/**/*'
     - 'db/migrate/*'
+    - 'db/schema.rb'
+    - 'lib/rspec/user_flow_formatter.rb'
     - 'lib/tasks/create_test_accounts.rb'
+    - 'lib/user_flow_exporter.rb'
+    - 'node_modules/**/*'
+    - 'tmp/**/*'
   TargetRubyVersion: 2.3
   TargetRailsVersion: 5.1
   UseCache: true
@@ -103,10 +101,13 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
-# This is a Rails 5 feature, so it should be disabled until we upgrade
+Naming/VariableName:
+  Exclude:
+    - 'spec/services/pii/nist_encryption_spec.rb'
+
 Rails/HttpPositionalArguments:
   Description: 'Use keyword arguments instead of positional arguments in http method calls.'
-  Enabled: false
+  Enabled: true
   Include:
     - 'spec/**/*'
     - 'test/**/*'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,12 +184,13 @@ class ApplicationController < ActionController::Base
   end
 
   def render_not_found
-    render template: 'pages/page_not_found', layout: false, status: 404, formats: :html
+    render template: 'pages/page_not_found', layout: false, status: :not_found, formats: :html
   end
 
   def render_timeout(exception)
     analytics.track_event(Analytics::RESPONSE_TIMED_OUT, analytics_exception_info(exception))
-    render template: 'pages/page_took_too_long', layout: false, status: 503, formats: :html
+    render template: 'pages/page_took_too_long',
+           layout: false, status: :service_unavailable, formats: :html
   end
 
   def analytics_exception_info(exception)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,6 @@ class PagesController < ApplicationController
   skip_before_action :disable_caching
 
   def page_not_found
-    render layout: false, status: 404, formats: :html
+    render layout: false, status: :not_found, formats: :html
   end
 end

--- a/spec/config/initializers/active_job_logger_patch_spec.rb
+++ b/spec/config/initializers/active_job_logger_patch_spec.rb
@@ -5,19 +5,19 @@ require 'rails_helper'
 # user data from being logged.
 describe ActiveJob::Logging::LogSubscriber do
   it 'overrides the default job logger to output only specified parameters in JSON format' do
-    class FakeJob < ActiveJob::Base
+    class FakeJob < ApplicationJob
       def perform(sensitive_param:); end
     end
 
     # This list corresponds to the initializer's output
-    permitted_attributes = %w(
+    permitted_attributes = %w[
       timestamp
       event_type
       job_class
       job_queue
       job_id
       duration
-    )
+    ]
 
     # In this case, we need to assert before the action which logs, block-style to
     # match the initializer
@@ -27,7 +27,7 @@ describe ActiveJob::Logging::LogSubscriber do
       # [Sidenote: The nested assertions don't seem to be reflected in the spec
       # count--perhaps because of the uncommon block format?--but reversing them
       # will show them failing as expected.]
-      output.keys.each { |k| expect(permitted_attributes).to include(k) }
+      output.each_key { |k| expect(permitted_attributes).to include(k) }
       expect(output.keys).to_not include('sensitive_param')
     end
 

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -37,7 +37,7 @@ describe Idv::ConfirmationsController do
       address2: 'Ste 456',
       city: 'Anywhere',
       state: 'KS',
-      zipcode: '66666'
+      zipcode: '66666',
     }
   end
   let(:profile) { subject.idv_session.profile }

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -53,7 +53,7 @@ describe SignUp::PasswordsController do
     render_views
     it 'instructs crawlers to not index this page' do
       token = 'foo token'
-      user = create(:user, :unconfirmed, confirmation_token: token, confirmation_sent_at: Time.zone.now)
+      create(:user, :unconfirmed, confirmation_token: token, confirmation_sent_at: Time.zone.now)
       get :new, params: { confirmation_token: token }
 
       expect(response.body).to match('<meta content="noindex,nofollow" name="robots" />')

--- a/spec/controllers/test/piv_cac_authentication_test_subject_controller_spec.rb
+++ b/spec/controllers/test/piv_cac_authentication_test_subject_controller_spec.rb
@@ -68,7 +68,7 @@ describe Test::PivCacAuthenticationTestSubjectController do
         uri.to_s
       end
 
-      let(:expected_token) { {'error' => 'certificate.none', 'nonce' => nonce }}
+      let(:expected_token) { { 'error' => 'certificate.none', 'nonce' => nonce } }
       let(:serialized_token) { expected_token.to_json }
       let(:nonce) { 'nonce' }
 

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 describe TwoFactorAuthentication::PivCacVerificationController do
   let(:user) do
     create(:user, :signed_up, :with_piv_or_cac,
-      phone: '+1 (555) 555-0000'
-    )
+           phone: '+1 (555) 555-0000')
   end
 
   let(:nonce) { 'once' }
@@ -17,12 +16,12 @@ describe TwoFactorAuthentication::PivCacVerificationController do
     allow(PivCacService).to receive(:decode_token).with('good-token').and_return(
       'uuid' => user.x509_dn_uuid,
       'dn' => x509_subject,
-      'nonce' => nonce,
+      'nonce' => nonce
     )
     allow(PivCacService).to receive(:decode_token).with('good-other-token').and_return(
       'uuid' => user.x509_dn_uuid + 'X',
       'dn' => x509_subject + 'X',
-      'nonce' => nonce,
+      'nonce' => nonce
     )
     allow(PivCacService).to receive(:decode_token).with('bad-token').and_return(
       'uuid' => 'bad-uuid',
@@ -58,7 +57,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         expect(subject.current_user).to receive(:confirm_piv_cac?).and_return(true)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
 
-        get :show, params: { token:  'good-token' }
+        get :show, params: { token: 'good-token' }
 
         expect(response).to redirect_to account_path
         expect(subject.user_session[:decrypted_x509]).to eq({
@@ -73,7 +72,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
           attributes: { second_factor_attempts_count: 1 }
         ).call
 
-        get :show, params: { token:  'good-token' }
+        get :show, params: { token: 'good-token' }
 
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
       end
@@ -88,7 +87,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         }
         expect(@analytics).to receive(:track_event).with(Analytics::MULTI_FACTOR_AUTH, attributes)
 
-        get :show, params: { token:  'good-token' }
+        get :show, params: { token: 'good-token' }
       end
     end
 
@@ -170,9 +169,8 @@ describe TwoFactorAuthentication::PivCacVerificationController do
 
       let(:user) do
         create(:user, :signed_up, :with_piv_or_cac,
-          second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
-          second_factor_attempts_count: 3
-        )
+               second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
+               second_factor_attempts_count: 3)
       end
 
       describe 'when user submits an incorrect piv/cac' do

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -76,7 +76,6 @@ describe Users::PhoneSetupController do
           :create,
           params: {
             user_phone_form: { phone: '703-555-0100',
-                              #  otp_delivery_preference: 'voice',
                                international_code: 'US' },
           }
         )
@@ -110,7 +109,6 @@ describe Users::PhoneSetupController do
           :create,
           params: {
             user_phone_form: { phone: '703-555-0100',
-                              #  otp_delivery_preference: :sms,
                                international_code: 'US' },
           }
         )
@@ -143,7 +141,6 @@ describe Users::PhoneSetupController do
           :create,
           params: {
             user_phone_form: { phone: '703-555-0100',
-                              #  otp_delivery_preference: :sms,
                                international_code: 'US' },
           }
         )

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Users::PivCacAuthenticationSetupController do
-
   describe 'when not signed in' do
     describe 'GET index' do
       it 'redirects to root url' do
@@ -33,9 +32,7 @@ describe Users::PivCacAuthenticationSetupController do
   describe 'when signing in' do
     before(:each) { stub_sign_in_before_2fa(user) }
     let(:user) do
-      create(:user, :signed_up, :with_piv_or_cac,
-        phone: '+1 (555) 555-0000'
-      )
+      create(:user, :signed_up, :with_piv_or_cac, phone: '+1 (555) 555-0000')
     end
 
     describe 'GET index' do
@@ -58,9 +55,7 @@ describe Users::PivCacAuthenticationSetupController do
 
     context 'without associated piv/cac' do
       let(:user) do
-        create(:user, :signed_up,
-          phone: '+1 (555) 555-0000'
-        )
+        create(:user, :signed_up, phone: '+1 (555) 555-0000')
       end
 
       before(:each) do
@@ -83,7 +78,7 @@ describe Users::PivCacAuthenticationSetupController do
       let(:bad_token) { 'bad-token' }
       let(:bad_token_response) do
         {
-          'error' => 'certificate.bad' ,
+          'error' => 'certificate.bad',
           'nonce' => nonce,
         }
       end
@@ -98,22 +93,24 @@ describe Users::PivCacAuthenticationSetupController do
 
         context 'when redirected with a good token' do
           it 'redirects to account page' do
-            get :new, params: {token: good_token}
+            get :new, params: { token: good_token }
             expect(response).to redirect_to(account_url)
           end
 
           it 'sets the piv/cac session information' do
-            get :new, params: {token: good_token}
-            expect(subject.user_session[:decrypted_x509]).to eq ({
+            get :new, params: { token: good_token }
+            json = {
               'subject' => 'some dn',
-              'presented' => true
-            }.to_json)
+              'presented' => true,
+            }.to_json
+
+            expect(subject.user_session[:decrypted_x509]).to eq json
           end
         end
 
         context 'when redirected with an error token' do
           it 'renders the error template' do
-            get :new, params: {token: bad_token}
+            get :new, params: { token: bad_token }
             expect(response).to render_template(:error)
           end
 

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -6,7 +6,7 @@ describe Users::TotpSetupController, devise: true do
       expect(subject).to have_actions(
         :before,
         :authenticate_user!,
-        [:confirm_two_factor_authenticated, if: :two_factor_enabled?],
+        [:confirm_two_factor_authenticated, if: :two_factor_enabled?]
       )
     end
   end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -50,7 +50,7 @@ describe Users::TwoFactorAuthenticationSetupController do
       voice_params = {
         two_factor_options_form: {
           selection: 'voice',
-        }
+        },
       }
       params = ActionController::Parameters.new(voice_params)
       response = FormResponse.new(success: true, errors: {}, extra: { selection: 'voice' })

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -43,7 +43,7 @@ feature 'Accessibility on IDV pages', :js, idv_job: true do
     end
 
     scenario 'review page' do
-      user = sign_in_and_2fa_user
+      sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
       click_idv_continue
@@ -55,7 +55,7 @@ feature 'Accessibility on IDV pages', :js, idv_job: true do
     end
 
     scenario 'personal key / confirmation page' do
-      user = sign_in_and_2fa_user
+      sign_in_and_2fa_user
       visit idv_session_path
       fill_out_idv_form_ok
       click_idv_continue

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -32,8 +32,10 @@ describe 'Account history' do
   let(:identity_with_link_timestamp) { identity_with_link.decorate.happened_at_in_words }
   let(:usps_mail_sent_again_timestamp) { usps_mail_sent_again_event.decorate.happened_at_in_words }
   let(:identity_without_link_timestamp) { identity_without_link.decorate.happened_at_in_words }
-  let(:new_personal_key_event) { create(:event, event_type: :new_personal_key,
-                                        user: user, created_at: Time.zone.now - 40.days) }
+  let(:new_personal_key_event) do
+    create(:event, event_type: :new_personal_key,
+                   user: user, created_at: Time.zone.now - 40.days)
+  end
 
   before do
     sign_in_and_2fa_user(user)
@@ -42,7 +44,13 @@ describe 'Account history' do
   end
 
   scenario 'viewing account history' do
-    [account_created_event, usps_mail_sent_event, usps_mail_sent_again_event, new_personal_key_event].each do |event|
+    events = [
+      account_created_event,
+      usps_mail_sent_event,
+      usps_mail_sent_again_event,
+      new_personal_key_event,
+    ]
+    events.each do |event|
       decorated_event = event.decorate
       expect(page).to have_content(decorated_event.event_type)
       expect(page).to have_content(decorated_event.happened_at_in_words)

--- a/spec/features/idv/steps/jurisdiction_step_spec.rb
+++ b/spec/features/idv/steps/jurisdiction_step_spec.rb
@@ -29,7 +29,8 @@ feature 'idv jurisdiction step' do
         select 'Alabama', from: 'jurisdiction_state'
         click_idv_continue
 
-        expect(page).to have_current_path(idv_jurisdiction_fail_path(reason: :unsupported_jurisdiction))
+        expect(page).
+          to have_current_path(idv_jurisdiction_fail_path(reason: :unsupported_jurisdiction))
         expect(page).to have_content(t('idv.titles.unsupported_jurisdiction', state: 'Alabama'))
       end
     end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -574,12 +574,15 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
     allow(Figaro.env).to receive(:cloudhsm_enabled).and_return('true')
     SamlIdp.configure { |config| SamlIdpEncryptionConfigurator.configure(config, true) }
     allow(PKCS11).to receive(:open).and_return('true')
-    allow_any_instance_of(SamlIdp::Configurator).to receive_message_chain(:pkcs11, :active_slots, :first, :open).and_yield(MockSession)
+    allow_any_instance_of(SamlIdp::Configurator).
+      to receive_message_chain(:pkcs11, :active_slots, :first, :open).and_yield(MockSession)
     allow(MockSession).to receive(:login).and_return(true)
     allow(MockSession).to receive(:logout).and_return(true)
     allow(MockSession).to receive_message_chain(:find_objects, :first).and_return(true)
-    allow(MockSession).to receive(:sign) do |algorithm, key, input|
-      JWT::Algos::Rsa.sign(JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key))
+    allow(MockSession).to receive(:sign) do |_algorithm, _key, input|
+      JWT::Algos::Rsa.sign(
+        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key)
+      )
     end
   end
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -283,7 +283,8 @@ shared_examples 'saml api' do |cloudhsm_enabled|
     allow(Figaro.env).to receive(:cloudhsm_enabled).and_return('true')
     SamlIdp.configure { |config| SamlIdpEncryptionConfigurator.configure(config, true) }
     allow(PKCS11).to receive(:open).and_return('true')
-    allow_any_instance_of(SamlIdp::Configurator).to receive_message_chain(:pkcs11, :active_slots, :first, :open).and_yield(MockSession)
+    allow_any_instance_of(SamlIdp::Configurator).
+      to receive_message_chain(:pkcs11, :active_slots, :first, :open).and_yield(MockSession)
     allow(MockSession).to receive(:login).and_return(true)
     allow(MockSession).to receive(:logout).and_return(true)
     allow(MockSession).to receive_message_chain(:find_objects, :first).and_return(true)

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -62,7 +62,6 @@ feature 'Two Factor Authentication' do
         fill_in 'Phone', with: unsupported_phone
         click_send_security_code
 
-
         expect(current_path).to eq phone_setup_path
 
         expect(page).to have_content t(
@@ -111,7 +110,7 @@ feature 'Two Factor Authentication' do
   end
 
   def select_country_and_type_phone_number(country:, number:)
-    find(".selected-flag").click
+    find('.selected-flag').click
     find(".country[data-country-code='#{country}']:not(.preferred)").click
     phone_field.send_keys(number)
   end
@@ -494,11 +493,10 @@ feature 'Two Factor Authentication' do
 
       nonce = visit_login_two_factor_piv_cac_and_get_nonce
 
-      visit_piv_cac_service(login_two_factor_piv_cac_path, {
-        uuid: user.x509_dn_uuid,
-        dn: "C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234",
-        nonce: nonce
-      })
+      visit_piv_cac_service(login_two_factor_piv_cac_path,
+                            uuid: user.x509_dn_uuid,
+                            dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                            nonce: nonce)
       expect(current_path).to eq account_path
     end
 
@@ -510,13 +508,12 @@ feature 'Two Factor Authentication' do
 
       nonce = visit_login_two_factor_piv_cac_and_get_nonce
 
-      visit_piv_cac_service(login_two_factor_piv_cac_path, {
-        uuid: user.x509_dn_uuid + 'X',
-        dn: "C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.12345",
-        nonce: nonce
-      })
+      visit_piv_cac_service(login_two_factor_piv_cac_path,
+                            uuid: user.x509_dn_uuid + 'X',
+                            dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.12345',
+                            nonce: nonce)
       expect(current_path).to eq login_two_factor_piv_cac_path
-      expect(page).to have_content(t("devise.two_factor_authentication.invalid_piv_cac"))
+      expect(page).to have_content(t('devise.two_factor_authentication.invalid_piv_cac'))
     end
   end
 

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 feature 'PIV/CAC Management' do
-
   def find_form(page, attributes)
     page.all('form').detect do |form|
       attributes.all? { |key, value| form[key] == value }
@@ -21,7 +20,7 @@ feature 'PIV/CAC Management' do
         Identity.create(
           user_id: user.id,
           service_provider: 'http://localhost:3000',
-          last_authenticated_at: Time.now,
+          last_authenticated_at: Time.zone.now
         )
       end
 
@@ -44,11 +43,10 @@ feature 'PIV/CAC Management' do
         expect(page).to have_link(t('forms.piv_cac_setup.submit'))
         nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
 
-        visit_piv_cac_service(setup_piv_cac_url, {
-          nonce: nonce,
-          uuid: uuid,
-          subject: 'SomeIgnoredSubject'
-        })
+        visit_piv_cac_service(setup_piv_cac_url,
+                              nonce: nonce,
+                              uuid: uuid,
+                              subject: 'SomeIgnoredSubject')
 
         expect(current_path).to eq account_path
 
@@ -75,7 +73,7 @@ feature 'PIV/CAC Management' do
         Identity.create(
           user_id: user.id,
           service_provider: 'http://localhost:3000',
-          last_authenticated_at: Time.now,
+          last_authenticated_at: Time.zone.now
         )
       end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -168,11 +168,12 @@ feature 'Sign Up' do
     sign_in_user(user)
     visit authenticator_setup_path
 
-    expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
+    expect(page).
+      to have_current_path login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
   end
 
   it 'prompts to sign in when accessing authenticator_setup_path before signing in' do
-    user = create(:user, :signed_up)
+    create(:user, :signed_up)
     visit authenticator_setup_path
 
     expect(page).to have_current_path root_path

--- a/spec/forms/idv/jurisdiction_form_spec.rb
+++ b/spec/forms/idv/jurisdiction_form_spec.rb
@@ -9,7 +9,7 @@ describe Idv::JurisdictionForm do
   describe '#submit' do
     context 'when the form is valid' do
       it 'returns a successful form response' do
-        result = subject.submit({ state: supported_jurisdiction })
+        result = subject.submit(state: supported_jurisdiction)
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(true)
@@ -19,7 +19,7 @@ describe Idv::JurisdictionForm do
 
     context 'when the form is invalid' do
       it 'returns an unsuccessful form response' do
-        result = subject.submit({ state: unsupported_jurisdiction })
+        result = subject.submit(state: unsupported_jurisdiction)
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(false)
@@ -30,7 +30,7 @@ describe Idv::JurisdictionForm do
 
   describe 'presence validations' do
     it 'is invalid when required attribute is not present' do
-      subject.submit({ state: nil })
+      subject.submit(state: nil)
 
       expect(subject).to_not be_valid
     end
@@ -38,7 +38,7 @@ describe Idv::JurisdictionForm do
 
   describe 'jurisdiction validity' do
     it 'populates error for unsupported jurisdiction ' do
-      subject.submit({ state: unsupported_jurisdiction })
+      subject.submit(state: unsupported_jurisdiction)
       expect(subject.valid?).to eq false
       expect(subject.errors[:state]).to eq [I18n.t('idv.errors.unsupported_jurisdiction')]
     end

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -32,7 +32,7 @@ describe TwoFactorOptionsForm do
           and_return(user_updater)
         expect(user_updater).to receive(:call)
 
-        result = subject.submit(selection: 'voice')
+        subject.submit(selection: 'voice')
       end
     end
 
@@ -40,7 +40,7 @@ describe TwoFactorOptionsForm do
       it "does not update the user's otp_delivery_preference" do
         expect(UpdateUser).to_not receive(:new)
 
-        result = subject.submit(selection: 'sms')
+        subject.submit(selection: 'sms')
       end
     end
 
@@ -48,7 +48,7 @@ describe TwoFactorOptionsForm do
       it "does not update the user's otp_delivery_preference" do
         expect(UpdateUser).to_not receive(:new)
 
-        result = subject.submit(selection: 'auth_app')
+        subject.submit(selection: 'auth_app')
       end
     end
   end

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -159,7 +159,7 @@ describe UserPhoneForm do
           otp_delivery_preference: 'voice',
         }
 
-        result = subject.submit(params)
+        subject.submit(params)
       end
     end
 
@@ -167,7 +167,7 @@ describe UserPhoneForm do
       it "does not update the user's otp_delivery_preference" do
         expect(UpdateUser).to_not receive(:new)
 
-        result = subject.submit(params)
+        subject.submit(params)
       end
     end
 

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -19,7 +19,7 @@ describe UserPivCacSetupForm do
         {
           'uuid' => x509_dn_uuid,
           'subject' => 'x509-subject',
-          'nonce' => nonce
+          'nonce' => nonce,
         }
       end
 
@@ -122,7 +122,7 @@ describe UserPivCacSetupForm do
     end
 
     context 'when token is missing' do
-      let(:token) { }
+      let(:token) {}
 
       it 'returns FormResponse with success: false' do
         result = instance_double(FormResponse)

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -18,7 +18,7 @@ describe UserPivCacVerificationForm do
         {
           'uuid' => x509_dn_uuid,
           'subject' => 'x509-subject',
-          'nonce' => nonce
+          'nonce' => nonce,
         }
       end
 
@@ -96,7 +96,7 @@ describe UserPivCacVerificationForm do
     end
 
     context 'when token is missing' do
-      let(:token) { }
+      let(:token) {}
 
       it 'returns FormResponse with success: false' do
         result = instance_double(FormResponse)

--- a/spec/lib/cloudhsm_jwt_spec.rb
+++ b/spec/lib/cloudhsm_jwt_spec.rb
@@ -54,10 +54,14 @@ describe CloudhsmJwt do
     allow(MockSession).to receive(:login).and_return(true)
     allow(MockSession).to receive(:logout).and_return(true)
     allow(MockSession).to receive_message_chain(:find_objects, :first).and_return(true)
-    allow(MockSession).to receive(:sign) do |algorithm, key, input|
-      JWT::Algos::Rsa.sign(JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key))
+    allow(MockSession).to receive(:sign) do |_algorithm, _key, input|
+      JWT::Algos::Rsa.sign(
+        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key)
+      )
     end
-    allow(SamlIdp).to receive_message_chain(:config, :pkcs11, :active_slots, :first, :open).and_yield(MockSession)
+    allow(SamlIdp).
+      to receive_message_chain(:config, :pkcs11, :active_slots, :first, :open).
+      and_yield(MockSession)
     allow(SamlIdp).to receive_message_chain(:config, :cloudhsm_pin).and_return(true)
   end
 end

--- a/spec/lib/queue_config_spec.rb
+++ b/spec/lib/queue_config_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Upaya::QueueConfig do
   describe '.choose_queue_adapter' do
     it 'raises ArgumentError given invalid choice' do
       expect(Figaro.env).to receive(:queue_adapter_weights).and_return('{"invalid": 1}')
-      expect {
+      expect do
         Upaya::QueueConfig.choose_queue_adapter
-      }.to raise_error(ArgumentError, /Unknown queue adapter/)
+      end.to raise_error(ArgumentError, /Unknown queue adapter/)
     end
 
     it 'handles sidekiq' do

--- a/spec/lib/random_tools_spec.rb
+++ b/spec/lib/random_tools_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Upaya::RandomTools do
   describe '#random_weighted_sample' do
     it 'raises ArgumentError given empty choices' do
-      expect {
+      expect do
         Upaya::RandomTools.random_weighted_sample({})
-      }.to raise_error(ArgumentError, /empty choices/)
+      end.to raise_error(ArgumentError, /empty choices/)
     end
 
     it 'handles equal weights -- 0' do
@@ -39,21 +39,21 @@ RSpec.describe Upaya::RandomTools do
     end
 
     it 'rejects non-integer weights' do
-      expect {
+      expect do
         Upaya::RandomTools.random_weighted_sample(a: 1.5)
-      }.to raise_error(ArgumentError, /integer/)
+      end.to raise_error(ArgumentError, /integer/)
     end
 
     it 'rejects negative weights' do
-      expect {
+      expect do
         Upaya::RandomTools.random_weighted_sample(a: 10, b: -1)
-      }.to raise_error(ArgumentError, />= 0/)
+      end.to raise_error(ArgumentError, />= 0/)
     end
 
     it 'rejects weights sum to zero' do
-      expect {
+      expect do
         Upaya::RandomTools.random_weighted_sample(a: 0)
-      }.to raise_error(ArgumentError, /non-zero/)
+      end.to raise_error(ArgumentError, /non-zero/)
     end
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -12,7 +12,6 @@ describe Profile do
       last_name: 'Doe'
     )
   end
-  #let(:user_access_key) { user.unlock_user_access_key(user.password) }
 
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:usps_confirmation_codes).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -324,7 +324,9 @@ describe User do
   describe 'deleting identities' do
     it 'does not delete identities when the user is destroyed preventing uuid reuse' do
       user = create(:user, :signed_up)
-      user.identities << Identity.create(service_provider: 'entity_id', session_uuid: SecureRandom.uuid)
+      user.identities << Identity.create(
+        service_provider: 'entity_id', session_uuid: SecureRandom.uuid
+      )
       user_id = user.id
       user.destroy!
       expect(Identity.where(user_id: user_id).length).to eq 1

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
     context 'when a piv/cac was used as second factor' do
       let(:x509) do
         {
-          subject: x509_subject
+          subject: x509_subject,
         }
       end
 
@@ -71,7 +71,6 @@ RSpec.describe OpenidConnectUserInfoPresenter do
           end
         end
       end
-
     end
 
     context 'when there is decrypted loa3 session data in redis' do

--- a/spec/presenters/piv_cac_authentication_setup_error_presenter_spec.rb
+++ b/spec/presenters/piv_cac_authentication_setup_error_presenter_spec.rb
@@ -37,13 +37,13 @@ describe PivCacAuthenticationSetupErrorPresenter do
   end
 
   describe '#title' do
-    let(:expected_title) { t('titles.piv_cac_setup.' + error ) }
+    let(:expected_title) { t('titles.piv_cac_setup.' + error) }
 
     it { expect(presenter.title).to eq expected_title }
   end
 
   describe '#heading' do
-    let(:expected_heading) { t('headings.piv_cac_setup.' + error ) }
+    let(:expected_heading) { t('headings.piv_cac_setup.' + error) }
 
     it { expect(presenter.heading).to eq expected_heading }
   end

--- a/spec/presenters/piv_cac_authentication_setup_presenter_spec.rb
+++ b/spec/presenters/piv_cac_authentication_setup_presenter_spec.rb
@@ -3,18 +3,17 @@ require 'rails_helper'
 describe PivCacAuthenticationSetupPresenter do
   let(:presenter) { described_class.new(form) }
   let(:form) do
-    OpenStruct.new(
-    )
+    OpenStruct.new
   end
 
   describe '#title' do
-    let(:expected_title) { t('titles.piv_cac_setup.new' ) }
+    let(:expected_title) { t('titles.piv_cac_setup.new') }
 
     it { expect(presenter.title).to eq expected_title }
   end
 
   describe '#heading' do
-    let(:expected_heading) { t('headings.piv_cac_setup.new' ) }
+    let(:expected_heading) { t('headings.piv_cac_setup.new') }
 
     it { expect(presenter.heading).to eq expected_heading }
   end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -9,7 +9,7 @@ describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
   end
 
   let(:user_email) { 'user@example.com' }
-  let(:reauthn) { }
+  let(:reauthn) {}
   let(:presenter) { presenter_with(reauthn: reauthn, user_email: user_email) }
 
   describe '#header' do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -205,7 +205,7 @@ describe 'throttling requests' do
       end
     end
 
-    context 'when number of logins per stripped/downcased email + ip is higher than limit per period' do
+    context 'when number of logins per email + ip is higher than limit per period' do
       it 'throttles with a custom response' do
         analytics = instance_double(Analytics)
         allow(Analytics).to receive(:new).and_return(analytics)
@@ -213,7 +213,7 @@ describe 'throttling requests' do
 
         (logins_per_email_and_ip_limit + 1).times do |index|
           post '/', params: {
-            user: { email: index % 2 == 0 ? 'test@example.com' : ' test@EXAMPLE.com   ' },
+            user: { email: index.even? ? 'test@example.com' : ' test@EXAMPLE.com   ' },
           }, headers: { REMOTE_ADDR: '1.2.3.4' }
         end
 

--- a/spec/services/encryption/encryptors/user_access_key_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/user_access_key_encryptor_spec.rb
@@ -57,20 +57,20 @@ describe Encryption::Encryptors::UserAccessKeyEncryptor do
     end
 
     it 'can decrypt contents created by different user access keys if the password is the same' do
-      uak_1 = Encryption::UserAccessKey.new(password: password, salt: salt)
-      uak_2 = Encryption::UserAccessKey.new(password: password, salt: salt)
-      payload_1 = described_class.new(uak_1).encrypt(plaintext)
-      payload_2 = described_class.new(uak_2).encrypt(plaintext)
+      uak1 = Encryption::UserAccessKey.new(password: password, salt: salt)
+      uak2 = Encryption::UserAccessKey.new(password: password, salt: salt)
+      payload1 = described_class.new(uak1).encrypt(plaintext)
+      payload2 = described_class.new(uak2).encrypt(plaintext)
 
-      expect(payload_1).to_not eq(payload_2)
+      expect(payload1).to_not eq(payload2)
 
       expect(user_access_key).to receive(:unlock).twice.and_call_original
 
-      result_1 = subject.decrypt(payload_1)
-      result_2 = subject.decrypt(payload_2)
+      result1 = subject.decrypt(payload1)
+      result2 = subject.decrypt(payload2)
 
-      expect(result_1).to eq(plaintext)
-      expect(result_2).to eq(plaintext)
+      expect(result1).to eq(plaintext)
+      expect(result2).to eq(plaintext)
     end
   end
 end

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -86,7 +86,7 @@ describe Idv::Agent do
             errors: {},
             messages: [resolution_message, state_id_message],
             success: true,
-            exception: nil,
+            exception: nil
           )
         end
       end
@@ -99,7 +99,7 @@ describe Idv::Agent do
             errors: { bad: ['stuff'] },
             messages: [failed_message],
             success: false,
-            exception: nil,
+            exception: nil
           )
         end
       end

--- a/spec/services/idv/proofer_spec.rb
+++ b/spec/services/idv/proofer_spec.rb
@@ -163,7 +163,7 @@ describe Idv::Proofer do
       let(:vendors) { { bar: class_double('Proofer::Base') } }
 
       it 'does raises an error' do
-        expect { subject }.to raise_error("No proofer vendor configured for stage(s): foo")
+        expect { subject }.to raise_error('No proofer vendor configured for stage(s): foo')
       end
     end
   end
@@ -200,20 +200,21 @@ describe Idv::Proofer do
       before do
         expect(config).to receive(:mock_fallback).and_return(false)
         expect(config).to receive(:raise_on_missing_proofers).and_return(true)
-        expect(described_class).to receive(:loaded_vendors).and_return(loaded_vendors, loaded_vendors)
+        expect(described_class).
+          to receive(:loaded_vendors).and_return(loaded_vendors, loaded_vendors)
       end
 
       context 'when a stage is missing an external vendor' do
         let(:stages) { %i[foo baz] }
 
         it 'raises' do
-          expect { subject }.to raise_error("No proofer vendor configured for stage(s): baz")
+          expect { subject }.to raise_error('No proofer vendor configured for stage(s): baz')
         end
       end
 
       context 'when all stages have vendors' do
         it 'maps the vendors, ignoring non-configured ones' do
-          expect(subject).to eq({ foo: loaded_vendors.second })
+          expect(subject).to eq(foo: loaded_vendors.second)
         end
       end
     end
@@ -242,7 +243,8 @@ describe Idv::Proofer do
       before do
         expect(config).to receive(:mock_fallback).and_return(false)
         expect(config).to receive(:raise_on_missing_proofers).and_return(false)
-        expect(described_class).to receive(:loaded_vendors).and_return(loaded_vendors, loaded_vendors)
+        expect(described_class).
+          to receive(:loaded_vendors).and_return(loaded_vendors, loaded_vendors)
       end
 
       context 'when a stage is missing an external vendor' do

--- a/spec/services/personal_key_generator_spec.rb
+++ b/spec/services/personal_key_generator_spec.rb
@@ -46,7 +46,10 @@ describe PersonalKeyGenerator do
       generator = PersonalKeyGenerator.new(user)
       generator.create
 
-      encrypted_recovery_code_data = JSON.parse(user.encrypted_recovery_code_digest, symbolize_names: true)
+      encrypted_recovery_code_data = JSON.parse(
+        user.encrypted_recovery_code_digest, symbolize_names: true
+      )
+
       expect(
         encrypted_recovery_code_data[:encryption_key]
       ).to eq(user.personal_key.split('.').first)

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Pii::Attributes do
-  # let(:user_access_key) { Encryption::UserAccessKey.new(password: 'sekrit', salt: SecureRandom.uuid) }
   let(:password) { 'I am the password' }
 
   describe '#new_from_hash' do

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -45,7 +45,6 @@ describe Pii::Cacher do
       # Create a new user object to drop the memoized encrypted attributes
       user_id = user.id
       reloaded_user = User.find(user_id)
-      reloaded_profile = user.profiles.first
 
       described_class.new(reloaded_user, user_session).save(password)
 

--- a/spec/services/pii/nist_encryption_spec.rb
+++ b/spec/services/pii/nist_encryption_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 # duplicated code in order to explicitly show the algorithm at work.
 
 describe 'NIST Encryption Model' do
-# Generate and store a 128-bit salt S.
-# Z1, Z2 = scrypt(S, password)   # split 256-bit output into two halves
-# Generate random R.
-# D = KMS_GCM_Encrypt(key=server_secret, plaintext=R) ^ Z1
-# E = hash( Z2 + R )
-# F = hash(E)
-# C = GCM_Encrypt(key = E, plaintext=PII)  #occurs outside AWS-KMS
-# Store F in password file, and store C and D.
-#
-# To decrypt PII and to verify passwords:
-# Compute Z1’, Z2’ = scrypt(S, password’)
-# R’ = KMS_GCM_Decrypt(key=server_secret, ciphertext=(D ^ Z1*)).
-# E’ = hash( Z2’ + R’)
-# F’ = hash(E’)
-# Check to see if F’ matches the entry in the password file; if so, allow the login.
-# plaintext_PII = GCM_Decrypt(key=E’, ciphertext = C)
+  # Generate and store a 128-bit salt S.
+  # Z1, Z2 = scrypt(S, password)   # split 256-bit output into two halves
+  # Generate random R.
+  # D = KMS_GCM_Encrypt(key=server_secret, plaintext=R) ^ Z1
+  # E = hash( Z2 + R )
+  # F = hash(E)
+  # C = GCM_Encrypt(key = E, plaintext=PII)  #occurs outside AWS-KMS
+  # Store F in password file, and store C and D.
+  #
+  # To decrypt PII and to verify passwords:
+  # Compute Z1, Z2 = scrypt(S, password)
+  # R = KMS_GCM_Decrypt(key=server_secret, ciphertext=(D ^ Z1)).
+  # E = hash(Z2 + R)
+  # F = hash(E)
+  # Check to see if F matches the entry in the password file; if so, allow the login.
+  # plaintext_PII = GCM_Decrypt(key=E, ciphertext = C)
 
   before do
     allow(FeatureManagement).to receive(:use_kms?).and_return(true)

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -10,17 +10,17 @@ describe PivCacService do
       end
 
       it 'raises an error if no token provided' do
-        expect {
+        expect do
           PivCacService.decode_token
-        }.to raise_error ArgumentError
+        end.to raise_error ArgumentError
       end
 
       it 'returns the test data' do
         token = 'TEST:{"uuid":"hijackedUUID","dn":"hijackedDN"}'
-        expect(PivCacService.decode_token(token)).to eq({
+        expect(PivCacService.decode_token(token)).to eq(
           'uuid' => 'hijackedUUID',
           'dn' => 'hijackedDN'
-        })
+        )
       end
     end
 
@@ -30,7 +30,7 @@ describe PivCacService do
       end
 
       it 'returns an error' do
-        expect(PivCacService.decode_token('foo')).to eq({ 'error' => 'service.disabled' })
+        expect(PivCacService.decode_token('foo')).to eq('error' => 'service.disabled')
       end
     end
 
@@ -41,9 +41,9 @@ describe PivCacService do
         end
 
         it 'raises an error if no token provided' do
-          expect {
+          expect do
             PivCacService.decode_token
-          }.to raise_error ArgumentError
+          end.to raise_error ArgumentError
         end
 
         describe 'when configured with a user-facing endpoint' do
@@ -96,18 +96,18 @@ describe PivCacService do
         end
 
         it 'returns the decoded JSON from the target service' do
-          expect(PivCacService.decode_token('foo')).to eq({
+          expect(PivCacService.decode_token('foo')).to eq(
             'dn' => 'dn',
             'uuid' => 'uuid'
-          })
+          )
         end
 
         describe 'with test data' do
           it 'returns an error' do
             token = 'TEST:{"uuid":"hijackedUUID","dn":"hijackedDN"}'
-            expect(PivCacService.decode_token(token)).to eq({
+            expect(PivCacService.decode_token(token)).to eq(
               'error' => 'token.bad'
-            })
+            )
           end
         end
       end
@@ -130,9 +130,9 @@ describe PivCacService do
 
         it 'returns an error' do
           token = 'foo'
-          expect(PivCacService.decode_token(token)).to eq({
+          expect(PivCacService.decode_token(token)).to eq(
             'error' => 'token.bad'
-          })
+          )
         end
       end
     end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -78,7 +78,8 @@ describe TwilioService do
       raw_message = 'Unable to create record: Account not authorized to call +123456789012.'
       error_code = '21215'
       status_code = 400
-      sanitized_message = "[HTTP #{status_code}] #{error_code} : Unable to create record: Account " \
+      sanitized_message = "[HTTP #{status_code}] #{error_code} : " \
+                          "Unable to create record: Account " \
                           "not authorized to call +12345#######.\n\n"
 
       service = TwilioService.new

--- a/spec/services/x509/attribute_spec.rb
+++ b/spec/services/x509/attribute_spec.rb
@@ -4,8 +4,6 @@ describe X509::Attribute do
   let(:x509_subject) { 'O=US, OU=DoD, CN=John.Doe.1234' }
 
   subject { described_class.new(raw: x509_subject) }
-
-  # rubocop:disable UnneededInterpolation
   describe 'delegation' do
     it 'delegates to raw' do
       expect(subject.blank?).to eq false
@@ -15,5 +13,4 @@ describe X509::Attribute do
       expect(subject).to eq x509_subject
     end
   end
-  # rubocop:enable UnneededInterpolation
 end

--- a/spec/services/x509/attributes_spec.rb
+++ b/spec/services/x509/attributes_spec.rb
@@ -12,7 +12,7 @@ describe X509::Attributes do
 
     it 'initializes from complex Hash' do
       x509 = described_class.new_from_hash(
-        subject: { raw: 'O=US, OU=DoD, CN=José', norm: 'O=US, OU=DoD, CN=Jose' },
+        subject: { raw: 'O=US, OU=DoD, CN=José', norm: 'O=US, OU=DoD, CN=Jose' }
       )
 
       expect(x509.subject.to_s).to eq 'O=US, OU=DoD, CN=José'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,7 @@
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 require 'rack_session_access/capybara'
-require "selenium/webdriver"
+require 'selenium/webdriver'
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
@@ -9,8 +9,8 @@ Capybara.register_driver :headless_chrome do |app|
   )
 
   Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -88,7 +88,7 @@ module IdvHelper
     click_on t('idv.buttons.cancel')
   end
 
-  def complete_idv_profile_ok(user, password = user_password)
+  def complete_idv_profile_ok(_user, password = user_password)
     fill_out_idv_form_ok
     click_idv_continue
     click_idv_continue

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -71,7 +71,9 @@ module IdvStepHelper
   end
 
   alias complete_idv_steps_before_review_step complete_idv_steps_with_phone_before_review_step
+  # rubocop:disable Metrics/LineLength
   alias complete_idv_steps_before_confirmation_step complete_idv_steps_with_phone_before_confirmation_step
+  # rubocop:enable Metrics/LineLength
 
   def complete_idv_steps_with_usps_before_review_step(user = user_with_2fa)
     complete_idv_steps_before_usps_step(user)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -107,9 +107,8 @@ module Features
 
     def user_with_piv_cac
       create(:user, :signed_up, :with_piv_or_cac,
-        phone: '+1 (555) 555-0000',
-        password: VALID_PASSWORD
-      )
+             phone: '+1 (555) 555-0000',
+             password: VALID_PASSWORD)
     end
 
     def confirm_last_user
@@ -142,8 +141,8 @@ module Features
       visit login_two_factor_piv_cac_path
       stub_piv_cac_service
       visit_piv_cac_service(
-        dn: "C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234",
-        uuid: user.x509_dn_uuid,
+        dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+        uuid: user.x509_dn_uuid
       )
     end
 

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -9,7 +9,8 @@ shared_examples 'remember device' do
   it 'requires 2FA on sign in after expiration' do
     user = remember_device_and_sign_out_user
 
-    Timecop.travel (Figaro.env.remember_device_expiration_days.to_i + 1).days.from_now do
+    days_to_travel = (Figaro.env.remember_device_expiration_days.to_i + 1).days.from_now
+    Timecop.travel days_to_travel do
       sign_in_user(user)
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))

--- a/spec/views/accounts/show.html.slim_spec.rb
+++ b/spec/views/accounts/show.html.slim_spec.rb
@@ -32,7 +32,7 @@ describe 'accounts/show.html.slim' do
 
       expect(rendered).to have_content t('account.items.delete_your_account', app: APP_NAME)
       expect(rendered).
-        to have_link(t('account.links.delete_account'), href: account_delete_path )
+        to have_link(t('account.links.delete_account'), href: account_delete_path)
     end
   end
 

--- a/spec/views/idv/come_back_later/show.html.slim_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.slim_spec.rb
@@ -24,8 +24,8 @@ describe 'idv/come_back_later/show.html.slim' do
       render
       expect(rendered).to have_content(
         strip_tags(t(
-          'idv.messages.come_back_later_sp_html',
-          sp: @decorated_session.sp_name
+                     'idv.messages.come_back_later_sp_html',
+                     sp: @decorated_session.sp_name
         ))
       )
     end
@@ -59,8 +59,8 @@ describe 'idv/come_back_later/show.html.slim' do
       render
       expect(rendered).to have_content(
         strip_tags(t(
-          'idv.messages.come_back_later_no_sp_html',
-          app: APP_NAME
+                     'idv.messages.come_back_later_no_sp_html',
+                     app: APP_NAME
         ))
       )
     end

--- a/spec/views/users/delete/show.html.slim_spec.rb
+++ b/spec/views/users/delete/show.html.slim_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe 'users/delete/show.html.slim' do
-  let(:user) {build_stubbed(:user, :signed_up)}
-  let(:decorated_user) {user.decorate}
+  let(:user) { build_stubbed(:user, :signed_up) }
+  let(:decorated_user) { user.decorate }
 
   before do
     allow(user).to receive(:decorate).and_return(decorated_user)


### PR DESCRIPTION
**Why**: Our Rubocop config mistakenly excluded the entire `spec`
directory. We want our specs to adhere to our Rubocop rules, and where
necessary, we can exclude individual specs.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
