### PR TITLE
LG-519 Fix: session timeout prevents return to SP and loses SP branding

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -38,13 +38,14 @@ module Users
 
     def timeout
       analytics.track_event(Analytics::SESSION_TIMED_OUT)
+      request_id = sp_session[:request_id]
       sign_out
       flash[:notice] = t(
         'session_timedout',
         app: APP_NAME,
         minutes: Figaro.env.session_timeout_in_minutes
       )
-      redirect_to root_url
+      redirect_to root_url(request_id: request_id)
     end
 
     private

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -119,8 +119,10 @@ feature 'LOA1 Single Sign On' do
 
       visit saml_authn_request
       sp_request_id = ServiceProviderRequest.last.uuid
-      page.set_rack_session(sp: {})
-      visit new_user_session_url(request_id: sp_request_id)
+
+      visit timeout_path
+      expect(current_url).to eq root_url(request_id: sp_request_id)
+
       fill_in_credentials_and_submit(user.email, user.password)
       click_submit_default
       click_continue


### PR DESCRIPTION
**Why**: Users can't return to their service provider.  They get stuck at the login.gov account page and don't know what to do.

**How**: After timeout put the request_id back on the url.  Fix the broken feature spec / test.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
