### PR TITLE
LG-599 LG-603 Allow webauthn at account creation. Allow webauthn for 2FA.

### DIFF
--- a/.reek
+++ b/.reek
@@ -90,6 +90,7 @@ TooManyInstanceVariables:
     - CloudhsmKeyGenerator
     - CloudhsmKeySharer
     - WebauthnSetupForm
+    - WebauthnVerificationForm
 TooManyStatements:
   max_statements: 6
   exclude:

--- a/.reek.yml
+++ b/.reek.yml
@@ -91,6 +91,7 @@ detectors:
       - CloudhsmKeyGenerator
       - CloudhsmKeySharer
       - WebauthnSetupForm
+      - WebauthnVerificationForm
   TooManyStatements:
     max_statements: 6
     exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,7 @@ Metrics/ClassLength:
   - app/controllers/users/two_factor_authentication_controller.rb
   - app/decorators/service_provider_session_decorator.rb
   - app/decorators/user_decorator.rb
+  - app/models/user.rb
   - app/services/analytics.rb
   - app/services/idv/session.rb
   - app/presenters/two_factor_auth_code/phone_delivery_presenter.rb

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -34,6 +34,7 @@ module TwoFactorAuthentication
         'sms' => otp_send_url(otp_delivery_selection_form: { otp_delivery_preference: 'sms' }),
         'auth_app' => login_two_factor_authenticator_url,
         'piv_cac' => login_two_factor_piv_cac_url,
+        'webauthn' => login_two_factor_webauthn_url,
       }
       url = factor_to_url[@two_factor_options_form.selection]
       redirect_to url if url

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     end
 
     def confirm_webauthn_enabled
-      return if current_user.webauthn_configurations.any?
+      return if current_user.webauthn_enabled?
 
       redirect_to user_two_factor_authentication_url
     end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -1,0 +1,69 @@
+module TwoFactorAuthentication
+  # The WebauthnVerificationController class is responsible webauthn verification at sign in
+  class WebauthnVerificationController < ApplicationController
+    include TwoFactorAuthenticatable
+
+    before_action :confirm_webauthn_enabled, only: :show
+
+    def show
+      save_challenge_in_session
+      @presenter = presenter_for_two_factor_authentication_method
+    end
+
+    def confirm
+      result = form.submit(request.protocol, params)
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH, result.to_h.merge(analytics_properties))
+      if result.success?
+        handle_valid_webauthn
+      else
+        handle_invalid_webauthn
+      end
+    end
+
+    private
+
+    def handle_valid_webauthn
+      handle_valid_otp_for_authentication_context
+      redirect_to after_otp_verification_confirmation_url
+      reset_otp_session_data
+    end
+
+    def handle_invalid_webauthn
+      flash[:error] = t('errors.invalid_authenticity_token')
+      redirect_to login_two_factor_webauthn_url
+    end
+
+    def confirm_webauthn_enabled
+      return if current_user.webauthn_configurations.any?
+
+      redirect_to user_two_factor_authentication_url
+    end
+
+    def presenter_for_two_factor_authentication_method
+      TwoFactorAuthCode::WebauthnAuthenticationPresenter.new(
+        view: view_context,
+        data: { credential_ids: credential_ids }
+      )
+    end
+
+    def save_challenge_in_session
+      credential_creation_options = ::WebAuthn.credential_request_options
+      user_session[:webauthn_challenge] = credential_creation_options[:challenge].bytes.to_a
+    end
+
+    def credential_ids
+      current_user.webauthn_configurations.map(&:credential_id).join(',')
+    end
+
+    def analytics_properties
+      {
+        context: context,
+        multi_factor_auth_method: 'webauthn',
+      }
+    end
+
+    def form
+      WebauthnVerificationForm.new(current_user, user_session)
+    end
+  end
+end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -202,8 +202,6 @@ module Users
         redirect_to login_two_factor_webauthn_url
       elsif current_user.totp_enabled?
         redirect_to login_two_factor_authenticator_url
-      else
-        false
       end
     end
   end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -4,21 +4,13 @@ module Users
 
     before_action :check_remember_device_preference
 
-    # rubocop:disable Metrics/MethodLength
     def show
