### PR TITLE
Update webauthn setup to match master branch

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -34,7 +34,6 @@ detectors:
       - reauthn?
       - mark_profile_inactive
       - EncryptedSidekiqRedis#zrem
-      - UserDecorator#should_acknowledge_personal_key?
       - Pii::Attributes#[]=
       - OpenidConnectLogoutForm#load_identity
       - Idv::ProfileMaker#pii_from_applicant

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -27,8 +27,8 @@ fr:
         instructions: Votre compte requiert la vérification d'un code secret.
         reactivate_button: Entrez le code que vous avez reçu par la poste
         success: Votre compte a été vérifié.
-      webauthn: Clé de sécurité matérielle
-      webauthn_add: "+ Ajouter une clé de sécurité matérielle"
+      webauthn: Clé de sécurité physique
+      webauthn_add: "+ Ajouter une clé de sécurité physique"
       webauthn_delete: Retirer
     items:
       delete_your_account: Supprimer votre compte

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -144,7 +144,7 @@ fr:
         sms_info: Obtenez votre code de sécurité par SMS
         voice: Appel téléphonique
         voice_info: Obtenez votre code de sécurité par appel téléphonique
-        webauthn: Clé de sécurité matérielle
-        webauthn_info: Utilisez une clé de sécurité matérielle pour sécuriser votre
+        webauthn: Clé de sécurité physique
+        webauthn_info: Utilisez une clé de sécurité physique pour sécuriser votre
           compte
-      webauthn_header_text: Présentez votre clé de sécurité matérielle
+      webauthn_header_text: Présentez votre clé de sécurité physique

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -51,5 +51,5 @@ fr:
     webauthn_setup:
       delete_last: Désolé, vous ne pouvez pas supprimer votre dernière option MFA
       general_error: Une erreur s'est produite lors de l'ajout de votre clé de sécurité
-        matérielle. Veuillez réessayer.
+        physique. Veuillez réessayer.
       unique_name: Ce nom est déjà pris. Veuillez choisir un autre nom.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -90,7 +90,7 @@ fr:
       title: Confirmez votre compte
     webauthn_setup:
       intro_html: Lorsque vous vous connectez, vous pouvez utiliser votre clé de sécurité
-        matérielle. %{link}
+        physique. %{link}
       step_1: Insérez votre clé de sécurité dans le port USB de votre ordinateur ou
         connectez-le avec un câble USB.
       step_2: Une fois connecté, appuyez sur le bouton ou le disque d'or si votre

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -55,4 +55,4 @@ fr:
       new: Activer une application d'authentification
     verify_email: Consultez vos courriels
     webauthn_setup:
-      new: Enregistrez votre clé de sécurité matérielle
+      new: Enregistrez votre clé de sécurité physique

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -40,8 +40,8 @@ fr:
         confirm_code_html: Vous voulez que nous vous appelions de nouveau? %{resend_code_link}
         number_message: Nous venons de vous appeler à %{number}.
       webauthn:
-        confirm_webauthn_html: Présentez la clé de sécurité matérielle associée à
-          votre compte.
+        confirm_webauthn_html: Présentez la clé de sécurité physique associée à votre
+          compte.
       wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir

--- a/config/locales/links/fr.yml
+++ b/config/locales/links/fr.yml
@@ -26,4 +26,4 @@ fr:
       app_option: Utilisez une application d'authentification à la place.
       get_another_code: Obtenir un autre code
     what_is_totp: Qu'est-ce qu'une application d'authentification?
-    what_is_webauthn: Qu'est-ce qu'une clé de sécurité matérielle?
+    what_is_webauthn: Qu'est-ce qu'une clé de sécurité physique?

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -47,8 +47,8 @@ fr:
     use_diff_email:
       link: utilisez une adresse courriel différente
       text_html: Or, %{link}
-    webauthn_added: Vous avez ajouté une clé de sécurité matérielle.
-    webauthn_deleted: Vous avez supprimé une clé de sécurité matérielle.
+    webauthn_added: Vous avez ajouté une clé de sécurité physique.
+    webauthn_deleted: Vous avez supprimé une clé de sécurité physique.
   session_timedout: Nous vous avons déconnecté. Pour votre sécurité, %{app} désactive
     votre session lorsque vous demeurez sur une page sans vous déplacer pendant %{minutes}
     minutes.

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -36,7 +36,7 @@ fr:
         invalid: NOT TRANSLATED YET
         missing: NOT TRANSLATED YET
     present_piv_cac: NOT TRANSLATED YET
-    present_webauthn: Présentez votre clé de sécurité matérielle
+    present_webauthn: Présentez votre clé de sécurité physique
     reactivate_account: Réactiver le profil
     registrations:
       new: S'inscrire et créer un compte

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -17,8 +17,8 @@ fr:
       voice: Appel téléphonique
       voice_info: Obtenez votre code de sécurité par appel téléphonique. (Seulement
         les numéros de téléphone en Amerique du Nord)
