### PR TITLE
LG-726 Confirm before removing security key

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -35,6 +35,10 @@ module Users
       redirect_to account_url
     end
 
+    def show_delete
+      render 'users/webauthn_setup/delete'
+    end
+
     private
 
     def flash_error(errors)
@@ -53,7 +57,6 @@ module Users
     end
 
     def handle_failed_delete
-      flash[:error] = t('errors.webauthn_setup.delete_last')
       track_delete(false)
     end
 

--- a/app/views/accounts/_webauthn.html.slim
+++ b/app/views/accounts/_webauthn.html.slim
@@ -10,6 +10,7 @@
     .col.col-8.sm-6.truncate
       = cfg.name
     .col.col-4.sm-6.right-align
-      = button_to(t('account.index.webauthn_delete'), webauthn_setup_path(id: cfg.id),
-        method: :delete, class: 'btn btn-link')
+      = link_to_if(MfaPolicy.new(current_user).multiple_factors_enabled?,
+        t('account.index.webauthn_delete'), webauthn_setup_delete_path(id: cfg.id),
+        method: :get, class: 'btn btn-link')
   .clearfix

--- a/app/views/users/webauthn_setup/delete.html.slim
+++ b/app/views/users/webauthn_setup/delete.html.slim
@@ -10,6 +10,7 @@ h1.h3.mb1.mt3.my0 = t('forms.webauthn_delete.confirm')
 br
 p == t('forms.webauthn_delete.caution')
 br
+br
 = button_to(t('account.index.webauthn_confirm_delete'), webauthn_setup_path(id: params[:id]),
           method: :delete, class: 'btn btn-primary col-6 mb2 p2 rounded')
 

--- a/app/views/users/webauthn_setup/delete.html.slim
+++ b/app/views/users/webauthn_setup/delete.html.slim
@@ -1,15 +1,17 @@
-.p0.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
-  h2.my2.fs-20p.sans-serif.regular.center
-    = t('forms.webauthn_delete.confirm')
-  hr.mb3.bw4.rounded
-  .mb1.bold
-    = t('forms.webauthn_delete.caution')
+- title t('forms.webauthn_delete.confirm')
 
-  ul.px2.yellow-dots
-    li.mb1 = t('forms.webauthn_delete.bullet_1', app: APP_NAME)
-  .center
-    = button_to(t('account.index.webauthn_delete'), webauthn_setup_path(id: params[:id]),
-            method: :delete, class: 'btn btn-primary col-12 mb2 p2 rounded-lg')
+= image_tag(asset_url('alert/warning-lg.svg'),
+        alt: t('forms.webauthn_delete.confirm'), width: 54)
 
-    = link_to t('users.delete.actions.cancel'), account_path,
-            class: 'btn col-12 p2 rounded-lg border border-blue blue border-box'
+h1.h3.mb1.mt3.my0 = t('forms.webauthn_delete.confirm')
+
+.col-2
+  hr class="mt3 mb2 bw4 rounded border-yellow"
+br
+p == t('forms.webauthn_delete.caution')
+br
+= button_to(t('account.index.webauthn_delete'), webauthn_setup_path(id: params[:id]),
+          method: :delete, class: 'btn btn-primary col-6 mb2 p2 rounded')
+
+= link_to t('links.cancel'), account_path,
+          class: 'btn col-6 p2 rounded-lg border border-blue blue border-box center'

--- a/app/views/users/webauthn_setup/delete.html.slim
+++ b/app/views/users/webauthn_setup/delete.html.slim
@@ -1,0 +1,15 @@
+.p0.cntnr-xxskinny.border-box.bg-white.rounded-xxl.modal-warning
+  h2.my2.fs-20p.sans-serif.regular.center
+    = t('forms.webauthn_delete.confirm')
+  hr.mb3.bw4.rounded
+  .mb1.bold
+    = t('forms.webauthn_delete.caution')
+
+  ul.px2.yellow-dots
+    li.mb1 = t('forms.webauthn_delete.bullet_1', app: APP_NAME)
+  .center
+    = button_to(t('account.index.webauthn_delete'), webauthn_setup_path(id: params[:id]),
+            method: :delete, class: 'btn btn-primary col-12 mb2 p2 rounded-lg')
+
+    = link_to t('users.delete.actions.cancel'), account_path,
+            class: 'btn col-12 p2 rounded-lg border border-blue blue border-box'

--- a/app/views/users/webauthn_setup/delete.html.slim
+++ b/app/views/users/webauthn_setup/delete.html.slim
@@ -10,7 +10,7 @@ h1.h3.mb1.mt3.my0 = t('forms.webauthn_delete.confirm')
 br
 p == t('forms.webauthn_delete.caution')
 br
