### PR TITLE
[LG-588] Rake task populating email addresses

### DIFF
--- a/app/services/populate_email_addresses_table.rb
+++ b/app/services/populate_email_addresses_table.rb
@@ -1,0 +1,39 @@
+class PopulateEmailAddressesTable
+  def initialize
+    @count = 0
+    @total = 0
+  end
+
+  # :reek:DuplicateMethodCall
+  def call
+    User.in_batches(of: 1000) do |relation|
+      sleep(1)
+      process_batch(relation)
+      Rails.logger.info "#{@count} / #{@total}"
+    end
+    Rails.logger.info "Processed #{@count} user email addresses"
+  end
+
+  private
+
+  def process_batch(relation)
+    User.transaction do
+      relation.each do |user|
+        @total += 1
+        next if user.email_address.present? || user.encrypted_email.blank?
+        user.create_email_address(email_info_for_user(user))
+        @count += 1
+      end
+    end
+  end
+
+  def email_info_for_user(user)
+    {
+      encrypted_email: user.encrypted_email,
+      email_fingerprint: user.email_fingerprint,
+      confirmed_at: user.confirmed_at,
+      confirmation_sent_at: user.confirmation_sent_at,
+      confirmation_token: user.confirmation_token,
+    }
+  end
+end

--- a/lib/tasks/migrate_email_addresses.rake
+++ b/lib/tasks/migrate_email_addresses.rake
@@ -1,0 +1,7 @@
+namespace :adhoc do
+  desc 'Copy email addresses to the new table'
+  task populate_email_addresses: :environment do
+    Rails.logger = Logger.new(STDOUT)
+    PopulateEmailAddressesTable.new.call
+  end
+end

--- a/spec/services/populate_email_addresses_table_spec.rb
+++ b/spec/services/populate_email_addresses_table_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe PopulateEmailAddressesTable do
+  let(:subject) { described_class.new }
+
+  describe '#call' do
+    context 'a user with no email' do
+      let!(:user) { create(:user, email: '', confirmed_at: nil) }
+
+      it 'migrates nothing' do
+        expect(user.email_address).to be_nil
+
+        expect { subject.call }.to change { EmailAddress.count }.by(0)
+      end
+    end
+
+    context 'a user with an email' do
+      let!(:user) { create(:user) }
+
+      context 'and no email_address entry' do
+        before(:each) do
+          user.email_address.delete
+          user.reload
+        end
+
+        it 'migrates without decrypting and re-encrypting' do
+          expect(EncryptedAttribute).to_not receive(:new)
+          subject.call
+        end
+
+        it 'migrates the email' do
+          expect { subject.call }.to change { EmailAddress.count }.by(1)
+
+          address = user.reload.email_address
+          expect(user.email).to eq address.email
+          expect(user.confirmed_at).to eq user.confirmed_at
+          expect(user.confirmation_sent_at).to eq user.confirmation_sent_at
+          expect(user.confirmation_token).to eq user.confirmation_token
+        end
+      end
+
+      context 'and an existing email_address entry' do
+        it 'adds no new rows' do
+          expect { subject.call }.to change { EmailAddress.count }.by(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**:
We want to support multiple email addresses per account. This
requires that we store email addresses in their own table.

**How**:
A rake task to copy existing email information to the new table.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
