### PR TITLE
Track additional IdV analytics

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -6,7 +6,8 @@ module Idv
     before_action :confirm_idv_needed
 
     def new
-      analytics.track_event(Analytics::IDV_CANCELLATION)
+      properties = ParseControllerFromReferer.new(request.referer).call
+      analytics.track_event(Analytics::IDV_CANCELLATION, properties)
       @presenter = CancellationPresenter.new(view_context: view_context)
     end
 

--- a/app/controllers/idv/come_back_later_controller.rb
+++ b/app/controllers/idv/come_back_later_controller.rb
@@ -4,7 +4,9 @@ module Idv
 
     before_action :confirm_user_needs_usps_confirmation
 
-    def show; end
+    def show
+      analytics.track_event(Analytics::IDV_COME_BACK_LATER_VISIT)
+    end
 
     private
 

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -16,10 +16,10 @@ module Idv
     delegate :attempts_exceeded?, to: :step, prefix: true
 
     def new
+      analytics.track_event(Analytics::IDV_BASIC_INFO_VISIT)
       user_session[:context] = 'idv'
       set_idv_form
       @selected_state = user_session[:idv_jurisdiction]
-      analytics.track_event(Analytics::IDV_BASIC_INFO_VISIT)
     end
 
     def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,10 +10,7 @@ class UsersController < ApplicationController
   private
 
   def track_account_deletion_event
-    controller_and_action_from_referer = ParseControllerFromReferer.new(request.referer).call
-    properties = {
-      request_came_from: controller_and_action_from_referer,
-    }
+    properties = ParseControllerFromReferer.new(request.referer).call
     analytics.track_event(Analytics::ACCOUNT_DELETION, properties)
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -64,6 +64,7 @@ class Analytics
   IDV_BASIC_INFO_SUBMITTED_VENDOR = 'IdV: basic info vendor submitted'.freeze
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
+  IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
   IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_INTRO_VISIT = 'IdV: intro visited'.freeze

--- a/app/services/parse_controller_from_referer.rb
+++ b/app/services/parse_controller_from_referer.rb
@@ -4,9 +4,7 @@ class ParseControllerFromReferer
   end
 
   def call
-    return 'no referer' if referer.nil?
-
-    controller_and_action_from_referer
+    { request_came_from: controller_and_action_from_referer }
   end
 
   private
@@ -14,6 +12,7 @@ class ParseControllerFromReferer
   attr_reader :referer
 
   def controller_and_action_from_referer
+    return 'no referer' if referer.nil?
     "#{controller_that_made_the_request}##{controller_action}"
   end
 

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -2,11 +2,23 @@ require 'rails_helper'
 
 describe Idv::CancellationsController do
   describe '#new' do
-    it 'tracks an analytics event' do
+    it 'tracks the event in analytics when referer is nil' do
       stub_sign_in
       stub_analytics
+      properties = { request_came_from: 'no referer' }
 
-      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION)
+      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
+
+      get :new
+    end
+
+    it 'tracks the event in analytics when referer is present' do
+      stub_sign_in
+      stub_analytics
+      request.env['HTTP_REFERER'] = 'http://example.com/'
+      properties = { request_came_from: 'users/sessions#new' }
+
+      expect(@analytics).to receive(:track_event).with(Analytics::IDV_CANCELLATION, properties)
 
       get :new
     end

--- a/spec/controllers/idv/come_back_later_controller_spec.rb
+++ b/spec/controllers/idv/come_back_later_controller_spec.rb
@@ -14,6 +14,10 @@ describe Idv::ComeBackLaterController do
 
   context 'user needs USPS address verification' do
     it 'renders the show template' do
+      stub_analytics
+
+      expect(@analytics).to receive(:track_event).with(Analytics::IDV_COME_BACK_LATER_VISIT)
+
       get :show
 
       expect(response).to render_template :show

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -58,7 +58,7 @@ describe UsersController do
       parser = instance_double(ParseControllerFromReferer)
 
       expect(ParseControllerFromReferer).to receive(:new).and_return(parser)
-      expect(parser).to receive(:call)
+      expect(parser).to receive(:call).and_return({})
 
       delete :destroy
     end

--- a/spec/services/parse_controller_from_referer_spec.rb
+++ b/spec/services/parse_controller_from_referer_spec.rb
@@ -5,16 +5,18 @@ describe ParseControllerFromReferer do
     context 'when the referer is nil' do
       it 'returns "no referer" string' do
         parser = ParseControllerFromReferer.new(nil)
+        result = { request_came_from: 'no referer' }
 
-        expect(parser.call).to eq 'no referer'
+        expect(parser.call).to eq result
       end
     end
 
     context 'when the referer is present' do
       it 'returns the corresponding controller and action' do
         parser = ParseControllerFromReferer.new('http://example.com/')
+        result = { request_came_from: 'users/sessions#new' }
 
-        expect(parser.call).to eq 'users/sessions#new'
+        expect(parser.call).to eq result
       end
     end
   end


### PR DESCRIPTION
**Why**: To help us better understand how people use the product and
where they are failing.

The main change here is to capture the controller where the user decided
to cancel verification. This will allow us to see if there's a
particular blocker in the flow. This information is used by other
controllers, so I refactored a bit to reduce duplication.

I also added a visit event for the come back later page, and made sure
that the call to track the visit event in the IdV Sessions Controller
was the first thing in the method. Otherwise, if an error happens before
the analytics call, it wouldn't be easy to tell whether or not the user
visited (or was redirected to) the sessions controller.

For troubleshooting, it's very helpful to have events for all page
visits.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
