### PR TITLE
[WIP] Add validation to Japanese phone numbers

### DIFF
--- a/app/javascript/app/phone-validation.js
+++ b/app/javascript/app/phone-validation.js
@@ -5,6 +5,12 @@ const isPhoneValid = (phone, countryCode) => {
   if (!phoneValid && countryCode === 'US') {
     phoneValid = isValidNumber(`+1 ${phone}`, countryCode);
   }
+  if (phoneValid && countryCode === 'JP') {
+    if (phone.length == 10 && document.getElementById('user_phone_form_otp_delivery_preference_sms').checked) {
+      // 10-digit phone number is landline and cannot receive SMS
+      phoneValid = false;
+    }
+  }
   return phoneValid;
 };
 

--- a/app/validators/form_phone_validator.rb
+++ b/app/validators/form_phone_validator.rb
@@ -8,8 +8,22 @@ module FormPhoneValidator
                 message: :improbable_phone,
                 country_specifier: ->(form) { form.international_code },
               }
-    validates :international_code, inclusion: {
-      in: PhoneNumberCapabilities::INTERNATIONAL_CODES.keys,
-    }
+    validates :international_code,
+              inclusion: {
+                in: PhoneNumberCapabilities::INTERNATIONAL_CODES.keys,
+              }
+    validate :supported_countries
+  end
+
+  private
+
+  def supported_countries
+    return if supported?
+    errors.clear
+    errors.add(:phone, I18n.t('errors.messages.country_not_supported'))
+  end
+
+  def supported?
+    return !['JP'].include?(international_code)
   end
 end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -23,6 +23,7 @@ en:
         or you already confirmed your account.
       confirmation_period_expired: Expired confirmation link. You can click "Resend
         confirmation instructions" to get another one.
+      country_not_supported: We're unable to make phone calls to people in your country at this time.
       expired: has expired, please request a new one
       format_mismatch: Please match the requested format.
       improbable_phone: Invalid phone number. Please make sure you enter a valid phone

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -23,6 +23,7 @@ es:
         expiró o usted ya ha confirmado su cuenta.
       confirmation_period_expired: El enlace de confirmación expiró. Puede hacer clic
         en "Reenviar instrucciones de confirmación" para obtener otro.
+      country_not_supported: No podemos hacer llamadas telefónicas a personas en tu país en este momento.
       expired: ha caducado, por favor solicite uno nuevo
       format_mismatch: Por favor, use el formato solicitado.
       improbable_phone: Número de teléfono no válido. Asegúrate de introducir un número

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -26,6 +26,7 @@ fr:
       confirmation_period_expired: Lien de confirmation expiré. Vous pouvez cliquer
         sur « Envoyer les instructions de confirmation de nouveau » pour en obtenir
         un autre.
+      country_not_supported: Nous ne pouvons pas appeler des personnes de votre pays pour le moment.
       expired: est expiré, veuillez en demander un nouveau
       format_mismatch: Veuillez vous assurer de respecter le format requis.
       improbable_phone: Numéro de téléphone non valide. Veillez à saisir un numéro


### PR DESCRIPTION
This is a Work in Progress PR.  Please feel free to give me comments and questions.

**Why**: 

Only 11 digit phone number can be used for SMS, and Japanese phone number is not currently being supported

**How**:
- Added validation in client-side to only allow user to continue if 11 digit is entered for SMS option
- Added validation in server-side to check countries that we support at this point

**Note:**
- I do not have access to create a branch in the repo, so I am using mine at the mean time.
- Feel free to give me suggestions if this is not implemented in the JS way and/or Rails way
- I used Google Translate for Spanish and French error messages, I would need someone to validate them for me.

**Todo:**
- Testing

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
