### PR TITLE
LG-371 Fix phone validation logic to prevent toggling disable

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
           input.addEventListener('input', function () {
             if (buttons.length !== 0 && input.checkValidity()) {
               [].forEach.call(buttons, function(button) {
-                if (button.disabled) {
+                if (button.disabled && !button.classList.contains('no-auto-enable')) {
                   button.disabled = false;
                 }
               });

--- a/app/views/users/phone_setup/index.html.slim
+++ b/app/views/users/phone_setup/index.html.slim
@@ -20,7 +20,8 @@ p.mt-tiny.mb0 = @presenter.info
     = f.input :phone, as: :tel, label: false, required: true,
         input_html: { class: 'phone col-8 mb4' }
   div
-    = f.button :submit, t('forms.buttons.send_security_code'), class: 'sm-col-6 col-12 btn-wide mb3'
+    = f.button :submit, t('forms.buttons.send_security_code'),
+        class: 'sm-col-6 col-12 btn-wide mb3 no-auto-enable'
 .mt2.pt1.border-top
   - path = current_user.piv_cac_enabled? ? account_recovery_setup_path : two_factor_options_path
   = link_to t('two_factor_authentication.choose_another_option'), path

--- a/spec/views/phone_setup/index.html.slim_spec.rb
+++ b/spec/views/phone_setup/index.html.slim_spec.rb
@@ -21,4 +21,9 @@ describe 'users/phone_setup/index.html.slim' do
       href: two_factor_options_path
     )
   end
+
+  it 'it has auto enable off for the submit button' do
+    expect(rendered).
+      to have_xpath('//input[@type="submit" and contains(@class, "no-auto-enable")]')
+  end
 end


### PR DESCRIPTION
**Why**: To stop the button from blinking (enabling/disabling) as the user types in a phone number

**How**: Add an opt-out class "no-auto-enable" to the button to prevent it from being auto enabled and update the associated javascript to not auto enable a button if this class is present.  The default state (opt in) is currently used for the personal key modal on failed key.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
