### PR TITLE
LG-319 Record password strength stats

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -46,10 +46,12 @@ module SignUp
 
     def process_successful_password_creation
       @user.confirm
+      password = permitted_params[:password]
       UpdateUser.new(
         user: @user,
-        attributes: { reset_requested_at: nil, password: permitted_params[:password] }
+        attributes: { reset_requested_at: nil, password: password }
       ).call
+      PasswordMetricsIncrementer.new(password).increment_password_metrics
       sign_in_and_redirect_user
     end
 

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -137,8 +137,13 @@ module Users
       attributes = { password: user_params[:password] }
       attributes[:confirmed_at] = Time.zone.now unless resource.confirmed?
       UpdateUser.new(user: resource, attributes: attributes).call
+      increment_password_metrics
 
       mark_profile_inactive
+    end
+
+    def increment_password_metrics
+      PasswordMetricsIncrementer.new(user_params[:password]).increment_password_metrics
     end
 
     def mark_profile_inactive

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -24,6 +24,7 @@ class UpdateUserPasswordForm
     update_user_password
     email_user_about_password_change
     encrypt_user_profile_if_active
+    increment_password_metrics
   end
 
   def update_user_password
@@ -40,6 +41,10 @@ class UpdateUserPasswordForm
     return if active_profile.blank?
 
     encryptor.call
+  end
+
+  def increment_password_metrics
+    PasswordMetricsIncrementer.new(password).increment_password_metrics
   end
 
   def encryptor

--- a/app/models/password_metric.rb
+++ b/app/models/password_metric.rb
@@ -3,24 +3,24 @@ class PasswordMetric < ApplicationRecord
 
   def self.increment(metric, value)
     create_row_for_metric_category(metric, value)
-    sql = <<-SQL
-      UPDATE password_metrics
-      SET count = count + 1
-      WHERE metric = #{metrics[metric.to_s]} AND value = #{value}
-    SQL
-    connection.execute(sql)
+    query = sanitize_sql_array [
+      'UPDATE password_metrics',
+      'SET count = count + 1',
+      "WHERE metric = #{metrics[metric.to_s]} AND value = #{value}",
+    ]
+    connection.execute(query)
   end
 
   private_class_method def self.create_row_for_metric_category(metric, value)
     metric_key = metrics[metric.to_s]
     # Insert a row with the count equal to 0 if a row does not already exist
-    sql = <<-SQL
-      INSERT INTO password_metrics (metric, value, count)
-      SELECT #{metric_key}, #{value}, 0
-      WHERE NOT EXISTS (
-        SELECT id FROM password_metrics WHERE metric = #{metric_key} AND value = #{value}
-      )
-    SQL
-    connection.execute(sql)
+    query = sanitize_sql_array [
+      'INSERT INTO password_metrics (metric, value, count)',
+      "SELECT #{metric_key}, #{value}, 0",
+      'WHERE NOT EXISTS (',
+      "SELECT id FROM password_metrics WHERE metric = #{metric_key} AND value = #{value}",
+      ')',
+    ]
+    connection.execute(query)
   end
 end

--- a/app/models/password_metric.rb
+++ b/app/models/password_metric.rb
@@ -3,24 +3,26 @@ class PasswordMetric < ApplicationRecord
 
   def self.increment(metric, value)
     create_row_for_metric_category(metric, value)
-    query = sanitize_sql_array [
-      'UPDATE password_metrics',
-      'SET count = count + 1',
-      "WHERE metric = #{metrics[metric.to_s]} AND value = #{value}",
-    ]
-    connection.execute(query)
+    query = <<-SQL
+      UPDATE password_metrics
+      SET count = count + 1
+      WHERE metric = ? AND value = ?
+    SQL
+    sanitized_query = sanitize_sql_array([query, metrics[metric.to_s], value])
+    connection.execute(sanitized_query)
   end
 
   private_class_method def self.create_row_for_metric_category(metric, value)
     metric_key = metrics[metric.to_s]
     # Insert a row with the count equal to 0 if a row does not already exist
-    query = sanitize_sql_array [
-      'INSERT INTO password_metrics (metric, value, count)',
-      "SELECT #{metric_key}, #{value}, 0",
-      'WHERE NOT EXISTS (',
-      "SELECT id FROM password_metrics WHERE metric = #{metric_key} AND value = #{value}",
-      ')',
-    ]
-    connection.execute(query)
+    query = <<-SQL
+      INSERT INTO password_metrics (metric, value, count)
+      SELECT ?, ?, 0
+      WHERE NOT EXISTS (
+        SELECT id FROM password_metrics WHERE metric = ? AND value = ?
+      )
+    SQL
+    sanitized_query = sanitize_sql_array([query, metric_key, value, metric_key, value])
+    connection.execute(sanitized_query)
   end
 end

--- a/app/models/password_metric.rb
+++ b/app/models/password_metric.rb
@@ -1,0 +1,26 @@
+class PasswordMetric < ApplicationRecord
+  enum metric: %i[length guesses_log10]
+
+  def self.increment(metric, value)
+    create_row_for_metric_category(metric, value)
+    sql = <<-SQL
+      UPDATE password_metrics
+      SET count = count + 1
+      WHERE metric = #{metrics[metric.to_s]} AND value = #{value}
+    SQL
+    connection.execute(sql)
+  end
+
+  private_class_method def self.create_row_for_metric_category(metric, value)
+    metric_key = metrics[metric.to_s]
+    # Insert a row with the count equal to 0 if a row does not already exist
+    sql = <<-SQL
+      INSERT INTO password_metrics (metric, value, count)
+      SELECT #{metric_key}, #{value}, 0
+      WHERE NOT EXISTS (
+        SELECT id FROM password_metrics WHERE metric = #{metric_key} AND value = #{value}
+      )
+    SQL
+    connection.execute(sql)
+  end
+end

