### PR TITLE
Set up a TOTP user for local development

### DIFF
--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -6,6 +6,8 @@ module TwoFactorAuthentication
 
     def show
       @presenter = presenter_for_two_factor_authentication_method
+      return unless FeatureManagement.prefill_otp_codes?
+      @code = ROTP::TOTP.new(current_user.otp_secret_key).now
     end
 
     def create

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -7,7 +7,7 @@ h1.h3.my0 = @presenter.header
   = label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
     class: 'block bold'
   .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
-    = text_field_tag :code, '', required: true, autofocus: true,
+    = text_field_tag :code, '', value: @code, required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
 
     trait :with_authentication_app do
       with_personal_key
-      otp_secret_key 'abc123'
+      otp_secret_key ROTP::Base32.random_base32
     end
 
     trait :admin do

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -12,7 +12,7 @@ describe 'dev rake tasks' do
     it 'runs successfully' do
       Rake::Task['dev:prime'].invoke
 
-      expect(User.count).to eq 2
+      expect(User.count).to eq 3
     end
   end
 


### PR DESCRIPTION
**Why**: To make it easier and faster to test with users who use an
authentication app only.

**How**:
- Update dev:rake task to create a TOTP user
- Prefill the TOTP code for that user

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