-      if current_user.piv_cac_enabled?
-        redirect_to login_two_factor_piv_cac_url
-      elsif current_user.totp_enabled?
-        redirect_to login_two_factor_authenticator_url
-      elsif phone_enabled?
-        validate_otp_delivery_preference_and_send_code
-      else
-        redirect_to two_factor_options_url
-      end
+      return if redirect_on_non_phone_enabled
+      return if redirect_on_phone_enabled
+      redirect_to two_factor_options_url
     rescue Twilio::REST::RestError, PhoneVerification::VerifyError => exception
       invalid_phone_number(exception, action: 'show')
     end
-    # rubocop:enable Metrics/MethodLength
 
     def send_code
       result = otp_delivery_selection_form.submit(delivery_params)
@@ -193,6 +185,24 @@ module Users
 
     def otp_rate_limiter
       @_otp_rate_limited ||= OtpRateLimiter.new(phone: phone_to_deliver_to, user: current_user)
+    end
+
+    def redirect_on_phone_enabled
+      return unless phone_enabled?
+      validate_otp_delivery_preference_and_send_code
+      true
+    end
+
+    def redirect_on_non_phone_enabled
+      if current_user.piv_cac_enabled?
+        redirect_to login_two_factor_piv_cac_url
+      elsif current_user.webauthn_configurations.any?
+        redirect_to login_two_factor_webauthn_url
+      elsif current_user.totp_enabled?
+        redirect_to login_two_factor_authenticator_url
+      else
+        false
+      end
     end
   end
 end

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -39,6 +39,8 @@ module Users
         redirect_to authenticator_setup_url
       when 'piv_cac'
         redirect_to setup_piv_cac_url
+      when 'webauthn'
+        redirect_to webauthn_setup_url
       end
     end
 

--- a/app/forms/two_factor_login_options_form.rb
+++ b/app/forms/two_factor_login_options_form.rb
@@ -3,7 +3,7 @@ class TwoFactorLoginOptionsForm
 
   attr_reader :selection
 
-  validates :selection, inclusion: { in: %w[voice sms auth_app piv_cac personal_key] }
+  validates :selection, inclusion: { in: %w[voice sms auth_app piv_cac personal_key webauthn] }
 
   def initialize(user)
     self.user = user

--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -3,7 +3,7 @@ class TwoFactorOptionsForm
 
   attr_reader :selection
 
-  validates :selection, inclusion: { in: %w[voice sms auth_app piv_cac] }
+  validates :selection, inclusion: { in: %w[voice sms auth_app piv_cac webauthn] }
 
   def initialize(user)
     self.user = user

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -1,0 +1,65 @@
+# The WebauthnVerificationForm class is responsible for validating webauthn verification input
+class WebauthnVerificationForm
+  include ActiveModel::Model
+
+  validates :user, presence: true
+  validates :challenge, presence: true
+  validates :authenticator_data, presence: true
+  validates :client_data_json, presence: true
+  validates :signature, presence: true
+
+  def initialize(user, user_session)
+    @user = user
+    @challenge = user_session[:webauthn_challenge]
+    @authenticator_data = nil
+    @client_data_json = nil
+    @signature = nil
+    @credential_id = nil
+  end
+
+  def submit(protocol, params)
+    consume_parameters(params)
+    success = valid? && valid_assertion_response?(protocol)
+    FormResponse.new(success: success, errors: errors.messages)
+  end
+
+  # this gives us a hook to override the domain embedded in the attestation test object
+  def self.domain_name
+    Figaro.env.domain_name
+  end
+
+  private
+
+  attr_reader :success, :user, :challenge, :authenticator_data, :client_data_json, :signature
+
+  def consume_parameters(params)
+    @authenticator_data = params[:authenticator_data]
+    @client_data_json = params[:client_data_json]
+    @signature = params[:signature]
+    @credential_id = params[:credential_id]
+  end
+
+  def valid_assertion_response?(protocol)
+    assertion_response = ::WebAuthn::AuthenticatorAssertionResponse.new(
+      authenticator_data: Base64.decode64(@authenticator_data),
+      client_data_json: Base64.decode64(@client_data_json),
+      signature: Base64.decode64(@signature),
+      credential_id: Base64.decode64(@credential_id)
+    )
+    original_origin = "#{protocol}#{self.class.domain_name}"
+    assertion_response.valid?(@challenge.pack('c*'), original_origin,
+                              allowed_credential: allowed_credential)
+  end
+
+  def allowed_credential
+    {
+      id: Base64.decode64(@credential_id),
+      public_key: Base64.decode64(public_key),
+    }
+  end
+
+  def public_key
+    WebauthnConfiguration.
+      where(user_id: user.id, credential_id: @credential_id).first.credential_public_key
+  end
+end

