### PR TITLE
LG-670 Handle SES timeouts gracefully

### DIFF
--- a/app/forms/password_reset_email_form.rb
+++ b/app/forms/password_reset_email_form.rb
@@ -27,6 +27,7 @@ class PasswordResetEmailForm
       user_id: user.uuid,
       role: user.role,
       confirmed: user.confirmed?,
+      active_profile: user.active_profile.present?,
     }.merge(@recaptcha_h)
   end
 

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -12,11 +12,13 @@ class ResetPasswordForm
   end
 
   def submit(params)
-    submitted_password = params[:password]
+    self.password = params[:password]
 
-    self.password = submitted_password
+    @success = valid?
 
-    FormResponse.new(success: valid?, errors: errors.messages, extra: extra_analytics_attributes)
+    handle_valid_password if success
+
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
   private
@@ -29,11 +31,37 @@ class ResetPasswordForm
     errors.add(:reset_password_token, 'token_expired')
   end
 
+  def handle_valid_password
+    create_password_changed_event
+    update_user
+    increment_password_metrics
+    mark_profile_inactive
+    notify_user_of_password_change_via_email
+  end
+
+  def create_password_changed_event
+    Event.create(user_id: user.id, event_type: :password_changed)
+  end
+
+  def update_user
+    attributes = { password: password }
+    attributes[:confirmed_at] = Time.zone.now unless user.confirmed?
+    UpdateUser.new(user: user, attributes: attributes).call
+  end
+
+  def increment_password_metrics
+    PasswordMetricsIncrementer.new(password).increment_password_metrics
+  end
+
+  def mark_profile_inactive
+    user.active_profile&.deactivate(:password_reset)
+  end
+
+  def notify_user_of_password_change_via_email
+    UserMailer.password_changed(user).deliver_later
+  end
+
   def extra_analytics_attributes
-    {
-      user_id: user.uuid,
-      active_profile: user.active_profile.present?,
-      confirmed: user.confirmed?,
-    }
+    { user_id: user.uuid }
   end
 end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -33,7 +33,7 @@ class UpdateUserPasswordForm
   end
 
   def email_user_about_password_change
-    EmailNotifier.new(user).send_password_changed_email
+    UserMailer.password_changed(user).deliver_later
   end
 
   def encrypt_user_profile_if_active

--- a/app/models/nonexistent_user.rb
+++ b/app/models/nonexistent_user.rb
@@ -22,4 +22,8 @@ class NonexistentUser
   def tech?
     false
   end
+
+  def active_profile
+    nil
+  end
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -106,6 +106,7 @@ class Analytics
   PASSWORD_RESET_EMAIL = 'Password Reset: Email Submitted'.freeze
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
+  PASSWORD_RESET_VISIT = 'Password Reset: Email Form Visited'.freeze
   PERSONAL_KEY_VIEWED = 'Personal Key Viewed'.freeze
   PHONE_CHANGE_REQUESTED = 'Phone Number Change: requested'.freeze
   PROFILE_ENCRYPTION_INVALID = 'Profile Encryption: Invalid'.freeze

--- a/app/services/email_notifier.rb
+++ b/app/services/email_notifier.rb
@@ -1,8 +1,4 @@
 EmailNotifier = Struct.new(:user) do
-  def send_password_changed_email
-    UserMailer.password_changed(user).deliver_later
-  end
-
   def send_email_changed_email
     UserMailer.email_changed(old_email).deliver_later if email_changed?
   end

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -23,7 +23,11 @@ module Aws
       end
 
       def ses_client_options
-        opts = {}
+        opts = {
+          # https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html
+          retry_limit: 3,
+          retry_backoff: ->(_context) { sleep(2) },
+        }
         opts[:region] = pick_region_from_pool if Figaro.env.aws_ses_region_pool.present?
         opts
       end

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -16,6 +16,7 @@ describe PasswordResetEmailForm do
           user_id: user.uuid,
           role: user.role,
           confirmed: true,
+          active_profile: false,
         }
 
         result = instance_double(FormResponse)
@@ -33,6 +34,7 @@ describe PasswordResetEmailForm do
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
+          active_profile: false,
         }
 
         result = instance_double(FormResponse)
@@ -53,6 +55,7 @@ describe PasswordResetEmailForm do
           user_id: 'nonexistent-uuid',
           role: 'nonexistent',
           confirmed: false,
+          active_profile: false,
         }
 
         result = instance_double(FormResponse)
@@ -74,6 +77,7 @@ describe PasswordResetEmailForm do
           user_id: user.uuid,
           role: user.role,
           confirmed: true,
