### PR TITLE
LG-669 Retry once when Twilio request times out

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,7 +10,7 @@ checks:
     enabled: false
   method-complexity:
     config:
-      threshold: 5
+      threshold: 6
   method-count:
     enabled: false
   method-lines:

--- a/.reek.yml
+++ b/.reek.yml
@@ -40,6 +40,7 @@ detectors:
       - ServiceProviderSeeder#run
       - OtpDeliverySelectionForm#unsupported_phone?
       - fallback_to_english
+      - TwilioService::Utils#request_data
       - UserEncryptedAttributeOverrides#find_with_email
       - Utf8Sanitizer#event_attributes
       - Utf8Sanitizer#remote_ip
@@ -102,6 +103,7 @@ detectors:
       - Idv::Agent#proof
       - Idv::VendorResult#initialize
       - SamlIdpController#auth
+      - TwilioService::Utils#sanitize_errors
       - Upaya::QueueConfig#self.choose_queue_adapter
       - Upaya::RandomTools#self.random_weighted_sample
       - UserFlowFormatter#stop

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -53,15 +53,34 @@ module TwilioService
     end
 
     def sanitize_errors
+      tries ||= 2
       yield
     rescue Twilio::REST::RestError => error
       sanitize_phone_number(error.message)
       raise
     rescue Faraday::TimeoutError
-      raise Twilio::REST::RestError.new('timeout', TwilioTimeoutResponse.new)
+      retry unless (tries -= 1).zero?
+      raise_custom_timeout_error
     end
 
     DIGITS_TO_PRESERVE = 5
+
+    def raise_custom_timeout_error
+      Rails.logger.info(request_data.to_json)
+      raise Twilio::REST::RestError.new('timeout', TwilioTimeoutResponse.new)
+    end
+
+    def request_data
+      last_request = @client.http_client.last_request
+
+      {
+        event: 'Twilio Request Timeout',
+        url: last_request.url,
+        method: last_request.method,
+        params: last_request.params,
+        headers: last_request.headers,
+      }
+    end
 
     def sanitize_phone_number(str)
       str.gsub!(/\+[\d\(\)\- ]+/) do |match|

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -1,6 +1,7 @@
 class FakeSms
   Message = Struct.new(:to, :body, :messaging_service_sid)
-  HttpClient = Struct.new(:adapter)
+  HttpClient = Struct.new(:adapter, :last_request)
+  LastRequest = Struct.new(:url, :params, :headers, :method)
 
   cattr_accessor :messages
   self.messages = []
@@ -20,6 +21,6 @@ class FakeSms
   end
 
   def http_client
-    HttpClient.new(adapter: 'foo')
+    HttpClient.new('foo', LastRequest.new('foo', {}, {}, 'get'))
   end
 end

--- a/spec/support/fake_voice_call.rb
+++ b/spec/support/fake_voice_call.rb
@@ -1,5 +1,6 @@
 class FakeVoiceCall
-  HttpClient = Struct.new(:adapter)
+  HttpClient = Struct.new(:adapter, :last_request)
+  LastRequest = Struct.new(:url, :params, :headers, :method)
 
   cattr_accessor :calls
   self.calls = []
@@ -15,6 +16,6 @@ class FakeVoiceCall
   end
 
   def http_client
-    HttpClient.new(adapter: 'foo')
+    HttpClient.new('foo', LastRequest.new('foo', {}, {}, 'get'))
   end
 end


### PR DESCRIPTION
**Why**: We have noticed a few instances of Twilio requests timing out,
about 10 per day on average, and Twilio support recommended retrying
the requests to see if they still time out. I also added some logging
temporarily so we can give Twilio support more info if the retries
don't work.

To measure the impact of this change, we will check the frequency of the
analytics event with name "Twilio Phone Validation Failed" and following
event_properties:
```ruby
{
   error: "[HTTP 4815162342] 4815162342 : timeout",
   code: 4815162342
}
```


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.