### PR TITLE
LG-609 Change language on phone / address confirmation page

### DIFF
--- a/app/views/idv/phone/new.html.slim
+++ b/app/views/idv/phone/new.html.slim
@@ -2,6 +2,8 @@
 
 h1.h3.my0 = t('idv.titles.session.phone')
 
+.py1.m0 = t('idv.messages.phone.description')
+
 .mt2
   == t('idv.messages.phone.alert')
 

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -129,9 +129,11 @@ en:
         safe place. You will need it if you ever lose your password.
       phone:
         alert: This phone number <strong>must be</strong>
+        description: We're checking records to make sure you are who you say you are,
+          and that you have ownership of your account.
         phone_of_record: Phone of record
         rules:
-        - in your name, or a family member's name
+        - on a phone plan with your name on it
         - not a virtual phone (such as Google Voice or Skype)
         - a U.S. number
       return_to_profile: "‹ Return to your login.gov profile"

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -128,9 +128,11 @@ es:
         seguro. La necesitará si pierde su contraseña.
       phone:
         alert: Este número de teléfono <strong>debe ser</strong>
+        description: Estamos verificando los registros para asegurarnos de que eres
+          quien eres, y de que eres el propietario de tu cuenta.
         phone_of_record: Teléfono del registro
         rules:
-        - a su nombre o el nombre de un miembro de familia
+        - en su teléfono con su nombre en él
         - no es un teléfono virtual (como Google Voice o Skype)
         - no es un número de teléfono prepago
         - un número de EE. UU.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -128,11 +128,11 @@ es:
         seguro. La necesitará si pierde su contraseña.
       phone:
         alert: Este número de teléfono <strong>debe ser</strong>
-        description: Estamos verificando los registros para asegurarnos de que eres
-          quien eres, y de que eres el propietario de tu cuenta.
+        description: Verificamos los registros para asegurarnos de que eres quien
+          eres, y de que eres el propietario de tu cuenta.
         phone_of_record: Teléfono del registro
         rules:
-        - en su teléfono con su nombre en él
+        - en un plan de teléfono con su nombre en él
         - no es un teléfono virtual (como Google Voice o Skype)
         - no es un número de teléfono prepago
         - un número de EE. UU.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -135,9 +135,11 @@ fr:
         de passe.
       phone:
         alert: Ce numéro de téléphone <strong>doit être</strong>
+        description: Nous vérifions les dossiers pour vous assurer que vous êtes ce
+          que vous dites et que vous êtes propriétaire de votre compte.
         phone_of_record: numéro de téléphone enregistré
         rules:
-        - en votre nom ou celui d'un membre de votre famille
+        - sur un plan de téléphone avec votre nom dessus
         - pas un téléphone virtuel (comme Google Voice ou Skype)
         - pas un numéro de téléphone prépayé
         - un numéro américain


### PR DESCRIPTION
**Why**: Users are confused / frustrated why we’re asking for the phone number again

**How**: Change language on the page to make it feel like users are verifying their identity rather than repeating an action.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
