### PR TITLE
[LG-487] Email based Suggesting scoped by agency

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -29,6 +29,6 @@ class Identity < ApplicationRecord
   end
 
   def piv_cac_available?
-    PivCacService.piv_cac_available_for_agency?(sp_metadata[:agency])
+    PivCacService.piv_cac_available_for_agency?(sp_metadata[:agency], user.email)
   end
 end

--- a/app/policies/piv_cac_login_option_policy.rb
+++ b/app/policies/piv_cac_login_option_policy.rb
@@ -18,5 +18,4 @@ class PivCacLoginOptionPolicy
   private
 
   attr_reader :user
-
 end

--- a/app/policies/piv_cac_login_option_policy.rb
+++ b/app/policies/piv_cac_login_option_policy.rb
@@ -12,27 +12,11 @@ class PivCacLoginOptionPolicy
   end
 
   def available?
-    enabled? || available_for_email? || user.identities.any?(&:piv_cac_available?)
+    enabled? || user.identities.any?(&:piv_cac_available?)
   end
 
   private
 
   attr_reader :user
 
-  def available_for_email?
-    piv_cac_email_domains = Figaro.env.piv_cac_email_domains
-    return if piv_cac_email_domains.blank?
-
-    domain_list = JSON.parse(piv_cac_email_domains)
-    (_, email_domain) = user.email.split(/@/, 2)
-    domain_list.any? { |supported_domain| domain_match?(email_domain, supported_domain) }
-  end
-
-  def domain_match?(given, matcher)
-    if matcher[0] == '.'
-      given.end_with?(matcher)
-    else
-      given == matcher
-    end
-  end
 end

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -35,7 +35,7 @@ module PivCacService
     private
 
     def available_for_agency?(agency)
-      return unless agency.present?
+      return if agency.blank?
       piv_cac_agencies = JSON.parse(Figaro.env.piv_cac_agencies || '[]')
       piv_cac_agencies.include?(agency)
     end
@@ -43,16 +43,15 @@ module PivCacService
     def available_for_email?(agency, email)
       return unless email.present? && agency_scoped_by_email?(agency)
 
-      piv_cac_email_domains = Figaro.env.piv_cac_email_domains
-      return if piv_cac_email_domains.blank?
+      piv_cac_email_domains = Figaro.env.piv_cac_email_domains || '[]'
 
-      domain_list = JSON.parse(piv_cac_email_domains)
       (_, email_domain) = email.split(/@/, 2)
-      domain_list.any? { |supported_domain| domain_match?(email_domain, supported_domain) }
+      domains = JSON.parse(piv_cac_email_domains)
+      domains.any? { |supported_domain| domain_match?(email_domain, supported_domain) }
     end
 
     def agency_scoped_by_email?(agency)
-      return unless agency.present?
+      return if agency.blank?
 
       piv_cac_agencies_email_scope =
         JSON.parse(Figaro.env.piv_cac_agencies_scoped_by_email || '[]')

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -28,18 +28,45 @@ module PivCacService
       Figaro.env.piv_cac_verify_token_url
     end
 
-    def piv_cac_available_for_agency?(agency)
-      return if agency.blank?
-      return unless FeatureManagement.piv_cac_enabled?
-      @piv_cac_agencies ||= begin
-        piv_cac_agencies = Figaro.env.piv_cac_agencies || '[]'
-        JSON.parse(piv_cac_agencies)
-      end
-
-      @piv_cac_agencies.include?(agency)
+    def piv_cac_available_for_agency?(agency, email = nil)
+      available_for_agency?(agency) || available_for_email?(agency, email)
     end
 
     private
+
+    def available_for_agency?(agency)
+      return unless agency.present?
+      piv_cac_agencies = JSON.parse(Figaro.env.piv_cac_agencies || '[]')
+      piv_cac_agencies.include?(agency)
+    end
+
+    def available_for_email?(agency, email)
+      return unless email.present? && agency_scoped_by_email?(agency)
+
+      piv_cac_email_domains = Figaro.env.piv_cac_email_domains
+      return if piv_cac_email_domains.blank?
+
+      domain_list = JSON.parse(piv_cac_email_domains)
+      (_, email_domain) = email.split(/@/, 2)
+      domain_list.any? { |supported_domain| domain_match?(email_domain, supported_domain) }
+    end
+
+    def agency_scoped_by_email?(agency)
+      return unless agency.present?
+
+      piv_cac_agencies_email_scope =
+        JSON.parse(Figaro.env.piv_cac_agencies_scoped_by_email || '[]')
+
+      piv_cac_agencies_email_scope.include?(agency)
+    end
+
+    def domain_match?(given, matcher)
+      if matcher[0] == '.'
+        given.end_with?(matcher)
+      else
+        given == matcher
+      end
+    end
 
     def randomize_uri(uri)
       # we only support {random}, so we're going for performance here
