### PR TITLE
Fix 500 errors on bad personal key and invalid otp_delivery_preference in path. Add specs.

### DIFF
--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -23,6 +23,10 @@ module TwoFactorAuthentication
 
     private
 
+    def presenter_for_two_factor_authentication_method
+      TwoFactorAuthCode::PersonalKeyPresenter.new
+    end
+
     def handle_result(result)
       if result.success?
         generate_new_personal_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,7 @@ Rails.application.routes.draw do
         get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
       end
       get  '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#show',
-           as: :login_two_factor
+           as: :login_two_factor, constraints: { otp_delivery_preference: /sms|voice/ }
       post '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#create',
            as: :login_otp
 

--- a/spec/features/two_factor_authentication/remember_device_spec.rb
+++ b/spec/features/two_factor_authentication/remember_device_spec.rb
@@ -104,7 +104,7 @@ feature 'Remembering a 2FA device' do
 
     it 'does not offer the option to remember device' do
       sign_in_user(user)
-      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :authenticator))
+      expect(current_path).to eq(login_two_factor_authenticator_path)
       expect(page).to_not have_content(
         t('forms.messages.remember_device', duration: Figaro.env.remember_device_expiration_days!)
       )

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -653,7 +653,7 @@ feature 'Two Factor Authentication' do
         click_submit_default
 
         expect(page).to have_content(t('devise.two_factor_authentication.invalid_otp'))
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :authenticator)
+        expect(current_path).to eq login_two_factor_authenticator_path
       end
     end
   end
@@ -675,6 +675,13 @@ feature 'Two Factor Authentication' do
 
       expect(current_path).to eq account_path
     end
+  end
+
+  it 'generates a 404 with bad otp_delivery_preference' do
+    sign_in_before_2fa
+    visit '/login/two_factor/bad'
+
+    expect(page.status_code).to eq(404)
   end
 
   describe 'visiting OTP delivery and verification pages after fully authenticating' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -425,6 +425,19 @@ feature 'Sign in' do
     end
   end
 
+  context 'user attempts sign in with bad personal key' do
+    it 'remains on the login with personal key page' do
+      user = create(:user, :signed_up)
+      signin(user.email, user.password)
+      choose_another_security_option('personal_key')
+      enter_personal_key(personal_key: 'foo')
+      click_submit_default
+
+      expect(page).to have_current_path(login_two_factor_personal_key_path)
+      expect(page).to have_content t('devise.two_factor_authentication.invalid_personal_key')
+    end
+  end
+
   it 'does not whitelist style-src in CSP' do
     allow(FeatureManagement).to receive(:recaptcha_enabled?).and_return(true)
     visit root_path


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
