### PR TITLE
LG-356 Add help text to the account creation screen for SAM

### DIFF
--- a/app/views/shared/_sp_alert.html.slim
+++ b/app/views/shared/_sp_alert.html.slim
@@ -5,6 +5,8 @@
     p.mb1
       - if current_page?(sign_up_start_path)
         = t("service_providers.#{sp_alert_name}.account_page.body")
+      - elsif current_page?(sign_up_email_path)
+        = t("service_providers.#{sp_alert_name}.create_account_page.body")
       - else
         - account_link = link_to t("service_providers.#{sp_alert_name}.create_account_link"),
           sign_up_email_url(request_id: params[:request_id])

--- a/app/views/sign_up/registrations/new.html.slim
+++ b/app/views/sign_up/registrations/new.html.slim
@@ -1,5 +1,7 @@
 - title t('titles.registrations.new')
 
+= render 'shared/sp_alert'
+
 h1.h3.my0 = t('headings.registrations.enter_email')
 
 = simple_form_for(@register_user_email_form,

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -8,6 +8,8 @@ en:
           account below.
       body_html: Your old GOES userID and password won't work. Please %{link}
       create_account_link: create a login.gov account.
+      create_account_page:
+        body: ''
     usa_jobs:
       header: First time here from USAJOBS?
       account_page:
@@ -16,6 +18,8 @@ en:
       body_html: Your old USAJOBS username and password won’t work. Please %{link}
         using the same email address you use for USAJOBS.
       create_account_link: create a login.gov account
+      create_account_page:
+        body: ''
     learn_more: Learn more.
     sam:
       header: First time here from SAM?
@@ -25,3 +29,6 @@ en:
       body_html: Your old SAM username and password won’t work. Please %{link} using
         the same email address you use for SAM.
       create_account_link: create a login.gov account
+      create_account_page:
+        body: Please create a login.gov account using the same email address you use
+          for SAM.

--- a/config/locales/service_providers/es.yml
+++ b/config/locales/service_providers/es.yml
@@ -9,6 +9,8 @@ es:
       body_html: Su antiguo ID de usuario y contraseña de GOES no funcionarán. Favor
         de %{link}
       create_account_link: crear un nueva cuenta de login.gov.
+      create_account_page:
+        body: ''
     usa_jobs:
       header: "¿Ha venido de USAJOBS?"
       account_page:
@@ -18,13 +20,18 @@ es:
       body_html: Si tiene un perfil de USAJOBS existente, favor de usar la dirección
         de correo electrónico primaria o secundaria que usó para USAJOBS para %{link}.
       create_account_link: crear su nueva cuenta de login.gov
+      create_account_page:
+        body: ''
     learn_more: Obtenga más información.
     sam:
       header: "¿Ha venido de SAM?"
       account_page:
-        body: Si tiene un perfil de SAM existente, favor de usar la dirección de correo
-          electrónico primaria o secundaria que usó para SAM para crear su nueva cuenta
-          de login.gov.
+        body: Su antiguo nombre de usuario y contraseña SAM no funcionará. Por favor
+          crea un login.gov cuenta usando la misma dirección de correo electrónico
+          que utiliza para SAM.
       body_html: Si tiene un perfil de SAM existente, favor de usar la dirección de
         correo electrónico primaria o secundaria que usó para SAM para %{link}.
       create_account_link: crear su nueva cuenta de login.gov
+      create_account_page:
+        body: Por favor crea un login.gov cuenta usando la misma dirección de correo
+          electrónico que utiliza para SAM.

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -9,6 +9,8 @@ fr:
       body_html: Votre ancien nom d'utilisateur et mot de passe GOES ne marchera pas.
         Veuillez %{link}
       create_account_link: créer un nouveau compte login.gov.
+      create_account_page:
+        body: ''
     usa_jobs:
       header: Êtes-vous venu(e) de USAJOBS?
       account_page:
@@ -18,13 +20,18 @@ fr:
       body_html: Si vous avez déjà un profil USAJOBS, veuillez utiliser l'adresse
         e-mail principale ou secondaire que vous avez utilisée pour USAJOBS pour %{link}.
       create_account_link: créer votre nouveau compte login.gov
+      create_account_page:
+        body: ''
     learn_more: En savoir plus.
     sam:
       header: Êtes-vous venu(e) de SAM?
       account_page:
-        body: Si vous avez déjà un profil SAM, veuillez utiliser l'adresse e-mail
-          principale ou secondaire que vous avez utilisée pour SAM pour créer votre
-          nouveau compte login.gov.
+        body: Votre ancien nom d'utilisateur et mot de passe SAM ne marchera pas.
+          Veuillez créer un nouveau compte login.gov avec la même adresse e-mail que
+          vous avez utilisée pour SAM.
       body_html: Si vous avez déjà un profil SAM, veuillez utiliser l'adresse e-mail
         principale ou secondaire que vous avez utilisée pour SAM pour %{link}.
       create_account_link: créer votre nouveau compte login.gov
+      create_account_page:
+        body: Veuillez créer un compte login.gov avec la même adresse e-mail que vous
+          avez utilisée pour SAM.

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -55,4 +55,55 @@ describe 'sign_up/registrations/new.html.slim' do
 
     expect(rendered).to have_selector('#recaptcha')
   end
+
+  context 'when SAM is present' do
+    before do
+      @sp = build_stubbed(
+        :service_provider,
+        friendly_name: 'SAM',
+        return_to_sp_url: 'www.awesomeness.com'
+      )
+      view_context = ActionController::Base.new.view_context
+      allow(view_context).to receive(:sign_up_start_url).
+        and_return('https://www.example.com/sign_up/start')
+      @decorated_session = DecoratedSession.new(
+        sp: @sp,
+        view_context: view_context,
+        sp_session: {},
+        service_provider_request: ServiceProviderRequest.new
+      ).call
+      allow(view).to receive(:decorated_session).and_return(@decorated_session)
+    end
+
+    it 'displays a custom alert message for SAM' do
+      render
+
+      expect(rendered).to \
+        have_content(t('service_providers.sam.create_account_page.body'))
+    end
+
+    it 'has sp alert for the SAM service provider' do
+      @sp.friendly_name = 'SAM'
+
+      render
+
+      expect(rendered).to have_selector('.alert')
+    end
+
+    it 'does not have an sp alert for the other service providers' do
+      @sp.friendly_name = 'other'
+      render
+
+      expect(rendered).to_not have_selector('.alert')
+    end
+  end
+
+  context 'when SP is not present' do
+    it 'does not display the branded content' do
+      render
+
+      expect(rendered).not_to \
+        have_content(t('service_providers.sam.create_account_page.body'))
+    end
+  end
 end


### PR DESCRIPTION
**Why**: To give SAM users clear instructions upon account creation

**How**: Conditionally show the sp alert partial and change it's contents for SAM

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
