### PR TITLE
Prioritize piv/cac during signin if configured

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -5,12 +5,12 @@ module Users
     before_action :check_remember_device_preference
 
     def show
-      if current_user.totp_enabled?
+      if current_user.piv_cac_enabled?
+        redirect_to login_two_factor_piv_cac_url
+      elsif current_user.totp_enabled?
         redirect_to login_two_factor_authenticator_url
       elsif current_user.phone_enabled?
         validate_otp_delivery_preference_and_send_code
-      elsif current_user.piv_cac_enabled?
-        redirect_to login_two_factor_piv_cac_url
       else
         redirect_to two_factor_options_url
       end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -444,8 +444,6 @@ feature 'Two Factor Authentication' do
       user = user_with_piv_cac
       sign_in_before_2fa(user)
 
-      click_link t('devise.two_factor_authentication.piv_cac_fallback.link')
-
       expect(current_path).to eq login_two_factor_piv_cac_path
 
       expect(page).not_to have_link(t('links.two_factor_authentication.app'))
@@ -465,8 +463,6 @@ feature 'Two Factor Authentication' do
       user = create(:user, :signed_up, :with_piv_or_cac, otp_secret_key: 'foo')
       sign_in_before_2fa(user)
 
-      click_link t('devise.two_factor_authentication.piv_cac_fallback.link')
-
       expect(current_path).to eq login_two_factor_piv_cac_path
 
       click_link t('links.two_factor_authentication.app')
@@ -477,7 +473,6 @@ feature 'Two Factor Authentication' do
     scenario 'user can cancel PIV/CAC process' do
       user = create(:user, :signed_up, :with_piv_or_cac)
       sign_in_before_2fa(user)
-      click_link t('devise.two_factor_authentication.piv_cac_fallback.link')
 
       expect(current_path).to eq login_two_factor_piv_cac_path
       click_link t('links.cancel')


### PR DESCRIPTION
**Why**:
If a user has configured their account with piv/cac, then
we want to show that rather than sending them a text. They
can still opt to receive a text if they aren't able to use
their piv/cac.

**How**:
Swap the ordering so piv/cac is ahead of sms/voice.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
