### PR TITLE
Downgrade to node v8 and ignore engines on install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             - v1-identity-idp-yarn-
       - run:
           name: Install Yarn
-          command: yarn install --cache-folder ~/.cache/yarn
+          command: yarn install --ingore-engines --cache-folder ~/.cache/yarn
       - save-cache:
           key: v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             - v1-identity-idp-yarn-
       - run:
           name: Install Yarn
-          command: yarn install --ingore-engines --cache-folder ~/.cache/yarn
+          command: yarn install --ignore-engines --cache-folder ~/.cache/yarn
       - save-cache:
           key: v1-identity-idp-yarn-{{ checksum "yarn.lock" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": "~10.x.x",
-    "npm": "~6.x.x"
+    "node": "~8.x.x",
+    "npm": "~5.x.x"
   },
   "scripts": {
     "test": "NODE_ENV=test mocha --require babel-core/register --require spec/javascripts/spec_helper.js spec/javascripts/**/*.js",


### PR DESCRIPTION
**Why**: The latest CircleCI image is running Node v10, but our IdP
servers are running v8. This change allows CI to work w/ v8 while we
upgrade the IdP servers to v10.