@@ -49,6 +76,7 @@ module PivCacService
     # Only used in tests
     def reset_piv_cac_avaialable_agencies
       @piv_cac_agencies = nil
+      @piv_cac_agencies_email_scope = nil
     end
 
     def token_present(token)

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -29,6 +29,7 @@ module PivCacService
     end
 
     def piv_cac_available_for_agency?(agency, email = nil)
+      return unless FeatureManagement.piv_cac_enabled?
       available_for_agency?(agency) || available_for_email?(agency, email)
     end
 

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -133,10 +133,7 @@ describe Identity do
   describe '#piv_cac_available?' do
     context 'when agency configured to support piv/cac' do
       before(:each) do
-        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
-          [service_provider.agency].to_json
-        )
-        PivCacService.send(:reset_piv_cac_avaialable_agencies)
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, identity_with_sp.user.email).and_return(true)
       end
 
       it 'returns truthy' do
@@ -146,10 +143,7 @@ describe Identity do
 
     context 'when agency is not configured to support piv/cac' do
       before(:each) do
-        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
-          [service_provider.agency + 'X'].to_json
-        )
-        PivCacService.send(:reset_piv_cac_avaialable_agencies)
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, identity_with_sp.user.email).and_return(false)
       end
 
       it 'returns falsey' do

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -133,7 +133,9 @@ describe Identity do
   describe '#piv_cac_available?' do
     context 'when agency configured to support piv/cac' do
       before(:each) do
-        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, identity_with_sp.user.email).and_return(true)
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(
+          service_provider.agency, identity_with_sp.user.email
+        ).and_return(true)
       end
 
       it 'returns truthy' do
@@ -143,7 +145,9 @@ describe Identity do
 
     context 'when agency is not configured to support piv/cac' do
       before(:each) do
-        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, identity_with_sp.user.email).and_return(false)
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).with(
+          service_provider.agency, identity_with_sp.user.email
+        ).and_return(false)
       end
 
       it 'returns falsey' do

--- a/spec/policies/piv_cac_login_option_policy_spec.rb
+++ b/spec/policies/piv_cac_login_option_policy_spec.rb
@@ -60,56 +60,15 @@ describe PivCacLoginOptionPolicy do
       it { expect(subject.available?).to be_truthy }
     end
 
-    context 'when not enabled and not available for the email and not a supported identity' do
+    context 'when not enabled and not a supported identity' do
       before(:each) do
         identity = double
         allow(identity).to receive(:piv_cac_available?).and_return(false)
         allow(user).to receive(:identities).and_return([identity])
         allow(subject).to receive(:enabled?).and_return(false)
-        allow(subject).to receive(:available_for_email?).and_return(false)
       end
 
       it { expect(subject.available?).to be_falsey }
-    end
-  end
-
-  describe '#available_for_email?' do
-    let(:result) { subject.send(:available_for_email?) }
-
-    context 'with a configured parent domain' do
-      before(:each) do
-        allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('[".example.com"]')
-      end
-
-      context 'and a supported email subdomain' do
-        let(:user) { build(:user, email: 'someone@foo.example.com') }
-
-        it { expect(result).to be_truthy }
-      end
-
-      context 'and a an email at that domain' do
-        let(:user) { build(:user, email: 'someone@example.com') }
-
-        it { expect(result).to be_falsey }
-      end
-    end
-
-    context 'with a configured full domain' do
-      before(:each) do
-        allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('["example.com"]')
-      end
-
-      context 'and an email subdomain' do
-        let(:user) { build(:user, email: 'someone@foo.example.com') }
-
-        it { expect(result).to be_falsey }
-      end
-
-      context 'and a an email at that domain' do
-        let(:user) { build(:user, email: 'someone@example.com') }
-
-        it { expect(result).to be_truthy }
-      end
     end
   end
 end

--- a/spec/policies/piv_cac_login_option_policy_spec.rb
+++ b/spec/policies/piv_cac_login_option_policy_spec.rb
@@ -42,14 +42,6 @@ describe PivCacLoginOptionPolicy do
       it { expect(subject.available?).to be_truthy }
     end
 
-    context 'when available for the email' do
-      before(:each) do
-        allow(subject).to receive(:available_for_email?).and_return(true)
-      end
-
-      it { expect(subject.available?).to be_truthy }
-    end
-
     context 'when associated with a supported identity' do
       before(:each) do
         identity = double

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -198,6 +198,7 @@ describe PivCacService do
 
     context 'with the agency not configured to be available' do
       before(:each) do
