### PR TITLE
[LG-498] Add phone configurations table

### DIFF
--- a/app/models/concerns/encryptable_attribute.rb
+++ b/app/models/concerns/encryptable_attribute.rb
@@ -1,11 +1,13 @@
 module EncryptableAttribute
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    cattr_accessor :encryptable_attributes do
+  def self.included(base)
+    base.send :cattr_accessor, :encryptable_attributes do
       []
     end
+  end
 
+  module ClassMethods
     private
 
     def encrypted_attribute_getter(name)

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -1,0 +1,11 @@
+class PhoneConfiguration < ApplicationRecord
+  include EncryptableAttribute
+
+  belongs_to :user, inverse_of: :phone_configuration
+  validates :user_id, presence: true
+  validates :encrypted_phone, presence: true
+
+  encrypted_attribute(name: :phone)
+
+  enum delivery_preference: { sms: 0, voice: 1 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ApplicationRecord
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
   has_one :account_reset_request, dependent: :destroy
+  has_one :phone_configuration, dependent: :destroy, inverse_of: :user
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true
 

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -1,23 +1,23 @@
 module KeyRotator
   class AttributeEncryption
-    def initialize(user)
-      @user = user
+    def initialize(model)
+      @model = model
       @encryptor = Encryption::Encryptors::AttributeEncryptor.new
     end
 
     # rubocop:disable Rails/SkipsModelValidations
     def rotate
-      user.update_columns(encrypted_attributes)
+      model.update_columns(encrypted_attributes)
     end
     # rubocop:enable Rails/SkipsModelValidations
 
     private
 
-    attr_reader :user, :encryptor
+    attr_reader :model, :encryptor
 
     def encrypted_attributes
-      User.encryptable_attributes.each_with_object({}) do |attribute, result|
-        plain_attribute = user.public_send(attribute)
+      model.class.encryptable_attributes.each_with_object({}) do |attribute, result|
+        plain_attribute = model.public_send(attribute)
         next unless plain_attribute
 
         result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -5,10 +5,57 @@ class UpdateUser
   end
 
   def call
-    user.update!(attributes)
+    result = user.update!(attributes)
+    manage_phone_configuration
+    result
   end
 
   private
 
   attr_reader :user, :attributes
+
+  def manage_phone_configuration
+    if user.phone_configuration.present?
+      update_phone_configuration
+    else
+      create_phone_configuration
+    end
+  end
+
+  def update_phone_configuration
+    configuration = user.phone_configuration
+    if phone_attributes[:phone].present?
+      configuration.update!(phone_attributes)
+    else
+      configuration.destroy
+      user.reload
+    end
+  end
+
+  def create_phone_configuration
+    return if phone_attributes[:phone].blank?
+    user.create_phone_configuration(phone_attributes)
+  end
+
+  def phone_attributes
+    @phone_attributes ||= {
+      phone: attribute(:phone),
+      confirmed_at: attribute(:phone_confirmed_at),
+      delivery_preference: attribute(:otp_delivery_preference),
+    }
+  end
+
+  # This returns the named attribute if it's included in the changes, even if
+  # it's nil. Otherwise, it pulls the information from the user object. This
+  # lets us create a phone_configuration row with all required information even
+  # if we're only updating the otp_delivery_preference in the user model. Once
+  # we no longer write data to the user model, we can remove this and simplify
+  # some of this code.
+  def attribute(name)
+    if attributes.include?(name)
+      attributes[name]
+    else
+      user.send(name)
+    end
+  end
 end

--- a/db/migrate/20180720152009_create_phone_configurations_table.rb
+++ b/db/migrate/20180720152009_create_phone_configurations_table.rb
@@ -1,0 +1,13 @@
+class CreatePhoneConfigurationsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :phone_configurations do |t|
+      t.references :user, null: false
+      t.text :encrypted_phone, null: false
+      t.integer :delivery_preference, default: 0, null: false
+      t.boolean :mfa_enabled, default: true, null: false
+      t.timestamp :confirmation_sent_at
+      t.timestamp :confirmed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180709141748) do
+ActiveRecord::Schema.define(version: 20180720152009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,18 @@ ActiveRecord::Schema.define(version: 20180709141748) do
     t.index ["metric", "value"], name: "index_password_metrics_on_metric_and_value", unique: true
     t.index ["metric"], name: "index_password_metrics_on_metric"
     t.index ["value"], name: "index_password_metrics_on_value"
+  end
+
+  create_table "phone_configurations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "encrypted_phone", null: false
+    t.integer "delivery_preference", default: 0, null: false
+    t.boolean "mfa_enabled", default: true, null: false
+    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_phone_configurations_on_user_id"
   end
 
   create_table "profiles", force: :cascade do |t|

--- a/lib/tasks/create_test_accounts.rb
+++ b/lib/tasks/create_test_accounts.rb
@@ -18,6 +18,11 @@ def create_account(email: 'joe.smith@email.com', password: 'salty pickles', mfa_
   user.phone = mfa_phone || phone
   user.phone_confirmed_at = Time.zone.now
   user.save!
+  user.create_phone_configuration(
+    phone: mfa_phone || phone,
+    confirmed_at: user.phone_confirmed_at,
+    delivery_preference: user.otp_delivery_preference
+  )
   Event.create(user_id: user.id, event_type: :account_created)
 
   if verified

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -85,10 +85,19 @@ namespace :dev do
     user.reset_password(args[:pw], args[:pw])
     user.phone = format('+1 (415) 555-%04d', args[:num])
     user.phone_confirmed_at = Time.zone.now
+    create_phone_configuration_for(user)
     Event.create(user_id: user.id, event_type: :account_created)
   end
 
   def fingerprint(email)
     Pii::Fingerprinter.fingerprint(email)
+  end
+
+  def create_phone_configuration_for(user)
+    user.create_phone_configuration(
+      phone: user.phone,
+      confirmed_at: user.phone_confirmed_at,
+      delivery_preference: user.otp_delivery_preference
+    )
   end
 end

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -13,6 +13,11 @@ namespace :rotate do
         users.each do |user|
           rotator = KeyRotator::AttributeEncryption.new(user)
           rotator.rotate
+          phone_configuration = user.phone_configuration
+          if phone_configuration.present?
+            rotator = KeyRotator::AttributeEncryption.new(phone_configuration)
+            rotator.rotate
+          end
           progress&.increment
         rescue StandardError => err # Don't use user.email in output...
           Kernel.puts "Error with user id:#{user.id} #{err.message} #{err.backtrace}"

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -47,6 +47,7 @@ describe AccountReset::CancelController do
       allow(SmsAccountResetCancellationNotifierJob).to receive(:perform_now)
       user.phone = nil
       user.save!
+      user.phone_configuration.destroy
 
       post :cancel, params: { token: AccountResetRequest.all[0].request_token }
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -324,6 +324,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
           it 'does not update user phone or phone_confirmed_at attributes' do
             expect(subject.current_user.phone).to eq('+1 202-555-1212')
             expect(subject.current_user.phone_confirmed_at).to eq(@previous_phone_confirmed_at)
+            expect(subject.current_user.phone_configuration.phone).to eq('+1 202-555-1212')
+            expect(
+              subject.current_user.phone_configuration.confirmed_at
+            ).to eq(@previous_phone_confirmed_at)
           end
 
           it 'renders :show' do
@@ -353,6 +357,8 @@ describe TwoFactorAuthentication::OtpVerificationController do
         before do
           subject.current_user.phone = nil
           subject.current_user.phone_confirmed_at = nil
+          subject.current_user.phone_configuration.destroy
+          subject.current_user.phone_configuration = nil
           subject.current_user.create_direct_otp
         end
 
@@ -491,6 +497,10 @@ describe TwoFactorAuthentication::OtpVerificationController do
         it 'does not update user phone attributes' do
           expect(subject.current_user.reload.phone).to eq '+1 202-555-1212'
           expect(subject.current_user.reload.phone_confirmed_at).to eq @previous_phone_confirmed_at
+
+          configuration = subject.current_user.reload.phone_configuration
+          expect(configuration.phone).to eq '+1 202-555-1212'
+          expect(configuration.confirmed_at).to eq @previous_phone_confirmed_at
         end
 
         it 'redirects to idv_review_path' do
@@ -516,6 +526,11 @@ describe TwoFactorAuthentication::OtpVerificationController do
         it 'does not update user phone or phone_confirmed_at attributes' do
           expect(subject.current_user.phone).to eq('+1 202-555-1212')
           expect(subject.current_user.phone_confirmed_at).to eq(@previous_phone_confirmed_at)
+
+          configuration = subject.current_user.reload.phone_configuration
+          expect(configuration.phone).to eq '+1 202-555-1212'
+          expect(configuration.confirmed_at).to eq @previous_phone_confirmed_at
+
           expect(subject.idv_session.params['phone_confirmed_at']).to be_nil
         end
 

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -26,6 +26,7 @@ describe Users::PhonesController do
       it 'lets user know they need to confirm their new phone' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
         expect(user.reload.phone).to_not eq '+1 202-555-4321'
+        expect(user.reload.phone_configuration.phone).to_not eq '+1 202-555-4321'
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to redirect_to(
@@ -48,6 +49,7 @@ describe Users::PhonesController do
         }
 
         expect(user.reload.phone).to be_present
+        expect(user.reload.phone_configuration.phone).to be_present
         expect(response).to render_template(:edit)
       end
     end
@@ -69,6 +71,7 @@ describe Users::PhonesController do
       it 'processes successfully and informs user' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
         expect(user.reload.phone).to_not eq second_user.phone
+        expect(user.reload.phone_configuration.phone).to_not eq second_user.phone
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to redirect_to(
@@ -93,6 +96,7 @@ describe Users::PhonesController do
         }
 
         expect(user.phone).not_to eq invalid_phone
+        expect(user.phone_configuration.phone).not_to eq invalid_phone
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/factories/phone_configurations.rb
+++ b/spec/factories/phone_configurations.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  Faker::Config.locale = :en
+
+  factory :phone_configuration do
+    confirmed_at Time.zone.now
+    phone '+1 202-555-1212'
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,16 @@ FactoryBot.define do
     email { Faker::Internet.safe_email }
     password '!1a Z@6s' * 16 # Maximum length password.
 
+    after :build do |user|
+      if user.phone
+        user.build_phone_configuration(
+          phone: user.phone,
+          confirmed_at: user.phone_confirmed_at,
+          delivery_preference: user.otp_delivery_preference
+        )
+      end
+    end
+
     trait :with_phone do
       phone '+1 202-555-1212'
       phone_confirmed_at Time.zone.now

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -40,6 +40,7 @@ feature 'Changing authentication factor' do
 
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')
       expect(user.reload.phone).to_not eq new_phone
+      expect(user.reload.phone_configuration.phone).to_not eq new_phone
       expect(page).to have_link t('forms.two_factor.try_again'), href: manage_phone_path
 
       submit_correct_otp
@@ -49,6 +50,9 @@ feature 'Changing authentication factor' do
       expect(mailer).to have_received(:deliver_later)
       expect(page).to have_content new_phone
       expect(user.reload.phone_confirmed_at).to_not eq(@previous_phone_confirmed_at)
+      expect(
+        user.reload.phone_configuration.confirmed_at
+      ).to_not eq(@previous_phone_confirmed_at)
 
       visit login_two_factor_path(otp_delivery_preference: 'sms')
       expect(current_path).to eq account_path

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -35,6 +35,7 @@ feature 'Two Factor Authentication' do
       expect(page).to_not have_content invalid_phone_message
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
       expect(user.reload.phone).to_not eq '+1 (703) 555-1212'
+      expect(user.reload.phone_configuration).to be_nil
       expect(user.sms?).to eq true
     end
 

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -73,6 +73,8 @@ feature 'PIV/CAC Management' do
           stub_piv_cac_service
 
           user.update(phone: nil, otp_secret_key: 'secret')
+          user.phone_configuration.destroy
+          user.phone_configuration = nil
           sign_in_and_2fa_user(user)
           visit account_path
           click_link t('forms.buttons.enable'), href: setup_piv_cac_url

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -22,6 +22,7 @@ feature 'Phone confirmation during sign up' do
       click_button t('forms.buttons.submit.default')
 
       expect(@user.reload.phone_confirmed_at).to be_present
+      expect(@user.reload.phone_configuration.confirmed_at).to be_present
       expect(current_path).to eq sign_up_personal_key_path
 
       click_acknowledge_personal_key
@@ -75,6 +76,7 @@ feature 'Phone confirmation during sign up' do
       click_submit_default
 
       expect(@user.reload.phone_confirmed_at).to be_nil
+      expect(@user.reload.phone_configuration).to be_nil
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
     end

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -79,6 +79,7 @@ describe UserPhoneForm do
 
         user.reload
         expect(user.phone).to_not eq('+1 504 444 1643')
+        expect(user.phone_configuration).to be_nil
       end
 
       it 'preserves the format of the submitted phone number if phone is invalid' do

--- a/spec/lib/tasks/rotate_rake_spec.rb
+++ b/spec/lib/tasks/rotate_rake_spec.rb
@@ -18,16 +18,23 @@ describe 'rotate' do
       old_phone = user.phone
       old_encrypted_email = user.encrypted_email
       old_encrypted_phone = user.encrypted_phone
+      old_encrypted_configuration_phone = user.phone_configuration.encrypted_phone
 
       rotate_attribute_encryption_key
 
       Rake::Task['rotate:attribute_encryption_key'].execute
 
       user.reload
+      user.phone_configuration.reload
       expect(user.phone).to eq old_phone
+      expect(user.phone_configuration.phone).to eq old_phone
       expect(user.email).to eq old_email
       expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(user.encrypted_phone).to_not eq old_encrypted_phone
+      expect(user.phone_configuration.encrypted_phone).to_not eq old_encrypted_configuration_phone
+      expect(user.phone_configuration.phone).to eq user.phone
+      # this double checks that we're not using the same IV for both
+      expect(user.phone_configuration.encrypted_phone).to_not eq user.encrypted_phone
     end
 
     it 'does not raise an exception when encrypting/decrypting a user' do

--- a/spec/models/phone_configuration_spec.rb
+++ b/spec/models/phone_configuration_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe PhoneConfiguration do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:encrypted_phone) }
+  end
+
+  let(:phone) { '+1 703 555 1212' }
+
+  let(:phone_configuration) { create(:phone_configuration, phone: phone) }
+
+  describe 'creation' do
+    it 'stores an encrypted form of the password' do
+      expect(phone_configuration.encrypted_phone).to_not be_blank
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ describe User do
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_one(:account_reset_request) }
+    it { is_expected.to have_one(:phone_configuration) }
   end
 
   it 'does not send an email when #create is called' do
