### PR TITLE
LG-735 Use remember_me_revoked_at to revoke remember device

### DIFF
--- a/spec/services/remember_device_cookie_spec.rb
+++ b/spec/services/remember_device_cookie_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe RememberDeviceCookie do
-  let(:phone_confirmed_at) { 90.days.ago }
-  let(:user) { create(:user, :with_phone, with: { confirmed_at: phone_confirmed_at }) }
+  let(:remember_device_revoked_at) { 90.days.ago }
+  let(:user) { create(:user, :with_phone, remember_device_revoked_at: remember_device_revoked_at) }
   let(:created_at) { Time.zone.now }
 
   subject { described_class.new(user_id: user.id, created_at: created_at) }
@@ -80,11 +80,17 @@ describe RememberDeviceCookie do
       end
     end
 
-    context 'when the user has changed their phone since creating the token' do
+    context 'when the user has revoked remember device since creating the token' do
       let(:created_at) { 5.days.ago }
-      let(:phone_confirmed_at) { 4.days.ago }
+      let(:remember_device_revoked_at) { 4.days.ago }
 
       it { expect(subject.valid_for_user?(user)).to eq(false) }
+    end
+
+    context 'when the remember_device_revoked_at value on the user is nil' do
+      let(:remember_device_revoked_at) { nil }
+
+      it { expect(subject.valid_for_user?(user)).to eq(true) }
     end
   end
 end


### PR DESCRIPTION
**Why**: To decouple the remember device action from the phone
configurations and make revoking remember device sessions an explicit
action rather than a side effect of updating the phone configuration

To be able to deploy this change, it needs to be spread over 2 releases.
One to add and write to the new column and a later one to read from it.
This PR also includes a rake task to backfill this column on the
existing user table.

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
