### PR TITLE
LG586 - Final LOA3 screen reflows poorly on mobile

### DIFF
--- a/app/views/sign_up/completions/_show_sp.html.slim
+++ b/app/views/sign_up/completions/_show_sp.html.slim
@@ -3,10 +3,10 @@
   p
     = button_to t('forms.buttons.continue'), sign_up_completed_path, \
               class: 'btn btn-primary btn-wide'
-p.mr5.ml5.mt3.mb3
+p.sm-mr5.sm-ml5.mt3.mb3
   = t('help_text.requested_attributes.intro_html', app_name: APP_NAME,
     sp: content_tag(:strong, decorated_session.sp_agency))
 
-<div class='ml5 mr5' >
+<div class='sm-ml5 sm-mr5' >
   = render @view_model.requested_attributes_partial, view_model: @view_model
 </div>


### PR DESCRIPTION
The last screen of the LOA3 flow before you are taken back to the SP was looking pretty cramped on mobile. This changes the margin classes that are used to be the mobile-friendly variant so the information spans the full width. 

This screen needs some more visual design help but since the experience may be getting re-worked a bit, we'll dig into that on another issue. 

![screen shot 2018-09-11 at 1 05 27 pm](https://user-images.githubusercontent.com/776987/45378528-52f77780-b5c3-11e8-8d97-ee0ab741007f.png)

