### PR TITLE
Use 2-letter phone country code for analytics

### DIFF
--- a/app/forms/otp_delivery_selection_form.rb
+++ b/app/forms/otp_delivery_selection_form.rb
@@ -46,7 +46,7 @@ class OtpDeliverySelectionForm
     {
       otp_delivery_preference: otp_delivery_preference,
       resend: resend,
-      country_code: parsed_phone.country_code,
+      country_code: parsed_phone.country,
       area_code: parsed_phone.area_code,
       context: context,
     }

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -167,7 +167,7 @@ describe Users::TwoFactorAuthenticationController do
           otp_delivery_preference: 'sms',
           resend: nil,
           context: 'authentication',
-          country_code: '1',
+          country_code: 'US',
           area_code: '202',
         }
 
@@ -236,7 +236,7 @@ describe Users::TwoFactorAuthenticationController do
           otp_delivery_preference: 'voice',
           resend: nil,
           context: 'authentication',
-          country_code: '1',
+          country_code: 'US',
           area_code: '202',
         }
 
@@ -341,7 +341,7 @@ describe Users::TwoFactorAuthenticationController do
           otp_delivery_preference: 'sms',
           resend: nil,
           context: 'confirmation',
-          country_code: '1',
+          country_code: 'US',
           area_code: '202',
         }
         twilio_error = "[HTTP 400]  : error message\n\n"
@@ -379,7 +379,7 @@ describe Users::TwoFactorAuthenticationController do
           otp_delivery_preference: 'sms',
           resend: nil,
           context: 'confirmation',
-          country_code: '1',
+          country_code: 'US',
           area_code: '202',
         }
         twilio_error_hash = {

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -25,7 +25,7 @@ describe OtpDeliverySelectionForm do
         extra = {
           otp_delivery_preference: 'sms',
           resend: true,
-          country_code: '1',
+          country_code: 'US',
           area_code: '202',
           context: 'authentication',
         }


### PR DESCRIPTION
**Why**: Phonelib's `country_code` method returns the dialing code
prefix, which can be the same across multiple countries, such as the
`1` dialing code, which is used by the USA, Canada, and many Carribean
countries. By using the `country` method, which returns the 2-letter
country abbreviation, it allows to more easily determine the country.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
