### PR TITLE
LG-711 Stop asking for webauthn attestation and catch errors

### DIFF
--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -52,7 +52,13 @@ class WebauthnSetupForm
       attestation_object: Base64.decode64(@attestation_object),
       client_data_json: Base64.decode64(@client_data_json)
     )
-    original_origin = "#{protocol}#{self.class.domain_name}"
+    safe_response("#{protocol}#{self.class.domain_name}")
+  end
+
+  def safe_response(original_origin)
     @attestation_response.valid?(@challenge.pack('c*'), original_origin)
+  rescue StandardError
+    errors.add :name, I18n.t('errors.webauthn_setup.attestation_error')
+    false
   end
 end

--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -36,7 +36,7 @@ function webauthn() {
         },
       ],
       timeout: 800000,
-      attestation: 'direct',
+      attestation: 'none',
       excludeList: [],
     },
   };

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -52,6 +52,9 @@ en:
         letter for a new code.
       weak_password: Your password is not strong enough. %{feedback}
     webauthn_setup:
+      attestation_error: Sorry, but your security key doesn't appear to be a U2F security
+        key.  Please make sure your device is listed at https://fidoalliance.org/certification/fido-certified-products/
+        and if you believe the error is ours, please contact us at hello@login.gov.
       delete_last: Sorry, you can not remove your last MFA option.
       general_error: There was an error adding your hardware security key. Please
         try again.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -52,8 +52,8 @@ en:
         letter for a new code.
       weak_password: Your password is not strong enough. %{feedback}
     webauthn_setup:
-      attestation_error: Sorry, but your security key doesn't appear to be a U2F security
-        key.  Please make sure your device is listed at https://fidoalliance.org/certification/fido-certified-products/
+      attestation_error: Sorry, but your security key doesn't appear to be a FIDO
+        security key.  Please make sure your device is listed at https://fidoalliance.org/certification/fido-certified-products/
         and if you believe the error is ours, please contact us at hello@login.gov.
       delete_last: Sorry, you can not remove your last MFA option.
       general_error: There was an error adding your hardware security key. Please

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -47,6 +47,9 @@ es:
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
     webauthn_setup:
+      attestation_error: Lo sentimos, pero su clave de seguridad no parece ser una
+        clave de seguridad U2F. Asegúrese de que su dispositivo esté en https://fidoalliance.org/certification/fido-certified-products/
+        y si cree que el error es nuestro, contáctenos en hello@login.gov.
       delete_last: Lo sentimos, no puedes eliminar tu última opción de MFA.
       general_error: Hubo un error al agregar su clave de seguridad de hardware. Inténtalo
         de nuevo.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -48,7 +48,7 @@ es:
       weak_password: Su contraseña no es suficientemente segura. %{feedback}
     webauthn_setup:
       attestation_error: Lo sentimos, pero su clave de seguridad no parece ser una
-        clave de seguridad U2F. Asegúrese de que su dispositivo esté en https://fidoalliance.org/certification/fido-certified-products/
+        clave de seguridad FIDO. Asegúrese de que su dispositivo esté en https://fidoalliance.org/certification/fido-certified-products/
         y si cree que el error es nuestro, contáctenos en hello@login.gov.
       delete_last: Lo sentimos, no puedes eliminar tu última opción de MFA.
       general_error: Hubo un error al agregar su clave de seguridad de hardware. Inténtalo

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -49,6 +49,10 @@ fr:
       usps_otp_expired: NOT TRANSLATED YET
       weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
     webauthn_setup:
+      attestation_error: Désolé, votre clé de sécurité ne semble pas être une clé
+        de sécurité U2F. Veuillez vous assurer que votre appareil est répertorié sur
+        https://fidoalliance.org/certification/fido-certified-products/ et si vous
+        pensez que l'erreur est la nôtre, veuillez nous contacter à l'adresse hello@login.gov.
       delete_last: Désolé, vous ne pouvez pas supprimer votre dernière option MFA
       general_error: Une erreur s'est produite lors de l'ajout de votre clé de sécurité
         physique. Veuillez réessayer.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -50,9 +50,10 @@ fr:
       weak_password: Votre mot de passe n'est pas assez fort. %{feedback}
     webauthn_setup:
       attestation_error: Désolé, votre clé de sécurité ne semble pas être une clé
-        de sécurité U2F. Veuillez vous assurer que votre appareil est répertorié sur
-        https://fidoalliance.org/certification/fido-certified-products/ et si vous
-        pensez que l'erreur est la nôtre, veuillez nous contacter à l'adresse hello@login.gov.
+        de sécurité FIDO. Veuillez vous assurer que votre appareil est répertorié
+        sur https://fidoalliance.org/certification/fido-certified-products/ et si
+        vous pensez que l'erreur est la nôtre, veuillez nous contacter à l'adresse
+        hello@login.gov.
       delete_last: Désolé, vous ne pouvez pas supprimer votre dernière option MFA
       general_error: Une erreur s'est produite lors de l'ajout de votre clé de sécurité
         physique. Veuillez réessayer.

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -37,6 +37,23 @@ describe WebauthnSetupForm do
           with(success: false, errors: {}).and_return(result)
         expect(subject.submit(protocol, params)).to eq result
       end
+
+      it 'returns false with an error when the attestation response raises an error' do
+        allow(Figaro.env).to receive(:domain_name).and_return('localhost:3000')
+        allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
+
+        result = instance_double(FormResponse)
+        params = {
+          attestation_object: attestation_object,
+          client_data_json: client_data_json,
+          name: 'mykey',
+        }
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors:
+            { name: [I18n.t('errors.webauthn_setup.attestation_error')] }).and_return(result)
+        expect(subject.submit(protocol, params)).to eq result
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: Attestation is not needed and we need to catch errors where an unsupported format is detected by AuthenticatorAttestationResponse#valid

**How**: Set the attestation to 'none' for the navigator.credentials.create options hash in the javascript.  Place a rescue block around the valid? call to the gem/object on the server side.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
