### PR TITLE
LG-625 Cancel flow modification

### DIFF
--- a/app/views/idv/cancellations/destroy.html.slim
+++ b/app/views/idv/cancellations/destroy.html.slim
@@ -4,4 +4,5 @@ ul class="list-reset #{@presenter.state_color}-dots"
   - @presenter.cancellation_effects.each do |effect|
     li = effect
 
-.mt2 = link_to t('idv.cancel.return_to_account'), account_path
+.mt2 = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
+  decorated_session.failure_to_proof_url

--- a/app/views/idv/cancellations/destroy.html.slim
+++ b/app/views/idv/cancellations/destroy.html.slim
@@ -4,5 +4,6 @@ ul class="list-reset #{@presenter.state_color}-dots"
   - @presenter.cancellation_effects.each do |effect|
     li = effect
 
-.mt2 = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
-  decorated_session.failure_to_proof_url
+- if decorated_session.sp_name
+  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
+    decorated_session.failure_to_proof_url

--- a/app/views/idv/cancellations/destroy.html.slim
+++ b/app/views/idv/cancellations/destroy.html.slim
@@ -5,7 +5,7 @@ ul class="list-reset #{@presenter.state_color}-dots"
     li = effect
 
 - if decorated_session.sp_name
-  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: '')}",
+  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
     decorated_session.failure_to_proof_url
 - else
   .mt2 = link_to "‹ #{t('links.back_to_sp', sp: t('links.my_account'))}", account_url

--- a/app/views/idv/cancellations/destroy.html.slim
+++ b/app/views/idv/cancellations/destroy.html.slim
@@ -5,5 +5,7 @@ ul class="list-reset #{@presenter.state_color}-dots"
     li = effect
 
 - if decorated_session.sp_name
-  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
+  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: '')}",
     decorated_session.failure_to_proof_url
+- else
+  .mt2 = link_to "‹ #{t('links.back_to_sp', sp: t('links.my_account'))}", account_url

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -11,7 +11,6 @@ en:
       send_confirmation_code: Continue
     cancel:
       modal_header: Are you sure you want to cancel?
-      return_to_account: Return to account
       warning_header: If you cancel now
       warnings:
         warning_1: We won't be able to verify your identity

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -11,7 +11,6 @@ es:
       send_confirmation_code: NOT TRANSLATED YET
     cancel:
       modal_header: "¿Está seguro que desea cancelar?"
-      return_to_account: NOT TRANSLATED YET
       warning_header: Si usted cancela ahora
       warnings:
         warning_1: NOT TRANSLATED YET

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -11,7 +11,6 @@ fr:
       send_confirmation_code: NOT TRANSLATED YET
     cancel:
       modal_header: Souhaitez-vous vraiment annuler?
-      return_to_account: NOT TRANSLATED YET
       warning_header: Si vous annulez maintenant
       warnings:
         warning_1: NOT TRANSLATED YET

--- a/config/locales/links/en.yml
+++ b/config/locales/links/en.yml
@@ -14,6 +14,7 @@ en:
     create_account: Create account
     go_back: Go back
     help: Help
+    my_account: my account
     next: Next
     passwords:
       forgot: Forgot your password?

--- a/config/locales/links/es.yml
+++ b/config/locales/links/es.yml
@@ -14,6 +14,7 @@ es:
     create_account: Crear cuenta
     go_back: Regresa
     help: Ayuda
+    my_account: mi cuenta
     next: Siguiente
     passwords:
       forgot: "¿Olvidó su contraseña?"

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -14,6 +14,7 @@ fr:
     create_account: Créer un compte
     go_back: Retourner
     help: Aide
+    my_account: mon compte
     next: Suivant
     passwords:
       forgot: Vous avez oublié votre mot de passe?

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -59,6 +59,8 @@ shared_examples 'cancel at idv step' do |step, sp|
 
       expect(page).to have_content(t('headings.cancellations.confirmation'))
       expect(current_path).to eq(idv_cancel_path)
+      expect(page).to have_link("‹ #{t('links.back_to_sp', sp: t('links.my_account'))}",
+                                href: account_url)
 
       # After visiting /verify, expect to redirect to the jurisdiction step,
       # the first step in the IdV flow

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -23,7 +23,6 @@ shared_examples 'cancel at idv step' do |step, sp|
     it 'shows the user a cancellation message with the option to cancel and reset idv' do
       failure_to_proof_url = 'https://www.example.com/failure'
       sp_name = 'Test SP'
-        and_return(failure_to_proof_url)
       allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
         and_return(failure_to_proof_url)
       allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -20,6 +20,15 @@ shared_examples 'cancel at idv step' do |step, sp|
   end
 
   it 'shows the user a cancellation message with the option to cancel and reset idv' do
+    failure_to_proof_url = 'https://www.example.com/failure'
+    sp_name = 'Test SP'
+    allow_any_instance_of(SessionDecorator).to receive(:failure_to_proof_url).
+      and_return(failure_to_proof_url)
+    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
+      and_return(failure_to_proof_url)
+    allow_any_instance_of(SessionDecorator).to receive(:sp_name).and_return(sp_name)
+    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).and_return(sp_name)
+
     click_link t('links.cancel')
 
     expect(page).to have_content(t('idv.cancel.modal_header'))
@@ -29,6 +38,9 @@ shared_examples 'cancel at idv step' do |step, sp|
 
     expect(page).to have_content(t('headings.cancellations.confirmation'))
     expect(current_path).to eq(idv_cancel_path)
