### PR TITLE
LG-491 Don't truncate scrypt digest in pii encryption

### DIFF
--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -38,7 +38,7 @@ module Encryption
       end
 
       def encrypt(plaintext)
-        salt = Devise.friendly_token[0, 20]
+        salt = SecureRandom.hex(32)
         cost = Figaro.env.scrypt_cost
         aes_encryption_key = scrypt_password_digest(salt: salt, cost: cost)
         aes_encrypted_ciphertext = aes_cipher.encrypt(plaintext, aes_encryption_key)
@@ -61,7 +61,7 @@ module Encryption
         scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
         scrypted = SCrypt::Engine.hash_secret password, scrypt_salt, 32
         scrypt_password_digest = SCrypt::Password.new(scrypted).digest
-        scrypt_password_digest[0...32]
+        [scrypt_password_digest].pack('H*')
       end
     end
   end

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -15,7 +15,6 @@ describe Encryption::Encryptors::PiiEncryptor do
 
     it 'uses the user access key encryptor to encrypt the plaintext' do
       salt = '0' * 64
-      allow(SecureRandom).to receive(:hex).and_call_original
       allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
 
       scrypt_digest = '31' * 32 # hex_encode('1111..')

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -15,8 +15,8 @@ describe Encryption::Encryptors::PiiEncryptor do
 
     it 'uses the user access key encryptor to encrypt the plaintext' do
       salt = '0' * 64
-      allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
       allow(SecureRandom).to receive(:hex).and_call_original
+      allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
 
       scrypt_digest = '31' * 32 # hex_encode('1111..')
       decoded_scrypt_digest = '1' * 32


### PR DESCRIPTION
**Why**: The original 2L-KMS implementation truncated the output from
the scrypt digest. We wanted to configure SCrypt to output 32 bytes, but
after checking, it was already configured to do that. The reason we had
to truncate, is because the output was hex encoded making it 64
characters long.

This commit hex decodes the digest and uses the 32 byte result to
encrypt the PII.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
