### PR TITLE
Refactor AccountReset::DeleteAccountController

### DIFF
--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -1,18 +1,30 @@
 module AccountReset
   class DeleteAccountController < ApplicationController
     before_action :check_feature_enabled
-    before_action :prevent_parameter_leak, only: :show
-    before_action :check_granted_token
 
-    def show; end
+    def show
+      render :show and return unless token
+
+      result = AccountReset::ValidateGrantedToken.new(token).call
+      analytics.track_event(Analytics::ACCOUNT_RESET, result.to_h)
+
+      if result.success?
+        handle_valid_token
+      else
+        handle_invalid_token(result)
+      end
+    end
 
     def delete
-      user = @account_reset_request.user
-      analytics.track_event(Analytics::ACCOUNT_RESET,
-                            event: :delete, token_valid: true, user_id: user.uuid)
-      email = reset_session_and_set_email(user)
-      UserMailer.account_reset_complete(email).deliver_later
-      redirect_to account_reset_confirm_delete_account_url
+      granted_token = session.delete(:granted_token)
+      result = AccountReset::DeleteAccount.new(granted_token).call
+      analytics.track_event(Analytics::ACCOUNT_RESET, result.to_h.except(:email))
+
+      if result.success?
+        handle_successful_deletion(result)
+      else
+        handle_invalid_token(result)
+      end
     end
 
     private
@@ -21,48 +33,24 @@ module AccountReset
       redirect_to root_url unless FeatureManagement.account_reset_enabled?
     end
 
-    def reset_session_and_set_email(user)
-      email = user.email
-      user.destroy!
+    def token
+      params[:token]
+    end
+
+    def handle_valid_token
+      session[:granted_token] = token
+      redirect_to url_for
+    end
+
+    def handle_invalid_token(result)
+      flash[:error] = result.errors[:token].first
+      redirect_to root_url
+    end
+
+    def handle_successful_deletion(result)
       sign_out
-      flash[:email] = email
-    end
-
-    def check_granted_token
-      @account_reset_request = AccountResetRequest.from_valid_granted_token(session[:granted_token])
-      return if @account_reset_request
-      analytics.track_event(Analytics::ACCOUNT_RESET, event: :delete, token_valid: false)
-      redirect_to root_url
-    end
-
-    def prevent_parameter_leak
-      token = params[:token]
-      return if token.blank?
-      remove_token_from_url(token)
-    end
-
-    def remove_token_from_url(token)
-      ar = AccountResetRequest.find_by(granted_token: token)
-      if ar&.granted_token_valid?
-        session[:granted_token] = token
-        redirect_to url_for
-        return
-      end
-      handle_expired_token(ar) if ar&.granted_token_expired?
-      redirect_to root_url
-    end
-
-    def handle_expired_token(ar)
-      analytics.track_event(Analytics::ACCOUNT_RESET,
-                            event: :delete,
-                            token_valid: true,
-                            expired: true,
-                            user_id: ar&.user&.uuid)
-      flash[:error] = link_expired
-    end
-
-    def link_expired
-      t('devise.two_factor_authentication.account_reset.link_expired')
+      flash[:email] = result.extra[:email]
+      redirect_to account_reset_confirm_delete_account_url
     end
   end
 end

--- a/app/models/account_reset_request.rb
+++ b/app/models/account_reset_request.rb
@@ -1,11 +1,6 @@
 class AccountResetRequest < ApplicationRecord
   belongs_to :user
 
-  def self.from_valid_granted_token(granted_token)
-    account_reset = AccountResetRequest.find_by(granted_token: granted_token)
-    account_reset&.granted_token_valid? ? account_reset : nil
-  end
-
   def granted_token_valid?
     granted_token.present? && !granted_token_expired?
   end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -10,4 +10,6 @@ class AnonymousUser
   def phone
     nil
   end
+
+  def email; end
 end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -1,0 +1,41 @@
+module AccountReset
+  class DeleteAccount
+    include ActiveModel::Model
+    include GrantedTokenValidator
+
+    def initialize(token)
+      @token = token
+    end
+
+    def call
+      @success = valid?
+
+      if success
+        notify_user_via_email_of_deletion
+        destroy_user
+      end
+
+      FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+    end
+
+    private
+
+    attr_reader :success
+
+    def destroy_user
+      user.destroy!
+    end
+
+    def notify_user_via_email_of_deletion
+      UserMailer.account_reset_complete(user.email).deliver_later
+    end
+
+    def extra_analytics_attributes
+      {
+        user_id: user.uuid,
+        event: 'delete',
+        email: user.email,
+      }
+    end
+  end
+end

