### PR TITLE
LG-340 Use Twilio Verify for international SMS

### DIFF
--- a/.reek
+++ b/.reek
@@ -64,6 +64,7 @@ NestedIterators:
 NilCheck:
   enabled: false
 LongParameterList:
+  max_params: 4
   exclude:
     - IdentityLinker#optional_attributes
     - Idv::ProoferJob#perform
@@ -127,6 +128,9 @@ UncommunicativeModuleName:
     - X509::Attribute
     - X509::Attributes
     - X509::SessionStore
+UnusedParameters:
+  exclude:
+    - SmsOtpSenderJob#perform
 UnusedPrivateMethod:
   exclude:
     - ApplicationController

--- a/app/errors/twilio_errors.rb
+++ b/app/errors/twilio_errors.rb
@@ -5,4 +5,14 @@ module TwilioErrors
     21_215 => I18n.t('errors.messages.invalid_calling_area'),
     21_614 => I18n.t('errors.messages.invalid_sms_number'),
   }.freeze
+
+  VERIFY_ERRORS = {
+    60_033 => I18n.t('errors.messages.invalid_phone_number'),
+    # invalid country code
+    60_078 => I18n.t('errors.messages.invalid_phone_number'),
+    # cannot send sms to landline
+    60_082 => I18n.t('errors.messages.invalid_sms_number'),
+    # phone number not provisioned with any carrier
+    60_083 => I18n.t('errors.messages.invalid_phone_number'),
+  }.freeze
 end

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -1,25 +1,49 @@
 class SmsOtpSenderJob < ApplicationJob
   queue_as :sms
 
-  def perform(code:, phone:, otp_created_at:)
-    send_otp(TwilioService.new, code, phone) if otp_valid?(otp_created_at)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def perform(code:, phone:, otp_created_at:, locale: nil)
+    return unless otp_valid?(otp_created_at)
+
+    if us_number?
+      send_sms_via_twilio_rest_api
+    else
+      send_sms_via_twilio_verify_api(locale)
+    end
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   private
 
-  def otp_valid?(otp_created_at)
-    time_zone = Time.zone
-    time_zone.now < time_zone.parse(otp_created_at) + Devise.direct_otp_valid_for
+  def code
+    arguments[0][:code]
   end
 
