### PR TITLE
[LG-272] Support randomizable Piv/Cac service URLs

### DIFF
--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -3,6 +3,8 @@ require 'net/https'
 
 module PivCacService
   class << self
+    RANDOM_HOSTNAME_BYTES = 2
+
     include Rails.application.routes.url_helpers
 
     def decode_token(token)
@@ -14,7 +16,7 @@ module PivCacService
       if FeatureManagement.development_and_piv_cac_entry_enabled?
         test_piv_cac_entry_url
       else
-        uri = URI(Figaro.env.piv_cac_service_url)
+        uri = URI(randomize_uri(Figaro.env.piv_cac_service_url))
         # add the nonce
         uri.query = "nonce=#{CGI.escape(nonce)}"
         uri.to_s
@@ -37,6 +39,11 @@ module PivCacService
     end
 
     private
+
+    def randomize_uri(uri)
+      # we only support {random}, so we're going for performance here
+      uri.gsub('{random}') { |_| SecureRandom.hex(RANDOM_HOSTNAME_BYTES) }
+    end
 
     # Only used in tests
     def reset_piv_cac_avaialable_agencies

--- a/spec/services/pii/nist_encryption_spec.rb
+++ b/spec/services/pii/nist_encryption_spec.rb
@@ -75,7 +75,9 @@ describe 'NIST Encryption Model' do
 
       expect(user.valid_password?(password)).to eq true
 
-      digest = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(user.encrypted_password_digest)
+      digest = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
+        user.encrypted_password_digest
+      )
       user_access_key = Encryption::UserAccessKey.new(
         password: password,
         salt: digest.password_salt,

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -3,6 +3,27 @@ require 'rails_helper'
 describe PivCacService do
   include Rails.application.routes.url_helpers
 
+  describe '#randomize_uri' do
+    let(:result) { PivCacService.send(:randomize_uri, uri) }
+
+    context 'when a static URL is configured' do
+      let(:uri) { 'http://localhost:1234/' }
+
+      it 'returns the URL unchanged' do
+        expect(result).to eq uri
+      end
+    end
+
+    context 'when a random URL is configured' do
+      let(:uri) { 'http://{random}.example.com/' }
+
+      it 'returns the URL with random bytes' do
+        expect(result).to_not eq uri
+        expect(result).to match(%r{http://[0-9a-f]+\.example\.com/$})
+      end
+    end
+  end
+
   describe '#decode_token' do
     context 'when configured for local development' do
       before(:each) do


### PR DESCRIPTION
**Why**:
Browsers cache information about which certificate was
used with which hostname. If a bad certificate is selected,
the only recourse is to shut down the browser and restart it.
This leads to a bad UX.

**How**:
We have wildcard hostnames for the piv/cac service, so we
generate a random hostname each time we redirect the browser.
We try to balance between randomness and DNS caching.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
