### PR TITLE
Add more email domains for .gov piv/cac support

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -74,6 +74,30 @@ twilio_timeout: '5'
 usps_download_sftp_timeout: '5'
 usps_upload_sftp_timeout: '5'
 
+piv_cac_email_domains: >-
+  [
+    ".eop.gov", ".mil", ".treas.gov", ".dhs.gov",
+    "abilityone.gov", "achp.gov", "acus.gov", "afrh.gov", "arc.gov",
+    "bea.gov", "bis.doc.gov",
+    "census.gov", "cftc.gov", "cigie.gov", "cns.gov",
+    "dhs.gov", "doc.gov", "dol.gov", "dra.gov",
+    "eac.gov", "ed.gov", "eda.gov", "epa.gov",
+    "fbi.gov", "fca.gov", "fcc.gov", "fcsic.gov", "federalreserve.gov", "ferc.gov", "fhfa.gov", "fhfaoig.gov", "fira.gov", "fmc.gov", "fmcs.gov", "fmshrc.gov", "ftc.gov",
+    "gao.gov", "gpo.gov", "gsa.gov",
+    "heritageabroad.gov", "hq.doe.gov", "hud.gov", "hudoig.gov",
+    "iaf.gov", "ibwc.gov", "imls.gov", "ios.doi.gov",
+    "jusfc.gov", "justice.gov",
+    "macpac.gov", "mail.frtib.gov", "mbda.gov", "mmc.gov",
+    "nara.gov", "nbrc.gov", "ncua.gov", "nea.gov", "neh.gov", "nist.gov", "nlrb.gov", "noaa.gov", "nsf.gov", "ntia.doc.gov", "ntis.gov", "ntsb.gov",
+    "oig.doc.gov", "oig.hhs.gov", "opm.gov",
+    "pclob.gov",
+    "restorethegulf.gov",
+    "sba.gov", "sec.gov", "si.edu", "sss.gov", "state.gov", "stateoig.gov",
+    "trade.gov", "truman.gov", "tsp.gov", "tva.gov",
+    "usadf.gov", "uscc.gov", "usccr.gov", "uscirf.gov",
+    "va.gov", "vef.gov"
+  ]
+
 development:
   aamva_cert_enabled: 'true'
   aamva_public_key: '123abc'
@@ -150,7 +174,6 @@ development:
   otp_valid_for: '10'
   password_pepper: 'f22d4b2cafac9066fe2f4416f5b7a32c'
   password_strength_enabled: 'true'
-  piv_cac_email_domains: '[".mil","state.gov"]'
   piv_cac_verify_token_secret: 'ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12'
   piv_cac_service_url: 'https://localhost:8443/'
   piv_cac_verify_token_url: 'https://localhost:8443/'
@@ -280,7 +303,6 @@ production:
   participate_in_dap: 'false' # pair with google_analytics_key
   password_pepper: # generate via `rake secret`
   password_strength_enabled: 'true'
-  piv_cac_email_domains: '[".mil","state.gov"]'
   pkcs11_lib: '/opt/cloudhsm/lib/libcloudhsm_pkcs11.so'
   platform_authenticator_analytics_enabled: 'true'
   programmable_sms_countries: 'US,CA,MX'
@@ -404,7 +426,6 @@ test:
   otp_valid_for: '10'
   password_pepper: 'f22d4b2cafac9066fe2f4416f5b7a32c'
   password_strength_enabled: 'false'
-  piv_cac_email_domains: '[".mil","state.gov"]'
   piv_cac_service_url: 'https://localhost:8443/'
   piv_cac_verify_token_secret: '3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f'
   piv_cac_verify_token_url: 'https://localhost:8443/'


### PR DESCRIPTION
**Why**: We want to roll out piv/cac as we find agencies that we believe
we can support.

**How**: We add the email domains for supported agencies to the list we
test against.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
