### PR TITLE
LG-359 Don't penalize users for IdV vendor errors

### DIFF
--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -7,7 +7,7 @@ module Idv
     def submit(step_params)
       self.step_params = step_params
       self.idv_result = Idv::Agent.new(applicant).proof(:address)
-      increment_attempts_count
+      increment_attempts_count unless failed_due_to_timeout_or_exception?
       success = idv_result[:success]
       update_idv_session if success
       FormResponse.new(
@@ -42,6 +42,10 @@ module Idv
 
     def increment_attempts_count
       idv_session.step_attempts[:phone] += 1
+    end
+
+    def failed_due_to_timeout_or_exception?
+      idv_result[:timed_out] || idv_result[:exception]
     end
 
     def update_idv_session

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -7,7 +7,7 @@ module Idv
     def submit(step_params)
       consume_step_params(step_params)
       self.idv_result = Idv::Agent.new(applicant).proof(:resolution, :state_id)
-      increment_attempts_count
+      increment_attempts_count unless failed_due_to_timeout_or_exception?
       success = idv_result[:success]
       update_idv_session if success
       FormResponse.new(
@@ -37,6 +37,10 @@ module Idv
 
     def increment_attempts_count
       attempter.increment
+    end
+
+    def failed_due_to_timeout_or_exception?
+      idv_result[:timed_out] || idv_result[:exception]
     end
 
     def attempter

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -54,6 +54,22 @@ describe Idv::PhoneStep do
       expect(idv_session.step_attempts[:phone]).to eq(original_step_attempts + 1)
     end
 
+    it 'does not increment step attempts when the vendor request times out' do
+      original_step_attempts = idv_session.step_attempts[:phone]
+
+      subject.submit(phone: timeout_phone)
+
+      expect(idv_session.step_attempts[:phone]).to eq(original_step_attempts)
+    end
+
+    it 'does not increment step attempts when the vendor raises an exception' do
+      original_step_attempts = idv_session.step_attempts[:phone]
+
+      subject.submit(phone: fail_phone)
+
+      expect(idv_session.step_attempts[:phone]).to eq(original_step_attempts)
+    end
+
     it 'marks the phone as confirmed if it matches 2FA phone' do
       user.phone_configurations = [build(:phone_configuration, user: user, phone: good_phone)]
 

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -64,6 +64,16 @@ describe Idv::ProfileStep do
     it 'increments attempts count' do
       expect { subject.submit(user_attrs) }.to change(user, :idv_attempts).by(1)
     end
+
+    it 'does not increment attempts count when the vendor request times out' do
+      expect { subject.submit(user_attrs.merge(first_name: 'Time')) }.
+        to_not change(user, :idv_attempts)
+    end
+
+    it 'does not increment attempts count when the vendor raises an exception' do
+      expect { subject.submit(user_attrs.merge(first_name: 'Fail')) }.
+        to_not change(user, :idv_attempts)
+    end
   end
 
   describe '#failure_reason' do


### PR DESCRIPTION
**Why**:
Previously, if a verification failure occurred due to a network error or
system error, it was treated the same as an issue with the data
provided by the user, thereby decrementing the user's remaining
attempts. The limit on attempts is meant to prevent bad actors from
fishing for data, not to penalize the user for technical issues that are
out of their control.

**How**:
Don't increment the attempts count if the errors result from non-data
related verification failures, such as vendor exceptions and timeouts.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [ ] The changes are compatible with data that was encrypted with the old code.


- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.