### PR TITLE
[LG-574] make phone_configuration plural

### DIFF
--- a/app/controllers/concerns/account_recoverable.rb
+++ b/app/controllers/concerns/account_recoverable.rb
@@ -1,5 +1,5 @@
 module AccountRecoverable
   def piv_cac_enabled_but_not_phone_enabled?
-    current_user.piv_cac_enabled? && !current_user.phone_configuration&.mfa_enabled?
+    current_user.piv_cac_enabled? && current_user.phone_configurations.none?(&:mfa_enabled?)
   end
 end

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -1,6 +1,6 @@
 module Authorizable
   def authorize_user
-    return unless current_user.phone_configuration&.mfa_enabled?
+    return unless current_user.phone_configurations.any?(&:mfa_enabled?)
 
     if user_fully_authenticated?
       redirect_to account_url

--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -15,6 +15,7 @@ module PhoneConfirmation
   def otp_delivery_method(phone, selected_delivery_method)
     return :sms if PhoneNumberCapabilities.new(phone).sms_only?
     return selected_delivery_method if selected_delivery_method.present?
-    current_user.phone_configuration&.delivery_preference || current_user.otp_delivery_preference
+    current_user.phone_configurations.first&.delivery_preference ||
+      current_user.otp_delivery_preference
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -140,7 +140,7 @@ module TwoFactorAuthenticatable
   end
 
   def old_phone
-    current_user.phone_configuration&.phone
+    current_user.phone_configurations.first&.phone
   end
 
   def phone_changed
@@ -233,7 +233,7 @@ module TwoFactorAuthenticatable
       two_factor_authentication_method: two_factor_authentication_method,
       user_email: current_user.email,
       remember_device_available: false,
-      phone_enabled: current_user.phone_configuration&.mfa_enabled?,
+      phone_enabled: current_user.phone_configurations.any?(&:mfa_enabled?),
     }.merge(generic_data)
   end
 
@@ -255,7 +255,7 @@ module TwoFactorAuthenticatable
 
   def voice_otp_delivery_unsupported?
     phone_number = if authentication_context?
-                     current_user.phone_configuration&.phone
+                     current_user.phone_configurations.first&.phone
                    else
                      user_session[:unconfirmed_phone]
                    end
@@ -268,7 +268,7 @@ module TwoFactorAuthenticatable
 
   def reenter_phone_number_path
     locale = LinkLocaleResolver.locale
-    if current_user.phone_configuration.present?
+    if current_user.phone_configurations.any?
       manage_phone_path(locale: locale)
     else
       phone_setup_path(locale: locale)
@@ -276,7 +276,7 @@ module TwoFactorAuthenticatable
   end
 
   def confirmation_for_phone_change?
-    confirmation_context? && current_user.phone_configuration.present?
+    confirmation_context? && current_user.phone_configurations.any?
   end
 
   def presenter_for_two_factor_authentication_method

--- a/app/controllers/idv/confirmations_controller.rb
+++ b/app/controllers/idv/confirmations_controller.rb
@@ -35,7 +35,9 @@ module Idv
     def track_final_idv_event
       result = {
         success: true,
-        new_phone_added: idv_session.params['phone'] != current_user.phone_configuration&.phone,
+        new_phone_added: !current_user.phone_configurations.map(&:phone).include?(
+          idv_session.params['phone']
+        ),
       }
       analytics.track_event(Analytics::IDV_FINAL, result)
     end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -36,7 +36,7 @@ module TwoFactorAuthentication
     end
 
     def phone_enabled?
-      current_user.phone_configuration&.mfa_enabled?
+      current_user.phone_configurations.any?(&:mfa_enabled?)
     end
 
     def confirm_voice_capability
@@ -54,7 +54,7 @@ module TwoFactorAuthentication
     end
 
     def phone
-      current_user&.phone_configuration&.phone || user_session[:unconfirmed_phone]
+      current_user&.phone_configurations&.first&.phone || user_session[:unconfirmed_phone]
     end
 
     def form_params

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -39,9 +39,11 @@ module TwoFactorAuthentication
     end
 
     def next_step
-      return account_recovery_setup_url unless current_user.phone_configuration&.mfa_enabled?
-
-      after_otp_verification_confirmation_url
+      if current_user.phone_configurations.any?(&:mfa_enabled?)
+        after_otp_verification_confirmation_url
+      else
+        account_recovery_setup_url
+      end
     end
 
     def handle_invalid_piv_cac
@@ -64,7 +66,7 @@ module TwoFactorAuthentication
         user_email: current_user.email,
         remember_device_available: false,
         totp_enabled: current_user.totp_enabled?,
-        phone_enabled: current_user.phone_configuration&.mfa_enabled?,
+        phone_enabled: current_user.phone_configurations.any?(&:mfa_enabled?),
         piv_cac_nonce: piv_cac_nonce,
       }.merge(generic_data)
     end

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -30,7 +30,8 @@ module Users
     private
 
     def delivery_preference
-      current_user.phone_configuration&.delivery_preference || current_user.otp_delivery_preference
+      current_user.phone_configurations.first&.delivery_preference ||
+        current_user.otp_delivery_preference
     end
 
     def two_factor_enabled?

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -27,7 +27,8 @@ module Users
     end
 
     def delivery_preference
-      current_user.phone_configuration&.delivery_preference || current_user.otp_delivery_preference
+      current_user.phone_configurations.first&.delivery_preference ||
+        current_user.otp_delivery_preference
     end
 
     def process_updates

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -79,7 +79,7 @@ module Users
     end
 
     def next_step