--- a/app/services/password_metrics_incrementer.rb
+++ b/app/services/password_metrics_incrementer.rb
@@ -1,0 +1,19 @@
+class PasswordMetricsIncrementer
+  def initialize(password)
+    @password = password
+  end
+
+  def increment_password_metrics
+    PasswordMetric.increment(:length, password.length)
+    PasswordMetric.increment(:guesses_log10, guesses_log10)
+  end
+
+  private
+
+  attr_reader :password
+
+  # Disable :reek:UncommunicativeMethodName b/c this method name ends with a number
+  def guesses_log10
+    Zxcvbn::Tester.new.test(password).guesses_log10.round(1)
+  end
+end

--- a/db/migrate/20180619145839_create_password_metrics.rb
+++ b/db/migrate/20180619145839_create_password_metrics.rb
@@ -1,0 +1,12 @@
+class CreatePasswordMetrics < ActiveRecord::Migration[5.1]
+  def change
+    create_table :password_metrics do |t|
+      t.integer :metric, null: false
+      t.float :value, null: false
+      t.integer :count, null: false
+      t.index :metric
+      t.index :value
+      t.index [:metric, :value], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180607144007) do
+ActiveRecord::Schema.define(version: 20180619145839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,15 @@ ActiveRecord::Schema.define(version: 20180607144007) do
     t.datetime "updated_at"
     t.index ["phone_fingerprint"], name: "index_otp_requests_trackers_on_phone_fingerprint", unique: true
     t.index ["updated_at"], name: "index_otp_requests_trackers_on_updated_at"
+  end
+
+  create_table "password_metrics", force: :cascade do |t|
+    t.integer "metric", null: false
+    t.float "value", null: false
+    t.integer "count", null: false
+    t.index ["metric", "value"], name: "index_password_metrics_on_metric_and_value", unique: true
+    t.index ["metric"], name: "index_password_metrics_on_metric"
+    t.index ["value"], name: "index_password_metrics_on_value"
   end
 
   create_table "profiles", force: :cascade do |t|

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -47,6 +47,16 @@ describe SignUp::PasswordsController do
 
       post :create, params: { password_form: { password: 'NewVal' }, confirmation_token: token }
     end
+
+    it 'saves password metrics' do
+      token = 'new token'
+      create(:user, confirmation_token: token, confirmation_sent_at: Time.zone.now)
+
+      post :create, params: { password_form: { password: 'saltypickles' }, confirmation_token: token }
+
+      expect(PasswordMetric.where(metric: 'length', value: 12, count: 1).count).to eq(1)
+      expect(PasswordMetric.where(metric: 'guesses_log10', value: 7.1, count: 1).count).to eq(1)
+    end
   end
 
   describe '#new' do

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -65,6 +65,16 @@ describe UpdateUserPasswordForm, type: :model do
 
         expect(email_notifier).to have_received(:send_password_changed_email)
       end
+
+      it 'increments password metrics for the password' do
+        params[:password] = 'saltypickles'
+        stub_email_delivery
+
+        subject.submit(params)
+
+        expect(PasswordMetric.where(metric: 'length', value: 12, count: 1).count).to eq(1)
+        expect(PasswordMetric.where(metric: 'guesses_log10', value: 7.1, count: 1).count).to eq(1)
+      end
     end
 
     context 'when the user has an active profile' do

--- a/spec/models/password_metric_spec.rb
+++ b/spec/models/password_metric_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe PasswordMetric do
+  describe '.increment' do
+    context 'when a metric with the given metric and value does not exists' do
+      it 'creates the metric with a count of 1' do
+        PasswordMetric.increment(:length, 10)
+
+        expect(PasswordMetric.count).to eq(1)
+        expect(PasswordMetric.find_by(metric: :length, value: 10).count).to eq(1)
+      end
+    end
+
+    context 'when a metric with the same value exists' do
+      before do
+        PasswordMetric.create(
+          metric: 'length',
+          value: 9.0,
+          count: 2
+        )
+      end
+
+      it 'creates the metric with a value of 1' do
+        PasswordMetric.increment(:length, 10)
+
+        expect(PasswordMetric.count).to eq(2)
+        expect(PasswordMetric.find_by(metric: :length, value: 10).count).to eq(1)
+      end
+    end
+
+    context 'when a metric with the given category and value does exist' do
+      before do
+        PasswordMetric.create(
+          metric: 'length',
+          value: 10.0,
+          count: 1
+        )
+      end
+
+      it 'increments the value' do
+        PasswordMetric.increment(:length, 10)
+
+        expect(PasswordMetric.count).to eq(1)
+        expect(PasswordMetric.find_by(metric: :length, value: 10).count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/password_metrics_incrementer_spec.rb
+++ b/spec/services/password_metrics_incrementer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe PasswordMetricsIncrementer do
+  let(:password) { 'saltypickles' }
+  let(:guesses_log10) { 7.1 }
+
+  subject { described_class.new(password) }
+
+  describe '#increment_password_metrics' do
+    it 'increments password metrics for the length and guesses' do
+      subject.increment_password_metrics
+
+      expect(PasswordMetric.where(metric: 'length', value: 12, count: 1).count).to eq(1)
+      expect(PasswordMetric.where(metric: 'guesses_log10', value: 7.1, count: 1).count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that we can measure how our password policies are affecting
the stength of passwords people are creating

**How**: We do not want the password metrics to be associated with the
user records, so we create a new record, named `PasswordMetric` which
captures the name of the metric we are calculating, value (e.g. the
length of the password), and count (e.g. how many users have a password
of a given length). The code then does an atomic insert any time a user
sets, resets, or changes their password.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