--- a/app/services/account_reset/validate_granted_token.rb
+++ b/app/services/account_reset/validate_granted_token.rb
@@ -1,0 +1,27 @@
+module AccountReset
+  class ValidateGrantedToken
+    include ActiveModel::Model
+    include GrantedTokenValidator
+
+    def initialize(token)
+      @token = token
+    end
+
+    def call
+      @success = valid?
+
+      FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+    end
+
+    private
+
+    attr_reader :success
+
+    def extra_analytics_attributes
+      {
+        user_id: user.uuid,
+        event: 'granted token validation',
+      }
+    end
+  end
+end

--- a/app/validators/account_reset/granted_token_validator.rb
+++ b/app/validators/account_reset/granted_token_validator.rb
@@ -1,0 +1,38 @@
+module AccountReset
+  module GrantedTokenValidator
+    extend ActiveSupport::Concern
+
+    included do
+      validates :token, presence: { message: I18n.t('errors.account_reset.granted_token_missing') }
+      validate :token_exists, if: :token_present?
+      validate :token_not_expired, if: :token_present?
+    end
+
+    private
+
+    attr_reader :token
+
+    def token_exists
+      return if account_reset_request
+
+      errors.add(:token, I18n.t('errors.account_reset.granted_token_invalid'))
+    end
+
+    def token_not_expired
+      return unless account_reset_request&.granted_token_expired?
+      errors.add(:token, I18n.t('errors.account_reset.granted_token_expired'))
+    end
+
+    def token_present?
+      token.present?
+    end
+
+    def account_reset_request
+      @account_reset_request ||= AccountResetRequest.find_by(granted_token: token)
+    end
+
+    def user
+      account_reset_request&.user || AnonymousUser.new
+    end
+  end
+end

--- a/app/views/account_reset/confirm_delete_account/show.html.slim
+++ b/app/views/account_reset/confirm_delete_account/show.html.slim
@@ -5,4 +5,5 @@
     class: 'absolute top-n24 left-0 right-0 mx-auto')
   h3 = t('account_reset.confirm_delete_account.title')
   p == t('account_reset.confirm_delete_account.info', \
-    email: email, link: link_to(t('account_reset.confirm_delete_account.link_text'), root_path))
+    email: email, \
+    link: link_to(t('account_reset.confirm_delete_account.link_text'), sign_up_email_path))

--- a/app/views/account_reset/delete_account/show.html.slim
+++ b/app/views/account_reset/delete_account/show.html.slim
@@ -7,7 +7,7 @@ br
 h4.my2 = t('account_reset.delete_account.are_you_sure')
 
 = button_to t('account_reset.delete_account.delete_button'), \
-    account_reset_delete_account_path(token: session[:granted_token]), method: :delete, \
+    account_reset_delete_account_path, method: :delete, \
     class: 'btn btn-red col-6 p2 rounded-lg border bw2 bg-lightest-red border-red border-box'
 br
 br

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -73,8 +73,6 @@ en:
       account_reset:
         cancel_link: Cancel your request
         link: deleting your account
-        link_expired: The link to delete your login.gov account has expired.  Please
-          create another request to delete your account.
         pending_html: You currently have a pending request to delete your account.
           It takes 24 hours from the time you made the request to complete the process.
           Please check back later. %{cancel_link}

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -75,8 +75,6 @@ es:
       account_reset:
         cancel_link: Cancelar su solicitud
         link: eliminando su cuenta
-        link_expired: El enlace para eliminar su cuenta de login.gov ha caducado.
-          Crea otra solicitud para eliminar tu cuenta.
         pending_html: Actualmente tiene una solicitud pendiente para eliminar su cuenta.
           Se necesitan 24 horas desde el momento en que realizó la solicitud para
           completar el proceso.  Por favor, vuelva más tarde. %{cancel_link}

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -81,8 +81,6 @@ fr:
       account_reset:
         cancel_link: Annuler votre demande
         link: supprimer votre compte
-        link_expired: Le lien pour supprimer votre compte login.gov a expiré. Veuillez
-          créer une autre demande pour supprimer votre compte.
         pending_html: Vous avez actuellement une demande en attente pour supprimer
           votre compte.  Il faut compter 24 heures à partir du moment où vous avez
           fait la demande pour terminer le processus.  Veuillez vérifier plus tard.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -4,6 +4,12 @@ en:
     account_reset:
       cancel_token_invalid: cancel token is invalid
       cancel_token_missing: cancel token is missing
