### PR TITLE
LG-382 Implement account reset via delayed delete

### DIFF
--- a/.reek
+++ b/.reek
@@ -115,6 +115,7 @@ TooManyMethods:
     - ServiceProviderSessionDecorator
     - SessionDecorator
     - HolidayService
+    - PhoneDeliveryPresenter
 UncommunicativeMethodName:
   exclude:
     - PhoneConfirmationFlow

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,7 @@ Metrics/ClassLength:
   - app/decorators/user_decorator.rb
   - app/services/analytics.rb
   - app/services/idv/session.rb
+  - app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
 
 Metrics/LineLength:
   Description: Limit lines to 100 characters.

--- a/app/assets/stylesheets/components/_background.scss
+++ b/app/assets/stylesheets/components/_background.scss
@@ -1,7 +1,7 @@
 .bg-gray-lighter { background-color: $gray-lighter; }
 .bg-light-blue { background-color: $blue-light; }
 .bg-lightest-blue { background-color: $blue-lightest; }
-.bg-lightest-red { background-color: #fff7f8; }
+.bg-lightest-red { background-color: $red-lightest; }
 
 @media #{$breakpoint-sm} {
   .sm-bg-light-blue { background-color: $blue-light; }

--- a/app/assets/stylesheets/components/_background.scss
+++ b/app/assets/stylesheets/components/_background.scss
@@ -1,6 +1,7 @@
 .bg-gray-lighter { background-color: $gray-lighter; }
 .bg-light-blue { background-color: $blue-light; }
 .bg-lightest-blue { background-color: $blue-lightest; }
+.bg-lightest-red { background-color: #fff7f8; }
 
 @media #{$breakpoint-sm} {
   .sm-bg-light-blue { background-color: $blue-light; }

--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -38,7 +38,7 @@ h4 {
 
 .button.large.expanded table a { padding: 20px 0; }
 
-.button.expanded.large btn-warn-bkg {
+.button.expanded.large .btn-warn-bkg {
   background-color: $white;
   border: 0;
 
@@ -47,7 +47,7 @@ h4 {
   }
 }
 
-.btn-warn-bkg btn-warn {
+.btn-warn-bkg .btn-warn {
   background-color: $red-lightest;
   border: 2px solid $red;
   border-radius: 8px;

--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -38,6 +38,28 @@ h4 {
 
 .button.large.expanded table a { padding: 20px 0; }
 
+.button.expanded.large btn-warn-bkg {
+  background-color: $white;
+  border: 0;
+
+  &:hover {
+    background-color: $white;
+  }
+}
+
+.btn-warn-bkg btn-warn {
+  background-color: #fff7f8;
+  border: 2px solid #f00;
+  border-radius: 8px;
+  color: $gray;
+  padding: 10px;
+  width: 50%;
+}
+
+.half {
+  width: 50%;
+}
+
 .footer {
   background: $secondary-color;
 

--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -48,8 +48,8 @@ h4 {
 }
 
 .btn-warn-bkg btn-warn {
-  background-color: #fff7f8;
-  border: 2px solid #f00;
+  background-color: $red-lightest;
+  border: 2px solid $red;
   border-radius: 8px;
   color: $gray;
   padding: 10px;

--- a/app/assets/stylesheets/variables/_colors.scss
+++ b/app/assets/stylesheets/variables/_colors.scss
@@ -22,3 +22,5 @@ $gray-light: #ddd !default;
 $gray-lighter: #fafafa !default;
 $black: #111 !default;
 $pink: #eb4d67 !default;
+$red: #f00 !default;
+$red-lightest: #fff7f8 !default;

--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -1,0 +1,25 @@
+module AccountReset
+  class CancelController < ApplicationController
+    def cancel
+      if AccountResetService.cancel_request(params[:token])
+        handle_success
+      else
+        handle_failure
+      end
+      redirect_to root_url
+    end
+
+    private
+
+    def handle_success
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :cancel, token_valid: true)
+      sign_out if current_user
+      flash[:success] = t('devise.two_factor_authentication.account_reset.successful_cancel')
+    end
+
+    def handle_failure
+      return if params[:token].blank?
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :cancel, token_valid: false)
+    end
+  end
+end

--- a/app/controllers/account_reset/confirm_delete_account_controller.rb
+++ b/app/controllers/account_reset/confirm_delete_account_controller.rb
@@ -1,10 +1,11 @@
 module AccountReset
   class ConfirmDeleteAccountController < ApplicationController
     def show
-      if flash[:email].blank?
+      email = flash[:email]
+      if email.blank?
         redirect_to root_url
       else
-        render :show, locals: { email: flash[:email] }
+        render :show, locals: { email: email }
       end
     end
   end

--- a/app/controllers/account_reset/confirm_delete_account_controller.rb
+++ b/app/controllers/account_reset/confirm_delete_account_controller.rb
@@ -1,0 +1,12 @@
+module AccountReset
+  class ConfirmDeleteAccountController < ApplicationController
+    def show
+      if session[:email].blank?
+        redirect_to root_url
+      else
+        email = session.delete(:email)
+        render :show, locals: { email: email }
+      end
+    end
+  end
+end

--- a/app/controllers/account_reset/confirm_delete_account_controller.rb
+++ b/app/controllers/account_reset/confirm_delete_account_controller.rb
@@ -1,11 +1,10 @@
 module AccountReset
   class ConfirmDeleteAccountController < ApplicationController
     def show
-      if session[:email].blank?
+      if flash[:email].blank?
         redirect_to root_url
       else
-        email = session.delete(:email)
-        render :show, locals: { email: email }
+        render :show, locals: { email: flash[:email] }
       end
     end
   end

--- a/app/controllers/account_reset/confirm_request_controller.rb
+++ b/app/controllers/account_reset/confirm_request_controller.rb
@@ -1,0 +1,12 @@
+module AccountReset
+  class ConfirmRequestController < ApplicationController
+    def show
+      if session[:email].blank?
+        redirect_to root_url
+      else
+        email = session.delete(:email)
+        render :show, locals: { email: email }
+      end
+    end
+  end
+end

--- a/app/controllers/account_reset/confirm_request_controller.rb
+++ b/app/controllers/account_reset/confirm_request_controller.rb
@@ -1,11 +1,10 @@
 module AccountReset
   class ConfirmRequestController < ApplicationController
     def show
-      if session[:email].blank?
+      if flash[:email].blank?
         redirect_to root_url
       else
-        email = session.delete(:email)
-        render :show, locals: { email: email }
+        render :show, locals: { email: flash[:email] }
       end
     end
   end

--- a/app/controllers/account_reset/confirm_request_controller.rb
+++ b/app/controllers/account_reset/confirm_request_controller.rb
@@ -1,10 +1,11 @@
 module AccountReset
   class ConfirmRequestController < ApplicationController
     def show
-      if flash[:email].blank?
+      email = flash[:email]
+      if email.blank?
         redirect_to root_url
       else
-        render :show, locals: { email: flash[:email] }
+        render :show, locals: { email: email }
       end
     end
   end

--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -1,0 +1,48 @@
+module AccountReset
+  class DeleteAccountController < ApplicationController
+    before_action :check_feature_enabled
+    before_action :prevent_parameter_leak, only: :show
+    before_action :check_granted_token
+
+    def show; end
+
+    def delete
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :delete, token_valid: true)
+      email = reset_session_and_set_email
+      UserMailer.account_reset_complete(email).deliver_later
+      redirect_to account_reset_confirm_delete_account_url
+    end
+
+    private
+
+    def check_feature_enabled
+      redirect_to root_url unless FeatureManagement.account_reset_enabled?
+    end
+
+    def reset_session_and_set_email
+      user = @account_reset_request.user
+      email = user.email
+      user.destroy!
+      sign_out
+      session[:email] = email
+    end
+
+    def check_granted_token
+      @account_reset_request = AccountResetRequest.from_valid_granted_token(session[:granted_token])
+      return if @account_reset_request
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :delete, token_valid: false)
+      redirect_to root_url
+    end
+
+    def prevent_parameter_leak
+      token = params[:token]
+      return if token.blank?
+      if AccountResetRequest.find_by(granted_token: token)&.granted_token_valid?
+        session[:granted_token] = token
+        redirect_to url_for
+      else
+        redirect_to root_url
+      end
+    end
+  end
+end

--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -24,7 +24,7 @@ module AccountReset
       email = user.email
       user.destroy!
       sign_out
-      session[:email] = email
+      flash[:email] = email
     end
 
     def check_granted_token

--- a/app/controllers/account_reset/report_fraud_controller.rb
+++ b/app/controllers/account_reset/report_fraud_controller.rb
@@ -1,0 +1,25 @@
+module AccountReset
+  class ReportFraudController < ApplicationController
+    def update
+      if AccountResetService.report_fraud(params[:token])
+        handle_success
+      else
+        handle_failure
+      end
+      redirect_to root_url
+    end
+
+    private
+
+    def handle_success
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :fraud, token_valid: true)
+      sign_out if current_user
+      flash[:success] = t('devise.two_factor_authentication.account_reset.successful_cancel')
+    end
+
+    def handle_failure
+      return if params[:token].blank?
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :fraud, token_valid: false)
+    end
+  end
+end

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -24,7 +24,7 @@ module AccountReset
     def reset_session_with_email
       email = current_user.email
       sign_out
-      session[:email] = email
+      flash[:email] = email
     end
 
     def send_notifications

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -1,0 +1,48 @@
+module AccountReset
+  class RequestController < ApplicationController
+    include TwoFactorAuthenticatable
+
+    before_action :check_account_reset_enabled
+    before_action :confirm_two_factor_enabled
+
+    def show; end
+
+    def create
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :request)
+      create_request
+      send_notifications
+      reset_session_with_email
+      redirect_to account_reset_confirm_request_url
+    end
+
+    private
+
+    def check_account_reset_enabled
+      redirect_to root_url unless FeatureManagement.account_reset_enabled?
+    end
+
+    def reset_session_with_email
+      email = current_user.email
+      sign_out
+      session[:email] = email
+    end
+
+    def send_notifications
+      SmsAccountResetNotifierJob.perform_now(
+        phone: current_user.phone,
+        cancel_token: current_user.account_reset_request.request_token
+      )
+      UserMailer.account_reset_request(current_user).deliver_later
+    end
+
+    def create_request
+      AccountResetService.new(current_user).create_request
+    end
+
+    def confirm_two_factor_enabled
+      return if current_user.two_factor_enabled?
+
+      redirect_to phone_setup_url
+    end
+  end
+end

--- a/app/controllers/account_reset/send_notifications_controller.rb
+++ b/app/controllers/account_reset/send_notifications_controller.rb
@@ -16,7 +16,7 @@ module AccountReset
     end
 
     def auth_token
-      request.headers['X-ACCOUNT-RESET-AUTH-TOKEN']
+      request.headers['X-API-AUTH-TOKEN']
     end
   end
 end

--- a/app/controllers/account_reset/send_notifications_controller.rb
+++ b/app/controllers/account_reset/send_notifications_controller.rb
@@ -1,0 +1,22 @@
+module AccountReset
+  class SendNotificationsController < ApplicationController
+    before_action :authorize
+
+    def update
+      count = AccountResetService.grant_tokens_and_send_notifications
+      analytics.track_event(Analytics::ACCOUNT_RESET, event: :notifications, count: count)
+      render plain: 'ok'
+    end
+
+    private
+
+    def authorize
+      return if auth_token == Figaro.env.account_reset_auth_token
+      head :unauthorized
+    end
+
+    def auth_token
+      request.headers['X-ACCOUNT-RESET-AUTH-TOKEN']
+    end
+  end
+end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -244,9 +244,14 @@ module TwoFactorAuthenticatable
       unconfirmed_phone: unconfirmed_phone?,
       totp_enabled: current_user.totp_enabled?,
       remember_device_available: !idv_context?,
+      account_reset_token: account_reset_token,
     }.merge(generic_data)
   end
   # rubocop:enable MethodLength
+
+  def account_reset_token
+    current_user&.account_reset_request&.request_token
+  end
 
   def authenticator_view_data
     {

--- a/app/jobs/sms_account_reset_notifier_job.rb
+++ b/app/jobs/sms_account_reset_notifier_job.rb
@@ -1,0 +1,15 @@
+class SmsAccountResetNotifierJob < ApplicationJob
+  queue_as :sms
+  include Rails.application.routes.url_helpers
+
+  def perform(phone:, cancel_token:)
+    TwilioService.new.send_sms(
+      to: phone,
+      body: I18n.t(
+        'jobs.sms_account_reset_notifier_job.message',
+        app: APP_NAME,
+        cancel_link: account_reset_cancel_url(token: cancel_token)
+      )
+    )
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -26,4 +26,20 @@ class UserMailer < ActionMailer::Base
     @sign_up_email_url = sign_up_email_url(request_id: request_id, locale: locale_url_param)
     mail(to: email, subject: t('user_mailer.account_does_not_exist.subject'))
   end
+
+  def account_reset_request(user)
+    account_reset = user.account_reset_request
+    @token = account_reset&.request_token
+    mail(to: user.email, subject: t('user_mailer.account_reset_request.subject'))
+  end
+
+  def account_reset_granted(user, account_reset)
+    @token = account_reset&.request_token
+    @granted_token = account_reset&.granted_token
+    mail(to: user.email, subject: t('user_mailer.account_reset_granted.subject'))
+  end
+
+  def account_reset_complete(email)
+    mail(to: email, subject: t('user_mailer.account_reset_complete.subject'))
+  end
 end

--- a/app/models/account_reset_request.rb
+++ b/app/models/account_reset_request.rb
@@ -1,0 +1,13 @@
+class AccountResetRequest < ApplicationRecord
+  belongs_to :user
+
+  def self.from_valid_granted_token(granted_token)
+    account_reset = AccountResetRequest.find_by(granted_token: granted_token)
+    account_reset&.granted_token_valid? ? account_reset : nil
+  end
+
+  def granted_token_valid?
+    !granted_token.nil? &&
+      ((Time.zone.now - granted_at) <= Figaro.env.account_reset_token_valid_for_days.to_i.days)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
   has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
+  has_one :account_reset_request, dependent: :destroy
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true
 

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -82,7 +82,7 @@ module TwoFactorAuthCode
       if account_reset_token
         t('devise.two_factor_authentication.account_reset.pending_html', cancel_link:
           view.link_to(t('devise.two_factor_authentication.account_reset.cancel_link'),
-                       account_reset_cancel_url(token: account_reset_token, only: 1)))
+                       account_reset_cancel_url(token: account_reset_token)))
       else
         t('devise.two_factor_authentication.account_reset.text_html', link:
           view.link_to(t('devise.two_factor_authentication.account_reset.link'),

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -21,6 +21,7 @@ module TwoFactorAuthCode
         update_phone_link,
         piv_cac_option,
         personal_key_link,
+        account_reset_link,
       ].compact
     end
 
@@ -43,6 +44,7 @@ module TwoFactorAuthCode
       :phone_number,
       :unconfirmed_phone,
       :otp_delivery_preference,
+      :account_reset_token,
       :confirmation_for_phone_change,
       :voice_otp_delivery_unsupported,
       :confirmation_for_idv
@@ -69,6 +71,23 @@ module TwoFactorAuthCode
 
       link = view.link_to(t('forms.two_factor.try_again'), reenter_phone_number_path)
       t('instructions.mfa.wrong_number_html', link: link)
+    end
+
+    def account_reset_link
+      return if unconfirmed_phone || !FeatureManagement.account_reset_enabled?
+      account_reset_or_cancel_link
+    end
+
+    def account_reset_or_cancel_link
+      if account_reset_token
+        t('devise.two_factor_authentication.account_reset.pending_html', cancel_link:
+          view.link_to(t('devise.two_factor_authentication.account_reset.cancel_link'),
+                       account_reset_cancel_url(token: account_reset_token, only: 1)))
+      else
+        t('devise.two_factor_authentication.account_reset.text_html', link:
+          view.link_to(t('devise.two_factor_authentication.account_reset.link'),
+                       account_reset_request_path(locale: LinkLocaleResolver.locale)))
+      end
     end
 
     def phone_fallback_link

--- a/app/services/account_reset_service.rb
+++ b/app/services/account_reset_service.rb
@@ -55,7 +55,7 @@ class AccountResetService
   def self.send_notifications_with_sql(users_sql)
     notifications_sent = 0
     AccountResetRequest.where(
-      users_sql, tvalue: Time.zone.now - FeatureManagement.account_reset_wait_period_days.days
+      users_sql, tvalue: Time.zone.now - Figaro.env.account_reset_wait_period_days.to_i.days
     ).order('requested_at ASC').each do |arr|
       notifications_sent += 1 if reset_and_notify(arr)
     end

--- a/app/services/account_reset_service.rb
+++ b/app/services/account_reset_service.rb
@@ -1,0 +1,83 @@
+class AccountResetService
+  def initialize(user)
+    @user_id = user.id
+  end
+
+  def create_request
+    account_reset = account_reset_request
+    account_reset.update(request_token: SecureRandom.uuid,
+                         requested_at: Time.zone.now,
+                         cancelled_at: nil,
+                         granted_at: nil,
+                         granted_token: nil)
+  end
+
+  def self.cancel_request(token)
+    account_reset = token.blank? ? nil : AccountResetRequest.find_by(request_token: token)
+    return false unless account_reset
+    account_reset.update(cancelled_at: Time.zone.now,
+                         request_token: nil,
+                         granted_token: nil)
+  end
+
+  def self.report_fraud(token)
+    account_reset = token.blank? ? nil : AccountResetRequest.find_by(request_token: token)
+    return false unless account_reset
+    now = Time.zone.now
+    account_reset.update(cancelled_at: now,
+                         reported_fraud_at: now,
+                         request_token: nil,
+                         granted_token: nil)
+  end
+
+  def grant_request
+    token = SecureRandom.uuid
+    arr = AccountResetRequest.find_by(user_id: @user_id)
+    arr.with_lock do
+      return false if arr.granted_token_valid?
+      account_reset_request.update(granted_at: Time.zone.now,
+                                   granted_token: token)
+    end
+    true
+  end
+
+  def self.grant_tokens_and_send_notifications
+    users_sql = <<~SQL
+      cancelled_at IS NULL AND
+      granted_at IS NULL AND
+      requested_at < :tvalue AND
+      request_token IS NOT NULL AND
+      granted_token IS NULL
+    SQL
+    send_notifications_with_sql(users_sql)
+  end
+
+  def self.send_notifications_with_sql(users_sql)
+    notifications_sent = 0
+    AccountResetRequest.where(
+      users_sql, tvalue: Time.zone.now - FeatureManagement.account_reset_wait_period_days.days
+    ).order('requested_at ASC').each do |arr|
+      notifications_sent += 1 if reset_and_notify(arr)
+    end
+    notifications_sent
+  end
+  private_class_method :send_notifications_with_sql
+
+  def self.reset_and_notify(arr)
+    user = arr.user
+    return false unless AccountResetService.new(user).grant_request
+    SmsAccountResetNotifierJob.perform_now(
+      phone: user.phone,
+      cancel_token: arr.request_token
+    )
+    UserMailer.account_reset_granted(user, arr).deliver_later
+    true
+  end
+  private_class_method :reset_and_notify
+
+  private
+
+  def account_reset_request
+    AccountResetRequest.find_or_create_by(user_id: @user_id)
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -54,6 +54,7 @@ class Analytics
   end
 
   # rubocop:disable Metrics/LineLength
+  ACCOUNT_RESET = 'Account Reset'.freeze
   ACCOUNT_DELETION = 'Account Deletion Requested'.freeze
   ACCOUNT_VISIT = 'Account Page Visited'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze

--- a/app/views/account_reset/confirm_delete_account/show.html.slim
+++ b/app/views/account_reset/confirm_delete_account/show.html.slim
@@ -1,0 +1,8 @@
+- title t('account_reset.confirm_delete_account.title')
+
+.my2.p3.sm-px4.border.border-red.rounded.rounded-xl.relative
+  = image_tag(asset_url('alert/fail-x.svg'), size: '48x48', alt: '',\
+    class: 'absolute top-n24 left-0 right-0 mx-auto')
+  h3 = t('account_reset.confirm_delete_account.title')
+  p == t('account_reset.confirm_delete_account.info', \
+    email: email, link: link_to(t('account_reset.confirm_delete_account.link_text'), root_path))

--- a/app/views/account_reset/confirm_request/show.html.slim
+++ b/app/views/account_reset/confirm_request/show.html.slim
@@ -1,0 +1,8 @@
+- title t('account_reset.confirm_request.check_your_email')
+
+.my2.p3.sm-px4.border.border-teal.rounded.rounded-xl.relative
+  = image_tag(asset_url('check-email.svg'), size: '48x48', alt: '',\
+    class: 'absolute top-n24 left-0 right-0 mx-auto')
+  h1.mt1.mb-12p.h3 = t('headings.verify_email')
+  p
+    == t('account_reset.confirm_request.instructions', email: email)

--- a/app/views/account_reset/delete_account/show.html.slim
+++ b/app/views/account_reset/delete_account/show.html.slim
@@ -1,0 +1,15 @@
+- title t('account_reset.delete_account.title')
+
+h1.h3.my0 = t('account_reset.delete_account.title')
+p.mt-tiny.mb0
+  = t('account_reset.delete_account.info')
+br
+h4.my2 = t('account_reset.delete_account.are_you_sure')
+
+= button_to t('account_reset.delete_account.delete_button'), \
+    account_reset_delete_account_path(token: session[:granted_token]), method: :delete, \
+    class: 'btn btn-red col-6 p2 rounded-lg border bw2 bg-lightest-red border-red border-box'
+br
+br
+hr
+= link_to t('account_reset.delete_account.cancel'), root_url

--- a/app/views/account_reset/request/show.html.slim
+++ b/app/views/account_reset/request/show.html.slim
@@ -1,0 +1,37 @@
+- title t('account_reset.request.title')
+
+h3.my0 = t('account_reset.request.title')
+p.mt-tiny.mb0 == t('account_reset.request.info')
+br
+h4.my0 = t('account_reset.request.personal_key')
+
+p.mt-tiny.mb0
+  = t('account_reset.request.personal_key_info')
+
+hr
+= render 'partials/personal_key/key', code: 'XXXX-XXXX-XXXX-XXXX'
+
+.mb3.right-align
+
+  = link_to t('users.personal_key.print'), '#',
+          data: { print: true },
+          class: 'ml2 btn-border ico ico-print text-decoration-none'
+
+hr
+p.mt-tiny.mb0 == t('account_reset.request.personal_key_trailer', \
+  link: link_to(t('account_reset.request.access_your_account'), login_two_factor_personal_key_url))
+br
+h4.my0 = t('account_reset.request.delete_account')
+p.mt-tiny.mb0 == t('account_reset.request.delete_account_info')
+br
+h5.my2 = t('account_reset.request.are_you_sure')
+= button_to t('account_reset.request.no_cancel'), root_url, method: :get,
+        class: 'btn btn-primary btn-wide mb1 personal-key-continue',
+        'data-toggle': 'modal'
+= button_to t('account_reset.request.yes_continue'), account_reset_request_path, \
+    class: 'btn btn-link'
+br
+br
+br
+hr
+= link_to t('forms.buttons.back'), root_url

--- a/app/views/user_mailer/account_reset_complete.html.slim
+++ b/app/views/user_mailer/account_reset_complete.html.slim
@@ -1,0 +1,18 @@
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
+
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;
+
+p == t('.help',
+        cancel_account_reset: link_to(t('user_mailer.account_reset_request.cancel_link_text'),
+                account_reset_cancel_url(token: @token), class: 'gray'),
+        app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+        help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
+        contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/app/views/user_mailer/account_reset_complete.html.slim
+++ b/app/views/user_mailer/account_reset_complete.html.slim
@@ -11,8 +11,6 @@ table.hr
       | &nbsp;
 
 p == t('.help',
-        cancel_account_reset: link_to(t('user_mailer.account_reset_request.cancel_link_text'),
-                account_reset_cancel_url(token: @token), class: 'gray'),
         app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
         contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/app/views/user_mailer/account_reset_granted.html.slim
+++ b/app/views/user_mailer/account_reset_granted.html.slim
@@ -1,0 +1,27 @@
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'))
+table.button.expanded.large
+  tbody
+    tr
+      td
+        table
+          tbody
+            tr
+              td.btn-warn-bkg
+                == link_to t('.button'), account_reset_delete_account_url(token: @granted_token), \
+                     target: '_blank', class: 'btn-warn'
+      td.half
+p = link_to account_reset_delete_account_url(token: @granted_token),
+        account_reset_delete_account_url(token: @granted_token), target: '_blank'
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;
+p= t('mailer.confirmation_instructions.footer', confirmation_period: '24 hours')
+p== t('user_mailer.account_reset_granted.help',
+        cancel_account_reset: link_to(t('user_mailer.account_reset_granted.cancel_link_text'),
+                account_reset_cancel_url(token: @token)))

--- a/app/views/user_mailer/account_reset_request.html.slim
+++ b/app/views/user_mailer/account_reset_request.html.slim
@@ -1,0 +1,20 @@
+p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'), \
+  contact_us_link: link_to(t('user_mailer.account_reset_request.contact_us'), \
+  account_reset_cancel_url(token: @token), class: 'blue'))
+
+table.spacer
+  tbody
+    tr
+      td.s10 height="10px"
+        | &nbsp;
+table.hr
+  tr
+    th
+      | &nbsp;
+
+p == t('.help',
+        cancel_account_reset: link_to(t('user_mailer.account_reset_request.cancel_link_text'),
+                account_reset_cancel_url(token: @token), class: 'gray'),
+        app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+        help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
+        contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/app/views/user_mailer/account_reset_request.html.slim
+++ b/app/views/user_mailer/account_reset_request.html.slim
@@ -1,5 +1,5 @@
 p.lead == t('.intro', app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'), \
-  contact_us_link: link_to(t('user_mailer.account_reset_request.contact_us'), \
+  cancel_account_reset: link_to(t('user_mailer.account_reset_granted.cancel_link_text'), \
   account_reset_cancel_url(token: @token), class: 'blue'))
 
 table.spacer

--- a/app/views/user_mailer/account_reset_request.html.slim
+++ b/app/views/user_mailer/account_reset_request.html.slim
@@ -13,8 +13,6 @@ table.hr
       | &nbsp;
 
 p == t('.help',
-        cancel_account_reset: link_to(t('user_mailer.account_reset_request.cancel_link_text'),
-                account_reset_cancel_url(token: @token), class: 'gray'),
         app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
         help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
         contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -74,6 +74,10 @@ development:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
+  account_reset_auth_token: 'abc123'
+  account_reset_enabled: 'true'
+  account_reset_token_valid_for_days: '1'
+  account_reset_wait_period_days: '1'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -203,6 +207,10 @@ production:
   aamva_public_key: # Base64 encoded public key for AAMVA
   aamva_private_key: # Base64 encoded private key for AAMVA
   aamva_verification_url: # DLDV Verification URL
+  account_reset_auth_token:
+  account_reset_enabled: 'true'
+  account_reset_token_valid_for_days: '1'
+  account_reset_wait_period_days: '1'
   async_job_refresh_interval_seconds: '5'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
@@ -311,6 +319,10 @@ test:
   aamva_public_key: '123abc'
   aamva_private_key: '123abc'
   aamva_verification_url: 'https://example.org:12345/verification/url'
+  account_reset_auth_token: 'test'
+  account_reset_enabled: 'true'
+  account_reset_token_valid_for_days: '1'
+  account_reset_wait_period_days: '1'
   async_job_refresh_interval_seconds: '1'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -1,0 +1,48 @@
+---
+en:
+  account_reset:
+    request:
+      title: Account deletion and reset
+      info: If you can't access your account through the security options you set
+        up previously, deleting your account and creating a new one is the only option.
+        <br><br> We can't undo an account delete, so please make sure you don't have
+        another security option you can use instead like your personal key.
+      personal_key: Do you have your personal key?
+      personal_key_info: Your personal key is a 16 character code that was given to
+        you at account creation as a recovery method--see example below.
+      personal_key_trailer: If you have your personal key, you can use it to %{link}
+        instead of resetting.
+      access_your_account: access your account
+      delete_account: Delete your account
+      delete_account_info: Deleting your existing account and creating a new one will
+        allow you to use the same email address and set up new security options.  However,
+        deleting will remove any agency applications you have linked to your account
+        and you will need to restore each connection. <br><br> If you continue, you
+        will first receive an email confirmation.  As a security measure, you will
+        receive another email with the link to continue deleting your account 24 hours
+        after the intial confirmation email arrives.
+      are_you_sure: Are you sure you don't have access to any of your security methods
+        OR your personal key?
+      no_cancel: No, cancel
+      yes_continue: Yes, continue deletion.
+    confirm_request:
+      check_your_email: Check your email
+      instructions: We sent an email to <strong>%{email}</strong> to begin the account
+        delete process. Follow the instructions in your email to complete the process.
+        <br><br> As a security measure, we also sent a text to your registered phone
+        number. <br><br> You can close this window if you are done.
+    delete_account:
+      title: Deleting your account should be your last resort
+      info: Deleting your account should be your last resort if you are locked out
+        of your account. You will not be able to recover any information linked to
+        your account.  Once your account is deleted, you can create a new one using
+        the same email address.
+      are_you_sure: Are you sure you want to delete your account?
+      delete_button: Delete account
+      cancel: Cancel
+    confirm_delete_account:
+      title: You have deleted your account
+      info: The account for <strong>%{email}</strong> has been deleted. We sent an
+        email confirmation of the account deletion. <br><br> You may %{link} or close
+        this window if you're done.
+      link_text: create a new account

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -1,0 +1,52 @@
+---
+es:
+  account_reset:
+    request:
+      title: Eliminación y restablecimiento de cuenta
+      info: Si no puede acceder a su cuenta a través de las opciones de seguridad
+        que configuró anteriormente, eliminar la cuenta y crear una nueva es la única
+        opción.  <br><br> No podemos deshacer la eliminación de una cuenta, así que
+        por favor asegúrese de no tener otra opción de seguridad que puede usar como
+        su clave personal.
+      personal_key: "¿Tienes tu clave personal?"
+      personal_key_info: Su clave personal es un código de 16 caracteres que se le
+        dio a en la creación de la cuenta como método de recuperación; consulte el
+        ejemplo a continuación.
+      personal_key_trailer: Si tiene su clave personal, puede usarla en %{link}         
+        en lugar de restablecer.
+      access_your_account: acceder a tu cuenta
+      delete_account: Eliminar su cuenta
+      delete_account_info: Eliminar su cuenta existente y crear una nueva         
+        le permite usar la misma dirección de correo electrónico y configurar nuevas
+        opciones de seguridad. Sin embargo, eliminar eliminará cualquier aplicación
+        de agencia que haya vinculado a su cuenta y deberá restaurar cada conexión.
+        <br><br> Si continúas, tú primero recibirá una confirmación por correo electrónico.
+        Como medida de seguridad, lo hará reciba otro correo electrónico con el enlace
+        para seguir eliminando su cuenta las 24 horas después del correo electrónico
+        de confirmación inicial llega.
+      are_you_sure: "¿Estás seguro de que no tienes acceso a ninguno de tus métodos
+        de seguridad?  O tu clave personal?"
+      no_cancel: No, cancelar
+      yes_continue: Sí, continúa la eliminación.
+    confirm_request:
+      check_your_email: Consultar su correo electrónico
+      instructions: Enviamos un correo electrónico a <strong>%{email}</strong> para
+        comenzar el proceso de eliminación de cuenta. Siga las instrucciones en su
+        correo electrónico para completar el proceso.<br><br>Como medida de seguridad,
+        también enviamos un mensaje de texto a su registro número de teléfono.<br><br>
+        Puede cerrar esta ventana si ha terminado.
+    delete_account:
+      title: Eliminar tu cuenta debería ser tu último recurso
+      info: Eliminar su cuenta debe ser su último recurso si está bloqueado         
+        de tu cuenta No podrá recuperar ninguna información vinculada a su cuenta.
+        Una vez que se elimine su cuenta, puede crear una nueva usando la misma dirección
+        de correo electrónico.
+      are_you_sure: "¿Seguro que quieres eliminar tu cuenta?"
+      delete_button: Borrar cuenta
+      cancel: Cancelar
+    confirm_delete_account:
+      title: Has eliminado tu cuenta
+      info: La cuenta para <strong>%{email}</strong> ha sido eliminada. Nosotros enviamos
+        una confirmación por correo electrónico de la eliminación de la cuenta. <br><br>
+        Puede %{link} o cierra esta ventana si ya terminaste.
+      link_text: crea una cuenta nueva

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -1,0 +1,53 @@
+---
+fr:
+  account_reset:
+    request:
+      title: Suppression de compte et réinitialisation
+      info: Si vous ne pouvez pas accéder à votre compte via les options de sécurité
+        que vous avez définies auparavant, la suppression de votre compte et la création
+        d'un nouveau compte est la seule option.  <br><br> Nous ne pouvons pas annuler
+        un compte supprimer, alors s'il vous plaît assurez-vous que vous n'avez pas
+        une autre option de sécurité que vous pouvez utiliser à la place comme votre
+        clé personnelle.
+      personal_key: Avez-vous votre clé personnelle?
+      personal_key_info: Votre clé personnelle est un code de 16 caractères qui a
+        été donné à vous à la création de compte comme une méthode de récupération
+        - voir l'exemple ci-dessous.
+      personal_key_trailer: Si vous avez votre clé personnelle, vous pouvez l'utiliser
+        pour %{link} au lieu de réinitialiser.
+      access_your_account: accéder à votre compte
+      delete_account: Supprimer votre compte
+      delete_account_info: Supprimer votre compte existant et en créer un nouveau
+        vous permet d'utiliser la même adresse e-mail et de définir de nouvelles options
+        de sécurité. cependant, la suppression supprimera toutes les applications
+        d'agence que vous avez liées à votre compte et vous devrez restaurer chaque
+        connexion. <br> <br> Si vous continuez, vous recevra d'abord un email de confirmation.
+        Par mesure de sécurité, vous devrez recevoir un autre e-mail avec le lien
+        pour continuer la suppression de votre compte 24 heures après l'email de confirmation
+        initial arrive.
+      are_you_sure: Êtes-vous sûr de n'avoir accès à aucune de vos méthodes de sécurité?
+        OU votre clé personnelle?
+      no_cancel: Non, annuler
+      yes_continue: Oui, continuez la suppression.
+    confirm_request:
+      check_your_email: Vérifiez votre email
+      instructions: Nous avons envoyé un e-mail à <strong>%{email}</strong> pour commencer
+        le compte. Supprimer le processus. Suivez les instructions dans votre e-mail
+        pour terminer le processus.<br> <br>Par mesure de sécurité, nous avons également
+        envoyé un SMS sur votre téléphone enregistré nombre. <br> <br> Vous pouvez
+        fermer cette fenêtre si vous avez terminé.
+    delete_account:
+      title: La suppression de votre compte devrait être votre dernier recours
+      info: La suppression de votre compte devrait être votre dernier recours si vous
+        êtes en lock-out de votre compte Vous ne pourrez pas récupérer les informations
+        liées à ton compte. Une fois votre compte supprimé, vous pouvez en créer un
+        nouveau en utilisant la même adresse e-mail.
+      are_you_sure: Êtes-vous sûr de vouloir supprimer votre compte?
+      delete_button: Supprimer le compte
+      cancel: Annuler
+    confirm_delete_account:
+      title: Vous avez supprimé votre compte
+      info: Le compte pour <strong>%{email}</strong> a été supprimé. Nous avons envoyé
+        un email de confirmation de la suppression du compte. <br> <br> Vous pouvez
+        %{link} ou fermer cette fenêtre si vous avez terminé.
+      link_text: créer un nouveau compte

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -136,7 +136,7 @@ en:
       phone_sms_label: Mobile phone number
       phone_sms_info_html: We'll text a security code <strong>each time you sign in</strong>.
       phone_voice_label: Phone number
-      phone_voice_info_html: We'll call you with a security code <strong>each time
+      phone_voice_info_html: We'll call you with a security code <strong>each timerecy
         you sign in</strong>.
       piv_cac_fallback:
         link: Use your PIV/CAC instead
@@ -145,6 +145,16 @@ en:
       please_confirm: Your phone number has been set. Confirm it by entering the security
         code below.
       please_try_again_html: Please try again in <strong id=%{id}>%{time_remaining}</strong>.
+      account_reset:
+        successful_cancel: Thank you. The request to delete your login.gov account
+          has been cancelled.
+        link: deleting your account
+        text_html: If you can't use any of these security options above, you can reset
+          your preferences by %{link}.
+        cancel_link: Cancel your request
+        pending_html: You currently have a pending request to delete your account.
+          It takes 24 hours from the time you made the request to complete the process.
+          Please check back later. %{cancel_link}
       read_about_two_factor_authentication:
         link: read about two-factor authentication
         text_html: You can %{link} and why we use it at our Help page.
@@ -169,6 +179,22 @@ en:
       two_factor_choice_intro: login.gov makes sure you can access your account by
         adding a second layer of security.
       two_factor_choice_cancel: "‹ Choose another option"
+      two_factor_login_choice: Secure your account
+      two_factor_login_choice_options:
+        voice: Phone call
+        voice_info: Get your security code via phone call.
+        sms: Text message / SMS
+        sms_info: Get your security code via text message / SMS.
+        auth_app: Authentication application
+        auth_app_info: Set up an authentication application to get your security code
+          without providing a phone number.
+        piv_cac: Government employees
+        piv_cac_info: Use your PIV/CAC card to secure your account.
+        personal_key: Personal Key
+        personal_key_info: Use the 12 character personal key you used at account creation.
+      two_factor_login_choice_intro: login.gov makes sure you can access your account
+        by adding a second layer of security.
+      two_factor_login_choice_cancel: "‹ Choose another option"
       two_factor_setup: Add a phone number
       user:
         new_otp_sent: We sent you a new one-time security code.

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -136,7 +136,7 @@ en:
       phone_sms_label: Mobile phone number
       phone_sms_info_html: We'll text a security code <strong>each time you sign in</strong>.
       phone_voice_label: Phone number
-      phone_voice_info_html: We'll call you with a security code <strong>each timerecy
+      phone_voice_info_html: We'll call you with a security code <strong>each time
         you sign in</strong>.
       piv_cac_fallback:
         link: Use your PIV/CAC instead

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -151,6 +151,16 @@ es:
       please_confirm: Su número de teléfono ha sido establecido. Confírmelo ingresando
         el código de seguridad a continuación.
       please_try_again_html: Inténtelo de nuevo en <strong id=%{id}>%{time_remaining}</strong>.
+      account_reset:
+        successful_cancel: Gracias. La solicitud para eliminar su cuenta de login.gov
+          ha sido cancelado.
+        link: eliminando su cuenta
+        text_html: Si no puede usar ninguna de estas opciones de seguridad anteriores,
+          puede restablecer tus preferencias por %{link}.
+        cancel_link: Cancelar su solicitud
+        pending_html: Actualmente tiene una solicitud pendiente para eliminar su cuenta.
+          Se necesitan 24 horas desde el momento en que realizó la solicitud para
+          completar el proceso.  Por favor, vuelva más tarde. %{cancel_link}
       read_about_two_factor_authentication:
         link: leer acerca de la autenticación de dos factores
         text_html: Puede %{link} y por qué la utilizamos en nuestra página de Ayuda.
@@ -176,6 +186,23 @@ es:
       two_factor_choice_intro: login.gov se asegura de que pueda acceder a su cuenta
         agregando una segunda capa de seguridad.
       two_factor_choice_cancel: "‹ Elige otra opción"
+      two_factor_login_choice: Asegure su cuenta
+      two_factor_login_choice_options:
+        voice: Llamada telefónica
+        voice_info: Obtenga su código de seguridad a través de una llamada telefónica.
+        sms: Mensaje de texto / SMS
+        sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS.
+        auth_app: Aplicación de autenticación
+        auth_app_info: Configure una aplicación de autenticación para obtener su código
+          de seguridad sin proporcionar un número de teléfono.
+        piv_cac: Empleados del Gobierno
+        piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta.
+        personal_key: Clave personal
+        personal_key_info: Use la clave personal de 12 caracteres que usó en la creación
+          de la cuenta.
+      two_factor_login_choice_intro: login.gov se asegura de que pueda acceder a su
+        cuenta agregando una segunda capa de seguridad.
+      two_factor_login_choice_cancel: "‹ Elige otra opción"
       two_factor_setup: Añada un número de teléfono
       user:
         new_otp_sent: Le enviamos un nuevo código de sólo un uso

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -158,6 +158,17 @@ fr:
       please_confirm: Votre numéro de téléphone a été entré. Confirmez-le en entrant
         le code de sécurité ci-dessous.
       please_try_again_html: Veuillez essayer de nouveau dans <strong id=%{id}>%{time_remaining}</strong>.
+      account_reset:
+        successful_cancel: Je vous remercie. La demande de suppression de votre compte
+          login.gov a été annulé.
+        link: supprimer votre compte
+        text_html: Si vous ne pouvez pas utiliser l'une de ces options de sécurité
+          ci-dessus, vous pouvez réinitialiser vos préférences par %{link}.
+        cancel_link: Annuler votre demande
+        pending_html: Vous avez actuellement une demande en attente pour supprimer
+          votre compte.  Il faut compter 24 heures à partir du moment où vous avez
+          fait la demande pour terminer le processus.  Veuillez vérifier plus tard.
+          %{cancel_link}
       read_about_two_factor_authentication:
         link: lire sur l'authentification à deux facteurs
         text_html: Vous pouvez %{link} et pourquoi nous l'utilisons sur notre page
@@ -184,6 +195,23 @@ fr:
       two_factor_choice_intro: login.gov s'assure que vous pouvez accéder à votre
         compte en ajoutant une deuxième couche de sécurité.
       two_factor_choice_cancel: "‹ Choisissez une autre option"
+      two_factor_login_choice: Sécurise ton compte
+      two_factor_login_choice_options:
+        voice: Appel téléphonique
+        voice_info: Obtenez votre code de sécurité par appel téléphonique.
+        sms: SMS
+        sms_info: Obtenez votre code de sécurité par SMS.
+        auth_app: Application d'authentification
+        auth_app_info: Configurez une application d'authentification pour obtenir
+          votre code de sécurité sans fournir de numéro de téléphone.
+        piv_cac: Employés du gouvernement
+        piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
+        personal_key: Clé personnelle
+        personal_key_info: Utilisez la clé personnelle de 12 caractères que vous avez
+          utilisée lors de la création du compte.
+      two_factor_login_choice_intro: login.gov s'assure que vous pouvez accéder à
+        votre compte en ajoutant une deuxième couche de sécurité.
+      two_factor_login_choice_cancel: "‹ Choisissez une autre option"
       two_factor_setup: Ajoutez un numéro de téléphone
       user:
         new_otp_sent: Nous vous avons envoyé un code de sécurité à utilisation unique.

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -4,3 +4,7 @@ en:
     sms_otp_sender_job:
       message: "%{code} is your %{app} one-time security code. This code will expire
         in %{expiration} minutes."
+    sms_account_reset_notifier_job:
+      message: 'You''ve requested to delete your login.gov account. Your request will
+        be processed in 24 hours. If you don’t want to delete your account, please
+        cancel: %{cancel_link}'

--- a/config/locales/jobs/es.yml
+++ b/config/locales/jobs/es.yml
@@ -4,3 +4,7 @@ es:
     sms_otp_sender_job:
       message: "%{code} es su %{app} código de seguridad de sólo un uso. Este código
         caducará en %{expiration} minutos."
+    sms_account_reset_notifier_job:
+      message: 'Has solicitado eliminar tu cuenta de login.gov. Su solicitud será
+        ser procesado en 24 horas. Si no desea eliminar su cuenta, por favor cancelar:
+        %{cancel_link}'

--- a/config/locales/jobs/fr.yml
+++ b/config/locales/jobs/fr.yml
@@ -4,3 +4,7 @@ fr:
     sms_otp_sender_job:
       message: "%{code} est votre %{app} code de sécurité à utilisation unique. Ce
         code expirera dans %{expiration} minutes."
+    sms_account_reset_notifier_job:
+      message: 'Vous avez demandé à supprimer votre compte login.gov. Votre demande
+        sera être traité en 24 heures. Si vous ne souhaitez pas supprimer votre compte,
+        veuillez cancel: %{cancel_link}'

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -9,7 +9,6 @@ en:
       link_text: Create your account
       subject: Your login.gov password reset request
     account_reset_request:
-      cancel_link_text: click here
       help: ''
       intro: You are receiving this email because you requested to delete your login.gov
         account. <br><br> <strong>Your request will be processed in 24 hours.</strong>
@@ -17,8 +16,8 @@ en:
       subject: Delete your account
       contact_us: contact us
     account_reset_granted:
-      cancel_link_text: click here
-      help: If you didn’t make this request, please %{cancel_account_reset}.
+      cancel_link_text: please cancel
+      help: If you don’t want to delete your account, %{cancel_account_reset}.
       intro: You are receiving this email because you requested to delete and reset
         your login.gov account. <br><br> Deleting your account should be your last
         resort if you are locked out of your account. You will not be able to recover

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -10,11 +10,10 @@ en:
       subject: Your login.gov password reset request
     account_reset_request:
       help: ''
-      intro: You are receiving this email because you requested to delete your login.gov
-        account. <br><br> <strong>Your request will be processed in 24 hours.</strong>
-        <br><br> If you did not request an accound delete, <u>%{contact_us_link}</u>.
+      intro: You’ve requested to delete your login.gov account. <br><br><strong>Your
+        request will be processed in 24 hours.</strong> <br><br> If you don’t want
+        to delete your account, <u>%{cancel_account_reset}</u>.
       subject: Delete your account
-      contact_us: contact us
     account_reset_granted:
       cancel_link_text: please cancel
       help: If you don’t want to delete your account, %{cancel_account_reset}.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -8,6 +8,29 @@ en:
         didn't request a password reset, you can ignore this message.
       link_text: Create your account
       subject: Your login.gov password reset request
+    account_reset_request:
+      cancel_link_text: click here
+      help: ''
+      intro: You are receiving this email because you requested to delete your login.gov
+        account. <br><br> <strong>Your request will be processed in 24 hours.</strong>
+        <br><br> If you did not request an accound delete, <u>%{contact_us_link}</u>.
+      subject: Delete your account
+      contact_us: contact us
+    account_reset_granted:
+      cancel_link_text: click here
+      help: If you didn’t make this request, please %{cancel_account_reset}.
+      intro: You are receiving this email because you requested to delete and reset
+        your login.gov account. <br><br> Deleting your account should be your last
+        resort if you are locked out of your account. You will not be able to recover
+        any information linked to your account. Once your account is deleted, you
+        can create a new one using the same email address. <br><br>Are you sure you
+        want to delete your account?
+      button: Yes, continue deleting
+      subject: Delete your account
+    account_reset_complete:
+      intro: This email confirms you have deleted your login.gov account.
+      subject: Account deleted
+      help: ''
     contact_link_text: contact us
     email_changed:
       help: If you did not want to change your email address, please visit the %{app}

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -7,11 +7,10 @@ es:
       subject: NOT TRANSLATED YET
     account_reset_request:
       help: ''
-      intro: Usted está recibiendo este correo electrónico porque solicitó eliminar
-        su login.gov cuenta.<br><br><strong>Su solicitud se procesará en 24 horas.</strong><br><br>Si
-        no solicitó una eliminación de confirmación, <u>%{contact_us_link}</u>.
+      intro: Has solicitado eliminar tu cuenta de login.gov.<br><br><strong>Su la
+        solicitud se procesará en 24 horas.</strong><br><br>Si no quieres para eliminar
+        su cuenta, <u>%{cancel_account_reset}</u>.
       subject: Eliminar su cuenta
-      contact_us: Contáctenos
     account_reset_granted:
       cancel_link_text: por favor cancele
       help: Si no desea eliminar su cuenta, %{cancel_account_reset}.

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -6,7 +6,6 @@ es:
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
     account_reset_request:
-      cancel_link_text: haga clic aquí
       help: ''
       intro: Usted está recibiendo este correo electrónico porque solicitó eliminar
         su login.gov cuenta.<br><br><strong>Su solicitud se procesará en 24 horas.</strong><br><br>Si
@@ -14,8 +13,8 @@ es:
       subject: Eliminar su cuenta
       contact_us: Contáctenos
     account_reset_granted:
-      cancel_link_text: haga clic aquí
-      help: Si no hizo esta solicitud, por favor %{cancel_account_reset}.
+      cancel_link_text: por favor cancele
+      help: Si no desea eliminar su cuenta, %{cancel_account_reset}.
       intro: Recibes este correo electrónico porque solicitaste eliminar y restablecer
         su cuenta de login.gov<br><br>Eliminar tu cuenta debería ser tu último recurso
         si está bloqueado de su cuenta. No podrás recuperar cualquier información

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -5,6 +5,29 @@ es:
       intro: NOT TRANSLATED YET
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
+    account_reset_request:
+      cancel_link_text: haga clic aquí
+      help: ''
+      intro: Usted está recibiendo este correo electrónico porque solicitó eliminar
+        su login.gov cuenta.<br><br><strong>Su solicitud se procesará en 24 horas.</strong><br><br>Si
+        no solicitó una eliminación de confirmación, <u>%{contact_us_link}</u>.
+      subject: Eliminar su cuenta
+      contact_us: Contáctenos
+    account_reset_granted:
+      cancel_link_text: haga clic aquí
+      help: Si no hizo esta solicitud, por favor %{cancel_account_reset}.
+      intro: Recibes este correo electrónico porque solicitaste eliminar y restablecer
+        su cuenta de login.gov<br><br>Eliminar tu cuenta debería ser tu último recurso
+        si está bloqueado de su cuenta. No podrás recuperar cualquier información
+        vinculada a su cuenta. Una vez que su cuenta es eliminada, usted puede crear
+        uno nuevo usando la misma dirección de correo electrónico.<br><br>¿Estás seguro
+        de que ¿Desea eliminar su cuenta?
+      button: Sí, continúa eliminando
+      subject: Eliminar su cuenta
+    account_reset_complete:
+      intro: Este correo electrónico confirma que ha eliminado su cuenta de login.gov.
+      subject: Cuenta borrada
+      help: ''
     contact_link_text: Contáctenos
     email_changed:
       help: Si no desea cambiar su email, visite el %{app} %{help_link} o el %{contact_link}.

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -7,11 +7,10 @@ fr:
       subject: NOT TRANSLATED YET
     account_reset_request:
       help: ''
-      intro: Vous recevez cet e-mail parce que vous avez demandé à supprimer votre
-        login.gov compte. <br><br><strong>Votre demande sera traitée dans les 24 heures.</strong><br><br>Si
-        vous n'avez pas demandé de suppression, <u>%{contact_us_link}</u>.
+      intro: Vous avez demandé à supprimer votre compte login.gov.<br><br><strong>Votre
+        la demande sera traitée dans les 24 heures.</strong><br><br>Si vous ne voulez
+        pas pour supprimer votre compte, <u>%{cancel_account_reset}</u>.
       subject: Supprimer votre compte
-      contact_us: Contactez nous
     account_reset_granted:
       cancel_link_text: veuillez annuler
       help: Si vous ne souhaitez pas supprimer votre compte, %{cancel_account_reset}.

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -5,6 +5,29 @@ fr:
       intro: NOT TRANSLATED YET
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
+    account_reset_request:
+      cancel_link_text: cliquez ici
+      help: ''
+      intro: Vous recevez cet e-mail parce que vous avez demandé à supprimer votre
+        login.gov compte. <br><br><strong>Votre demande sera traitée dans les 24 heures.</strong><br><br>Si
+        vous n'avez pas demandé de suppression, <u>%{contact_us_link}</u>.
+      subject: Supprimer votre compte
+      contact_us: Contactez nous
+    account_reset_granted:
+      cancel_link_text: cliquez ici
+      help: Si vous n'avez pas fait cette demande, veuillez %{cancel_account_reset}.
+      intro: Vous recevez cet e-mail parce que vous avez demandé à supprimer et à
+        réinitialiser votre compte login.gov. <br> <br> Supprimer votre compte devrait
+        être votre dernier recours si vous êtes exclu de votre compte. Vous ne serez
+        pas en mesure de récupérer toute information liée à votre compte. Une fois
+        votre compte supprimé, vous pouvez en créer un nouveau en utilisant la même
+        adresse email.<br><br>Es-tu sûr de toi voulez-vous supprimer votre compte?
+      button: Oui, continuez la suppression
+      subject: Supprimer votre compte
+    account_reset_complete:
+      intro: Cet e-mail confirme que vous avez supprimé votre compte login.gov.
+      subject: Compte supprimé
+      help: ''
     contact_link_text: communiquez avec nous
     email_changed:
       help: Si vous préférez ne pas changer votre adresse courriel, veuillez visiter

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -6,7 +6,6 @@ fr:
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
     account_reset_request:
-      cancel_link_text: cliquez ici
       help: ''
       intro: Vous recevez cet e-mail parce que vous avez demandé à supprimer votre
         login.gov compte. <br><br><strong>Votre demande sera traitée dans les 24 heures.</strong><br><br>Si
@@ -14,8 +13,8 @@ fr:
       subject: Supprimer votre compte
       contact_us: Contactez nous
     account_reset_granted:
-      cancel_link_text: cliquez ici
-      help: Si vous n'avez pas fait cette demande, veuillez %{cancel_account_reset}.
+      cancel_link_text: veuillez annuler
+      help: Si vous ne souhaitez pas supprimer votre compte, %{cancel_account_reset}.
       intro: Vous recevez cet e-mail parce que vous avez demandé à supprimer et à
         réinitialiser votre compte login.gov. <br> <br> Supprimer votre compte devrait
         être votre dernier recours si vous êtes exclu de votre compte. Vous ne serez

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,16 @@ Rails.application.routes.draw do
       post '/' => 'users/sessions#create', as: :user_session
       get '/active' => 'users/sessions#active'
 
+      get '/account_reset/request' => 'account_reset/request#show'
+      post '/account_reset/request' => 'account_reset/request#create'
+      get '/account_reset/cancel' => 'account_reset/cancel#cancel'
+      get '/account_reset/report_fraud' => 'account_reset/report_fraud#update'
+      get '/account_reset/confirm_request' => 'account_reset/confirm_request#show'
+      get '/account_reset/delete_account' => 'account_reset/delete_account#show'
+      delete '/account_reset/delete_account' => 'account_reset/delete_account#delete'
+      get '/account_reset/confirm_delete_account' => 'account_reset/confirm_delete_account#show'
+      post '/account_reset/send_notifications' => 'account_reset/send_notifications#update'
+
       get '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#show'
       post '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#create'
       get '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
       get '/account_reset/delete_account' => 'account_reset/delete_account#show'
       delete '/account_reset/delete_account' => 'account_reset/delete_account#delete'
       get '/account_reset/confirm_delete_account' => 'account_reset/confirm_delete_account#show'
-      post '/account_reset/send_notifications' => 'account_reset/send_notifications#update'
+      post '/api/account_reset/send_notifications' => 'account_reset/send_notifications#update'
 
       get '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#show'
       post '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#create'

--- a/db/migrate/20180620233914_create_account_reset_requests.rb
+++ b/db/migrate/20180620233914_create_account_reset_requests.rb
@@ -1,0 +1,18 @@
+class CreateAccountResetRequests < ActiveRecord::Migration[5.1]
+  def change
+    create_table :account_reset_requests do |t|
+      t.integer :user_id, null: false
+      t.datetime :requested_at
+      t.string :request_token
+      t.datetime :cancelled_at
+      t.datetime :reported_fraud_at
+      t.datetime :granted_at
+      t.string :granted_token
+      t.timestamps
+      t.index ['user_id'], unique: true
+      t.index ['cancelled_at','granted_at','requested_at'], name: 'index_account_reset_requests_on_timestamps'
+      t.index ['request_token'], unique: true
+      t.index ['granted_token'], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180619145839) do
+ActiveRecord::Schema.define(version: 20180620233914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "account_reset_requests", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "requested_at"
+    t.string "request_token"
+    t.datetime "cancelled_at"
+    t.datetime "reported_fraud_at"
+    t.datetime "granted_at"
+    t.string "granted_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cancelled_at", "granted_at", "requested_at"], name: "index_account_reset_requests_on_timestamps"
+    t.index ["granted_token"], name: "index_account_reset_requests_on_granted_token", unique: true
+    t.index ["request_token"], name: "index_account_reset_requests_on_request_token", unique: true
+    t.index ["user_id"], name: "index_account_reset_requests_on_user_id", unique: true
+  end
 
   create_table "agencies", force: :cascade do |t|
     t.string "name", null: false

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -101,4 +101,12 @@ class FeatureManagement
   def self.disallow_all_web_crawlers?
     Figaro.env.disallow_all_web_crawlers == 'true'
   end
+
+  def self.account_reset_wait_period_days
+    Figaro.env.account_reset_wait_period_days.to_i
+  end
+
+  def self.account_reset_enabled?
+    Figaro.env.account_reset_enabled != 'false' # if value not set it defaults to enabled
+  end
 end

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -102,10 +102,6 @@ class FeatureManagement
     Figaro.env.disallow_all_web_crawlers == 'true'
   end
 
-  def self.account_reset_wait_period_days
-    Figaro.env.account_reset_wait_period_days.to_i
-  end
-
   def self.account_reset_enabled?
     Figaro.env.account_reset_enabled != 'false' # if value not set it defaults to enabled
   end

--- a/lib/tasks/account_reset.rake
+++ b/lib/tasks/account_reset.rake
@@ -1,0 +1,6 @@
+namespace :account_reset do
+  desc 'Send Notifications'
+  task send_notifications: :environment do
+    AccountResetService.grant_tokens_and_send_notifications
+  end
+end

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe AccountReset::CancelController do
+  describe '#cancel' do
+    it 'logs a good token to the analytics' do
+      user = create(:user)
+      AccountResetService.new(user).create_request
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :cancel, token_valid: true})
+
+      post :cancel, params: {token:AccountResetRequest.all[0].request_token}
+    end
+
+    it 'logs a bad token to the analytics' do
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :cancel, token_valid: false})
+
+      post :cancel, params: {token:'FOO'}
+    end
+
+    it 'redirects to the root' do
+
+      post :cancel
+      expect(response).to redirect_to root_url
+    end
+  end
+end

--- a/spec/controllers/account_reset/confirm_delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_delete_account_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AccountReset::ConfirmDeleteAccountController do
+  describe '#show' do
+    context 'email in session' do
+      it 'renders the page and deletes the email from the session' do
+        session[:email] = 'test@example.com'
+
+        get :show
+
+        expect(session[:email]).to be_nil
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'no email in session' do
+      it 'redirects to the new user registration path' do
+        session[:email] = nil
+
+        get :show
+
+        expect(response).to redirect_to(root_url)
+      end
+    end
+  end
+end

--- a/spec/controllers/account_reset/confirm_delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_delete_account_controller_spec.rb
@@ -4,19 +4,16 @@ RSpec.describe AccountReset::ConfirmDeleteAccountController do
   describe '#show' do
     context 'email in session' do
       it 'renders the page and deletes the email from the session' do
-        session[:email] = 'test@example.com'
+        allow(controller).to receive(:flash).and_return(email: 'test@example.com')
 
         get :show
 
-        expect(session[:email]).to be_nil
         expect(response).to render_template(:show)
       end
     end
 
     context 'no email in session' do
       it 'redirects to the new user registration path' do
-        session[:email] = nil
-
         get :show
 
         expect(response).to redirect_to(root_url)

--- a/spec/controllers/account_reset/confirm_request_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_request_controller_spec.rb
@@ -4,19 +4,16 @@ RSpec.describe AccountReset::ConfirmRequestController do
   describe '#show' do
     context 'email in session' do
       it 'renders the page and deletes the email from the session' do
-        session[:email] = 'test@example.com'
+        allow(controller).to receive(:flash).and_return(email: 'test@example.com')
 
         get :show
 
-        expect(session[:email]).to be_nil
         expect(response).to render_template(:show)
       end
     end
 
     context 'no email in session' do
       it 'redirects to the new user registration path' do
-        session[:email] = nil
-
         get :show
 
         expect(response).to redirect_to(root_url)

--- a/spec/controllers/account_reset/confirm_request_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_request_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe AccountReset::ConfirmRequestController do
+  describe '#show' do
+    context 'email in session' do
+      it 'renders the page and deletes the email from the session' do
+        session[:email] = 'test@example.com'
+
+        get :show
+
+        expect(session[:email]).to be_nil
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'no email in session' do
+      it 'redirects to the new user registration path' do
+        session[:email] = nil
+
+        get :show
+
+        expect(response).to redirect_to(root_url)
+      end
+    end
+  end
+end

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe AccountReset::DeleteAccountController do
+  describe '#delete' do
+    it 'logs a good token to the analytics' do
+      user = create(:user)
+      AccountResetService.new(user).create_request
+      AccountResetService.new(user).grant_request
+
+      session[:granted_token] = AccountResetRequest.all[0].granted_token
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :delete, token_valid: true})
+
+      delete :delete
+    end
+
+    it 'logs a bad token to the analytics' do
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :delete, token_valid: false})
+
+      delete :delete, params: {token:'FOO'}
+    end
+
+    it 'redirects to root if there is no token' do
+      delete :delete
+
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  describe '#show' do
+    it 'prevents parameter leak' do
+      user = create(:user)
+      AccountResetService.new(user).create_request
+      AccountResetService.new(user).grant_request
+
+      get :show, params: {token: AccountResetRequest.all[0].granted_token}
+
+      expect(response).to redirect_to(account_reset_delete_account_url)
+    end
+
+    it 'redirects to root if the token is bad' do
+      get :show, params: {token: 'FOO'}
+
+      expect(response).to redirect_to(root_url)
+    end
+
+    it 'renders the page' do
+      user = create(:user)
+      AccountResetService.new(user).create_request
+      AccountResetService.new(user).grant_request
+      session[:granted_token] = AccountResetRequest.all[0].granted_token
+
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/controllers/account_reset/report_fraud_controller_spec.rb
+++ b/spec/controllers/account_reset/report_fraud_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe AccountReset::ReportFraudController do
+  describe '#update' do
+    it 'logs a good token to the analytics' do
+      user = create(:user)
+      AccountResetService.new(user).create_request
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :fraud, token_valid: true})
+
+      post :update, params: {token:AccountResetRequest.all[0].request_token}
+    end
+
+    it 'logs a bad token to the analytics' do
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :fraud, token_valid: false})
+
+      post :update, params: {token:'FOO'}
+    end
+
+    it 'redirects to the root' do
+
+      post :update
+      expect(response).to redirect_to root_url
+    end
+  end
+end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -15,6 +15,14 @@ describe AccountReset::RequestController do
 
       expect(response).to redirect_to root_url
     end
