### PR TITLE
LG-403 Create an AWS lambda function to upload USPS verification to GPO

### DIFF
--- a/app/controllers/usps_upload_controller.rb
+++ b/app/controllers/usps_upload_controller.rb
@@ -1,4 +1,6 @@
 class UspsUploadController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def create
     authorize do
       UspsUploader.new.run unless HolidayService.observed_holiday?(today)
@@ -17,11 +19,11 @@ class UspsUploadController < ApplicationController
     end
   end
 
-  def authorization_token
-    request.headers['X-USPS-UPLOAD-TOKEN']
-  end
-
   def today
     Time.zone.today
+  end
+
+  def authorization_token
+    request.headers['X-API-AUTH-TOKEN']
   end
 end

--- a/spec/controllers/usps_upload_controller_spec.rb
+++ b/spec/controllers/usps_upload_controller_spec.rb
@@ -56,6 +56,6 @@ describe UspsUploadController do
   end
 
   def headers(token)
-    request.headers['X-USPS-UPLOAD-TOKEN'] = token
+    request.headers['X-API-AUTH-TOKEN'] = token
   end
 end


### PR DESCRIPTION
**Why**: The USPS upload to GPO needs to occur once per day.

**How**: Reuse the generic lambda created for account reset which passes the api token in the X-API-AUTH-TOKEN header. The code can be found here: https://github.com/18F/identity-idp/pull/2310

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