-  def send_otp(twilio_service, code, phone)
-    twilio_service.send_sms(
+  def phone
+    arguments[0][:phone]
+  end
+
+  def send_sms_via_twilio_rest_api
+    TwilioService.new.send_sms(
       to: phone,
       body: I18n.t(
         'jobs.sms_otp_sender_job.message',
         code: code, app: APP_NAME, expiration: otp_valid_for_minutes
       )
     )
+  end
+
+  def send_sms_via_twilio_verify_api(locale)
+    PhoneVerification.new(phone: phone, locale: locale, code: code).send_sms
+  end
+
+  def us_number?
+    Phonelib.parse(phone).country == 'US'
+  end
+
+  def otp_valid?(otp_created_at)
+    time_zone = Time.zone
+    time_zone.now < time_zone.parse(otp_created_at) + Devise.direct_otp_valid_for
   end
 
   def otp_valid_for_minutes

--- a/app/services/phone_verification.rb
+++ b/app/services/phone_verification.rb
@@ -1,0 +1,83 @@
+class PhoneVerification
+  AUTHY_START_ENDPOINT = 'https://api.authy.com/protected/json/phones/verification/start'.freeze
+
+  HEADERS = { 'X-Authy-API-Key' => Figaro.env.twilio_verify_api_key }.freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 5
+
+  AVAILABLE_LOCALES = %w[af ar ca zh zh-CN zh-HK hr cs da nl en fi fr de el he hi hu id it ja ko ms
+                         nb pl pt-BR pt ro ru es sv tl th tr vi].freeze
+
+  cattr_accessor :adapter do
+    Typhoeus
+  end
+
+  def initialize(phone:, code:, locale: nil)
+    @phone = phone
+    @code = code
+    @locale = locale
+  end
+
+  def send_sms
+    raise VerifyError.new(code: error_code, message: error_message) unless start_request.success?
+  end
+
+  private
+
+  attr_reader :phone, :code, :locale
+
+  def error_code
+    response_body.fetch('error_code', nil).to_i
+  end
+
+  def error_message
+    response_body.fetch('message', '')
+  end
+
+  def response_body
+    @response_body ||= JSON.parse(start_request.response_body)
+  end
+
+  def start_request
+    @start_request ||= adapter.post(AUTHY_START_ENDPOINT, start_params)
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def start_params
+    {
+      headers: HEADERS,
+      body: {
+        code_length: 6,
+        country_code: country_code,
+        custom_code: code,
+        locale: locale,
+        phone_number: number_without_country_code,
+        via: 'sms',
+      },
+      connecttimeout: OPEN_TIMEOUT,
+      timeout: READ_TIMEOUT,
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def number_without_country_code
+    parsed_phone.raw_national
+  end
+
+  def parsed_phone
+    @parsed_phone ||= Phonelib.parse(phone)
+  end
+
+  def country_code
+    parsed_phone.country_code
+  end
+
+  class VerifyError < StandardError
+    attr_reader :code, :message
+
+    def initialize(code:, message:)
+      @code = code
+      @message = message
+    end
+  end
+end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -296,6 +296,7 @@ production:
   twilio_auth_token: # Twilio auth token
   twilio_messaging_service_sid: # Twilio CoPilot SID
   twilio_record_voice: 'false'
+  twilio_verify_api_key: 'change-me'
   use_kms: 'true'
   usps_confirmation_max_days: '30'
   enable_i18n_mode: 'false'
@@ -411,6 +412,7 @@ test:
   twilio_auth_token: 'token1'
   twilio_messaging_service_sid: '123abc'
   twilio_record_voice: 'true'
+  twilio_verify_api_key: 'secret'
   use_kms: 'false'
   usps_confirmation_max_days: '10'
   enable_i18n_mode: 'false'

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -135,7 +135,8 @@ describe Users::TwoFactorAuthenticationController do
         expect(SmsOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
           phone: subject.current_user.phone,
-          otp_created_at: subject.current_user.direct_otp_sent_at.to_s
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          locale: nil
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -203,7 +204,8 @@ describe Users::TwoFactorAuthenticationController do
         expect(VoiceOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
           phone: subject.current_user.phone,
-          otp_created_at: subject.current_user.direct_otp_sent_at.to_s
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          locale: nil
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
@@ -251,7 +253,8 @@ describe Users::TwoFactorAuthenticationController do
         expect(SmsOtpSenderJob).to have_received(:perform_now).with(
           code: subject.current_user.direct_otp,
           phone: @unconfirmed_phone,
-          otp_created_at: subject.current_user.direct_otp_sent_at.to_s
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          locale: nil
         )
       end
 
@@ -312,7 +315,7 @@ describe Users::TwoFactorAuthenticationController do
         expect(flash[:error]).to eq(failed_to_send_otp)
       end
 
-      it 'records an analytics event when Twilio responds with an error' do
+      it 'records an analytics event when Twilio responds with a RestError' do
         stub_analytics
         twilio_error = Twilio::REST::RestError.new(
           'error message', FakeTwilioErrorResponse.new
@@ -334,6 +337,32 @@ describe Users::TwoFactorAuthenticationController do
 
         expect(@analytics).to receive(:track_event).
           with(Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: twilio_error, code: '')
+
+        get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
+      end
+
+      it 'records an analytics event when Twilio responds with a VerifyError' do
+        stub_analytics
+        code = 60_033
+        error_message = 'error'
+        verify_error = PhoneVerification::VerifyError.new(code: code, message: error_message)
+
+        allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(verify_error)
+        analytics_hash = {
+          success: true,
+          errors: {},
+          otp_delivery_preference: 'sms',
+          resend: nil,
+          context: 'confirmation',
+          country_code: '1',
+          area_code: '202',
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::TWILIO_PHONE_VALIDATION_FAILED, error: error_message, code: code)
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -90,7 +90,8 @@ feature 'Changing authentication factor' do
           with(
             code: user.reload.direct_otp,
             phone: old_phone,
-            otp_created_at: user.reload.direct_otp_sent_at.to_s
+            otp_created_at: user.reload.direct_otp_sent_at.to_s,
+            locale: nil
           )
 
         expect(page).to have_content UserDecorator.new(user).masked_two_factor_phone_number
@@ -114,7 +115,8 @@ feature 'Changing authentication factor' do
             with(
               code: user.reload.direct_otp,
               phone: old_phone,
-              otp_created_at: user.reload.direct_otp_sent_at.to_s
+              otp_created_at: user.reload.direct_otp_sent_at.to_s,
+              locale: nil
             )
 
           expect(current_path).

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -13,7 +13,8 @@ feature 'Phone confirmation during sign up' do
       expect(SmsOtpSenderJob).to have_received(:perform_now).with(
         code: @user.reload.direct_otp,
         phone: '+1 703-555-5555',
-        otp_created_at: @user.direct_otp_sent_at.to_s
+        otp_created_at: @user.direct_otp_sent_at.to_s,
+        locale: nil
       )
     end
 

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -82,5 +82,27 @@ describe SmsOtpSenderJob do
         expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to eq []
       end
     end
+
+    context 'when the parsed country of the phone number is not US' do
+      it 'sends the SMS via PhoneVerification class' do
+        PhoneVerification.adapter = FakeAdapter
+        phone = '+1 787-327-0143'
+        code = '123456'
+        verification = instance_double(PhoneVerification)
+        locale = 'fr'
+
+        expect(PhoneVerification).to receive(:new).
+          with(phone: phone, locale: locale, code: code).
+          and_return(verification)
+        expect(verification).to receive(:send_sms)
+
+        SmsOtpSenderJob.perform_now(
+          code: code,
+          phone: phone,
+          otp_created_at: otp_created_at,
+          locale: locale
+        )
+      end
+    end
   end
 end

--- a/spec/services/phone_verification_spec.rb
+++ b/spec/services/phone_verification_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe PhoneVerification do
+  describe '#send_sms' do
+    it 'makes a POST request to Twilio Verify endpoint' do
+      PhoneVerification.adapter = FakeAdapter
+
+      phone = '17873270143'
+      headers = { 'X-Authy-API-Key' => 'secret' }
+      locale = 'es'
+      code = '123456'
+      body = {
+        code_length: 6,
+        country_code: '1',
+        custom_code: code,
+        locale: locale,
+        phone_number: '7873270143',
+        via: 'sms',
+      }
+      connecttimeout = PhoneVerification::OPEN_TIMEOUT
+      timeout = PhoneVerification::READ_TIMEOUT
+
+      expect(FakeAdapter).to receive(:post).
+        with(
+          PhoneVerification::AUTHY_START_ENDPOINT,
+          headers: headers,
+          body: body,
+          connecttimeout: connecttimeout,
+          timeout: timeout
+        ).and_return(FakeAdapter::SuccessResponse.new)
+
+      PhoneVerification.new(phone: phone, locale: locale, code: code).send_sms
+    end
+
+    it 'raises VerifyError when response is not successful' do
+      PhoneVerification.adapter = FakeAdapter
+      phone = '17035551212'
+      code = '123456'
+
+      allow(FakeAdapter).to receive(:post).and_return(FakeAdapter::ErrorResponse.new)
+
+      expect { PhoneVerification.new(phone: phone, code: code).send_sms }.to raise_error do |error|
+        expect(error.code).to eq 60_033
+        expect(error.message).to eq 'Invalid number'
+        expect(error).to be_a(PhoneVerification::VerifyError)
+      end
+    end
+  end
+end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -24,7 +24,7 @@ describe TwilioService do
 
       SmsOtpSenderJob.perform_now(
         code: '1234',
-        phone: '555-5555',
+        phone: '17035551212',
         otp_created_at: Time.zone.now.to_s
       )
 

--- a/spec/support/fake_adapter.rb
+++ b/spec/support/fake_adapter.rb
@@ -1,0 +1,24 @@
+module FakeAdapter
+  def self.post(_endpoint, _params)
+    SuccessResponse.new
+  end
+
+  class SuccessResponse
+    def success?
+      true
+    end
+  end
+
+  class ErrorResponse
+    def success?
+      false
+    end
+
+    def response_body
+      {
+        error_code: '60033',
+        message: 'Invalid number',
+      }.to_json
+    end
+  end
+end


### PR DESCRIPTION
**Why**: It purports to be more reliable than the Twilio REST API.
Another benefit is that they provide localized messages in a bunch of
languages (whereas we only support English, French, and Spanish).
By default, the Verify service uses their own generated code, but they
also allow you to use your own code and validation, which is what I've
done in this PR.

The advantage of using Twilio's code is that it can be cheaper because
once a user requests an SMS, it is valid for 10 minutes, and if the user
requests another SMS while the first one is still valid, Twilio will
resend the original code at no additional cost.

The disadvantage is that we no longer retain control of how the code
is generated, and how it is validated. It would also require a second
API call to verify the code entered by the user.

From the documentation, it seems that if we want to take advantage of
the localization, we cannot use our own custom text. We are meeting with
Twilio to get confirmation.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
