### PR TITLE
Testing out PR creation

### DIFF
--- a/scripts/load_testing/locustfile.py
+++ b/scripts/load_testing/locustfile.py
@@ -396,8 +396,9 @@ class UserBehavior(locust.TaskSet):
         signup(self, resp.url)
         
         # Unless we said not to, sign out now.
-        if not os.getenv('NO_LOGOUT'):
+        if "NO_LOGOUT" in os.environ:
             print("Found 'NO_LOGOUT' in env vars. Skipping logout.")
+        else:
             logout(self)
 
 

--- a/scripts/load_testing/locustfile.py
+++ b/scripts/load_testing/locustfile.py
@@ -52,7 +52,6 @@ def login(t, credentials):
     2. figure out how to handle invalid login attempts.
     3. Handle account locks
     """
-    print('beginning sign in with credentials: {}'.format(credentials))
     t.client.get('/sign_up/start')
 
     # then go from splash page to sign-in page and submit credentials
@@ -83,7 +82,6 @@ def login(t, credentials):
             }
         )
         resp.raise_for_status()
-        print('Sign in complete. Currently at {}.'.format(resp.url))
     except Exception as error:
         print(error)
 
@@ -92,7 +90,6 @@ def logout(t):
     Takes a locustTask object and signs you out.
     Naively assumes the user is actually logged in already.
     """
-    print('Beginning sign out')
     resp = t.client.get('/')
     resp.raise_for_status()
     dom = pyquery.PyQuery(resp.content)
@@ -105,8 +102,6 @@ def logout(t):
         resp = t.client.get(sign_out_link.attr('href'))
         resp.raise_for_status()
         dom = pyquery.PyQuery(resp.content)
-        # Let's confirm:
-        print(dom.find('div.alert-success').eq(0).text())
     except Exception as error:
         print(error)
 
@@ -148,11 +143,9 @@ def change_pass(t, password):
             }
         )
         resp.raise_for_status()
-        dom = pyquery.PyQuery(resp.content)
-        print(dom.find('div.alert-notice').eq(0).text())
     else:
         # To-do: handle reauthn case
-        print(resp.url)
+        print("Failed to find correct page. Currently at {}".format(resp.url))
 
 def signup(t, signup_url=None):
     """
@@ -212,7 +205,8 @@ def signup(t, signup_url=None):
         'commit': 'Submit',
     }
     resp = t.client.post(
-        '/sign_up/create_password', data=data, auth=auth)
+        '/sign_up/create_password', data=data, auth=auth
+    )
     resp.raise_for_status()
 
     # visit phone setup page and submit phone number
@@ -228,14 +222,15 @@ def signup(t, signup_url=None):
     resp = t.client.post('/phone_setup', data=data, auth=auth)
     resp.raise_for_status()
 
-    # visit enter security code page and submit pre-filled OTP
+    # visit security code page and submit pre-filled OTP
     dom = pyquery.PyQuery(resp.content)
     try:
         otp_code = dom.find('input[name="code"]')[0].attrib['value']
     except Exception as error:
-        print("There is a problem creating this account.")
-        print(error)
-        print(resp.content)
+        print("""
+            There is a problem creating this account: {}. 
+            Here is the response content: {}
+            """.format(error, resp.content))
         return
 
     data = {
@@ -256,11 +251,6 @@ def signup(t, signup_url=None):
 
 
 class UserBehavior(locust.TaskSet):
-    """
-    # TO-DO: Put logout in on_stop once it's merged into locust
-        # https://github.com/locustio/locust/pull/658
-
-    """
     def on_start(self):
         pass
 
@@ -272,7 +262,6 @@ class UserBehavior(locust.TaskSet):
         This is given a very low weight, since we do not expect
         it to be a common pattern in the real world.
         """
-        print("Task: Change pass from IDP")
         credentials = random_cred()
         login(self, credentials)
         change_pass(self, "thisisanewpass")
@@ -289,13 +278,12 @@ class UserBehavior(locust.TaskSet):
         This is given a very low weight, since we do not expect
         it to be a common pattern in the real world.
         """
-        print("Task: Change pass from sp_rails")
         resp = self.client.get('http://localhost:3003')
         resp.raise_for_status()
         dom = pyquery.PyQuery(resp.content)
 
-        # now submit the LOA1/LOA3 form
         """
+        # TO-DO: submit the LOA1/LOA3 form
         # We can't do this programmatically yet, because there's a mismatch
         # in how we're handling the trailing slash on host in locust and elsewhere:
         # in requests/models.py", line 371, in prepare_url
@@ -311,7 +299,7 @@ class UserBehavior(locust.TaskSet):
                 'authenticity_token': authenticity_token(dom)
             }
         )
-        For now, we're taking advantage of login() going to host + /sign_in
+        # For now, we're taking advantage of login() going to host + /sign_in
         """
         credentials = random_cred()
         login(self, credentials)
@@ -324,15 +312,16 @@ class UserBehavior(locust.TaskSet):
     def usajobs_change_pass(self):
         """
         Login, change pass, change it back and logout from USAjobs.
+
+        This is most common task and is heavily weighted.
         """
-        print("Task: Change pass from usajobs")
         resp = self.client.get('https://www.test.usajobs.gov/')
         resp.raise_for_status()
         resp = self.client.get('https://www.test.usajobs.gov/Applicant/ProfileDashboard/Home')
         resp.raise_for_status()
-        # we should now have been redirected to
+        # we should have been redirected to
         # https://login.test.usajobs.gov/Access/Transition
-        # we could put a resp.url check in here to verify that
+        # 
         # We'll now navigate into the regular IDP login flow.
         credentials = random_cred()
         login(self, credentials)
@@ -343,23 +332,41 @@ class UserBehavior(locust.TaskSet):
 
     @locust.task(2)
     def idp_create_account(self):
-        print("Task: Create account from idp")
+        """
+        Create an account from within the IDP.
+
+        This is given a low weight because it's not common
+        in the real world.
+        """
         signup(self)
         logout(self)
 
     @locust.task(25)
     def usajobs_create_account(self):
-        print("Task: Create account from usajobs")
+        """
+        Create an account from within USAjobs test domain. 
+
+        This is given a relatively low weight.
+        It's much more common than account creation from within IDP
+        but much lower than a simple login/logout.
+
+        If the os env var "NO_LOGOUT" has been set, this will skip 
+        the logout step to help show the load of many open sessions.
+        """
         resp = self.client.get('https://www.test.usajobs.gov/')
         resp.raise_for_status()
         resp = self.client.get('https://www.test.usajobs.gov/Applicant/ProfileDashboard/Home')
         resp.raise_for_status()
-        # A quick post to setup for the SP handshake
+        # A quick post is required to setup for the SP handshake.
+        # We'll pass the response url to signup()
         resp = self.client.post('https://login.test.usajobs.gov/Access/Transition')
         resp.raise_for_status()
-        signup_url = resp.url
-        signup(self, signup_url)
-        logout(self)
+        signup(self, resp.url)
+        
+        # Unless we said not to, sign out now.
+        if not os.getenv('NO_LOGOUT'):
+            print("Found 'NO_LOGOUT' in env vars. Skipping logout.")
+            logout(self)
 
 
 class WebsiteUser(locust.HttpLocust):


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
