### PR TITLE
LG-466 Remove unnecessary code from UserPhoneForm

### DIFF
--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -38,10 +38,13 @@ module Users
     end
 
     def process_updates
-      if @user_phone_form.phone_changed?
+      form = @user_phone_form
+      if form.phone_changed?
         analytics.track_event(Analytics::PHONE_CHANGE_REQUESTED)
         flash[:notice] = t('devise.registrations.phone_update_needs_confirmation')
-        prompt_to_confirm_phone(phone: @user_phone_form.phone)
+        prompt_to_confirm_phone(
+          phone: form.phone, selected_delivery_method: form.otp_delivery_preference
+        )
       else
         redirect_to account_url
       end

--- a/app/forms/user_phone_form.rb
+++ b/app/forms/user_phone_form.rb
@@ -25,9 +25,6 @@ class UserPhoneForm
     success = valid?
     self.phone = submitted_phone unless success
 
-    update_otp_delivery_preference_for_user if
-      success && otp_delivery_preference.present? && otp_delivery_preference_changed?
-
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
@@ -56,15 +53,6 @@ class UserPhoneForm
     tfa_prefs = params[:otp_delivery_preference]
 
     self.otp_delivery_preference = tfa_prefs if tfa_prefs
-  end
-
-  def otp_delivery_preference_changed?
-    otp_delivery_preference != phone_configuration&.delivery_preference
-  end
-
-  def update_otp_delivery_preference_for_user
-    user_attributes = { otp_delivery_preference: otp_delivery_preference }
-    UpdateUser.new(user: user, attributes: user_attributes).call
   end
 
   def formatted_user_phone

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -160,36 +160,6 @@ describe UserPhoneForm do
       end
     end
 
-    context "when the submitted otp_delivery_preference is different from the user's" do
-      it "updates the user's otp_delivery_preference" do
-        user_updater = instance_double(UpdateUser)
-        allow(UpdateUser).
-          to receive(:new).
-          with(
-            user: user,
-            attributes: { otp_delivery_preference: 'voice' }
-          ).
-          and_return(user_updater)
-        expect(user_updater).to receive(:call)
-
-        params = {
-          phone: '703-555-5000',
-          international_code: 'US',
-          otp_delivery_preference: 'voice',
-        }
-
-        subject.submit(params)
-      end
-    end
-
-    context "when the submitted otp_delivery_preference is the same as the user's" do
-      it "does not update the user's otp_delivery_preference" do
-        expect(UpdateUser).to_not receive(:new)
-
-        subject.submit(params)
-      end
-    end
-
     it 'does not raise inclusion errors for Norwegian phone numbers' do
       # ref: https://github.com/18F/identity-private/issues/2392
       params[:phone] = '21 11 11 11'


### PR DESCRIPTION
**Why**: It's not necessary to update the user's
`otp_delivery_preference` in UserPhoneForm because
`TwoFactorAuthenticationController#send_code` takes care of it via
`update_otp_delivery_preference_if_needed`.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [x] The changes are compatible with data that was encrypted with the old code.


- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.