### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/lib/rspec/formatters/user_flow_formatter.rb
+++ b/lib/rspec/formatters/user_flow_formatter.rb
@@ -70,7 +70,7 @@ class UserFlowFormatter < RSpec::Core::Formatters::DocumentationFormatter
 
   def flows_output_url
     host = Rails.application.config.action_controller.asset_host || 'localhost:3000'
-    protocol = host =~ /localhost/ ? 'http://' : 'https://'
+    protocol = host.match?(/localhost/) ? 'http://' : 'https://'
 
     "#{protocol}#{host}/user_flows"
   end

--- a/lib/tasks/remote_settings.rake
+++ b/lib/tasks/remote_settings.rake
@@ -1,11 +1,11 @@
 namespace :remote_settings do
-  task :update, [:name, :url] => [:environment] do |task, args|
+  task :update, %i[name url] => [:environment] do |_task, args|
     RemoteSettingsService.update_setting(args[:name], args[:url])
-    Kernel.puts "Update successful"
+    Kernel.puts 'Update successful'
   end
 
-  task :view, [:name] => [:environment] do |task, args|
-    Kernel.puts  RemoteSetting.find_by(name: args[:name])&.contents
+  task :view, [:name] => [:environment] do |_task, args|
+    Kernel.puts RemoteSetting.find_by(name: args[:name])&.contents
   end
 
   task list: :environment do
@@ -14,13 +14,15 @@ namespace :remote_settings do
     end
   end
 
-  task :delete, [:name] => [:environment] do |task, args|
+  task :delete, [:name] => [:environment] do |_task, args|
     RemoteSetting.where(name: args[:name]).delete_all
-    Kernel.puts "Delete successful"
+    Kernel.puts 'Delete successful'
   end
 end
 
+# rubocop:disable Metrics/LineLength
 # example invocations:
 # rake "remote_settings:update[agencies.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml]"
 # rake "remote_settings:update[agencies.yml,https://login.gov/assets/idp/config/agencies.yml"
 # rake "remote_settings:update[service_providers.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/service_providers.yml]"
+# rubocop:enable Metrics/LineLength

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -50,9 +50,10 @@ describe SignUp::PasswordsController do
 
     it 'saves password metrics' do
       token = 'new token'
+      params = { password_form: { password: 'saltypickles' }, confirmation_token: token }
       create(:user, confirmation_token: token, confirmation_sent_at: Time.zone.now)
 
-      post :create, params: { password_form: { password: 'saltypickles' }, confirmation_token: token }
+      post :create, params: params
 
       expect(PasswordMetric.where(metric: 'length', value: 12, count: 1).count).to eq(1)
       expect(PasswordMetric.where(metric: 'guesses_log10', value: 7.1, count: 1).count).to eq(1)

--- a/spec/features/flows/sp_authentication_flows_spec.rb
+++ b/spec/features/flows/sp_authentication_flows_spec.rb
@@ -334,9 +334,7 @@ feature 'SP-initiated authentication with login.gov', :user_flow do
 
   def complete_phone_form_with_valid_phone
     phone = Faker::PhoneNumber.cell_phone
-    until Phonelib.valid_for_country?(phone, 'US')
-      phone = Faker::PhoneNumber.cell_phone
-    end
+    phone = Faker::PhoneNumber.cell_phone until Phonelib.valid_for_country?(phone, 'US')
     fill_in 'user_phone_form_phone', with: phone
   end
 end

--- a/spec/models/remote_setting_spec.rb
+++ b/spec/models/remote_setting_spec.rb
@@ -4,19 +4,19 @@ describe RemoteSetting do
   describe 'validations' do
     it 'validates that our github repo is white listed' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
-      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents: '')
       expect(valid_setting).to be_valid
     end
 
     it 'validates that the login.gov static site is white listed' do
       location = 'https://login.gov/agencies.yml'
-      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents: '')
       expect(valid_setting).to be_valid
     end
 
     it 'does not accept http' do
       location = 'http://login.gov/agencies.yml'
-      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents:'')
+      valid_setting = RemoteSetting.create(name: 'agencies.yml', url: location, contents: '')
       expect(valid_setting).to_not be_valid
     end
   end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe AgencySeeder do
     context 'when agencies.yml has a remote setting' do
       before do
         location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
-        RemoteSetting.create(name: 'agencies.yml', url:location, contents: "test:\n  1:\n    name: 'CBP'")
+        RemoteSetting.create(
+          name: 'agencies.yml', url: location, contents: "test:\n  1:\n    name: 'CBP'"
+        )
       end
 
       it 'updates the attributes based on the current value of the yml file' do

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -106,7 +106,7 @@ describe PivCacService do
           stub_request(:post, 'localhost:8443').
             with(
               body: 'token=foo',
-              headers: {'Authentication' => %r<^hmac\s+:.+:.+$>}
+              headers: { 'Authentication' => /^hmac\s+:.+:.+$/ }
             ).
             to_return(
               status: [200, 'Ok'],

--- a/spec/services/remote_settings_service_spec.rb
+++ b/spec/services/remote_settings_service_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 describe RemoteSettingsService do
   subject(:service) { RemoteSettingsService }
-  before {
-    WebMock.allow_net_connect!
-  }
+  before { WebMock.allow_net_connect! }
 
   describe '.load_yml_erb' do
     it 'loads the remote location' do
@@ -34,13 +32,11 @@ describe RemoteSettingsService do
     end
   end
 
-
   describe '.load' do
     it 'loads the remote location' do
       expect do
         service.load('https://github.com/18F/identity-idp/blob/master/public/images/logo.svg')
       end.to_not raise_error
-
     end
 
     it 'raises an error if the location is not https://' do

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ServiceProviderSeeder do
     context 'when service_providers.yml has a remote setting' do
       before do
         location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/service_providers.yml'
-        RemoteSetting.create(name: 'service_providers.yml', url:location,
+        RemoteSetting.create(name: 'service_providers.yml', url: location,
                              contents: "test:\n  'issuer1':\n    friendly_name: 'name1'")
       end
 

--- a/spec/support/idv_examples/failed_idv_job.rb
+++ b/spec/support/idv_examples/failed_idv_job.rb
@@ -82,7 +82,7 @@ shared_examples 'failed idv job' do |step|
     end
   end
 
-  # rubocop:disable Lint/HandleExceptions
+  # rubocop:disable Lint/HandleExceptions, Style/RedundantBegin
   def stub_idv_job_to_raise_error_in_background(idv_job_class)
     allow(Idv::Agent).to receive(:new).and_raise('this is a test error')
     allow(idv_job_class).to receive(:perform_now).and_wrap_original do |perform_now, *args|
@@ -93,7 +93,7 @@ shared_examples 'failed idv job' do |step|
       end
     end
   end
-  # rubocop:enable Lint/HandleExceptions
+  # rubocop:enable Lint/HandleExceptions, Style/RedundantBegin
 
   def stub_idv_job_to_timeout_in_background(idv_job_class)
     allow(idv_job_class).to receive(:perform_now)

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -34,7 +34,7 @@ class SamlResponseDoc
   def raw_xml_response
     if @test_type == 'feature'
       xml_response
-    elsif @response.body =~ /<html>/
+    elsif @response.body.match?(/<html>/)
       html_response
     else
       @response.body
@@ -53,7 +53,7 @@ class SamlResponseDoc
   end
 
   def response_doc
-    if raw_xml_response =~ /EncryptedData/
+    if raw_xml_response.match?(/EncryptedData/)
       @original_encrypted = true
       Nokogiri::XML(
         OneLogin::RubySaml::Response.new(


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
