### PR TITLE
LG-643 Add timeout to Twilio API calls

### DIFF
--- a/app/errors/twilio_errors.rb
+++ b/app/errors/twilio_errors.rb
@@ -4,6 +4,7 @@ module TwilioErrors
     21_211 => I18n.t('errors.messages.invalid_phone_number'),
     21_215 => I18n.t('errors.messages.invalid_calling_area'),
     21_614 => I18n.t('errors.messages.invalid_sms_number'),
+    4_815_162_342 => I18n.t('errors.messages.twilio_timeout'),
   }.freeze
 
   VERIFY_ERRORS = {

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -67,6 +67,7 @@ use_dashboard_service_providers: 'false'
 dashboard_url: 'https://dashboard.demo.login.gov'
 valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
 
+twilio_timeout: '5'
 usps_upload_sftp_timeout: '5'
 
 development:

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -49,6 +49,7 @@ Figaro.require_keys(
   'twilio_auth_token',
   'twilio_record_voice',
   'twilio_messaging_service_sid',
+  'twilio_timeout',
   'use_kms',
   'valid_authn_contexts'
 )

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -44,6 +44,7 @@ en:
       phone_unsupported: Sorry, we are unable to send SMS at this time. Please try
         the phone call option below, or use your personal key.
       twilio_inbound_sms_invalid: The inbound Twilio SMS message failed validation.
+      twilio_timeout: The server took too long to respond. Please try again.
       unauthorized_authn_context: Unauthorized authentication context
       unauthorized_nameid_format: Unauthorized nameID format
       unauthorized_service_provider: Unauthorized Service Provider

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -40,6 +40,7 @@ es:
       phone_unsupported: Lo sentimos, no podemos enviar SMS en este momento. Pruebe
         la opción de llamada telefónica a continuación o use su clave personal.
       twilio_inbound_sms_invalid: El mensaje de Twilio SMS de entrada falló la validación.
+      twilio_timeout: NOT TRANSLATED YET
       unauthorized_authn_context: Contexto de autenticación no autorizado
       unauthorized_nameid_format: NOT TRANSLATED YET
       unauthorized_service_provider: Proveedor de servicio no autorizado

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -42,6 +42,7 @@ fr:
         le moment. S'il vous plaît essayez l'option d'appel téléphonique ci-dessous,
         ou utilisez votre clé personnelle.
       twilio_inbound_sms_invalid: Le message SMS Twilio entrant a échoué à la validation.
+      twilio_timeout: NOT TRANSLATED YET
       unauthorized_authn_context: Contexte d'authentification non autorisé
       unauthorized_nameid_format: NOT TRANSLATED YET
       unauthorized_service_provider: Fournisseur de service non autorisé

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -5,7 +5,7 @@ class FakeSms
   cattr_accessor :messages
   self.messages = []
 
-  def initialize(_account_sid, _auth_token); end
+  def initialize(_username, _password, _account_sid, _region, _http_client); end
 
   def messages
     self

--- a/spec/support/fake_voice_call.rb
+++ b/spec/support/fake_voice_call.rb
@@ -4,7 +4,7 @@ class FakeVoiceCall
   cattr_accessor :calls
   self.calls = []
 
-  def initialize(_account_sid, _auth_token); end
+  def initialize(_username, _password, _account_sid, _region, _http_client); end
 
   def calls
     self


### PR DESCRIPTION
**Why**: It is a best practice — some might say a requirement — to add a
timeout to all network requests. Without a timeout, some requests could
tie up an app server for literally more than 15 minutes, as reported by
New Relic.

**How**:
- Define an `http_client` with a configurable timeout option and modify
the Twilio REST client to use this `http_client`
- Rescue the `Faraday::TimeoutError` in the Twilio service class, and
raise a custom Twilio error that the 2FA controller can process to
display a helpful message to the user and make it easier for them to try
again.

**How to test locally*:
- Run `bundle open twilio-ruby` to open the gem in your text editor
- In `lib/twilio-ruby/rest/api.rb` change the value of `@base_url` to
`'https://httpstat.us'`, and `@host` to `'httpstat.us'`
- In `lib/twilio-ruby/rest/api/v2010.rb`, change the value of `@version`
to an empty string
- In `lib/twilio-ruby/rest/api/v2010/account/message.rb`, on line 27,
change the value of `@uri` to `"/200"`. On line 120, replace the
`payload` with this:
```ruby
payload = @version.create(
              'GET',
              @uri,
              data: data,
              params: { sleep: '10000' }
          )
```
- Run `bundle list twilio-ruby` to get the path to the gem
- Copy the path of the gem and update the Gemfile to point to your local
gem: `gem 'twilio-ruby', path: [path_to_gem]`
- Run `bundle update twilio-ruby`
- In your local `application.yml`, set `telephony_disabled` to `'false'`
- Run `make run`
- Create an account and use your real phone number for 2FA (to minimize
the chances of spamming someone else's phone). You should see a flash
message saying the server took too long after you enter your phone
number.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.