-= button_to(t('account.index.webauthn_delete'), webauthn_setup_path(id: params[:id]),
+= button_to(t('account.index.webauthn_confirm_delete'), webauthn_setup_path(id: params[:id]),
           method: :delete, class: 'btn btn-primary col-6 mb2 p2 rounded')
 
 = link_to t('links.cancel'), account_path,

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -26,9 +26,10 @@ en:
         instructions: Your account requires a secret code to be verified.
         reactivate_button: Enter the code you received via US mail
         success: Your account has been verified.
-      webauthn: Hardware security key
-      webauthn_add: "+ Add hardware security key"
-      webauthn_delete: Yes, remove key
+      webauthn: Security key
+      webauthn_add: "+ Add security key"
+      webauthn_confirm_delete: Yes, remove key
+      webauthn_delete: Remove key
     items:
       delete_your_account: Delete your account
       personal_key: Personal key

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -28,7 +28,7 @@ en:
         success: Your account has been verified.
       webauthn: Hardware security key
       webauthn_add: "+ Add hardware security key"
-      webauthn_delete: Remove
+      webauthn_delete: Yes, remove key
     items:
       delete_your_account: Delete your account
       personal_key: Personal key

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -26,9 +26,10 @@ es:
         instructions: Su cuenta requiere que un código secreto sea verificado.
         reactivate_button: Ingrese el código que recibió por correo postal.
         success: Su cuenta ha sido verificada.
-      webauthn: Clave de seguridad de hardware
-      webauthn_add: "+ Agregar clave de seguridad de hardware"
-      webauthn_delete: Si quitar la llave
+      webauthn: Clave de seguridad
+      webauthn_add: "+ Añadir clave de seguridad"
+      webauthn_confirm_delete: Si quitar la llave
+      webauthn_delete: Quitar llave
     items:
       delete_your_account: Eliminar su cuenta
       personal_key: Clave personal

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -28,7 +28,7 @@ es:
         success: Su cuenta ha sido verificada.
       webauthn: Clave de seguridad de hardware
       webauthn_add: "+ Agregar clave de seguridad de hardware"
-      webauthn_delete: Retirar
+      webauthn_delete: Si quitar la llave
     items:
       delete_your_account: Eliminar su cuenta
       personal_key: Clave personal

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -30,7 +30,7 @@ fr:
         success: Votre compte a été vérifié.
       webauthn: Clé de sécurité physique
       webauthn_add: "+ Ajouter une clé de sécurité physique"
-      webauthn_delete: Retirer
+      webauthn_delete: Oui, retirer la clé
     items:
       delete_your_account: Supprimer votre compte
       personal_key: Clé personnelle

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -30,8 +30,8 @@ fr:
         success: Votre compte a été vérifié.
       webauthn: Clé de sécurité
       webauthn_add: "+ Ajouter une clé de sécurité"
-      webauthn_confirm_delete: Oui, retirer la clé
-      webauthn_delete: Enlever la clé
+      webauthn_confirm_delete: Oui, supprimer la clé
+      webauthn_delete: Supprimer la clé
     items:
       delete_your_account: Supprimer votre compte
       personal_key: Clé personnelle

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -28,9 +28,10 @@ fr:
         instructions: Votre compte requiert la vérification d'un code secret.
         reactivate_button: Entrez le code que vous avez reçu par la poste
         success: Votre compte a été vérifié.
-      webauthn: Clé de sécurité physique
-      webauthn_add: "+ Ajouter une clé de sécurité physique"
-      webauthn_delete: Oui, retirer la clé
+      webauthn: Clé de sécurité
+      webauthn_add: "+ Ajouter une clé de sécurité"
+      webauthn_confirm_delete: Oui, retirer la clé
+      webauthn_delete: Enlever la clé
     items:
       delete_your_account: Supprimer votre compte
       personal_key: Clé personnelle

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -57,7 +57,6 @@ en:
       attestation_error: Sorry, but your security key doesn't appear to be a FIDO
         security key.  Please make sure your device is listed at https://fidoalliance.org/certification/fido-certified-products/
         and if you believe the error is ours, please contact us at hello@login.gov.
-      delete_last: Sorry, you can not remove your last MFA option.
       general_error: There was an error adding your hardware security key. Please
         try again.
       not_supported: Sorry, your browser does not support FIDO security keys.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -58,7 +58,6 @@ es:
       attestation_error: Lo sentimos, pero su clave de seguridad no parece ser una
         clave de seguridad FIDO. Asegúrese de que su dispositivo esté en https://fidoalliance.org/certification/fido-certified-products/
         y si cree que el error es nuestro, contáctenos en hello@login.gov.
-      delete_last: Lo sentimos, no puedes eliminar tu última opción de MFA.
       general_error: Hubo un error al agregar su clave de seguridad de hardware. Inténtalo
         de nuevo.
       not_supported: Lo sentimos, su navegador no admite las claves de seguridad FIDO.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -64,7 +64,6 @@ fr:
         sur https://fidoalliance.org/certification/fido-certified-products/ et si
         vous pensez que l'erreur est la nôtre, veuillez nous contacter à l'adresse
         hello@login.gov.
-      delete_last: Désolé, vous ne pouvez pas supprimer votre dernière option MFA
       general_error: Une erreur s'est produite lors de l'ajout de votre clé de sécurité
         physique. Veuillez réessayer.
       not_supported: Désolé, votre navigateur ne supporte pas les clés de sécurité

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -89,10 +89,9 @@ en:
       submit: Confirm account
       title: Confirm your account
     webauthn_delete:
-      bullet_1: You won't be able to use your security key to securely access your
-        information using login.gov.
-      caution: If you delete your security key
-      confirm: Are you sure you want to delete your security key?
+      caution: If you remove your security key you won't be able to use it to access
+        your login.gov account.
+      confirm: Are you sure you want to remove your security key?
     webauthn_setup:
       continue: Continue
       instructions_text: Press the button on your security key to register it with

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -88,6 +88,11 @@ en:
       name: Confirmation code
       submit: Confirm account
       title: Confirm your account
+    webauthn_delete:
+      bullet_1: You won't be able to use your security key to securely access your
+        information using login.gov.
+      caution: If you delete your security key
+      confirm: Are you sure you want to delete your security key?
     webauthn_setup:
       continue: Continue
       instructions_text: Press the button on your security key to register it with

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -89,6 +89,11 @@ es:
       name: Código de confirmación
       submit: Confirmar cuenta
       title: Confirme su cuenta
+    webauthn_delete:
+      bullet_1: No podrá usar su clave de seguridad para acceder de forma segura a
+        su información utilizando login.gov.
+      caution: Si borras tu clave de seguridad
+      confirm: "¿Estás seguro de que quieres eliminar tu clave de seguridad?"
     webauthn_setup:
       continue: Continuar
       instructions_text: Presione el botón en su clave de seguridad para registrarlo

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -90,9 +90,8 @@ es:
       submit: Confirmar cuenta
       title: Confirme su cuenta
     webauthn_delete:
-      bullet_1: No podrá usar su clave de seguridad para acceder de forma segura a
-        su información utilizando login.gov.
-      caution: Si borras tu clave de seguridad
+      caution: Si elimina su clave de seguridad, no podrá usarla para acceder a su
+        cuenta login.gov.
       confirm: "¿Estás seguro de que quieres eliminar tu clave de seguridad?"
     webauthn_setup:
       continue: Continuar

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -97,9 +97,8 @@ fr:
       submit: Confirmer le compte
       title: Confirmez votre compte
     webauthn_delete:
-      bullet_1: Vous ne pourrez pas utiliser votre clé de sécurité pour accéder en
-        toute sécurité à vos informations à l'aide de login.gov.
-      caution: Si vous supprimez votre clé de sécurité
+      caution: Si vous supprimez votre clé de sécurité, vous ne pourrez plus l'utiliser
+        pour accéder à votre compte login.gov.
       confirm: Êtes-vous sûr de vouloir supprimer votre clé de sécurité?
     webauthn_setup:
       continue: Continuer

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -96,6 +96,11 @@ fr:
       name: Code de confirmation
       submit: Confirmer le compte
       title: Confirmez votre compte
+    webauthn_delete:
+      bullet_1: Vous ne pourrez pas utiliser votre clé de sécurité pour accéder en
+        toute sécurité à vos informations à l'aide de login.gov.
+      caution: Si vous supprimez votre clé de sécurité
+      confirm: Êtes-vous sûr de vouloir supprimer votre clé de sécurité?
     webauthn_setup:
       continue: Continuer
       instructions_text: Appuyez sur le bouton de votre clé de sécurité pour l’enregistrer

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -37,8 +37,8 @@ en:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         number_message: We just called you at %{number}.
       webauthn:
-        confirm_webauthn_html: Present the hardware security key that you associated
-          with your account.
+        confirm_webauthn_html: Present the security key that you associated with your
+          account.
       wrong_number_html: Entered the wrong phone number? %{link}
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -38,8 +38,7 @@ es:
         confirm_code_html: "¿Desea que le llamemos de nuevo? %{resend_code_link}"
         number_message: Acabamos de llamarte en %{number}.
       webauthn:
-        confirm_webauthn_html: Presente la clave de seguridad de hardware que ha asociado
-          con su cuenta.
+        confirm_webauthn_html: Presente la clave de seguridad que asoció con su cuenta.
       wrong_number_html: "¿Ingresó el número de teléfono equivocado? %{link}"
     password:
       forgot: "¿No sabe su contraseña? Restablézcala después de confirmar su email."

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -41,8 +41,8 @@ fr:
         confirm_code_html: Vous voulez que nous vous appelions de nouveau? %{resend_code_link}
         number_message: Nous venons de vous appeler à %{number}.
       webauthn:
-        confirm_webauthn_html: Présentez la clé de sécurité physique associée à votre
-          compte.
+        confirm_webauthn_html: Présentez la clé de sécurité que vous avez associée
+          à votre compte.
       wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -41,8 +41,7 @@ fr:
         confirm_code_html: Vous voulez que nous vous appelions de nouveau? %{resend_code_link}
         number_message: Nous venons de vous appeler à %{number}.
       webauthn:
-        confirm_webauthn_html: Présentez la clé de sécurité que vous avez associée
-          à votre compte.
+        confirm_webauthn_html: Présentez la clé de sécurité associée à votre compte.
       wrong_number_html: Vous avez entré un mauvais numéro de téléphone? %{link}
     password:
       forgot: Vous ne connaissez pas votre mot de passe? Réinitialisez-le après avoir

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -45,4 +45,4 @@ en:
     use_diff_email:
       link: use a different email address
       text_html: Or, %{link}
-    webauthn_deleted: You deleted a hardware security key.
+    webauthn_deleted: You removed a security key.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -45,4 +45,4 @@ es:
     use_diff_email:
       link: use un email diferente
       text_html: O %{link}
-    webauthn_deleted: Has eliminado una clave de seguridad de hardware.
+    webauthn_deleted: Has eliminado una clave de seguridad.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -48,4 +48,4 @@ fr:
     use_diff_email:
       link: utilisez une adresse courriel différente
       text_html: Or, %{link}
-    webauthn_deleted: Vous avez supprimé une clé de sécurité physique.
+    webauthn_deleted: Vous avez supprimé une clé de sécurité.

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -97,8 +97,8 @@ en:
       sms_info: Get your security code via text message / SMS
       voice: Phone call
       voice_info: Get your security code via phone call
-      webauthn: Hardware security key
+      webauthn: Security key
       webauthn_info: Use a security key to secure your account
     webauthn_fallback:
-      question: Don't have your hardware security key available?
+      question: Don't have your security key available?
     webauthn_header_text: Present your security key

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -65,8 +65,8 @@ en:
       be provided a new key.
     phone:
       delete:
-        success: Your phone has been removed.
         failure: Unable to remove your phone.
+        success: Your phone has been removed.
     phone_fallback:
       question: Don't have access to your phone right now?
     phone_sms_info_html: We'll text a security code <strong>each time you sign in</strong>.

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -68,8 +68,8 @@ es:
       se le dará una nueva clave.
     phone:
       delete:
-        success: Su teléfono ha sido eliminado.
         failure: No se puede eliminar el teléfono.
+        success: Su teléfono ha sido eliminado.
     phone_fallback:
       question: "¿No tiene acceso a su teléfono ahora mismo?"
     phone_sms_info_html: Le enviaremos un mensaje de texto con un código de seguridad

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -101,8 +101,8 @@ es:
       sms_info: Obtenga su código de seguridad a través de mensajes de texto / SMS
       voice: Llamada telefónica
       voice_info: Obtenga su código de seguridad a través de una llamada telefónica
-      webauthn: Clave de seguridad de hardware
+      webauthn: Clave de seguridad
       webauthn_info: Use una clave de seguridad para proteger su cuenta
     webauthn_fallback:
-      question: "¿No tienes tu clave de seguridad de hardware disponible?"
+      question: "¿No tienes tu clave de seguridad disponible?"
     webauthn_header_text: Presenta tu clave de seguridad

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -67,8 +67,8 @@ fr:
       Une fois que vous l'entrez, vous recevrez une nouvelle clé.
     phone:
       delete:
-        success: Votre numéro de téléphone a été supprimé.
         failure: Impossible de supprimer votre numéro de téléphone.
+        success: Votre numéro de téléphone a été supprimé.
     phone_fallback:
       question: Vous n'avez pas accès à votre téléphone maintenant?
     phone_sms_info_html: Nous vous enverrons un code de sécurité <strong>chaque fois

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -100,8 +100,8 @@ fr:
       sms_info: Obtenez votre code de sécurité par SMS
       voice: Appel téléphonique
       voice_info: Obtenez votre code de sécurité par appel téléphonique
-      webauthn: Clé de sécurité physique
+      webauthn: Clé de sécurité
       webauthn_info: Utilisez une clé de sécurité pour sécuriser votre compte
     webauthn_fallback:
-      question: Votre clé de sécurité physique n'est pas disponible?
+      question: Votre clé de sécurité n'est-elle pas disponible?
     webauthn_header_text: Présentez votre clé de sécurité

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
       get '/webauthn_setup' => 'users/webauthn_setup#new', as: :webauthn_setup
       patch '/webauthn_setup' => 'users/webauthn_setup#confirm'
       delete '/webauthn_setup' => 'users/webauthn_setup#delete'
+      get '/webauthn_setup_delete' => 'users/webauthn_setup#show_delete'
       get '/webauthn_setup_success' => 'users/webauthn_setup#success'
     end
 

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -113,7 +113,7 @@ feature 'Webauthn Management' do
 
       expect(current_path).to eq webauthn_setup_delete_path
 
-      click_button t('account.index.webauthn_delete')
+      click_button t('account.index.webauthn_confirm_delete')
 
       expect(page).to_not have_content 'key1'
       expect(page).to have_content t('notices.webauthn_deleted')

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -90,7 +90,7 @@ feature 'Webauthn Management' do
   end
 
   context 'with webauthn associations' do
-    it 'displays the user supplied names of the webauthn keys' do
+    it 'displays the user supplied names of the security keys' do
       create_webauthn_configuration(user, 'key1', '1', 'foo1')
       create_webauthn_configuration(user, 'key2', '2', 'bar2')
 
@@ -101,7 +101,7 @@ feature 'Webauthn Management' do
       expect(page).to have_content 'key2'
     end
 
-    it 'allows the user to delete the webauthn key' do
+    it 'allows user to delete security key when another 2FA option is set up' do
       create_webauthn_configuration(user, 'key1', '1', 'foo1')
 
       sign_in_and_2fa_user(user)
@@ -119,7 +119,7 @@ feature 'Webauthn Management' do
       expect(page).to have_content t('notices.webauthn_deleted')
     end
 
-    it 'allows the user to cancel delete the webauthn key' do
+    it 'allows the user to cancel delete the security key' do
       create_webauthn_configuration(user, 'key1', '1', 'foo1')
 
       sign_in_and_2fa_user(user)

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -131,7 +131,7 @@ feature 'Webauthn Management' do
 
       expect(current_path).to eq webauthn_setup_delete_path
 
-      click_link t('users.delete.actions.cancel')
+      click_link t('links.cancel')
 
       expect(page).to have_content 'key1'
     end

--- a/spec/features/users/webauthn_management_spec.rb
+++ b/spec/features/users/webauthn_management_spec.rb
@@ -109,10 +109,31 @@ feature 'Webauthn Management' do
 
       expect(page).to have_content 'key1'
 
+      click_link t('account.index.webauthn_delete')
+
+      expect(current_path).to eq webauthn_setup_delete_path
+
       click_button t('account.index.webauthn_delete')
 
       expect(page).to_not have_content 'key1'
       expect(page).to have_content t('notices.webauthn_deleted')
+    end
+
+    it 'allows the user to cancel delete the webauthn key' do
+      create_webauthn_configuration(user, 'key1', '1', 'foo1')
+
+      sign_in_and_2fa_user(user)
+      visit account_path
+
+      expect(page).to have_content 'key1'
+
+      click_link t('account.index.webauthn_delete')
+
+      expect(current_path).to eq webauthn_setup_delete_path
+
+      click_link t('users.delete.actions.cancel')
+
+      expect(page).to have_content 'key1'
     end
 
     it 'prevents a user from deleting the last key' do
@@ -123,11 +144,7 @@ feature 'Webauthn Management' do
       visit account_path
 
       expect(page).to have_content 'key1'
-
-      click_button t('account.index.webauthn_delete')
-
-      expect(page).to have_content 'key1'
-      expect(page).to have_content t('errors.webauthn_setup.delete_last')
+      expect(page).to_not have_link t('account.index.webauthn_delete')
     end
   end
 


### PR DESCRIPTION
**Why**: So the user can confirm they want to remove their security key or choose to cancel.

**How**: If their security key is their last 2FA option disable the delete link.  If they have another 2FA option allow them to delete by first showing a modal.  This modal will allow them to proceed or cancel and return to the account page.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