--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -1,0 +1,47 @@
+function webauthn() {
+  const base64ToArrayBuffer = function(base64) {
+    const binaryString = window.atob(base64);
+    const len = binaryString.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i += 1) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes.buffer;
+  };
+  const arrayBufferToBase64 = function(buffer) {
+    let binary = '';
+    const bytes = new Uint8Array(buffer);
+    const len = bytes.byteLength;
+    for (let i = 0; i < len; i += 1) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return window.btoa(binary);
+  };
+  const challengeBytes = new Uint8Array(JSON.parse(document.getElementById('user_challenge').value));
+  let credentialIds = document.getElementById('credential_ids').value;
+  credentialIds = credentialIds.split(',');
+  const allowCredentials2 = [];
+  credentialIds.forEach(function(credentialId) {
+    allowCredentials2.push({
+      type: 'public-key',
+      id: base64ToArrayBuffer(credentialId),
+    });
+  });
+  const getOptions = {
+    publicKey: {
+      challenge: challengeBytes,
+      rpId: window.location.hostname,
+      allowCredentials: allowCredentials2,
+      timeout: 800000,
+    },
+  };
+  const p = navigator.credentials.get(getOptions);
+  p.then((newCred) => {
+    document.getElementById('credential_id').value = arrayBufferToBase64(newCred.rawId);
+    document.getElementById('authenticator_data').value = arrayBufferToBase64(newCred.response.authenticatorData);
+    document.getElementById('client_data_json').value = arrayBufferToBase64(newCred.response.clientDataJSON);
+    document.getElementById('signature').value = arrayBufferToBase64(newCred.response.signature);
+    document.getElementById('webauthn_form').submit();
+  });
+}
+document.addEventListener('DOMContentLoaded', webauthn);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
 
   def two_factor_enabled?
     phone_configurations.any?(&:mfa_enabled?) || totp_enabled? || piv_cac_enabled? ||
-      webauthn_configurations.any?
+      webauthn_enabled?
   end
 
   def send_two_factor_authentication_code(_code)
@@ -168,6 +168,10 @@ class User < ApplicationRecord
 
   def phone_mfa_enabled?
     phone_configurations.any?(&:mfa_enabled?)
+  end
+
+  def webauthn_enabled?
+    WebauthnLoginOptionPolicy.new(self).configured?
   end
 end
 # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/app/policies/webauthn_login_option_policy.rb
+++ b/app/policies/webauthn_login_option_policy.rb
@@ -1,0 +1,14 @@
+# The WebauthnLoginOptionPolicy class is responsible for handling the user policy of webauthn
+class WebauthnLoginOptionPolicy
+  def initialize(user)
+    @user = user
+  end
+
+  def configured?
+    FeatureManagement.webauthn_enabled? && user.webauthn_configurations.any?
+  end
+
+  private
+
+  attr_reader :user
+end

--- a/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
@@ -1,0 +1,26 @@
+module TwoFactorAuthCode
+  # The WebauthnAuthenticationPresenter class is the presenter for webauthn verification
+  class WebauthnAuthenticationPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::TranslationHelper
+
+    attr_reader :credential_ids
+
+    def help_text
+      ''
+    end
+
+    def cancel_link
+      locale = LinkLocaleResolver.locale
+      if reauthn
+        account_path(locale: locale)
+      else
+        sign_out_path(locale: locale)
+      end
+    end
+
+    def fallback_question
+      t('two_factor_authentication.webauthn_fallback.question')
+    end
+  end
+end

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -1,13 +1,14 @@
 class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
   include ActionView::Helpers::TranslationHelper
 