+
+    it 'redirects to phone setup url if 2fa not setup' do
+      user = create(:user)
+      sign_in_before_2fa(user)
+      get :show
+
+      expect(response).to redirect_to phone_setup_url
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe AccountReset::RequestController do
+  describe '#show' do
+    it 'renders the page' do
+      sign_in_before_2fa
+
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+  end
+
+  describe '#create' do
+    it 'logs the request in the analytics' do
+      TwilioService.telephony_service = FakeSms
+      sign_in_before_2fa
+
+      stub_analytics
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, {event: :request})
+
+      post :create
+    end
+  end
+end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -28,5 +28,11 @@ describe AccountReset::RequestController do
 
       post :create
     end
+
+    it 'redirects to root without 2fa' do
+      post :create
+
+      expect(response).to redirect_to root_url
+    end
   end
 end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -42,5 +42,13 @@ describe AccountReset::RequestController do
 
       expect(response).to redirect_to root_url
     end
+
+    it 'redirects to phone setup url if 2fa not setup' do
+      user = create(:user)
+      sign_in_before_2fa(user)
+      post :create
+
+      expect(response).to redirect_to phone_setup_url
+    end
   end
 end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -9,6 +9,12 @@ describe AccountReset::RequestController do
 
       expect(response).to render_template(:show)
     end