+          active_profile: false,
           recaptcha_valid: true,
           recaptcha_present: true,
           recaptcha_enabled: true,
@@ -99,6 +103,7 @@ describe PasswordResetEmailForm do
           user_id: user.uuid,
           role: user.role,
           confirmed: true,
+          active_profile: false,
           recaptcha_valid: false,
           recaptcha_present: true,
           recaptcha_enabled: true,

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -17,11 +17,7 @@ describe ResetPasswordForm, type: :model do
 
         errors = { reset_password_token: ['token_expired'] }
 
-        extra = {
-          user_id: '123',
-          active_profile: false,
-          confirmed: true,
-        }
+        extra = { user_id: '123' }
 
         result = instance_double(FormResponse)
 
@@ -42,11 +38,7 @@ describe ResetPasswordForm, type: :model do
 
         errors = { password: ['is too short (minimum is 9 characters)'] }
 
-        extra = {
-          user_id: '123',
-          active_profile: false,
-          confirmed: true,
-        }
+        extra = { user_id: '123' }
 
         result = instance_double(FormResponse)
 
@@ -60,19 +52,17 @@ describe ResetPasswordForm, type: :model do
       it 'sets the user password to the submitted password' do
         user = build_stubbed(:user, uuid: '123')
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+        expect(Event).to receive(:create).with(user_id: user.id, event_type: :password_changed)
 
         form = ResetPasswordForm.new(user)
-
         password = 'valid password'
-
-        extra = {
-          user_id: '123',
-          active_profile: false,
-          confirmed: true,
-        }
-
+        extra = { user_id: '123' }
         result = instance_double(FormResponse)
+        user_updater = instance_double(UpdateUser)
+        allow(UpdateUser).to receive(:new).
+          with(user: user, attributes: { password: password }).and_return(user_updater)
 
+        expect(user_updater).to receive(:call)
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
         expect(form.submit(password: password)).to eq result
@@ -93,11 +83,7 @@ describe ResetPasswordForm, type: :model do
           reset_password_token: ['token_expired'],
         }
 
-        extra = {
-          user_id: '123',
-          active_profile: false,
-          confirmed: true,
-        }
+        extra = { user_id: '123' }
 
         result = instance_double(FormResponse)
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -57,13 +57,12 @@ describe UpdateUserPasswordForm, type: :model do
       end
 
       it 'sends an email to notify of the password change' do
-        email_notifier = instance_double(EmailNotifier)
-        allow(EmailNotifier).to receive(:new).with(user).and_return(email_notifier)
-        allow(email_notifier).to receive(:send_password_changed_email)
+        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(UserMailer).to receive(:password_changed).with(user).and_return(mailer)
 
         subject.submit(params)
 
-        expect(email_notifier).to have_received(:send_password_changed_email)
+        expect(mailer).to have_received(:deliver_later)
       end
 
       it 'increments password metrics for the password' do
@@ -99,10 +98,8 @@ describe UpdateUserPasswordForm, type: :model do
 
     context 'when the user does not have an active profile' do
       it 'does not call ActiveProfileEncryptor' do
-        email_notifier = instance_double(EmailNotifier)
-
-        expect(EmailNotifier).to receive(:new).with(user).and_return(email_notifier)
-        expect(email_notifier).to receive(:send_password_changed_email)
+        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        expect(UserMailer).to receive(:password_changed).with(user).and_return(mailer)
         expect(ActiveProfileEncryptor).to_not receive(:new)
 
         subject.submit(params)
@@ -111,8 +108,7 @@ describe UpdateUserPasswordForm, type: :model do
   end
 
   def stub_email_delivery
-    email_notifier = instance_double(EmailNotifier)
-    allow(EmailNotifier).to receive(:new).with(user).and_return(email_notifier)
-    allow(email_notifier).to receive(:send_password_changed_email)
+    mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+    allow(UserMailer).to receive(:password_changed).with(user).and_return(mailer)
   end
 end

--- a/spec/lib/aws/ses_spec.rb
+++ b/spec/lib/aws/ses_spec.rb
@@ -38,6 +38,16 @@ describe Aws::SES::Base do
       expect(mail.message_id).to eq('123abc@email.amazonses.com')
     end
 
