### PR TITLE
Use Hash to map Twilio errors to user-facing text

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -58,22 +58,11 @@ module Users
       redirect_back(fallback_location: account_url)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def flash_error_for_exception(exception)
-      flash[:error] = case exception.code
-                      when TwilioService::SMS_ERROR_CODE
-                        t('errors.messages.invalid_sms_number')
-                      when TwilioService::INVALID_ERROR_CODE
-                        t('errors.messages.invalid_phone_number')
-                      when TwilioService::INVALID_CALLING_AREA_ERROR_CODE
-                        t('errors.messages.invalid_calling_area')
-                      when TwilioService::INVALID_VOICE_NUMBER_ERROR_CODE
-                        t('errors.messages.invalid_voice_number')
-                      else
-                        t('errors.messages.otp_failed')
-                      end
+      flash[:error] = TwilioErrors::REST_ERRORS.fetch(
+        exception.code, t('errors.messages.otp_failed')
+      )
     end
-    # rubocop:enable Metrics/MethodLength
 
     def otp_delivery_selection_form
       OtpDeliverySelectionForm.new(current_user, phone_to_deliver_to, context)

--- a/app/errors/twilio_errors.rb
+++ b/app/errors/twilio_errors.rb
@@ -1,0 +1,8 @@
+module TwilioErrors
+  REST_ERRORS = {
+    13_224 => I18n.t('errors.messages.invalid_voice_number'),
+    21_211 => I18n.t('errors.messages.invalid_phone_number'),
+    21_215 => I18n.t('errors.messages.invalid_calling_area'),
+    21_614 => I18n.t('errors.messages.invalid_sms_number'),
+  }.freeze
+end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -1,11 +1,6 @@
 require 'typhoeus/adapters/faraday'
 
 class TwilioService
-  INVALID_VOICE_NUMBER_ERROR_CODE = 13_224
-  SMS_ERROR_CODE = 21_614
-  INVALID_ERROR_CODE = 21_211
-  INVALID_CALLING_AREA_ERROR_CODE = 21_215
-
   cattr_accessor :telephony_service do
     Twilio::REST::Client
   end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -257,7 +257,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'flashes an sms error when twilio responds with an sms error' do
         twilio_error = Twilio::REST::RestError.new(
-          '', FakeTwilioErrorResponse.new(TwilioService::SMS_ERROR_CODE)
+          '', FakeTwilioErrorResponse.new(21_614)
         )
 
         allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)
@@ -268,7 +268,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'flashes an invalid error when twilio responds with an invalid error' do
         twilio_error = Twilio::REST::RestError.new(
-          '', FakeTwilioErrorResponse.new(TwilioService::INVALID_ERROR_CODE)
+          '', FakeTwilioErrorResponse.new(21_211)
         )
 
         allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)
@@ -279,7 +279,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'flashes an error when twilio responds with an invalid calling area error' do
         twilio_error = Twilio::REST::RestError.new(
-          '', FakeTwilioErrorResponse.new(TwilioService::INVALID_CALLING_AREA_ERROR_CODE)
+          '', FakeTwilioErrorResponse.new(21_215)
         )
 
         allow(VoiceOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)
@@ -291,7 +291,7 @@ describe Users::TwoFactorAuthenticationController do
 
       it 'flashes an error when twilio responds with an invalid voice number' do
         twilio_error = Twilio::REST::RestError.new(
-          '', FakeTwilioErrorResponse.new(TwilioService::INVALID_VOICE_NUMBER_ERROR_CODE)
+          '', FakeTwilioErrorResponse.new(13_224)
         )
 
         allow(VoiceOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -50,7 +50,7 @@ feature 'Sign Up' do
 
   scenario 'renders an error when twilio api responds with an error' do
     twilio_error = Twilio::REST::RestError.new(
-      '', FakeTwilioErrorResponse.new(TwilioService::SMS_ERROR_CODE)
+      '', FakeTwilioErrorResponse.new(21_614)
     )
 
     allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(twilio_error)


### PR DESCRIPTION
**Why**: To remove unnecessary conditionals in the controller and to
have one place to define the text that goes with each error. This will
make it easier to implement Twilio Verify.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
