### PR TITLE
LG-504 Create a health checker for account reset notifications

### DIFF
--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -6,6 +6,7 @@ module Health
       checkers = {
         database: DatabaseHealthChecker,
         workers: WorkerHealthChecker,
+        account_reset: AccountResetHealthChecker,
       }
       # Don't run worker health checks if we're not using workers (i.e. if the
       # queue adapter is inline or async)

--- a/app/services/account_reset_health_checker.rb
+++ b/app/services/account_reset_health_checker.rb
@@ -1,0 +1,35 @@
+module AccountResetHealthChecker
+  module_function
+
+  Summary = Struct.new(:healthy, :result) do
+    def as_json(*args)
+      to_h.as_json(*args)
+    end
+
+    alias_method :healthy?, :healthy
+  end
+
+  # @return [Summary]
+  def check
+    rec = find_request_not_serviced_within_26_hours
+    Summary.new(rec.nil?, rec)
+  end
+
+  # @api private
+  def find_request_not_serviced_within_26_hours
+    records = AccountResetRequest.where(
+      sql, tvalue: Time.zone.now - Figaro.env.account_reset_wait_period_days.to_i.days - 2.hours
+    ).order('requested_at ASC').limit(1)
+    records.first
+  end
+
+  def sql
+    <<~SQL
+      cancelled_at IS NULL AND
+      granted_at IS NULL AND
+      requested_at < :tvalue AND
+      request_token IS NOT NULL AND
+      granted_token IS NULL
+    SQL
+  end
+end

--- a/spec/controllers/health/health_controller_spec.rb
+++ b/spec/controllers/health/health_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Health::HealthController do
         expect(json[:healthy]).to eq(true)
         expect(json[:statuses][:workers][:all_healthy]).to eq(true)
         expect(json[:statuses][:database][:healthy]).to eq(true)
+        expect(json[:statuses][:account_reset][:healthy]).to eq(true)
       end
     end
 

--- a/spec/services/account_reset_health_checker_spec.rb
+++ b/spec/services/account_reset_health_checker_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe AccountResetHealthChecker do
+  let(:wait_period) { Figaro.env.account_reset_wait_period_days.to_i.days }
+  let(:buffer_period) { 2.hours } # window buffer to allow servicing requests after 24 hours
+  describe '.check' do
+    subject(:summary) { AccountResetHealthChecker.check }
+
+    context 'when there are no requests' do
+      it 'returns a healthy check' do
+        expect(summary.result).to eq(nil)
+        expect(summary.healthy).to eq(true)
+      end
+    end
+
+    context 'when a request is not serviced on time' do
+      before do
+        AccountResetRequest.create(id: 1,
+                                   user_id: 2,
+                                   requested_at: Time.zone.now - wait_period - buffer_period,
+                                   request_token: 'foo')
+      end
+
+      it 'returns an unhealthy check' do
+        expect(summary.healthy).to eq(false)
+      end
+    end
+
+    context 'when an old request was cancelled' do
+      before do
+        AccountResetRequest.create(id: 1,
+                                   user_id: 2,
+                                   requested_at: Time.zone.now - wait_period - buffer_period,
+                                   request_token: 'foo',
+                                   cancelled_at: Time.zone.now)
+      end
+
+      it 'returns an unhealthy check' do
+        expect(summary.healthy).to eq(true)
+      end
+    end
+
+    context 'when all requests are serviced on time' do
+      before do
+        AccountResetRequest.create(id: 1,
+                                   user_id: 2,
+                                   requested_at: Time.zone.now - wait_period - buffer_period,
+                                   request_token: 'foo',
+                                   granted_at: Time.zone.now - buffer_period,
+                                   granted_token: 'bar')
+      end
+
+      it 'returns a healthy check' do
+        expect(summary.healthy).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: When a user requests an account reset we tell them their request will be processed in 24 hours. We have to be sure that the asyncronous processing of the grant notifications are occurring on a timely basis.

**How**: Add a health checker to the health_controller.  Search for a single record in account_reset_requests where the request was not serviced in 26 hours (24 hours + a 2 hour buffer to service the requests).  Return a bad health status if such a record is found.  The table has an index that is optimized for this type of query while factoring in timestamps, cancellations, and requests already granted.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
