### PR TITLE
Refactor and fix account reset requests

### DIFF
--- a/app/controllers/account_reset/confirm_request_controller.rb
+++ b/app/controllers/account_reset/confirm_request_controller.rb
@@ -5,7 +5,10 @@ module AccountReset
       if email.blank?
         redirect_to root_url
       else
-        render :show, locals: { email: email }
+        render :show, locals: {
+          email: email, sms_phone: SmsLoginOptionPolicy.new(current_user).configured?
+        }
+        sign_out
       end
     end
   end

--- a/app/jobs/sms_account_reset_notifier_job.rb
+++ b/app/jobs/sms_account_reset_notifier_job.rb
@@ -2,13 +2,13 @@ class SmsAccountResetNotifierJob < ApplicationJob
   queue_as :sms
   include Rails.application.routes.url_helpers
 
-  def perform(phone:, cancel_token:)
+  def perform(phone:, token:)
     TwilioService::Utils.new.send_sms(
       to: phone,
       body: I18n.t(
         'jobs.sms_account_reset_notifier_job.message',
         app: APP_NAME,
-        cancel_link: account_reset_cancel_url(token: cancel_token)
+        cancel_link: account_reset_cancel_url(token: token)
       )
     )
   end

--- a/app/services/account_reset/create_request.rb
+++ b/app/services/account_reset/create_request.rb
@@ -1,0 +1,41 @@
+module AccountReset
+  class CreateRequest
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      create_request
+      notify_user_by_email
+      notify_user_by_sms_if_applicable
+    end
+
+    private
+
+    attr_reader :user
+
+    def create_request
+      request = AccountResetRequest.find_or_create_by(user: user)
+      request.update!(
+        request_token: SecureRandom.uuid,
+        requested_at: Time.zone.now,
+        cancelled_at: nil,
+        granted_at: nil,
+        granted_token: nil
+      )
+    end
+
+    def notify_user_by_email
+      UserMailer.account_reset_request(user).deliver_later
+    end
+
+    def notify_user_by_sms_if_applicable
+      phone = user.phone
+      return unless phone
+      SmsAccountResetNotifierJob.perform_now(
+        phone: phone,
+        token: user.account_reset_request.request_token
+      )
+    end
+  end
+end

--- a/app/services/account_reset_service.rb
+++ b/app/services/account_reset_service.rb
@@ -3,15 +3,6 @@ class AccountResetService
     @user_id = user.id
   end
 
-  def create_request
-    account_reset = account_reset_request
-    account_reset.update(request_token: SecureRandom.uuid,
-                         requested_at: Time.zone.now,
-                         cancelled_at: nil,
-                         granted_at: nil,
-                         granted_token: nil)
-  end
-
   def self.report_fraud(token)
     account_reset = token.blank? ? nil : AccountResetRequest.find_by(request_token: token)
     return false unless account_reset

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -56,6 +56,7 @@ class Analytics
   # rubocop:disable Metrics/LineLength
   ACCOUNT_RESET = 'Account Reset'.freeze
   ACCOUNT_DELETION = 'Account Deletion Requested'.freeze
+  ACCOUNT_RESET_VISIT = 'Account deletion and reset visited'.freeze
   ACCOUNT_VISIT = 'Account Page Visited'.freeze
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze

--- a/app/views/account_reset/confirm_request/show.html.slim
+++ b/app/views/account_reset/confirm_request/show.html.slim
@@ -6,3 +6,8 @@
   h1.mt1.mb-12p.h3 = t('headings.verify_email')
   p
     == t('account_reset.confirm_request.instructions', email: email)
+  - if sms_phone
+    p
+      == t('account_reset.confirm_request.security_note')
+  p
+    == t('account_reset.confirm_request.close_window')

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -9,10 +9,11 @@ en:
       title: You have deleted your account
     confirm_request:
       check_your_email: Check your email
+      close_window: You can close this window if you're done.
       instructions: We sent an email to <strong>%{email}</strong> to begin the account
         delete process. Follow the instructions in your email to complete the process.
