### PR TITLE
Fix error in IdV flow when USPS is disabled

### DIFF
--- a/app/views/idv/otp_delivery_method/new.html.slim
+++ b/app/views/idv/otp_delivery_method/new.html.slim
@@ -37,9 +37,10 @@ p.mt1 = t('idv.messages.otp_delivery_method.phone_number_html',
               = t('devise.two_factor_authentication.otp_delivery_preference.voice')
             .regular.gray-dark.fs-10p.mb-tiny
               = t('devise.two_factor_authentication.two_factor_choice_options.voice_info')
-      .mt3
-        = t('idv.form.no_alternate_phone_html',
-        link: link_to(t('idv.form.activate_by_mail'), idv_usps_path))
+      - if FeatureManagement.enable_usps_verification?
+        .mt3
+          = t('idv.form.no_alternate_phone_html',
+          link: link_to(t('idv.form.activate_by_mail'), idv_usps_path))
       .mt2
         = t('instructions.mfa.wrong_number_html',
         link: link_to(t('forms.two_factor.try_again'), idv_phone_path))

--- a/spec/features/idv/usps_disabled_spec.rb
+++ b/spec/features/idv/usps_disabled_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+feature 'disabling USPS address verification', :idv_job do
+  include IdvStepHelper
+
+  context 'with USPS address verification disabled' do
+    before do
+      allow(Figaro.env).to receive(:enable_usps_verification).and_return('false')
+      # Whether USPS is available affects the routes that are available
+      # We want path helpers for unavailable routes to raise and fail the tests
+      # so we reload the routes here
+      Rails.application.reload_routes!
+    end
+
+    after do
+      allow(Figaro.env).to receive(:enable_usps_verification).and_call_original
+      Rails.application.reload_routes!
+    end
+
+    it 'allows verification without the option to confirm address with usps' do
+      user = user_with_2fa
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step(user)
+
+      # Link to the USPS flow should not be visible
+      expect(page).to_not have_content(t('idv.form.activate_by_mail'))
+
+      fill_out_phone_form_ok('2342255432')
+      click_idv_continue
+
+      # Link to the USPS flow should not be visible
+      expect(page).to_not have_content(t('idv.form.activate_by_mail'))
+
+      choose_idv_otp_delivery_method_sms
+      enter_correct_otp_code_for_user(user)
+      fill_in 'Password', with: user.password
+      click_continue
+      click_acknowledge_personal_key
+
+      expect(page).to have_current_path(sign_up_completed_path)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: The OTP confirmation page had a call to `idv_usps_path` which
was not behind a conditional for whether USPS verification was disabled
for the app. This meant that a path helper for a route that does not
exist was called. This raised and caused a 500.

This commit puts the path method behind a conditional and adds a feature
spec that goes through IdV with USPS disabled to make sure this doesn't
happen in the future.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the following checklist:

- [x] For DB changes, check for missing indexes, check to see if the changes
affect other apps (such as the dashboard), make sure the DB columns in the
various environments are properly populated, coordinate with devops, plan
migrations in separate steps.

- [x] For route changes, make sure GET requests don't change state or result in
destructive behavior. GET requests should only result in information being
read, not written.

- [x] For encryption changes, make sure it is compatible with data that was
encrypted with the old code.

- [x] For secrets changes, [make sure to update the S3 secrets bucket](https://github.com/18F/identity-private/wiki/Secrets-S3-buckets) with the 
new configs in **all** environments. 

- [x] Do not disable Rubocop or Reek offenses unless you are absolutely sure
they are false positives. If you're not sure how to fix the offense, please
ask a teammate.

- [x] When reading data, write tests for nil values, empty strings,
and invalid formats.

- [x] When calling `redirect_to` in a controller, use `_url`, not `_path`.

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`.
