### PR TITLE
LG-490 Verify password hashes without digesting salts

### DIFF
--- a/app/services/encryption/encryptors/deprecated_attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/deprecated_attribute_encryptor.rb
@@ -26,7 +26,9 @@ module Encryption
         @_scypt_hashes_by_key ||= {}
         scrypt_hash = @_scypt_hashes_by_key["#{key}:#{cost}"]
         return UserAccessKey.new(scrypt_hash: scrypt_hash) if scrypt_hash.present?
-        uak = UserAccessKey.new(password: key, salt: key, cost: cost)
+        uak = UserAccessKey.new(
+          password: key, salt: OpenSSL::Digest::SHA256.hexdigest(key), cost: cost
+        )
         @_scypt_hashes_by_key["#{key}:#{cost}"] = uak.as_scrypt_hash
         uak
       end

--- a/app/services/encryption/encryptors/session_encryptor.rb
+++ b/app/services/encryption/encryptors/session_encryptor.rb
@@ -17,7 +17,9 @@ module Encryption
         end
 
         key = Figaro.env.session_encryption_key
-        user_access_key = UserAccessKey.new(password: key, salt: key)
+        user_access_key = UserAccessKey.new(
+          password: key, salt: OpenSSL::Digest::SHA256.hexdigest(key)
+        )
         @user_access_key_scrypt_hash = user_access_key.as_scrypt_hash
         user_access_key
       end

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -76,7 +76,7 @@ module Encryption
       #
       # Also note that the salt arg will have a lenghth of 64 chars since it is
       # a hex digest of 32 random bytes
-      return OpenSSL::Digest::SHA256.hexdigest(salt) if salt.length == 20
+      return OpenSSL::Digest::SHA256.hexdigest(salt) if salt.length != 64
       salt
     end
 

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -74,7 +74,7 @@ module Encryption
       # to 32 bytes. While passwords exist with 20 byte salts, we will need this
       # line, otherwise the passwords are effectively expired.
       #
-      # Also note that the salt arg will have a lenghth of 64 chars since it is
+      # Also note that the salt arg will have a length of 64 chars since it is
       # a hex digest of 32 random bytes
       return OpenSSL::Digest::SHA256.hexdigest(salt) if salt.length != 64
       salt

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -68,7 +68,7 @@ describe Encryption::PasswordVerifier do
     it 'allows verification of a legacy password with a 20 byte salt' do
       # Legacy passwords had 20 bytes salts, which were SHA256 digested to get
       # to a 32 byte salt (64 char hexdigest). This test verifies that the
-      # password verifier is capabale of properly verifying those passwords
+      # password verifier is capable of properly verifying those passwords
       # using known values.
 
       password = 'saltypickles'

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -41,6 +41,54 @@ describe Encryption::PasswordVerifier do
 
       expect(result).to eq(false)
     end
+
+    it 'allows verification of a password with a 32 byte salt' do
+      # Once all new password digests are 32 bytes, this test can be torn down
+      # as it will be covered by the tests above
+
+      password = 'saltypickles'
+      password_digest = {
+        encrypted_password: '8a5c5b165fd3a2fce81bc914d91a106b76dfdd9e8c2addf0e0f27424a32ca4cb',
+        encryption_key: 'VUl6QFRZeQZ5Xl9IUVsBZmRndkNkXHJDYgAFRX9nYVl8c3paUWhyX2p
+        oegBqaFgAeVpfWWpmcgRRXnJHfANAaFJdfQR/eHJbfXVASn0AYnx9dlRifAJ2BFF4dkFmdWZ
+        /Y3VASn0DfUlqZHp2aWdEAWZlWHRhWmZnY2dbAFMAfQFiW0hCVWNEAmFoan9TSnEEZUpcdmR
+        nanZ/dHZ/agJqR1VkWEd+XlgCUnRUXFFnYkdqXVQBZHRiUVMCantRAVRef3ZYZmNnW0JTdHJ
+        RfltYR353akVRAAV9VHZmAmUBZkBlXlxnZXVUe1RKWAJVXGp2Y1tqSmQBVFlnXWpiYkp6eWZ
+        dQEd/eFhHYWVYd2VKflhpA3lKZGZlSH5dal1+eHZJZWQACXlZR1lUd3ZeeVpfWVNnelhmewB
+        VZ2p7C3hqf3lhXV0XYDp0YmBnL0dlZQcKLQtUXA=='.gsub(/\s/, ''),
+        password_salt: '6bb7555423136772304b40c10afe11e459c4021a1a47dfd11fcc955e0a2161e2',
+        password_cost: '4000$8$4$',
+      }.to_json
+
+      result = described_class.verify(password: password, digest: password_digest)
+
+      expect(result).to eq(true)
+    end
+
+    it 'allows verification of a legacy password with a 20 byte salt' do
+      # Legacy passwords had 20 bytes salts, which were SHA256 digested to get
+      # to a 32 byte salt (64 char hexdigest). This test verifies that the
+      # password verifier is capabale of properly verifying those passwords
+      # using known values.
+
+      password = 'saltypickles'
+      legacy_password_digest = {
+        encrypted_password: '6245274034d8d4dcc2d9930b431c4356aeaac9c7d0b7e2148ac19dcd12dfbc7a',
+        encryption_key: 'VUl6QFRZeQZ5XnZofXhTBGN3WABqdGZnamZTR30CeVl8c3paUWhyX2p
+        oegBqaFgAeVpfWWReZnhjd2pHZV1AX3wAQH1nW1hKY1t+BGd4agFnaF8AZFxASmd1SAV/ZXV
+        Kal1IUX50WAV7AFRpZ15hR1J4WANlZXZKZAB6BGYACQJSdURkYV1HA2JdanJRAFMEZQB+dGY
+        BVH5nWlhJZQNyflJnfgFqA2VJUV1IQ35dampVZVxbUwFmZWRZCWhSd0RyYwBEempnXFxmW3p
+        8UQJ+An10XGJ/eGphU1kJY1FdZgJmaHpaZF5pSWV3XH5hZUhbfEp5SWp4cgRlZGpZY2ZUemV
+        bBXhnaFRqfgBDBGZnREN/aFx4fnZbR1J0aQJmZ0ABVEoACXlZR1lUd3ZeeVpfWX54VF10Gg0
+        KZGA/XSt2L2YCbGMHYjNzXFBtDCUwMgdafV5RWA=='.gsub(/\s/, ''),
+        password_salt: 'u4KDouyiHwPgksKphAp1',
+        password_cost: '4000$8$4$',
+      }.to_json
+
+      result = described_class.verify(password: password, digest: legacy_password_digest)
+
+      expect(result).to eq(true)
+    end
   end
 
   it 'raises an encryption error when the password digest is nil' do


### PR DESCRIPTION
**Why**: Previously, we generated 20 char random strings for our
password salts. To get those string to an appropriate length for an
SCrypt salt, we took a SHA256 digest of the string.

We plan to start using 32 random bytes for the salt so we can use them
directly instead of hashing them. This commit adds the code to read the
new digests and tests to verify the old digests can still be verified
after the change to 32 random bytes is implemented.

This commit will not have any impact when deployed, but allows instances
generating 20 byte and 32 byte digests to serve traffic together so that
we can make the change to 32 byte digests.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
afect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
