### PR TITLE
LG-464 Update attribute encryption rake task to log errors and continue

### DIFF
--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -11,9 +11,13 @@ namespace :rotate do
     User.find_in_batches.with_index do |users, _batch|
       User.transaction do
         users.each do |user|
-          rotator = KeyRotator::AttributeEncryption.new(user)
-          rotator.rotate
-          progress&.increment
+          begin
+            rotator = KeyRotator::AttributeEncryption.new(user)
+            rotator.rotate
+            progress&.increment
+          rescue StandardError => err # Don't use user.email in output...
+            Kernel.puts "Error with user id:#{user.id} #{err.message} #{err.backtrace}"
+          end
         end
       end
     end


### PR DESCRIPTION
Why: The script halts if there is an encryption exception with a single account

How: Put an EncryptionError rescue block in the rake task

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
