### PR TITLE
Fix PIV/CAC and Webauthn errors when disabled

### DIFF
--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -33,8 +33,8 @@ module TwoFactorAuthentication
         'personal_key' => login_two_factor_personal_key_url,
         'sms' => otp_send_url(otp_delivery_selection_form: { otp_delivery_preference: 'sms' }),
         'auth_app' => login_two_factor_authenticator_url,
-        'piv_cac' => login_two_factor_piv_cac_url,
-        'webauthn' => login_two_factor_webauthn_url,
+        'piv_cac' => FeatureManagement.piv_cac_enabled? ? login_two_factor_piv_cac_url : nil,
+        'webauthn' => FeatureManagement.webauthn_enabled? ? login_two_factor_webauthn_url : nil,
       }
       url = factor_to_url[@two_factor_options_form.selection]
       redirect_to url if url

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -38,7 +38,11 @@ class TwoFactorOptionsPresenter
   private
 
   def available_2fa_types
-    %w[sms voice auth_app webauthn] + piv_cac_if_available
+    %w[sms voice auth_app] + webauthn_if_available + piv_cac_if_available
+  end
+
+  def webauthn_if_available
+    FeatureManagement.webauthn_enabled? ? %w[webauthn] : []
   end
 
   def piv_cac_if_available

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -25,14 +25,15 @@ describe TwoFactorAuthentication::OptionsController do
     before { sign_in_before_2fa }
 
     it 'redirects to login_two_factor_url if sms and piv/cac and webauthn disabled' do
-      set_piv_cac_webauthn_enabled('false')
+      piv_cac_webauthn_enabled('false')
 
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
 
       expect(response).to redirect_to otp_send_url( \
-        otp_delivery_selection_form: { otp_delivery_preference: 'sms' })
+        otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
+      )
 
-      set_piv_cac_webauthn_enabled('true')
+      piv_cac_webauthn_enabled('true')
     end
 
     it 'redirects to login_two_factor_url if user selects sms' do
@@ -92,7 +93,7 @@ describe TwoFactorAuthentication::OptionsController do
     end
   end
 
-  def set_piv_cac_webauthn_enabled(bool)
+  def piv_cac_webauthn_enabled(bool)
     allow(Figaro.env).to receive(:piv_cac_enabled) { bool }
     allow(Figaro.env).to receive(:webauthn_enabled) { bool }
     Rails.application.reload_routes!

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -24,6 +24,17 @@ describe TwoFactorAuthentication::OptionsController do
   describe '#create' do
     before { sign_in_before_2fa }
 
+    it 'redirects to login_two_factor_url if sms and piv/cac and webauthn disabled' do
+      set_piv_cac_webauthn_enabled('false')
+
+      post :create, params: { two_factor_options_form: { selection: 'sms' } }
+
+      expect(response).to redirect_to otp_send_url( \
+        otp_delivery_selection_form: { otp_delivery_preference: 'sms' })
+
+      set_piv_cac_webauthn_enabled('true')
+    end
+
     it 'redirects to login_two_factor_url if user selects sms' do
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
 
@@ -79,5 +90,11 @@ describe TwoFactorAuthentication::OptionsController do
 
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
     end
+  end
+
+  def set_piv_cac_webauthn_enabled(bool)
+    allow(Figaro.env).to receive(:piv_cac_enabled) { bool }
+    allow(Figaro.env).to receive(:webauthn_enabled) { bool }
+    Rails.application.reload_routes!
   end
 end

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -24,7 +24,7 @@ describe TwoFactorAuthentication::OptionsController do
   describe '#create' do
     before { sign_in_before_2fa }
 
-    it 'redirects to login_two_factor_url if sms and piv/cac and webauthn disabled' do
+    it 'redirects to login_two_factor_url for sms with piv/cac and webauthn disabled' do
       piv_cac_webauthn_enabled('false')
 
       post :create, params: { two_factor_options_form: { selection: 'sms' } }


### PR DESCRIPTION
**Why**: When the feature flags are disabled the routes are not valid so references to the urls throw an error unless guarded with a feature flag.

**How**: Add feature flag checks for all PIV/CAC and webauthn urls

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
