### PR TITLE
Fix redirect when not presenting FIDO

### DIFF
--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -17,6 +17,9 @@ function webauthn() {
     }
     return window.btoa(binary);
   };
+  if (!(navigator && navigator.credentials && navigator.credentials.create)) {
+    window.location.href = '/login/two_factor/options';
+  }
   const challengeBytes = new Uint8Array(JSON.parse(document.getElementById('user_challenge').value));
   let credentialIds = document.getElementById('credential_ids').value;
   credentialIds = credentialIds.split(',');

--- a/app/javascript/packs/webauthn-authenticate.js
+++ b/app/javascript/packs/webauthn-authenticate.js
@@ -17,6 +17,7 @@ function webauthn() {
     }
     return window.btoa(binary);
   };
+  // If webauthn is not supported redirect back to the 2fa options list
   if (!(navigator && navigator.credentials && navigator.credentials.create)) {
     window.location.href = '/login/two_factor/options';
   }

--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -71,7 +71,7 @@ function webauthn() {
   };
   if (location.href.indexOf('?error=') === -1 &&
     !(navigator && navigator.credentials && navigator.credentials.create)) {
-    window.location.href = '/login/two_factor/options';
+    window.location.href = '/webauthn_setup?error=NotSupportedError';
   }
   const continueButton = document.getElementById('continue-button');
   continueButton.addEventListener('click', () => {


### PR DESCRIPTION
**Why**: The 2FA options list for login does not display FIDO when it is not supported.  However the code bypasses the selection list and takes you to the preferred option that you have configured.  A redirect was added to take the user back to the selection list but it was added to the setup js and not the authenticate js

**How**: In webauthn-authenticate.js, redirect to /login/two_factor/options when the user is on the webauthn login screen and FIDO is not supported.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
