### PR TITLE
LG-597 Create WebAuthn Configurations Table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ApplicationRecord
   has_many :events, dependent: :destroy
   has_one :account_reset_request, dependent: :destroy
   has_one :phone_configuration, dependent: :destroy, inverse_of: :user
+  has_many :webauthn_configurations, dependent: :destroy
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true
 

--- a/app/models/webauthn_configuration.rb
+++ b/app/models/webauthn_configuration.rb
@@ -1,0 +1,7 @@
+class WebauthnConfiguration < ApplicationRecord
+  belongs_to :user, inverse_of: :webauthn_configuration
+  validates :user_id, presence: true
+  validates :name, presence: true
+  validates :credential_id, presence: true
+  validates :credential_public_key, presence: true
+end

--- a/db/migrate/20180827225542_create_webauthn_configurations_table.rb
+++ b/db/migrate/20180827225542_create_webauthn_configurations_table.rb
@@ -1,0 +1,13 @@
+class CreateWebauthnConfigurationsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :webauthn_configurations do |t|
+      t.references :user, null: false
+      t.string :name, null: false
+      t.text :credential_id, null: false
+      t.text :credential_public_key, null: false
+      t.timestamps
+
+      t.index ['user_id'], name: "index_webauthn_configurations_on_user_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180728122856) do
+ActiveRecord::Schema.define(version: 20180827225542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,6 +249,16 @@ ActiveRecord::Schema.define(version: 20180728122856) do
     t.text "entry", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "webauthn_configurations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.text "credential_id", null: false
+    t.text "credential_public_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_webauthn_configurations_on_user_id"
   end
 
   add_foreign_key "events", "users"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,7 @@ describe User do
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_one(:account_reset_request) }
     it { is_expected.to have_one(:phone_configuration) }
+    it { is_expected.to have_many(:webauthn_configurations) }
   end
 
   it 'does not send an email when #create is called' do


### PR DESCRIPTION
**Why**: We want a table to hold configurations for webauthn as a second factor for users.

**How**: Create a new webauthn_configurations table with a one to many from users.  Store the name (user defined), credential_public_key,  and credential_id with each configuration and create an index on user_id

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
