### PR TITLE
Fix personal key 2fa selection

### DIFF
--- a/.reek
+++ b/.reek
@@ -47,7 +47,6 @@ FeatureEnvy:
     - Utf8Sanitizer#event_attributes
     - Utf8Sanitizer#remote_ip
     - Idv::Proofer#validate_vendors
-    - PersonalKeyGenerator#create_legacy_recovery_code
     - TwoFactorAuthenticationController#capture_analytics_for_exception
     - Users::SessionsController#configure_permitted_parameters
 InstanceVariableAssumption:

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -224,7 +224,9 @@ module TwoFactorAuthenticatable
   end
 
   def personal_key_unavailable?
-    idv_or_confirmation_context? || profile_context? || current_user.personal_key.blank?
+    idv_or_confirmation_context? ||
+      profile_context? ||
+      current_user.encrypted_recovery_code_digest.blank?
   end
 
   def unconfirmed_phone?

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -72,7 +72,7 @@ module Idv
     end
 
     def handle_idv_redirect
-      redirect_to account_url and return if current_user.personal_key.present?
+      redirect_to account_url and return if current_user.encrypted_recovery_code_digest.present?
       user_session[:personal_key] = create_new_code
       redirect_to manage_personal_key_url
     end

--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -20,11 +20,12 @@ module SignUp
 
     def confirm_user_needs_initial_personal_key
       redirect_to(account_url) if user_session[:personal_key].nil? &&
-                                  current_user.personal_key.present?
+                                  current_user.encrypted_recovery_code_digest.present?
     end
 
     def assign_initial_personal_key
-      user_session[:personal_key] = create_new_code if current_user.personal_key.nil?
+      return if current_user.encrypted_recovery_code_digest.present?
+      user_session[:personal_key] = create_new_code
     end
 
     def next_step

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -112,7 +112,7 @@ class UserDecorator
 
     sp_session = session[:sp]
 
-    user.personal_key.blank? && (sp_session.blank? || sp_session[:loa3] == false)
+    user.encrypted_recovery_code_digest.blank? && (sp_session.blank? || sp_session[:loa3] == false)
   end
 
   def recent_events

--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -17,7 +17,24 @@ module UserAccessKeyOverrides
   def password=(new_password)
     @password = new_password
     return if @password.blank?
-    self.encrypted_password_digest = Encryption::PasswordVerifier.digest(@password).to_s
+    self.encrypted_password_digest = Encryption::PasswordVerifier.digest(@password)
+  end
+
+  def valid_personal_key?(normalized_personal_key)
+    Encryption::PasswordVerifier.verify(
+      password: normalized_personal_key,
+      digest: encrypted_recovery_code_digest
+    )
+  end
+
+  def personal_key
+    @personal_key
+  end
+
+  def personal_key=(new_personal_key)
+    @personal_key = new_personal_key
+    return if @personal_key.blank?
+    self.encrypted_recovery_code_digest = Encryption::PasswordVerifier.digest(@personal_key)
   end
 
   # This is a devise method, which we are overriding. This should not be removed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,14 +43,6 @@ class User < ApplicationRecord
 
   attr_accessor :asserted_attributes
 
-  def personal_key
-    recovery_code
-  end
-
-  def personal_key=(value)
-    self.recovery_code = value
-  end
-
   def set_default_role
     self.role ||= :user
   end

--- a/app/policies/personal_key_login_option_policy.rb
+++ b/app/policies/personal_key_login_option_policy.rb
@@ -4,7 +4,7 @@ class PersonalKeyLoginOptionPolicy
   end
 
   def configured?
-    user.personal_key.present?
+    user.encrypted_recovery_code_digest.present?
   end
 
   private

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -37,7 +37,7 @@ module Encryption
         uak.encryption_key,
         salt,
         uak.cost
-      )
+      ).to_s
     end
 
     def self.verify(password:, digest:)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
     trait :with_personal_key do
       after :build do |user|
-        user.personal_key = PersonalKeyGenerator.new(user).create
+        PersonalKeyGenerator.new(user).create
       end
     end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -662,14 +662,14 @@ feature 'Two Factor Authentication' do
     # For example, when migrating users from another DB
     it 'displays personal key and redirects to profile' do
       user = create(:user, :signed_up)
-      UpdateUser.new(user: user, attributes: { personal_key: nil }).call
+      UpdateUser.new(user: user, attributes: { encrypted_recovery_code_digest: nil }).call
 
       sign_in_user(user)
       click_button t('forms.buttons.submit.default')
       fill_in 'code', with: user.reload.direct_otp
       click_button t('forms.buttons.submit.default')
 
-      expect(user.reload.personal_key).not_to be_nil
+      expect(user.reload.encrypted_recovery_code_digest).not_to be_nil
 
       click_acknowledge_personal_key
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -26,11 +26,11 @@ feature 'View personal key' do
     context 'regenerating personal key' do
       scenario 'displays new code' do
         user = sign_in_and_2fa_user
-        old_code = user.personal_key
+        old_digest = user.encrypted_recovery_code_digest
 
         click_button t('account.links.regenerate_personal_key')
 
-        expect(user.reload.personal_key).to_not eq old_code
+        expect(user.reload.encrypted_recovery_code_digest).to_not eq old_digest
       end
     end
 
@@ -40,13 +40,13 @@ feature 'View personal key' do
 
         user = sign_in_and_2fa_user
 
-        old_code = user.personal_key
+        old_digest = user.encrypted_recovery_code_digest
 
         first(:link, t('forms.buttons.edit')).click
         click_on(t('links.cancel'))
         click_on(t('account.links.regenerate_personal_key'))
 
-        expect(user.reload.personal_key).to_not eq old_code
+        expect(user.reload.encrypted_recovery_code_digest).to_not eq old_digest
       end
     end
 
