### PR TITLE
Update Reek from 4.8.1 to 5.0.2

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,220 @@
+detectors:
+  Attribute:
+    enabled: false
+  ControlParameter:
+    exclude:
+      - CustomDeviseFailureApp#i18n_message
+      - OpenidConnectRedirector#initialize
+      - NoRetryJobs#call
+      - PhoneFormatter#self.format
+      - Users::TwoFactorAuthenticationController#invalid_phone_number
+  DuplicateMethodCall:
+    exclude:
+      - ApplicationController#disable_caching
+      - IdvFailureConcern#render_failure
+      - ServiceProviderSessionDecorator#registration_heading
+      - MfaConfirmationController#handle_invalid_password
+      - needs_to_confirm_email_change?
+      - WorkerHealthChecker#status
+      - UserFlowExporter#self.massage_assets
+      - BasicAuthUrl#build
+      - fallback_to_english
+      - Upaya::RandomTools#self.random_weighted_sample
+      - SmsController#authenticate
+  FeatureEnvy:
+    exclude:
+      - ActiveJob::Logging::LogSubscriber#json_for
+      - Ahoy::Store#track_event
+      - Aws::SES::Base#deliver
+      - CustomDeviseFailureApp#build_options
+      - CustomDeviseFailureApp#keys
+      - track_registration
+      - append_info_to_payload
+      - generate_slo_request
+      - reauthn?
+      - mark_profile_inactive
+      - EncryptedSidekiqRedis#zrem
+      - UserDecorator#should_acknowledge_personal_key?
+      - Pii::Attributes#[]=
+      - OpenidConnectLogoutForm#load_identity
+      - Idv::ProfileMaker#pii_from_applicant
+      - Idv::Step#vendor_validator_result
+      - IdvSession#vendor_result_timed_out?
+      - ServiceProviderSeeder#run
+      - OtpDeliverySelectionForm#unsupported_phone?
+      - fallback_to_english
+      - UserEncryptedAttributeOverrides#find_with_email
+      - Utf8Sanitizer#event_attributes
+      - Utf8Sanitizer#remote_ip
+      - TwoFactorAuthenticationController#capture_analytics_for_exception
+      - UspsConfirmationExporter#make_entry_row
+  InstanceVariableAssumption:
+    exclude:
+      - User
+      - JWT
+  IrresponsibleModule:
+    enabled: false
+  ManualDispatch:
+    exclude:
+      - EncryptedSidekiqRedis#respond_to_missing?
+      - CloudhsmKeyGenerator#initialize_settings
+  NestedIterators:
+    exclude:
+      - UserFlowExporter#self.massage_html
+      - TwilioService::Utils#sanitize_phone_number
+      - ServiceProviderSeeder#run
+      - UspsConfirmationUploader#upload_export
+  NilCheck:
+    enabled: false
+  LongParameterList:
+    max_params: 4
+    exclude:
+      - IdentityLinker#optional_attributes
+      - Idv::ProoferJob#perform
+      - Idv::VendorResult#initialize
+      - JWT
+      - SmsOtpSenderJob#perform
+  RepeatedConditional:
+    exclude:
+      - Users::ResetPasswordsController
+      - IdvController
+      - Idv::Base
+      - Rack::Attack
+  TooManyConstants:
+    exclude:
+      - Analytics
+  TooManyInstanceVariables:
+    exclude:
+      - OpenidConnectAuthorizeForm
+      - OpenidConnectRedirector
+      - Idv::VendorResult
+      - CloudhsmKeyGenerator
+      - CloudhsmKeySharer
+      - WebauthnSetupForm
+  TooManyStatements:
+    max_statements: 6
+    exclude:
+      - IdvFailureConcern#render_failure
+      - OpenidConnect::AuthorizationController#index
+      - OpenidConnect::AuthorizationController#store_request
+      - SamlIdpAuthConcern#store_saml_request
+      - Users::PhoneConfirmationController
+      - UserFlowExporter#self.massage_assets
+      - UserFlowExporter#self.massage_html
+      - UserFlowExporter#self.run
+      - Idv::Agent#proof
+      - Idv::VendorResult#initialize
+      - SamlIdpController#auth
+      - Upaya::QueueConfig#self.choose_queue_adapter
+      - Upaya::RandomTools#self.random_weighted_sample
+      - UserFlowFormatter#stop
+      - Upaya::QueueConfig#self.choose_queue_adapter
+      - Users::TwoFactorAuthenticationController#send_code
+  TooManyMethods:
+    exclude:
+      - Users::ConfirmationsController
+      - ApplicationController
+      - OpenidConnectAuthorizeForm
+      - OpenidConnect::AuthorizationController
+      - Idv::Session
+      - User
+      - Idv::SessionsController
+      - ServiceProviderSessionDecorator
+      - SessionDecorator
+      - HolidayService
+      - PhoneDeliveryPresenter
+      - CloudhsmKeyGenerator
+  UncommunicativeMethodName:
+    exclude:
+      - PhoneConfirmationFlow
+      - render_401
+      - SessionDecorator#registration_bullet_1
+      - ServiceProviderSessionDecorator#registration_bullet_1
+  UncommunicativeModuleName:
+    exclude:
+      - X509
+      - X509::Attribute
+      - X509::Attributes
+      - X509::SessionStore
+  UnusedParameters:
+    exclude:
+      - SmsOtpSenderJob#perform
+      - VoiceOtpSenderJob#perform
+  UnusedPrivateMethod:
+    exclude:
+      - ApplicationController
+      - ActiveJob::Logging::LogSubscriber
+      - SamlIdpController
+      - Users::PhoneConfirmationController
+      - ssn_is_unique
+  UtilityFunction:
+    public_methods_only: true
+    exclude:
+      - AnalyticsEventJob#perform
+      - ApplicationController#default_url_options
+      - ApplicationHelper#step_class
+      - NullTwilioClient#http_client
+      - PersonalKeyFormatter#regexp
+      - SessionTimeoutWarningHelper#frequency
+      - SessionTimeoutWarningHelper#start
+      - SessionTimeoutWarningHelper#warning
+      - SessionDecorator
+      - WorkerHealthChecker::Middleware#call
+      - UserEncryptedAttributeOverrides#create_fingerprint
+      - LocaleHelper#locale_url_param
+      - IdvSession#timed_out_vendor_error
+      - JWT::Signature#sign
+      - SmsAccountResetCancellationNotifierJob#perform
+directories:
+  'app/controllers':
+    InstanceVariableAssumption:
+      enabled: false
+  'spec':
+    BooleanParameter:
+      exclude:
+       - SamlAuthHelper#generate_saml_response
+    ControlParameter:
+      exclude:
+        - complete_idv_session
+        - SamlAuthHelper#link_user_to_identity
+        - visit_idp_from_sp_with_loa1
+        - visit_idp_from_sp_with_loa3
+    DuplicateMethodCall:
+      enabled: false
+    FeatureEnvy:
+      enabled: false
+    NestedIterators:
+      exclude:
+        - complete_idv_questions_fail
+        - complete_idv_questions_ok
+        - create_sidekiq_queues
+    NilCheck:
+      exclude:
+        - complete_idv_questions_fail
+        - complete_idv_questions_ok
+    TooManyInstanceVariables:
+      enabled: false
+    TooManyMethods:
+      enabled: false
+    TooManyStatements:
+      enabled: false
+    UncommunicativeMethodName:
+      exclude:
+        - visit_idp_from_sp_with_loa1
+        - visit_idp_from_sp_with_loa3
+        - visit_idp_from_mobile_app_with_loa1
+        - visit_idp_from_oidc_sp_with_loa1
+        - visit_idp_from_oidc_sp_with_loa3
+    UncommunicativeParameterName:
+      exclude:
+        - begin_sign_up_with_sp_and_loa
+    UncommunicativeVariableName:
+      exclude:
+        - complete_idv_questions_fail
+        - complete_idv_questions_ok
+    UtilityFunction:
+      enabled: false
+exclude_paths:
+  - db/migrate
+  - spec
+  - lib/tasks/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,7 @@ GEM
     jwt (2.1.0)
     knapsack (1.16.0)
       rake
+    kwalify (0.7.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -452,9 +453,10 @@ GEM
     recaptcha (4.12.0)
       json
     redis (3.3.5)
-    reek (4.8.1)
+    reek (5.0.2)
       codeclimate-engine-rb (~> 0.4.0)
-      parser (>= 2.5.0.0, < 2.6)
+      kwalify (~> 0.7.0)
+      parser (>= 2.5.0.0, < 2.6, != 2.5.1.1)
       rainbow (>= 2.0, < 4.0)
     referer-parser (0.3.0)
     request_store (1.4.1)


### PR DESCRIPTION
See upgrade guide for more info:
https://github.com/troessner/reek/blob/master/docs/Reek-4-to-Reek-5-migration.md

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