+
+    it 'redirects to root without 2fa' do
+      get :show
+
+      expect(response).to redirect_to root_url
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/account_reset/send_notifications_controller_spec.rb
+++ b/spec/controllers/account_reset/send_notifications_controller_spec.rb
@@ -40,6 +40,6 @@ describe AccountReset::SendNotificationsController do
   end
 
   def headers(token)
-    request.headers['X-ACCOUNT-RESET-AUTH-TOKEN'] = token
+    request.headers['X-API-AUTH-TOKEN'] = token
   end
 end

--- a/spec/controllers/account_reset/send_notifications_controller_spec.rb
+++ b/spec/controllers/account_reset/send_notifications_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe AccountReset::SendNotificationsController do
+  describe '#update' do
+    context 'with a good auth token' do
+      before do
+        headers(Figaro.env.account_reset_auth_token)
+      end
+
+      it 'returns ok' do
+        headers(Figaro.env.account_reset_auth_token)
+        post :update
+
+        expect(response).to be_ok
+      end
+
+      it 'logs the number of notifications sent in the analytics' do
+        allow(AccountResetService).to receive(:grant_tokens_and_send_notifications).and_return(7)
+
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::ACCOUNT_RESET, event: :notifications, count: 7)
+
+        post :update
+      end
+    end
+
+    context 'with a bad auth token' do
+      before do
+        headers('foo')
+      end
+
+      it 'returns unauthorized' do
+        headers('foo')
+        post :update
+
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
+  def headers(token)
+    request.headers['X-ACCOUNT-RESET-AUTH-TOKEN'] = token
+  end
+end