-        <br><br> As a security measure, we also sent a text to your registered phone
-        number. <br><br> You can close this window if you are done.
+      security_note: As a security measure, we also sent a text to your registered
+        phone number.
     delete_account:
       are_you_sure: Are you sure you want to delete your account?
       cancel: Cancel

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -9,11 +9,12 @@ es:
       title: Has eliminado tu cuenta
     confirm_request:
       check_your_email: Consultar su correo electrónico
+      close_window: Puede cerrar esta ventana si ha terminado.
       instructions: Enviamos un correo electrónico a <strong>%{email}</strong> para
         comenzar el proceso de eliminación de cuenta. Siga las instrucciones en su
-        correo electrónico para completar el proceso.<br><br>Como medida de seguridad,
-        también enviamos un mensaje de texto a su registro número de teléfono.<br><br>
-        Puede cerrar esta ventana si ha terminado.
+        correo electrónico para completar el proceso.
+      security_note: Como medida de seguridad, también enviamos un mensaje de texto
+        a su registro número de teléfono.
     delete_account:
       are_you_sure: "¿Seguro que quieres eliminar tu cuenta?"
       cancel: Cancelar

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -9,11 +9,12 @@ fr:
       title: Vous avez supprimé votre compte
     confirm_request:
       check_your_email: Vérifiez votre email
+      close_window: Vous pouvez fermer cette fenêtre si vous avez terminé.
       instructions: Nous avons envoyé un e-mail à <strong>%{email}</strong> pour commencer
         le compte. Supprimer le processus. Suivez les instructions dans votre e-mail
-        pour terminer le processus.<br> <br>Par mesure de sécurité, nous avons également
-        envoyé un SMS sur votre téléphone enregistré nombre. <br> <br> Vous pouvez
-        fermer cette fenêtre si vous avez terminé.
+        pour terminer le processus.
+      security_note: Par mesure de sécurité, nous avons également envoyé un SMS à
+        votre numéro de téléphone enregistré.
     delete_account:
       are_you_sure: Êtes-vous sûr de vouloir supprimer votre compte?
       cancel: Annuler

--- a/spec/controllers/account_reset/confirm_request_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_request_controller_spec.rb
@@ -2,17 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AccountReset::ConfirmRequestController do
   describe '#show' do
-    context 'email in session' do
-      it 'renders the page and deletes the email from the session' do
-        allow(controller).to receive(:flash).and_return(email: 'test@example.com')
-
-        get :show
-
-        expect(response).to render_template(:show)
-      end
-    end
-
-    context 'no email in session' do
+    context 'no email in flash' do
       it 'redirects to the new user registration path' do
         get :show
 

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 describe AccountReset::DeleteAccountController do
+  include AccountResetHelper
+
   describe '#delete' do
     it 'logs a good token to the analytics' do
       user = create(:user)
-      AccountResetService.new(user).create_request
+      create_account_reset_request_for(user)
       AccountResetService.new(user).grant_request
 
       session[:granted_token] = AccountResetRequest.all[0].granted_token
@@ -33,7 +35,7 @@ describe AccountReset::DeleteAccountController do
   describe '#show' do
     it 'prevents parameter leak' do
       user = create(:user)
-      AccountResetService.new(user).create_request
+      create_account_reset_request_for(user)
       AccountResetService.new(user).grant_request
 
       get :show, params: { token: AccountResetRequest.all[0].granted_token }
@@ -49,7 +51,7 @@ describe AccountReset::DeleteAccountController do
 
     it 'renders the page' do
       user = create(:user)
-      AccountResetService.new(user).create_request
+      create_account_reset_request_for(user)
       AccountResetService.new(user).grant_request
       session[:granted_token] = AccountResetRequest.all[0].granted_token
 
@@ -60,7 +62,7 @@ describe AccountReset::DeleteAccountController do
 
     it 'displays a flash and redirects to root if the token is expired' do
       user = create(:user)
-      AccountResetService.new(user).create_request
+      create_account_reset_request_for(user)
       AccountResetService.new(user).grant_request
 
       stub_analytics

