### PR TITLE
[LG-256] Add spinner when presenting piv/cac cert

### DIFF
--- a/app/assets/stylesheets/components/_spinner.scss
+++ b/app/assets/stylesheets/components/_spinner.scss
@@ -1,0 +1,5 @@
+.spinner {
+  margin-left: auto;
+  margin-right: auto;
+  width: 144px;
+}

--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -6,6 +6,8 @@
 
 .invisible { visibility: hidden; }
 
+.hidden { display: none; }
+
 .truncate-inline {
   max-width: 80%;
   overflow: hidden;

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -23,6 +23,7 @@
 @import 'accordion';
 @import 'util';
 @import 'verification-badge';
+@import 'spinner';
 
 @import 'space-addon';
 @import 'space-misc';

--- a/app/views/shared/_spinner.html.slim
+++ b/app/views/shared/_spinner.html.slim
@@ -1,0 +1,18 @@
+.spinner.hidden
+  div
+    = image_tag(asset_url('spinner.gif'),
+        srcset: asset_url('spinner@2x.gif'),
+        height: 144,
+        width: 144,
+        alt: '')
+- nonce = content_security_policy_script_nonce
+= nonced_javascript_tag do
+  | var nonce="#{ nonce }";
+  | document.addEventListener('DOMContentLoaded', () => {
+  |   const button = document.querySelector('.no-spinner');
+  |   const info = document.querySelector('.spinner');
+  |   button.addEventListener('click', () => {
+  |     button.classList.add('hidden');
+  |     info.classList.remove('hidden');
+  |   });
+  | });

--- a/app/views/two_factor_authentication/piv_cac_verification/show.html.slim
+++ b/app/views/two_factor_authentication/piv_cac_verification/show.html.slim
@@ -1,11 +1,12 @@
 - title t('titles.present_piv_cac')
 
 h1.h3.my0 = @presenter.header
-p.mt-tiny.mb3 = @presenter.help_text
+.no-spinner
+  p.mt-tiny.mb3 = @presenter.help_text
 
-= link_to @presenter.piv_cac_capture_text,
-              @presenter.piv_cac_service_link,
-              class: 'btn btn-primary'
-
+  = link_to @presenter.piv_cac_capture_text,
+                @presenter.piv_cac_service_link,
+                class: 'btn btn-primary activate-spinner'
+= render 'shared/spinner'
 = render 'shared/fallback_links', presenter: @presenter
 = render 'shared/cancel', link: @presenter.cancel_link

--- a/app/views/users/piv_cac_authentication_setup/new.html.slim
+++ b/app/views/users/piv_cac_authentication_setup/new.html.slim
@@ -1,11 +1,12 @@
 - title @presenter.title
 
 h1.h3.my0 = @presenter.heading
-p.mt-tiny.mb3 = @presenter.description
+.no-spinner
+  p.mt-tiny.mb3 = @presenter.description
 
-= link_to @presenter.piv_cac_capture_text,
-              @presenter.piv_cac_service_link,
-              class: 'btn btn-primary'
+  = link_to @presenter.piv_cac_capture_text,
+                @presenter.piv_cac_service_link,
+                class: 'btn btn-primary activate-spinner'
+
+= render 'shared/spinner'
 = render 'shared/cancel_or_back_to_options'
-
-== javascript_pack_tag 'clipboard'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -103,6 +103,7 @@ ignore_unused:
   - 'devise.two_factor_authentication.max_otp_login_attempts_reached'
   - 'devise.two_factor_authentication.max_otp_requests_reached'
   - 'devise.two_factor_authentication.max_personal_key_login_attempts_reached'
+  - 'devise.two_factor_authentication.max_piv_cac_login_attempts_reached'
   - 'devise.two_factor_authentication.phone_sms_info_html'
   - 'devise.two_factor_authentication.phone_sms_label'
   - 'devise.two_factor_authentication.phone_voice_info_html'

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -97,6 +97,9 @@ en:
       max_personal_key_login_attempts_reached: For your security, your account is
         temporarily locked because you have entered the personal key incorrectly too
         many times.
+      max_piv_cac_login_attempts_reached: For your security, your account is temporarily
+        locked because you have presented your piv/cac credential incorrectly too
+        many times.
       otp_delivery_preference:
         instruction: You can change this selection the next time you log in. If you
           entered a landline, please select "Phone call" below.

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -99,6 +99,7 @@ es:
       max_personal_key_login_attempts_reached: Para su seguridad, su cuenta ha sido
         bloqueada temporalmente porque ha ingresado incorrectamente la clave personal
         demasiadas veces.
+      max_piv_cac_login_attempts_reached: NOT TRANSLATED YET
       otp_delivery_preference:
         instruction: Puede cambiar esta selección la próxima vez que inicie sesión.
         phone_unsupported: NOT TRANSLATED YET

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -106,6 +106,7 @@ fr:
       max_personal_key_login_attempts_reached: Pour votre sécurité, votre compte est
         temporairement verrouillé, car vous avez entré le code de sécurité à utilisation
         unique de façon erronée à de trop nombreuses reprises.
+      max_piv_cac_login_attempts_reached: NOT TRANSLATED YET
       otp_delivery_preference:
         instruction: Vous pouvez changer cette sélection la prochaine fois que vous
           vous connectez.


### PR DESCRIPTION
**Why**:
The browser UX might take a while, and we don't want the
user to feel that everything is frozen up.

**How**:
When the user clicks on the button to present their piv/cac
cert, we intercept the event and change the content to be a
GIF spinner. We let the event continue so the browser follows
through with the request.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
