### PR TITLE
LG-450 Use different text in SMS for login vs verify phone number

### DIFF
--- a/.reek
+++ b/.reek
@@ -76,6 +76,7 @@ LongParameterList:
     - Idv::ProoferJob#perform
     - Idv::VendorResult#initialize
     - JWT
+    - SmsOtpSenderJob#perform
 RepeatedConditional:
   exclude:
     - Users::ResetPasswordsController

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -2,11 +2,11 @@ class SmsOtpSenderJob < ApplicationJob
   queue_as :sms
 
   # rubocop:disable Lint/UnusedMethodArgument
-  def perform(code:, phone:, otp_created_at:, locale: nil)
+  def perform(code:, phone:, otp_created_at:, message:, locale: nil)
     return unless otp_valid?(otp_created_at)
 
     if programmable_sms_number?
-      send_sms_via_twilio_rest_api
+      send_sms_via_twilio_rest_api(message)
     else
       send_sms_via_twilio_verify_api(locale)
     end
@@ -23,11 +23,11 @@ class SmsOtpSenderJob < ApplicationJob
     arguments[0][:phone]
   end
 
-  def send_sms_via_twilio_rest_api
+  def send_sms_via_twilio_rest_api(message)
     TwilioService::Utils.new.send_sms(
       to: phone,
       body: I18n.t(
-        'jobs.sms_otp_sender_job.message',
+        message,
         code: code, app: APP_NAME, expiration: otp_valid_for_minutes
       )
     )

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -115,11 +115,12 @@ ignore_unused:
   - 'headings.piv_cac_setup.*'
   - 'idv.errors.pattern_mismatch.*'
   - 'idv.messages.jurisdiction.{no_id,unsupported_jurisdiction}_failure'
+  - 'jobs.sms_otp_sender_job.login_message'
+  - 'jobs.sms_otp_sender_job.verify_message'
   - 'simple_form.*'
   - 'time.*'
   - 'titles.piv_cac_setup.*'
   - 'valid_email.validations.email.invalid'
-
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
 # - 'simple_form.{error_notification,required}.:'

--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -8,5 +8,7 @@ en:
         be processed in 24 hours. If you don’t want to delete your account, please
         cancel: %{cancel_link}'
     sms_otp_sender_job:
-      message: "%{code} is your %{app} one-time security code. This code will expire
-        in %{expiration} minutes."
+      login_message: "%{code} is your %{app} security code. Use this to continue signing
+        in to your account. This code will expire in %{expiration} minutes."
+      verify_message: "%{code} is your %{app} confirmation code. Use this to confirm
+        your phone number. This code will expire in %{expiration} minutes."

--- a/config/locales/jobs/es.yml
+++ b/config/locales/jobs/es.yml
@@ -8,5 +8,7 @@ es:
         ser procesado en 24 horas. Si no desea eliminar su cuenta, por favor cancelar:
         %{cancel_link}'
     sms_otp_sender_job:
-      message: "%{code} es su %{app} código de seguridad de sólo un uso. Este código
-        caducará en %{expiration} minutos."
+      login_message: "%{code} es tu código de seguridad de %{app}. Use esto para continuar
+        ingresando a su cuenta. Este código caducará en %{expiration} minutos."
+      verify_message: "%{code} es tu código de confirmación de %{app}. Use esto para
+        confirmar su número de teléfono. Este código caducará en %{expiration} minutos."

--- a/config/locales/jobs/fr.yml
+++ b/config/locales/jobs/fr.yml
@@ -8,5 +8,9 @@ fr:
         sera être traité en 24 heures. Si vous ne souhaitez pas supprimer votre compte,
         veuillez cancel: %{cancel_link}'
     sms_otp_sender_job:
-      message: "%{code} est votre %{app} code de sécurité à utilisation unique. Ce
-        code expirera dans %{expiration} minutes."
+      login_message: "%{code} est votre code de sécurité %{app}. Utilisez-le pour
+        continuer à vous connecter à votre compte. Ce code expirera dans %{expiration}
+        minutes."
+      verify_message: "%{code} est votre code de confirmation %{app}. Utilisez-le
+        pour confirmer votre numéro de téléphone. Ce code expirera dans %{expiration}
+        minutes."

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -129,19 +129,32 @@ describe Users::TwoFactorAuthenticationController do
         allow(SmsOtpSenderJob).to receive(:perform_later)
       end
 
-      it 'sends OTP via SMS' do
+      it 'sends OTP via SMS for login' do
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
 
         expect(SmsOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
           phone: subject.current_user.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          message: 'jobs.sms_otp_sender_job.login_message',
           locale: nil
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
         expect(response).to redirect_to(
           login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
+        )
+      end
+
+      it 'sends OTP via SMS for signing in' do
+        get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
+
+        expect(SmsOtpSenderJob).to have_received(:perform_later).with(
+          code: subject.current_user.direct_otp,
+          phone: subject.current_user.phone,
+          otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          message: 'jobs.sms_otp_sender_job.login_message',
+          locale: nil
         )
       end
 
@@ -254,6 +267,7 @@ describe Users::TwoFactorAuthenticationController do
           code: subject.current_user.direct_otp,
           phone: @unconfirmed_phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
+          message: 'jobs.sms_otp_sender_job.verify_message',
           locale: nil
         )
       end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -91,6 +91,7 @@ feature 'Changing authentication factor' do
             code: user.reload.direct_otp,
             phone: old_phone,
             otp_created_at: user.reload.direct_otp_sent_at.to_s,
+            message: 'jobs.sms_otp_sender_job.login_message',
             locale: nil
           )
 
@@ -116,6 +117,7 @@ feature 'Changing authentication factor' do
               code: user.reload.direct_otp,
               phone: old_phone,
               otp_created_at: user.reload.direct_otp_sent_at.to_s,
+              message: 'jobs.sms_otp_sender_job.login_message',
               locale: nil
             )
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -122,6 +122,7 @@ feature 'Two Factor Authentication' do
           code: user.reload.direct_otp,
           phone: '+212 661-289324',
           otp_created_at: user.direct_otp_sent_at.to_s,
+          message: 'jobs.sms_otp_sender_job.verify_message',
           locale: 'ar'
         )
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
@@ -557,6 +558,7 @@ feature 'Two Factor Authentication' do
           code: user.reload.direct_otp,
           phone: '+212 661-289324',
           otp_created_at: user.direct_otp_sent_at.to_s,
+          message: 'jobs.sms_otp_sender_job.login_message',
           locale: 'ar'
         )
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -14,6 +14,7 @@ feature 'Phone confirmation during sign up' do
         code: @user.reload.direct_otp,
         phone: '+1 703-555-5555',
         otp_created_at: @user.direct_otp_sent_at.to_s,
+        message: 'jobs.sms_otp_sender_job.verify_message',
         locale: nil
       )
     end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -25,6 +25,7 @@ describe TwilioService::Utils do
       SmsOtpSenderJob.perform_now(
         code: '1234',
         phone: '17035551212',
+        message: 'jobs.sms_otp_sender_job.verify_message',
         otp_created_at: Time.zone.now.to_s
       )
 


### PR DESCRIPTION
**Why**: Currently we use the same notification text when sending verification codes during the login as we do during phone verification. This means that if a user unexpectedly receives a verification code, they cannot distinguish between these two scenarios: A. (no big deal) Someone typo'd their phone number and is trying to create an account. B. (Huge deal, should change password immediately) Someone has their password and is attempting to log in to their actual account.

**How**: Update the SmsOtpSenderJob#perform method to take a message parameter. Use the SmsLoginOptionPolicy.configured? as the condition to send a sign in message vs verifying phone number message.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
