### PR TITLE
LG-769 Notify exception trackers about IdV errors

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -14,14 +14,12 @@ module Idv
       results = init_results
 
       stages.each do |stage|
-        vendor = Idv::Proofer.get_vendor(stage).new
-        log_vendor(vendor, results, stage)
-        proofer_result = vendor.proof(@applicant)
+        proofer_result = submit_applicant(applicant: @applicant, stage: stage, results: results)
+        track_exception_in_result(proofer_result)
         results = merge_results(results, proofer_result)
         results[:timed_out] = proofer_result.timed_out?
         break unless proofer_result.success?
       end
-
       results
     end
 
@@ -40,6 +38,12 @@ module Idv
       }
     end
 
+    def submit_applicant(applicant:, stage:, results:)
+      vendor = Idv::Proofer.get_vendor(stage).new
+      log_vendor(vendor, results, stage)
+      vendor.proof(applicant)
+    end
+
     def log_vendor(vendor, results, stage)
       v_class = vendor.class
       results[:context][:stages].push(stage => v_class.vendor_name || v_class.inspect)
@@ -49,6 +53,14 @@ module Idv
       results.merge(proofer_result.to_h) do |key, orig, current|
         key == :messages ? orig + current : current
       end
+    end
+
+    def track_exception_in_result(proofer_result)
+      exception = proofer_result.exception
+      return if exception.nil?
+
+      NewRelic::Agent.notice_error(exception)
+      ExceptionNotifier.notify_exception(exception)
     end
   end
 end

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -58,10 +58,12 @@ describe Idv::Agent do
       let(:state_id_message) { 'reason 2' }
       let(:failed_message) { 'bah humbug' }
       let(:error) { { bad: 'stuff' } }
+      let(:exception) { StandardError.new }
 
       subject { agent.proof(*stages) }
 
       before do
+        exception_instance = exception
         allow(Idv::Proofer).to receive(:get_vendor) do |stage|
           logic = case stage
                   when :resolution
@@ -72,6 +74,8 @@ describe Idv::Agent do
                     proc { |_, r| r.add_message('bah humbug').add_error(:bad, 'stuff') }
                   when :timed_out
                     proc { |_, r| r.instance_variable_set(:@exception, Proofer::TimeoutError.new) }
+                  when :exception
+                    proc { |_, r| r.instance_variable_set(:@exception, exception_instance) }
                   end
           Class.new(Proofer::Base) do
             required_attributes(:foo)
@@ -115,6 +119,20 @@ describe Idv::Agent do
           expect(subject.to_h).to include(
             success: false,
             timed_out: true
+          )
+        end
+      end
+
+      context 'when there is an exception' do
+        let(:stages) { %i[exception state_id] }
+
+        it 'returns an unsuccessful result and notifies exception trackers' do
+          expect(NewRelic::Agent).to receive(:notice_error).with(exception)
+          expect(ExceptionNotifier).to receive(:notify_exception).with(exception)
+
+          expect(subject.to_h).to include(
+            success: false,
+            exception: exception
           )
         end
       end


### PR DESCRIPTION
**Why**: So that when there are errors in the IdV vendor gems we will
have visibility into them in New Relic and ExceptionNotifier

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
