### PR TITLE
Read 2L-KMS encrypted sessions

### DIFF
--- a/app/services/encryption/encryptors/deprecated_session_encryptor.rb
+++ b/app/services/encryption/encryptors/deprecated_session_encryptor.rb
@@ -1,0 +1,28 @@
+module Encryption
+  module Encryptors
+    class DeprecatedSessionEncryptor
+      def encrypt(plaintext)
+        user_access_key = self.class.load_or_init_user_access_key
+        UserAccessKeyEncryptor.new(user_access_key).encrypt(plaintext)
+      end
+
+      def decrypt(ciphertext)
+        user_access_key = self.class.load_or_init_user_access_key
+        UserAccessKeyEncryptor.new(user_access_key).decrypt(ciphertext)
+      end
+
+      def self.load_or_init_user_access_key
+        if @user_access_key_scrypt_hash.present?
+          return UserAccessKey.new(scrypt_hash: @user_access_key_scrypt_hash)
+        end
+
+        key = Figaro.env.session_encryption_key
+        user_access_key = UserAccessKey.new(
+          password: key, salt: OpenSSL::Digest::SHA256.hexdigest(key)
+        )
+        @user_access_key_scrypt_hash = user_access_key.as_scrypt_hash
+        user_access_key
+      end
+    end
+  end
+end

--- a/spec/services/encryption/encryptors/deprecated_session_encryptor.rb
+++ b/spec/services/encryption/encryptors/deprecated_session_encryptor.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Encryption::Encryptors::DeprecatedSessionEncryptor do
+  let(:plaintext) { '{ "foo": "bar" }' }
+
+  before do
+    described_class.instance_variable_set(:@user_access_key_scrypt_hash, nil)
+  end
+
+  describe '#encrypt' do
+    it 'returns encrypted text' do
+      ciphertext = subject.encrypt(plaintext)
+
+      expect(ciphertext).to_not eq(plaintext)
+    end
+
+    it 'only computes an scrypt hash on the first encryption' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      subject.encrypt(plaintext)
+
+      expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+      subject.encrypt(plaintext)
+    end
+  end
+
+  describe '#decrypt' do
+    let(:ciphertext) do
+      result = subject.encrypt(plaintext)
+      described_class.instance_variable_set(:@user_access_key_scrypt_hash, nil)
+      result
+    end
+
+    before do
+      # Memoize the ciphertext and purge memoized key so that encryption does not
+      # affect expected call counts
+      ciphertext
+    end
+
+    it 'returns a decrypted ciphertext' do
+      expect(subject.decrypt(ciphertext)).to eq(plaintext)
+    end
+
+    it 'only computes and scrypt hash on the first decryption' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      subject.decrypt(ciphertext)
+
+      expect(SCrypt::Engine).to_not receive(:hash_secret)
+
+      subject.decrypt(ciphertext)
+    end
+  end
+
+  describe '.load_or_init_user_access_key' do
+    it 'does not return the same key object for the same salt and cost' do
+      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
+
+      key1 = described_class.load_or_init_user_access_key
+      key2 = described_class.load_or_init_user_access_key
+
+      expect(key1.as_scrypt_hash).to eq(key2.as_scrypt_hash)
+      expect(key1).to_not eq(key2)
+    end
+  end
+
+  it 'makes a roundtrip across multiple encryptors' do
+    encryptor1 = described_class.new
+    encryptor2 = described_class.new
+
+    # Memoize user access key scrypt hash
+    encryptor1.decrypt(encryptor1.encrypt('asdf'))
+    encryptor2.decrypt(encryptor2.encrypt('1234'))
+
+    encrypted_text = encryptor1.encrypt(plaintext)
+    expect(encryptor2.decrypt(encrypted_text)).to eq(plaintext)
+  end
+end

--- a/spec/services/encryption/encryptors/session_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/session_encryptor_spec.rb
@@ -3,77 +3,43 @@ require 'rails_helper'
 describe Encryption::Encryptors::SessionEncryptor do
   let(:plaintext) { '{ "foo": "bar" }' }
 
