### PR TITLE
LG-572 Visual design tweaks on /verify/session

### DIFF
--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -33,19 +33,20 @@ p = link_to t('links.access_help'),
   p = t('idv.messages.sessions.id_information_message')
 
   fieldset.m0.p0.border-none
-    = f.label :state_id_type, label: t('idv.form.state_id_type_label'), class: 'bold',
-        id: 'profile_state_id_type_label', required: true
-    - state_id_types.each do |state_id_type|
-      = f.label 'profile[state_id_type]', class: 'block mb1',
-          for: "profile_state_id_type_#{state_id_type[1]}"
-        .radio
-          = radio_button_tag 'profile[state_id_type]', state_id_type[1],
-            state_id_type[1] == 'drivers_license',
-            'aria-labelledby': 'profile_state_id_type_label'
-          span.indicator
-          .block = state_id_type[0]
-    = f.input :state_id_number, label: t('idv.form.state_id'), required: true
-    = f.input :address1, label: t('idv.form.address1'), required: true
+    .mb1
+      = f.label :state_id_type, label: t('idv.form.state_id_type_label'), class: 'bold',
+          id: 'profile_state_id_type_label', required: true
+      - state_id_types.each do |state_id_type|
+        = f.label 'profile[state_id_type]', class: 'block mb1',
+            for: "profile_state_id_type_#{state_id_type[1]}"
+          .radio
+            = radio_button_tag 'profile[state_id_type]', state_id_type[1],
+              state_id_type[1] == 'drivers_license',
+              'aria-labelledby': 'profile_state_id_type_label'
+            span.indicator
+            .block = state_id_type[0]
+    = f.input :state_id_number, label: t('idv.form.state_id'), input_html: { class: 'sm-col-8' }, required: true
+    = f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'mb1' }, required: true
     = f.input :address2, label: t('idv.form.address2')
     = f.input :city, label: t('idv.form.city'), required: true
 

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -45,8 +45,10 @@ p = link_to t('links.access_help'),
               'aria-labelledby': 'profile_state_id_type_label'
             span.indicator
             .block = state_id_type[0]
-    = f.input :state_id_number, label: t('idv.form.state_id'), input_html: { class: 'sm-col-8' }, required: true
-    = f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'mb1' }, required: true
+    = f.input :state_id_number, label: t('idv.form.state_id'), input_html: { class: 'sm-col-8' },
+        required: true
+    = f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'mb1' },
+        required: true
     = f.input :address2, label: t('idv.form.address2')
     = f.input :city, label: t('idv.form.city'), required: true
 

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -3,7 +3,8 @@
 h1.h3 = t('idv.titles.sessions')
 
 p = link_to t('links.access_help'),
-  'https://login.gov/help/privacy-and-security/how-does-logingov-protect-my-data/'
+  'https://login.gov/help/privacy-and-security/how-does-logingov-protect-my-data/',
+  target: :_blank
 
 = simple_form_for(@idv_form, url: idv_session_path,
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   links:
-    access_help: Protect your data.
+    access_help: How login.gov protects your data.
     account:
       reactivate:
         with_key: I have my key

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -1,7 +1,7 @@
 ---
 es:
   links:
-    access_help: Protege tus datos.
+    access_help: Cómo login.gov protege sus datos.
     account:
       reactivate:
         with_key: Tengo mi clave

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   links:
-    access_help: Protégez vos données.
+    access_help: Comment login.gov protège vos données.
     account:
       reactivate:
         with_key: J'ai ma clé

--- a/config/locales/simple_form/en.yml
+++ b/config/locales/simple_form/en.yml
@@ -4,6 +4,8 @@ en:
     error_notification:
       default_message: 'Please review the problems below:'
     'no': 'No'
+    optional:
+      html: '<small class="italic">optional</small>'
     required:
       html: <abbr title="required" class="red display-none">*</abbr>
       mark: "*"

--- a/config/locales/simple_form/en.yml
+++ b/config/locales/simple_form/en.yml
@@ -4,8 +4,6 @@ en:
     error_notification:
       default_message: 'Please review the problems below:'
     'no': 'No'
-    optional:
-      html: '<small class="italic">optional</small>'
     required:
       html: <abbr title="required" class="red display-none">*</abbr>
       mark: "*"


### PR DESCRIPTION
I was able to handle a few of these things but for others there were blockers that would best be solved in another issue 

- [x] Change US copy for the help center link
- [x] Shorter form field for ID
- [x] Adjust spacing for the group of license types

Not completed in this: 
 
- Styling the _optional_ text in a consistent way across the app may some reconfiguration of how we do the Address 2 label in simpleforms (some hints [for future reference](https://jeremysmith.co/posts/2015-12-03-how-to-mark-optional-form-fields-with-simple-form/))
- Overall form input spacing adjustments. Form fields built with simpleforms use a default bottom margin `mb3`. While I could manually adjust a few fields on this page to be closer together like in the visual design mock it would probably be better to re-consider things app-wide (e.g. making everything `mb1` and adding more space when necessary) 
 

![info-about-you](https://user-images.githubusercontent.com/776987/44554890-4e444f80-a6f8-11e8-83fe-8ca8d8478dca.png)