--- a/spec/controllers/account_reset/report_fraud_controller_spec.rb
+++ b/spec/controllers/account_reset/report_fraud_controller_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 describe AccountReset::ReportFraudController do
+  include AccountResetHelper
+
   describe '#update' do
     it 'logs a good token to the analytics' do
       user = create(:user)
-      AccountResetService.new(user).create_request
+      create_account_reset_request_for(user)
 
       stub_analytics
       expect(@analytics).to receive(:track_event).

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -13,6 +13,14 @@ describe 'Account Reset Request: Delete Account', email: true do
       click_link t('two_factor_authentication.login_options_link_text')
       click_link t('devise.two_factor_authentication.account_reset.link')
       click_button t('account_reset.request.yes_continue')
+
+      expect(page).
+        to have_content strip_tags(
+          t('account_reset.confirm_request.instructions', email: user.email)
+        )
+      expect(page).to have_content t('account_reset.confirm_request.security_note')
+      expect(page).to have_content t('account_reset.confirm_request.close_window')
+
       reset_email
 
       Timecop.travel(Time.zone.now + 2.days) do
@@ -37,6 +45,28 @@ describe 'Account Reset Request: Delete Account', email: true do
         expect(page).to have_current_path(account_reset_confirm_delete_account_path)
         expect(User.where(id: user.id)).to be_empty
       end
+    end
+  end
+
+  context 'as an LOA1 user without a phone' do
+    it 'does not tell the user that an SMS was sent to their registered phone' do
+      user = create(:user, :with_authentication_app)
+      signin(user.email, user.password)
+      click_link t('two_factor_authentication.login_options_link_text')
+      click_link t('devise.two_factor_authentication.account_reset.link')
+      click_button t('account_reset.request.yes_continue')
+
+      expect(page).
+        to have_content strip_tags(
+          t('account_reset.confirm_request.instructions', email: user.email)
+        )
+      expect(page).to_not have_content t('account_reset.confirm_request.security_note')
+      expect(page).to have_content t('account_reset.confirm_request.close_window')
+
+      # user should now be signed out
+      visit account_path
+
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 

--- a/spec/jobs/sms_account_reset_notifier_job_spec.rb
+++ b/spec/jobs/sms_account_reset_notifier_job_spec.rb
@@ -14,7 +14,7 @@ describe SmsAccountResetNotifierJob do
     subject(:perform) do
       SmsAccountResetNotifierJob.perform_now(
         phone: '+1 (888) 555-5555',
-        cancel_token: 'UUID1'
+        token: 'UUID1'
       )
     end
 

--- a/spec/support/account_reset_helper.rb
+++ b/spec/support/account_reset_helper.rb
@@ -1,6 +1,6 @@
 module AccountResetHelper
   def create_account_reset_request_for(user)
-    AccountResetService.new(user).create_request
+    AccountReset::CreateRequest.new(user).call
     account_reset_request = AccountResetRequest.find_by(user_id: user.id)
     account_reset_request.request_token
   end

--- a/spec/views/account_reset/confirm_request/show.html.slim_spec.rb
+++ b/spec/views/account_reset/confirm_request/show.html.slim_spec.rb
@@ -3,20 +3,12 @@ require 'rails_helper'
 describe 'account_reset/confirm_request/show.html.slim' do
   before do
     allow(view).to receive(:email).and_return('foo@bar.com')
+    allow(view).to receive(:sms_phone).and_return(true)
   end
 
   it 'has a localized title' do
     expect(view).to receive(:title).with(t('account_reset.confirm_request.check_your_email'))
 
     render
-  end
-
-  it 'contains the user email' do
-    email = 'foo@bar.com'
-    session[:email] = email
-
-    render
-
-    expect(rendered).to have_content(email)
   end
 end


### PR DESCRIPTION
**Why**:
- We value lean controllers with minimal business logic
- To fix a bug where users without a phone would see a message that an
SMS was sent to their phone
- To fix a bug where users who had not yet set up 2FA were redirected to
the phone setup page instead of the 2FA setup page
- To fix the French translation for the SMS message
- To capture analytics about what kind of 2FA options the user has
configured, to see if phone users request account deletion more than
TOTP users, for example.
- To capture analytics for visiting the account deletion page

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
