### PR TITLE
LG-651 Allow newrelic_rpm to be updated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    newrelic_rpm (5.2.0.345)
+    newrelic_rpm (5.4.0.347)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -4,6 +4,11 @@ describe Encryption::PasswordVerifier do
   describe '.digest' do
     it 'creates a digest from the password' do
       salt = '1' * 64 # 32 hex encoded bytes is 64 characters
+      # The newrelic_rpm gem added a call to `SecureRandom.hex(8)` in
+      # abstract_segment.rb on 6/13/18. Our New Relic tracers in
+      # config/initializers/new_relic_tracers.rb trigger this call, which
+      # is why we stub with a default value first.
+      allow(SecureRandom).to receive(:hex) { salt }
       allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
 
       digest = described_class.digest('saltypickles')


### PR DESCRIPTION
**Why**: The `newrelic_rpm` gem added a call to `SecureRandom.hex(8)`
on 6/13/18:
https://github.com/newrelic/rpm/commit/60ef61c512a29107de5015b1d574efc4566d08f6

Some of our tests stub calls to `SecureRandom`, and because we have
New Relic tracers in an initializer, the newly-added call to
`SecureRandom` in the gem caused the tests to fail because they are
not expecting that additional call.

RSpec tells us to stub the call with a default value first in this case.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
