### PR TITLE
Add mfa_enabled field to Users table

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -121,6 +121,7 @@ module TwoFactorAuthenticatable
 
   def handle_valid_otp_for_confirmation_context
     assign_phone
+    MarkUserAsMfaEnabled.new(current_user).call
   end
 
   def handle_valid_otp_for_authentication_context

--- a/app/forms/totp_setup_form.rb
+++ b/app/forms/totp_setup_form.rb
@@ -26,6 +26,7 @@ class TotpSetupForm
   def process_valid_submission
     user.save!
     Event.create(user_id: user.id, event_type: :authenticator_enabled)
+    MarkUserAsMfaEnabled.new(user).call
   end
 
   def extra_analytics_attributes

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -19,6 +19,7 @@ class UserPivCacSetupForm
     user.x509_dn_uuid = x509_dn_uuid
     user.save!
     Event.create(user_id: user.id, event_type: :piv_cac_enabled)
+    MarkUserAsMfaEnabled.new(user).call
     true
   rescue PG::UniqueViolation
     self.error_type = 'piv_cac.already_associated'

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -25,6 +25,7 @@ class WebauthnSetupForm
     if success
       create_webauthn_configuration
       create_user_event
+      MarkUserAsMfaEnabled.new(user).call
     end
 
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)

--- a/app/services/mark_user_as_mfa_enabled.rb
+++ b/app/services/mark_user_as_mfa_enabled.rb
@@ -1,0 +1,15 @@
+class MarkUserAsMfaEnabled
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    return if user.mfa_enabled?
+
+    UpdateUser.new(user: user, attributes: { mfa_enabled: true }).call
+  end
+
+  private
+
+  attr_reader :user
+end

--- a/db/migrate/20181121044822_add_mfa_enabled_to_users.rb
+++ b/db/migrate/20181121044822_add_mfa_enabled_to_users.rb
@@ -1,0 +1,10 @@
+class AddMfaEnabledToUsers < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :mfa_enabled, :boolean
+    change_column_default :users, :mfa_enabled, false
+  end
+
+  def down
+    remove_column :users, :mfa_enabled
+  end
+end

--- a/db/migrate/20181121051244_add_mfa_enabled_index_to_users.rb
+++ b/db/migrate/20181121051244_add_mfa_enabled_index_to_users.rb
@@ -1,0 +1,7 @@
+class AddMfaEnabledIndexToUsers < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :mfa_enabled, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181029203754) do
+ActiveRecord::Schema.define(version: 20181121051244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,9 +250,11 @@ ActiveRecord::Schema.define(version: 20181029203754) do
     t.string "encrypted_password_digest", default: ""
     t.string "encrypted_recovery_code_digest", default: ""
     t.datetime "remember_device_revoked_at"
+    t.boolean "mfa_enabled", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
+    t.index ["mfa_enabled"], name: "index_users_on_mfa_enabled"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"
     t.index ["unlock_token"], name: "index_users_on_unlock_token"


### PR DESCRIPTION
**Why**: To make it easier to query how many users have configured MFA.

For example: `User.count(:mfa_enabled)`

Note that you want to use the above command, not any of these:
```
User.count(&:mfa_enabled)
User.count(&:mfa_enabled?)
```

The former does `SELECT COUNT("users"."mfa_enabled") FROM "users"`
whereas the latter ones use Ruby's Enumerable, which is a lot slower.

I believe the former is also faster than this:
```
User.where(mfa_enabled: true).count
```

What I don't know is whether the former benefits from an index.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.