### PR TITLE
LG-268 Serve assets from Cloudfront CDN

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,9 +5,9 @@ Rails.application.configure do
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local = false
-  config.action_controller.asset_host = Figaro.env.domain_name
   config.action_controller.perform_caching = true
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  config.action_controller.asset_host = Figaro.env.asset_host || Figaro.env.domain_name
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true
@@ -19,7 +19,7 @@ Rails.application.configure do
     host: Figaro.env.domain_name,
     protocol: 'https',
   }
-  config.action_mailer.asset_host = Figaro.env.mailer_domain_name
+  config.action_mailer.asset_host = Figaro.env.asset_host || Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_options = { from: Figaro.env.email_from }
   config.action_mailer.delivery_method = if Figaro.env.disable_email_sending == 'true'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -18,8 +18,8 @@ SecureHeaders::Configuration.default do |config|
       '*.nr-data.net',
       '*.google-analytics.com',
     ],
-    font_src: ["'self'", 'data:'],
-    img_src: ["'self'", 'data:', 'login.gov'],
+    font_src: ["'self'", 'data:', Figaro.env.asset_host],
+    img_src: ["'self'", 'data:', 'login.gov', Figaro.env.asset_host],
     media_src: ["'self'"],
     object_src: ["'none'"],
     script_src: [
@@ -30,8 +30,9 @@ SecureHeaders::Configuration.default do |config|
       '*.google-analytics.com',
       'www.google.com',
       'www.gstatic.com',
+      Figaro.env.asset_host,
     ],
-    style_src: ["'self'"],
+    style_src: ["'self'", Figaro.env.asset_host],
     base_uri: ["'self'"],
   }
 


### PR DESCRIPTION
**Why**: Moving assets to be served from Cloudfront as opposed to nginx
will reduce the load on our servers, and will make the site faster for
users across the globe.

On the Rails app side, this is a trivial change. The tricky part is
setting up the Cloudfront distribution and making sure to select
`Whitelist` from the `Cache Based on Selected Request Headers` dropdown,
and add the `Origin` header to the `Whitelist Headers`. Then, add the
following headers to the nginx config for fonts:
`Access-Control-Allow-Origin` set to the current server domain name,
including the protocol, such as `https://secure.login.gov`, and
`Access-Control-Allow-Methods` set to `GET`.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
