### PR TITLE
Rename analytics log event key from host to hostname

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -24,7 +24,7 @@ class Analytics
   def request_attributes
     {
       user_ip: request.remote_ip,
-      host: request.host,
+      hostname: request.host,
       pid: Process.pid,
       service_provider: sp,
     }.merge!(browser_attributes)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -12,7 +12,7 @@ describe Analytics do
       browser_device_name: nil,
       browser_device_type: nil,
       browser_bot: false,
-      host: FakeRequest.new.host,
+      hostname: FakeRequest.new.host,
       pid: Process.pid,
       service_provider: 'http://localhost:3000',
     }


### PR DESCRIPTION
__Why__
When we ingest these logs into elasticsearch it creates a namespace collision with events from filebeat which automatically add a `host` key to all events. This results in a mapping conflict which limits our ability to search and filter by these values.
