### PR TITLE
LG-489 Adjust scrypt cost

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -173,7 +173,7 @@ development:
   saml_secret_rotation_path_suffix:
   saml_secret_rotation_secret_key:
   saml_secret_rotation_secret_key_password:
-  scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
+  scrypt_cost: '10000$8$1$'
   secret_key_base: 'development_secret_key_base'
   service_timeout: '30'
   session_encryption_key: '27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120'
@@ -295,7 +295,7 @@ production:
   saml_secret_rotation_path_suffix:
   saml_secret_rotation_secret_key:
   saml_secret_rotation_secret_key_password:
-  scrypt_cost: '4000$8$4$' # SCrypt::Engine.calibrate(max_time: 0.5)
+  scrypt_cost: '10000$8$1$'
   secret_key_base: # generate via `rake secret`
   session_encryption_key: # generate via `rake secret`
   session_timeout_in_minutes: '15'


### PR DESCRIPTION
**Why**: A 2017 paper on the SCrypt site offers the following guidelines
for SCrypt parameters for an interactive login:

    N = 2^14; r = 8; p = 4

Note that the parameter p offers the same time-memory tradeoff for both
the legitimate user and the attacker, while the parameter N offers more
advantage for the user. For that reason, this commit sets the default
scrypt cost to:

    N = 2^16; r = 8; p = 1

ref: https://blog.filippo.io/the-scrypt-parameters/

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