-      return account_url if current_user.phone_configuration&.mfa_enabled?
+      return account_url if current_user.phone_configurations.any?(&:mfa_enabled?)
       account_recovery_setup_url
     end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -41,7 +41,7 @@ module Users
     end
 
     def phone_configuration
-      current_user.phone_configuration
+      current_user.phone_configurations.first
     end
 
     def validate_otp_delivery_preference_and_send_code
@@ -87,7 +87,7 @@ module Users
     def redirect_to_otp_verification_with_error
       flash[:error] = t('errors.messages.phone_unsupported')
       redirect_to login_two_factor_url(
-        otp_delivery_preference: current_user.phone_configuration.delivery_preference,
+        otp_delivery_preference: phone_configuration.delivery_preference,
         reauthn: reauthn?
       )
     end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -36,7 +36,7 @@ class UserDecorator
   end
 
   def masked_two_factor_phone_number
-    masked_number(user.phone_configuration&.phone)
+    masked_number(user.phone_configurations.first&.phone)
   end
 
   def active_identity_for(service_provider)

--- a/app/forms/idv/phone_form.rb
+++ b/app/forms/idv/phone_form.rb
@@ -10,7 +10,7 @@ module Idv
     def initialize(idv_params, user)
       @idv_params = idv_params
       @user = user
-      self.phone = initial_phone_value(idv_params[:phone] || user.phone_configuration&.phone)
+      self.phone = initial_phone_value(idv_params[:phone] || user.phone_configurations.first&.phone)
       self.international_code = PhoneFormatter::DEFAULT_COUNTRY
     end
 
@@ -45,11 +45,11 @@ module Idv
       idv_params[:phone] = normalized_phone
 
       return idv_params[:phone_confirmed_at] = nil unless phone == formatted_user_phone
-      idv_params[:phone_confirmed_at] = user.phone_configuration&.confirmed_at
+      idv_params[:phone_confirmed_at] = user.phone_configurations.first&.confirmed_at
     end
 
     def formatted_user_phone
-      Phonelib.parse(user.phone_configuration&.phone).international
+      Phonelib.parse(user.phone_configurations.first&.phone).international
     end
 
     def parsed_phone

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -36,7 +36,7 @@ class TwoFactorOptionsForm
 
   def user_needs_updating?
     return false unless %w[voice sms].include?(selection)
-    return false if selection == user.phone_configuration&.delivery_preference
+    return false if selection == user.phone_configurations.first&.delivery_preference
     selection != user.otp_delivery_preference
   end
 

--- a/app/forms/user_phone_form.rb
+++ b/app/forms/user_phone_form.rb
@@ -5,11 +5,11 @@ class UserPhoneForm
 
   validates :otp_delivery_preference, inclusion: { in: %w[voice sms] }
 
-  attr_accessor :phone, :international_code, :otp_delivery_preference
+  attr_accessor :phone, :international_code, :otp_delivery_preference, :phone_configuration
 
   def initialize(user)
     self.user = user
-    phone_configuration = user.phone_configuration
+    self.phone_configuration = user.phone_configurations.first
     if phone_configuration.nil?
       self.otp_delivery_preference = user.otp_delivery_preference
     else
@@ -59,7 +59,7 @@ class UserPhoneForm
   end
 
   def otp_delivery_preference_changed?
-    otp_delivery_preference != user.phone_configuration&.delivery_preference
+    otp_delivery_preference != phone_configuration&.delivery_preference
   end
 
   def update_otp_delivery_preference_for_user
@@ -68,6 +68,6 @@ class UserPhoneForm
   end
 
   def formatted_user_phone
-    user.phone_configuration&.formatted_phone
+    phone_configuration&.formatted_phone
   end
 end

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -1,7 +1,7 @@
 class PhoneConfiguration < ApplicationRecord
   include EncryptableAttribute
 
-  belongs_to :user, inverse_of: :phone_configuration
+  belongs_to :user, inverse_of: :phone_configurations
   validates :user_id, presence: true
   validates :encrypted_phone, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   has_many :profiles, dependent: :destroy
   has_many :events, dependent: :destroy
   has_one :account_reset_request, dependent: :destroy
-  has_one :phone_configuration, dependent: :destroy, inverse_of: :user
+  has_many :phone_configurations, dependent: :destroy, inverse_of: :user
   has_many :webauthn_configurations, dependent: :destroy
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true
@@ -69,7 +69,7 @@ class User < ApplicationRecord
   end
 
   def two_factor_enabled?
-    phone_configuration&.mfa_enabled? || totp_enabled? || piv_cac_enabled?
+    phone_configurations.any?(&:mfa_enabled?) || totp_enabled? || piv_cac_enabled?
   end
 
   def send_two_factor_authentication_code(_code)

--- a/app/policies/sms_login_option_policy.rb
+++ b/app/policies/sms_login_option_policy.rb
@@ -5,7 +5,7 @@ class SmsLoginOptionPolicy
 
   def configured?
     return false unless user
-    user.phone_configuration.present?
+    user.phone_configurations.any?
   end
 
   private

--- a/app/policies/voice_login_option_policy.rb
+++ b/app/policies/voice_login_option_policy.rb
@@ -12,7 +12,8 @@ class VoiceLoginOptionPolicy
   attr_reader :user
 
   def user_has_a_phone_number_that_we_can_call?
-    phone = user.phone_configuration&.phone
-    phone.present? && !PhoneNumberCapabilities.new(phone).sms_only?
+    user.phone_configurations.any? do |phone_configuration|
+      !PhoneNumberCapabilities.new(phone_configuration.phone).sms_only?
+    end
   end
 end

