### PR TITLE
Get link right for adding a phone

### DIFF
--- a/app/views/accounts/_phone.html.slim
+++ b/app/views/accounts/_phone.html.slim
@@ -5,7 +5,7 @@
     .right-align.col.col-6
       - if MfaContext.new(current_user).phone_configurations.empty?
         .btn.btn-account-action.rounded-lg.bg-light-blue
-          = link_to t('account.index.phone_add'), path: manage_phone_url
+          = link_to t('account.index.phone_add'), manage_phone_path
   - MfaContext.new(current_user).phone_configurations.each do |phone_configuration|
     .p2.col.col-12.border-top.border-blue-light
       .col.col-8.sm-6.truncate

--- a/spec/views/accounts/show.html.slim_spec.rb
+++ b/spec/views/accounts/show.html.slim_spec.rb
@@ -147,4 +147,47 @@ describe 'accounts/show.html.slim' do
 
     expect(view).to render_template(partial: '_delete_account_item_heading')
   end
+
+  context 'phone listing and adding' do
+    it 'renders the phone section' do
+      render
+
+      expect(view).to render_template(partial: '_phone')
+    end
+
+    context 'user has no phone' do
+      let(:user) do
+        record = build_stubbed(:user, :signed_up, :with_piv_or_cac)
+        record.phone_configurations = []
+        record
+      end
+
+      it 'shows the add phone link' do
+        render
+
+        expect(rendered).to have_link(
+          t('account.index.phone_add'), href: manage_phone_path
+        )
+      end
+    end
+
+    context 'user has a phone' do
+      it 'shows no add phone link' do
+        render
+
+        expect(rendered).to_not have_content t('account.index.phone_add')
+        expect(rendered).to_not have_link(
+          t('account.index.phone_add'), href: manage_phone_path
+        )
+      end
+
+      it 'shows an edit link' do
+        render
+
+        expect(rendered).to have_link(
+          t('account.index.phone'), href: manage_phone_url
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
The link accidently included a `path:` component, making a
bad link.

**How**:
Remove the `path:` part of the call and add tests to make sure
we don't introduce it back in.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
