### PR TITLE
LG-373 Use correct 2FA options link for PIV/CAC

### DIFF
--- a/app/views/users/phone_setup/index.html.slim
+++ b/app/views/users/phone_setup/index.html.slim
@@ -21,7 +21,8 @@ p.mt-tiny.mb0 = @presenter.info
         input_html: { class: 'phone col-8 mb4' }
   = f.button :submit, t('forms.buttons.send_security_code')
 .mt2.pt1.border-top
-  = link_to t('devise.two_factor_authentication.two_factor_choice_cancel'), two_factor_options_path
+  - path = current_user.piv_cac_enabled? ? account_recovery_setup_path : two_factor_options_path
+  = link_to t('devise.two_factor_authentication.two_factor_choice_cancel'), path
 
   = stylesheet_link_tag 'intl-tel-number/intlTelInput'
   = javascript_pack_tag 'intl-tel-input'

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -77,6 +77,12 @@ shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
 
     expect(page).to have_current_path(account_recovery_setup_path)
     expect(page).to have_content t('instructions.account_recovery_setup.piv_cac_next_step')
+
+    select_2fa_option('sms')
+    click_link t('devise.two_factor_authentication.two_factor_choice_cancel')
+
+    expect(page).to have_current_path account_recovery_setup_path
+
     configure_backup_phone
     click_acknowledge_personal_key
 


### PR DESCRIPTION
**Why**: When implementing the feature that requires PIV/CAC users
to set up a backup phone, I reused an existing view but didn't update
the link to point back to the account recovery form that's specific
to PIV/CAC users. This fixes the link.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
