### PR TITLE
LG-833 Don't let user's remove last 2fa method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,7 @@ Metrics/ClassLength:
   - app/services/analytics.rb
   - app/services/idv/session.rb
   - app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+  - app/view_models/account_show.rb
   - lib/cloudhsm/cloudhsm_key_generator.rb
 
 Metrics/LineLength:

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -97,7 +97,8 @@ module Users
     end
 
     def authorize_piv_cac_disable
-      redirect_to account_url unless piv_cac_enabled?
+      return redirect_to account_url unless piv_cac_enabled? &&
+                                            MfaPolicy.new(current_user).multiple_factors_enabled?
     end
 
     def authorize_piv_cac_setup

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -26,11 +26,8 @@ module Users
     end
 
     def disable
-      if current_user.totp_enabled?
-        analytics.track_event(Analytics::TOTP_USER_DISABLED)
-        create_user_event(:authenticator_disabled)
-        UpdateUser.new(user: current_user, attributes: { otp_secret_key: nil }).call
-        flash[:success] = t('notices.totp_disabled')
+      if current_user.totp_enabled? && MfaPolicy.new(current_user).multiple_factors_enabled?
+        process_successful_disable
       end
       redirect_to account_url
     end
@@ -58,6 +55,13 @@ module Users
       flash[:success] = t('notices.totp_configured')
       redirect_to url_after_entering_valid_code
       user_session.delete(:new_totp_secret)
+    end
+
+    def process_successful_disable
+      analytics.track_event(Analytics::TOTP_USER_DISABLED)
+      create_user_event(:authenticator_disabled)
+      UpdateUser.new(user: current_user, attributes: { otp_secret_key: nil }).call
+      flash[:success] = t('notices.totp_disabled')
     end
 
     def mark_user_as_fully_authenticated

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -58,18 +58,36 @@ class AccountShow
 
   def totp_partial
     if TwoFactorAuthentication::AuthAppPolicy.new(decorated_user.user).enabled?
-      'accounts/actions/disable_totp'
+      disable_totp_partial
     else
-      'accounts/actions/enable_totp'
+      enable_totp_partial
     end
+  end
+
+  def disable_totp_partial
+    return 'shared/null' unless MfaPolicy.new(decorated_user.user).multiple_factors_enabled?
+    'accounts/actions/disable_totp'
+  end
+
+  def enable_totp_partial
+    'accounts/actions/enable_totp'
   end
 
   def piv_cac_partial
     if TwoFactorAuthentication::PivCacPolicy.new(decorated_user.user).enabled?
-      'accounts/actions/disable_piv_cac'
+      disable_piv_cac_partial
     else
-      'accounts/actions/enable_piv_cac'
+      enable_piv_cac_partial
     end
+  end
+
+  def disable_piv_cac_partial
+    return 'shared/null' unless MfaPolicy.new(decorated_user.user).multiple_factors_enabled?
+    'accounts/actions/disable_piv_cac'
+  end
+
+  def enable_piv_cac_partial
+    'accounts/actions/enable_piv_cac'
   end
 
   def manage_personal_key_partial

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -129,7 +129,7 @@ describe Users::PivCacAuthenticationSetupController do
     end
 
     context 'with associated piv/cac' do
-      let(:user) { create(:user, :with_piv_or_cac) }
+      let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
 
       describe 'GET index' do
         it 'redirects to account page' do
@@ -153,6 +153,15 @@ describe Users::PivCacAuthenticationSetupController do
           subject.user_session[:decrypted_x509] = {}
           delete :delete
           expect(subject.user_session[:decrypted_x509]).to be_nil
+        end
+
+        it 'does not remove the piv/cac association if it is the last mfa method' do
+          user.phone_configurations.destroy_all
+
+          delete :delete
+
+          expect(response).to redirect_to(account_url)
+          expect(user.reload.x509_dn_uuid).to_not be_nil
         end
       end
     end

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -251,5 +251,16 @@ describe Users::TotpSetupController, devise: true do
         expect(subject).to have_received(:create_user_event).with(:authenticator_disabled)
       end
     end
+
+    context 'when totp is the last mfa method' do
+      it 'does not disable totp' do
+        user = create(:user, :with_authentication_app)
+        sign_in user
+
+        delete :disable
+        expect(user.reload.otp_secret_key).to_not be_nil
+        expect(response).to redirect_to(account_path)
+      end
+    end
   end
 end

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -190,4 +190,19 @@ feature 'PIV/CAC Management' do
       expect(user.x509_dn_uuid).to be_nil
     end
   end
+
+  context 'with PIV/CAC as the only MFA method' do
+    let(:user) { create(:user, :with_piv_or_cac) }
+
+    scenario 'disallows disassociation PIV/CAC' do
+      sign_in_and_2fa_user(user)
+      visit account_path
+
+      form = find_form(page, action: disable_piv_cac_url)
+      expect(form).to be_nil
+
+      user.reload
+      expect(user.x509_dn_uuid).to_not be_nil
+    end
+  end
 end

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe 'totp management' do
+  context 'when the user has totp enabled' do
+    let(:user) { create(:user, :signed_up, :with_authentication_app) }
+
+    it 'allows the user to disable their totp app' do
+      sign_in_and_2fa_user(user)
+
+      expect(page).to have_content(t('account.index.authentication_app'))
+      form = find_form(page, action: disable_totp_url)
+      expect(form).to_not be_nil
+
+      form.click_button(t('forms.buttons.disable'))
+
+      expect(page).to have_current_path(account_path)
+      expect(user.reload.otp_secret_key).to be_nil
+    end
+  end
+
+  context 'when totp is the only mfa method' do
+    let(:user) { create(:user, :with_authentication_app) }
+
+    it 'does not shot the user the option to disable their totp app' do
+      sign_in_and_2fa_user(user)
+
+      expect(page).to have_content(t('account.index.authentication_app'))
+      form = find_form(page, action: disable_totp_url)
+      expect(form).to be_nil
+    end
+  end
+
+  context 'when the user has totp disabled' do
+    let(:user) { create(:user, :signed_up) }
+
+    it 'allows the user to setup a totp app' do
+      sign_in_and_2fa_user(user)
+
+      click_link t('forms.buttons.enable'), href: authenticator_setup_url
+
+      secret = find('#qr-code').text
+      fill_in 'code', with: generate_totp_code(secret)
+      click_button 'Submit'
+
+      expect(user.reload.otp_secret_key).to_not be_nil
+    end
+  end
+
+  # :reek:NestedIterators
+  def find_form(page, attributes)
+    page.all('form').detect do |form|
+      attributes.all? { |key, value| form[key] == value }
+    end
+  end
+end

--- a/spec/view_models/account_show_spec.rb
+++ b/spec/view_models/account_show_spec.rb
@@ -126,6 +126,9 @@ describe AccountShow do
         allow_any_instance_of(
           TwoFactorAuthentication::AuthAppPolicy
         ).to receive(:enabled?).and_return(true)
+        allow_any_instance_of(
+          MfaPolicy
+        ).to receive(:multiple_factors_enabled?).and_return(true)
 
         profile_index = AccountShow.new(
           decrypted_pii: {}, personal_key: '', decorated_user: user.decorate


### PR DESCRIPTION
**Why**: A user could delete their TOTP or PIV/CAC if it was their last
MFA method, meaning they had to start their MFA setup again. This commit
fixes that by checking that the user has multiple MFA methods before
displaying the disable button for those and checking that they aren't
the last MFA method before disabling them.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
