### PR TITLE
LG-379 Stop reading old password digest columns

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -17,10 +17,7 @@ module UserAccessKeyOverrides
   def password=(new_password)
     @password = new_password
     return if @password.blank?
-    digest = Encryption::PasswordVerifier.digest(@password)
-    self.encrypted_password_digest = digest.to_s
-    # Until we drop the old columns, still write to them so that we can rollback
-    write_legacy_password_attributes(digest)
+    self.encrypted_password_digest = Encryption::PasswordVerifier.digest(@password).to_s
   end
 
   # This is a devise method, which we are overriding. This should not be removed
@@ -34,13 +31,6 @@ module UserAccessKeyOverrides
   end
 
   private
-
-  def write_legacy_password_attributes(digest)
-    self.encrypted_password = digest.encrypted_password
-    self.encryption_key = digest.encryption_key
-    self.password_salt = digest.password_salt
-    self.password_cost = digest.password_cost
-  end
 
   def log_password_verification_failure
     metadata = {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -417,19 +417,4 @@ describe User do
       expect(user.authenticatable_salt).to eq(salt)
     end
   end
-
-  context 'when a password is updated' do
-    it 'writes encrypted_password_digest and the legacy password attributes' do
-      user = create(:user)
-
-      expected = {
-        encrypted_password: user.encrypted_password,
-        encryption_key: user.encryption_key,
-        password_salt: user.password_salt,
-        password_cost: user.password_cost,
-      }.to_json
-
-      expect(user.encrypted_password_digest).to eq(expected)
-    end
-  end
 end


### PR DESCRIPTION
**Why**: All of the contents of these columns have been moved into the
`encrypted_password_digest` column.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
