### PR TITLE
LG-484 Display a message to the user when an account reset link is expired

### DIFF
--- a/app/models/account_reset_request.rb
+++ b/app/models/account_reset_request.rb
@@ -7,7 +7,11 @@ class AccountResetRequest < ApplicationRecord
   end
 
   def granted_token_valid?
-    !granted_token.nil? &&
-      ((Time.zone.now - granted_at) <= Figaro.env.account_reset_token_valid_for_days.to_i.days)
+    granted_token.present? && !granted_token_expired?
+  end
+
+  def granted_token_expired?
+    granted_at.present? &&
+      ((Time.zone.now - granted_at) > Figaro.env.account_reset_token_valid_for_days.to_i.days)
   end
 end

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -46,7 +46,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
   end
 
   def account_reset_or_cancel_link
-    account_reset_token ? account_reset_cancel_link : account_reset_link
+    account_reset_token_valid? ? account_reset_cancel_link : account_reset_link
   end
 
   private
@@ -69,6 +69,10 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def account_reset_token
     current_user&.account_reset_request&.request_token
+  end
+
+  def account_reset_token_valid?
+    current_user&.account_reset_request&.granted_token_valid?
   end
 
   def configured_2fa_types

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -146,6 +146,8 @@ en:
         code below.
       please_try_again_html: Please try again in <strong id=%{id}>%{time_remaining}</strong>.
       account_reset:
+        link_expired: The link to delete your login.gov account has expired.  Please
+          create another request to delete your account.
         successful_cancel: Thank you. Your request to delete your login.gov account
           has been cancelled.
         link: deleting your account

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -151,6 +151,8 @@ es:
         el código de seguridad a continuación.
       please_try_again_html: Inténtelo de nuevo en <strong id=%{id}>%{time_remaining}</strong>.
       account_reset:
+        link_expired: El enlace para eliminar su cuenta de login.gov ha caducado.
+          Crea otra solicitud para eliminar tu cuenta.
         successful_cancel: Gracias. Su solicitud para eliminar su cuenta de login.gov
           ha sido cancelada.
         link: eliminando su cuenta

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -158,6 +158,8 @@ fr:
         le code de sécurité ci-dessous.
       please_try_again_html: Veuillez essayer de nouveau dans <strong id=%{id}>%{time_remaining}</strong>.
       account_reset:
+        link_expired: Le lien pour supprimer votre compte login.gov a expiré. Veuillez
+          créer une autre demande pour supprimer votre compte.
         successful_cancel: Je vous remercie. Votre demande de suppression de votre
           compte login.gov a été annulée.
         link: supprimer votre compte

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -9,7 +9,7 @@ en:
       link_text: Create your account
       subject: Your login.gov password reset request
     account_reset_cancel:
-      intro: This email confirms you have cancelled the request to delete your login.gov
+      intro: This email confirms you have cancelled your request to delete your login.gov
         account.
       subject: Delete your account
       help: ''

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -6,7 +6,7 @@ es:
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
     account_reset_cancel:
-      intro: Este correo electrónico confirma que ha cancelado la solicitud para eliminar
+      intro: Este correo electrónico confirma que ha cancelado su solicitud para eliminar
         su cuenta de login.gov.
       subject: Eliminar su cuenta
       help: ''

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -6,8 +6,8 @@ fr:
       link_text: NOT TRANSLATED YET
       subject: NOT TRANSLATED YET
     account_reset_cancel:
-      intro: Cet e-mail confirme que vous avez annulé la demande de suppression de
-        votre compte login.gov.
+      intro: Cet e-mail confirme que vous avez annulé votre demande de suppression
+        de votre compte login.gov.
       subject: Supprimer votre compte
       help: ''
     account_reset_request:

--- a/spec/models/account_reset_request_spec.rb
+++ b/spec/models/account_reset_request_spec.rb
@@ -28,6 +28,29 @@ describe AccountResetRequest do
     end
   end
 
+  describe '#granted_token_expired?' do
+    it 'returns false if the token does not exist' do
+      subject.granted_token = nil
+      subject.granted_at = nil
+
+      expect(subject.granted_token_expired?).to eq(false)
+    end
+
+    it 'returns true if the token is expired' do
+      subject.granted_token = '123'
+      subject.granted_at = Time.zone.now - 7.days
+
+      expect(subject.granted_token_expired?).to eq(true)
+    end
+
+    it 'returns false if the token is valid' do
+      subject.granted_token = '123'
+      subject.granted_at = Time.zone.now
+
+      expect(subject.granted_token_expired?).to eq(false)
+    end
+  end
+
   describe '.from_valid_granted_token' do
     it 'returns nil if the token does not exist' do
       expect(AccountResetRequest.from_valid_granted_token('123')).to eq(nil)

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -19,9 +19,13 @@ describe TwoFactorLoginOptionsPresenter do
       t('two_factor_authentication.login_options_title')
   end
 
-  it 'supplies a cancel link when there is an account reset token' do
+  it 'supplies a cancel link when the token is valid' do
+    allow_any_instance_of(TwoFactorLoginOptionsPresenter).to \
+      receive(:account_reset_token_valid?).and_return(true)
+
     allow_any_instance_of(TwoFactorLoginOptionsPresenter).to \
       receive(:account_reset_token).and_return('foo')
+
     expect(presenter.account_reset_or_cancel_link).to eq \
       t('devise.two_factor_authentication.account_reset.pending_html',
         cancel_link: view.link_to(
@@ -30,9 +34,10 @@ describe TwoFactorLoginOptionsPresenter do
         ))
   end
 
-  it 'supplies a reset link when there is no account reset token' do
+  it 'supplies a reset link when the token is not valid' do
     allow_any_instance_of(TwoFactorLoginOptionsPresenter).to \
-      receive(:account_reset_token).and_return(nil)
+      receive(:account_reset_token_valid?).and_return(false)
+
     expect(presenter.account_reset_or_cancel_link).to eq \
       t('devise.two_factor_authentication.account_reset.text_html',
         link: view.link_to(


### PR DESCRIPTION
**Why**: Currently when a link to delete account is expired the user has no indication that the link was expired after clicking on it.  Moreover when there is a pending request for account reset and the token is expired, a cancel link still shows.  The user can cancel and create a new request.  However we should remove the cancel link when the token expires so that they can immediately create a new request.

**How**: Display a flash message to the user when the token is expired.  When there is a pending request check for a valid token rather than the existence of a token.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
