### PR TITLE
LG-610 Don't show recovery code before IdV flow

### DIFF
--- a/.reek
+++ b/.reek
@@ -33,7 +33,6 @@ FeatureEnvy:
     - reauthn?
     - mark_profile_inactive
     - EncryptedSidekiqRedis#zrem
-    - UserDecorator#should_acknowledge_personal_key?
     - Pii::Attributes#[]=
     - OpenidConnectLogoutForm#load_identity
     - Idv::ProfileMaker#pii_from_applicant

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -173,13 +173,17 @@ module TwoFactorAuthenticatable
   end
 
   def after_otp_action_required?
+    policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
+
     decorated_user.password_reset_profile.present? ||
       @updating_existing_number ||
-      decorated_user.should_acknowledge_personal_key?(session)
+      policy.show_personal_key_after_initial_2fa_setup?
   end
 
   def after_otp_action_url
-    if decorated_user.should_acknowledge_personal_key?(user_session)
+    policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
+
+    if policy.show_personal_key_after_initial_2fa_setup?
       sign_up_personal_key_url
     elsif @updating_existing_number
       account_url

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -63,11 +63,19 @@ module Users
     end
 
     def url_after_entering_valid_code
-      if current_user.decorate.should_acknowledge_personal_key?(user_session)
+      return account_url if user_already_has_a_personal_key?
+
+      policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
+
+      if policy.show_personal_key_after_initial_2fa_setup?
         sign_up_personal_key_url
       else
-        account_url
+        idv_jurisdiction_url
       end
+    end
+
+    def user_already_has_a_personal_key?
+      PersonalKeyLoginOptionPolicy.new(current_user).configured?
     end
 
     def process_invalid_code

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -99,14 +99,6 @@ class UserDecorator
     user.second_factor_locked_at.present? && lockout_period_expired?
   end
 
-  def should_acknowledge_personal_key?(session)
-    return true if session[:personal_key]
-
-    sp_session = session[:sp]
-
-    user.encrypted_recovery_code_digest.blank? && (sp_session.blank? || sp_session[:loa3] == false)
-  end
-
   def recent_events
     events = user.events.order('created_at DESC').limit(MAX_RECENT_EVENTS).map(&:decorate)
     identities = user.identities.order('last_authenticated_at DESC').map(&:decorate)

--- a/app/policies/personal_key_for_new_user_policy.rb
+++ b/app/policies/personal_key_for_new_user_policy.rb
@@ -1,0 +1,34 @@
+class PersonalKeyForNewUserPolicy
+  def initialize(user:, session:)
+    @user = user
+    @session = session
+  end
+
+  # For new users who visit the site directly or via an LOA1 request,
+  # we show them their personal key after they set up 2FA for the first
+  # time during account creation. These users only see the personal key
+  # once during account creation. LOA3 users, on the other hand, need to
+  # confirm their personal key after verifying their identity because
+  # the key is used to encrypt their PII. Rather than making LOA3 users
+  # confirm personal keys twice, once after 2FA setup, and once after
+  # proofing, we only show it to them once after proofing.
+  def show_personal_key_after_initial_2fa_setup?
+    user_does_not_have_a_personal_key? && user_did_not_make_an_loa3_request?
+  end
+
+  private
+
+  attr_reader :user, :session
+
+  def user_does_not_have_a_personal_key?
+    user.encrypted_recovery_code_digest.blank?
+  end
+
+  def user_did_not_make_an_loa3_request?
+    sp_session.empty? || sp_session[:loa3] == false
+  end
+
+  def sp_session
+    session.fetch(:sp, {})
+  end
+end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -204,42 +204,6 @@ describe UserDecorator do
     end
   end
 
