### PR TITLE
Deploy RC 63.4 to int

### DIFF
--- a/app/services/encryption/encryptors/session_encryptor.rb
+++ b/app/services/encryption/encryptors/session_encryptor.rb
@@ -3,7 +3,11 @@ module Encryption
     class SessionEncryptor
       include Encodable
 
-      delegate :encrypt, to: :deprecated_encryptor
+      def encrypt(plaintext)
+        aes_ciphertext = AesEncryptor.new.encrypt(plaintext, aes_encryption_key)
+        kms_ciphertext = KmsClient.new.encrypt(aes_ciphertext)
+        encode(kms_ciphertext)
+      end
 
       def decrypt(ciphertext)
         return deprecated_encryptor.decrypt(ciphertext) if legacy?(ciphertext)

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -4,79 +4,165 @@ describe Encryption::KmsClient do
   let(:password_pepper) { '1' * 32 }
   let(:local_plaintext) { 'local plaintext' }
   let(:local_ciphertext) { 'local ciphertext' }
-  let(:kms_plaintext) { 'kms plaintext' }
-  let(:kms_ciphertext) { 'kms ciphertext' }
-  let(:kms_enabled) { true }
 
-  before do
-    allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
+  context 'with kms plaintext less than 4k' do
+    let(:kms_plaintext) { 'kms plaintext' }
+    let(:kms_ciphertext) { 'kms ciphertext' }
+    let(:kms_enabled) { true }
 
-    encryptor = Encryption::Encryptors::AesEncryptor.new
-    allow(encryptor).to receive(:encrypt).
-      with(local_plaintext, password_pepper).
-      and_return(local_ciphertext)
-    allow(encryptor).to receive(:decrypt).
-      with(local_ciphertext, password_pepper).
-      and_return(local_plaintext)
-    allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
+    before do
+      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
 
-    stub_aws_kms_client(kms_plaintext, kms_ciphertext)
-    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+      encryptor = Encryption::Encryptors::AesEncryptor.new
+      allow(encryptor).to receive(:encrypt).
+        with(local_plaintext, password_pepper).
+        and_return(local_ciphertext)
+      allow(encryptor).to receive(:decrypt).
+        with(local_ciphertext, password_pepper).
+        and_return(local_plaintext)
+      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
+
+      stub_aws_kms_client(kms_plaintext, kms_ciphertext)
+      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    end
+
+    describe '#encrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to encrypt the plaintext' do
+          result = subject.encrypt(kms_plaintext)
+
+          expect(result).to eq('KMSx' + kms_ciphertext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to encrypt the plaintext and signs it' do
+          result = subject.encrypt(local_plaintext)
+
+          expect(result).to eq(local_ciphertext)
+        end
+      end
+    end
+
+    describe '#decrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
+          result = subject.decrypt('KMSx' + kms_ciphertext)
+
+          expect(result).to eq(kms_plaintext)
+        end
+
+        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to decrypt a ciphertext' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+    end
+
+    describe '#looks_like_kms?' do
+      it 'returns true for kms encrypted data' do
+        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
+      end
+
+      it 'returns false for non kms encrypted data' do
+        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      end
+    end
   end
 
-  describe '#encrypt' do
-    context 'with KMS enabled' do
-      it 'uses KMS to encrypt the plaintext' do
-        result = subject.encrypt(kms_plaintext)
+  context 'with kms plaintext greater than 4k' do
+    let(:long_kms_plaintext) { SecureRandom.random_bytes(4096 * 1.8) }
+    let(:long_kms_plaintext_bytesize) { long_kms_plaintext.bytesize }
+    let(:long_kms_plaintext_chunksize) { long_kms_plaintext_bytesize / 2 }
+    let(:kms_ciphertext) { %w[chunk1 chunk2].map { |c| Base64.strict_encode64(c) }.to_json }
+    let(:kms_enabled) { true }
 
-        expect(result).to eq('KMSx' + kms_ciphertext)
+    before do
+      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
+
+      encryptor = Encryption::Encryptors::AesEncryptor.new
+      allow(encryptor).to receive(:encrypt).
+        with(local_plaintext, password_pepper).
+        and_return(local_ciphertext)
+      allow(encryptor).to receive(:decrypt).
+        with(local_ciphertext, password_pepper).
+        and_return(local_plaintext)
+      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
+
+      stub_mapped_aws_kms_client(
+        long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
+        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2'
+      )
+      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    end
+
+    describe '#encrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to encrypt the plaintext' do
+          result = subject.encrypt(long_kms_plaintext)
+
+          expect(result).to eq('KMSx' + kms_ciphertext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to encrypt the plaintext and signs it' do
+          result = subject.encrypt(local_plaintext)
+
+          expect(result).to eq(local_ciphertext)
+        end
       end
     end
 
-    context 'without KMS enabled' do
-      let(:kms_enabled) { false }
+    describe '#decrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
+          result = subject.decrypt('KMSx' + kms_ciphertext)
 
-      it 'uses the password pepper to encrypt the plaintext and signs it' do
-        result = subject.encrypt(local_plaintext)
+          expect(result).to eq(long_kms_plaintext)
+        end
 
-        expect(result).to eq(local_ciphertext)
-      end
-    end
-  end
+        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
+          result = subject.decrypt(local_ciphertext)
 
-  describe '#decrypt' do
-    context 'with KMS enabled' do
-      it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
-        result = subject.decrypt('KMSx' + kms_ciphertext)
-
-        expect(result).to eq(kms_plaintext)
+          expect(result).to eq(local_plaintext)
+        end
       end
 
-      it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
-        result = subject.decrypt(local_ciphertext)
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
 
-        expect(result).to eq(local_plaintext)
+        it 'uses the password pepper to decrypt a ciphertext' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
       end
     end
 
-    context 'without KMS enabled' do
-      let(:kms_enabled) { false }
-
-      it 'uses the password pepper to decrypt a ciphertext' do
-        result = subject.decrypt(local_ciphertext)
-
-        expect(result).to eq(local_plaintext)
+    describe '#looks_like_kms?' do
+      it 'returns true for kms encrypted data' do
+        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
       end
-    end
-  end
 
-  describe '#looks_like_kms?' do
-    it 'returns true for kms encrypted data' do
-      expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
-    end
-
-    it 'returns false for non kms encrypted data' do
-      expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      it 'returns false for non kms encrypted data' do
+        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      end
     end
   end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -10,6 +10,21 @@ module AwsKmsClientHelper
     [random_key, ciphered_key]
   end
 
+  def stub_mapped_aws_kms_client(forward = {})
+    reverse = forward.invert
+    aws_key_id = Figaro.env.aws_kms_key_id
+    Aws.config[:kms] = {
+      stub_responses: {
+        encrypt: lambda { |context|
+          { ciphertext_blob: forward[context.params[:plaintext]], key_id: aws_key_id }
+        },
+        decrypt: lambda { |context|
+          { plaintext: reverse[context.params[:ciphertext_blob]], key_id: aws_key_id }
+        },
+      },
+    }
+  end
+
   def stub_aws_kms_client_invalid_ciphertext(ciphered_key = random_str)
     aws_key_id = Figaro.env.aws_kms_key_id
     Aws.config[:kms] = {


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