+        allow(FeatureManagement).to receive(:piv_cac_enabled?).and_return(true)
         allow(Figaro.env).to receive(:piv_cac_agencies).and_return('["bar"]')
       end
 
@@ -206,6 +207,7 @@ describe PivCacService do
 
     context 'with the agency configured to be available' do
       before(:each) do
+        allow(FeatureManagement).to receive(:piv_cac_enabled?).and_return(true)
         allow(Figaro.env).to receive(:piv_cac_agencies).and_return('["bar","foo"]')
       end
 
@@ -218,6 +220,7 @@ describe PivCacService do
 
     context 'with the agency not configured to be available' do
       before(:each) do
+        allow(FeatureManagement).to receive(:piv_cac_enabled?).and_return(true)
         allow(Figaro.env).to receive(:piv_cac_agencies_scoped_by_email).and_return('["bar"]')
       end
 
@@ -226,6 +229,7 @@ describe PivCacService do
 
     context 'with the agency configured to be available' do
       before(:each) do
+        allow(FeatureManagement).to receive(:piv_cac_enabled?).and_return(true)
         allow(Figaro.env).to receive(:piv_cac_agencies_scoped_by_email).and_return('["bar","foo"]')
       end
 

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -161,4 +161,97 @@ describe PivCacService do
       end
     end
   end
+
+  describe '#piv_cac_available_for_agency?' do
+    let(:subject) { PivCacService.piv_cac_available_for_agency?('foo', 'foo@example.com') }
+
+    context 'with an agency not encouraged to use piv/cac for anyone' do
+      before(:each) do
+        allow(PivCacService).to receive(:available_for_agency?).and_return(false)
+        allow(PivCacService).to receive(:available_for_email?).and_return(false)
+      end
+
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'with an agency encouraged to use piv/cac for everyone' do
+      before(:each) do
+        allow(PivCacService).to receive(:available_for_agency?).and_return(true)
+        allow(PivCacService).to receive(:available_for_email?).and_return(false)
+      end
+
+      it { expect(subject).to eq true }
+    end
+
+    context 'with an agency encouraged to use piv/cac for certain email domains' do
+      before(:each) do
+        allow(PivCacService).to receive(:available_for_agency?).and_return(false)
+        allow(PivCacService).to receive(:available_for_email?).and_return(true)
+      end
+
+      it { expect(subject).to eq true }
+    end
+  end
+
+  describe '#available_for_agency?' do
+    let(:subject) { PivCacService.send(:available_for_agency?, 'foo') }
+
+    context 'with the agency not configured to be available' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies).and_return('["bar"]')
+      end
+
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'with the agency configured to be available' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies).and_return('["bar","foo"]')
+      end
+
+      it { expect(subject).to eq true }
+    end
+  end
+
+  describe '#available_for_email?' do
+    let(:subject) { PivCacService.send(:available_for_email?, 'foo', 'foo@bar.example.com') }
+
+    context 'with the agency not configured to be available' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies_scoped_by_email).and_return('["bar"]')
+      end
+
+      it { expect(subject).to be_falsey }
+    end
+
+    context 'with the agency configured to be available' do
+      before(:each) do
+        allow(Figaro.env).to receive(:piv_cac_agencies_scoped_by_email).and_return('["bar","foo"]')
+      end
+
+      context 'but not in the right email domain' do
+        before(:each) do
+          allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('["example.com", "baz.example.com"]')
+        end
+
+        it { expect(subject).to be_falsey }
+      end
+
+      context 'in the right full domain' do
+        before(:each) do
+          allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('["bar.example.com"]')
+        end
+
+        it { expect(subject).to eq true }
+      end
+
+      context 'in the right subdomain' do
+        before(:each) do
+          allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('[".example.com"]')
+        end
+
+        it { expect(subject).to eq true }
+      end
+    end
+  end
 end

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -231,7 +231,9 @@ describe PivCacService do
 
       context 'but not in the right email domain' do
         before(:each) do
-          allow(Figaro.env).to receive(:piv_cac_email_domains).and_return('["example.com", "baz.example.com"]')
+          allow(Figaro.env).to receive(:piv_cac_email_domains).and_return(
+            '["example.com", "baz.example.com"]'
+          )
         end
 
         it { expect(subject).to be_falsey }


### PR DESCRIPTION
**Why**:
Because user messaging is done based on SPs, we want to make
sure we restrict our suggestion of piv/cac use for folks to
those interacting with select SPs *and* email domains.

**How**:
Switch from an OR to an AND. Moves some code around.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
