### PR TITLE
[LG-257] Use redirection to hide nonce from HTML

### DIFF
--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -3,14 +3,13 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
     include PivCacConcern
 
-    before_action :confirm_piv_cac_enabled
+    before_action :confirm_piv_cac_enabled, only: :show
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :show
 
     def show
       if params[:token]
         process_token
       else
-        create_piv_cac_nonce
         @presenter = presenter_for_two_factor_authentication_method
       end
     end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -4,7 +4,9 @@ module Users
     include PivCacConcern
 
     before_action :authenticate_user!
-    before_action :confirm_two_factor_authenticated, if: :two_factor_enabled?
+    before_action :confirm_two_factor_authenticated,
+                  if: :two_factor_enabled?,
+                  except: :redirect_to_piv_cac_service
     before_action :authorize_piv_cac_setup, only: :new
     before_action :authorize_piv_cac_disable, only: :delete
 
@@ -12,9 +14,7 @@ module Users
       if params.key?(:token)
         process_piv_cac_setup
       else
-        # add a nonce that we track for the return
         analytics.track_event(Analytics::USER_REGISTRATION_PIV_CAC_SETUP_VISIT)
-        create_piv_cac_nonce
         @presenter = PivCacAuthenticationSetupPresenter.new(user_piv_cac_form)
         render :new
       end
@@ -27,6 +27,11 @@ module Users
       Event.create(user_id: current_user.id, event_type: :piv_cac_disabled)
       flash[:success] = t('notices.piv_cac_disabled')
       redirect_to account_url
+    end
+
+    def redirect_to_piv_cac_service
+      create_piv_cac_nonce
+      redirect_to PivCacService.piv_cac_service_link(piv_cac_nonce)
     end
 
     private
@@ -68,7 +73,6 @@ module Users
     end
 
     def process_invalid_submission
-      create_piv_cac_nonce
       @presenter = PivCacAuthenticationSetupErrorPresenter.new(user_piv_cac_form)
       clear_piv_cac_information
       render :error

--- a/app/presenters/piv_cac_authentication_setup_base_presenter.rb
+++ b/app/presenters/piv_cac_authentication_setup_base_presenter.rb
@@ -8,15 +8,11 @@ class PivCacAuthenticationSetupBasePresenter
     @form = form
   end
 
-  def piv_cac_nonce
-    @form.nonce
-  end
-
   def piv_cac_capture_text
     t('forms.piv_cac_setup.submit')
   end
 
   def piv_cac_service_link
-    PivCacService.piv_cac_service_link(piv_cac_nonce)
+    redirect_to_piv_cac_service_url
   end
 end

--- a/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
@@ -35,7 +35,7 @@ module TwoFactorAuthCode
     end
 
     def piv_cac_service_link
-      PivCacService.piv_cac_service_link(piv_cac_nonce)
+      redirect_to_piv_cac_service_url
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
     if FeatureManagement.piv_cac_enabled?
       get '/piv_cac' => 'users/piv_cac_authentication_setup#new', as: :setup_piv_cac
       delete '/piv_cac' => 'users/piv_cac_authentication_setup#delete', as: :disable_piv_cac
+      get '/present_piv_cac' => 'users/piv_cac_authentication_setup#redirect_to_piv_cac_service', as: :redirect_to_piv_cac_service
     end
 
     delete '/authenticator_setup' => 'users/totp_setup#disable', as: :disable_totp

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -470,8 +470,16 @@ module Features
       get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_mfa.submit')))
     end
 
+    # This is a bit convoluted because we generate a nonce when we visit the
+    # link. The link provides a redirect to the piv/cac service with the nonce.
+    # This way, even if JavaScript fetches the link to grab the nonce, a new nonce
+    # is generated when the user clicks on the link.
     def get_piv_cac_nonce_from_link(link)
-      CGI.unescape(URI(link['href']).query.sub(/^nonce=/, ''))
+      go_back = current_path
+      visit link['href']
+      nonce = CGI.unescape(URI(current_url).query.sub(/^nonce=/, ''))
+      visit go_back
+      nonce
     end
 
     def link_identity(user, client_id, ial = nil)


### PR DESCRIPTION
**Why**:
We don't want the nonce discoverable by JavaScript.

**How**:
We use an endpoint to create a redirect to the
piv/cac service. We create a new nonce when we
send the redirect.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