--- a/app/services/account_reset/cancel.rb
+++ b/app/services/account_reset/cancel.rb
@@ -54,7 +54,7 @@ module AccountReset
     end
 
     def phone
-      user.phone_configuration&.phone
+      user.phone_configurations.first&.phone
     end
 
     def extra_analytics_attributes

--- a/app/services/account_reset/create_request.rb
+++ b/app/services/account_reset/create_request.rb
@@ -30,7 +30,7 @@ module AccountReset
     end
 
     def notify_user_by_sms_if_applicable
-      phone = user.phone_configuration&.phone
+      phone = user.phone_configurations.first&.phone
       return unless phone
       SmsAccountResetNotifierJob.perform_now(
         phone: phone,

--- a/app/services/otp_delivery_preference_updater.rb
+++ b/app/services/otp_delivery_preference_updater.rb
@@ -21,7 +21,7 @@ class OtpDeliveryPreferenceUpdater
 
   def otp_delivery_preference_changed?
     return true if preference != user.otp_delivery_preference
-    phone_configuration = user.phone_configuration
+    phone_configuration = user.phone_configurations.first
     phone_configuration.present? && preference != phone_configuration.delivery_preference
   end
 end

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -38,9 +38,9 @@ module Pii
 
     def rotate_encrypted_attributes
       KeyRotator::AttributeEncryption.new(user).rotate
-      phone_configuration = user.phone_configuration
-      return if phone_configuration.blank?
-      KeyRotator::AttributeEncryption.new(phone_configuration).rotate
+      user.phone_configurations.each do |phone_configuration|
+        KeyRotator::AttributeEncryption.new(phone_configuration).rotate
+      end
     end
 
     def stale_fingerprints?(profile)
@@ -52,7 +52,7 @@ module Pii
     end
 
     def stale_attributes?
-      user.phone_configuration&.stale_encrypted_phone? || user.stale_encrypted_email? ||
+      user.phone_configurations.any?(&:stale_encrypted_phone?) || user.stale_encrypted_email? ||
         user.stale_encrypted_otp_secret_key?
     end
 

--- a/app/services/remember_device_cookie.rb
+++ b/app/services/remember_device_cookie.rb
@@ -46,6 +46,8 @@ class RememberDeviceCookie
   end
 
   def user_has_changed_phone?(user)
-    user.phone_configuration&.confirmed_at.to_i > created_at.to_i
+    user.phone_configurations.any? do |phone_configuration|
+      phone_configuration.confirmed_at.to_i > created_at.to_i
+    end
   end
 end

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -15,7 +15,7 @@ class UpdateUser
   attr_reader :user, :attributes
 
   def manage_phone_configuration
-    if user.phone_configuration.present?
+    if user.phone_configurations.any?
       update_phone_configuration
     else
       create_phone_configuration
@@ -23,12 +23,12 @@ class UpdateUser
   end
 
   def update_phone_configuration
-    user.phone_configuration.update!(phone_attributes)
+    user.phone_configurations.first.update!(phone_attributes)
   end
 
   def create_phone_configuration
     return if phone_attributes[:phone].blank?
-    user.create_phone_configuration(phone_attributes)
+    user.phone_configurations.create(phone_attributes)
   end
 
   def phone_attributes

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -36,7 +36,7 @@ h1.hide = t('titles.account')
 
   = render 'account_item',
     name: t('account.index.phone'),
-    content: current_user.phone_configuration&.phone,
+    content: current_user.phone_configurations.first&.phone,
     path: manage_phone_path,
     action: @view_model.edit_action_partial
 

--- a/app/views/exception_notifier/_session.text.erb
+++ b/app/views/exception_notifier/_session.text.erb
@@ -18,8 +18,8 @@ Session: <%= session %>
 
 <% user = @kontroller.analytics_user || AnonymousUser.new %>
 User UUID: <%= user.uuid %>
-<% if user.phone_configuration %>
-  User's Country (based on phone): <%= Phonelib.parse(user.phone_configuration.phone).country %>
+<% if user.phone_configurations.any? %>
+  User's Country (based on first phone): <%= Phonelib.parse(user.phone_configurations.first.phone).country %>
 <% end %>
 
 Visitor ID: <%= @request.cookies['ahoy_visitor'] %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = true
     Bullet.add_whitelist(
-      type: :n_plus_one_query, class_name: 'User', association: :phone_configuration
+      type: :n_plus_one_query, class_name: 'User', association: :phone_configurations
     )
   end
 

--- a/lib/tasks/create_test_accounts.rb
+++ b/lib/tasks/create_test_accounts.rb
@@ -16,7 +16,7 @@ def create_account(email: 'joe.smith@email.com', password: 'salty pickles', mfa_
   user.skip_confirmation!
   user.reset_password(password, password)
   user.save!
-  user.create_phone_configuration(
+  user.phone_configurations.create(
     phone: mfa_phone || phone,
     confirmed_at: Time.zone.now,
     delivery_preference: user.otp_delivery_preference

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -100,6 +100,10 @@ namespace :dev do
     Event.create(user_id: user.id, event_type: :account_created)
   end
 
+  def fingerprint(email)
+    Pii::Fingerprinter.fingerprint(email)
+  end
+
   def phone_configuration_data(user, args)
     {
       delivery_preference: user.otp_delivery_preference,

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -88,11 +88,7 @@ namespace :dev do
     user.encrypted_email = args[:ee].encrypted
     user.skip_confirmation!
     user.reset_password(args[:pw], args[:pw])
-    user.create_phone_configuration(
-      delivery_preference: user.otp_delivery_preference,
-      phone: format('+1 (415) 555-%04d', args[:num]),
-      confirmed_at: Time.zone.now
-    )
+    user.phone_configurations.create(phone_configuration_data(user, args))
     Event.create(user_id: user.id, event_type: :account_created)
   end
 
@@ -104,7 +100,11 @@ namespace :dev do
     Event.create(user_id: user.id, event_type: :account_created)
   end
 
-  def fingerprint(email)
-    Pii::Fingerprinter.fingerprint(email)
+  def phone_configuration_data(user, args)
+    {
+      delivery_preference: user.otp_delivery_preference,
+      phone: format('+1 (415) 555-%04d', args[:num]),
+      confirmed_at: Time.zone.now,
+    }
   end
 end

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -13,8 +13,7 @@ namespace :rotate do
         users.each do |user|
           rotator = KeyRotator::AttributeEncryption.new(user)
           rotator.rotate
-          phone_configuration = user.phone_configuration
-          if phone_configuration.present?
+          user.phone_configurations.each do |phone_configuration|
             rotator = KeyRotator::AttributeEncryption.new(phone_configuration)
             rotator.rotate
           end

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -110,7 +110,7 @@ describe Idv::ConfirmationsController do
 
     context 'user used 2FA phone as phone of record' do
       before do
-        subject.idv_session.params['phone'] = user.phone_configuration.phone
+        subject.idv_session.params['phone'] = user.phone_configurations.first.phone
       end
 
       it 'tracks final IdV event' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -138,7 +138,7 @@ describe Idv::PhoneController do
 
           expected_params = {
             phone: normalized_phone,
-            phone_confirmed_at: user.phone_configuration.confirmed_at,
+            phone_confirmed_at: user.phone_configurations.first.confirmed_at,
           }
           expect(subject.idv_session.params).to eq expected_params
         end

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -20,7 +20,7 @@ describe Idv::ReviewController do
       city: 'Somewhere',
       state: 'KS',
       zipcode: zipcode,
-      phone: user.phone_configuration&.phone,
+      phone: user.phone_configurations.first&.phone,
       ssn: '12345678',
     }
   end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -264,7 +264,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         sign_in_as_user
         subject.user_session[:unconfirmed_phone] = '+1 (703) 555-5555'
         subject.user_session[:context] = 'confirmation'
-        @previous_phone_confirmed_at = subject.current_user.phone_configuration&.confirmed_at
+        @previous_phone_confirmed_at = subject.current_user.phone_configurations.first&.confirmed_at
         subject.current_user.create_direct_otp
         stub_analytics
         allow(@analytics).to receive(:track_event)
@@ -272,7 +272,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         @mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
         allow(UserMailer).to receive(:phone_changed).with(subject.current_user).
           and_return(@mailer)
-        @previous_phone = subject.current_user.phone_configuration&.phone
+        @previous_phone = subject.current_user.phone_configurations.first&.phone
       end
 
       context 'user has an existing phone number' do
@@ -322,9 +322,9 @@ describe TwoFactorAuthentication::OtpVerificationController do
           end
 
           it 'does not update user phone or phone_confirmed_at attributes' do
-            expect(subject.current_user.phone_configuration.phone).to eq('+1 202-555-1212')
+            expect(subject.current_user.phone_configurations.first.phone).to eq('+1 202-555-1212')
             expect(
-              subject.current_user.phone_configuration.confirmed_at
+              subject.current_user.phone_configurations.first.confirmed_at
             ).to eq(@previous_phone_confirmed_at)
           end
 
@@ -353,8 +353,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
 
       context 'when user does not have an existing phone number' do
         before do
-          subject.current_user.phone_configuration.destroy
-          subject.current_user.phone_configuration = nil
+          subject.current_user.phone_configurations.clear
           subject.current_user.create_direct_otp
         end
 

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -25,7 +25,7 @@ describe Users::PhonesController do
 
       it 'lets user know they need to confirm their new phone' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
-        expect(user.reload.phone_configuration.phone).to_not eq '+1 202-555-4321'
+        expect(user.phone_configurations.reload.first.phone).to_not eq '+1 202-555-4321'
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to redirect_to(
@@ -47,7 +47,7 @@ describe Users::PhonesController do
                              otp_delivery_preference: 'sms' },
         }
 
-        expect(user.reload.phone_configuration.phone).to be_present
+        expect(user.phone_configurations.reload.first).to be_present
         expect(response).to render_template(:edit)
       end
     end
@@ -60,7 +60,7 @@ describe Users::PhonesController do
         allow(@analytics).to receive(:track_event)
 
         put :update, params: {
-          user_phone_form: { phone: second_user.phone_configuration.phone,
+          user_phone_form: { phone: second_user.phone_configurations.first.phone,
                              international_code: 'US',
                              otp_delivery_preference: 'sms' },
         }
@@ -68,8 +68,8 @@ describe Users::PhonesController do
 
       it 'processes successfully and informs user' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
-        expect(user.phone_configuration.reload.phone).to_not eq(
-          second_user.phone_configuration.phone
+        expect(user.phone_configurations.reload.first.phone).to_not eq(
+          second_user.phone_configurations.first.phone
         )
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
@@ -94,7 +94,7 @@ describe Users::PhonesController do
                              otp_delivery_preference: 'sms' },
         }
 
-        expect(user.phone_configuration.phone).not_to eq invalid_phone
+        expect(user.phone_configurations.first.phone).not_to eq invalid_phone
         expect(response).to render_template(:edit)
       end
     end
@@ -104,7 +104,7 @@ describe Users::PhonesController do
         stub_sign_in(user)
 
         put :update, params: {
-          user_phone_form: { phone: user.phone_configuration.phone,
+          user_phone_form: { phone: user.phone_configurations.first.phone,
                              international_code: 'US',
                              otp_delivery_preference: 'sms' },
         }

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -134,7 +134,7 @@ describe Users::TwoFactorAuthenticationController do
 
         expect(SmsOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
-          phone: subject.current_user.phone_configuration.phone,
+          phone: subject.current_user.phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.login_message',
           locale: nil
@@ -151,7 +151,7 @@ describe Users::TwoFactorAuthenticationController do
 
         expect(SmsOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
-          phone: subject.current_user.phone_configuration.phone,
+          phone: subject.current_user.phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.login_message',
           locale: nil
@@ -180,7 +180,7 @@ describe Users::TwoFactorAuthenticationController do
       it 'calls OtpRateLimiter#exceeded_otp_send_limit? and #increment' do
         otp_rate_limiter = instance_double(OtpRateLimiter)
         allow(OtpRateLimiter).to receive(:new).with(
-          phone: @user.phone_configuration.phone,
+          phone: @user.phone_configurations.first.phone,
           user: @user
         ).and_return(otp_rate_limiter)
 
@@ -218,7 +218,7 @@ describe Users::TwoFactorAuthenticationController do
 
         expect(VoiceOtpSenderJob).to have_received(:perform_later).with(
           code: subject.current_user.direct_otp,
-          phone: subject.current_user.phone_configuration.phone,
+          phone: subject.current_user.phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           locale: nil
         )

--- a/spec/factories/phone_configurations.rb
+++ b/spec/factories/phone_configurations.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     confirmed_at { Time.zone.now }
     phone { '+1 202-555-1212' }
     mfa_enabled { true }
-    association :user
+    user { association :user }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,18 +12,27 @@ FactoryBot.define do
 
     trait :with_phone do
       after(:build) do |user, evaluator|
-        if user.phone_configuration.nil?
-          user.phone_configuration = build(
-            :phone_configuration,
-            { user: user, delivery_preference: user.otp_delivery_preference }.merge(
-              evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
+        if user.phone_configurations.empty?
+          user.save!
+          if user.id.present?
+            create(:phone_configuration,
+                   { user: user, delivery_preference: user.otp_delivery_preference }.merge(
+                     evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
+                   ))
+            user.reload
+          else
+            user.phone_configurations << build(
+              :phone_configuration,
+              { delivery_preference: user.otp_delivery_preference }.merge(
+                evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
+              )
             )
-          )
+          end
         end
       end
 
       after(:create) do |user, evaluator|
-        if user.phone_configuration.nil?
+        if user.phone_configurations.empty?
           create(:phone_configuration,
                  { user: user, delivery_preference: user.otp_delivery_preference }.merge(
                    evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
@@ -33,10 +42,10 @@ FactoryBot.define do
       end
 
       after(:stub) do |user, evaluator|
-        if user.phone_configuration.nil?
-          user.phone_configuration = build_stubbed(
+        if user.phone_configurations.empty?
+          user.phone_configurations << build(
             :phone_configuration,
-            { user: user, delivery_preference: user.otp_delivery_preference }.merge(
+            { delivery_preference: user.otp_delivery_preference }.merge(
               evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
             )
           )

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -19,7 +19,7 @@ feature 'idv phone step', :idv_job do
       user = user_with_2fa
       start_idv_from_sp
       complete_idv_steps_before_phone_step(user)
-      fill_out_phone_form_ok(user.phone_configuration.phone)
+      fill_out_phone_form_ok(user.phone_configurations.first.phone)
       click_idv_continue
 
       expect(page).to have_content(t('idv.titles.session.review'))

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -20,7 +20,7 @@ feature 'Changing authentication factor' do
       mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(UserMailer).to receive(:phone_changed).with(user).and_return(mailer)
 
-      @previous_phone_confirmed_at = user.phone_configuration.reload.confirmed_at
+      @previous_phone_confirmed_at = user.phone_configurations.reload.first.confirmed_at
       new_phone = '+1 703-555-0100'
 
       visit manage_phone_path
@@ -39,7 +39,7 @@ feature 'Changing authentication factor' do
       enter_incorrect_otp_code
 
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')
-      expect(user.phone_configuration.reload.phone).to_not eq new_phone
+      expect(user.phone_configurations.reload.first.phone).to_not eq new_phone
       expect(page).to have_link t('forms.two_factor.try_again'), href: manage_phone_path
 
       submit_correct_otp
@@ -49,7 +49,7 @@ feature 'Changing authentication factor' do
       expect(mailer).to have_received(:deliver_later)
       expect(page).to have_content new_phone
       expect(
-        user.phone_configuration.reload.confirmed_at
+        user.phone_configurations.reload.first.confirmed_at
       ).to_not eq(@previous_phone_confirmed_at)
 
       visit login_two_factor_path(otp_delivery_preference: 'sms')
@@ -58,7 +58,7 @@ feature 'Changing authentication factor' do
 
     scenario 'editing phone number with no voice otp support only allows sms delivery' do
       user.update(otp_delivery_preference: 'voice')
-      user.phone_configuration.update(delivery_preference: 'voice')
+      user.phone_configurations.first.update(delivery_preference: 'voice')
       unsupported_phone = '242-327-0143'
 
       visit manage_phone_path
@@ -81,7 +81,7 @@ feature 'Changing authentication factor' do
       allow(SmsOtpSenderJob).to receive(:perform_later)
 
       user = sign_in_and_2fa_user
-      old_phone = user.phone_configuration.phone
+      old_phone = user.phone_configurations.first.phone
       visit manage_phone_path
       update_phone_number
 
@@ -108,7 +108,7 @@ feature 'Changing authentication factor' do
         allow(SmsOtpSenderJob).to receive(:perform_later)
 
         user = sign_in_and_2fa_user
-        old_phone = user.phone_configuration.phone
+        old_phone = user.phone_configurations.first.phone
 
         Timecop.travel(Figaro.env.reauthn_window.to_i + 1) do
           visit manage_phone_path

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -34,7 +34,7 @@ feature 'Two Factor Authentication' do
 
       expect(page).to_not have_content invalid_phone_message
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
-      expect(user.reload.phone_configuration).to be_nil
+      expect(user.phone_configurations).to be_empty
       expect(user.sms?).to eq true
     end
 
@@ -349,7 +349,7 @@ feature 'Two Factor Authentication' do
 
         expect(current_path).to eq account_path
 
-        phone_fingerprint = Pii::Fingerprinter.fingerprint(user.phone_configuration.phone)
+        phone_fingerprint = Pii::Fingerprinter.fingerprint(user.phone_configurations.first.phone)
         rate_limited_phone = OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint)
 
         # let findtime period expire
@@ -386,7 +386,9 @@ feature 'Two Factor Authentication' do
 
         sign_in_before_2fa(second_user)
         click_link t('links.two_factor_authentication.get_another_code')
-        phone_fingerprint = Pii::Fingerprinter.fingerprint(first_user.phone_configuration.phone)
+        phone_fingerprint = Pii::Fingerprinter.fingerprint(
+          first_user.phone_configurations.first.phone
+        )
         rate_limited_phone = OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint)
 
         expect(current_path).to eq otp_send_path

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -107,9 +107,8 @@ feature 'PIV/CAC Management' do
           stub_piv_cac_service
 
           user.update(otp_secret_key: 'secret')
-          user.phone_configuration.destroy
-          user.reload
-          expect(user.phone_configuration).to be_nil
+          user.phone_configurations.clear
+          expect(user.phone_configurations).to be_empty
           sign_in_and_2fa_user(user)
           visit account_path
           click_link t('forms.buttons.enable'), href: setup_piv_cac_url

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -65,12 +65,16 @@ feature 'User profile' do
     end
 
     it 'allows credentials to be reused for sign up' do
+      expect(User.count).to eq 0
       pii = { ssn: '1234', dob: '1920-01-01' }
       profile = create(:profile, :active, :verified, pii: pii)
+      expect(User.count).to eq 1
       sign_in_live_with_2fa(profile.user)
       visit account_path
       click_link(t('account.links.delete_account'))
       click_button t('users.delete.actions.delete')
+
+      expect(User.count).to eq 0
 
       profile = create(:profile, :active, :verified, pii: pii)
       sign_in_live_with_2fa(profile.user)

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -4,7 +4,7 @@ feature 'Webauthn Management' do
   include WebauthnHelper
 
   context 'with no webauthn associated yet' do
-    let(:user) { create(:user, :signed_up, phone: '+1 202-555-1212') }
+    let(:user) { create(:user, :signed_up, with: { phone: '+1 202-555-1212' }) }
 
     it 'allows user to add a webauthn configuration' do
       mock_challenge

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -22,7 +22,7 @@ feature 'Phone confirmation during sign up' do
     it 'updates phone_confirmed_at and redirects to acknowledge personal key' do
       click_button t('forms.buttons.submit.default')
 
-      expect(@user.reload.phone_configuration.confirmed_at).to be_present
+      expect(@user.phone_configurations.reload.first.confirmed_at).to be_present
       expect(current_path).to eq sign_up_personal_key_path
 
       click_acknowledge_personal_key
@@ -60,7 +60,8 @@ feature 'Phone confirmation during sign up' do
       @existing_user = create(:user, :signed_up)
       @user = sign_in_before_2fa
       select_2fa_option('sms')
-      fill_in 'user_phone_form_phone', with: @existing_user.phone_configuration.phone
+      fill_in 'user_phone_form_phone',
+              with: @existing_user.phone_configurations.detect(&:mfa_enabled?).phone
       click_send_security_code
     end
 
@@ -75,7 +76,7 @@ feature 'Phone confirmation during sign up' do
       fill_in 'code', with: 'foobar'
       click_submit_default
 
-      expect(@user.reload.phone_configuration).to be_nil
+      expect(@user.phone_configurations.reload).to be_empty
       expect(page).to have_content t('devise.two_factor_authentication.invalid_otp')
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
     end

--- a/spec/forms/idv/phone_form_spec.rb
+++ b/spec/forms/idv/phone_form_spec.rb
@@ -45,7 +45,7 @@ describe Idv::PhoneForm do
 
       expected_params = {
         phone: '2025551212',
-        phone_confirmed_at: user.phone_configuration.confirmed_at,
+        phone_confirmed_at: user.phone_configurations.first.confirmed_at,
       }
 
       expect(subject.idv_params).to eq expected_params

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -23,7 +23,7 @@ describe UserPhoneForm do
     )
     subject = UserPhoneForm.new(user)
 
-    expect(subject.phone).to eq(user.phone_configuration.phone)
+    expect(subject.phone).to eq(user.phone_configurations.first.phone)
     expect(subject.international_code).to eq('US')
     expect(subject.otp_delivery_preference).to eq(user.otp_delivery_preference)
   end
@@ -78,7 +78,7 @@ describe UserPhoneForm do
         subject.submit(params)
 
         user.reload
-        expect(user.phone_configuration).to be_nil
+        expect(user.phone_configurations).to be_empty
       end
 
       it 'preserves the format of the submitted phone number if phone is invalid' do
@@ -211,7 +211,7 @@ describe UserPhoneForm do
     end
 
     it 'returns false if the user phone has not changed' do
-      params[:phone] = user.phone_configuration.phone
+      params[:phone] = user.phone_configurations.first.phone
       subject.submit(params)
 
       expect(subject.phone_changed?).to eq(false)
@@ -219,8 +219,7 @@ describe UserPhoneForm do
 
     context 'when a user has no phone' do
       it 'returns true' do
-        user.phone_configuration.destroy
-        user.reload
+        user.phone_configurations.clear
 
         params[:phone] = '+1 504 444 1643'
         subject.submit(params)

--- a/spec/lib/tasks/rotate_rake_spec.rb
+++ b/spec/lib/tasks/rotate_rake_spec.rb
@@ -15,20 +15,20 @@ describe 'rotate' do
   describe 'attribute_encryption_key' do
     it 'runs successfully' do
       old_email = user.email
-      old_phone = user.phone_configuration.phone
+      old_phone = user.phone_configurations.first.phone
       old_encrypted_email = user.encrypted_email
-      old_encrypted_phone = user.phone_configuration.encrypted_phone
+      old_encrypted_phone = user.phone_configurations.first.encrypted_phone
 
       rotate_attribute_encryption_key
 
       Rake::Task['rotate:attribute_encryption_key'].execute
 
       user.reload
-      user.phone_configuration.reload
-      expect(user.phone_configuration.phone).to eq old_phone
+      user.phone_configurations.reload
+      expect(user.phone_configurations.first.phone).to eq old_phone
       expect(user.email).to eq old_email
       expect(user.encrypted_email).to_not eq old_encrypted_email
-      expect(user.phone_configuration.encrypted_phone).to_not eq old_encrypted_phone
+      expect(user.phone_configurations.first.encrypted_phone).to_not eq old_encrypted_phone
     end
 
     it 'does not raise an exception when encrypting/decrypting a user' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ describe User do
     it { is_expected.to have_many(:profiles) }
     it { is_expected.to have_many(:events) }
     it { is_expected.to have_one(:account_reset_request) }
-    it { is_expected.to have_one(:phone_configuration) }
+    it { is_expected.to have_many(:phone_configurations) }
     it { is_expected.to have_many(:webauthn_configurations) }
   end
 

--- a/spec/services/account_reset/cancel_spec.rb
+++ b/spec/services/account_reset/cancel_spec.rb
@@ -22,7 +22,7 @@ describe AccountReset::Cancel do
   context 'when the token is valid' do
     context 'when the user has a phone enabled for SMS' do
       before(:each) do
-        user.phone_configuration.update!(delivery_preference: :sms)
+        user.phone_configurations.first.update!(delivery_preference: :sms)
       end
 
       it 'notifies the user via SMS of the account reset cancellation' do
@@ -32,7 +32,7 @@ describe AccountReset::Cancel do
         AccountReset::Cancel.new(token).call
 
         expect(SmsAccountResetCancellationNotifierJob).
-          to have_received(:perform_now).with(phone: user.phone_configuration.phone)
+          to have_received(:perform_now).with(phone: user.phone_configurations.first.phone)
       end
     end
 
@@ -40,8 +40,7 @@ describe AccountReset::Cancel do
       it 'does not notify the user via SMS' do
         token = create_account_reset_request_for(user)
         allow(SmsAccountResetCancellationNotifierJob).to receive(:perform_now)
-        user.phone_configuration.destroy!
-        user.reload
+        user.phone_configurations.clear
 
         AccountReset::Cancel.new(token).call
 
@@ -87,7 +86,7 @@ describe AccountReset::Cancel do
     context 'when the user does not have a phone enabled for SMS' do
       it 'does not notify the user via SMS' do
         allow(SmsAccountResetCancellationNotifierJob).to receive(:perform_now)
-        user.phone_configuration.update!(mfa_enabled: false)
+        user.phone_configurations.first.update!(mfa_enabled: false)
 
         AccountReset::Cancel.new('foo').call
 

--- a/spec/services/otp_rate_limiter_spec.rb
+++ b/spec/services/otp_rate_limiter_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 RSpec.describe OtpRateLimiter do
   let(:current_user) { build(:user, :with_phone) }
   subject(:otp_rate_limiter) do
-    OtpRateLimiter.new(phone: current_user.phone_configuration.phone, user: current_user)
+    OtpRateLimiter.new(phone: current_user.phone_configurations.first.phone, user: current_user)
   end
 
-  let(:phone_fingerprint) { Pii::Fingerprinter.fingerprint(current_user.phone_configuration.phone) }
+  let(:phone_fingerprint) do
+    Pii::Fingerprinter.fingerprint(current_user.phone_configurations.first.phone)
+  end
   let(:rate_limited_phone) { OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint) }
 
   describe '#exceeded_otp_send_limit?' do
@@ -27,7 +29,9 @@ RSpec.describe OtpRateLimiter do
 
   describe '#increment' do
     it 'updates otp_last_sent_at' do
-      tracker = OtpRequestsTracker.find_or_create_with_phone(current_user.phone_configuration.phone)
+      tracker = OtpRequestsTracker.find_or_create_with_phone(
+        current_user.phone_configurations.first.phone
+      )
       old_otp_last_sent_at = tracker.reload.otp_last_sent_at
       otp_rate_limiter.increment
       new_otp_last_sent_at = tracker.reload.otp_last_sent_at

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -38,7 +38,7 @@ describe Pii::Cacher do
       old_ssn_signature = profile.ssn_signature
       old_email_fingerprint = user.email_fingerprint
       old_encrypted_email = user.encrypted_email
-      old_encrypted_phone = user.phone_configuration.encrypted_phone
+      old_encrypted_phone = user.phone_configurations.first.encrypted_phone
       old_encrypted_otp_secret_key = user.encrypted_otp_secret_key
 
       rotate_all_keys
@@ -55,7 +55,7 @@ describe Pii::Cacher do
       expect(user.email_fingerprint).to_not eq old_email_fingerprint
       expect(user.encrypted_email).to_not eq old_encrypted_email
       expect(profile.ssn_signature).to_not eq old_ssn_signature
-      expect(user.phone_configuration.encrypted_phone).to_not eq old_encrypted_phone
+      expect(user.phone_configurations.first.encrypted_phone).to_not eq old_encrypted_phone
       expect(user.encrypted_otp_secret_key).to_not eq old_encrypted_otp_secret_key
     end
 

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -25,7 +25,7 @@ describe UpdateUser do
         }
         updater = UpdateUser.new(user: user, attributes: attributes)
         updater.call
-        phone_configuration = user.reload.phone_configuration
+        phone_configuration = user.phone_configurations.reload.first
         expect(phone_configuration.delivery_preference).to eq 'voice'
         expect(phone_configuration.confirmed_at).to eq confirmed_at
         expect(phone_configuration.phone).to eq '+1 222 333-4444'
@@ -35,7 +35,7 @@ describe UpdateUser do
         attributes = { phone: nil }
         updater = UpdateUser.new(user: user, attributes: attributes)
         updater.call
-        expect(user.reload.phone_configuration).to_not be_nil
+        expect(user.phone_configurations.reload).to_not be_empty
       end
     end
 
@@ -50,7 +50,7 @@ describe UpdateUser do
         }
         updater = UpdateUser.new(user: user, attributes: attributes)
         updater.call
-        phone_configuration = user.reload.phone_configuration
+        phone_configuration = user.phone_configurations.reload.first
         expect(phone_configuration.delivery_preference).to eq 'voice'
         expect(phone_configuration.confirmed_at).to eq confirmed_at
         expect(phone_configuration.phone).to eq '+1 222 333-4444'

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -63,7 +63,7 @@ module IdvStepHelper
 
   def complete_idv_steps_with_phone_before_review_step(user = user_with_2fa)
     complete_idv_steps_before_phone_step(user)
-    fill_out_phone_form_ok(user.phone_configuration.phone)
+    fill_out_phone_form_ok(user.phone_configurations.first.phone)
     click_idv_continue
   end
 

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -81,7 +81,7 @@ module Features
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       login_as(user, scope: :user, run_callbacks: false)
 
-      if user.phone_configuration.present?
+      if user.phone_configurations.any?
         Warden.on_next_request do |proxy|
           session = proxy.env['rack.session']
           session['warden.user.user.session'] = {}

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -175,8 +175,7 @@ shared_examples 'signing with while PIV/CAC enabled but not phone enabled' do |s
     stub_piv_cac_service
 
     user = create(:user, :signed_up, :with_piv_or_cac)
-    user.phone_configuration.destroy
-    user.reload
+    user.phone_configurations.clear
     visit_idp_from_sp_with_loa1(sp)
     click_link t('links.sign_in')
     fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/support/shared_examples_for_phone_validation.rb
+++ b/spec/support/shared_examples_for_phone_validation.rb
@@ -16,10 +16,10 @@ shared_examples 'a phone form' do
         second_user = build_stubbed(:user, :signed_up, with: { phone: '+1 (202) 555-1213' })
         allow(User).to receive(:exists?).with(email: 'new@gmail.com').and_return(false)
         allow(User).to receive(:exists?).with(
-          phone_configuration: { phone: second_user.phone_configuration.phone }
+          phone_configuration: { phone: second_user.phone_configurations.first.phone }
         ).and_return(true)
 
-        params[:phone] = second_user.phone_configuration.phone
+        params[:phone] = second_user.phone_configurations.first.phone
 
         result = subject.submit(params)
         expect(result).to be_kind_of(FormResponse)
@@ -37,8 +37,8 @@ shared_examples 'a phone form' do
 
     context 'when phone is same as current user' do
       it 'is valid' do
-        user.phone_configuration.phone = '+1 (703) 500-5000'
-        params[:phone] = user.phone_configuration.phone
+        user.phone_configurations.first.phone = '+1 (703) 500-5000'
+        params[:phone] = user.phone_configurations.first.phone
         result = subject.submit(params)
 
         expect(result).to be_kind_of(FormResponse)

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -27,7 +27,7 @@ module SpAuthHelper
     fill_out_idv_form_ok
     click_idv_continue
     click_idv_continue
-    fill_out_phone_form_ok(user.phone_configuration.phone)
+    fill_out_phone_form_ok(user.phone_configurations.detect(&:mfa_enabled?).phone)
     click_idv_continue
     fill_in :user_password, with: user.password
     click_continue

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -6,7 +6,7 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
     attributes_for(:generic_otp_presenter).merge(
       two_factor_authentication_method: 'authenticator',
       user_email: view.current_user.email,
-      phone_enabled: user.phone_configuration&.mfa_enabled?
+      phone_enabled: user.phone_configurations.any?(&:mfa_enabled?)
     )
   end
 


### PR DESCRIPTION
**Why**: We want to support multiple phone numbers. This is
an intermediate step in that direction.
    
**How**: We go through and look for all the places we call
phone_configuration. We pluralize and try to see if we're
asking a question about the collection or a particular one.

*N.B.* This builds on #2478 so shouldn't be merged or reviewed
before that one is merged.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
