### PR TITLE
LG-741 LG-739 Fix Webauthn enter key after nickname

### DIFF
--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -61,5 +61,18 @@ function webauthn() {
       document.getElementById('webauthn_form').submit();
     });
   });
+  const input = document.getElementById('nickname');
+  input.addEventListener('keypress', function(event) {
+    if (event.keyCode === 13) {
+      // prevent form submit
+      event.preventDefault();
+    }
+  });
+  input.addEventListener('keyup', function(event) {
+    event.preventDefault();
+    if (event.keyCode === 13 && input.value) {
+      continueButton.click();
+    }
+  });
 }
 document.addEventListener('DOMContentLoaded', webauthn);

--- a/app/views/users/webauthn_setup/new.html.slim
+++ b/app/views/users/webauthn_setup/new.html.slim
@@ -16,7 +16,7 @@ div
     = hidden_field_tag :attestation_object, '', id: 'attestation_object'
     = hidden_field_tag :client_data_json, '', id: 'client_data_json'
     = label_tag 'code', t('forms.webauthn_setup.nickname'), class: 'block bold'
-    = text_field_tag :name, '', required: true, id: 'name',
+    = text_field_tag :name, '', required: true, id: 'nickname',
           class: 'block col-12 field monospace', size: 16, maxlength: 20,
           'aria-labelledby': 'totp-label'
     = submit_tag t('forms.buttons.submit.default'), id: 'submit-button', class: 'hidden'


### PR DESCRIPTION
**Why**: When focus is on the security key nickname and the user presses the enter key instead of clicking 'Continue' they will get an error.

**How**: Add handlers to the security key nickname input box.  Add a handler for the keypress event and prevent it from doing a form submit on enter.  Add a handler for the keyup event and if it is the enter key have it do the 'Continue' button click.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