+      granted_token_expired: The link to delete your login.gov account has expired.
+        Please create another request to delete your account.
+      granted_token_invalid: The link to delete your login.gov account is invalid.
+        Please try clicking the link in your email again.
+      granted_token_missing: The link to delete your login.gov account is invalid.
+        Please try clicking the link in your email again.
     confirm_password_incorrect: Incorrect password.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -4,6 +4,10 @@ es:
     account_reset:
       cancel_token_invalid: NOT TRANSLATED YET
       cancel_token_missing: NOT TRANSLATED YET
+      granted_token_expired: El enlace para eliminar su cuenta de login.gov ha caducado.
+        Crea otra solicitud para eliminar tu cuenta.
+      granted_token_invalid: NOT TRANSLATED YET
+      granted_token_missing: NOT TRANSLATED YET
     confirm_password_incorrect: La contraseña es incorrecta.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -4,6 +4,10 @@ fr:
     account_reset:
       cancel_token_invalid: NOT TRANSLATED YET
       cancel_token_missing: NOT TRANSLATED YET
+      granted_token_expired: Le lien pour supprimer votre compte login.gov a expiré.
+        Veuillez créer une autre demande pour supprimer votre compte.
+      granted_token_invalid: NOT TRANSLATED YET
+      granted_token_missing: NOT TRANSLATED YET
     confirm_password_incorrect: Mot de passe incorrect.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -11,53 +11,53 @@ describe AccountReset::DeleteAccountController do
 
       session[:granted_token] = AccountResetRequest.all[0].granted_token
       stub_analytics
-      expect(@analytics).to receive(:track_event).
-        with(Analytics::ACCOUNT_RESET, event: :delete, token_valid: true, user_id: user.uuid)
+      properties = {
+        user_id: user.uuid,
+        event: 'delete',
+        success: true,
+        errors: {},
+      }
+      expect(@analytics).
+        to receive(:track_event).with(Analytics::ACCOUNT_RESET, properties)
 
       delete :delete
+
+      expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
-    it 'logs a bad token to the analytics' do
+    it 'redirects to root if the token does not match one in the DB' do
+      session[:granted_token] = 'foo'
       stub_analytics
-      expect(@analytics).to receive(:track_event).
-        with(Analytics::ACCOUNT_RESET, event: :delete, token_valid: false)
+      properties = {
+        user_id: 'anonymous-uuid',
+        event: 'delete',
+        success: false,
+        errors: { token: [t('errors.account_reset.granted_token_invalid')] },
+      }
+      expect(@analytics).
+        to receive(:track_event).with(Analytics::ACCOUNT_RESET, properties)
 
-      delete :delete, params: { token: 'FOO' }
-    end
-
-    it 'redirects to root if there is no token' do
       delete :delete
 
       expect(response).to redirect_to(root_url)
-    end
-  end
-
-  describe '#show' do
-    it 'prevents parameter leak' do
-      user = create(:user)
-      create_account_reset_request_for(user)
-      AccountResetService.new(user).grant_request
-
-      get :show, params: { token: AccountResetRequest.all[0].granted_token }
-
-      expect(response).to redirect_to(account_reset_delete_account_url)
+      expect(flash[:error]).to eq t('errors.account_reset.granted_token_invalid')
     end
 
-    it 'redirects to root if the token is bad' do
-      get :show, params: { token: 'FOO' }
+    it 'displays a flash and redirects to root if the token is missing' do
+      stub_analytics
+      properties = {
+        user_id: 'anonymous-uuid',
+        event: 'delete',
+        success: false,
+        errors: { token: [t('errors.account_reset.granted_token_missing')] },
+      }
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, properties)
+
+      delete :delete
 
       expect(response).to redirect_to(root_url)
-    end
-
-    it 'renders the page' do
-      user = create(:user)
-      create_account_reset_request_for(user)
-      AccountResetService.new(user).grant_request
-      session[:granted_token] = AccountResetRequest.all[0].granted_token
-
-      get :show
-
-      expect(response).to render_template(:show)
+      expect(flash[:error]).to eq t('errors.account_reset.granted_token_missing')
     end
 
     it 'displays a flash and redirects to root if the token is expired' do
@@ -66,16 +66,86 @@ describe AccountReset::DeleteAccountController do
       AccountResetService.new(user).grant_request
 
       stub_analytics
+      properties = {
+        user_id: user.uuid,
+        event: 'delete',
+        success: false,
+        errors: { token: [t('errors.account_reset.granted_token_expired')] },
+      }
       expect(@analytics).to receive(:track_event).
