### PR TITLE
LG-429 Create an AWS lambda function for delayed notifications with account reset

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,6 +138,8 @@ Rails/TimeZone:
   SupportedStyles:
     - strict
     - flexible
+  Exclude:
+    - 'lib/lambdas/account_reset_lambda.rb'
 
 Layout/AlignParameters:
   # Alignment of parameters in multi-line method calls.

--- a/lib/lambdas/account_reset_lambda.rb
+++ b/lib/lambdas/account_reset_lambda.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+
+class AccountResetLambda
+  def initialize(url, auth_token)
+    @url = url
+    @auth_token = auth_token
+  end
+
+  def send_notifications
+    Kernel.puts "Sending delayed account reset notifications to #{@url}"
+    time = now
+    results = post
+    Kernel.puts "Response #{results.code} #{results.message}: #{results.body}"
+    duration = now - time
+    Kernel.puts "Completed in #{duration.round(2)} seconds"
+  end
+
+  private
+
+  def post
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.open_timeout = 60
+    http.read_timeout = 300
+    http.use_ssl = true if uri.scheme == 'https'
+    req = Net::HTTP::Post.new(uri.path, 'X-API-AUTH-TOKEN' => @auth_token)
+    http.request(req)
+  end
+
+  def uri
+    @uri ||= URI.parse(@url)
+  end
+
+  def now
+    Time.now.to_f
+  end
+end
+
+# This lambda is triggered by cloudwatch to run on a recurring basis.
+# It is invoked with the following parameters:
+# AccountResetLambda.new(ENV['LOGIN_GOV_URL'], ENV['X_API_AUTH_TOKEN']).send_notifications

--- a/spec/lib/lambdas/account_reset_lambda_spec.rb
+++ b/spec/lib/lambdas/account_reset_lambda_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'lambdas/account_reset_lambda'
+
+describe AccountResetLambda do
+  let(:subject) { AccountResetLambda }
+  let(:auth_token) { 'abc123' }
+  let(:test_url) { 'https://fakelogin.gov/path1/path2' }
+
+  describe '#send_notifications' do
+    it 'calls the url supplying the auth token in the header' do
+      stub_request(:post, test_url).
+        with(headers: { 'X-Api-Auth-Token' => auth_token }).
+        to_return(status: 200, body: '', headers: {})
+
+      subject.new(test_url, auth_token).send_notifications
+    end
+  end
+end


### PR DESCRIPTION
**Why**: We need to notify and grant users the ability to delete their account after waiting 24 hours.

**How**: Create a lambda function that is triggered by cloudwatch to run on a recurring basis.  Have this lambda function call the API endpoint /api/account_reset/send_notifications on IDP which determines users that need to be notified. The API then issues grant tokens and sends notifications. Notifications are sent via email and contain urls with the grant token.  The API endpoint uses locking to ensure that a user is notified only once.  The API is protected by an auth token that is sent in the header X-Api-Auth-Token of the post.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
