### PR TITLE
Change the indexes in Rails link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ will warn you about unsafe migrations and has great step-by-step instructions
 for various scenarios.
 
 - [ ] Indexes were added if necessary. This article provides a good overview
-of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).
+of [indexes in Rails](https://goo.gl/1DARYi).
 
 - [ ] Verified that the changes don't affect other apps (such as the dashboard)
 


### PR DESCRIPTION
Whenever there is a new PR the github slack integration shows a preview image from a piece of documentation we link to in our PR template. It adds a lot of noise to the channel and makes the posts take up a lot of space. Until github makes a change in their integration (sounds like others [others want this too](https://github.com/integrations/slack/issues/487)) we could change the link to a shortened version to purposely break this image preview.