-      webauthn: Clé de sécurité matérielle
-      webauthn_info: Utilisez votre clé de sécurité matérielle au lieu d'un code de
+      webauthn: Clé de sécurité physique
+      webauthn_info: Utilisez votre clé de sécurité physique au lieu d'un code de
         sécurité.
     login_options_link_text: Choisissez une autre option de sécurité
     login_options_title: Sélectionnez votre option de sécurité
@@ -31,4 +31,4 @@ fr:
     totp_fallback:
       question: Vous n'avez pas votre application d'authentification?
     webauthn_fallback:
-      question: Votre clé de sécurité matérielle n'est pas disponible?
+      question: Votre clé de sécurité physique n'est pas disponible?

--- a/spec/features/idv/account_creation_spec.rb
+++ b/spec/features/idv/account_creation_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 describe 'LOA3 account creation' do
   include IdvHelper
   include SamlAuthHelper
+  include WebauthnHelper
 
   it_behaves_like 'creating an LOA3 account using authenticator app for 2FA', :saml
   it_behaves_like 'creating an LOA3 account using authenticator app for 2FA', :oidc
+
+  it_behaves_like 'creating an LOA3 account using webauthn for 2FA', :saml
+  it_behaves_like 'creating an LOA3 account using webauthn for 2FA', :oidc
 end

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -15,7 +15,7 @@ feature 'Webauthn Management' do
       click_link t('account.index.webauthn_add'), href: webauthn_setup_url
       expect(current_path).to eq webauthn_setup_path
 
-      mock_press_button_on_hardware_key
+      mock_press_button_on_hardware_key_and_fill_in_name_field
       click_submit_default
 
       expect(current_path).to eq account_path
@@ -30,7 +30,7 @@ feature 'Webauthn Management' do
       click_link t('account.index.webauthn_add'), href: webauthn_setup_url
       expect(current_path).to eq webauthn_setup_path
 
-      mock_press_button_on_hardware_key
+      mock_press_button_on_hardware_key_and_fill_in_name_field
       click_submit_default
 
       expect(current_path).to eq account_path
@@ -62,7 +62,7 @@ feature 'Webauthn Management' do
       click_link t('account.index.webauthn_add'), href: webauthn_setup_url
       expect(current_path).to eq webauthn_setup_path
 
-      mock_press_button_on_hardware_key
+      mock_press_button_on_hardware_key_and_fill_in_name_field
       click_submit_default
 
       expect(current_path).to eq account_path
@@ -71,7 +71,7 @@ feature 'Webauthn Management' do
       click_link t('account.index.webauthn_add'), href: webauthn_setup_url
       expect(current_path).to eq webauthn_setup_path
 
-      mock_press_button_on_hardware_key
+      mock_press_button_on_hardware_key_and_fill_in_name_field
       click_submit_default
 
       expect(current_path).to eq webauthn_setup_path
@@ -126,25 +126,6 @@ feature 'Webauthn Management' do
       expect(page).to have_content 'key1'
       expect(page).to have_content t('errors.webauthn_setup.delete_last')
     end
-  end
-
-  def mock_challenge
-    allow(WebAuthn).to receive(:credential_creation_options).and_return(
-      challenge: challenge.pack('c*')
-    )
-  end
-
-  def mock_press_button_on_hardware_key
-    # this is required because the domain is embedded in the supplied attestation object
-    allow(WebauthnSetupForm).to receive(:domain_name).and_return('localhost:3000')
-
-    set_hidden_field('attestation_object', attestation_object)
-    set_hidden_field('client_data_json', client_data_json)
-    set_hidden_field('name', 'mykey')
-  end
-
-  def set_hidden_field(id, value)
-    first("input##{id}", visible: false).set(value)
   end
 
   def create_webauthn_configuration(user, name, id, key)

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -1,4 +1,23 @@
 module WebauthnHelper
+  def mock_challenge
+    allow(WebAuthn).to receive(:credential_creation_options).and_return(
+      challenge: challenge.pack('c*')
+    )
+  end
+
+  def mock_press_button_on_hardware_key_and_fill_in_name_field
+    # this is required because the domain is embedded in the supplied attestation object
+    allow(WebauthnSetupForm).to receive(:domain_name).and_return('localhost:3000')
+
+    set_hidden_field('attestation_object', attestation_object)
+    set_hidden_field('client_data_json', client_data_json)
+    fill_in 'name', with: 'mykey'
+  end
+
+  def set_hidden_field(id, value)
+    first("input##{id}", visible: false).set(value)
+  end
+
   def protocol
     'http://'
   end


### PR DESCRIPTION
**Why**: PR #2501 was not rebased against master, and caused specs to
fail on master and on other branches based on master.

**How**:
- Update webauthn setup controller to use the new personal key
policy object and fix the logic so that LOA3 users don't see the
personal key before the IdV flow.
- Update French translations


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.