-  before do
-    described_class.instance_variable_set(:@user_access_key_scrypt_hash, nil)
-  end
-
   describe '#encrypt' do
-    it 'returns encrypted text' do
+    it 'returns ciphertext created by the deprecated session encryptor' do
+      expected_ciphertext = '123abc'
+
+      deprecated_encryptor = Encryption::Encryptors::DeprecatedSessionEncryptor.new
+      expect(deprecated_encryptor).to receive(:encrypt).
+        with(plaintext).
+        and_return(expected_ciphertext)
+      expect(Encryption::Encryptors::DeprecatedSessionEncryptor).to receive(:new).
+        and_return(deprecated_encryptor)
+
       ciphertext = subject.encrypt(plaintext)
 
-      expect(ciphertext).to_not eq(plaintext)
-    end
-
-    it 'only computes an scrypt hash on the first encryption' do
-      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-
-      subject.encrypt(plaintext)
-
-      expect(SCrypt::Engine).to_not receive(:hash_secret)
-
-      subject.encrypt(plaintext)
+      expect(ciphertext).to eq(expected_ciphertext)
     end
   end
 
   describe '#decrypt' do
-    let(:ciphertext) do
-      result = subject.encrypt(plaintext)
-      described_class.instance_variable_set(:@user_access_key_scrypt_hash, nil)
-      result
+    context 'with a legacy ciphertext' do
+      let(:ciphertext) { Encryption::Encryptors::DeprecatedSessionEncryptor.new.encrypt(plaintext) }
+
+      it 'decrypts the ciphertext' do
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
     end
 
-    before do
-      # Memoize the ciphertext and purge memoized key so that encryption does not
-      # affect expected call counts
-      ciphertext
+    context 'with a 2L-KMS ciphertext' do
+      let(:ciphertext) do
+        key = Figaro.env.session_encryption_key[0...32]
+        aes_ciphertext = Encryption::Encryptors::AesEncryptor.new.encrypt(plaintext, key)
+        kms_ciphertext = Encryption::KmsClient.new.encrypt(aes_ciphertext)
+        Base64.strict_encode64(kms_ciphertext)
+      end
+
+      it 'decrypts the ciphertext' do
+        expect(subject.decrypt(ciphertext)).to eq(plaintext)
+      end
     end
-
-    it 'returns a decrypted ciphertext' do
-      expect(subject.decrypt(ciphertext)).to eq(plaintext)
-    end
-
-    it 'only computes and scrypt hash on the first decryption' do
-      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-
-      subject.decrypt(ciphertext)
-
-      expect(SCrypt::Engine).to_not receive(:hash_secret)
-
-      subject.decrypt(ciphertext)
-    end
-  end
-
-  describe '.load_or_init_user_access_key' do
-    it 'does not return the same key object for the same salt and cost' do
-      expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-
-      key1 = described_class.load_or_init_user_access_key
-      key2 = described_class.load_or_init_user_access_key
-
-      expect(key1.as_scrypt_hash).to eq(key2.as_scrypt_hash)
-      expect(key1).to_not eq(key2)
-    end
-  end
-
-  it 'makes a roundtrip across multiple encryptors' do
-    encryptor1 = described_class.new
-    encryptor2 = described_class.new
-
-    # Memoize user access key scrypt hash
-    encryptor1.decrypt(encryptor1.encrypt('asdf'))
-    encryptor2.decrypt(encryptor2.encrypt('1234'))
-
-    encrypted_text = encryptor1.encrypt(plaintext)
-    expect(encryptor2.decrypt(encrypted_text)).to eq(plaintext)
   end
 end


### PR DESCRIPTION
**Why**: To start the migration to 2L-KMS. This commit wraps an AES
encrypted ciphertext with KMS. This commit allows new and old instances
to exist in parallel when we start writing 2L-KMS encrypted cihpertexts
to the session.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
