### PR TITLE
Remove unused personal_key method

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -27,14 +27,9 @@ module UserAccessKeyOverrides
     )
   end
 
-  def personal_key
-    @personal_key
-  end
-
   def personal_key=(new_personal_key)
-    @personal_key = new_personal_key
-    return if @personal_key.blank?
-    self.encrypted_recovery_code_digest = Encryption::PasswordVerifier.digest(@personal_key)
+    return if new_personal_key.blank?
+    self.encrypted_recovery_code_digest = Encryption::PasswordVerifier.digest(new_personal_key)
   end
 
   # This is a devise method, which we are overriding. This should not be removed

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -3,18 +3,16 @@ require 'rails_helper'
 feature 'Signing in via one-time use personal key' do
   it 'destroys old key, displays new one, and redirects to profile after acknowledging' do
     user = create(:user, :signed_up)
+    raw_key = PersonalKeyGenerator.new(user).create
+    old_key = user.reload.encrypted_recovery_code_digest
+
     sign_in_before_2fa(user)
-
-    personal_key = PersonalKeyGenerator.new(user).create
-
     choose_another_security_option('personal_key')
-
-    enter_personal_key(personal_key: personal_key)
-
+    enter_personal_key(personal_key: raw_key)
     click_submit_default
     click_acknowledge_personal_key
 
-    expect(user.reload.personal_key).to_not eq personal_key
+    expect(user.reload.encrypted_recovery_code_digest).to_not eq old_key
     expect(current_path).to eq account_path
   end
 

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -6,7 +6,7 @@ describe PersonalKeyForm do
       it 'returns FormResponse with success: true' do
         user = create(:user)
         raw_code = PersonalKeyGenerator.new(user).create
-        old_key = user.reload.personal_key
+        old_code = user.reload.encrypted_recovery_code_digest
 
         form = PersonalKeyForm.new(user, raw_code)
         result = instance_double(FormResponse)
@@ -15,7 +15,7 @@ describe PersonalKeyForm do
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.reload.personal_key).to eq old_key
+        expect(user.reload.encrypted_recovery_code_digest).to eq old_code
       end
     end
 
@@ -31,7 +31,7 @@ describe PersonalKeyForm do
         expect(FormResponse).to receive(:new).
           with(success: false, errors: errors, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.personal_key).to_not be_nil
+        expect(user.encrypted_recovery_code_digest).to_not be_nil
         expect(form.personal_key).to be_nil
       end
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -30,12 +30,12 @@ describe Profile do
     it 'generates new personal key' do
       expect(profile.encrypted_pii_recovery).to be_nil
 
-      initial_personal_key = user.personal_key
+      initial_personal_key = user.encrypted_recovery_code_digest
 
       profile.encrypt_pii(pii, user.password)
 
       expect(profile.encrypted_pii_recovery).to_not be_nil
-      expect(user.personal_key).to_not eq initial_personal_key
+      expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
     end
   end
 
@@ -43,13 +43,13 @@ describe Profile do
     it 'generates new personal key' do
       expect(profile.encrypted_pii_recovery).to be_nil
 
-      initial_personal_key = user.personal_key
+      initial_personal_key = user.encrypted_recovery_code_digest
 
       profile.encrypt_recovery_pii(pii)
 
       expect(profile.encrypted_pii_recovery).to_not be_nil
-      expect(user.personal_key).to_not eq initial_personal_key
-      expect(profile.personal_key).to_not eq user.personal_key
+      expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
+      expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest
     end
   end
 


### PR DESCRIPTION
**Why**: I originally created this PR to address a performance issue
flagged by the `fasterer` gem, which said to use `attr_reader` instead
of an ivar for `personal_key`, but then I noticed that we're not even
using that method except for in some specs, so I removed it and updated
the specs to use `encrypted_recovery_code_digest` instead.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
