### PR TITLE
[LG-587] Add email address table

### DIFF
--- a/app/models/concerns/email_address_callback.rb
+++ b/app/models/concerns/email_address_callback.rb
@@ -1,0 +1,49 @@
+module EmailAddressCallback
+  extend ActiveSupport::Concern
+
+  def self.included(base)
+    base.send(:after_save, :update_email_address)
+  end
+
+  def update_email_address
+    if email_address.present?
+      update_email_address_record
+    elsif encrypted_email.present?
+      create_full_email_address_record
+    elsif unconfirmed_email.present?
+      create_pending_email_address_record
+    end
+  end
+
+  private
+
+  def update_email_address_record
+    email_address.update!(
+      encrypted_email: encrypted_email,
+      confirmation_token: confirmation_token,
+      confirmed_at: confirmed_at,
+      confirmation_sent_at: confirmation_sent_at,
+      email_fingerprint: email_fingerprint
+    )
+  end
+
+  def create_full_email_address_record
+    create_email_address!(
+      user: self,
+      encrypted_email: encrypted_email,
+      confirmation_token: confirmation_token,
+      confirmed_at: confirmed_at,
+      confirmation_sent_at: confirmation_sent_at,
+      email_fingerprint: email_fingerprint
+    )
+  end
+
+  def create_pending_email_address_record
+    create_email_address!(
+      user: self,
+      email: unconfirmed_email,
+      confirmation_token: confirmation_token,
+      confirmation_sent_at: confirmation_sent_at
+    )
+  end
+end

--- a/app/models/concerns/email_address_callback.rb
+++ b/app/models/concerns/email_address_callback.rb
@@ -10,8 +10,6 @@ module EmailAddressCallback
       update_email_address_record
     elsif encrypted_email.present?
       create_full_email_address_record
-    elsif unconfirmed_email.present?
-      create_pending_email_address_record
     end
   end
 
@@ -35,15 +33,6 @@ module EmailAddressCallback
       confirmed_at: confirmed_at,
       confirmation_sent_at: confirmation_sent_at,
       email_fingerprint: email_fingerprint
-    )
-  end
-
-  def create_pending_email_address_record
-    create_email_address!(
-      user: self,
-      email: unconfirmed_email,
-      confirmation_token: confirmation_token,
-      confirmation_sent_at: confirmation_sent_at
     )
   end
 end

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,0 +1,15 @@
+class EmailAddress < ApplicationRecord
+  include EncryptableAttribute
+
+  encrypted_attribute_without_setter(name: :email)
+
+  belongs_to :user, inverse_of: :email_address
+  validates :user_id, presence: true
+  validates :encrypted_email, presence: true
+  validates :email_fingerprint, presence: true
+
+  def email=(email)
+    set_encrypted_attribute(name: :email, value: email)
+    self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   # IMPORTANT this comes *after* devise() call.
   include UserAccessKeyOverrides
   include UserEncryptedAttributeOverrides
+  include EmailAddressCallback
 
   enum role: { user: 0, tech: 1, admin: 2 }
   enum otp_delivery_preference: { sms: 0, voice: 1 }
@@ -42,6 +43,7 @@ class User < ApplicationRecord
   has_many :events, dependent: :destroy
   has_one :account_reset_request, dependent: :destroy
   has_many :phone_configurations, dependent: :destroy, inverse_of: :user
+  has_one :email_address, dependent: :destroy, inverse_of: :user
   has_many :webauthn_configurations, dependent: :destroy
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -164,12 +164,8 @@ class User < ApplicationRecord
   end
 
   def total_mfa_options_enabled
