### PR TITLE
Add trailing period to a french idv translation

### DIFF
--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -35,7 +35,7 @@ fr:
         de cet état.
       unsupported_jurisdiction_sp: Veuillez visiter %{sp_name} pour accéder à votre
         compte.
-      unsupported_otp_delivery_method: Sélectionnez une méthode pour recevoir un code
+      unsupported_otp_delivery_method: Sélectionnez une méthode pour recevoir un code.
     failure:
       attempts:
         one: Il ne vous reste qu' strongune tentative./strong


### PR DESCRIPTION
**Why**: So it is consistent with the other translations. This is left
over from https://github.com/18F/identity-idp/pull/2511.