### PR TITLE
Re-add authenticable salt method

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -23,6 +23,9 @@ module UserAccessKeyOverrides
     write_legacy_password_attributes(digest)
   end
 
+  # This is a devise method, which we are overriding. This should not be removed
+  # as Devise depends on this for things like building the key to use when
+  # storing the user in the session.
   def authenticatable_salt
     return if encrypted_password_digest.blank?
     Encryption::PasswordVerifier::PasswordDigest.parse_from_string(

--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -23,6 +23,13 @@ module UserAccessKeyOverrides
     write_legacy_password_attributes(digest)
   end
 
+  def authenticatable_salt
+    return if encrypted_password_digest.blank?
+    Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
+      encrypted_password_digest
+    ).password_salt
+  end
+
   private
 
   def write_legacy_password_attributes(digest)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -409,6 +409,15 @@ describe User do
     end
   end
 
+  describe '#authenticatable_salt' do
+    it 'returns the password salt' do
+      user = create(:user)
+      salt = JSON.parse(user.encrypted_password_digest)['password_salt']
+
+      expect(user.authenticatable_salt).to eq(salt)
+    end
+  end
+
   context 'when a password is updated' do
     it 'writes encrypted_password_digest and the legacy password attributes' do
       user = create(:user)


### PR DESCRIPTION
**Why**: Devise depends on the authenticable salt method, namely for
serializing a user into the session:

https://github.com/plataformatec/devise/blob/master/lib/devise/models/authenticatable.rb#L233-L235

Credit to @monfresh for finding this bug.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
