### PR TITLE
Match host on redirect URIs

### DIFF
--- a/app/services/openid_connect_redirector.rb
+++ b/app/services/openid_connect_redirector.rb
@@ -73,11 +73,25 @@ class OpenidConnectRedirector
     errors.add(error_attr, t('openid_connect.authorization.errors.redirect_uri_no_match'))
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
   def redirect_uri_matches_sp_redirect_uri?
-    redirect_uri.present? &&
-      service_provider.active? &&
-      service_provider.redirect_uris.any? do |sp_redirect_uri|
-        redirect_uri.start_with?(sp_redirect_uri)
-      end
+    return unless redirect_uri.present? && service_provider.active?
+    parsed_redirect_uri = URI(redirect_uri)
+    service_provider.redirect_uris.any? do |sp_redirect_uri|
+      parsed_sp_redirect_uri = URI(sp_redirect_uri)
+
+      parsed_redirect_uri.scheme == parsed_sp_redirect_uri.scheme &&
+        parsed_redirect_uri.port == parsed_sp_redirect_uri.port &&
+        parsed_redirect_uri.host == parsed_sp_redirect_uri.host &&
+        parsed_redirect_uri.path.start_with?(parsed_sp_redirect_uri.path)
+    end
+  rescue URI::Error
+    false
   end
+
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
 end

--- a/spec/services/openid_connect_redirector_spec.rb
+++ b/spec/services/openid_connect_redirector_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe OpenidConnectRedirector do
   end
 
   describe '#validate' do
+    context 'with a redirect_uri that spoofs a hostname' do
+      let(:redirect_uri) { 'https://example.com.evilish.com/' }
+
+      it 'is invalid' do
+        redirector.validate
+        expect(errors[:redirect_uri]).
+          to include(t('openid_connect.authorization.errors.redirect_uri_no_match'))
+      end
+    end
+
     context 'with a valid redirect_uri' do
       let(:redirect_uri) { 'http://localhost:7654/result/more/extra' }
       it 'is valid' do


### PR DESCRIPTION
**Why**:
If we only test that the redirect starts with a valid
string, then we are open to some SPs having redirects
with incorrect hosts redirecting users to the wrong server.

**How**:
We parse the redirect URI and compare significant parts.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
