### PR TITLE
LG-289 Drop old encrypted password columns

### DIFF
--- a/db/migrate/20180709141748_drop_encrypted_password_column_from_user.rb
+++ b/db/migrate/20180709141748_drop_encrypted_password_column_from_user.rb
@@ -1,0 +1,15 @@
+class DropEncryptedPasswordColumnFromUser < ActiveRecord::Migration[5.1]
+  def up
+    safety_assured do
+      remove_column :users, :encrypted_password
+      remove_column :users, :password_salt
+      remove_column :users, :password_cost
+    end
+  end
+
+  def down
+    add_column :users, :encrypted_password, :string, limit: 255, default: ''
+    add_column :users, :password_salt, :string
+    add_column :users, :password_cost, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180620233914) do
+ActiveRecord::Schema.define(version: 20180709141748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,7 +171,6 @@ ActiveRecord::Schema.define(version: 20180620233914) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "encrypted_password", limit: 255, default: ""
     t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -201,11 +200,9 @@ ActiveRecord::Schema.define(version: 20180620233914) do
     t.datetime "idv_attempted_at"
     t.integer "idv_attempts", default: 0
     t.string "recovery_code"
-    t.string "password_salt"
     t.string "encryption_key"
     t.string "unique_session_id"
     t.string "recovery_salt"
-    t.string "password_cost"
     t.string "recovery_cost"
     t.string "email_fingerprint", default: "", null: false
     t.text "encrypted_email", default: "", null: false


### PR DESCRIPTION
**Why**: We are no longer using these columns in favor of
`encrypted_password_digest`

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
