### PR TITLE
Deploy RC 65 patch 2 to Int

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -92,7 +92,7 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_return_url
-    if sp.redirect_uris.present? && openid_connect_redirector.valid?
+    if sp.redirect_uris.present? && request_url.is_a?(String) && openid_connect_redirector.valid?
       openid_connect_redirector.decline_redirect_uri
     else
       sp.return_to_sp_url

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -7,6 +7,10 @@ class AnonymousUser
     nil
   end
 
+  def phone_configuration
+    nil
+  end
+
   def phone
     nil
   end

--- a/app/policies/sms_login_option_policy.rb
+++ b/app/policies/sms_login_option_policy.rb
@@ -4,6 +4,7 @@ class SmsLoginOptionPolicy
   end
 
   def configured?
+    return false unless user
     user.phone_configuration.present?
   end
 

--- a/app/views/idv/shared/_failure_to_proof_url.html.slim
+++ b/app/views/idv/shared/_failure_to_proof_url.html.slim
@@ -1,9 +1,0 @@
-- if decorated_session.sp_name
-  hr
-    .mb2.mt2
-      .right = link_to image_tag(asset_url('carat-right.svg'), size: '10'),
-        decorated_session.failure_to_proof_url, class: 'bold block btn-link text-decoration-none'
-      = link_to t('idv.failure.help.get_help_html', sp_name: decorated_session.sp_name),
-        decorated_session.failure_to_proof_url,
-        class: 'block btn-link text-decoration-none'
-  hr

--- a/app/views/idv/shared/verification_failure.html.slim
+++ b/app/views/idv/shared/verification_failure.html.slim
@@ -1,7 +1,7 @@
 = render 'shared/failure', presenter: presenter
 p == presenter.warning_message
 
-= render 'idv/shared/failure_to_proof_url', presenter: presenter
+= render 'shared/failure_url', presenter: presenter
 
 .mt3
   = link_to presenter.button_text, presenter.button_path, class: 'btn btn-primary btn-link'

--- a/app/views/shared/_failure.html.slim
+++ b/app/views/shared/_failure.html.slim
@@ -12,7 +12,7 @@ p == presenter.description
 
 - if presenter.message.present?
   h2.h4.mb2.mt3.my0 = presenter.message
-  = render 'idv/shared/failure_to_proof_url', presenter: presenter
+  = render 'shared/failure_url', presenter: presenter
 
 - presenter.next_steps.each do |step|
   p == step

--- a/app/views/shared/_failure_url.html.slim
+++ b/app/views/shared/_failure_url.html.slim
@@ -1,0 +1,12 @@
+- if decorated_session.sp_name
+  hr
+    .mb2.mt2
+      .right = link_to image_tag(asset_url('carat-right.svg'), size: '10'),
+        decorated_session.failure_to_proof_url, class: 'bold block btn-link text-decoration-none'
+      - if request.path.starts_with?('/verify/')
+        = link_to t('idv.failure.help.get_help_html', sp_name: decorated_session.sp_name),
+          decorated_session.failure_to_proof_url, class: 'block btn-link text-decoration-none'
+      - elsif decorated_session.sp_return_url
+        = link_to t('links.back_to_sp', sp: decorated_session.sp_name),
+          decorated_session.sp_return_url, class: 'block btn-link text-decoration-none'
+  hr

--- a/spec/controllers/account_reset/confirm_request_controller_spec.rb
+++ b/spec/controllers/account_reset/confirm_request_controller_spec.rb
@@ -9,5 +9,14 @@ RSpec.describe AccountReset::ConfirmRequestController do
         expect(response).to redirect_to(root_url)
       end
     end
+
+    context 'email is present in flash' do
+      it 'renders the show template' do
+        allow(controller).to receive(:flash).and_return(email: 'test@test.com')
+        get :show
+
+        expect(response).to render_template(:show)
+      end
+    end
   end
 end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -204,4 +204,12 @@ RSpec.describe ServiceProviderSessionDecorator do
       expect(subject.failure_to_proof_url).to eq url
     end
   end
+
+  describe '#sp_return_url' do
+    it 'does not raise an error if request_url is nil' do
+      allow(subject).to receive(:request_url).and_return(nil)
+      allow(sp).to receive(:redirect_uris).and_return(['foo'])
+      subject.sp_return_url
+    end
+  end
 end


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
