### PR TITLE
[LG-860] Allow piv/cac based on email

### DIFF
--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -42,10 +42,6 @@ class MfaContext
     phone_configurations + webauthn_configurations + [piv_cac_configuration, auth_app_configuration]
   end
 
-  def enabled_two_factor_configurations_count
-    two_factor_configurations.count(&:mfa_enabled?)
-  end
-
   # returns a hash showing the count for each enabled 2FA configuration,
   # such as: { phone: 2, webauthn: 1 }. This is useful for analytics purposes.
   def enabled_two_factor_configuration_counts_hash

--- a/app/policies/two_factor_authentication/piv_cac_policy.rb
+++ b/app/policies/two_factor_authentication/piv_cac_policy.rb
@@ -13,7 +13,7 @@ module TwoFactorAuthentication
     end
 
     def available?
-      !enabled? && user.identities.any?(&:piv_cac_available?)
+      !enabled? && available_if_not_enabled?
     end
 
     def visible?
@@ -21,6 +21,14 @@ module TwoFactorAuthentication
     end
 
     private
+
+    def available_if_not_enabled?
+      if FeatureManagement.allow_piv_cac_by_email_only?
+        PivCacService.piv_cac_available_for_email?(user.email_addresses.map(&:email))
+      else
+        user.identities.any?(&:piv_cac_available?)
+      end
+    end
 
     attr_reader :user
   end

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -29,13 +29,11 @@ module PivCacService
     end
 
     def piv_cac_available_for_sp?(sp, emails = [])
-      sp.piv_cac || available_for_email?(sp, emails)
+      sp.piv_cac? || sp.piv_cac_scoped_by_email? && piv_cac_available_for_email?(emails)
     end
 
-    private
-
-    def available_for_email?(sp, emails)
-      return unless emails.any? && sp.piv_cac_scoped_by_email
+    def piv_cac_available_for_email?(emails)
+      return unless emails.any?
 
       piv_cac_email_domains = Figaro.env.piv_cac_email_domains || '[]'
       supported_domains = JSON.parse(piv_cac_email_domains)
@@ -44,6 +42,8 @@ module PivCacService
 
       emails_match_domains?(email_domains, supported_domains)
     end
+
+    private
 
     def emails_match_domains?(email_domains, supported_domains)
       partial_domains, exact_domains = supported_domains.partition { |domain| domain[0] == '.' }

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -98,6 +98,8 @@ piv_cac_email_domains: >-
     "va.gov", "vef.gov"
   ]
 
+allow_piv_cac_by_email_only: 'true'
+
 development:
   aamva_cert_enabled: 'true'
   aamva_public_key: '123abc'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -20,6 +20,10 @@ class FeatureManagement
       !env.piv_cac_verify_token_url
   end
 
+  def self.allow_piv_cac_by_email_only?
+    Figaro.env.allow_piv_cac_by_email_only == 'true'
+  end
+
   def self.development_and_identity_pki_disabled?
     # This controls if we try to hop over to identity-pki or just throw up
     # a screen asking for a Subject or one of a list of error conditions.

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -11,18 +11,11 @@ feature 'PIV/CAC Management' do
     let(:uuid) { SecureRandom.uuid }
     let(:user) { create(:user, :signed_up, :with_phone, with: { phone: '+1 202-555-1212' }) }
 
-    context 'with a service provider allowed to use piv/cac' do
-      let(:identity_with_sp) do
-        Identity.create(
-          user_id: user.id,
-          service_provider: 'http://localhost:3000',
-          last_authenticated_at: Time.zone.now
-        )
-      end
-
+    context 'with an account allowed to use piv/cac' do
       before(:each) do
-        user.identities << [identity_with_sp]
-        allow_any_instance_of(ServiceProvider).to receive(:piv_cac).and_return(true)
+        allow_any_instance_of(
+          TwoFactorAuthentication::PivCacPolicy
+        ).to receive(:available?).and_return(true)
       end
 
       scenario 'allows association of a piv/cac with an account' do
@@ -118,18 +111,11 @@ feature 'PIV/CAC Management' do
       end
     end
 
-    context 'with a service provider not allowed to use piv/cac' do
-      let(:identity_with_sp) do
-        Identity.create(
-          user_id: user.id,
-          service_provider: 'http://localhost:3000',
-          last_authenticated_at: Time.zone.now
-        )
-      end
-
+    context 'with an account not allowed to use piv/cac' do
       before(:each) do
-        user.identities << [identity_with_sp]
-        allow_any_instance_of(ServiceProvider).to receive(:piv_cac).and_return(false)
+        allow_any_instance_of(
+          TwoFactorAuthentication::PivCacPolicy
+        ).to receive(:available?).and_return(false)
       end
 
       scenario "doesn't advertise association of a piv/cac with an account" do
@@ -152,7 +138,7 @@ feature 'PIV/CAC Management' do
     end
   end
 
-  context 'with a piv/cac associated and no identities allowing piv/cac' do
+  context 'with a piv/cac associated' do
     let(:user) do
       create(:user, :signed_up, :with_piv_or_cac, :with_phone, with: { phone: '+1 202-555-1212' })
     end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -214,6 +214,28 @@ describe 'FeatureManagement', type: :feature do
   end
 
   describe 'piv/cac feature' do
+    describe '#allow_piv_cac_by_email_only?' do
+      context 'when enabled' do
+        before(:each) do
+          allow(Figaro.env).to receive(:allow_piv_cac_by_email_only) { 'true' }
+        end
+
+        it 'has the feature disabled' do
+          expect(FeatureManagement.allow_piv_cac_by_email_only?).to be_truthy
+        end
+      end
+
+      context 'when not enabled' do
+        before(:each) do
+          allow(Figaro.env).to receive(:allow_piv_cac_by_email_only) { 'not-true' }
+        end
+
+        it 'has the feature disabled' do
+          expect(FeatureManagement.allow_piv_cac_by_email_only?).to be_falsey
+        end
+      end
+    end
+
     describe '#identity_pki_disabled?' do
       context 'when enabled' do
         before(:each) do


### PR DESCRIPTION
**Why**: We are confident that for folk registering with an
email in a set of known domains, we can support their PIV/CAC.

**How**: Rather than check for SP affiliation, just check the
domain of their registered email address.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