-  POSSIBLE_OPTIONS = %i[sms voice auth_app piv_cac personal_key].freeze
+  POSSIBLE_OPTIONS = %i[sms voice auth_app piv_cac personal_key webauthn].freeze
   POLICIES = {
     sms: SmsLoginOptionPolicy,
     voice: VoiceLoginOptionPolicy,
     auth_app: AuthAppLoginOptionPolicy,
     piv_cac: PivCacLoginOptionPolicy,
     personal_key: PersonalKeyLoginOptionPolicy,
+    webauthn: WebauthnLoginOptionPolicy,
   }.freeze
 
   attr_reader :current_user

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -38,7 +38,7 @@ class TwoFactorOptionsPresenter
   private
 
   def available_2fa_types
-    %w[sms voice auth_app] + piv_cac_if_available
+    %w[sms voice auth_app webauthn] + piv_cac_if_available
   end
 
   def piv_cac_if_available

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.slim
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.slim
@@ -1,0 +1,39 @@
+- title t('titles.present_webauthn')
+
+h1.h3.my0 = t('devise.two_factor_authentication.webauthn_header_text')
+.no-spinner
+  p.mt-tiny.mb3 = t('instructions.mfa.webauthn.confirm_webauthn_html')
+
+ul.list-reset
+  li.py2.border-top
+    .mr1.inline-block.circle.circle-number.bg-blue.white
+      | 1
+    .inline.bold = t('forms.webauthn_setup.step_1')
+  li.py2.border-top
+    .mb2
+      .mr1.inline-block.circle.circle-number.bg-blue.white
+        | 2
+      .inline.bold = t('forms.webauthn_setup.step_2')
+    .sm-col-9.sm-ml-28p
+      = form_tag(login_two_factor_webauthn_path, method: :patch, role: 'form', class: 'mb1',
+        id: 'webauthn_form') do
+        = hidden_field_tag :user_challenge,
+          '[' + user_session[:webauthn_challenge].split.join(',') + ']', id: 'user_challenge'
+        = hidden_field_tag :credential_ids, @presenter.credential_ids, id: 'credential_ids'
+        = hidden_field_tag :credential_id, '', id: 'credential_id'
+        = hidden_field_tag :authenticator_data, '', id: 'authenticator_data'
+        = hidden_field_tag :signature, '', id: 'signature'
+        = hidden_field_tag :client_data_json, '', id: 'client_data_json'
+.spinner[id='spinner']
+  div
+    = image_tag(asset_url('spinner.gif'),
+            srcset: asset_url('spinner@2x.gif'),
+            height: 144,
+            width: 144,
+            alt: '')
+
+= render 'shared/fallback_links', presenter: @presenter
+= render 'shared/cancel', link: @presenter.cancel_link
+
+== javascript_pack_tag 'clipboard'
+== javascript_pack_tag 'webauthn-authenticate'

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -136,3 +136,6 @@ en:
         sms_info: Get your security code via text message / SMS
         voice: Phone call
         voice_info: Get your security code via phone call
+        webauthn: Hardware security key
+        webauthn_info: Use a hardware security key to secure your account
+      webauthn_header_text: Present your hardware security key

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -135,3 +135,6 @@ es:
         sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS
         voice: Llamada telefónica
         voice_info: Obtenga su código de seguridad a través de una llamada telefónica
+        webauthn: Clave de seguridad de hardware
+        webauthn_info: Use una clave de seguridad de hardware para proteger su cuenta
+      webauthn_header_text: Presente su clave de seguridad de hardware

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -144,3 +144,7 @@ fr:
         sms_info: Obtenez votre code de sécurité par SMS
         voice: Appel téléphonique
         voice_info: Obtenez votre code de sécurité par appel téléphonique
+        webauthn: Clé de sécurité matérielle
+        webauthn_info: Utilisez une clé de sécurité matérielle pour sécuriser votre
+          compte
+      webauthn_header_text: Présentez votre clé de sécurité matérielle

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -36,6 +36,9 @@ en:
       voice:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         number_message: We just called you at %{number}.
