### PR TITLE
[LG-324] Add piv/cac subject to attributes for move.mil

### DIFF
--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -59,7 +59,7 @@ class UserPivCacSetupForm
 
   def piv_cac_not_already_associated
     self.x509_dn_uuid = @data['uuid']
-    self.x509_dn = @data['dn']
+    self.x509_dn = @data['subject']
     if User.find_by(x509_dn_uuid: x509_dn_uuid)
       self.error_type = 'piv_cac.already_associated'
       false

--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -44,7 +44,7 @@ class UserPivCacVerificationForm
       false
     else
       self.x509_dn_uuid = @data['uuid']
-      self.x509_dn = @data['dn']
+      self.x509_dn = @data['subject']
       true
     end
   end

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -17,6 +17,7 @@ class SignUpCompletionsShow
     [[:email], :email],
     [[:birthdate], :birthdate],
     [[:social_security_number], :social_security_number],
+    [[:x509_subject], :x509_subject],
   ].freeze
 
   MAX_RECENT_IDENTITIES = 5

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -11,6 +11,7 @@ en:
       intro_html: 'This is the only information %{app_name} will share with %{sp}:'
       phone: Phone number
       social_security_number: Social Security number
+      x509_subject: PIV/CAC Identity
     no_factor:
       delete_account: To delete your account, please confirm your password and security
         code.

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -11,6 +11,7 @@ es:
       intro_html: 'Esta es la única información que %{app_name} compartirá con %{sp}:'
       phone: Teléfono
       social_security_number: Número de Seguro Social
+      x509_subject: NOT TRANSLATED YET
     no_factor:
       delete_account: Para eliminar su cuenta, confirme su contraseña y código de
         seguridad.

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -12,6 +12,7 @@ fr:
         %{sp}:'
       phone: Numéro de téléphone
       social_security_number: Numéro de sécurité sociale
+      x509_subject: NOT TRANSLATED YET
     no_factor:
       delete_account: Pour supprimer votre compte, veuillez confirmer votre mot de
         passe et votre code de sécurité.

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -584,7 +584,7 @@ production:
       - 'https://portal.dot.gov/'
     restrict_to_deploy_env: 'prod'
 
-  # NGA GEOWorks Symphony 
+  # NGA GEOWorks Symphony
   'urn:gov:gsa:openidconnect.profiles:sp:sso:mitre:symphony':
     agency_id: 5
     friendly_name: 'GEOWorks/Symphony'
@@ -628,7 +628,10 @@ production:
       - 'https://office.dp3.us'
       - 'https://office.dp3.us/auth/login-gov/callback'
     restrict_to_deploy_env: 'prod'
-
+    attribute_bundle:
+      - x509_subject
+      - x509_presented
+  
   # My Move.mil
   'urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemilprod':
     agency_id: 8
@@ -643,6 +646,9 @@ production:
       - 'https://my.dp3.us'
       - 'https://my.dp3.us/auth/login-gov/callback'
     restrict_to_deploy_env: 'prod'
+    attribute_bundle:
+      - x509_subject
+      - x509_presented
 
   # DOT – National Registry of Certified Medical Examiners App
   'urn:gov:dot:openidconnect.profiles:sp:sso:dot:nr_auth':

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -15,22 +15,22 @@ describe TwoFactorAuthentication::PivCacVerificationController do
     allow(subject).to receive(:user_session).and_return(session_info)
     allow(PivCacService).to receive(:decode_token).with('good-token').and_return(
       'uuid' => user.x509_dn_uuid,
-      'dn' => x509_subject,
+      'subject' => x509_subject,
       'nonce' => nonce
     )
     allow(PivCacService).to receive(:decode_token).with('good-other-token').and_return(
       'uuid' => user.x509_dn_uuid + 'X',
-      'dn' => x509_subject + 'X',
+      'subject' => x509_subject + 'X',
       'nonce' => nonce
     )
     allow(PivCacService).to receive(:decode_token).with('bad-token').and_return(
       'uuid' => 'bad-uuid',
-      'dn' => 'bad-dn',
+      'subject' => 'bad-dn',
       'nonce' => nonce
     )
     allow(PivCacService).to receive(:decode_token).with('bad-nonce').and_return(
       'uuid' => user.x509_dn_uuid,
-      'dn' => x509_subject,
+      'subject' => x509_subject,
       'nonce' => 'bad-' + nonce
     )
   end

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -69,7 +69,7 @@ describe Users::PivCacAuthenticationSetupController do
       let(:good_token) { 'good-token' }
       let(:good_token_response) do
         {
-          'dn' => 'some dn',
+          'subject' => 'some dn',
           'uuid' => 'some-random-string',
           'nonce' => nonce,
         }

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -37,10 +37,10 @@ describe PivCacService do
       end
 
       it 'returns the test data' do
-        token = 'TEST:{"uuid":"hijackedUUID","dn":"hijackedDN"}'
+        token = 'TEST:{"uuid":"hijackedUUID","subject":"hijackedDN"}'
         expect(PivCacService.decode_token(token)).to eq(
           'uuid' => 'hijackedUUID',
-          'dn' => 'hijackedDN'
+          'subject' => 'hijackedDN'
         )
       end
     end
@@ -110,7 +110,7 @@ describe PivCacService do
             ).
             to_return(
               status: [200, 'Ok'],
-              body: '{"dn":"dn","uuid":"uuid"}'
+              body: '{"subject":"dn","uuid":"uuid"}'
             )
         end
 
@@ -121,14 +121,14 @@ describe PivCacService do
 
         it 'returns the decoded JSON from the target service' do
           expect(PivCacService.decode_token('foo')).to eq(
-            'dn' => 'dn',
+            'subject' => 'dn',
             'uuid' => 'uuid'
           )
         end
 
         describe 'with test data' do
           it 'returns an error' do
-            token = 'TEST:{"uuid":"hijackedUUID","dn":"hijackedDN"}'
+            token = 'TEST:{"uuid":"hijackedUUID","subject":"hijackedDN"}'
             expect(PivCacService.decode_token(token)).to eq(
               'error' => 'token.bad'
             )


### PR DESCRIPTION
**Why**:
Move.mil needs to know the subject of the piv/cac so
they can link the user's account to resources in DoD.

**How**:
Add the subject of the cert to the attribute bundle
provided via OIDC.

**N.B.**: Looks like I needed to tweak a few other things for the piv/cac subject to show up in a test OIDC client. Added them to this PR since they're all aimed at the same goal.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
