### PR TITLE
LG-368 Account History should log when password changed from reset

### DIFF
--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -111,8 +111,8 @@ module Users
     end
 
     def handle_successful_password_reset
+      create_user_event(:password_changed, resource)
       update_user
-      mark_profile_inactive
 
       flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
 
@@ -137,6 +137,8 @@ module Users
       attributes = { password: user_params[:password] }
       attributes[:confirmed_at] = Time.zone.now unless resource.confirmed?
       UpdateUser.new(user: resource, attributes: attributes).call
+
+      mark_profile_inactive
     end
 
     def mark_profile_inactive

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -183,6 +183,8 @@ describe Users::ResetPasswordsController, devise: true do
           expect(@analytics).to have_received(:track_event).
             with(Analytics::PASSWORD_RESET_PASSWORD, analytics_hash)
 
+          expect(user.events.password_changed.size).to be 1
+
           expect(response).to redirect_to new_user_session_path
           expect(flash[:notice]).to eq t('devise.passwords.updated_not_active')
           expect(user.reload.confirmed_at).to eq old_confirmed_at

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -36,6 +36,10 @@ describe 'Account history' do
     create(:event, event_type: :new_personal_key,
                    user: user, created_at: Time.zone.now - 40.days)
   end
+  let(:password_changed_event) do
+    create(:event, event_type: :password_changed,
+                   user: user, created_at: Time.zone.now - 30.days)
+  end
 
   before do
     sign_in_and_2fa_user(user)
@@ -49,6 +53,7 @@ describe 'Account history' do
       usps_mail_sent_event,
       usps_mail_sent_again_event,
       new_personal_key_event,
+      password_changed_event,
     ]
     events.each do |event|
       decorated_event = event.decorate
@@ -81,5 +86,6 @@ describe 'Account history' do
     identity_with_link
     identity_without_link
     new_personal_key_event
+    password_changed_event
   end
 end


### PR DESCRIPTION
Why: A user should be aware of sensitive account changes

How: Create a new password change event when a user resets their password.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
