### PR TITLE
Define locale argument for VoiceOtpSenderJob

### DIFF
--- a/.reek
+++ b/.reek
@@ -133,6 +133,7 @@ UncommunicativeModuleName:
 UnusedParameters:
   exclude:
     - SmsOtpSenderJob#perform
+    - VoiceOtpSenderJob#perform
 UnusedPrivateMethod:
   exclude:
     - ApplicationController

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -4,9 +4,15 @@ class VoiceOtpSenderJob < ApplicationJob
 
   queue_as :voice
 
-  def perform(code:, phone:, otp_created_at:)
+  # rubocop:disable Lint/UnusedMethodArgument
+  # locale is an argument used for the Twilio/Authy Verify service, which uses
+  # a localized message for delivering OTPs via SMS and Voice. As of this
+  # writing, we are only using Verify for non-US SMS, but we might expand
+  # to Voice later.
+  def perform(code:, phone:, otp_created_at:, locale: nil)
     send_otp(TwilioService::Utils.new, code, phone) if otp_valid?(otp_created_at)
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   private
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -125,6 +125,17 @@ feature 'Two Factor Authentication' do
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end
     end
+
+    context 'with voice option and US number' do
+      it 'sends the code via VoiceOtpSenderJob and redirects to prompt for the code' do
+        sign_in_before_2fa
+        select_2fa_option('voice')
+        fill_in 'user_phone_form_phone', with: '7035551212'
+        click_send_security_code
+
+        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
+      end
+    end
   end
 
   def phone_field


### PR DESCRIPTION
**Why**: The controller calls it with that argument. I overlooked this
when working on #2280

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