+      webauthn:
+        confirm_webauthn_html: Present the hardware security key that you associated
+          with your account.
       wrong_number_html: Entered the wrong phone number? %{link}
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -37,6 +37,9 @@ es:
       voice:
         confirm_code_html: "¿Desea que le llamemos de nuevo? %{resend_code_link}"
         number_message: Acabamos de llamarte en %{number}.
+      webauthn:
+        confirm_webauthn_html: Presente la clave de seguridad de hardware que ha asociado
+          con su cuenta.
       wrong_number_html: "¿Ingresó el número de teléfono equivocado? %{link}"
     password:
       forgot: "¿No sabe su contraseña? Restablézcala después de confirmar su email."

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -39,6 +39,9 @@ fr:
       voice:
         confirm_code_html: Vous voulez que nous vous appelions de nouveau? %{resend_code_link}
         number_message: Nous venons de vous appeler à %{number}.
+      webauthn:
+        confirm_webauthn_html: Présentez la clé de sécurité matérielle associée à
+          votre compte.
       wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -36,6 +36,7 @@ en:
         invalid: PIV/CAC certificate error
         missing: Internal error
     present_piv_cac: Present your PIV/CAC
+    present_webauthn: Present your hardware security key
     reactivate_account: Reactivate your account
     registrations:
       new: Sign up for a account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -36,6 +36,7 @@ es:
         invalid: NOT TRANSLATED YET
         missing: NOT TRANSLATED YET
     present_piv_cac: NOT TRANSLATED YET
+    present_webauthn: Presente su clave de seguridad de hardware
     reactivate_account: Reactive su cuenta
     registrations:
       new: Regístrese para una cuenta

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -36,6 +36,7 @@ fr:
         invalid: NOT TRANSLATED YET
         missing: NOT TRANSLATED YET
     present_piv_cac: NOT TRANSLATED YET
+    present_webauthn: Présentez votre clé de sécurité matérielle
     reactivate_account: Réactiver le profil
     registrations:
       new: S'inscrire et créer un compte

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -15,6 +15,8 @@ en:
       sms_info: Get security code via text message.
       voice: Automated phone call
       voice_info: Get security code via phone call (North America phone numbers only).
+      webauthn: Hardware security key
+      webauthn_info: Use your hardware security key instead of a security code.
     login_options_link_text: Choose another security option
     login_options_title: Select your security option
     personal_key_fallback:
@@ -25,3 +27,5 @@ en:
       question: Don't have your piv/cac card available?
     totp_fallback:
       question: Don't have your authenticator app?
+    webauthn_fallback:
+      question: Don't have your hardware security key available?

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -17,6 +17,9 @@ es:
       voice: Llamada telefónica automatizada
       voice_info: Obtenga su código de seguridad a través de una llamada telefónica.
         (Solo números de teléfono de América del Norte).
+      webauthn: Clave de seguridad de hardware
+      webauthn_info: Use su clave de seguridad de hardware en lugar de un código de
+        seguridad.
     login_options_link_text: Elige otra opción de seguridad
     login_options_title: Seleccione su opción de seguridad
     personal_key_fallback:
@@ -27,3 +30,5 @@ es:
       question: "¿No tiene su tarjeta PIV/CAC disponible?"
     totp_fallback:
       question: "¿No tiene su aplicación de autenticación?"
+    webauthn_fallback:
+      question: "¿No tienes tu clave de seguridad de hardware disponible?"

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -17,6 +17,9 @@ fr:
       voice: Appel téléphonique
       voice_info: Obtenez votre code de sécurité par appel téléphonique. (Seulement
         les numéros de téléphone en Amerique du Nord)
+      webauthn: Clé de sécurité matérielle
+      webauthn_info: Utilisez votre clé de sécurité matérielle au lieu d'un code de
+        sécurité.
     login_options_link_text: Choisissez une autre option de sécurité
     login_options_title: Sélectionnez votre option de sécurité
     personal_key_fallback:
@@ -27,3 +30,5 @@ fr:
       question: Vous n'avez pas accès à votre carte PIV/CAC?
     totp_fallback:
       question: Vous n'avez pas votre application d'authentification?
