### PR TITLE
LG-553 LOA3: Cancel verification doesn't remove pending status

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -8,6 +8,7 @@ module Idv
     before_action :confirm_step_needed
     before_action :confirm_step_allowed, except: [:failure]
     before_action :set_idv_form, except: [:failure]
+    before_action :ensure_profile_verification_not_pending, only: :new
 
     def new
       analytics.track_event(Analytics::IDV_PHONE_RECORD_VISIT)
@@ -75,6 +76,19 @@ module Idv
 
     def failure_url(reason)
       idv_phone_failure_url(reason)
+    end
+
+    def ensure_profile_verification_not_pending
+      verification_pending_profiles.each do |profile|
+        profile.update!(deactivation_reason: nil)
+      end
+    end
+
+    def verification_pending_profiles
+      Profile.where(
+        user_id: current_user.id,
+        deactivation_reason: :verification_pending
+      )
     end
   end
 end

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -80,7 +80,7 @@ module Idv
 
     def ensure_profile_verification_not_pending
       verification_pending_profiles.each do |profile|
-        profile.update!(deactivation_reason: nil)
+        profile.update!(deactivation_reason: :verification_cancelled)
       end
     end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,6 +14,7 @@ class Profile < ApplicationRecord
     password_reset: 1,
     encryption_error: 2,
     verification_pending: 3,
+    verification_cancelled: 4,
   }
 
   attr_reader :personal_key

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -62,6 +62,21 @@ describe Idv::PhoneController do
 
       expect(response).to redirect_to idv_phone_failure_url(:fail)
     end
+
+    context 'when there is a pending verification' do
+      let(:pending_profile) do
+        create(:profile, user_id: user.id, deactivation_reason: :verification_pending)
+      end
+
+      it 'clears the pending verification' do
+        pending_profile
+        expect(Profile.all.first.deactivation_reason).to eq('verification_pending')
+
+        get :new
+
+        expect(Profile.all.first.deactivation_reason).to eq(nil)
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -74,7 +74,7 @@ describe Idv::PhoneController do
 
         get :new
 
-        expect(Profile.all.first.deactivation_reason).to eq(nil)
+        expect(Profile.all.first.deactivation_reason).to eq('verification_cancelled')
       end
     end
   end


### PR DESCRIPTION
**Why**: When a user chooses to verify by mail and then returns to say they can't receive mail at this address we should remove their verification pending status

**How**: Ensure that if they are on the phone verification page they have effectively cancelled their pending status.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
