### PR TITLE
Fix webauthn success icon in int

### DIFF
--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -55,7 +55,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def all_sms_and_voice_options_plus_one_of_each_remaining_option(configurations)
     presenters = configurations.flat_map(&:selection_presenters)
-    presenters_for_options_that_are_not_phone(presenters) + presenters_for_phone_options(presenters)
+    presenters_for_phone_options(presenters) + presenters_for_options_that_are_not_phone(presenters)
   end
 
   def presenters_for_options_that_are_not_phone(presenters)

--- a/app/views/users/webauthn_setup/success.html.slim
+++ b/app/views/users/webauthn_setup/success.html.slim
@@ -1,7 +1,7 @@
-- title t('doc_auth.titles.doc_auth')
+- title t('forms.webauthn_setup.success_title')
 
-= image_tag(asset_url('alert/success'),
-        alt: t('idv.titles.session.success'), width: 60)
+= image_tag(asset_url('alert/success.svg'),
+        alt: t('forms.webauthn_setup.success_title'), width: 60)
 
 h1.h3.mb2.mt3.my0 = t('forms.webauthn_setup.success_title')
 


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
