### PR TITLE
Remove constant already initialized warning on MAX_BACKTRACE_FRAMES

### DIFF
--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -1,11 +1,14 @@
-# monkeypatch to prevent new relic from truncating backtraces.  length is not configurable
+# monkeypatch to prevent new relic from truncating backtraces.
+# stack length is not currently configurable in new relic.
+# The MAX_BACKTRACE_FRAMES constant is commented out for reference
+
 module NewRelic
   module Agent
     class ErrorCollector
       # Maximum number of frames in backtraces. May be made configurable
       # in the future.
-      MAX_BACKTRACE_FRAMES = 50
-      def truncate_trace(trace, _keep_frames = MAX_BACKTRACE_FRAMES)
+      # MAX_BACKTRACE_FRAMES = 50
+      def truncate_trace(trace, _keep_frames = nil)
         trace
       end
     end


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
