### PR TITLE
LG-569 adjusting visual styles of 2FA options

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -65,11 +65,9 @@
   display: inline-block;
   padding: $space-1 $space-2;
 
-  // &.is-focused {
-  //   border-color: $field-focus-color;
-  //   box-shadow: 0 0 0 2px rgba($field-focus-color, .5);
-  //   outline: none;
-  // }
+  &.is-focused {
+    border-color: $field-focus-color;
+  }
 }
 
 .btn-disabled {

--- a/app/javascript/app/radio-btn.js
+++ b/app/javascript/app/radio-btn.js
@@ -4,7 +4,7 @@ function clearHighlight(name) {
   const radioGroup = document.querySelectorAll(`input[name='${name}']`);
 
   Array.prototype.forEach.call(radioGroup, (radio) => {
-    radio.parentNode.parentNode.classList.remove('bg-light-blue');
+    radio.parentNode.parentNode.classList.remove('bg-lightest-blue');
   });
 }
 
@@ -16,11 +16,11 @@ function highlightRadioBtn() {
       const label = radio.parentNode.parentNode;
       const name = radio.getAttribute('name');
 
-      if (radio.checked) label.classList.add('bg-light-blue');
+      if (radio.checked) label.classList.add('bg-lightest-blue');
 
       radio.addEventListener('change', function() {
         clearHighlight(name);
-        if (radio.checked) label.classList.add('bg-light-blue');
+        if (radio.checked) label.classList.add('bg-lightest-blue');
       });
 
       radio.addEventListener('focus', function() {

--- a/app/views/account_recovery_setup/index.html.slim
+++ b/app/views/account_recovery_setup/index.html.slim
@@ -9,9 +9,9 @@ p.mt-tiny.mb3 = @presenter.info
       url: two_factor_options_path) do |f|
   .mb3
     fieldset.m0.p0.border-none.
-      legend.mb1.h4.serif.bold = @presenter.label
+      legend.mb2.serif.bold = @presenter.label
       - @presenter.options.each do |option|
-        label.btn-border.col-12.mb1 for="two_factor_options_form_selection_#{option.type}"
+        label.btn-border.col-12.mb2 for="two_factor_options_form_selection_#{option.type}"
           .radio
             = radio_button_tag('two_factor_options_form[selection]',
               option.type,

--- a/app/views/two_factor_authentication/options/index.html.slim
+++ b/app/views/two_factor_authentication/options/index.html.slim
@@ -9,9 +9,9 @@ p.mt-tiny.mb3 = @presenter.info
         url: login_two_factor_options_path) do |f|
   .mb3
     fieldset.m0.p0.border-none.
-      legend.mb1.h4.serif.bold = @presenter.label
+      legend.mb2.serif.bold = @presenter.label
       - @presenter.options.each do |option|
-        label.btn-border.col-12.mb1 for="two_factor_options_form_selection_#{option.type}"
+        label.btn-border.col-12.mb2 for="two_factor_options_form_selection_#{option.type}"
           .radio
             = radio_button_tag('two_factor_options_form[selection]',
                     option.type,

--- a/app/views/users/two_factor_authentication_setup/index.html.slim
+++ b/app/views/users/two_factor_authentication_setup/index.html.slim
@@ -9,18 +9,18 @@ p.mt-tiny.mb3 = @presenter.info
       url: two_factor_options_path) do |f|
   .mb3
     fieldset.m0.p0.border-none.
-      legend.mb1.h4.serif.bold = @presenter.label
+      legend.mb2.serif.bold = @presenter.label
       - @presenter.options.each do |option|
-        label.btn-border.col-12.mb1 for="two_factor_options_form_selection_#{option.type}"
+        label.btn-border.col-12.mb2 for="two_factor_options_form_selection_#{option.type}"
           .radio
             = radio_button_tag('two_factor_options_form[selection]',
               option.type,
               @two_factor_options_form.selected?(option.type))
             span.indicator.mt-tiny
             span.blue.bold.fs-20p = option.label
-            .regular.gray-dark.fs-10p.mb-tiny = option.info
+            .regular.gray-dark.fs-10p.mt0.mb-tiny = option.info
 
   div
-    = f.button :submit, t('forms.buttons.continue'), class: 'sm-col-6 col-12 btn-wide mb3'
+    = f.button :submit, t('forms.buttons.continue'), class: 'sm-col-6 col-12 btn-wide mb1'
 
 = render 'shared/cancel', link: destroy_user_session_path

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -131,10 +131,10 @@ en:
       two_factor_choice_options:
         auth_app: Authentication application
         auth_app_info: Set up an authentication application to get your security code
-          without providing a phone number.
+          without providing a phone number
         piv_cac: Government employees
-        piv_cac_info: Use your PIV/CAC card to secure your account.
+        piv_cac_info: Use your PIV/CAC card to secure your account
         sms: Text message / SMS
-        sms_info: Get your security code via text message / SMS.
+        sms_info: Get your security code via text message / SMS
         voice: Phone call
-        voice_info: Get your security code via phone call.
+        voice_info: Get your security code via phone call

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -130,10 +130,10 @@ es:
       two_factor_choice_options:
         auth_app: Aplicación de autenticación
         auth_app_info: Configure una aplicación de autenticación para obtener su código
-          de seguridad sin proporcionar un número de teléfono.
+          de seguridad sin proporcionar un número de teléfono
         piv_cac: Empleados del Gobierno
-        piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta.
+        piv_cac_info: Use su tarjeta PIV / CAC para asegurar su cuenta
         sms: Mensaje de texto / SMS
-        sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS.
+        sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS
         voice: Llamada telefónica
-        voice_info: Obtenga su código de seguridad a través de una llamada telefónica.
+        voice_info: Obtenga su código de seguridad a través de una llamada telefónica

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -139,10 +139,10 @@ fr:
       two_factor_choice_options:
         auth_app: Application d'authentification
         auth_app_info: Configurez une application d'authentification pour obtenir
-          votre code de sécurité sans fournir de numéro de téléphone.
+          votre code de sécurité sans fournir de numéro de téléphone
         piv_cac: Employés du gouvernement
-        piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte.
+        piv_cac_info: Utilisez votre carte PIV / CAC pour sécuriser votre compte
         sms: SMS
         sms_info: Obtenez votre code de sécurité par SMS
         voice: Appel téléphonique
-        voice_info: Obtenez votre code de sécurité par appel téléphonique.
+        voice_info: Obtenez votre code de sécurité par appel téléphonique


### PR DESCRIPTION
A few visual changes to satisfy LG-569

**Changed**
- [x] Darker border on focus state
- [x] lighter background on active selections
- [x] 2 spacing units between buttons
- [x] periods removed from 2FA copy

**Unchanged/Other Issues** (Things that were in the spec but I didn't do as part of this issue)
- Cancel should potentially just say "cancel"? 
- Spacing between the 2FA method label and 2FA method description, in the spec they are closer together than what our current styles allow unless we write a mixin to trim line-height from the top of elements that we could apply to the description
- "Select an option to secure your account" is in a font size we don't have specified in code
- 3 different places in the code use a somewhat similar radio button grouping meaning I had to make some of these spacing changes in 3 places. Should probably be re-factored. 




![screen shot 2018-08-31 at 3 56 51 pm](https://user-images.githubusercontent.com/776987/44935558-d1882580-ad36-11e8-892a-709b241bfe31.png)
