### PR TITLE
LG-695 Enable Webauthn when there is no SP

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,8 @@ class AccountsController < ApplicationController
     @view_model = AccountShow.new(
       decrypted_pii: cacher.fetch,
       personal_key: flash[:personal_key],
-      decorated_user: current_user.decorate
+      decorated_user: current_user.decorate,
+      sp: current_sp
     )
   end
 

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     end
 
     def confirm_webauthn_enabled
-      return if TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
+      return if TwoFactorAuthentication::WebauthnPolicy.new(current_user, current_sp).enabled?
 
       redirect_to user_two_factor_authentication_url
     end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -198,7 +198,7 @@ module Users
     def redirect_url
       if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled?
         login_two_factor_piv_cac_url
-      elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
+      elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user, current_sp).enabled?
         login_two_factor_webauthn_url
       elsif TwoFactorAuthentication::AuthAppPolicy.new(current_user).enabled?
         login_two_factor_authenticator_url

--- a/app/policies/two_factor_authentication/webauthn_policy.rb
+++ b/app/policies/two_factor_authentication/webauthn_policy.rb
@@ -1,12 +1,13 @@
 module TwoFactorAuthentication
   # The WebauthnPolicy class is responsible for handling the user policy of webauthn
   class WebauthnPolicy
-    def initialize(user)
+    def initialize(user, sp)
       @mfa_user = MfaContext.new(user)
+      @sp = sp
     end
 
     def configured?
-      FeatureManagement.webauthn_enabled? && mfa_user.webauthn_configurations.any?
+      webauthn_enabled? && mfa_user.webauthn_configurations.any?
     end
 
     def enabled?
@@ -15,16 +16,20 @@ module TwoFactorAuthentication
 
     # :reek:UtilityFunction
     def available?
-      FeatureManagement.webauthn_enabled?
+      webauthn_enabled?
     end
 
     # :reek:UtilityFunction
     def visible?
-      FeatureManagement.webauthn_enabled?
+      webauthn_enabled?
     end
 
     private
 
-    attr_reader :mfa_user
+    attr_reader :mfa_user, :sp
+
+    def webauthn_enabled?
+      sp.nil? && FeatureManagement.webauthn_enabled?
+    end
   end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -42,7 +42,7 @@ class TwoFactorOptionsPresenter
   end
 
   def webauthn_option
-    if TwoFactorAuthentication::WebauthnPolicy.new(current_user).available?
+    if TwoFactorAuthentication::WebauthnPolicy.new(current_user, service_provider).available?
       [TwoFactorAuthentication::WebauthnSelectionPresenter.new]
     else
       []

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -1,11 +1,12 @@
 # :reek:TooManyMethods
 class AccountShow
-  attr_reader :decorated_user, :decrypted_pii, :personal_key
+  attr_reader :decorated_user, :decrypted_pii, :personal_key, :sp
 
-  def initialize(decrypted_pii:, personal_key:, decorated_user:)
+  def initialize(decrypted_pii:, personal_key:, decorated_user:, sp: '')
     @decrypted_pii = decrypted_pii
     @personal_key = personal_key
     @decorated_user = decorated_user
+    @sp = sp
   end
 
   def header_partial

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -43,7 +43,7 @@ h1.hide = t('titles.account')
       content: content_tag(:em, @view_model.totp_content),
       action: @view_model.totp_partial
 
-  - if TwoFactorAuthentication::WebauthnPolicy.new(current_user).visible?
+  - if TwoFactorAuthentication::WebauthnPolicy.new(current_user, @view_model.sp).visible?
     = render 'webauthn'
 
   - if TwoFactorAuthentication::PivCacPolicy.new(current_user).visible?

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -53,6 +53,6 @@ en:
       weak_password: Your password is not strong enough. %{feedback}
     webauthn_setup:
       delete_last: Sorry, you can not remove your last MFA option.
-      general_error: There was an error adding your hardward security key. Please
+      general_error: There was an error adding your hardware security key. Please
         try again.
       unique_name: That name is already taken. Please choose a different name.

--- a/spec/policies/webauthn_login_option_policy_spec.rb
+++ b/spec/policies/webauthn_login_option_policy_spec.rb
@@ -3,23 +3,46 @@ require 'rails_helper'
 describe TwoFactorAuthentication::WebauthnPolicy do
   include WebauthnVerificationHelper
 
-  let(:subject) { described_class.new(user) }
-
   describe '#configured?' do
-    context 'without a webauthn configured' do
-      let(:user) { build(:user) }
+    context 'with no sp' do
+      let(:subject) { described_class.new(user, nil) }
 
-      it { expect(subject.configured?).to be_falsey }
-    end
+      context 'without a webauthn configured' do
+        let(:user) { build(:user) }
 
-    context 'with a webauthn configured' do
-      let(:user) { create(:user) }
-      before do
-        create_webauthn_configuration(user)
+        it { expect(subject.configured?).to be_falsey }
       end
 
-      it 'returns a truthy value' do
-        expect(subject.configured?).to be_truthy
+      context 'with a webauthn configured' do
+        let(:user) { create(:user) }
+        before do
+          create_webauthn_configuration(user)
+        end
+
+        it 'returns a truthy value' do
+          expect(subject.configured?).to be_truthy
+        end
+      end
+    end
+
+    context 'with an sp' do
+      let(:subject) { described_class.new(user, 'foo') }
+
+      context 'without a webauthn configured' do
+        let(:user) { build(:user) }
+
+        it { expect(subject.configured?).to be_falsey }
+      end
+
+      context 'with a webauthn configured' do
+        let(:user) { create(:user) }
+        before do
+          create_webauthn_configuration(user)
+        end
+
+        it 'returns a truthy value' do
+          expect(subject.configured?).to be_falsey
+        end
       end
     end
   end

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -136,7 +136,15 @@ shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
 end
 
 shared_examples 'creating an LOA3 account using webauthn for 2FA' do |sp|
-  it 'does not prompt for recovery code before IdV flow', email: true do
+  it 'does not have webauthn as an option', email: true do
+    mock_challenge
+    visit_idp_from_sp_with_loa3(sp)
+    confirm_email_and_password('test@test.com')
+    expect(page).to_not have_css("label[for='two_factor_options_form_selection_webauthn']")
+  end
+
+  # Remove the above test and enable this one when we enable webauthn for the SPs
+  xit 'does not prompt for recovery code before IdV flow', email: true do
     mock_challenge
     visit_idp_from_sp_with_loa3(sp)
     confirm_email_and_password('test@test.com')


### PR DESCRIPTION
**Why**: To allow us to test in production without enabling the feature for all users.

**How**: Update the policy object to include the current SP and enable webauthn when the SP is nil.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
