### PR TITLE
[LG-499] Rake task copies phone info to new table

### DIFF
--- a/app/services/populate_phone_configurations_table.rb
+++ b/app/services/populate_phone_configurations_table.rb
@@ -1,0 +1,28 @@
+class PopulatePhoneConfigurationsTable
+  def call
+    # we don't have a uniqueness constraint in the database to let us blindly insert
+    # everything in a single SQL statement. So we have to load by batches and copy
+    # over. Much slower, but doesn't duplicate information.
+    User.in_batches(of: 1000) { |relation| process_batch(relation) }
+  end
+
+  private
+
+  # :reek:FeatureEnvy
+  def process_batch(relation)
+    User.transaction do
+      relation.each do |user|
+        next if user.phone_configuration.present? || user.phone.blank?
+        user.create_phone_configuration(phone_info_for_user(user))
+      end
+    end
+  end
+
+  def phone_info_for_user(user)
+    {
+      phone: user.phone,
+      confirmed_at: user.phone_confirmed_at,
+      delivery_preference: user.otp_delivery_preference,
+    }
+  end
+end

--- a/lib/tasks/migrate_phone_configurations.rake
+++ b/lib/tasks/migrate_phone_configurations.rake
@@ -1,0 +1,7 @@
+namespace :adhoc do
+  desc 'Copy phone configurations to the new table'
+  task populate_phone_configurations: :environment do
+    Rails.logger = Logger.new(STDOUT)
+    PopulatePhoneConfigurationsTable.new.call
+  end
+end

--- a/spec/services/populate_phone_configurations_table_spec.rb
+++ b/spec/services/populate_phone_configurations_table_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe PopulatePhoneConfigurationsTable do
+  let(:subject) { described_class.new }
+
+  describe '#call' do
+    context 'a user with no phone' do
+      let!(:user) { create(:user) }
+
+      it 'migrates nothing' do
+        subject.call
+        expect(user.reload.phone_configuration).to be_nil
+      end
+    end
+
+    context 'a user with a phone' do
+      let!(:user) { create(:user, :with_phone) }
+
+      context 'and no phone_configuration entry' do
+        before(:each) do
+          user.phone_configuration.delete
+          user.reload
+        end
+
+        it 'migrates the phone' do
+          subject.call
+          configuration = user.reload.phone_configuration
+          expect(configuration.phone).to eq user.phone
+          expect(configuration.confirmed_at).to eq user.phone_confirmed_at
+          expect(configuration.delivery_preference).to eq user.otp_delivery_preference
+        end
+      end
+
+      context 'and an existing phone_configuration entry' do
+        it 'adds no new rows' do
+          expect(PhoneConfiguration.where(user_id: user.id).count).to eq 1
+          subject.call
+          expect(PhoneConfiguration.where(user_id: user.id).count).to eq 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
We want to make sure all phone configurations are present in
the new table before we start reading data from the table.

**How**:
We use a rake task that processes users in batches to make
sure a phone configuration row exists for the user.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
