### PR TITLE
Hardcode session encryption cost for migration

### DIFF
--- a/app/services/encryption/encryptors/deprecated_session_encryptor.rb
+++ b/app/services/encryption/encryptors/deprecated_session_encryptor.rb
@@ -18,7 +18,7 @@ module Encryption
 
         key = Figaro.env.session_encryption_key
         user_access_key = UserAccessKey.new(
-          password: key, salt: OpenSSL::Digest::SHA256.hexdigest(key)
+          password: key, salt: OpenSSL::Digest::SHA256.hexdigest(key), cost: '4000$8$4$'
         )
         @user_access_key_scrypt_hash = user_access_key.as_scrypt_hash
         user_access_key


### PR DESCRIPTION
**Why**: In #2353 we changed the scrypt cost with changed the scrypt
cost which affected the session encryptor causing sessions encrypted by
old and new hosts to be incompatible. This commit hardcodes the cost in
the deprecated encryptor so that the sessions will be compatible between
hosts.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