+    it 'retries timed out requests' do
+      allow(Figaro.env).to receive(:aws_ses_region_pool).and_return(nil)
+      Aws::SES::Base.new.deliver!(mail)
+
+      expect(Aws::SES::Client).to have_received(:new) do |options|
+        expect(options[:retry_limit]).to eq 3
+        expect(options.key?(:retry_backoff)).to eq true
+      end
+    end
+
     context 'with an ses region pool in the configuration' do
       before do
         allow(Figaro.env).to receive(:aws_ses_region_pool).
@@ -66,12 +76,9 @@ describe Aws::SES::Base do
         allow(described_class.region_pool).to receive(:sample).and_return('us-fake-1')
         described_class.new.deliver!(mail)
 
-        expect(Aws::SES::Client).to have_received(:new).with(region: 'us-fake-1')
-
-        allow(described_class.region_pool).to receive(:sample).and_return('us-phony-2')
-        described_class.new.deliver!(mail)
-
-        expect(Aws::SES::Client).to have_received(:new).with(region: 'us-phony-2')
+        expect(Aws::SES::Client).to have_received(:new) do |options|
+          expect(options[:region]).to eq 'us-fake-1'
+        end
       end
     end
 

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -1,21 +1,6 @@
 require 'rails_helper'
 
 describe EmailNotifier do
-  describe '#send_password_changed_email' do
-    let(:mailer) { instance_double(ActionMailer::MessageDelivery) }
-
-    context 'when the password has changed' do
-      it 'sends an email notifiying the user of the password change' do
-        user = create(:user, :signed_up, password: 'newValidPass!!00')
-
-        expect(UserMailer).to receive(:password_changed).with(user).and_return(mailer)
-        expect(mailer).to receive(:deliver_later)
-
-        EmailNotifier.new(user).send_password_changed_email
-      end
-    end
-  end
-
   describe '#send_email_changed_email' do
     context 'when the email has not changed' do
       it 'does not send an email' do

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -22,8 +22,6 @@ shared_examples 'strong password' do |form_class|
     elsif form_class == 'ResetPasswordForm'
       extra = {
         user_id: '123',
-        active_profile: false,
-        confirmed: true,
       }
     end
     result = instance_double(FormResponse)
@@ -56,8 +54,6 @@ shared_examples 'strong password' do |form_class|
     elsif form_class == 'ResetPasswordForm'
       extra = {
         user_id: '123',
-        active_profile: false,
-        confirmed: true,
       }
     end
     result = instance_double(FormResponse)
@@ -90,8 +86,6 @@ shared_examples 'strong password' do |form_class|
     elsif form_class == 'ResetPasswordForm'
       extra = {
         user_id: '123',
-        active_profile: false,
-        confirmed: true,
       }
     end
     result = instance_double(FormResponse)
@@ -124,8 +118,6 @@ shared_examples 'strong password' do |form_class|
     elsif form_class == 'ResetPasswordForm'
       extra = {
         user_id: '123',
-        active_profile: false,
-        confirmed: true,
       }
     end
     result = instance_double(FormResponse)


### PR DESCRIPTION
**Why**: In a few rare cases, SES does not respond in time when the app
tries to send an email. In the reset password scenario, the controller
was attempting to send an email after it redirected the user, but if
the call to AWS SES takes longer than 15 seconds, RackTimeout kicks in,
and `ApplicationController` calls `render_timeout`, which then causes
the following exception:

```
An AbstractController::DoubleRenderError occurred in reset_passwords#update:

Render and/or redirect were called multiple times in this action.
Please note that you may only call render OR redirect, and at most once
per action. Also note that neither redirect nor render terminate
execution of the action, so if you want to exit an action after
redirecting, you need to do something like "redirect_to(...) and return".
```

The quick and easy solution to prevent the 500 error is to send the
email before redirecting. However, we can go a step further and try to
make the experience better for the user by retrying before timing out.

Note that the AWS documentation is not great, and seems to indicate
that these retries do not apply to SES, but it doesn't hurt to include
the retry options just in case they do work with SES.

I also took the opportunity to refactor the controller and move the
business logic out of it and into the Form Object. With this change,
the extra analytics attributes that check if the user is confirmed
or if they are verified no longer make sense in `ResetPasswordForm`
because they won't reflect the state of the user prior to the password
change. Before, the controller was handling the user updates after the
form returned the analytics attributes. Now that the form is updating
the user before it returns the FormResponse object, the data is no
longer valid.

What we are really interested in here is the state of the user at the
time they request a password reset. We want to see what percentage of
users request a password reset before they have finished creating their
account, and how often verified users request password resets. The point
in time at which it makes the most sense to capture this state is when
they enter their email in the password reset form, which is why those
analytics attributes were moved to `PasswordResetEmailForm`.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.