### PR TITLE
LG-542 Don't allow LOA3 users to request delete account

### DIFF
--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -23,7 +23,7 @@ module AccountReset
     end
 
     def confirm_user_not_verified
-      # IAL1 users should not be able to reset account to comply with AAL2 reqs
+      # IAL2 users should not be able to reset account to comply with AAL2 reqs
       redirect_to account_url if decorated_user.identity_verified?
     end
 

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -4,6 +4,7 @@ module AccountReset
 
     before_action :check_account_reset_enabled
     before_action :confirm_two_factor_enabled
+    before_action :confirm_user_not_verified
 
     def show; end
 
@@ -19,6 +20,11 @@ module AccountReset
 
     def check_account_reset_enabled
       redirect_to root_url unless FeatureManagement.account_reset_enabled?
+    end
+
+    def confirm_user_not_verified
+      # IAL1 users should not be able to reset account to comply with AAL2 reqs
+      redirect_to account_url if decorated_user.identity_verified?
     end
 
     def reset_session_with_email

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -45,6 +45,11 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
     end
   end
 
+  def should_display_account_reset_or_cancel_link?
+    # IAL1 users should not be able to reset account to comply with AAL2 reqs
+    !current_user.decorate.identity_verified?
+  end
+
   def account_reset_or_cancel_link
     account_reset_token_valid? ? account_reset_cancel_link : account_reset_link
   end

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -46,7 +46,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
   end
 
   def should_display_account_reset_or_cancel_link?
-    # IAL1 users should not be able to reset account to comply with AAL2 reqs
+    # IAL2 users should not be able to reset account to comply with AAL2 reqs
     !current_user.decorate.identity_verified?
   end
 

--- a/app/services/account_reset_service.rb
+++ b/app/services/account_reset_service.rb
@@ -58,7 +58,7 @@ class AccountResetService
   def self.reset_and_notify(arr)
     user = arr.user
     return false unless AccountResetService.new(user).grant_request
-    UserMailer.account_reset_granted(user, arr).deliver_later
+    UserMailer.account_reset_granted(user, arr.reload).deliver_later
     true
   end
   private_class_method :reset_and_notify

--- a/app/views/two_factor_authentication/options/index.html.slim
+++ b/app/views/two_factor_authentication/options/index.html.slim
@@ -23,5 +23,6 @@ p.mt-tiny.mb3 = @presenter.info
   = f.button :submit, t('forms.buttons.continue')
 
 br
-p = @presenter.account_reset_or_cancel_link
+- if @presenter.should_display_account_reset_or_cancel_link?
+  p = @presenter.account_reset_or_cancel_link
 = render 'shared/cancel', link: destroy_user_session_path

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe 'Account Reset Request: Delete Account', email: true do
+  let(:user) { create(:user, :signed_up) }
+
+  before do
+    TwilioService::Utils.telephony_service = FakeSms
+  end
+
+  context 'as an LOA1 user' do
+    it 'allows the user to delete their account after 24 hours' do
+      signin(user.email, user.password)
+      click_link t('two_factor_authentication.login_options_link_text')
+      click_link t('devise.two_factor_authentication.account_reset.link')
+      click_button t('account_reset.request.yes_continue')
+      reset_email
+
+      Timecop.travel(Time.zone.now + 2.days) do
+        AccountResetService.grant_tokens_and_send_notifications
+        open_last_email
+        click_email_link_matching(/delete_account\?token/)
+
+        expect(page).to have_content(t('account_reset.delete_account.title'))
+        expect(page).to have_current_path(account_reset_delete_account_path)
+
+        click_on t('account_reset.delete_account.delete_button')
+
+        expect(page).to have_content(
+          strip_tags(
+            t(
+              'account_reset.confirm_delete_account.info',
+              email: user.email,
+              link: t('account_reset.confirm_delete_account.link_text')
+            )
+          )
+        )
+        expect(page).to have_current_path(account_reset_confirm_delete_account_path)
+        expect(User.where(id: user.id)).to be_empty
+      end
+    end
+  end
+
+  context 'as an LOA3 user' do
+    let(:user) do
+      create(
+        :profile,
+        :active,
+        :verified,
+        pii: { first_name: 'John', ssn: '111223333' }
+      ).user
+    end
+
+    it 'does not allow the user to delete their account from 2FA screen' do
+      signin(user.email, user.password)
+      click_link t('two_factor_authentication.login_options_link_text')
+
+      # Account reset link should not be present
+      expect(page).to_not have_content(t('devise.two_factor_authentication.account_reset.link'))
+
+      # Visiting account reset directly should redirect to 2FA
+      visit account_reset_request_path
+
+      expect(page.current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To disable account reset for LOA3 users while we determine how
the LOA3 account reset process will work

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
