### PR TITLE
LG-834 Limit field lengths

### DIFF
--- a/app/validators/idv/form_profile_validator.rb
+++ b/app/validators/idv/form_profile_validator.rb
@@ -3,8 +3,7 @@ module Idv
     extend ActiveSupport::Concern
 
     included do
-      validates :address1, :city, :dob, :first_name, :last_name, :ssn, :state, :zipcode,
-                presence: true
+      validates :dob, :ssn, :state, :zipcode, presence: true
 
       validate :dob_is_sane, :ssn_is_unique
 
@@ -16,6 +15,12 @@ module Idv
                           with: /\A\d{3}-?\d{2}-?\d{4}\z/,
                           message: I18n.t('idv.errors.pattern_mismatch.ssn'),
                           allow_blank: true
+
+      validates :city, presence: true, length: { maximum: 255 }
+      validates :first_name, presence: true, length: { maximum: 255 }
+      validates :last_name, presence: true, length: { maximum: 255 }
+      validates :address1, presence: true, length: { maximum: 255 }
+      validates :address2, length: { maximum: 255 }
     end
 
     def duplicate_ssn?

--- a/app/views/idv/sessions/new.html.slim
+++ b/app/views/idv/sessions/new.html.slim
@@ -10,8 +10,8 @@ p = link_to t('links.access_help'),
     html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.error_notification
   fieldset.ml0.p0.border-none
-    = f.input :first_name, label: t('idv.form.first_name'), required: true
-    = f.input :last_name, label: t('idv.form.last_name'), required: true
+    = f.input :first_name, label: t('idv.form.first_name'), required: true, maxlength: 255
+    = f.input :last_name, label: t('idv.form.last_name'), required: true, maxlength: 255
     .clearfix.mxn1
       .sm-col.sm-col-6.px1
         / using :tel for mobile numeric keypad
@@ -52,9 +52,9 @@ p = link_to t('links.access_help'),
         pattern: '^.{0,25}$',
         input_html: { class: 'sm-col-8 state_id_number', value: @idv_form.state_id_number }
     = f.input :address1, label: t('idv.form.address1'), wrapper_html: { class: 'mb1' },
-        required: true
-    = f.input :address2, label: t('idv.form.address2')
-    = f.input :city, label: t('idv.form.city'), required: true
+        required: true, maxlength: 255
+    = f.input :address2, label: t('idv.form.address2'), maxlength: 255
+    = f.input :city, label: t('idv.form.city'), required: true, maxlength: 255
 
     .clearfix.mxn1
       .sm-col.sm-col-8.px1

--- a/spec/forms/idv/profile_form_spec.rb
+++ b/spec/forms/idv/profile_form_spec.rb
@@ -197,4 +197,18 @@ describe Idv::ProfileForm do
       expect(subject.errors).to include(:state_id_number)
     end
   end
+
+  describe 'field lengths' do
+    it 'populates error for invalid lengths' do
+      %i[city first_name last_name address1 address2]. each do |symbol|
+        max_length(symbol)
+      end
+    end
+  end
+
+  def max_length(symbol)
+    subject.submit(profile_attrs.merge(symbol => 'a' * 256))
+    expect(subject.valid?).to eq false
+    expect(subject.errors).to include(symbol)
+  end
 end


### PR DESCRIPTION
**Why**: To provide reasonable limits on data we collect

**How**: Limit profile fields to 255.  Put a maximum on the field validation in the form validator.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
