### PR TITLE
LG-554 Fix already authenticated users redirecting to account page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,7 +126,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_user)
-    user_session[:stored_location] || sp_session[:request_url] || signed_in_url
+    user_session.delete(:stored_location) || sp_session[:request_url] || signed_in_url
   end
 
   def signed_in_url

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -54,7 +54,7 @@ module TwoFactorAuthenticatable
   def check_already_authenticated
     return unless initial_authentication_context?
 
-    redirect_to account_url if user_fully_authenticated?
+    redirect_to after_otp_verification_confirmation_url if user_fully_authenticated?
   end
 
   def reset_attempt_count_if_user_no_longer_locked_out

--- a/spec/features/two_factor_authentication/multiple_tabs_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_tabs_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+feature 'user interacts with 2FA across multiple browser tabs' do
+  include SpAuthHelper
+  include SamlAuthHelper
+
+  it_behaves_like 'visiting 2fa when fully authenticated', :oidc
+  it_behaves_like 'visiting 2fa when fully authenticated', :saml
+end


### PR DESCRIPTION
**Why**: So users redirect back to their service provider rather than getting stuck at the account page.

**How**: Fix the before filter check_already_authenticated which incorrectly redirects to the account page instead of the service provider.  Add a feature spec that tests for this.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
