### PR TITLE
LG-559 Allow sign in via remember me after idling

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -161,6 +161,7 @@ describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: false,
         stored_location: 'http://example.com',
+        sp_request_url_present: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -178,6 +179,7 @@ describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: false,
         stored_location: nil,
+        sp_request_url_present: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -193,6 +195,7 @@ describe Users::SessionsController, devise: true do
         user_id: 'anonymous-uuid',
         user_locked_out: false,
         stored_location: nil,
+        sp_request_url_present: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -214,12 +217,30 @@ describe Users::SessionsController, devise: true do
         user_id: user.uuid,
         user_locked_out: true,
         stored_location: nil,
+        sp_request_url_present: false,
       }
 
       expect(@analytics).to receive(:track_event).
         with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
 
       post :create, params: { user: { email: user.email.upcase, password: user.password } }
+    end
+
+    it 'tracks the presence of SP request_url in session' do
+      subject.session[:sp] = { request_url: 'http://example.com' }
+      stub_analytics
+      analytics_hash = {
+        success: false,
+        user_id: 'anonymous-uuid',
+        user_locked_out: false,
+        stored_location: nil,
+        sp_request_url_present: true,
+      }
+
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
+
+      post :create, params: { user: { email: 'foo@example.com', password: 'password' } }
     end
 
     context 'LOA1 user' do
@@ -281,6 +302,7 @@ describe Users::SessionsController, devise: true do
           user_id: user.uuid,
           user_locked_out: false,
           stored_location: nil,
+          sp_request_url_present: false,
         }
 
         expect(@analytics).to receive(:track_event).

--- a/spec/features/two_factor_authentication/remember_device_spec.rb
+++ b/spec/features/two_factor_authentication/remember_device_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Remembering a 2FA device' do
   include IdvHelper
+  include SamlAuthHelper
 
   before do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
@@ -22,6 +23,7 @@ feature 'Remembering a 2FA device' do
     end
 
     it_behaves_like 'remember device'
+    it_behaves_like 'remember device after being idle on sign in page'
   end
 
   context 'sign up' do

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -83,3 +83,36 @@ shared_examples 'remember device' do
     expect(current_url).to start_with('http://localhost:7654/auth/result')
   end
 end
+
+shared_examples 'remember device after being idle on sign in page' do
+  it 'redirects to the OIDC SP even though session is deleted' do
+    # We want to simulate a user that has already visited an OIDC SP and that
+    # has checked "remember me for 30 days", such that the next URL the app will
+    # redirect to after signing in with email and password is the SP redirect
+    # URI.
+    user = remember_device_and_sign_out_user
+    IdentityLinker.new(
+      user, 'urn:gov:gsa:openidconnect:sp:server'
+    ).link_identity(verified_attributes: %w[email])
+
+    visit_idp_from_sp_with_loa1(:oidc)
+    request_id = ServiceProviderRequest.last.uuid
+    click_link t('links.sign_in')
+
+    Timecop.travel(Devise.timeout_in + 1.minute) do
+      # Simulate being idle on the sign in page long enough for the session to
+      # be deleted from Redis, but since Redis doesn't respect Timecop, we need
+      # to expire the session manually.
+      session_store.send(:destroy_session_from_sid, session_cookie.value)
+      # Simulate refreshing the page with JS to avoid a CSRF error
+      visit new_user_session_url(request_id: request_id)
+
+      expect(page.response_headers['Content-Security-Policy']).
+        to(include('form-action \'self\' http://localhost:7654/auth/result'))
+
+      fill_in_credentials_and_submit(user.email, user.password)
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: I found a bug that I can consistently reproduce in Chrome (but
not in other browsers for some reason):
If you already have an identity associated with an SP, and are using the
"remember me" feature, you won't be able to sign in during this
scenario:
1. Visit the SP
2. Click through to the IdP
3. Click "Sign in" but don't sign in yet
4. Wait 15 minutes, or until the page refreshes and says "For your
security, we clear what you entered..."
5. Enter your email and password and submit the form

Result: Chrome will prevent the redirect back to the SP because the
redirect URI is not in the CSP headers.

**How**: Store the SP info in the session when the sign in page is
visited because the CSP headers only get updated if the SP info is in
the session, but if you stay idle for 15 minutes, the session gets
deleted from Redis.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
