### PR TITLE
Only show webauthn option at most once

### DIFF
--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -45,4 +45,19 @@ describe TwoFactorLoginOptionsPresenter do
           account_reset_request_path(locale: LinkLocaleResolver.locale)
         ))
   end
+
+  context 'with multiple webauthn configurations' do
+    let(:user) { create(:user) }
+    before(:each) do
+      create_list(:webauthn_configuration, 2, user: user)
+      user.webauthn_configurations.reload
+    end
+
+    it 'has only one webauthn selection presenter' do
+      webauthn_selection_presenters = presenter.options.map(&:class).select do |klass|
+        klass == TwoFactorAuthentication::WebauthnSelectionPresenter
+      end
+      expect(webauthn_selection_presenters.count).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
**Why**:
We send all the webauthn configurations to the browser when
a user is using FIDO, so it doesn't make sense to have multiple
entries in the selection list.

**How**:
Special case the webauthn configurations list so we call the
extension to get the selection presenter for the collection
rather than the individual configurations.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
