### PR TITLE
LG-721 Track account age and enabled MFA methods

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -153,6 +153,7 @@ detectors:
     public_methods_only: true
     exclude:
       - AnalyticsEventJob#perform
+      - AnonymousUser#confirmed_at
       - ApplicationController#default_url_options
       - ApplicationHelper#step_class
       - NullTwilioClient#http_client

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -40,4 +40,17 @@ class MfaContext
   def enabled_two_factor_configurations_count
     two_factor_configurations.count(&:mfa_enabled?)
   end
+
+  # returns a hash showing the count for each enabled 2FA configuration,
+  # such as: { phone: 2, webauthn: 1 }. This is useful for analytics purposes.
+  def enabled_two_factor_configuration_counts_hash
+    names = enabled_two_factor_configuration_names
+    names.each_with_object(Hash.new(0)) { |name, count| count[name] += 1 }
+  end
+
+  private
+
+  def enabled_two_factor_configuration_names
+    two_factor_configurations.select(&:mfa_enabled?).map(&:friendly_name)
+  end
 end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -21,9 +21,21 @@ class AnonymousUser
     nil
   end
 
+  def webauthn_configurations
+    []
+  end
+
+  def x509_dn_uuid; end
+
+  def otp_secret_key; end
+
   def email; end
 
   def email_address
     EMPTY_EMAIL_ADDRESS
+  end
+
+  def confirmed_at
+    Time.zone.now
   end
 end

--- a/app/models/auth_app_configuration.rb
+++ b/app/models/auth_app_configuration.rb
@@ -18,4 +18,8 @@ class AuthAppConfiguration
       []
     end
   end
+
+  def name
+    :auth_app if mfa_enabled?
+  end
 end

--- a/app/models/auth_app_configuration.rb
+++ b/app/models/auth_app_configuration.rb
@@ -19,7 +19,7 @@ class AuthAppConfiguration
     end
   end
 
-  def name
-    :auth_app if mfa_enabled?
+  def friendly_name
+    :auth_app
   end
 end

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -20,4 +20,8 @@ class PhoneConfiguration < ApplicationRecord
     end
     options
   end
+
+  def name
+    :phone if mfa_enabled?
+  end
 end

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -21,7 +21,7 @@ class PhoneConfiguration < ApplicationRecord
     options
   end
 
-  def name
-    :phone if mfa_enabled?
+  def friendly_name
+    :phone
   end
 end

--- a/app/models/piv_cac_configuration.rb
+++ b/app/models/piv_cac_configuration.rb
@@ -23,7 +23,7 @@ class PivCacConfiguration
     end
   end
 
-  def name
-    :piv_cac if mfa_enabled?
+  def friendly_name
+    :piv_cac
   end
 end

--- a/app/models/piv_cac_configuration.rb
+++ b/app/models/piv_cac_configuration.rb
@@ -22,4 +22,8 @@ class PivCacConfiguration
       []
     end
   end
+
+  def name
+    :piv_cac if mfa_enabled?
+  end
 end

--- a/app/models/webauthn_configuration.rb
+++ b/app/models/webauthn_configuration.rb
@@ -13,4 +13,8 @@ class WebauthnConfiguration < ApplicationRecord
   def selection_presenters
     [TwoFactorAuthentication::WebauthnSelectionPresenter.new(self)]
   end
+
+  def name
+    :webauthn if mfa_enabled?
+  end
 end

--- a/app/models/webauthn_configuration.rb
+++ b/app/models/webauthn_configuration.rb
@@ -14,7 +14,7 @@ class WebauthnConfiguration < ApplicationRecord
     [TwoFactorAuthentication::WebauthnSelectionPresenter.new(self)]
   end
 
-  def name
-    :webauthn if mfa_enabled?
+  def friendly_name
+    :webauthn
   end
 end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -30,15 +30,7 @@ module AccountReset
     end
 
     def track_mfa_method_counts
-      @mfa_method_counts = mfa_methods.empty? ? {} : mfa_method_counts_hash
-    end
-
-    def mfa_method_counts_hash
-      mfa_methods.each_with_object(Hash.new(0)) { |name, count| count[name] += 1 }
-    end
-
-    def mfa_methods
-      @mfa_methods ||= MfaContext.new(user).two_factor_configurations.map(&:name).compact
+      @mfa_method_counts = MfaContext.new(user).enabled_two_factor_configuration_counts_hash
     end
 
     def destroy_user

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -62,4 +62,111 @@ describe MfaContext do
       end
     end
   end
