### PR TITLE
LG-668 Capture use of remember me feature

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@ module Users
   class SessionsController < Devise::SessionsController
     include ::ActionView::Helpers::DateHelper
     include SecureHeadersConcern
+    include RememberDeviceConcern
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
 
@@ -112,6 +113,7 @@ module Users
         user_locked_out: user_locked_out?(user),
         stored_location: session['user_return_to'],
         sp_request_url_present: sp_session[:request_url].present?,
+        remember_device: remember_device_cookie.present?,
       }
 
       analytics.track_event(Analytics::EMAIL_AND_PASSWORD_AUTH, properties)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -162,6 +162,7 @@ describe Users::SessionsController, devise: true do
         user_locked_out: false,
         stored_location: 'http://example.com',
         sp_request_url_present: false,
+        remember_device: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -180,6 +181,7 @@ describe Users::SessionsController, devise: true do
         user_locked_out: false,
         stored_location: nil,
         sp_request_url_present: false,
+        remember_device: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -196,6 +198,7 @@ describe Users::SessionsController, devise: true do
         user_locked_out: false,
         stored_location: nil,
         sp_request_url_present: false,
+        remember_device: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -218,6 +221,7 @@ describe Users::SessionsController, devise: true do
         user_locked_out: true,
         stored_location: nil,
         sp_request_url_present: false,
+        remember_device: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -235,6 +239,7 @@ describe Users::SessionsController, devise: true do
         user_locked_out: false,
         stored_location: nil,
         sp_request_url_present: true,
+        remember_device: false,
       }
 
       expect(@analytics).to receive(:track_event).
@@ -303,6 +308,7 @@ describe Users::SessionsController, devise: true do
           user_locked_out: false,
           stored_location: nil,
           sp_request_url_present: false,
+          remember_device: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -355,6 +361,59 @@ describe Users::SessionsController, devise: true do
       end
 
       post :create, params: { user: { email: user.email, password: user.password } }
+    end
+
+    context 'with remember_device cookie present and valid' do
+      it 'tracks the cookie validity in analytics' do
+        user = create(:user, :signed_up)
+
+        cookies.encrypted[:remember_device] = {
+          value: RememberDeviceCookie.new(user_id: user.id, created_at: Time.zone.now).to_json,
+          expires: 2.days.from_now,
+        }
+
+        stub_analytics
+        analytics_hash = {
+          success: true,
+          user_id: user.uuid,
+          user_locked_out: false,
+          stored_location: nil,
+          sp_request_url_present: false,
+          remember_device: true,
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
+
+        post :create, params: { user: { email: user.email, password: user.password } }
+      end
+    end
+
+    context 'with remember_device cookie present but expired' do
+      it 'only tracks the cookie presence in analytics' do
+        user = create(:user, :signed_up)
+
+        allow(Figaro.env).to receive(:remember_device_expiration_days).and_return('2')
+
+        cookies.encrypted[:remember_device] = {
+          value: RememberDeviceCookie.new(user_id: user.id, created_at: 2.days.ago).to_json,
+        }
+
+        stub_analytics
+        analytics_hash = {
+          success: true,
+          user_id: user.uuid,
+          user_locked_out: false,
+          stored_location: nil,
+          sp_request_url_present: false,
+          remember_device: true,
+        }
+
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::EMAIL_AND_PASSWORD_AUTH, analytics_hash)
+
+        post :create, params: { user: { email: user.email, password: user.password } }
+      end
     end
   end
 


### PR DESCRIPTION
**Why**: To get a better sense of how many users use the remember me
feature.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [ ] The changes are compatible with data that was encrypted with the old code.


- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.