--- a/spec/jobs/sms_account_reset_notifier_job_spec.rb
+++ b/spec/jobs/sms_account_reset_notifier_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe SmsAccountResetNotifierJob do
+  include Features::ActiveJobHelper
+  include Rails.application.routes.url_helpers
+
+  describe '.perform' do
+    before do
+      reset_job_queues
+      TwilioService.telephony_service = FakeSms
+      FakeSms.messages = []
+    end
+
+    subject(:perform) do
+      SmsAccountResetNotifierJob.perform_now(
+        phone: '+1 (888) 555-5555',
+        cancel_token: 'UUID1'
+      )
+    end
+
+    it 'sends a message containing the cancel link to the mobile number', twilio: true do
+      allow(Figaro.env).to receive(:twilio_messaging_service_sid).and_return('fake_sid')
+
+      TwilioService.telephony_service = FakeSms
+
+      perform
+
+      messages = FakeSms.messages
+
+      expect(messages.size).to eq(1)
+
+      msg = messages.first
+
+      expect(msg.messaging_service_sid).to eq('fake_sid')
+      expect(msg.to).to eq('+1 (888) 555-5555')
+      expect(msg.body).to eq(I18n.t('jobs.sms_account_reset_notifier_job.message', app: APP_NAME,
+                                    cancel_link: account_reset_cancel_url(token: 'UUID1')))
+    end
+  end
+end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -431,4 +431,46 @@ describe 'FeatureManagement', type: :feature do
       expect(FeatureManagement.disallow_all_web_crawlers?).to eq(false)
     end
   end
