### PR TITLE
Don't set up 2fa without authenticating first

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -253,6 +253,7 @@ module TwoFactorAuthenticatable
       two_factor_authentication_method: two_factor_authentication_method,
       user_email: current_user.email,
       remember_device_available: false,
+      phone_enabled: current_user.phone_enabled?,
     }.merge(generic_data)
   end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -26,9 +26,17 @@ module TwoFactorAuthentication
     private
 
     def confirm_two_factor_enabled
-      return if confirmation_context? || current_user.phone_enabled?
+      return if confirmation_context? || phone_enabled?
+
+      if current_user.two_factor_enabled? && !phone_enabled? && user_signed_in?
+        return redirect_to user_two_factor_authentication_url
+      end
 
       redirect_to phone_setup_url
+    end
+
+    def phone_enabled?
+      current_user.phone_enabled?
     end
 
     def confirm_voice_capability

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -57,6 +57,7 @@ module TwoFactorAuthentication
         user_email: current_user.email,
         remember_device_available: false,
         totp_enabled: current_user.totp_enabled?,
+        phone_enabled: current_user.phone_enabled?,
         piv_cac_nonce: piv_cac_nonce,
       }.merge(generic_data)
     end

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -6,6 +6,7 @@ module Users
 
     before_action :authenticate_user
     before_action :authorize_user
+    before_action :confirm_two_factor_authenticated, if: :two_factor_enabled?
 
     def index
       @user_phone_form = UserPhoneForm.new(current_user)
@@ -27,6 +28,10 @@ module Users
     end
 
     private
+
+    def two_factor_enabled?
+      current_user.two_factor_enabled?
+    end
 
     def user_phone_form_params
       params.require(:user_phone_form).permit(

--- a/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/authenticator_delivery_presenter.rb
@@ -30,9 +30,10 @@ module TwoFactorAuthCode
 
     private
 
-    attr_reader :user_email, :two_factor_authentication_method
+    attr_reader :user_email, :two_factor_authentication_method, :phone_enabled
 
     def otp_fallback_options
+      return unless phone_enabled
       t(
         'devise.two_factor_authentication.totp_fallback.text_html',
         sms_link: sms_link,

--- a/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
@@ -40,9 +40,10 @@ module TwoFactorAuthCode
 
     private
 
-    attr_reader :user_email, :two_factor_authentication_method, :totp_enabled, :piv_cac_nonce
+    attr_reader :user_email, :two_factor_authentication_method, :totp_enabled, :phone_enabled
 
     def otp_fallback_options
+      return unless phone_enabled
       t(
         'devise.two_factor_authentication.totp_fallback.text_html',
         sms_link: sms_link,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,6 +15,17 @@ FactoryBot.define do
       x509_dn_uuid { SecureRandom.uuid }
     end
 
+    trait :with_personal_key do
+      after :build do |user|
+        user.personal_key = PersonalKeyGenerator.new(user).create
+      end
+    end
+
+    trait :with_authentication_app do
+      with_personal_key
+      otp_secret_key 'abc123'
+    end
+
     trait :admin do
       role :admin
     end
@@ -25,9 +36,7 @@ FactoryBot.define do
 
     trait :signed_up do
       with_phone
-      after :build do |user|
-        user.personal_key = PersonalKeyGenerator.new(user).create
-      end
+      with_personal_key
     end
 
     trait :unconfirmed do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -526,9 +526,9 @@ feature 'Two Factor Authentication' do
     end
   end
 
-  describe 'when the user is TOTP enabled' do
+  describe 'when the user is TOTP enabled and phone enabled' do
     it 'allows SMS and Voice fallbacks' do
-      user = create(:user, :signed_up, otp_secret_key: 'foo')
+      user = create(:user, :with_authentication_app, :with_phone)
       sign_in_before_2fa(user)
 
       click_link t('devise.two_factor_authentication.totp_fallback.sms_link_text')

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -431,4 +431,34 @@ feature 'Sign in' do
     expect(page.response_headers['Content-Security-Policy']).
       to(include('style-src \'self\''))
   end
+
+  context 'user is totp_enabled but not phone_enabled' do
+    before do
+      user = create(:user, :with_authentication_app)
+      signin(user.email, user.password)
+    end
+
+    it 'requires 2FA before allowing access to phone setup form' do
+      visit phone_setup_path
+
+      expect(page).to have_current_path login_two_factor_authenticator_path
+    end
+
+    it 'does not redirect to phone setup form when visiting /login/two_factor/sms' do
+      visit login_two_factor_path(otp_delivery_preference: 'sms')
+
+      expect(page).to have_current_path login_two_factor_authenticator_path
+    end
+
+    it 'does not redirect to phone setup form when visiting /login/two_factor/voice' do
+      visit login_two_factor_path(otp_delivery_preference: 'voice')
+
+      expect(page).to have_current_path login_two_factor_authenticator_path
+    end
+
+    it 'does not display OTP Fallback text and links' do
+      expect(page).
+        to_not have_content t('devise.two_factor_authentication.totp_fallback.sms_link_text')
+    end
+  end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -212,4 +212,34 @@ feature 'Sign Up' do
         to(include('style-src \'self\' \'unsafe-inline\''))
     end
   end
+
+  describe 'user is partially authenticated and phone 2fa is not configured' do
+    context 'with piv/cac enabled' do
+      let(:user) do
+        create(:user, :with_piv_or_cac)
+      end
+
+      before(:each) do
+        sign_in_user(user)
+      end
+
+      scenario 'can not access phone_setup' do
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+        visit phone_setup_path
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+      end
+
+      scenario 'can not access phone_setup via login/two_factor/sms' do
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+        visit login_two_factor_path(otp_delivery_preference: :sms)
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+      end
+
+      scenario 'can not access phone_setup via login/two_factor/voice' do
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+        visit login_two_factor_path(otp_delivery_preference: :voice)
+        expect(page).to have_current_path login_two_factor_piv_cac_path
+      end
+    end
+  end
 end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -35,8 +35,24 @@ describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
   end
 
   describe '#fallback_links' do
-    it 'has two options' do
-      expect(presenter.fallback_links.count).to eq 2
+    context 'with phone enabled' do
+      let(:presenter) do
+        presenter_with(reauthn: reauthn, user_email: user_email, phone_enabled: true)
+      end
+
+      it 'has two options' do
+        expect(presenter.fallback_links.count).to eq 2
+      end
+    end
+
+    context 'with phone disabled' do
+      let(:presenter) do
+        presenter_with(reauthn: reauthn, user_email: user_email, phone_enabled: false)
+      end
+
+      it 'has one option' do
+        expect(presenter.fallback_links.count).to eq 1
+      end
     end
   end
 

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -5,7 +5,8 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
   let(:presenter_data) do
     attributes_for(:generic_otp_presenter).merge(
       two_factor_authentication_method: 'authenticator',
-      user_email: view.current_user.email
+      user_email: view.current_user.email,
+      phone_enabled: user.phone_enabled?
     )
   end
 


### PR DESCRIPTION
**Why**:
If someone creates an account and adds their piv/cac
and then logs out, on subsequent login, they had the
option of adding a phone number when prompted for
their piv/cac. This allowed someone with the username
and password to bypass the piv/cac second factor and
set the phone, which would then be used as the
second factor.

**How**:
Only allow phone setup during account creation or after
authenticating with a second factor.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