@@ -379,6 +380,7 @@ describe User do
         user = create(:user, phone: '  555 555 5555    ')
 
         expect(user.phone).to eq '555 555 5555'
+        expect(user.phone_configuration.phone).to eq '555 555 5555'
       end
     end
 
@@ -386,6 +388,7 @@ describe User do
       user = create(:user, phone: '+1 (202) 555-1212', otp_secret_key: 'abc123')
 
       expect(user.phone).to eq '+1 (202) 555-1212'
+      expect(user.phone_configuration.phone).to eq '+1 (202) 555-1212'
       expect(user.otp_secret_key).to eq 'abc123'
     end
   end

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -12,5 +12,49 @@ describe UpdateUser do
       expect(user.otp_delivery_preference).to eq 'voice'
       expect(user.voice?).to eq true
     end
+
+    context 'with a phone already configured' do
+      let(:user) { create(:user, :with_phone) }
+
+      it 'updates the phone configuration' do
+        confirmed_at = 1.day.ago.change(usec: 0)
+        attributes = {
+          otp_delivery_preference: 'voice',
+          phone: '+1 222 333-4444',
+          phone_confirmed_at: confirmed_at,
+        }
+        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater.call
+        phone_configuration = user.reload.phone_configuration
+        expect(phone_configuration.delivery_preference).to eq 'voice'
+        expect(phone_configuration.confirmed_at).to eq confirmed_at
+        expect(phone_configuration.phone).to eq '+1 222 333-4444'
+      end
+
+      it 'deletes the phone configuration' do
+        attributes = { phone: nil }
+        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater.call
+        expect(user.reload.phone_configuration).to be_nil
+      end
+    end
+
+    context 'with no phone configured' do
+      let(:user) { create(:user) }
+      it 'creates a phone configuration' do
+        confirmed_at = 1.day.ago.change(usec: 0)
+        attributes = {
+          otp_delivery_preference: 'voice',
+          phone: '+1 222 333-4444',
+          phone_confirmed_at: confirmed_at,
+        }
+        updater = UpdateUser.new(user: user, attributes: attributes)
+        updater.call
+        phone_configuration = user.reload.phone_configuration
+        expect(phone_configuration.delivery_preference).to eq 'voice'
+        expect(phone_configuration.confirmed_at).to eq confirmed_at
+        expect(phone_configuration.phone).to eq '+1 222 333-4444'
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**:
We want to support multiple phone configurations for a user.

**How**:
Move the phone configuration from the users table to a new table.
This PR is step 1 of several: create the table and write to it.

The critical work here is to make sure that every time we update
the user's 2fa phone, we also update or write to the new table.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [ ] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [ ] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [ ] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [ ] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [ ] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [ ] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [ ] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