+
+  describe '#account_reset_enabled?' do
+    context 'when enabled' do
+      before do
+        allow(Figaro.env).to receive(:account_reset_enabled).and_return('true')
+      end
+
+      it 'enables the feature' do
+        expect(FeatureManagement.account_reset_enabled?).to eq(true)
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Figaro.env).to receive(:account_reset_enabled).and_return('false')
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.account_reset_enabled?).to eq(false)
+      end
+    end
+  end
+
+  describe '#account_reset_wait_period_days' do
+    it 'returns zero when not set' do
+      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return(nil)
+
+      expect(FeatureManagement.account_reset_wait_period_days).to eq(0)
+    end
+
+    it 'returns zero when set to blank' do
+      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return('')
+
+      expect(FeatureManagement.account_reset_wait_period_days).to eq(0)
+    end
+
+    it 'returns the integer value of the string' do
+      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return('9')
+
+      expect(FeatureManagement.account_reset_wait_period_days).to eq(9)
+    end
+  end
 end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -453,24 +453,4 @@ describe 'FeatureManagement', type: :feature do
       end
     end
   end
-
-  describe '#account_reset_wait_period_days' do
-    it 'returns zero when not set' do
-      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return(nil)
-
-      expect(FeatureManagement.account_reset_wait_period_days).to eq(0)
-    end
-
-    it 'returns zero when set to blank' do
-      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return('')
-
-      expect(FeatureManagement.account_reset_wait_period_days).to eq(0)
-    end
-
-    it 'returns the integer value of the string' do
-      allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return('9')
-
-      expect(FeatureManagement.account_reset_wait_period_days).to eq(9)
-    end
-  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -130,4 +130,65 @@ describe UserMailer, type: :mailer do
       t('user_mailer.contact_link_text'), href: MarketingSite.contact_url
     )
   end
