### PR TITLE
Add a regression spec for IdV users w/o phones

### DIFF
--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -25,6 +25,18 @@ feature 'idv phone step', :idv_job do
       expect(page).to have_content(t('idv.titles.session.review'))
       expect(page).to have_current_path(idv_review_path)
     end
+
+    it 'allows a user without a phone number to continue' do
+      user = create(:user, otp_secret_key: '123abc')
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step(user)
+
+      fill_out_phone_form_ok
+      click_idv_continue
+
+      expect(page).to have_content(t('idv.titles.otp_delivery_method'))
+      expect(page).to have_current_path(idv_otp_delivery_method_path)
+    end
   end
 
   context 'after submitting valid information' do


### PR DESCRIPTION
**Why**: So that any changes to the IdV flow involving the user's 2FA
phone number won't introduce a regression that breaks the flow for TOTP
or PIV/CAC users.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
