### PR TITLE
LG-677 Add confirm screen on account reset cancel

### DIFF
--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -1,9 +1,24 @@
 module AccountReset
   class CancelController < ApplicationController
-    def create
-      result = AccountReset::Cancel.new(params[:token]).call
+    before_action :check_feature_enabled
 
-      analytics.track_event(Analytics::ACCOUNT_RESET, result.to_h)
+    def show
+      render :show and return unless token
+
+      result = AccountReset::ValidateCancelToken.new(token).call
+      track_event(result)
+
+      if result.success?
+        handle_valid_token
+      else
+        handle_invalid_token(result)
+      end
+    end
+
+    def create
+      result = AccountReset::Cancel.new(session[:cancel_token]).call
+
+      track_event(result)
 
       handle_success if result.success?
 
@@ -12,9 +27,31 @@ module AccountReset
 
     private
 
+    def check_feature_enabled
+      redirect_to root_url unless FeatureManagement.account_reset_enabled?
+    end
+
+    def track_event(result)
+      analytics.track_event(Analytics::ACCOUNT_RESET, result.to_h)
+    end
+
+    def handle_valid_token
+      session[:cancel_token] = token
+      redirect_to url_for
+    end
+
+    def handle_invalid_token(result)
+      flash[:error] = result.errors[:token].first
+      redirect_to root_url
+    end
+
     def handle_success
       sign_out if current_user
       flash[:success] = t('two_factor_authentication.account_reset.successful_cancel')
+    end
+
+    def token
+      params[:token]
     end
   end
 end

--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -3,7 +3,7 @@ module AccountReset
     before_action :check_feature_enabled
 
     def show
-      render :show and return unless token
+      return render :show unless token
 
       result = AccountReset::ValidateCancelToken.new(token).call
       track_event(result)

--- a/app/services/account_reset/cancel.rb
+++ b/app/services/account_reset/cancel.rb
@@ -1,9 +1,7 @@
 module AccountReset
   class Cancel
     include ActiveModel::Model
-
-    validates :token, presence: { message: I18n.t('errors.account_reset.cancel_token_missing') }
-    validate :valid_token
+    include CancelTokenValidator
 
     def initialize(token)
       @token = token
@@ -25,12 +23,6 @@ module AccountReset
 
     attr_reader :success, :token
 
-    def valid_token
-      return if account_reset_request
-
-      errors.add(:token, I18n.t('errors.account_reset.cancel_token_invalid')) if token
-    end
-
     def notify_user_via_email_of_account_reset_cancellation
       UserMailer.account_reset_cancel(user.email).deliver_later
     end
@@ -43,10 +35,6 @@ module AccountReset
       account_reset_request.update!(cancelled_at: Time.zone.now,
                                     request_token: nil,
                                     granted_token: nil)
-    end
-
-    def account_reset_request
-      @account_reset_request ||= AccountResetRequest.find_by(request_token: token)
     end
 
     def user

--- a/app/services/account_reset/validate_cancel_token.rb
+++ b/app/services/account_reset/validate_cancel_token.rb
@@ -1,9 +1,7 @@
 module AccountReset
   class ValidateCancelToken
     include ActiveModel::Model
-
-    validates :token, presence: { message: I18n.t('errors.account_reset.cancel_token_missing') }
-    validate :valid_token
+    include CancelTokenValidator
 
     def initialize(token)
       @token = token
@@ -17,17 +15,7 @@ module AccountReset
 
     private
 
-    attr_reader :success, :token, :validate_and_cancel
-
-    def valid_token
-      return if account_reset_request
-
-      errors.add(:token, I18n.t('errors.account_reset.cancel_token_invalid')) if token
-    end
-
-    def account_reset_request
-      @account_reset_request ||= AccountResetRequest.find_by(request_token: token)
-    end
+    attr_reader :success, :token
 
     def user
       account_reset_request&.user || AnonymousUser.new

