### PR TITLE
LG-671 Don't raise if TOTP secret not in session

### DIFF
--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -6,8 +6,8 @@ module Users
     def new
       return redirect_to account_url if current_user.totp_enabled?
 
-      track_event
       store_totp_secret_in_session
+      track_event
 
       @code = new_totp_secret
       @qrcode = current_user.decorate.qrcode(new_totp_secret)
@@ -42,7 +42,10 @@ module Users
     end
 
     def track_event
-      properties = { user_signed_up: MfaPolicy.new(current_user).two_factor_enabled? }
+      properties = {
+        user_signed_up: MfaPolicy.new(current_user).two_factor_enabled?,
+        totp_secret_present: new_totp_secret.present?,
+      }
       analytics.track_event(Analytics::TOTP_SETUP_VISIT, properties)
     end
 

--- a/app/forms/totp_setup_form.rb
+++ b/app/forms/totp_setup_form.rb
@@ -10,7 +10,7 @@ class TotpSetupForm
 
     process_valid_submission if success
 
-    FormResponse.new(success: success, errors: {})
+    FormResponse.new(success: success, errors: {}, extra: extra_analytics_attributes)
   end
 
   private
@@ -18,11 +18,17 @@ class TotpSetupForm
   attr_reader :user, :code, :secret, :success
 
   def valid_totp_code?
+    # The two_factor_authentication gem raises an error if the secret is nil.
+    return false if secret.nil?
     user.confirm_totp_secret(secret, code)
   end
 
   def process_valid_submission
     user.save!
     Event.create(user_id: user.id, event_type: :authenticator_enabled)
+  end
+
+  def extra_analytics_attributes
+    { totp_secret_present: secret.present? }
   end
 end

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -12,7 +12,7 @@ describe TotpSetupForm do
         result = instance_double(FormResponse)
 
         expect(FormResponse).to receive(:new).
-          with(success: true, errors: {}).and_return(result)
+          with(success: true, errors: {}, extra: { totp_secret_present: true }).and_return(result)
         expect(Event).to receive(:create).
           with(user_id: user.id, event_type: :authenticator_enabled)
         expect(form.submit).to eq result
@@ -26,7 +26,22 @@ describe TotpSetupForm do
         result = instance_double(FormResponse)
 
         expect(FormResponse).to receive(:new).
-          with(success: false, errors: {}).and_return(result)
+          with(success: false, errors: {}, extra: { totp_secret_present: true }).and_return(result)
+        expect(Event).to_not receive(:create)
+        expect(form.submit).to eq result
+        expect(user.reload.totp_enabled?).to eq false
+      end
+    end
+
+    # We've seen a few cases in production where the authentication app
+    # setup page was submitted without a secret_key in the user_session
+    context 'when the secret key is not present' do
+      it 'returns FormResponse with success: false' do
+        form = TotpSetupForm.new(user, nil, 'kode')
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: {}, extra: { totp_secret_present: false }).and_return(result)
         expect(Event).to_not receive(:create)
         expect(form.submit).to eq result
         expect(user.reload.totp_enabled?).to eq false


### PR DESCRIPTION
**Why**: We see half a dozen or so errors in production every month due
to folks submitting the authentication app setup form when the TOTP
secret is no longer in the session. The `two_factor_authentication` gem
raises an error if the secret is nil, but we don't want to raise an
error. We want to display a helpful message to the user so they can try
again.

**How**: Don't call the gem's `confirm_totp_secret` method if the
secret is nil. Instead, treat it as an invalid input.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.