### PR TITLE
Don't tell users to contact us on 2FA key use.

### DIFF
--- a/config/locales/jobs/en.yml
+++ b/config/locales/jobs/en.yml
@@ -14,7 +14,7 @@ en:
         your phone number. This code will expire in %{expiration} minutes."
     sms_personal_key_regeneration_notifier_job:
       message: A new personal key has been issued for your %{app} account. If this
-        wasn’t you, reset your password and contact us at security@login.gov.
+        wasn’t you, reset your password.
     sms_personal_key_sign_in_notifier_job:
       message: Your personal key was just used to sign into your %{app} account. If
-        this wasn’t you, reset your password and contact us at security@login.gov.
+        this wasn’t you, reset your password.

--- a/config/locales/jobs/es.yml
+++ b/config/locales/jobs/es.yml
@@ -14,7 +14,7 @@ es:
         confirmar su número de teléfono. Este código caducará en %{expiration} minutos."
     sms_personal_key_regeneration_notifier_job:
       message: Se ha emitido una nueva clave personal para tu cuenta %{app}. Si no
-        eres tú, restablece tu contraseña y ponte en contacto con nosotros en security@login.gov.
+        eres tú, restablece tu contraseña.
     sms_personal_key_sign_in_notifier_job:
       message: Su clave personal solo se utilizó para iniciar sesión en su cuenta
-        %{app}. Si no fue así, reinicie su contraseña y contáctenos en security@login.gov.
+        %{app}. Si no fue así, reinicie su contraseña.

--- a/config/locales/jobs/fr.yml
+++ b/config/locales/jobs/fr.yml
@@ -16,9 +16,7 @@ fr:
         minutes."
     sms_personal_key_regeneration_notifier_job:
       message: Une nouvelle clé personnelle a été émise pour votre compte %{app}.
-        Si vous ne l'avez pas demandée, réinitialisez votre mot de passe et contactez-nous
-        à security@login.gov.
+        Si vous ne l'avez pas demandée, réinitialisez votre mot de passe.
     sms_personal_key_sign_in_notifier_job:
       message: Votre clé personnelle a été utilisée pour vous connecter à votre compte
-        %{app}. Si ce n’était pas vous, changez votre mot de passe et contactez-nous
-        à security@login.gov.
+        %{app}. Si ce n’était pas vous, changez votre mot de passe.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -57,8 +57,7 @@ en:
         two-factor authentication, such as phone number, authentication app, or security
         key.</li><li><strong>On your <a href="%{account_url}">login.gov account page</a>,
         request a new personal key.</strong> Remember, never share it unless you are
-        using it to sign into a trusted website that uses login.gov.</li></ol></p><p>You
-        should then contact us by calling 844-875-6446 or emailing <a href="mailto:security@login.gov">security@login.gov</a>.</p><br>Thanks,<br>The
+        using it to sign into a trusted website that uses login.gov.</li></ol></p><br>Thanks,<br>The
         login.gov team
       intro: New personal key issued
       subject: Account Security Alert
@@ -75,8 +74,7 @@ en:
         two-factor authentication, such as phone number, authentication app, or security
         key.</li><li><strong>On your <a href="%{account_url}">login.gov account page</a>,
         request a new personal key.</strong> Remember, never share it unless you are
-        using it to sign into a trusted website that uses login.gov.</li></ol></p><p>You
-        should then contact us by calling 844-875-6446 or emailing <a href="mailto:security@login.gov">security@login.gov</a>.</p>
+        using it to sign into a trusted website that uses login.gov.</li></ol></p>
         <br>Thanks,<br>The login.gov team
       intro: Personal key used to sign in
       subject: Account Security Alert

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -58,9 +58,7 @@ es:
         o la clave de seguridad. </li><li><strong>En la <a href="%{account_url}">página
         de tu cuenta de login.gov</a>, solicita una nueva clave personal</strong>.
         Recuerda no compartirla nunca a menos que la estés usando para acceder a un
-        sitio web de confianza que utilice login.gov.</li></ol></p><p>Deberías ponerte
-        en contacto con nosotros llamando al 844-875-6446 o enviando un correo electrónico
-        a <a href="mailto:security@login.gov">security@login.gov</a>.</p><br>Gracias,<br>El
+        sitio web de confianza que utilice login.gov.</li></ol></p><br>Gracias,<br>El
         equipo de login.gov
       intro: Nueva clave personal emitida
       subject: Alerta de seguridad de la cuenta
@@ -78,9 +76,7 @@ es:
         de teléfono, la aplicación de autenticación, o la clave de seguridad.</li><li><strong>En
         la página de su cuenta login.gov, solicite una nueva clave personal.</strong>
         Recuerde, nunca lo comparta a menos que lo esté utilizando para iniciar sesión
-        en un sitio web de confianza que utiliza login.gov.</li></ol></p><p>Luego
-        debe comunicarse con nosotros llamando al 844-875-6446 o enviando un e-mail
-        a <a href="mailto:security@login.gov">security@login.gov</a>.</p> <br>Gracias,<br>El
+        en un sitio web de confianza que utiliza login.gov.</li></ol></p><br>Gracias,<br>El
         equipo de login.gov
       intro: Clave personal utilizada para iniciar sesión
       subject: Alerta de seguridad de cuenta

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -61,8 +61,7 @@ fr:
         ou la clé de sécurité.</li><li><strong>Sur votre <a href="%{account_url}">page
         de compte login.gov</a>, demandez une nouvelle clé personnelle.</strong> N'oubliez
         pas de ne jamais la partager, sauf si vous l'utilisez pour vous connecter
-        à un site de confiance qui utilise login.gov.</li></ol></p><p>Veuillez ensuite
-        nous contacter en appelant le 844-875-6446 ou par e-mail à <a href="mailto:security@login.gov">security@login.gov</a>.</p><br>Merci,<br>L'équipe
+        à un site de confiance qui utilise login.gov.</li></ol></p><br>Merci,<br>L'équipe
         login.gov
       intro: Nouvelle clé personnelle émise
       subject: Alerte de sécurité du compte
@@ -81,9 +80,7 @@ fr:
         téléphone, l'application d'authentification ou la clé de sécurité.</li><li><strong>Sur
         la page de votre compte login.gov, demandez une nouvelle clé personnelle.</strong>
         N'oubliez pas de ne jamais le partager à moins que vous ne l'utilisiez pour
-        vous connecter à un site Web de confiance utilisant login.gov.</li></ol></p><p>Vous
-        devriez a nous contacter par téléphone au 844-875-6446 ou par courriel à <a
-        href="mailto:security@login.gov">security@login.gov</a>.</p><br>Merci,<br>L'équipe
+        vous connecter à un site Web de confiance utilisant login.gov.</li></ol></p><br>Merci,<br>L'équipe
         login.gov
       intro: La clé personnelle utilisée pour vous connecter
       subject: Alerte de sécurité du compte


### PR DESCRIPTION
**Why**: We don't currently take any action when users write in about
this. This is a very frustrating experience: they are just doing what we
say but we aren't doing anything about it.

**How**: Remove contact us language from email and SMS around personal
key use.