### PR TITLE
LG-646 Add CBP I-94 SP

### DIFF
--- a/config/agencies.yml
+++ b/config/agencies.yml
@@ -1,6 +1,6 @@
 test:
   1:
-    name: 'CBP'
+    name: 'DHS'
   2:
     name: 'OPM'
   3:
@@ -12,7 +12,7 @@ test:
   6:
     name: 'DOT'
   7:
-    name: 'DHS'
+    name: 'USSS'
   8:
     name: 'DOD'
   9:
@@ -24,7 +24,7 @@ test:
 
 development:
   1:
-    name: 'CBP'
+    name: 'DHS'
   2:
     name: 'OPM'
   3:
@@ -48,7 +48,7 @@ development:
 
 production:
   1:
-    name: 'CBP'
+    name: 'DHS'
   2:
     name: 'OPM'
   3:

--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -779,3 +779,15 @@ production:
       - ssn
       - phone
     restrict_to_deploy_env: 'prod'
+
+  # CBP I-94
+  'urn:gov:dhs.cbp.pspd.i94:openidconnect:prod:app':
+    agency_id: 1
+    uuid_priority: 30
+    friendly_name: 'CBP I-94'
+    agency: 'DHS'
+    logo: 'cbp.png'
+    redirect_uris:
+      - 'gov.dhs.cbp.pspd.i94.user.prod://result'
+      - 'gov.dhs.cbp.pspd.i94.user.prod://result/logout'
+    restrict_to_deploy_env: 'prod'

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AgencySeeder do
 
     it 'inserts agencies in the proper order from agencies.yml' do
       run
-      expect(Agency.find_by(id: 1).name).to eq('CBP')
+      expect(Agency.find_by(id: 1).name).to eq('DHS')
       expect(Agency.find_by(id: 2).name).to eq('OPM')
       expect(Agency.find_by(id: 3).name).to eq('EOP')
     end
@@ -29,7 +29,7 @@ RSpec.describe AgencySeeder do
       it 'updates the attributes based on the current value of the yml file' do
         expect(Agency.find_by(id: 1).name).to eq('FOO')
         run
-        expect(Agency.find_by(id: 1).name).to eq('CBP')
+        expect(Agency.find_by(id: 1).name).to eq('DHS')
       end
     end
 

--- a/spec/services/link_agency_identities_spec.rb
+++ b/spec/services/link_agency_identities_spec.rb
@@ -45,7 +45,7 @@ describe LinkAgencyIdentities do
       create_identity(user, 'urn:gov:gsa:openidconnect:test', 'UUID2')
       LinkAgencyIdentities.new.link
       report = LinkAgencyIdentities.report
-      expect(report[0]['name']).to eq('CBP')
+      expect(report[0]['name']).to eq('DHS')
       expect(report[0]['old_uuid']).to eq('UUID2')
       expect(report[0]['new_uuid']).to eq('UUID1')
       expect(report.cmd_tuples).to eq(1)
@@ -56,7 +56,7 @@ describe LinkAgencyIdentities do
       create_identity(user, 'http://localhost:3000', 'UUID1')
       LinkAgencyIdentities.new.link
       report = LinkAgencyIdentities.report
-      expect(report[0]['name']).to eq('CBP')
+      expect(report[0]['name']).to eq('DHS')
       expect(report[0]['old_uuid']).to eq('UUID2')
       expect(report[0]['new_uuid']).to eq('UUID1')
       expect(report.cmd_tuples).to eq(1)


### PR DESCRIPTION
**Why**: The SP has completed integration testing and is ready to be promoted to production

**How**: Update the service_providers.yml file.  Fix agency naming issues (CBP should be DHS)

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