-  describe '#should_acknowledge_personal_key?' do
-    context 'user has no personal key' do
-      context 'service provider with loa1' do
-        it 'returns true' do
-          user_decorator = UserDecorator.new(User.new)
-          session = { sp: { loa3: false } }
-
-          expect(user_decorator.should_acknowledge_personal_key?(session)).to eq true
-        end
-      end
-
-      context 'no service provider' do
-        it 'returns true' do
-          user_decorator = UserDecorator.new(User.new)
-          session = {}
-
-          expect(user_decorator.should_acknowledge_personal_key?(session)).to eq true
-        end
-      end
-
-      it 'returns false when the user has a personal key' do
-        user_decorator = UserDecorator.new(User.new(personal_key: 'foo'))
-        session = {}
-
-        expect(user_decorator.should_acknowledge_personal_key?(session)).to eq false
-      end
-
-      it 'returns false if the user is loa3' do
-        user_decorator = UserDecorator.new(User.new)
-        session = { sp: { loa3: true } }
-
-        expect(user_decorator.should_acknowledge_personal_key?(session)).to eq false
-      end
-    end
-  end
-
   describe '#recent_events' do
     let!(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
     let(:decorated_user) { user.decorate }

--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'LOA3 account creation' do
+  include IdvHelper
+  include SamlAuthHelper
+
+  it_behaves_like 'creating an LOA3 account using authenticator app for 2FA', :saml
+  it_behaves_like 'creating an LOA3 account using authenticator app for 2FA', :oidc
+end

--- a/spec/policies/personal_key_for_new_user_policy_spec.rb
+++ b/spec/policies/personal_key_for_new_user_policy_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe PersonalKeyForNewUserPolicy do
+  describe '#show_personal_key_after_initial_2fa_setup?' do
+    context 'user has no personal key and made LOA1 request' do
+      it 'returns true' do
+        user = User.new
+        session = { sp: { loa3: false } }
+        policy = PersonalKeyForNewUserPolicy.new(user: user, session: session)
+
+        expect(policy.show_personal_key_after_initial_2fa_setup?).to eq true
+      end
+    end
+
+    context 'user has no personal key and visited the site directly' do
+      it 'returns true' do
+        user = User.new
+        session = {}
+        policy = PersonalKeyForNewUserPolicy.new(user: user, session: session)
+
+        expect(policy.show_personal_key_after_initial_2fa_setup?).to eq true
+      end
+    end
+
+    context 'user has a personal key' do
+      it 'returns false' do
+        user = User.new(personal_key: 'foo')
+        session = {}
+        policy = PersonalKeyForNewUserPolicy.new(user: user, session: session)
+
+        expect(policy.show_personal_key_after_initial_2fa_setup?).to eq false
+      end
+    end
+
+    context 'user does not have a personal key and made an LOA3 request' do
+      it 'returns false' do
+        user = User.new
+        session = { sp: { loa3: true } }
+        policy = PersonalKeyForNewUserPolicy.new(user: user, session: session)
+
+        expect(policy.show_personal_key_after_initial_2fa_setup?).to eq false
+      end
+    end
+
+    context 'user has a personal key and made an LOA3 request' do
+      it 'returns false' do
+        user = User.new(personal_key: 'foo')
+        session = { sp: { loa3: true } }
+        policy = PersonalKeyForNewUserPolicy.new(user: user, session: session)
+
+        expect(policy.show_personal_key_after_initial_2fa_setup?).to eq false
+      end
+    end
+  end
+end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -394,7 +394,7 @@ module Features
 
     def confirm_email_and_password(email)
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      click_link t('sign_up.registrations.create_account')
+      find_link(t('sign_up.registrations.create_account')).click
       submit_form_with_valid_email(email)
       click_confirmation_link_in_email(email)
       submit_form_with_valid_password


### PR DESCRIPTION
**Why**: During LOA1 account creation, the user is given their personal
key after setting up 2FA. However, once an LOA3 user passes the
verification steps, and after they are prompted for their password in
order to encrypt their data, they must receive a new personal key.
In order to provide a better account creation experience for LOA3 users,
we only show them the personal key once, instead of once after 2FA
setup, and then again after verification.

This was working as expected for users who used a phone for 2FA, but the
logic for authentication app users was wrong.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
