### PR TITLE
Log the jurisdiction state in analytics

### DIFF
--- a/app/forms/idv/jurisdiction_form.rb
+++ b/app/forms/idv/jurisdiction_form.rb
@@ -5,29 +5,26 @@ module Idv
 
     ATTRIBUTES = [:state].freeze
 
-    attr_accessor :state
+    attr_reader :state
 
     def self.model_name
       ActiveModel::Name.new(self, nil, 'Jurisdiction')
     end
 
     def submit(params)
-      consume_params(params)
+      self.state = params[:state]
 
-      FormResponse.new(success: valid?, errors: errors.messages)
+      FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
     end
 
     private
 
-    def consume_params(params)
-      params.each do |key, value|
-        raise_invalid_jurisdiction_parameter_error(key) unless ATTRIBUTES.include?(key.to_sym)
-        send("#{key}=", value)
-      end
-    end
+    attr_writer :state
 
-    def raise_invalid_jurisdiction_parameter_error(key)
-      raise ArgumentError, "#{key} is an invalid jurisdiction attribute"
+    def extra_analytics_attributes
+      {
+        state: state,
+      }
     end
   end
 end

--- a/spec/controllers/idv/jurisdiction_controller_spec.rb
+++ b/spec/controllers/idv/jurisdiction_controller_spec.rb
@@ -37,7 +37,11 @@ describe Idv::JurisdictionController do
 
   describe '#create' do
     it 'tracks analytics' do
-      result = { success: true, errors: {} }
+      result = {
+        success: true,
+        errors: {},
+        state: supported_jurisdiction,
+      }
 
       post :create, params: { jurisdiction: { state: supported_jurisdiction } }
 
@@ -54,9 +58,18 @@ describe Idv::JurisdictionController do
 
     context 'with an unsupported jurisdiction' do
       it 'redirects to the unsupported jurisdiction fail page' do
+        result = {
+          success: false,
+          errors: { state: [t('idv.errors.unsupported_jurisdiction')] },
+          state: unsupported_jurisdiction,
+        }
+
         post :create, params: { jurisdiction: { state: unsupported_jurisdiction } }
 
         expect(response).to redirect_to(idv_jurisdiction_failure_url(:unsupported_jurisdiction))
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::IDV_JURISDICTION_FORM, result
+        )
       end
     end
 


### PR DESCRIPTION
**Why**:
- To see which unsupported states gets requested the most, which will
help us prioritize which ones to add next
- To see if any particular states have a higher proofing failure than
others

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
