### PR TITLE
LG-508 Add client-side Crockford Base32 encoding helper

### DIFF
--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -45,29 +45,6 @@ function resetForm() {
   unsetInvalidHTML();
 }
 
-function handleSubmit(event) {
-  event.preventDefault();
-
-  // As above, in case browser lacks HTML5 validation (e.g., IE < 11)
-  if(input.value.length < 19) {
-    setInvalidHTML();
-    return;
-  }
-
-  let value = formatInput(input.value);
-
-  if (value === personalKey) {
-    unsetInvalidHTML();
-    // Recovery code page, without js enabled, has a form submission that posts
-    // to the server with no body.
-    // Mimic that here.
-    formEl.removeEventListener('submit', handleSubmit);
-    formEl.submit();
-  } else {
-    setInvalidHTML();
-  }
-}
-
 function formatInput(value) {
   // Coerce mistaken user input from 'problem' letters:
   // https://en.wikipedia.org/wiki/Base32#Crockford.27s_Base32
@@ -79,6 +56,29 @@ function formatInput(value) {
 
   // And uppercase
   return value.toUpperCase();
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+
+  // As above, in case browser lacks HTML5 validation (e.g., IE < 11)
+  if (input.value.length < 19) {
+    setInvalidHTML();
+    return;
+  }
+
+  const value = formatInput(input.value);
+
+  if (value === personalKey) {
+    unsetInvalidHTML();
+    // Recovery code page, without js enabled, has a form submission that posts
+    // to the server with no body.
+    // Mimic that here.
+    formEl.removeEventListener('submit', handleSubmit);
+    formEl.submit();
+  } else {
+    setInvalidHTML();
+  }
 }
 
 function show(event) {

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -1,3 +1,5 @@
+import base32Crockford from 'base32-crockford-browser';
+
 const modalSelector = '#personal-key-confirm';
 const modal = new window.LoginGov.Modal({ el: modalSelector });
 
@@ -46,9 +48,15 @@ function resetForm() {
 function handleSubmit(event) {
   event.preventDefault();
 
-  const value = input.value;
+  // As above, in case browser lacks HTML5 validation (e.g., IE < 11)
+  if(input.value.length < 19) {
+    setInvalidHTML();
+    return;
+  }
 
-  if (value.toUpperCase() === personalKey) {
+  let value = formatInput(input.value);
+
+  if (value === personalKey) {
     unsetInvalidHTML();
     // Recovery code page, without js enabled, has a form submission that posts
     // to the server with no body.
@@ -58,6 +66,19 @@ function handleSubmit(event) {
   } else {
     setInvalidHTML();
   }
+}
+
+function formatInput(value) {
+  // Coerce mistaken user input from 'problem' letters:
+  // https://en.wikipedia.org/wiki/Base32#Crockford.27s_Base32
+  value = base32Crockford.decode(value);
+  value = base32Crockford.encode(value);
+
+  // Add back the dashes
+  value = value.toString().match(/.{4}/g).join('-');
+
+  // And uppercase
+  return value.toUpperCase();
 }
 
 function show(event) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^3.5.5",
+    "base32-crockford-browser": "^1.0.0",
     "basscss-sass": "^3.0.0",
     "classlist.js": "^1.1.20150312",
     "clipboard": "^1.6.1",

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -81,7 +81,7 @@ feature 'LOA1 Single Sign On' do
     it 'user can view and confirm personal key during sign up', :js do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :with_phone)
-      code = 'ABC1-DEF2-GHI3-JKL4'
+      code = 'ABC1-DEF2-GH13-JK14'
       stub_personal_key(user: user, code: code)
 
       loa1_sp_session
@@ -90,6 +90,25 @@ feature 'LOA1 Single Sign On' do
 
       click_on(t('forms.buttons.continue'))
       enter_personal_key_words_on_modal(code)
+      click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
+
+      expect(current_path).to eq sign_up_completed_path
+    end
+
+    it 'coerces invalid characters into their Crockford Base32 equivalents', :js do
+      displayed_personal_key = '0000-1111-1111-1234'
+      misread_personal_key = 'ooOO-iiII-llLL-1234'
+
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+      user = create(:user, :with_phone)
+      stub_personal_key(user: user, code: displayed_personal_key)
+
+      loa1_sp_session
+      sign_in_and_require_viewing_personal_key(user)
+      expect(current_path).to eq sign_up_personal_key_path
+
+      click_on(t('forms.buttons.continue'))
+      enter_personal_key_words_on_modal(misread_personal_key)
       click_on t('forms.buttons.continue'), class: 'personal-key-confirm'
 
       expect(current_path).to eq sign_up_completed_path

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,6 +876,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base32-crockford-browser@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base32-crockford-browser/-/base32-crockford-browser-1.0.0.tgz#3684970a5826ba1430f01e719cf923b00d773dd8"
+  dependencies:
+    optimist ">=0.1.0"
+
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
@@ -4099,6 +4105,10 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
 mississippi@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-1.3.1.tgz#2a8bb465e86550ac8b36a7b6f45599171d78671e"
@@ -4464,6 +4474,13 @@ opn@^5.1.0:
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
   dependencies:
     is-wsl "^1.1.0"
+
+optimist@>=0.1.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
 
 optimize-css-assets-webpack-plugin@^3.2.0:
   version "3.2.0"
@@ -6850,6 +6867,10 @@ window-size@0.1.0:
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Why**: Personal key confirmation modal lacks
conversion helper present in server-side code.

**How**: Add corresponding client-side code to
coerce mistakenly read characters into their
Crockford Base32 equivalents.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
