### PR TITLE
LG-684 Rescue Faraday::ConnectionFailed errors

### DIFF
--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -58,7 +58,7 @@ module TwilioService
     rescue Twilio::REST::RestError => error
       sanitize_phone_number(error.message)
       raise
-    rescue Faraday::TimeoutError
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed
       retry unless (tries -= 1).zero?
       raise_custom_timeout_error
     end


### PR DESCRIPTION
**Why**: Rarely (16 times since the beginning of the year), the app is
not able to connect to the Twilio servers and the Faraday gem raises a
`Faraday::ConnectionFailed` error. This results in the user seeing the
500 error page. For a better experience, we rescue the error, try to
connect to Twilio again, and if it still fails, we display a helpful
message to the user and ask them to try again.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.