### PR TITLE
[LG-487] Scope piv/cac push by SP/email

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -29,7 +29,6 @@ class Identity < ApplicationRecord
   end
 
   def piv_cac_available?
-    puts sp_metadata.inspect
     PivCacService.piv_cac_available_for_agency?(sp_metadata[:agency], user.email)
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -29,6 +29,7 @@ class Identity < ApplicationRecord
   end
 
   def piv_cac_available?
+    puts sp_metadata.inspect
     PivCacService.piv_cac_available_for_agency?(sp_metadata[:agency], user.email)
   end
 end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -42,8 +42,8 @@ class ServiceProvider < ApplicationRecord
     active? && approved?
   end
 
-  def piv_cac_available?
-    PivCacService.piv_cac_available_for_agency?(agency)
+  def piv_cac_available?(user = nil)
+    PivCacService.piv_cac_available_for_agency?(agency, user&.email)
   end
 
   private

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -43,7 +43,7 @@ class TwoFactorOptionsPresenter
 
   def piv_cac_if_available
     return [] if current_user.piv_cac_enabled?
-    return [] unless current_user.piv_cac_available? || service_provider&.piv_cac_available?
+    return [] unless current_user.piv_cac_available? || service_provider&.piv_cac_available?(current_user)
     %w[piv_cac]
   end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -43,7 +43,8 @@ class TwoFactorOptionsPresenter
 
   def piv_cac_if_available
     return [] if current_user.piv_cac_enabled?
-    return [] unless current_user.piv_cac_available? || service_provider&.piv_cac_available?(current_user)
+    return [] unless current_user.piv_cac_available? ||
+                     service_provider&.piv_cac_available?(current_user)
     %w[piv_cac]
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -255,6 +255,7 @@ production:
   password_pepper: # generate via `rake secret`
   password_strength_enabled: 'true'
   piv_cac_agencies: '["DOD","NGA","EOP"]'
+  piv_cac_agencies_scoped_by_email: '["GSA"]'
   piv_cac_email_domains: '[".mil"]'
   piv_cac_enabled: 'false'
   pkcs11_lib: '/opt/cloudhsm/lib/libcloudhsm_pkcs11.so'

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -87,7 +87,9 @@ describe ServiceProvider do
       let(:user) { build(:user) }
 
       it 'calls with the user email' do
-        expect(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, user.email)
+        expect(PivCacService).to receive(
+          :piv_cac_available_for_agency?
+        ).with(service_provider.agency, user.email)
 
         service_provider.piv_cac_available?(user)
       end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -70,23 +70,26 @@ describe ServiceProvider do
   describe 'piv_cac_available?' do
     context 'when the service provider is with an enabled agency' do
       it 'is truthy' do
-        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
-          [service_provider.agency].to_json
-        )
-        PivCacService.send(:reset_piv_cac_avaialable_agencies)
-
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).and_return(true)
         expect(service_provider.piv_cac_available?).to be_truthy
       end
     end
 
     context 'when the service provider agency is not enabled' do
       it 'is falsey' do
-        allow(Figaro.env).to receive(:piv_cac_agencies).and_return(
-          [service_provider.agency + 'X'].to_json
-        )
-        PivCacService.send(:reset_piv_cac_avaialable_agencies)
+        allow(PivCacService).to receive(:piv_cac_available_for_agency?).and_return(false)
 
         expect(service_provider.piv_cac_available?).to be_falsey
+      end
+    end
+
+    context 'when the service provider setting depends on the user email' do
+      let(:user) { build(:user) }
+
+      it 'calls with the user email' do
+        expect(PivCacService).to receive(:piv_cac_available_for_agency?).with(service_provider.agency, user.email)
+
+        service_provider.piv_cac_available?(user)
       end
     end
   end


### PR DESCRIPTION
**Why**:
We want to manage our rollout of PIV/CAC support.
We want people able to configure piv/cac during account
creation if they are at the right SP with the right
email domain.

**How**:
Pass the user through the service provider check.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