+
+  describe 'account_reset_request' do
+    let(:mail) { UserMailer.account_reset_request(user) }
+
+    it_behaves_like 'a system email'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq [user.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_reset_request.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).to have_content(strip_tags( \
+        t('user_mailer.account_reset_request.intro', \
+        contact_us_link: t('user_mailer.account_reset_request.contact_us'))))
+    end
+  end
+
+  describe 'account_reset_granted' do
+    let(:mail) { UserMailer.account_reset_granted(user, user.account_reset_request) }
+
+    it_behaves_like 'a system email'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq [user.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_reset_granted.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).to \
+        have_content(strip_tags(t('user_mailer.account_reset_granted.intro')))
+    end
+  end
+
+  describe 'account_reset_complete' do
+    let(:mail) { UserMailer.account_reset_complete(user.email) }
+
+    it_behaves_like 'a system email'
+
+    it 'sends to the current email' do
+      expect(mail.to).to eq [user.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('user_mailer.account_reset_complete.subject')
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).to have_content(strip_tags(t('user_mailer.account_reset_complete.intro')))
+    end
+  end
+
+  def strip_tags(str)
+    ActionController::Base.helpers.strip_tags(str)
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -147,7 +147,7 @@ describe UserMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(strip_tags( \
         t('user_mailer.account_reset_request.intro', \
-        contact_us_link: t('user_mailer.account_reset_request.contact_us'))))
+        cancel_account_reset: t('user_mailer.account_reset_granted.cancel_link_text'))))
     end
   end
 