+
+  describe '#enabled_two_factor_configuration_counts_hash' do
+    let(:count_hash) { MfaContext.new(user).enabled_two_factor_configuration_counts_hash }
+
+    context 'no 2FA configurations' do
+      let(:user) { build(:user) }
+
+      it 'returns an empty hash' do
+        hash = {}
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with phone configuration' do
+      let(:user) { build(:user, :signed_up) }
+
+      it 'returns 1 for phone' do
+        hash = { phone: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with PIV/CAC configuration' do
+      let(:user) { build(:user, :with_piv_or_cac) }
+
+      it 'returns 1 for piv_cac' do
+        hash = { piv_cac: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with authentication app configuration' do
+      let(:user) { build(:user, :with_authentication_app) }
+
+      it 'returns 1 for auth_app' do
+        hash = { auth_app: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with webauthn configuration' do
+      let(:user) { build(:user, :with_webauthn) }
+
+      it 'returns 1 for webauthn' do
+        hash = { webauthn: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with authentication app and webauthn configurations' do
+      let(:user) { build(:user, :with_authentication_app, :with_webauthn) }
+
+      it 'returns 1 for each' do
+        hash = { auth_app: 1, webauthn: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with authentication app and phone configurations' do
+      let(:user) { build(:user, :with_authentication_app, :signed_up) }
+
+      it 'returns 1 for each' do
+        hash = { phone: 1, auth_app: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with PIV/CAC and phone configurations' do
+      let(:user) { build(:user, :with_piv_or_cac, :signed_up) }
+
+      it 'returns 1 for each' do
+        hash = { phone: 1, piv_cac: 1 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with 1 phone and 2 webauthn configurations' do
+      let(:user) { build(:user, :signed_up) }
+
+      it 'returns 1 for phone and 2 for webauthn' do
+        create_list(:webauthn_configuration, 2, user: user)
+        hash = { phone: 1, webauthn: 2 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+
+    context 'with 2 phones and 2 webauthn configurations' do
+      it 'returns 2 for each' do
+        user = create(:user, :signed_up)
+        create(:phone_configuration, user: user, phone: '+1 703-555-1213')
+        create_list(:webauthn_configuration, 2, user: user)
+        count_hash = MfaContext.new(user.reload).enabled_two_factor_configuration_counts_hash
+        hash = { phone: 2, webauthn: 2 }
+
+        expect(count_hash).to eq hash
+      end
+    end
+  end
 end

--- a/spec/support/account_reset_helper.rb
+++ b/spec/support/account_reset_helper.rb
@@ -1,8 +1,15 @@
 module AccountResetHelper
   def create_account_reset_request_for(user)
-    AccountReset::CreateRequest.new(user).call
-    account_reset_request = AccountResetRequest.find_by(user_id: user.id)
-    account_reset_request.request_token
+    request = AccountResetRequest.find_or_create_by(user: user)
+    request_token = SecureRandom.uuid
+    request.update!(
+      request_token: request_token,
+      requested_at: Time.zone.now,
+      cancelled_at: nil,
+      granted_at: nil,
+      granted_token: nil
+    )
+    request_token
   end
 
   def cancel_request_for(user)


### PR DESCRIPTION
**Why**:
Since the account deletion feature deletes a user's account, we cannot
look up some of their attributes after the fact. Some attributes that
would be useful to capture before the account is deleted are:

- The account age, i.e. the difference in time between the time of
deletion request and the account confirmation time (note that this can
be obtained from analytics data, but having the number right there in
the event is more convenient)

- Which MFA methods are configured

This will allow us to measure the current state of affairs, and then
compare it after we introduce the ability to add backup phone numbers.
For example, if one of our goals is to reduce the amount of account
deletion requests, and if we notice that the average amount of time it
takes for users to lose access to their phone is 1 month, then we know
we should wait at least a month before looking at the new numbers.

Similarly, if most account deletion requests are currently made by folks
who only have 1 phone as their MFA method, and if a month after we
deploy backup phone support the number of deletion requests from folks
with only 1 phone as their MFA method doesn't go down, it could mean
that we need to improve the way we are making users aware of the
feature, or that perhaps backup phone numbers is the wrong solution
because most folks who lose access to their devices don't have a backup
phone number to provide.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
