### PR TITLE
Update capybara-screenshot to point to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :development, :test do
   gem 'i18n-tasks'
   gem 'knapsack'
   gem 'pry-byebug'
+  gem 'puma'
   gem 'rspec-rails', '~> 3.7'
   gem 'slim_lint'
   gem 'thin'
@@ -93,7 +94,7 @@ end
 
 group :test do
   gem 'axe-matchers', '~> 1.3.4'
-  gem 'capybara-screenshot', github: 'mattheworiordan/capybara-screenshot'
+  gem 'capybara-screenshot'
   gem 'capybara-selenium'
   gem 'chromedriver-helper'
   gem 'codeclimate-test-reporter', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,14 +55,6 @@ GIT
       pkcs11
       uuid
 
-GIT
-  remote: https://github.com/mattheworiordan/capybara-screenshot.git
-  revision: fe47a6816677d573fd5428dae60a31bc8898f623
-  specs:
-    capybara-screenshot (1.0.14)
-      capybara (>= 1.0, < 3)
-      launchy
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -169,13 +161,16 @@ GEM
       rainbow
       thor
     byebug (10.0.2)
-    capybara (2.17.0)
+    capybara (3.7.2)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
+    capybara-screenshot (1.0.21)
+      capybara (>= 1.0, < 4)
+      launchy
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
@@ -348,7 +343,7 @@ GEM
       mini_mime (>= 0.1.1)
     memory_profiler (0.9.11)
     method_source (0.9.0)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_xml (0.6.0)
@@ -390,7 +385,8 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-attack (5.4.0)
       rack (>= 1.0, < 3)
@@ -642,7 +638,7 @@ GEM
       xmlmapper (>= 0.7.3)
     xmlmapper (0.7.3)
       nokogiri (~> 1.5)