--- a/spec/models/account_reset_request_spec.rb
+++ b/spec/models/account_reset_request_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe AccountResetRequest do
+  it { is_expected.to belong_to(:user) }
+
+  let(:subject) { AccountResetRequest.new }
+
+  describe '#granted_token_valid?' do
+    it 'returns false if the token does not exist' do
+      subject.granted_token = nil
+      subject.granted_at = Time.zone.now
+
+      expect(subject.granted_token_valid?).to eq(false)
+    end
+
+    it 'returns false if the token is expired' do
+      subject.granted_token = '123'
+      subject.granted_at = Time.zone.now - 7.days
+
+      expect(subject.granted_token_valid?).to eq(false)
+    end
+
+    it 'returns true if the token is valid' do
+      subject.granted_token = '123'
+      subject.granted_at = Time.zone.now
+
+      expect(subject.granted_token_valid?).to eq(true)
+    end
+  end
+
+  describe '.from_valid_granted_token' do
+    it 'returns nil if the token does not exist' do
+      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(nil)
+    end
+
+    it 'returns nil if the token is expired' do
+      granted_at = Time.zone.now - 7.days
+      AccountResetRequest.create(id: 1, user_id: 2, granted_token: '123', granted_at: granted_at)
+
+      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(nil)
+    end
+
+    it 'returns the record if the token is valid' do
+      arr = AccountResetRequest.create(id: 1, user_id: 2, granted_token: '123', granted_at: Time.zone.now)
+
+      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(arr)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ describe User do
     it { is_expected.to have_many(:agency_identities) }
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
+    it { is_expected.to have_one(:account_reset_request) }
   end
 
   it 'does not send an email when #create is called' do

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -31,9 +31,6 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
     )
   end
 
