### PR TITLE
Add NGA and EOP as agencies which allow piv/cac

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -273,7 +273,7 @@ production:
   participate_in_dap: 'false' # pair with google_analytics_key
   password_pepper: # generate via `rake secret`
   password_strength_enabled: 'true'
-  piv_cac_agencies: '["DOD"]'
+  piv_cac_agencies: '["DOD","NGA","EOP"]'
   piv_cac_enabled: 'false'
   pkcs11_lib: '/opt/cloudhsm/lib/libcloudhsm_pkcs11.so'
   programmable_sms_countries: 'US,CA,MX'


### PR DESCRIPTION
**Why**:
We want to slowly roll out piv/cac use so we can make sure
the users to whom we show the option are most likely to
find it useful and usable.

**How**:
Add NGA and EOP as supported agencies for their respective
SPs.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