-    xpath (3.0.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
     zonebie (0.6.1)
     zxcvbn-js (4.4.3)
@@ -664,7 +660,7 @@ DEPENDENCIES
   brakeman
   bullet
   bummr
-  capybara-screenshot!
+  capybara-screenshot
   capybara-selenium
   chromedriver-helper
   codeclimate-test-reporter
@@ -705,6 +701,7 @@ DEPENDENCIES
   premailer-rails
   proofer!
   pry-byebug
+  puma
   rack-attack
   rack-cors
   rack-headers_filter

--- a/app/views/account_reset/confirm_delete_account/show.html.slim
+++ b/app/views/account_reset/confirm_delete_account/show.html.slim
@@ -4,6 +4,6 @@
   = image_tag(asset_url('alert/fail-x.svg'), size: '48x48', alt: '',\
     class: 'absolute top-n24 left-0 right-0 mx-auto')
   h3 = t('account_reset.confirm_delete_account.title')
-  p == t('account_reset.confirm_delete_account.info', \
-    email: email, \
+  p == t('account_reset.confirm_delete_account.info', email: email)
+  p == t('account_reset.confirm_delete_account.cta', \
     link: link_to(t('account_reset.confirm_delete_account.link_text'), sign_up_email_path))

--- a/app/views/shared/_personal_key.html.slim
+++ b/app/views/shared/_personal_key.html.slim
@@ -17,7 +17,7 @@ p.mt-tiny.mb0
     class: 'ml2 btn-border ico ico-print text-decoration-none'
 
 = accordion('personal-key-info', t('users.personal_key.help_text_header')) do
-  = simple_format(t('users.personal_key.help_text'))
+  = t('users.personal_key.help_text_html')
 
 div
   = button_to t('forms.buttons.continue'), update_path,

--- a/config/locales/account_reset/en.yml
+++ b/config/locales/account_reset/en.yml
@@ -2,9 +2,9 @@
 en:
   account_reset:
     confirm_delete_account:
+      cta: You may %{link} or close this window if you're done.
       info: The account for <strong>%{email}</strong> has been deleted. We sent an
-        email confirmation of the account deletion. <br><br> You may %{link} or close
-        this window if you're done.
+        email confirmation of the account deletion.
       link_text: create a new account
       title: You have deleted your account
     confirm_request:
@@ -20,7 +20,7 @@ en:
       delete_button: Delete account
       info: Deleting your account should be your last resort if you are locked out
         of your account. You will not be able to recover any information linked to
-        your account.  Once your account is deleted, you can create a new one using
+        your account. Once your account is deleted, you can create a new one using
         the same email address.
       title: Deleting your account should be your last resort
     request:

--- a/config/locales/account_reset/es.yml
+++ b/config/locales/account_reset/es.yml
@@ -2,9 +2,9 @@
 es:
   account_reset:
     confirm_delete_account:
+      cta: Puede %{link} o cierra esta ventana si ya terminaste.
       info: La cuenta para <strong>%{email}</strong> ha sido eliminada. Nosotros enviamos
-        una confirmación por correo electrónico de la eliminación de la cuenta. <br><br>
-        Puede %{link} o cierra esta ventana si ya terminaste.
+        una confirmación por correo electrónico de la eliminación de la cuenta.
       link_text: crea una cuenta nueva
       title: Has eliminado tu cuenta
     confirm_request:

--- a/config/locales/account_reset/fr.yml
+++ b/config/locales/account_reset/fr.yml
@@ -2,9 +2,9 @@
 fr:
   account_reset:
     confirm_delete_account:
+      cta: Vous pouvez %{link} ou fermer cette fenêtre si vous avez terminé.
       info: Le compte pour <strong>%{email}</strong> a été supprimé. Nous avons envoyé
-        un email de confirmation de la suppression du compte. <br> <br> Vous pouvez
-        %{link} ou fermer cette fenêtre si vous avez terminé.
+        un email de confirmation de la suppression du compte.
       link_text: créer un nouveau compte
       title: Vous avez supprimé votre compte
     confirm_request:

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -27,8 +27,8 @@ en:
       format_mismatch: Please match the requested format.
       improbable_phone: Invalid phone number. Please make sure you enter a valid phone
         number.
-      invalid_calling_area: Calls to that phone number are not supported.  Please
-        try SMS if you have an SMS-capable phone.
+      invalid_calling_area: Calls to that phone number are not supported. Please try
+        SMS if you have an SMS-capable phone.
       invalid_phone_number: The phone number entered is not valid.
       invalid_sms_number: The phone number entered doesn't support text messaging.
         Try the Phone call option.
@@ -53,6 +53,6 @@ en:
       weak_password: Your password is not strong enough. %{feedback}
     webauthn_setup:
       delete_last: Sorry, you can not remove your last MFA option.
-      general_error: There was an error adding your hardward security key.  Please
+      general_error: There was an error adding your hardward security key. Please
         try again.
-      unique_name: That name is already taken.  Please choose a different name.
+      unique_name: That name is already taken. Please choose a different name.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -68,8 +68,8 @@ en:
     phone_voice_label: Phone number
     piv_cac_fallback:
       link: Use your PIV/CAC instead
-      text_html: Do you have your PIV/CAC? %{link}
       question: Don't have your piv/cac card available?
+      text_html: Do you have your PIV/CAC? %{link}
     piv_cac_header_text: Present your PIV/CAC
     please_try_again_html: Please try again in <strong id=%{id}>%{time_remaining}</strong>.
     read_about_two_factor_authentication:

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -69,8 +69,8 @@ es:
     phone_voice_label: Número de teléfono
     piv_cac_fallback:
       link: Use su PIV/CAC en su lugar
-      text_html: "¿Tiene usted PIV/CAC? %{link}"
       question: "¿No tiene su tarjeta PIV/CAC disponible?"
+      text_html: "¿Tiene usted PIV/CAC? %{link}"
     piv_cac_header_text: NOT TRANSLATED YET
     please_try_again_html: Inténtelo de nuevo en <strong id=%{id}>%{time_remaining}</strong>.
     read_about_two_factor_authentication:

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -70,8 +70,8 @@ fr:
     phone_voice_label: Numéro de téléphone
     piv_cac_fallback:
       link: Utilisez plutôt votre PIV/CAC
-      text_html: Avez-vous votre PIV/CAC? %{link}
       question: Vous n'avez pas accès à votre carte PIV/CAC?
+      text_html: Avez-vous votre PIV/CAC? %{link}
     piv_cac_header_text: NOT TRANSLATED YET
     please_try_again_html: Veuillez essayer de nouveau dans <strong id=%{id}>%{time_remaining}</strong>.
     read_about_two_factor_authentication:

--- a/config/locales/users/en.yml
+++ b/config/locales/users/en.yml
@@ -19,15 +19,12 @@ en:
       generated_on_html: Generated on %{date}
       get_another: Get another key
       header: Your personal key
-      help_text: |-
-        To protect your account, you need a password and access to your telephone or authentication application at sign-in. If you can’t use your phone or app, you can sign in with your personal key instead.
-
-        For your privacy and security, login.gov does not store your password and personal key. Only you know them. Only you can access or share your personal information.
-
-        We require you to store your personal key outside your computer or mobile device so that it will be safe even if your devices are stolen or your online accounts are hacked.
-
-        If you don’t have your personal key and you forget your password, the only way to keep your account safe is to verify that you are the legal owner.
       help_text_header: Why do I need to store my new key on paper?
+      help_text_html: |-
+        <p>To protect your account, you need a password and access to your telephone or authentication application at sign-in. If you can’t use your phone or app, you can sign in with your personal key instead.</p>
+        <p>For your privacy and security, login.gov does not store your password and personal key. Only you know them. Only you can access or share your personal information.</p>
+        <p>We require you to store your personal key outside your computer or mobile device so that it will be safe even if your devices are stolen or your online accounts are hacked.</p>
+        <p>If you don’t have your personal key and you forget your password, the only way to keep your account safe is to verify that you are the legal owner.</p>
       print: Print this page
     totp_setup:
       new:

--- a/config/locales/users/es.yml
+++ b/config/locales/users/es.yml
@@ -19,15 +19,12 @@ es:
       generated_on_html: Generado el %{date}
       get_another: Obtener otra clave
       header: Su clave personal
-      help_text: |-
-        Para proteger su cuenta, necesita una contraseña y acceso a su teléfono o app de autenticación al iniciar una sesión. Si no puede utilizar su teléfono o app, puede iniciar una sesión con su clave personal.
-
-        Para su privacidad y seguridad, login.gov no guarda su contraseña y clave personal. Sólo usted las conoce. Sólo usted puede acceder o compartir su información personal.
-
-        Le pedimos que guarde su clave personal afuera de su computadora o dispositivo móvil para que mantenerla segura en caso de que le roben sus aparatos o sus cuentas en línea sean hackeadas.
-
-        Si no tiene su clave personal y olvida su contraseña, la única manera de mantener su cuenta segura es verificando que usted es el propietario legal.
       help_text_header: "¿Por qué necesito guardar mi nueva clave en papel?"
+      help_text_html: |-
+        <p>Para proteger su cuenta, necesita una contraseña y acceso a su teléfono o app de autenticación al iniciar una sesión. Si no puede utilizar su teléfono o app, puede iniciar una sesión con su clave personal.</p>
+        <p>Para su privacidad y seguridad, login.gov no guarda su contraseña y clave personal. Sólo usted las conoce. Sólo usted puede acceder o compartir su información personal.</p>
+        <p>Le pedimos que guarde su clave personal afuera de su computadora o dispositivo móvil para que mantenerla segura en caso de que le roben sus aparatos o sus cuentas en línea sean hackeadas.</p>
+        <p>Si no tiene su clave personal y olvida su contraseña, la única manera de mantener su cuenta segura es verificando que usted es el propietario legal.</p>
       print: Imprima esta página
     totp_setup:
       new:

--- a/config/locales/users/fr.yml
+++ b/config/locales/users/fr.yml
@@ -21,15 +21,12 @@ fr:
       generated_on_html: Générée le %{date}
       get_another: Obtenir une autre clé
       header: Votre clé personnelle
-      help_text: |-
-        Pour protéger votre compte, vous devez avoir un mot de passe et l'accès à votre téléphone ou application d'authentification au moment de la connexion. Si vous ne pouvez utiliser votre téléphone ou application, vous pouvez vous connecter avec votre clé personnelle.
-
-        Pour votre confidentialité et votre sécurité, login.gov ne conserve pas votre mot de passe ni votre clé personnelle. Seul(e) vous les connaissez. Seul(e) vous pouvez accéder à votre information personnelle et la partager .
-
-        Nous vous demandons de conserver votre clé personnelle à l'extérieur de votre ordinateur ou appareil mobile afin qu'elle soit en sûreté même si vos appareils sont volés ou si vos comptes en ligne sont piratés.
-
-        Si vous n'avez pas votre clé personnelle et que vous oubliez votre mot de passe, la seule façon de garder votre compte en sécurité est de vérifier que vous en êtes le(la) propriétaire légal(e).
       help_text_header: Pourquoi dois-je conserver ma nouvelle clé sur papier?
+      help_text_html: |-
+        <p>Pour protéger votre compte, vous devez avoir un mot de passe et l'accès à votre téléphone ou application d'authentification au moment de la connexion. Si vous ne pouvez utiliser votre téléphone ou application, vous pouvez vous connecter avec votre clé personnelle.</p>
+        <p>Pour votre confidentialité et votre sécurité, login.gov ne conserve pas votre mot de passe ni votre clé personnelle. Seul(e) vous les connaissez. Seul(e) vous pouvez accéder à votre information personnelle et la partager.</p>
+        <p>Nous vous demandons de conserver votre clé personnelle à l'extérieur de votre ordinateur ou appareil mobile afin qu'elle soit en sûreté même si vos appareils sont volés ou si vos comptes en ligne sont piratés.</p>
+        <p>Si vous n'avez pas votre clé personnelle et que vous oubliez votre mot de passe, la seule façon de garder votre compte en sécurité est de vérifier que vous en êtes le(la) propriétaire légal(e).</p>
       print: Imprimer cette page
     totp_setup:
       new:

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -153,7 +153,7 @@ end
 
 def expect_accordion_content_to_be_hidden_by_default
   expect(page).to have_xpath("//#{accordion_control_selector}")
-  expect(page).not_to have_content(t('users.personal_key.help_text'))
+  expect(page).not_to have_content strip_tags(t('users.personal_key.help_text_html'))
   expect(page).to have_xpath(
     "//div[@id='personal-key-confirm'][@class='display-none']", visible: false
   )
@@ -165,7 +165,7 @@ end
 
 def expect_accordion_content_to_become_visible
   expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='true']")
-  expect(page).to have_content(t('users.personal_key.help_text'))
+  expect(page).to have_content strip_tags(t('users.personal_key.help_text_html'))
 end
 
 def expect_confirmation_modal_to_appear_with_first_code_field_in_focus

--- a/spec/support/shared_examples_for_personal_keys.rb
+++ b/spec/support/shared_examples_for_personal_keys.rb
@@ -24,7 +24,7 @@ shared_examples_for 'personal key page' do
       scenario 'content is visible by default' do
         expect(page).to have_xpath("//#{accordion_control_selector}[@aria-expanded='true']")
         expect(page).to have_xpath("//#{content_selector}")
-        expect(page).to have_content(t('users.personal_key.help_text'))
+        expect(page).to have_content strip_tags(t('users.personal_key.help_text_html'))
       end
     end
 


### PR DESCRIPTION
**Why**: To have the most stable version. I was working on another PR
and I started having bundler issues due to capybara-screenshot.

Note that by updating capybara-screenshot, capybara was also updated
to 3.7.2, which is good because we were quite behind at 2.17.0.
Version 3 changes the way text is matched. It no longer normalizes
whitespace and returns text as close as possible to "as rendered", which
allows us to find bugs such as extra spaces in our localizations.

Version 3 also uses puma by default, so I added the gem.

More upgrade details here:
https://github.com/teamcapybara/capybara/blob/master/UPGRADING.md


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.