### PR TITLE
Configure the omniauth redirect URL for the dashboard

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -116,20 +116,6 @@ development:
     attribute_bundle:
       - email
 
-  'https://dashboard.login.gov':
-    friendly_name: 'Dashboard'
-    agency: 'GSA'
-    agency_id: 2
-    uuid_priority: 30
-    logo: '18f.svg'
-    acs_url: 'http://localhost:3001/users/auth/saml/callback'
-    assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout'
-    sp_initiated_login_url: 'http://localhost:3001/users/auth/saml'
-    block_encryption: 'aes256-cbc'
-    cert: 'identity_dashboard_cert'
-    attribute_bundle:
-      - email
-
   'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
     friendly_name: 'Dashboard'
     agency: 'GSA'
@@ -139,7 +125,7 @@ development:
     cert: 'identity_dashboard_cert'
     return_to_sp_url: 'http://localhost:3001'
     redirect_uris:
-      - 'http://localhost:3001/users/result'
+      - 'http://localhost:3001/auth/logindotgov/callback'
 
   'urn:gov:gsa:openidconnect:development':
     redirect_uris:
@@ -230,20 +216,6 @@ production:
       - email
   <% end %>
 
-  # Dashboard
-  <% if LoginGov::Hostdata.in_datacenter? %>
-  'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>':
-    friendly_name: 'Dashboard'
-    agency: 'GSA'
-    logo: '18f.svg'
-    acs_url: 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/users/auth/saml/callback'
-    assertion_consumer_logout_service_url: 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/users/auth/saml/logout'
-    sp_initiated_login_url: 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/users/auth/saml'
-    block_encryption: 'aes256-cbc'
-    cert: 'identity_dashboard_cert'
-    attribute_bundle:
-      - email
-
   'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
     friendly_name: 'Dashboard'
     agency: 'GSA'
@@ -253,8 +225,8 @@ production:
     cert: 'identity_dashboard_cert'
     return_to_sp_url: 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>'
     redirect_uris:
+      - 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/auth/logindotgov/callback'
       - 'https://dashboard.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/users/result'
-  <% end %>
 
   'urn:gov:gsa:openidconnect:sp:sinatra':
     agency: 'GSA'
@@ -881,4 +853,3 @@ production:
       - 'https://rule19d1.sec.gov/auth/login-gov/callback/loa-1'
       - 'https://rule19d1.sec.gov/auth/login-gov/logout'
     restrict_to_deploy_env: 'prod'
-


### PR DESCRIPTION
**Why**: So that when we switch the dashboard over to the omniauth gem,
it will still work. This commit also removes the decomissioned saml SPs
for the dashboard.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
