### PR TITLE
LG-549 LOA3 Fix 500 error w/verify phone after verify by mail then switching to phone

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -188,11 +188,19 @@ module TwoFactorAuthenticatable
 
   def after_otp_verification_confirmation_url
     if idv_context?
-      idv_review_url
+      idv_context_url
     elsif after_otp_action_required?
       after_otp_action_url
     else
       after_sign_in_path_for(current_user)
+    end
+  end
+
+  def idv_context_url
+    if current_user.decorate.activate_if_pending_profile_required_verification
+      after_sign_in_path_for(current_user)
+    else
+      idv_review_url
     end
   end
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -44,6 +44,8 @@ module Idv
     def redirect_to_next_step
       if phone_confirmation_required?
         redirect_to idv_otp_delivery_method_url
+      elsif current_user.decorate.activate_if_pending_profile_required_verification
+        redirect_to after_sign_in_path_for(current_user)
       else
         redirect_to idv_review_url
       end

--- a/app/controllers/idv/review_controller.rb
+++ b/app/controllers/idv/review_controller.rb
@@ -8,7 +8,9 @@ module Idv
     before_action :confirm_current_password, only: [:create]
 
     def confirm_idv_steps_complete
-      return redirect_to(idv_session_url) unless idv_profile_complete?
+      unless idv_profile_complete? || current_user.decorate.pending_profile_requires_verification?
+        return redirect_to(idv_session_url)
+      end
       return redirect_to(idv_phone_url) unless idv_address_complete?
     end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -47,6 +47,12 @@ class UserDecorator
     user.active_profile || pending_profile
   end
 
+  def activate_if_pending_profile_required_verification
+    return unless pending_profile_requires_verification?
+    Idv::ProfileActivator.new(user: user).call
+    true
+  end
+
   def pending_profile_requires_verification?
     return false if pending_profile.blank?
     return true if identity_not_verified?


### PR DESCRIPTION
**Why**: To allow a user to complete the LOA3 verification process after choosing to verify by mail.

**How**: When confirming idv steps are complete in the review screen put a check in to make sure that there isn't a pending profile that requires verification.  This will fix the 500 error and cause a redirect to the phone flow instead of the idv session flow.  Now correct the rest of the flows by checking if a user has a pending profile that requires verification after completing the phone verification but before the review screen.  In those cases activate the user's profile and skip the review screen (which was already completed when they requested verification by mail) and allow them to return back to the SP and complete the LOA3 authentication flow.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
