### PR TITLE
LG-568 Visual design tweak: address confirmation page

### DIFF
--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -1,6 +1,6 @@
 - title t('idv.titles.phone')
 
-h1.h2.my0 = t('idv.titles.session.phone')
+h1.h3.my0 = t('idv.titles.session.phone')
 
 .mt2
   == t('idv.messages.phone.alert')
@@ -12,7 +12,7 @@ ul.py1.m0
 = simple_form_for(@idv_form, url: idv_phone_path,
     html: { autocomplete: 'off', method: :put, role: 'form', class: 'mt2' }) do |f|
   = f.label :phone, label: t('idv.form.phone'), class: 'bold'
-  = f.input :phone, required: true, input_html: { class: 'us-phone' }, label: false,
+  = f.input :phone, required: true, input_html: { class: 'us-phone sm-col-8' }, label: false,
     wrapper_html: { class: 'mr2' }
 
   - if FeatureManagement.enable_usps_verification?

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -135,7 +135,6 @@ en:
         rules:
         - in your name, or a family member's name
         - not a virtual phone (such as Google Voice or Skype)
-        - not a pre-paid phone number
         - a U.S. number
       read_about_security_and_privacy:
         link: read about how login.gov keeps your information safe


### PR DESCRIPTION
This updates the visual design of the address verification page to reduce the size of the header and remove a phone number requirement. 


![screen shot 2018-08-21 at 1 10 04 pm](https://user-images.githubusercontent.com/776987/44420432-85bdcb00-a543-11e8-8e12-0cb58c077355.png)