+    webauthn_fallback:
+      question: Votre clé de sécurité matérielle n'est pas disponible?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,10 @@ Rails.application.routes.draw do
       if FeatureManagement.piv_cac_enabled?
         get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
       end
+      if FeatureManagement.webauthn_enabled?
+        get '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#show'
+        patch '/login/two_factor/webauthn' => 'two_factor_authentication/webauthn_verification#confirm'
+      end
       get  '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#show',
            as: :login_two_factor, constraints: { otp_delivery_preference: /sms|voice/ }
       post '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#create',

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -52,6 +52,12 @@ describe TwoFactorAuthentication::OptionsController do
       expect(response).to redirect_to login_two_factor_authenticator_url
     end
 
+    it 'redirects to login_two_factor_webauthn_url if user selects webauthn' do
+      post :create, params: { two_factor_options_form: { selection: 'webauthn' } }
+
+      expect(response).to redirect_to login_two_factor_webauthn_url
+    end
+
     it 'rerenders the page with errors on failure' do
       post :create, params: { two_factor_options_form: { selection: 'foo' } }
 

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe TwoFactorAuthentication::WebauthnVerificationController do
+  include WebauthnVerificationHelper
+
+  describe 'before_actions' do
+    it 'includes appropriate before_actions' do
+      expect(subject).to have_actions(:before, :confirm_webauthn_enabled)
+    end
+  end
+
+  describe 'when not signed in' do
+    describe 'GET show' do
+      it 'redirects to root url' do
+        get :show
+
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    describe 'patch confirm' do
+      it 'redirects to root url' do
+        patch :confirm
+
+        expect(response).to redirect_to(root_url)
+      end
+    end
+  end
+
+  describe 'when signed in before 2fa' do
+    before do
+      stub_analytics
+      sign_in_before_2fa
+    end
+
+    describe 'GET show' do
+      it 'saves challenge in session and renders show' do
+        create_webauthn_configuration(controller.current_user)
+        get :show
+
+        expect(subject.user_session[:webauthn_challenge].length).to eq(16)
+        expect(response).to render_template(:show)
+      end
+
+      it 'redirects if no webauthn configured' do
+        get :show
+
+        expect(response).to redirect_to(user_two_factor_authentication_url)
+      end
+    end
+
+    describe 'patch confirm' do
+      let(:params) do
+        {
+          authenticator_data: authenticator_data,
+          client_data_json: client_data_json,
+          signature: signature,
+          credential_id: credential_id,
+        }
+      end
+      before do
+        controller.user_session[:webauthn_challenge] = challenge
+        create_webauthn_configuration(controller.current_user)
+      end
+
+      it 'processes an invalid webauthn' do
+        # the wrong domain name is embedded in the assertion test data
+        patch :confirm, params: params
+
+        expect(response).to redirect_to(login_two_factor_webauthn_url)
+      end
+
+      it 'processes a valid webauthn' do
+        allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
+        patch :confirm, params: params
+
+        expect(response).to redirect_to(account_url)
+      end
+
+      it 'tracks the submission' do
+        allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
+        result = { context: 'authentication', errors: {}, multi_factor_auth_method: 'webauthn',
+                   success: true }
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::MULTI_FACTOR_AUTH, result)
+
+        patch :confirm, params: params
+      end
+    end
+  end
+end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -89,6 +89,16 @@ describe Users::TwoFactorAuthenticationController do
       end
     end
 
+    context 'when user is webauthn enabled' do
+      it 'renders the :webauthn view' do
+        stub_sign_in_before_2fa(build(:user))
+        allow(subject.current_user).to receive(:webauthn_enabled?).and_return(true)
+        get :show
+
+        expect(response).to redirect_to login_two_factor_webauthn_path
+      end
+    end
+
     context 'when there is no session (signed out or locked out), and the user reloads the page' do
       it 'redirects to the home page' do
         expect(controller.user_session).to be_nil

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -138,6 +138,20 @@ describe Users::TwoFactorAuthenticationSetupController do
       end
     end
 
