### PR TITLE
Copy phone info to new table sans crypto

### DIFF
--- a/app/services/populate_phone_configurations_table.rb
+++ b/app/services/populate_phone_configurations_table.rb
@@ -12,7 +12,7 @@ class PopulatePhoneConfigurationsTable
   def process_batch(relation)
     User.transaction do
       relation.each do |user|
-        next if user.phone_configuration.present? || user.phone.blank?
+        next if user.phone_configuration.present? || user.encrypted_phone.blank?
         user.create_phone_configuration(phone_info_for_user(user))
       end
     end
@@ -20,7 +20,7 @@ class PopulatePhoneConfigurationsTable
 
   def phone_info_for_user(user)
     {
-      phone: user.phone,
+      encrypted_phone: user.encrypted_phone,
       confirmed_at: user.phone_confirmed_at,
       delivery_preference: user.otp_delivery_preference,
     }

--- a/app/services/populate_phone_configurations_table.rb
+++ b/app/services/populate_phone_configurations_table.rb
@@ -1,9 +1,19 @@
 class PopulatePhoneConfigurationsTable
+  def initialize
+    @count = 0
+    @total = 0
+  end
+
   def call
     # we don't have a uniqueness constraint in the database to let us blindly insert
     # everything in a single SQL statement. So we have to load by batches and copy
     # over. Much slower, but doesn't duplicate information.
-    User.in_batches(of: 1000) { |relation| process_batch(relation) }
+    User.in_batches(of: 1000) do |relation| 
+      sleep(1)
+      process_batch(relation)
+      puts "#{@count} / #{@total}"
+    end
+    puts "Processed #{@count} user phone configurations"
   end
 
   private
@@ -12,8 +22,10 @@ class PopulatePhoneConfigurationsTable
   def process_batch(relation)
     User.transaction do
       relation.each do |user|
+        @total += 1
         next if user.phone_configuration.present? || user.encrypted_phone.blank?
         user.create_phone_configuration(phone_info_for_user(user))
+        @count += 1
       end
     end
   end

--- a/app/services/populate_phone_configurations_table.rb
+++ b/app/services/populate_phone_configurations_table.rb
@@ -4,16 +4,17 @@ class PopulatePhoneConfigurationsTable
     @total = 0
   end
 
+  # :reek:DuplicateMethodCall
   def call
     # we don't have a uniqueness constraint in the database to let us blindly insert
     # everything in a single SQL statement. So we have to load by batches and copy
     # over. Much slower, but doesn't duplicate information.
-    User.in_batches(of: 1000) do |relation| 
+    User.in_batches(of: 1000) do |relation|
       sleep(1)
       process_batch(relation)
-      puts "#{@count} / #{@total}"
+      Rails.logger.info "#{@count} / #{@total}"
     end
-    puts "Processed #{@count} user phone configurations"
+    Rails.logger.info "Processed #{@count} user phone configurations"
   end
 
   private

--- a/spec/services/populate_phone_configurations_table_spec.rb
+++ b/spec/services/populate_phone_configurations_table_spec.rb
@@ -22,6 +22,11 @@ describe PopulatePhoneConfigurationsTable do
           user.reload
         end
 
+        it 'migrates without decrypting and re-encrypting' do
+          expect(EncryptedAttribute).to_not receive(:new)
+          subject.call
+        end
+
         it 'migrates the phone' do
           subject.call
           configuration = user.reload.phone_configuration


### PR DESCRIPTION
**Why**:
Each time we decrypt/encrypt in AWS, we call KMS.
Since we don't really need to know the content of
the phone number to do the copy, we don't need to
risk running into KMS limits during the copy.

**How**:
We copy the encrypted data rather than going through
the crypto round-trip.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
