### PR TITLE
LG-746 Return 400 error for invalid String params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
+require 'core_extensions/string/permit'
+
 class ApplicationController < ActionController::Base
+  String.include CoreExtensions::String::Permit
   include UserSessionContext
   include VerifyProfileConcern
   include LocaleHelper

--- a/app/controllers/sign_up/email_resend_controller.rb
+++ b/app/controllers/sign_up/email_resend_controller.rb
@@ -1,7 +1,5 @@
 module SignUp
   class EmailResendController < ApplicationController
-    include UnconfirmedUserConcern
-
     def new
       @user = User.new
       @resend_email_confirmation_form = ResendEmailConfirmationForm.new

--- a/lib/core_extensions/string/permit.rb
+++ b/lib/core_extensions/string/permit.rb
@@ -1,0 +1,18 @@
+# When a controller uses Strong Parameters such as:
+# params.require(:user).permit(:email), the `user` param is assumed to
+# be a Hash, but it's easy for a pentester (for example) to set the
+# `user` param to a String instead, which by default would raise a 500
+# error because the String class doesn't respond to `permit`. To get
+# around that, we monkey patched the Ruby String class to raise an
+# instance of ActionController::ParameterMissing, which will return
+# a 400 error. 500 errors can potentially page people in the middle of
+# the night, whereas 400 errors don't.
+module CoreExtensions
+  module String
+    module Permit
+      def permit(*)
+        raise ActionController::ParameterMissing, '#permit called on String'
+      end
+    end
+  end
+end

--- a/spec/requests/invalid_sign_in_params_spec.rb
+++ b/spec/requests/invalid_sign_in_params_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 describe 'visiting sign in page with invalid user params' do
-  it 'does not raise an exception' do
-    get new_user_session_path, params: { user: 'test@test.com' }
+  it 'raises ActionController::ParameterMissing' do
+    params = { user: 'test@test.com' }
+    message_string = 'param is missing or the value is empty: #permit called on String'
+
+    expect { get new_user_session_path, params: params }.
+      to raise_error(ActionController::ParameterMissing, message_string)
   end
 end
 

--- a/spec/requests/params_is_string_instead_of_hash_spec.rb
+++ b/spec/requests/params_is_string_instead_of_hash_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+# When a controller uses Strong Parameters such as:
+# params.require(:user).permit(:email), the `user` param is assumed to
+# be a Hash, but it's easy for a pentester (for example) to set the
+# `user` param to a String instead, which by default would raise a 500
+# error because the String class doesn't respond to `permit`. To get
+# around that, we monkey patched the Ruby String class to raise an
+# instance of ActionController::ParameterMissing, which will return
+# a 400 error. 500 errors can potentially page people in the middle of
+# the night, whereas 400 errors don't.
+describe 'submitting email resend form with required param as String' do
+  it 'raises ActionController::ParameterMissing' do
+    params = { resend_email_confirmation_form: 'abcdef' }
+    message_string = 'param is missing or the value is empty: #permit called on String'
+
+    expect { post sign_up_create_email_resend_path, params: params }.
+      to raise_error(ActionController::ParameterMissing, message_string)
+  end
+end
+
+describe 'submitting email registration form with required param as String' do
+  it 'raises ActionController::ParameterMissing' do
+    params = { user: 'abcdef' }
+    message_string = 'param is missing or the value is empty: #permit called on String'
+
+    expect { post sign_up_register_path, params: params }.
+      to raise_error(ActionController::ParameterMissing, message_string)
+  end
+end


### PR DESCRIPTION
**Why**:
When a controller uses Strong Parameters such as:
`params.require(:user).permit(:email)`, the `user` param is assumed to
be a Hash, but it's easy for a pentester (for example) to set the
`user` param to a String instead, which by default would raise a 500
error because the String class doesn't respond to `permit`.

**How**:
To get around that, we monkey patched the Ruby String class to raise an
instance of `ActionController::ParameterMissing`, which will return a
400 error. 500 errors can potentially page people in the middle of the
night, whereas 400 errors don't.

Note that Devise handles this scenario gracefully in SessionsController,
but because it determines whether or not to call `permit` based on
whether or not the object responds to `permit`, the Devise code will
end up calling `permit` because all Strings respond to it now after our
monkey patch. This is why the `invalid_sign_in_params_spec` had to
change.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [ ] The changes are compatible with data that was encrypted with the old code.


- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.