-        with(Analytics::ACCOUNT_RESET,
-             event: :delete, token_valid: true, expired: true, user_id: user.uuid)
+        with(Analytics::ACCOUNT_RESET, properties)
+
+      Timecop.travel(Time.zone.now + 2.days) do
+        session[:granted_token] = AccountResetRequest.all[0].granted_token
+        delete :delete
+      end
+
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq t('errors.account_reset.granted_token_expired')
+    end
+
+    it 'redirects to root if feature is not enabled' do
+      allow(FeatureManagement).to receive(:account_reset_enabled?).and_return(false)
+
+      delete :delete
+
+      expect(response).to redirect_to root_url
+    end
+  end
+
+  describe '#show' do
+    it 'redirects to root if the token does not match one in the DB' do
+      stub_analytics
+      properties = {
+        user_id: 'anonymous-uuid',
+        event: 'granted token validation',
+        success: false,
+        errors: { token: [t('errors.account_reset.granted_token_invalid')] },
+      }
+      expect(@analytics).
+        to receive(:track_event).with(Analytics::ACCOUNT_RESET, properties)
+
+      get :show, params: { token: 'FOO' }
+
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq t('errors.account_reset.granted_token_invalid')
+    end
+
+    it 'displays a flash and redirects to root if the token is expired' do
+      user = create(:user)
+      create_account_reset_request_for(user)
+      AccountResetService.new(user).grant_request
+
+      stub_analytics
+      properties = {
+        user_id: user.uuid,
+        event: 'granted token validation',
+        success: false,
+        errors: { token: [t('errors.account_reset.granted_token_expired')] },
+      }
+      expect(@analytics).to receive(:track_event).
+        with(Analytics::ACCOUNT_RESET, properties)
 
       Timecop.travel(Time.zone.now + 2.days) do
         get :show, params: { token: AccountResetRequest.all[0].granted_token }
       end
 
       expect(response).to redirect_to(root_url)
-      expect(flash[:error]).to eq t('devise.two_factor_authentication.account_reset.link_expired')
+      expect(flash[:error]).to eq t('errors.account_reset.granted_token_expired')
+    end
+
+    it 'renders the show view if the token is missing' do
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+
+    it 'redirects to root if feature is not enabled' do
+      allow(FeatureManagement).to receive(:account_reset_enabled?).and_return(false)
+
+      get :show
+
+      expect(response).to redirect_to root_url
     end
   end
 end

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -44,6 +44,11 @@ describe 'Account Reset Request: Delete Account', email: true do
         )
         expect(page).to have_current_path(account_reset_confirm_delete_account_path)
         expect(User.where(id: user.id)).to be_empty
+        expect(last_email.subject).to eq t('user_mailer.account_reset_complete.subject')
+
+        click_link t('account_reset.confirm_delete_account.link_text')
+
+        expect(page).to have_current_path(sign_up_email_path)
       end
     end
   end

--- a/spec/models/account_reset_request_spec.rb
+++ b/spec/models/account_reset_request_spec.rb
@@ -50,25 +50,4 @@ describe AccountResetRequest do
       expect(subject.granted_token_expired?).to eq(false)
     end
   end
-
-  describe '.from_valid_granted_token' do
-    it 'returns nil if the token does not exist' do
-      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(nil)
-    end
-
-    it 'returns nil if the token is expired' do
-      granted_at = Time.zone.now - 7.days
-      AccountResetRequest.create(id: 1, user_id: 2, granted_token: '123', granted_at: granted_at)
-
-      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(nil)
-    end
-
-    it 'returns the record if the token is valid' do
-      arr = AccountResetRequest.create(
-        id: 1, user_id: 2, granted_token: '123', granted_at: Time.zone.now
-      )
-
-      expect(AccountResetRequest.from_valid_granted_token('123')).to eq(arr)
-    end
-  end
 end

--- a/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
+++ b/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
@@ -25,7 +25,7 @@ describe 'account_reset/confirm_delete_account/show.html.slim' do
 
     expect(rendered).to have_link(
       t('account_reset.confirm_delete_account.link_text', app: APP_NAME),
-      href: root_path
+      href: sign_up_email_path
     )
   end
 end


### PR DESCRIPTION
**Why**: To make it more consistent with other controllers and ensure
all desired analytics are properly captured.

**How**:
- Use service objects to validate the granted token, capture analytics,
and process the account deletion
- Fix the link to create a new account to point to the email sign up
page instead of the home page
- Remove unnecessary token param from `delete_account/show` view
- Move localizations out of Devise and into the `errors` file
- Update controller specs to test all analytics and before_action
- Update feature spec to test that the deletion confirmation email is
sent

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