--- a/app/services/account_reset/validate_cancel_token.rb
+++ b/app/services/account_reset/validate_cancel_token.rb
@@ -1,0 +1,43 @@
+module AccountReset
+  class ValidateCancelToken
+    include ActiveModel::Model
+
+    validates :token, presence: { message: I18n.t('errors.account_reset.cancel_token_missing') }
+    validate :valid_token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def call
+      @success = valid?
+
+      FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+    end
+
+    private
+
+    attr_reader :success, :token, :validate_and_cancel
+
+    def valid_token
+      return if account_reset_request
+
+      errors.add(:token, I18n.t('errors.account_reset.cancel_token_invalid')) if token
+    end
+
+    def account_reset_request
+      @account_reset_request ||= AccountResetRequest.find_by(request_token: token)
+    end
+
+    def user
+      account_reset_request&.user || AnonymousUser.new
+    end
+
+    def extra_analytics_attributes
+      {
+        event: 'visit',
+        user_id: user.uuid,
+      }
+    end
+  end
+end

--- a/app/validators/account_reset/cancel_token_validator.rb
+++ b/app/validators/account_reset/cancel_token_validator.rb
@@ -1,0 +1,24 @@
+module AccountReset
+  module CancelTokenValidator
+    extend ActiveSupport::Concern
+
+    included do
+      validates :token, presence: { message: I18n.t('errors.account_reset.cancel_token_missing') }
+      validate :valid_token
+    end
+
+    private
+
+    attr_reader :token
+
+    def valid_token
+      return if account_reset_request
+
+      errors.add(:token, I18n.t('errors.account_reset.cancel_token_invalid')) if token
+    end
+
+    def account_reset_request
+      @account_reset_request ||= AccountResetRequest.find_by(request_token: token)
+    end
+  end
+end

--- a/app/views/account_reset/cancel/show.html.slim
+++ b/app/views/account_reset/cancel/show.html.slim
@@ -1,0 +1,13 @@
+- title t('account_reset.cancel_request.title')
+
+h1.h3.my0 = t('account_reset.cancel_request.title')
+br
+h4.my2 = t('account_reset.cancel_request.are_you_sure')
+
+= button_to t('account_reset.cancel_request.cancel_button'), \
+    account_reset_cancel_path, method: :post, \
+    class: 'btn btn-primary btn-wide'
+br
+br
+hr
+= link_to t('account_reset.cancel_request.cancel'), root_url

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -1,6 +1,11 @@
 ---
 en:
   account_reset:
+    cancel_request:
+      are_you_sure: Are you sure you want to cancel your delete account request?
+      cancel: Exit
+      cancel_button: Cancel delete account
+      title: Cancel delete account
     confirm_delete_account:
       cta: You may %{link} or close this window if you're done.
       info: The account for <strong>%{email}</strong> has been deleted. We sent an

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -1,6 +1,11 @@
 ---
 es:
   account_reset:
+    cancel_request:
+      are_you_sure: "¿Seguro que quieres cancelar tu solicitud de eliminación de cuenta?"
+      cancel: Salida
+      cancel_button: Cancelar la cuenta eliminada
+      title: Cancelar la cuenta eliminada
     confirm_delete_account:
       cta: Puede %{link} o cierra esta ventana si ya terminaste.
       info: La cuenta para <strong>%{email}</strong> ha sido eliminada. Nosotros enviamos

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -1,6 +1,12 @@
 ---
 fr:
   account_reset:
+    cancel_request:
+      are_you_sure: Êtes-vous sûr de vouloir annuler votre demande de suppression
+        de compte?
+      cancel: Sortie
+      cancel_button: Annuler supprimer un compte
+      title: Annuler supprimer un compte
     confirm_delete_account:
       cta: Vous pouvez %{link} ou fermer cette fenêtre si vous avez terminé.
       info: Le compte pour <strong>%{email}</strong> a été supprimé. Nous avons envoyé

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,8 @@ Rails.application.routes.draw do
 
       get '/account_reset/request' => 'account_reset/request#show'
       post '/account_reset/request' => 'account_reset/request#create'
-      get '/account_reset/cancel' => 'account_reset/cancel#create'
+      get '/account_reset/cancel' => 'account_reset/cancel#show'
+      post '/account_reset/cancel' => 'account_reset/cancel#create'
       get '/account_reset/confirm_request' => 'account_reset/confirm_request#show'
       get '/account_reset/delete_account' => 'account_reset/delete_account#show'
       delete '/account_reset/delete_account' => 'account_reset/delete_account#delete'

