### PR TITLE
Fix Dockerfile by using non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
 RUN echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y --no-install-recommends yarn
 
+RUN \
+  groupadd --gid 999 appuser && \
+  useradd --system --create-home --uid 999 --gid appuser appuser
+USER appuser
+
 WORKDIR /upaya
 
 COPY package.json /upaya


### PR DESCRIPTION
**Why**:
- Setting up the project with `bin/setup --docker` fails because setup commands should not be run as root.

**How**:
- While building the Docker image for the Rails application, create a new user and switch users to it from root. The remaining commands, including those run by `docker-compose run`, run as this new user instead of root.

Fixes #2690.