+    context 'when the selection is webauthn' do
+      it 'redirects to webauthn setup page' do
+        stub_sign_in_before_2fa
+
+        patch :create, params: {
+          two_factor_options_form: {
+            selection: 'webauthn',
+          },
+        }
+
+        expect(response).to redirect_to webauthn_setup_url
+      end
+    end
+
     context 'when the selection is piv_cac' do
       it 'redirects to piv/cac setup page' do
         stub_sign_in_before_2fa

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -34,7 +34,8 @@ describe Users::WebauthnSetupController do
   describe 'when signed in' do
     before do
       stub_analytics
-      stub_sign_in
+      user = build(:user, personal_key: 'ABCD-DEFG-HIJK-LMNO')
+      stub_sign_in(user)
     end
 
     describe 'GET new' do

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -31,7 +31,7 @@ describe Users::WebauthnSetupController do
     end
   end
 
-  describe 'when signed in' do
+  describe 'when signed in and not account creation' do
     before do
       stub_analytics
       user = build(:user, personal_key: 'ABCD-DEFG-HIJK-LMNO')
@@ -68,7 +68,7 @@ describe Users::WebauthnSetupController do
         controller.user_session[:webauthn_challenge] = challenge
       end
 
-      it 'processes a valid webauthn' do
+      it 'processes a valid webauthn and redirects to account page' do
         patch :confirm, params: params
 
         expect(response).to redirect_to(account_url)
@@ -105,6 +105,33 @@ describe Users::WebauthnSetupController do
         expect(@analytics).to receive(:track_event).with(Analytics::WEBAUTHN_DELETED, result)
 
         delete :delete, params: { id: cfg.id }
+      end
+    end
+  end
+
+  describe 'when signed in and account creation' do
+    before do
+      user = build(:user)
+      stub_sign_in(user)
+    end
+
+    describe 'patch confirm' do
+      let(:params) do
+        {
+          attestation_object: attestation_object,
+          client_data_json: client_data_json,
+          name: 'mykey',
+        }
+      end
+      before do
+        allow(Figaro.env).to receive(:domain_name).and_return('localhost:3000')
+        controller.user_session[:webauthn_challenge] = challenge
+      end
+
+      it 'processes a valid webauthn and redirects to personal key page' do
+        patch :confirm, params: params
+
+        expect(response).to redirect_to(sign_up_personal_key_url)
       end
     end
   end

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe WebauthnVerificationForm do
+  include WebauthnVerificationHelper
+
+  let(:user) { create(:user) }
+  let(:user_session) { { webauthn_challenge: challenge } }
+  let(:subject) { WebauthnVerificationForm.new(user, user_session) }
+
+  describe '#submit' do
+    before do
+      create_webauthn_configuration(user)
+    end
+    context 'when the input is valid' do
+      it 'returns FormResponse with success: true' do
+        allow(Figaro.env).to receive(:domain_name).and_return('localhost:3000')
+        result = instance_double(FormResponse)
+        params = {
+          authenticator_data: authenticator_data,
+          client_data_json: client_data_json,
+          signature: signature,
+          credential_id: credential_id,
+        }
+        expect(FormResponse).to receive(:new).
+          with(success: true, errors: {}).and_return(result)
+        expect(subject.submit(protocol, params)).to eq result
+      end
+    end
+
+    context 'when the input is invalid' do
+      it 'returns FormResponse with success: false' do
+        result = instance_double(FormResponse)
+        params = {
+          authenticator_data: authenticator_data,
+          client_data_json: client_data_json,
+          signature: signature,
+          credential_id: credential_id,
+        }
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: {}).and_return(result)
+        expect(subject.submit(protocol, params)).to eq result
+      end
+    end
+  end
+end

