### PR TITLE
Guard against nil email in password validator

### DIFF
--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -36,7 +36,6 @@ module Users
     # PUT /resource/password
     def update
       self.resource = user_matching_token(user_params[:reset_password_token])
-
       @reset_password_form = ResetPasswordForm.new(resource)
 
       result = @reset_password_form.submit(user_params)
@@ -112,8 +111,9 @@ module Users
     end
 
     def handle_unsuccessful_password_reset(result)
-      if result.errors[:reset_password_token].present?
-        flash[:error] = t('devise.passwords.token_expired')
+      reset_password_token_errors = result.errors[:reset_password_token]
+      if reset_password_token_errors.present?
+        flash[:error] = t("devise.passwords.#{reset_password_token_errors.first}")
         redirect_to new_user_password_url
         return
       end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -26,9 +26,13 @@ class ResetPasswordForm
   attr_reader :success
 
   def valid_token
-    return if user.reset_password_period_valid?
-
-    errors.add(:reset_password_token, 'token_expired')
+    if !user.persisted?
+      # If the user is not saved in the database, that means looking them up by
+      # their token failed
+      errors.add(:reset_password_token, 'invalid_token')
+    elsif !user.reset_password_period_valid?
+      errors.add(:reset_password_token, 'token_expired')
+    end
   end
 
   def handle_valid_password

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -25,7 +25,7 @@ module FormPasswordValidator
   def password_score
     @password_score = ZXCVBN_TESTER.test(
       password,
-      ForbiddenPasswords.new(user.email_address.email).call
+      ForbiddenPasswords.new(user.email_address&.email).call
     )
   end
 

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -95,6 +95,25 @@ describe ResetPasswordForm, type: :model do
       end
     end
 
+    context 'when the user does not exist in the db' do
+      it 'returns a hash with errors' do
+        user = User.new
+
+        form = ResetPasswordForm.new(user)
+        errors = {
+          reset_password_token: ['invalid_token'],
+        }
+
+        extra = { user_id: nil }
+
+        result = instance_double(FormResponse)
+
+        expect(FormResponse).to receive(:new).
+          with(success: false, errors: errors, extra: extra).and_return(result)
+        expect(form.submit(password: 'a good and powerful password')).to eq result
+      end
+    end
+
     it_behaves_like 'strong password', 'ResetPasswordForm'
   end
 end


### PR DESCRIPTION
**Why**: We were seeing `NoMethodErrors` on `email` in production
pointing at this code in the `FormPasswordValidator`:

```ruby
def password_score
  @password_score = ZXCVBN_TESTER.test(
    password,
    ForbiddenPasswords.new(user.email_address.email).call
  )
end
```

When the reset password controller cannot find a user for a given
password reset token, it initializes an empty user with an error.
Once we added the `#email_address` method this started causing problems
because the nil user does not have an email.

This commit fixes the bug and also changes the form to differentiate
between invalid and expired tokens so the user sees the right error
message if their token is invalid.

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