@@ -62,13 +62,13 @@ feature 'View personal key' do
     context 'visitting the personal key path' do
       scenario 'does not regenerate the personal and redirects to account' do
         user = sign_in_and_2fa_user
-        old_code = user.personal_key
+        old_digest = user.encrypted_recovery_code_digest
 
         visit sign_up_personal_key_path
 
         user.reload
 
-        expect(user.personal_key).to eq(old_code)
+        expect(user.encrypted_recovery_code_digest).to eq(old_digest)
         expect(current_path).to eq(account_path)
       end
     end

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -9,7 +9,7 @@ describe PasswordResetEmailForm do
   describe '#submit' do
     context 'when email is valid and user exists' do
       it 'returns hash with properties about the event and the user' do
-        user = build(:user, :signed_up, email: 'test1@test.com')
+        user = create(:user, :signed_up, email: 'test1@test.com')
         subject = PasswordResetEmailForm.new('Test1@test.com')
 
         extra = {
@@ -65,7 +65,7 @@ describe PasswordResetEmailForm do
 
     context 'when recaptcha is valid' do
       it 'returns hash with properties about the event and the user' do
-        user = build(:user, :signed_up, email: 'test1@test.com')
+        user = create(:user, :signed_up, email: 'test1@test.com')
 
         captcha_results = mock_captcha(enabled: true, present: true, valid: true)
         subject = PasswordResetEmailForm.new('Test1@test.com', captcha_results)
@@ -90,7 +90,7 @@ describe PasswordResetEmailForm do
 
     context 'when recaptcha is invalid' do
       it 'returns hash with properties about the event and the user' do
-        user = build(:user, :signed_up, email: 'test1@test.com')
+        user = create(:user, :signed_up, email: 'test1@test.com')
 
         captcha_results = mock_captcha(enabled: true, present: true, valid: false)
         subject = PasswordResetEmailForm.new('Test1@test.com', captcha_results)

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -9,12 +9,13 @@ describe Encryption::PasswordVerifier do
       digest = described_class.digest('saltypickles')
 
       uak = Encryption::UserAccessKey.new(password: 'saltypickles', salt: salt)
-      uak.unlock(digest.encryption_key)
+      parsed_digest = JSON.parse(digest, symbolize_names: true)
+      uak.unlock(parsed_digest[:encryption_key])
 
-      expect(digest.encrypted_password).to eq(uak.encrypted_password)
-      expect(digest.encryption_key).to eq(uak.encryption_key)
-      expect(digest.password_salt).to eq(salt)
-      expect(digest.password_cost).to eq(uak.cost)
+      expect(parsed_digest[:encrypted_password]).to eq(uak.encrypted_password)
+      expect(parsed_digest[:encryption_key]).to eq(uak.encryption_key)
+      expect(parsed_digest[:password_salt]).to eq(salt)
+      expect(parsed_digest[:password_cost]).to eq(uak.cost)
     end
   end
 
@@ -22,14 +23,14 @@ describe Encryption::PasswordVerifier do
     it 'returns true if the password matches' do
       password = 'saltypickles'
 
-      digest = described_class.digest(password).to_s
+      digest = described_class.digest(password)
       result = described_class.verify(password: password, digest: digest)
 
       expect(result).to eq(true)
     end
 
     it 'returns false if the password does not match' do
-      digest = described_class.digest('saltypickles').to_s
+      digest = described_class.digest('saltypickles')
       result = described_class.verify(password: 'pepperpickles', digest: digest)
 
       expect(result).to eq(false)

--- a/spec/services/personal_key_generator_spec.rb
+++ b/spec/services/personal_key_generator_spec.rb
@@ -27,7 +27,7 @@ describe PersonalKeyGenerator do
 
       generator.create
 
-      expect(user.personal_key).to_not eq personal_key
+      expect(user.encrypted_recovery_code_digest).to_not eq personal_key
     end
 
     it 'generates a phrase of 4 words by default' do
@@ -44,20 +44,10 @@ describe PersonalKeyGenerator do
     it 'sets the encrypted recovery code digest' do
       user = create(:user)
       generator = PersonalKeyGenerator.new(user)
-      generator.create
+      key = generator.create
 
-      encrypted_recovery_code_data = JSON.parse(
-        user.encrypted_recovery_code_digest, symbolize_names: true
-      )
-
-      expect(
-        encrypted_recovery_code_data[:encryption_key]
-      ).to eq(user.personal_key.split('.').first)
-      expect(
-        encrypted_recovery_code_data[:encrypted_password]
-      ).to eq(user.personal_key.split('.').second)
-      expect(encrypted_recovery_code_data[:password_cost]).to eq(user.recovery_cost)
-      expect(encrypted_recovery_code_data[:password_salt]).to eq(user.recovery_salt)
+      expect(user.encrypted_recovery_code_digest).to_not be_empty
+      expect(generator.verify(key)).to eq(true)
     end
   end
 

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -3,11 +3,11 @@ shared_examples_for 'personal key page' do
 
   context 'regenerating personal key with `Get another code` button' do
     scenario 'displays a flash message and a new code' do
-      old_code = @user.reload.personal_key
+      old_digest = @user.reload.encrypted_recovery_code_digest
 
       click_button t('users.personal_key.get_another')
 
-      expect(@user.reload.personal_key).to_not eq old_code
+      expect(@user.reload.encrypted_recovery_code_digest).to_not eq old_digest
       expect(page).to have_content t('notices.send_code.personal_key')
     end
   end


### PR DESCRIPTION
This branch has 2 commits:

- The first commit reverts the reversion to remove the personal key changes that broke on master
- The second commit fixes the bug that broke the 2FA selection form on master

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
