### PR TITLE
LG-793 Add user event when removing phone number

### DIFF
--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -26,7 +26,7 @@ module Users
       ).submit
       analytics.track_event(Analytics::PHONE_DELETION_REQUESTED, result.to_h)
       if result.success?
-        flash[:success] = t('two_factor_authentication.phone.delete.success')
+        handle_successful_delete
       else
         flash[:error] = t('two_factor_authentication.phone.delete.failure')
       end
@@ -62,6 +62,11 @@ module Users
       else
         redirect_to account_url
       end
+    end
+
+    def handle_successful_delete
+      flash[:success] = t('two_factor_authentication.phone.delete.success')
+      create_user_event(:phone_removed)
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,6 +17,7 @@ class Event < ApplicationRecord
     personal_key_used: 13,
     webauthn_key_added: 14,
     webauthn_key_removed: 15,
+    phone_removed: 16,
   }
 
   validates :event_type, presence: true

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -14,6 +14,7 @@ en:
     personal_key_used: Personal key used to sign in
     phone_changed: Phone number changed
     phone_confirmed: Phone confirmed
+    phone_removed: Phone number removed
     piv_cac_disabled: PIV/CAC card unassociated
     piv_cac_enabled: PIV/CAC card associated
     usps_mail_sent: Letter sent

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -14,6 +14,7 @@ es:
     personal_key_used: Clave personal utilizada para iniciar sesión
     phone_changed: Número de teléfono cambiado
     phone_confirmed: Teléfono confirmado
+    phone_removed: Teléfono eliminado
     piv_cac_disabled: Tarjeta PIV/CAC no asociada
     piv_cac_enabled: Tarjeta PIV/CAC asociada
     usps_mail_sent: Carta enviada

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -14,6 +14,7 @@ fr:
     personal_key_used: Clé personnelle utilisée pour la connexion
     phone_changed: Numéro de téléphone modifié
     phone_confirmed: Numéro de téléphone confirmé
+    phone_removed: Numéro de téléphone supprimé
     piv_cac_disabled: Carte PIV/CAC non associée
     piv_cac_enabled: Carte PIV/CAC associée
     usps_mail_sent: Lettre envoyée

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -89,6 +89,7 @@ feature 'User edit' do
         click_button t('forms.phone.buttons.delete')
         expect(page).to have_current_path(account_path)
         expect(MfaPolicy.new(user.reload).multiple_factors_enabled?).to eq false
+        expect(page).to have_content t('event_types.phone_removed')
       end
     end
   end


### PR DESCRIPTION
**Why**: To allow the user to check for unusual activity on their
account page, and to make it easier for us to troubleshoot security
issues.


Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines


- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.


- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.


- [ ] The changes are compatible with data that was encrypted with the old code.


- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).


- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.


- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.