### PR TITLE
LG-641 Handle nil request_id properly

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -140,7 +140,7 @@ module Users
     end
 
     def store_sp_metadata_in_session
-      return if sp_session[:issuer] || request_id.empty?
+      return if sp_session[:issuer] || request_id.blank?
       StoreSpMetadataInSession.new(session: session, request_id: request_id).call
     end
 

--- a/spec/requests/invalid_sign_in_params_spec.rb
+++ b/spec/requests/invalid_sign_in_params_spec.rb
@@ -5,3 +5,9 @@ describe 'visiting sign in page with invalid user params' do
     get new_user_session_path, params: { user: 'test@test.com' }
   end
 end
+
+context 'when the request_id param is present but with a nil value' do
+  it 'does not raise an error' do
+    get new_user_session_path, params: { request_id: nil }
+  end
+end


### PR DESCRIPTION
**Why**: In SessionsController, we were using `.empty?` instead of
`.blank?`. I forgot that `fetch` with a default value only works if
the hash key itself is not present, not if it's present and has a nil
value.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [ ] The changes are compatible with data that was encrypted with the old code.


- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.