-  describe '#account_reset_link' do
-  end
-
   describe '#cancel_link' do
     it 'returns the sign out path during authentication' do
       expect(presenter.cancel_link).to eq sign_out_path
@@ -56,6 +53,34 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
   end
 
   describe '#fallback_links' do
+    it 'does not list an account reset link when the phone is unconfirmed' do
+      allow(presenter).to receive(:unconfirmed_phone).and_return(true)
+
+      expect(presenter.fallback_links.join(' ')).to_not include(account_reset_delete_account_link)
+    end
+
+    it 'does not list an account reset link when the feature is disabled' do
+      allow(presenter).to receive(:unconfirmed_phone).and_return(false)
+      allow(Figaro.env).to receive(:account_reset_enabled).and_return('false')
+
+      expect(presenter.fallback_links.join(' ')).to_not include(account_reset_delete_account_link)
+    end
+
+    it 'shows an account reset link when the user has not requested a delete' do
+      allow(presenter).to receive(:unconfirmed_phone).and_return(false)
+      allow(Figaro.env).to receive(:account_reset_enabled).and_return('enabled')
+
+      expect(presenter.fallback_links.join(' ')).to include(account_reset_delete_account_link)
+    end
+
+    it 'shows a cancel link when the user has requested a delete' do
+      allow(presenter).to receive(:unconfirmed_phone).and_return(false)
+      allow(presenter).to receive(:account_reset_token).and_return('foo')
+      allow(Figaro.env).to receive(:account_reset_enabled).and_return('enabled')
+
+      expect(presenter.fallback_links.join(' ')).to include(account_reset_cancel_link('foo'))
+    end
+
     it 'handles multiple locales' do
       I18n.available_locales.each do |locale|
         presenter_for_locale = presenter_with_locale(locale)
@@ -165,5 +190,17 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
                                "#{locale == :en ? nil : '/' + locale.to_s}/idv/phone"),
       view: view
     )
+  end
+
+  def account_reset_cancel_link(account_reset_token)
+    I18n.t('devise.two_factor_authentication.account_reset.pending_html', cancel_link:
+      view.link_to(t('devise.two_factor_authentication.account_reset.cancel_link'),
+                   account_reset_cancel_url(token: account_reset_token)))
+  end
+
+  def account_reset_delete_account_link
+    I18n.t('devise.two_factor_authentication.account_reset.text_html', link:
+      view.link_to(t('devise.two_factor_authentication.account_reset.link'),
+                   account_reset_request_path(locale: LinkLocaleResolver.locale)))
   end
 end

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -31,6 +31,9 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
     )
   end
 
+  describe '#account_reset_link' do
+  end
+
   describe '#cancel_link' do
     it 'returns the sign out path during authentication' do
       expect(presenter.cancel_link).to eq sign_out_path

--- a/spec/services/account_reset_service_spec.rb
+++ b/spec/services/account_reset_service_spec.rb
@@ -1,0 +1,169 @@
+require 'rails_helper'
+
+describe AccountResetService do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { create(:user) }
+  let(:subject) { AccountResetService.new(user) }
+  let(:user2) { create(:user) }
+  let(:subject2) { AccountResetService.new(user2) }
+
+  before {
+    allow(Figaro.env).to receive(:account_reset_wait_period_days).and_return('1')
+  }
+
+  describe '#create_request' do
+    it 'creates a new account reset request on the user' do
+      subject.create_request
+      arr = user.account_reset_request
+      expect(arr.request_token).to be_present
+      expect(arr.requested_at).to be_present
+      expect(arr.cancelled_at).to be_nil
+      expect(arr.granted_at).to be_nil
+      expect(arr.granted_token).to be_nil
+    end
+
+    it 'creates a new account reset request in the db' do
+      subject.create_request
+      arr = AccountResetRequest.find_by(user_id: user.id)
+      expect(arr.request_token).to be_present
+      expect(arr.requested_at).to be_present
+      expect(arr.cancelled_at).to be_nil
+      expect(arr.granted_at).to be_nil
+      expect(arr.granted_token).to be_nil
+    end
+  end
+
+  describe '#cancel_request' do
+    it 'removes tokens from a account reset request' do
+      subject.create_request
+      AccountResetService.cancel_request(user.account_reset_request.request_token)
+      arr = AccountResetRequest.find_by(user_id: user.id)
+      expect(arr.request_token).to_not be_present
+      expect(arr.granted_token).to_not be_present
+      expect(arr.requested_at).to be_present
+      expect(arr.cancelled_at).to be_present
+    end
+
+    it 'does not raise an error for a cancel request with a blank token' do
+      AccountResetService.cancel_request('')
+    end
+
+    it 'does not raise an error for a cancel request with a nil token' do
+      AccountResetService.cancel_request('')
+    end
+
+    it 'does not raise an error for a cancel request with a bad token' do
+      AccountResetService.cancel_request('ABC')
+    end
+  end
+
+  describe '#report_fraud' do
+    it 'removes tokens from the request' do
+      subject.create_request
+      AccountResetService.report_fraud(user.account_reset_request.request_token)
+      arr = AccountResetRequest.find_by(user_id: user.id)
+      expect(arr.request_token).to_not be_present
+      expect(arr.granted_token).to_not be_present
+      expect(arr.requested_at).to be_present
+      expect(arr.cancelled_at).to be_present
+      expect(arr.reported_fraud_at).to be_present
+    end
+
+    it 'does not raise an error for a fraud request with a blank token' do
+      token_found = AccountResetService.report_fraud('')
+      expect(token_found).to be(false)
+    end
+
+    it 'does not raise an error for a cancel request with a nil token' do
+      token_found = AccountResetService.report_fraud('')
+      expect(token_found).to be(false)
+    end
+
+    it 'does not raise an error for a cancel request with a bad token' do
+      token_found = AccountResetService.report_fraud('ABC')
+      expect(token_found).to be(false)
+    end
+  end
+
+  describe '#grant_request' do
+    it 'adds a notified at timestamp and granted token to the user' do
+      rd = subject
+      rd.create_request
+      rd.grant_request
+      arr = AccountResetRequest.find_by(user_id: user.id)
+      expect(arr.granted_at).to be_present
+      expect(arr.granted_token).to be_present
+    end
+  end
+
+  describe '.grant_tokens_and_send_notifications' do
+    context 'after waiting the full wait period' do
+      it 'does not send notifications when the notifications were already sent' do
+        subject.create_request
+
+        after_waiting_the_full_wait_period do
+          notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+          notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+          expect(notifications_sent).to eq(0)
+        end
+      end
+
+      it 'does not send notifications when the request was cancelled' do
+        arr = subject.create_request
+        AccountResetService.cancel_request(AccountResetRequest.all[0].request_token)
+
+        after_waiting_the_full_wait_period do
+          notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+          expect(notifications_sent).to eq(0)
+        end
+      end
+
+      it 'sends notifications after a request is granted' do
+        subject.create_request
+
+        after_waiting_the_full_wait_period do
+          notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+
+          expect(notifications_sent).to eq(1)
+        end
+      end
+
+      it 'sends 2 notifications after 2 requests are granted' do
+        subject.create_request
+        subject2.create_request
+
+        after_waiting_the_full_wait_period do
+          notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+
+          expect(notifications_sent).to eq(2)
+        end
+      end
+    end
+
+    context 'after not waiting the full wait period' do
+      it 'does not send notifications after a request' do
+        subject.create_request
+
+        notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+        expect(notifications_sent).to eq(0)
+      end
+
+      it 'does not send notifications when the request was cancelled' do
+        arr = subject.create_request
+        AccountResetService.cancel_request(AccountResetRequest.all[0].request_token)
+
+        notifications_sent = AccountResetService.grant_tokens_and_send_notifications
+        expect(notifications_sent).to eq(0)
+      end
+    end
+  end
+
+  def after_waiting_the_full_wait_period
+    TwilioService.telephony_service = FakeSms
+    days = Figaro.env.account_reset_wait_period_days.to_i.days
+    Timecop.travel(Time.zone.now + days) do
+      yield
+    end
+  end
+end

--- a/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
+++ b/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'account_reset/confirm_delete_account/show.html.slim' do
+  before do
+    allow(view).to receive(:email).and_return('foo@bar.com')
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('account_reset.confirm_delete_account.title'))
+
+    render
+  end
+
+  it 'contains the user email' do
+    email = 'foo@bar.com'
+    session[:email] = email
+
+    render
+
+    expect(rendered).to have_content(email)
+  end
+
+  it 'contains link to create a new account' do
+    render
+
+    puts rendered.inspect
+    expect(rendered).to have_link(
+                          t('account_reset.confirm_delete_account.link_text', app: APP_NAME),
+                          href: root_path
+                        )
+  end
+end

--- a/spec/views/account_reset/confirm_request/show.html.slim_spec.rb
+++ b/spec/views/account_reset/confirm_request/show.html.slim_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'account_reset/confirm_request/show.html.slim' do
+  before do
+    allow(view).to receive(:email).and_return('foo@bar.com')
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('account_reset.confirm_request.check_your_email'))
+
+    render
+  end
+
+  it 'contains the user email' do
+    email = 'foo@bar.com'
+    session[:email] = email
+
+    render
+
+    expect(rendered).to have_content(email)
+  end
+end

--- a/spec/views/account_reset/delete_account/show.html.slim_spec.rb
+++ b/spec/views/account_reset/delete_account/show.html.slim_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'account_reset/delete_account/show.html.slim' do
+  before do
+    allow(view).to receive(:email).and_return('foo@bar.com')
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('account_reset.delete_account.title'))
+
+    render
+  end
+
+  it 'has button to delete' do
+
+    render
+    expect(rendered).to have_button t('account_reset.delete_account.delete_button')
+  end
+end

--- a/spec/views/account_reset/request/show.html.slim_spec.rb
+++ b/spec/views/account_reset/request/show.html.slim_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'account_reset/request/show.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('account_reset.request.title'))
+
+    render
+  end
+
+  it 'has button to delete' do
+
+    render
+    expect(rendered).to have_button t('account_reset.request.yes_continue')
+  end
+end


### PR DESCRIPTION
**Why**: Users that are unable to 2FA are forced to create a new account with a new email.

**How**: Allow users to request to delete their account if they are unable to 2FA. After 24 hours they will receive a link which allows them to delete their account.

Note~ links embedded in emails and texts are GET requests and some are destructive.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
