### PR TITLE
LG-439 Don't raise error for invalid user params

### DIFF
--- a/.reek
+++ b/.reek
@@ -49,6 +49,7 @@ FeatureEnvy:
     - Idv::Proofer#validate_vendors
     - PersonalKeyGenerator#create_legacy_recovery_code
     - TwoFactorAuthenticationController#capture_analytics_for_exception
+    - Users::SessionsController#configure_permitted_parameters
 InstanceVariableAssumption:
   exclude:
     - User
@@ -59,6 +60,7 @@ ManualDispatch:
   exclude:
     - EncryptedSidekiqRedis#respond_to_missing?
     - CloudhsmKeyGenerator#initialize_settings
+    - Users::SessionsController#configure_permitted_parameters
 NestedIterators:
   exclude:
     - UserFlowExporter#self.massage_html

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,7 @@ module Users
     skip_before_action :require_no_authentication, only: [:new]
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new]
+    before_action :configure_permitted_parameters, only: [:new]
 
     def new
       analytics.track_event(
@@ -47,6 +48,12 @@ module Users
     end
 
     private
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_in) do |user_params|
+        user_params.permit(:email) if user_params.respond_to?(:permit)
+      end
+    end
 
     def redirect_to_signin
       controller_info = 'users/sessions#create'

--- a/spec/requests/invalid_sign_in_params_spec.rb
+++ b/spec/requests/invalid_sign_in_params_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe 'visiting sign in page with invalid user params' do
+  it 'does not raise an exception' do
+    get new_user_session_path, params: { user: 'test@test.com' }
+  end
+end


### PR DESCRIPTION
**Why**: There is a bug in Devise where if you visit the sign in page
with a `user` param set to a String, it will raise an exception. The
bug has been fixed and merged into master, but hasn't been released
to Rubygems yet. We could either point our gem to Devise's master
branch, or temporarily add some code to prevent the bug until the fix
is released. I opted for the latter because I don't know how stable the
master branch is and what kind of changes are in it.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
