### PR TITLE
Remove unused code that inflated our session size

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -62,8 +62,6 @@ module OpenidConnect
     end
 
     def build_authorize_form_from_params
-      user_session[:openid_auth_request] = authorization_params if user_session
-
       @authorize_form = OpenidConnectAuthorizeForm.new(authorization_params)
 
       @authorize_decorator = OpenidConnectAuthorizeDecorator.new(


### PR DESCRIPTION
**Why**: This is the root cause for the KMS errors we experienced in
production yesterday. We were storing the OIDC request params in the
session for no reason. The more parameters an agency included in their
initial OIDC request, the bigger the session size. In the case of
USAJOBS, storing this data in the session increased the length of the
string that was sent to KMS after 2FA from 2948 to 4128.

There were exactly 2 SAML requests during the outage, so they played
an insignificant role. This most likely affected every single USAJOBS
session, which accounted for 74% of requests during that time. I don't
believe TTP was affected. The rest of the requests (4% of total
requests) came from 3 other SPs that I haven't looked into yet.

Note that this only solves the problem for LOA1 OIDC requests (as they
are currently made). SAML requests remain much larger than 4096 bytes.
In general, this KMS limit problem can be solved by one or more of these
solutions, which we have considered in the past:

- Storing the SP requests in the DB instead of the session
- Only encrypting the info that needs to be encrypted, as opposed to
the entire session

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