-    total = [phone_mfa_enabled?, piv_cac_enabled?, totp_enabled?].count { |tf| tf }
-    total + webauthn_configurations.size
-  end
-
-  def phone_mfa_enabled?
-    phone_configurations.any?(&:mfa_enabled?)
+    phone_configurations.count(&:mfa_enabled?) + webauthn_configurations.size +
+      [piv_cac_enabled?, totp_enabled?].count { |tf| tf }
   end
 end
 # rubocop:enable Rails/HasManyOrHasOneDependent

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
     Bullet.add_whitelist(
       type: :n_plus_one_query, class_name: 'User', association: :phone_configurations
     )
+    Bullet.add_whitelist(
+      type: :n_plus_one_query, class_name: 'User', association: :email_address
+    )
   end
 
   config.active_support.test_order = :random

--- a/db/migrate/20180906181420_create_email_address_table.rb
+++ b/db/migrate/20180906181420_create_email_address_table.rb
@@ -1,0 +1,16 @@
+class CreateEmailAddressTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :email_addresses do |t|
+      t.references :user
+      t.string :confirmation_token, limit: 255
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string :email_fingerprint, null: false, default: ""
+      t.string :encrypted_email, null: false, default: ""
+
+      t.timestamps
+
+      t.index :email_fingerprint, unique: true, where: 'confirmed_at IS NOT NULL'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180827225542) do
+ActiveRecord::Schema.define(version: 20180906181420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,19 @@ ActiveRecord::Schema.define(version: 20180827225542) do
     t.datetime "authorized_at"
     t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid"
     t.index ["user_id"], name: "index_authorizations_on_user_id"
+  end
+
+  create_table "email_addresses", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "confirmation_token", limit: 255
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "email_fingerprint", default: "", null: false
+    t.string "encrypted_email", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
+    t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/spec/factories/email_addresses.rb
+++ b/spec/factories/email_addresses.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  Faker::Config.locale = :en
+
+  factory :email_address do
+    confirmed_at { Time.zone.now }
+    email { 'jd@example.com' }
+    association :user
+  end
+end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe EmailAddress do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:encrypted_email) }
+    it { is_expected.to validate_presence_of(:email_fingerprint) }
+  end
+
+  let(:email) { 'jd@example.com' }
+
+  let(:email_address) { create(:email_address, email: email) }
+
+  describe 'creation' do
+    it 'stores an encrypted form of the email address' do
+      expect(email_address.encrypted_email).to_not be_blank
+    end
+  end
+
+  describe 'encrypted attributes' do
+    it 'decrypts email' do
+      expect(email_address.email).to eq email
+    end
+
+    context 'with unnormalized email' do
+      let(:email) { '  jD@Example.Com ' }
+      let(:normalized_email) { 'jd@example.com' }
+
+      it 'normalizes email' do
+        expect(email_address.email).to eq normalized_email
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,32 @@ describe User do
     end.to change(ActionMailer::Base.deliveries, :count).by(0)
   end
 
+  describe 'email_address' do
+    it 'creates an entry for the user when created' do
+      expect do
+        User.create(email: 'nobody@nobody.com')
+      end.to change(EmailAddress, :count).by(1)
+    end
+
+    it 'mirrors the info from the user object on creation' do
+      user = create(:user)
+      email_address = user.email_address
+      expect(email_address).to be_present
+      expect(email_address.encrypted_email).to eq user.encrypted_email
+      expect(email_address.email).to eq user.email
+      expect(email_address.confirmed_at).to eq user.confirmed_at
+    end
+
+    it 'mirrors the info from an unconfirmed user object' do
+      user = create(:user, :unconfirmed)
+      email_address = user.email_address
+      expect(email_address).to be_present
+      expect(email_address.encrypted_email).to eq user.encrypted_email
+      expect(email_address.email).to eq user.email
+      expect(email_address.confirmed_at).to be_nil
+    end
+  end
+
   describe 'password validations' do
     it 'allows long phrases that contain common words' do
       user = create(:user)


### PR DESCRIPTION
**Why**:
We want to support multiple email addresses per account.

**How**:
We start by creating a table that lets us store more than
one email address for a user. We tie in to the user model
because we need to support Devise for creating accounts.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