--- a/spec/controllers/account_reset/cancel_controller_spec.rb
+++ b/spec/controllers/account_reset/cancel_controller_spec.rb
@@ -11,6 +11,7 @@ describe AccountReset::CancelController do
   describe '#create' do
     it 'logs a good token to the analytics' do
       token = create_account_reset_request_for(user)
+      session[:cancel_token] = token
 
       stub_analytics
       analytics_hash = {
@@ -23,7 +24,7 @@ describe AccountReset::CancelController do
       expect(@analytics).to receive(:track_event).
         with(Analytics::ACCOUNT_RESET, analytics_hash)
 
-      post :create, params: { token: token }
+      post :create
     end
 
     it 'logs a bad token to the analytics' do
@@ -37,8 +38,9 @@ describe AccountReset::CancelController do
 
       expect(@analytics).to receive(:track_event).
         with(Analytics::ACCOUNT_RESET, analytics_hash)
+      session[:cancel_token] = 'FOO'
 
-      post :create, params: { token: 'FOO' }
+      post :create
     end
 
     it 'logs a missing token to the analytics' do
@@ -63,8 +65,9 @@ describe AccountReset::CancelController do
 
     it 'redirects to the root with a flash message when the token is valid' do
       token = create_account_reset_request_for(user)
+      session[:cancel_token] = token
 
-      post :create, params: { token: token }
+      post :create
 
       expect(flash[:success]).
         to eq t('two_factor_authentication.account_reset.successful_cancel')
@@ -75,10 +78,44 @@ describe AccountReset::CancelController do
       stub_sign_in(user)
 
       token = create_account_reset_request_for(user)
+      session[:cancel_token] = token
 
       expect(controller).to receive(:sign_out)
 
-      post :create, params: { token: token }
+      post :create
+    end
+  end
+
+  describe '#show' do
+    it 'redirects to root if the token does not match one in the DB' do
+      stub_analytics
+      properties = {
+        user_id: 'anonymous-uuid',
+        event: 'visit',
+        success: false,
+        errors: { token: [t('errors.account_reset.cancel_token_invalid')] },
+      }
+      expect(@analytics).
+        to receive(:track_event).with(Analytics::ACCOUNT_RESET, properties)
+
+      get :show, params: { token: 'FOO' }
+
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq t('errors.account_reset.cancel_token_invalid')
+    end
+
+    it 'renders the show view if the token is missing' do
+      get :show
+
+      expect(response).to render_template(:show)
+    end
+
+    it 'redirects to root if feature is not enabled' do
+      allow(FeatureManagement).to receive(:account_reset_enabled?).and_return(false)
+
+      get :show
+
+      expect(response).to redirect_to root_url
     end
   end
 end

--- a/spec/features/account_reset/cancel_request_spec.rb
+++ b/spec/features/account_reset/cancel_request_spec.rb
@@ -11,6 +11,7 @@ describe 'Account Reset Request: Cancellation' do
       click_button t('account_reset.request.yes_continue')
       open_last_email
       click_email_link_matching(/cancel\?token/)
+      click_button t('account_reset.cancel_request.cancel_button')
 
       expect(page).to have_current_path new_user_session_path
       expect(page).
@@ -37,6 +38,7 @@ describe 'Account Reset Request: Cancellation' do
         AccountResetService.grant_tokens_and_send_notifications
         open_last_email
         click_email_link_matching(/cancel\?token/)
+        click_button t('account_reset.cancel_request.cancel_button')
 
         expect(page).to have_current_path new_user_session_path
         expect(page).

--- a/spec/views/account_reset/cancel/show.html.slim_spec.rb
+++ b/spec/views/account_reset/cancel/show.html.slim_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'account_reset/cancel/show.html.slim' do
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('account_reset.cancel_request.title'))
+
+    render
+  end
+
+  it 'has button to cancel request' do
+    render
+    expect(rendered).to have_button t('account_reset.cancel_request.cancel_button')
+  end
+end


### PR DESCRIPTION
**Why**: Some phones will visit the SMS link to retrieve a thumbnail and this triggers a cancel.

**How**: Add a confirm screen and have it call the old logic via a post request.  Prevent token leakage by placing a valid token in session.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
