### PR TITLE
LG-17 Production Error: ERROR: duplicate key (email)

### DIFF
--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -4,6 +4,8 @@ module SignUp
 
     def create
       validate_token
+    rescue ActiveRecord::RecordNotUnique
+      process_already_confirmed_user
     end
 
     private


### PR DESCRIPTION
**Why**: To prevent throwing 500 errors in production. This will improve the user experience and also minimize devops alerting.

**How**: There is a race condition with two users simultaneously validating the same token on email confirmation or a double click of the confirmation button.  Rescue the exception and provide a helpful message to the user that the address has already been confirmed.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
