### PR TITLE
LG-460 Display fake banner in lower environments.

### DIFF
--- a/app/views/layouts/base.html.slim
+++ b/app/views/layouts/base.html.slim
@@ -51,8 +51,10 @@ html lang="#{I18n.locale}" class='no-js'
   body class="#{Rails.env}-env site #{yield(:background_cls)}"
     .site-wrap
       = render 'shared/i18n_mode' if FeatureManagement.enable_i18n_mode?
-      = render 'shared/no_pii_banner' if FeatureManagement.no_pii_mode?
-      = render 'shared/usa_banner'
+      - if FeatureManagement.fake_banner_mode?
+        = render 'shared/fake_banner'
+      - else
+        = render 'shared/usa_banner'
       - if content_for?(:nav)
         = yield(:nav)
       - else

--- a/app/views/shared/_fake_banner.html.slim
+++ b/app/views/shared/_fake_banner.html.slim
@@ -1,0 +1,6 @@
+.py1.bg-maroon.white.fs-12p.line-height-1.center
+  = t('idv.messages.sessions.no_pii')
+.py1.bg-navy.white.fs-12p.line-height-1.center
+  = image_tag(asset_url('us-flag.png'), size: '18x12',
+          alt: 'US flag', class: 'mr1 align-bottom')
+  = t('.fake_site')

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -152,7 +152,7 @@ en:
       sessions:
         id_information_message: as it appears on your state-issued ID
         id_information_subtitle: ID Information
-        no_pii: Do not use real personal information (demo purposes only)
+        no_pii: FAKE Do not use real personal information (demo purposes only) FAKE
         review_message: When you enter your password, login.gov will secure your personal
           information. We do this to make sure no one else can access your information.
         success: Next, we'll need a phone number.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -152,7 +152,8 @@ es:
       sessions:
         id_information_message: como aparece en su identificación emitida por el estado
         id_information_subtitle: Información de identificación
-        no_pii: No utilice información personal real (sólo para propósitos de demostración)
+        no_pii: FALSO No utilice información personal real (sólo para propósitos de
+          demostración) FALSO
         review_message: Cuando ingrese su contraseña, login.gov protegerá su información
           personal. Hacemos esto para asegurarnos de que nadie más pueda acceder a
           su información.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -161,8 +161,8 @@ fr:
       sessions:
         id_information_message: tel qu'il apparaît sur votre carte d'identité officielle
         id_information_subtitle: Informations d'identification
-        no_pii: N'utilisez pas de véritables données personnelles (il s'agit d'une
-          démonstration seulement)
+        no_pii: TRUQUÉ N'utilisez pas de véritables données personnelles (il s'agit
+          d'une démonstration seulement) TRUQUÉ
         review_message: Lorsque vous entrez votre mot de passe, login.gov sécurise
           vos informations personnelles. Nous faisons cela pour nous assurer que personne
           d'autre ne puisse accéder à vos informations.

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   shared:
+    fake_banner:
+      fake_site: A FAKE website of the United States government
     footer_lite:
       gsa: U.S. General Services Administration
     usa_banner:

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -1,6 +1,8 @@
 ---
 es:
   shared:
+    fake_banner:
+      fake_site: Un FALSO sitio web del gobierno de Estados Unidos
     footer_lite:
       gsa: Administración General de Servicios de EE. UU.
     usa_banner:

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -1,6 +1,8 @@
 ---
 fr:
   shared:
+    fake_banner:
+      fake_site: Un site TRUQUÉ du gouvernement des États-Unis
     footer_lite:
       gsa: Administration des services généraux des États-Unis
     usa_banner:

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -81,8 +81,8 @@ class FeatureManagement
     ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED.include?(Figaro.env.domain_name)
   end
 
-  def self.no_pii_mode?
-    enable_identity_verification? && Figaro.env.profile_proofing_vendor == :mock
+  def self.fake_banner_mode?
+    Rails.env.production? && Figaro.env.domain_name != 'secure.login.gov'
   end
 
   def self.enable_saml_cert_rotation?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -181,48 +181,34 @@ describe 'FeatureManagement', type: :feature do
     end
   end
 
-  describe '.no_pii_mode?' do
-    let(:proofing_vendor) { :mock }
-    let(:enable_identity_verification) { false }
-
-    before do
-      allow_any_instance_of(Figaro.env).to receive(:profile_proofing_vendor).
-        and_return(proofing_vendor)
-      allow(Figaro.env).to receive(:enable_identity_verification).
-        and_return(enable_identity_verification.to_json)
-    end
-
-    subject(:no_pii_mode?) { FeatureManagement.no_pii_mode? }
-
-    context 'with mock ID-proofing vendors' do
-      let(:proofing_vendor) { :mock }
-
-      context 'with identity verification enabled' do
-        let(:enable_identity_verification) { true }
-
-        it { expect(no_pii_mode?).to eq(true) }
-      end
-
-      context 'with identity verification disabled' do
-        let(:enable_identity_verification) { false }
-
-        it { expect(no_pii_mode?).to eq(false) }
+  describe '.fake_banner_mode?' do
+    context 'when on secure.login.gov' do
+      it 'does not display the fake banner' do
+        allow(Figaro.env).to receive(:domain_name).
+          and_return('secure.login.gov')
+        allow(Rails.env).to receive(:production?).
+          and_return(true)
+        expect(FeatureManagement.fake_banner_mode?).to eq(false)
       end
     end
 
-    context 'with real ID-proofing vendors' do
-      let(:proofing_vendor) { :not_mock }
-
-      context 'with identity verification enabled' do
-        let(:enable_identity_verification) { true }
-
-        it { expect(no_pii_mode?).to eq(false) }
+    context 'when the host is not secure.login.gov and the Rails env is production' do
+      it 'displays the fake banner' do
+        allow(Figaro.env).to receive(:domain_name).
+          and_return('test.login.gov')
+        allow(Rails.env).to receive(:production?).
+          and_return(true)
+        expect(FeatureManagement.fake_banner_mode?).to eq(true)
       end
+    end
 
-      context 'with identity verification disabled' do
-        let(:enable_identity_verification) { false }
-
-        it { expect(no_pii_mode?).to eq(false) }
+    context 'when the host is not secure.login.gov and the Rails env is not in production' do
+      it 'does not display the fake banner' do
+        allow(Figaro.env).to receive(:domain_name).
+          and_return('test.login.gov')
+        allow(Rails.env).to receive(:production?).
+          and_return(false)
+        expect(FeatureManagement.fake_banner_mode?).to eq(false)
       end
     end
   end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -29,6 +29,24 @@ describe 'layouts/application.html.slim' do
     end
   end
 
+  context 'when FeatureManagement.fake_banner_mode? is true' do
+    it 'displays the fake banner' do
+      allow(FeatureManagement).to receive(:fake_banner_mode?).and_return(true)
+      render
+
+      expect(rendered).to have_content('FAKE')
+    end
+  end
+
+  context 'when FeatureManagement.fake_banner_mode? is false' do
+    it 'does not display the fake banner' do
+      allow(FeatureManagement).to receive(:fake_banner_mode?).and_return(false)
+      render
+
+      expect(rendered).to_not have_content('FAKE')
+    end
+  end
+
   context 'when i18n mode enabled' do
     before do
       allow(FeatureManagement).to receive(:enable_i18n_mode?).and_return(true)


### PR DESCRIPTION
**Why**: Our lower environment websites (dev, int, qa, staging, etc.)
are public, and sometimes people visit them without realizing they are
not on secure.login.gov. When that happens, we want to make sure they
know they are not on the production site by displaying a banner at the
top of the site that says this is a FAKE site.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
