### PR TITLE
LG-775 Do not present FIDO auth option if browser does not support FIDO

### DIFF
--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -71,7 +71,7 @@ function webauthn() {
   };
   if (location.href.indexOf('?error=') === -1 &&
     !(navigator && navigator.credentials && navigator.credentials.create)) {
-    window.location.href = '/webauthn_setup?error=NotSupportedError';
+    window.location.href = '/login/two_factor/options';
   }
   const continueButton = document.getElementById('continue-button');
   continueButton.addEventListener('click', () => {

--- a/app/javascript/packs/webauthn-unhide.js
+++ b/app/javascript/packs/webauthn-unhide.js
@@ -1,0 +1,17 @@
+function unhideWebauthn() {
+  if (navigator && navigator.credentials && navigator.credentials.create) {
+    const elem = document.getElementById('select_webauthn');
+    if (elem) {
+      elem.classList.remove('hidden');
+    }
+  } else {
+    const checkboxes = document.querySelectorAll('input[name="two_factor_options_form[selection]"]');
+    for (let i = 0, len = checkboxes.length; i < len; i += 1) {
+      if (!checkboxes[i].classList.contains('hidden')) {
+        checkboxes[i].checked = true;
+        break;
+      }
+    }
+  }
+}
+document.addEventListener('DOMContentLoaded', unhideWebauthn);

--- a/app/presenters/two_factor_authentication/selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/selection_presenter.rb
@@ -30,5 +30,9 @@ module TwoFactorAuthentication
         'two_factor_choice_options'
       end
     end
+
+    def html_class
+      ''
+    end
   end
 end

--- a/app/presenters/two_factor_authentication/selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/selection_presenter.rb
@@ -21,6 +21,10 @@ module TwoFactorAuthentication
       t("two_factor_authentication.#{option_mode}.#{method}_info")
     end
 
+    def html_class
+      ''
+    end
+
     private
 
     def option_mode
@@ -29,10 +33,6 @@ module TwoFactorAuthentication
       else
         'two_factor_choice_options'
       end
-    end
-
-    def html_class
-      ''
     end
   end
 end

--- a/app/presenters/two_factor_authentication/webauthn_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/webauthn_selection_presenter.rb
@@ -3,5 +3,9 @@ module TwoFactorAuthentication
     def method
       :webauthn
     end
+
+    def html_class
+      'hidden'
+    end
   end
 end

--- a/app/views/two_factor_authentication/options/index.html.slim
+++ b/app/views/two_factor_authentication/options/index.html.slim
@@ -11,14 +11,16 @@ p.mt-tiny.mb3 = @presenter.info
     fieldset.m0.p0.border-none.
       legend.mb2.serif.bold = @presenter.label
       - @presenter.options.each_with_index do |option, index|
-        label.btn-border.col-12.mb2 for="two_factor_options_form_selection_#{option.type}"
-          .radio
-            = radio_button_tag('two_factor_options_form[selection]',
+        span id="select_#{option.type}" class="#{option.html_class}"
+          label.btn-border.col-12.mb2 for="two_factor_options_form_selection_#{option.type}"
+            .radio
+              = radio_button_tag('two_factor_options_form[selection]',
                     option.type,
-                    index.zero?)
-            span.indicator.mt-tiny
-            span.blue.bold.fs-20p = option.label
-            .regular.gray-dark.fs-10p.mb-tiny = option.info
+                    index.zero?,
+                    class: option.html_class.to_s)
+              span.indicator.mt-tiny
+              span.blue.bold.fs-20p = option.label
+              .regular.gray-dark.fs-10p.mb-tiny = option.info
 
   = f.button :submit, t('forms.buttons.continue')
 
@@ -26,3 +28,5 @@ br
 - if @presenter.should_display_account_reset_or_cancel_link?
   p = @presenter.account_reset_or_cancel_link
 = render 'shared/cancel', link: destroy_user_session_path
+
+== javascript_pack_tag 'webauthn-unhide'

--- a/spec/presenters/two_factor_authentication/webauthn_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/webauthn_selection_presenter_spec.rb
@@ -9,4 +9,10 @@ describe TwoFactorAuthentication::WebauthnSelectionPresenter do
       expect(subject.type).to eq 'webauthn'
     end
   end
+
+  describe '#html_class' do
+    it 'returns hidden' do
+      expect(subject.html_class).to eq 'hidden'
+    end
+  end
 end


### PR DESCRIPTION
**Why**: So the user is not presented with an option they can't use.

**How**: Display the security key option as hidden in the list of 2FA options.  Use javascript to determine if FIDO is supported.  If it is supported unhide the security key option.  If it is not supported make sure that the next 2FA option is selected by default.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