--- a/spec/policies/webauthn_login_option_policy_spec.rb
+++ b/spec/policies/webauthn_login_option_policy_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe WebauthnLoginOptionPolicy do
+  include WebauthnVerificationHelper
+
+  let(:subject) { described_class.new(user) }
+
+  describe '#configured?' do
+    context 'without a webauthn configured' do
+      let(:user) { build(:user) }
+
+      it { expect(subject.configured?).to be_falsey }
+    end
+
+    context 'with a webauthn configured' do
+      let(:user) { create(:user) }
+      before do
+        create_webauthn_configuration(user)
+      end
+
+      it 'returns a truthy value' do
+        expect(subject.configured?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
+  include Rails.application.routes.url_helpers
+
+  let(:view) { ActionController::Base.new.view_context }
+  let(:reauthn) {}
+  let(:presenter) do
+    TwoFactorAuthCode::WebauthnAuthenticationPresenter.
+      new(data: { reauthn: reauthn }, view: view)
+  end
+
+  describe '#help_text' do
+    it 'supplies no help text' do
+      expect(presenter.help_text).to eq('')
+    end
+  end
+
+  describe '#fallback_question' do
+    it 'supplies a fallback_question' do
+      expect(presenter.fallback_question).to \
+        eq(t('two_factor_authentication.webauthn_fallback.question'))
+    end
+  end
+
+  describe '#cancel_link' do
+    let(:locale) { LinkLocaleResolver.locale }
+
+    context 'reauthn' do
+      let(:reauthn) { true }
+
+      it 'returns the account path' do
+        expect(presenter.cancel_link).to eq account_path(locale: locale)
+      end
+    end
+
+    context 'not reauthn' do
+      let(:reauthn) { false }
+
+      it 'returns the sign out path' do
+        expect(presenter.cancel_link).to eq sign_out_path(locale: locale)
+      end
+    end
+  end
+
+  it 'handles multiple locales' do
+    I18n.available_locales.each do |locale|
+      I18n.locale = locale
+      if locale == :en
+        expect(presenter.cancel_link).not_to match(%r{/en/})
+      else
+        expect(presenter.cancel_link).to match(%r{/#{locale}/})
+      end
+    end
+  end
+end

--- a/spec/support/features/webauth_verification_helper.rb
+++ b/spec/support/features/webauth_verification_helper.rb
@@ -1,0 +1,44 @@
+module WebauthnVerificationHelper
+  def protocol
+    'http://'
+  end
+
+  def challenge
+    [152, 207, 129, 117, 183, 199, 18, 19, 51, 104, 207, 109, 12, 50, 143, 155]
+  end
+
+  def credential_ids
+    '60Aa7rKEJJEkqDM0flq4NoNu3L/ZpZfamNbScSG+I9AZnV3efKCyRNXK78lRxuqmxmfa87fwrrS1+5PJvJdG0A=='
+  end
+
+  def credential_id
+    '60Aa7rKEJJEkqDM0flq4NoNu3L/ZpZfamNbScSG+I9AZnV3efKCyRNXK78lRxuqmxmfa87fwrrS1+5PJvJdG0A=='
+  end
+
+  def authenticator_data
+    'SZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2MBAAAAJg=='
+  end
+
+  def signature
+    'MEUCIQDlEB4VUN/X15N/Jmgx4ACbOlLLHRRcKsBkejpdQj81vQIgIo97sxdpP/hZgQpIXJMa3cBnAzcnfw+1CJ2LP3VvOg\
+4='
+  end
+
+  def client_data_json
+    'eyJjaGFsbGVuZ2UiOiJtTS1CZGJmSEVoTXphTTl0RERLUG13Iiwib3JpZ2luIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwI\
+iwidHlwZSI6IndlYmF1dGhuLmdldCJ9'
+  end
+
+  def public_key
+    'BBWEWPFKW60xPIcf/U098QEsiB3wUmJm9TN+bU1d5Y9noAnfr412Wu3KOrX0uhy/t14t4aFuUfNu054zkKVhQDM='
+  end
+
+  def create_webauthn_configuration(user)
+    WebauthnConfiguration.create(
+      user_id: user.id,
+      credential_id: credential_id,
+      credential_public_key: public_key,
+      name: 'foo'
+    )
+  end
+end


### PR DESCRIPTION
Why: So we can support strong authentication via hardware security keys as a new 2FA option

How: Generate a challenge on the server side and present the browser with a list of credentials that are registered to the user. Use the Credential Manager API (navigator.credentials.get) to ask the browser to sign the challenge if the authenticator contains one of the given credentials and the user gives consent.  The web page then automatically submits the form with the signed assertion for the server to verify. Use the webauthn gem to verify the assertion response. Upon success the user is authenticated.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