+
+    expect(page).to have_link("‹ #{t('links.back_to_sp', sp: sp_name)}",
+                              href: failure_to_proof_url)
 
     # After visiting /verify, expect to redirect to the jurisdiction step,
     # the first step in the IdV flow

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -19,15 +19,13 @@ shared_examples 'cancel at idv step' do |step, sp|
     expect(current_path).to eq(original_path)
   end
 
-  context 'with an sp' do
+  context 'with an sp', if: sp do
     it 'shows the user a cancellation message with the option to cancel and reset idv' do
       failure_to_proof_url = 'https://www.example.com/failure'
       sp_name = 'Test SP'
-      allow_any_instance_of(SessionDecorator).to receive(:failure_to_proof_url).
         and_return(failure_to_proof_url)
       allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
         and_return(failure_to_proof_url)
-      allow_any_instance_of(SessionDecorator).to receive(:sp_name).and_return(sp_name)
       allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).
         and_return(sp_name)
 
@@ -52,7 +50,7 @@ shared_examples 'cancel at idv step' do |step, sp|
   end
 
   context 'without an sp' do
-    it 'shows the user a cancellation message with the option to cancel and reset idv' do
+    it 'shows a cancellation message with option to cancel and reset idv', if: sp.nil? do
       click_link t('links.cancel')
 
       expect(page).to have_content(t('idv.cancel.modal_header'))

--- a/spec/support/idv_examples/cancel_at_idv_step.rb
+++ b/spec/support/idv_examples/cancel_at_idv_step.rb
@@ -19,32 +19,54 @@ shared_examples 'cancel at idv step' do |step, sp|
     expect(current_path).to eq(original_path)
   end
 
-  it 'shows the user a cancellation message with the option to cancel and reset idv' do
-    failure_to_proof_url = 'https://www.example.com/failure'
-    sp_name = 'Test SP'
-    allow_any_instance_of(SessionDecorator).to receive(:failure_to_proof_url).
-      and_return(failure_to_proof_url)
-    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
-      and_return(failure_to_proof_url)
-    allow_any_instance_of(SessionDecorator).to receive(:sp_name).and_return(sp_name)
-    allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).and_return(sp_name)
+  context 'with an sp' do
+    it 'shows the user a cancellation message with the option to cancel and reset idv' do
+      failure_to_proof_url = 'https://www.example.com/failure'
+      sp_name = 'Test SP'
+      allow_any_instance_of(SessionDecorator).to receive(:failure_to_proof_url).
+        and_return(failure_to_proof_url)
+      allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:failure_to_proof_url).
+        and_return(failure_to_proof_url)
+      allow_any_instance_of(SessionDecorator).to receive(:sp_name).and_return(sp_name)
+      allow_any_instance_of(ServiceProviderSessionDecorator).to receive(:sp_name).
+        and_return(sp_name)
 
-    click_link t('links.cancel')
+      click_link t('links.cancel')
 
-    expect(page).to have_content(t('idv.cancel.modal_header'))
-    expect(current_path).to eq(idv_cancel_path)
+      expect(page).to have_content(t('idv.cancel.modal_header'))
+      expect(current_path).to eq(idv_cancel_path)
 
-    click_on t('forms.buttons.cancel')
+      click_on t('forms.buttons.cancel')
 
-    expect(page).to have_content(t('headings.cancellations.confirmation'))
-    expect(current_path).to eq(idv_cancel_path)
+      expect(page).to have_content(t('headings.cancellations.confirmation'))
+      expect(current_path).to eq(idv_cancel_path)
 
-    expect(page).to have_link("‹ #{t('links.back_to_sp', sp: sp_name)}",
-                              href: failure_to_proof_url)
+      expect(page).to have_link("‹ #{t('links.back_to_sp', sp: sp_name)}",
+                                href: failure_to_proof_url)
 
-    # After visiting /verify, expect to redirect to the jurisdiction step,
-    # the first step in the IdV flow
-    visit idv_path
-    expect(current_path).to eq(idv_jurisdiction_path)
+      # After visiting /verify, expect to redirect to the jurisdiction step,
+      # the first step in the IdV flow
+      visit idv_path
+      expect(current_path).to eq(idv_jurisdiction_path)
+    end
+  end
+
+  context 'without an sp' do
+    it 'shows the user a cancellation message with the option to cancel and reset idv' do
+      click_link t('links.cancel')
+
+      expect(page).to have_content(t('idv.cancel.modal_header'))
+      expect(current_path).to eq(idv_cancel_path)
+
+      click_on t('forms.buttons.cancel')
+
+      expect(page).to have_content(t('headings.cancellations.confirmation'))
+      expect(current_path).to eq(idv_cancel_path)
+
+      # After visiting /verify, expect to redirect to the jurisdiction step,
+      # the first step in the IdV flow
+      visit idv_path
+      expect(current_path).to eq(idv_jurisdiction_path)
+    end
   end
 end


### PR DESCRIPTION
**Why**: The current cancel flow takes the user back to the user's account. It will be more useful for them to go back to the SP.

**How**: Replace the link to the accounts page with the failure_to_proof_url which will use the return_to_sp link if a failure to proof url is not provided.  Thus, it will satisfy requirements for both LOA1 and LOA3.  Finally, add a feature test/spec for the link which had no coverage previously.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
