### PR TITLE
LG-353 Add sufficient request tracing to be able to better diagnose timeouts

### DIFF
--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -1,0 +1,13 @@
+# monkeypatch to prevent new relic from truncating backtraces.  length is not configurable
+module NewRelic
+  module Agent
+    class ErrorCollector
+      # Maximum number of frames in backtraces. May be made configurable
+      # in the future.
+      MAX_BACKTRACE_FRAMES = 50
+      def truncate_trace(trace, _keep_frames = MAX_BACKTRACE_FRAMES)
+        trace
+      end
+    end
+  end
+end

--- a/config/initializers/new_relic_tracers.rb
+++ b/config/initializers/new_relic_tracers.rb
@@ -59,3 +59,15 @@ CloudhsmJwt.class_eval do
   add_method_tracer :rs256_algorithm, "Custom/#{name}/rs256_algorithm"
   add_method_tracer :sign, "Custom/#{name}/sign"
 end
+
+Encryption::KmsClient.class_eval do
+  include ::NewRelic::Agent::MethodTracer
+  add_method_tracer :decrypt, "Custom/#{name}/decrypt"
+  add_method_tracer :encrypt, "Custom/#{name}/encrypt"
+end
+
+TwilioService.class_eval do
+  include ::NewRelic::Agent::MethodTracer
+  add_method_tracer :place_call, "Custom/#{name}/place_call"
+  add_method_tracer :send_sms, "Custom/#{name}/send_sms"
+end


### PR DESCRIPTION
**Why**: To be able to diagnose timeouts in production

**How**: Monkeypatch the newrelic gem and override the code to truncate backtraces.  The length of backtraces is not currently configurable but may be in the future.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
