### PR TITLE
LG-544 Prevent calling unsupported countries

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -83,10 +83,6 @@ module FormHelper
     end
   end
 
-  def unsupported_area_codes
-    PhoneNumberCapabilities::VOICE_UNSUPPORTED_US_AREA_CODES
-  end
-
   def supported_jurisdictions
     Idv::FormJurisdictionValidator::SUPPORTED_JURISDICTIONS
   end

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -1,37 +1,10 @@
-import { PhoneFormatter } from 'field-kit';
-
 const INTERNATIONAL_CODE_REGEX = /^\+(\d+) |^1 /;
 
 const I18n = window.LoginGov.I18n;
-const phoneFormatter = new PhoneFormatter();
-
-const getPhoneUnsupportedAreaCodeCountry = (areaCode) => {
-  const form = document.querySelector('[data-international-phone-form]');
-  const phoneUnsupportedAreaCodes = JSON.parse(form.dataset.unsupportedAreaCodes);
-  return phoneUnsupportedAreaCodes[areaCode];
-};
-
-const areaCodeFromUSPhone = (phone) => {
-  const digits = phoneFormatter.digitsWithoutCountryCode(phone);
-  if (digits.length >= 10) {
-    return digits.slice(0, 3);
-  }
-  return null;
-};
 
 const selectedInternationCodeOption = () => {
   const dropdown = document.querySelector('[data-international-phone-form] .international-code');
   return dropdown.item(dropdown.selectedIndex);
-};
-
-const unsupportedUSPhoneOTPDeliveryWarningMessage = (phone) => {
-  const areaCode = areaCodeFromUSPhone(phone);
-  const country = getPhoneUnsupportedAreaCodeCountry(areaCode);
-  if (country) {
-    const messageTemplate = I18n.t('devise.two_factor_authentication.otp_delivery_preference.phone_unsupported');
-    return messageTemplate.replace('%{location}', country);
-  }
-  return null;
 };
 
 const unsupportedInternationalPhoneOTPDeliveryWarningMessage = () => {
@@ -57,14 +30,6 @@ const enablePhoneState = (phoneRadio, phoneLabel, deliveryMethodHint) => {
   deliveryMethodHint.innerText = I18n.t('devise.two_factor_authentication.otp_delivery_preference.instruction');
 };
 
-const unsupportedPhoneOTPDeliveryWarningMessage = (phone) => {
-  const internationCodeOption = selectedInternationCodeOption();
-  if (internationCodeOption.dataset.countryCode === '1') {
-    return unsupportedUSPhoneOTPDeliveryWarningMessage(phone);
-  }
-  return unsupportedInternationalPhoneOTPDeliveryWarningMessage();
-};
-
 const updateOTPDeliveryMethods = () => {
   const phoneRadio = document.querySelector('[data-international-phone-form] .otp_delivery_preference_voice');
   const smsRadio = document.querySelector('[data-international-phone-form] .otp_delivery_preference_sms');
@@ -73,13 +38,10 @@ const updateOTPDeliveryMethods = () => {
     return;
   }
 
-  const phoneInput = document.querySelector('[data-international-phone-form] .phone');
   const phoneLabel = phoneRadio.parentNode.parentNode;
   const deliveryMethodHint = document.querySelector('#otp_delivery_preference_instruction');
 
-  const phone = phoneInput.value;
-
-  const warningMessage = unsupportedPhoneOTPDeliveryWarningMessage(phone);
+  const warningMessage = unsupportedInternationalPhoneOTPDeliveryWarningMessage();
   if (warningMessage) {
     disablePhoneState(phoneRadio, phoneLabel, smsRadio, deliveryMethodHint,
       warningMessage);

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -1,26 +1,4 @@
 class PhoneNumberCapabilities
-  VOICE_UNSUPPORTED_US_AREA_CODES = {
-    '264' => 'Anguilla',
-    '268' => 'Antigua and Barbuda',
-    '242' => 'Bahamas',
-    '246' => 'Barbados',
-    '441' => 'Bermuda',
-    '284' => 'British Virgin Islands',
-    '345' => 'Cayman Islands',
-    '767' => 'Dominica',
-    '809' => 'Dominican Republic',
-    '829' => 'Dominican Republic',
-    '849' => 'Dominican Republic',
-    '473' => 'Grenada',
-    '876' => 'Jamaica',
-    '664' => 'Montserrat',
-    '869' => 'Saint Kitts and Nevis',
-    '758' => 'Saint Lucia',
-    '784' => 'Saint Vincent Grenadines',
-    '868' => 'Trinidad and Tobago',
-    '649' => 'Turks and Caicos Islands',
-  }.freeze
-
   INTERNATIONAL_CODES = YAML.load_file(
     Rails.root.join('config', 'country_dialing_codes.yml')
   ).freeze
@@ -32,38 +10,27 @@ class PhoneNumberCapabilities
   end
 
   def sms_only?
-    if international_code == '1'
-      VOICE_UNSUPPORTED_US_AREA_CODES[area_code].present?
-    elsif country_code_data
-      country_code_data['sms_only']
-    end
+    return true if country_code_data.nil?
+    country_code_data['sms_only']
   end
 
   def unsupported_location
-    if international_code == '1'
-      VOICE_UNSUPPORTED_US_AREA_CODES[area_code]
-    elsif country_code_data
-      country_code_data['name']
-    end
+    country_code_data['name'] if country_code_data
   end
 
   private
 
-  def area_code
-    @area_code ||= parsed_phone.area_code
-  end
-
   def country_code_data
-    @country_code_data ||= INTERNATIONAL_CODES.select do |_, value|
-      value['country_code'] == international_code
+    @country_code_data ||= INTERNATIONAL_CODES.select do |key, _|
+      key == two_letter_country_code
     end.values.first
   end
 
-  def international_code
-    @international_code ||= parsed_phone.country_code
+  def two_letter_country_code
+    parsed_phone.country
   end
 
   def parsed_phone
-    @parsed_phone ||= Phonelib.parse(phone)
+    Phonelib.parse(phone)
   end
 end

--- a/app/views/users/phone_setup/index.html.slim
+++ b/app/views/users/phone_setup/index.html.slim
@@ -5,8 +5,7 @@ h1.h3.my0 = @presenter.heading
 p.mt-tiny.mb0 = @presenter.info
 = simple_form_for(@user_phone_form,
     html: { autocomplete: 'off', role: 'form' },
-    data: { unsupported_area_codes: unsupported_area_codes,
-      international_phone_form: true },
+    data: { international_phone_form: true },
     method: :patch,
     url: phone_setup_path) do |f|
   .sm-col-8.js-intl-tel-code-select

--- a/app/views/users/phones/edit.html.slim
+++ b/app/views/users/phones/edit.html.slim
@@ -3,8 +3,7 @@
 h1.h3.my0 = t('headings.edit_info.phone')
 = simple_form_for(@user_phone_form,
     html: { autocomplete: 'off', method: :put, role: 'form' },
-    data: { unsupported_area_codes: unsupported_area_codes,
-      international_phone_form: true },
+    data: { international_phone_form: true },
     url: manage_phone_path) do |f|
   .sm-col-8.js-intl-tel-code-select
     = f.input :international_code,

--- a/spec/features/sign_in/two_factor_options_spec.rb
+++ b/spec/features/sign_in/two_factor_options_spec.rb
@@ -61,6 +61,26 @@ describe '2FA options when signing in' do
     end
   end
 
+  context "the user's otp_delivery_preference is voice but number is unsupported" do
+    it 'only displays SMS and Personal key' do
+      user = create(:user, :signed_up, otp_delivery_preference: 'voice', phone: '+12423270143')
+      sign_in_user(user)
+
+      click_link t('two_factor_authentication.login_options_link_text')
+
+      expect(page).
+        to have_content t('two_factor_authentication.login_options.sms')
+      expect(page).
+        to_not have_content t('two_factor_authentication.login_options.voice')
+      expect(page).
+        to have_content t('two_factor_authentication.login_options.personal_key')
+      expect(page).
+        to_not have_content t('two_factor_authentication.login_options.piv_cac')
+      expect(page).
+        to_not have_content t('two_factor_authentication.login_options.auth_app')
+    end
+  end
+
   context 'when the user only has TOTP configured' do
     it 'only displays TOTP and Personal key' do
       user = create(:user, :with_authentication_app)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -320,7 +320,7 @@ feature 'Sign in' do
     it 'falls back to SMS with an error message' do
       allow(SmsOtpSenderJob).to receive(:perform_later)
       allow(VoiceOtpSenderJob).to receive(:perform_later)
-      user = create(:user, :signed_up, phone: '+91 1234567890', otp_delivery_preference: 'voice')
+      user = create(:user, :signed_up, phone: '+1 441-295-9644', otp_delivery_preference: 'voice')
       signin(user.email, user.password)
 
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
@@ -329,7 +329,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'devise.two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India'
+        location: 'Bermuda'
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -8,7 +8,7 @@ feature 'verify profile with OTP' do
     profile = create(
       :profile,
       deactivation_reason: :verification_pending,
-      pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '703-555-9999' },
+      pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '+1 703-555-9999' },
       user: user
     )
     otp_fingerprint = Pii::Fingerprinter.fingerprint(otp)

--- a/spec/services/phone_number_capabilities_spec.rb
+++ b/spec/services/phone_number_capabilities_spec.rb
@@ -9,8 +9,13 @@ describe PhoneNumberCapabilities do
       it { expect(subject.sms_only?).to eq(false) }
     end
 
-    context 'voice is not supported for the area code' do
+    context 'Bahamas number' do
       let(:phone) { '+1 (242) 327-0143' }
+      it { expect(subject.sms_only?).to eq(true) }
+    end
+
+    context 'Bermuda number' do
+      let(:phone) { '+1 (441) 295-9644' }
       it { expect(subject.sms_only?).to eq(true) }
     end
 
@@ -20,48 +25,33 @@ describe PhoneNumberCapabilities do
       xit { expect(subject.sms_only?).to eq(false) }
     end
 
-    context 'voice is not supported for the international code' do
-      let(:phone) { '+212 1234 12345' }
+    context 'Morocco number' do
+      let(:phone) { '+212 661-289325' }
+      it { expect(subject.sms_only?).to eq(true) }
+    end
+
+    context "phonelib returns nil or a 2-letter country code that doesn't match our YAML" do
+      let(:phone) { '703-555-1212' }
       it { expect(subject.sms_only?).to eq(true) }
     end
   end
 
   describe '#unsupported_location' do
-    it 'returns the name of the unsupported area code location' do
+    it 'returns the name of the unsupported country (Bahamas)' do
       locality = PhoneNumberCapabilities.new('+1 (242) 327-0143').unsupported_location
       expect(locality).to eq('Bahamas')
     end
 
-    it 'returns the name of the unsupported international code location' do
-      locality = PhoneNumberCapabilities.new('+355 1234 12345').unsupported_location
-      expect(locality).to eq('Albania')
+    it 'returns the name of the unsupported country (Bermuda)' do
+      locality = PhoneNumberCapabilities.new('+1 (441) 295-9644').unsupported_location
+      expect(locality).to eq('Bermuda')
     end
-  end
 
-  describe 'list of unsupported area codes' do
-    it 'is up to date' do
-      unsupported_area_codes = {
-        '264' => 'Anguilla',
-        '268' => 'Antigua and Barbuda',
-        '242' => 'Bahamas',
-        '246' => 'Barbados',
-        '441' => 'Bermuda',
-        '284' => 'British Virgin Islands',
-        '345' => 'Cayman Islands',
-        '767' => 'Dominica',
-        '809' => 'Dominican Republic',
-        '829' => 'Dominican Republic',
-        '849' => 'Dominican Republic',
-        '473' => 'Grenada',
-        '876' => 'Jamaica',
-        '664' => 'Montserrat',
-        '869' => 'Saint Kitts and Nevis',
-        '758' => 'Saint Lucia',
-        '784' => 'Saint Vincent Grenadines',
-        '868' => 'Trinidad and Tobago',
-        '649' => 'Turks and Caicos Islands',
-      }
-      expect(PhoneNumberCapabilities::VOICE_UNSUPPORTED_US_AREA_CODES).to eq unsupported_area_codes
+    context 'phonelib returns nil' do
+      it 'returns nil' do
+        locality = PhoneNumberCapabilities.new('703-555-1212').unsupported_location
+        expect(locality).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: Due to a bug that has since been fixed, there still exist
users in the database whose `otp_delivery_preference` is set to `voice`
even though our Twilio account does not allow us to call their phone
number. This means that every time they sign in, we try to make a call,
which results in a Twilio error, then the user has to choose a different
2FA option.

I had noticed this scenario a while back and fixed it, when the country
in question was India, but this time, people in Bermuda are experiencing
this. The reason why it was failing for Bermuda is because it uses the
same `+1` dialing code as the US, and we were treating all countries
that use `+1` as having "area codes", and we were trying to match the
area code by calling the `area_code` method on the parsed phone. It's
possible that this was working with `phony_rails`, but it doesn't with
`Phonelib` (which is accurate).

**How**: Given that we have a list of all countries in our YAML file
and in the UI dropdown, and that Phonelib knows which country the number
comes from, we don't need to treat countries with `+1` differently. This
allows us to remove all code related to unsupported area codes.

Instead of looking for an area code, we look up the 2-letter code from
the parsed phone, and find a match in our YAML file.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://semaphoreci.com/blog/2017/05/09/faster-rails-is-your-database-properly-indexed.html).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
