### PR TITLE
Adjust response code for SMS reply

### DIFF
--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -44,7 +44,9 @@ class SmsController < ApplicationController
       result.to_h
     )
 
-    head :forbidden
+    # Invalid requests don't require a response for now, and 4xx
+    # errors from random incoming messages junk up the logs
+    head :ok
   end
 
   # `http_basic_authenticate_with name` had issues related to testing, so using

--- a/app/services/twilio_service/sms/request.rb
+++ b/app/services/twilio_service/sms/request.rb
@@ -32,10 +32,6 @@ module TwilioService
         }
       end
 
-      private
-
-      attr_reader :url, :params, :signature
-
       # First, validate the message signature using Twilio's library:
       # https://github.com/twilio/twilio-ruby/wiki/Request-Validator
       def signature_valid?
@@ -51,6 +47,10 @@ module TwilioService
         # before processing the submission; however this is on-hold during the
         # initial phase.
       end
+
+      private
+
+      attr_reader :url, :params, :signature
     end
   end
 end


### PR DESCRIPTION
**Why**: 4xx-class errors caused by random
incoming messages would clutter log output.

**How**: Adjust the response code.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
