### PR TITLE
LG-27 Set PKCE or JWT mode per SP for OpenID Connect

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -116,6 +116,7 @@ detectors:
       - Users::ConfirmationsController
       - ApplicationController
       - OpenidConnectAuthorizeForm
+      - OpenidConnectTokenForm
       - OpenidConnect::AuthorizationController
       - Idv::Session
       - User

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Metrics/ClassLength:
   - app/controllers/users/two_factor_authentication_controller.rb
   - app/decorators/service_provider_session_decorator.rb
   - app/decorators/user_decorator.rb
+  - app/forms/openid_connect_token_form.rb
   - app/models/user.rb
   - app/services/analytics.rb
   - app/services/idv/session.rb

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -33,6 +33,8 @@ class NullServiceProvider
 
   def return_to_sp_url; end
 
+  def pkce; end
+
   def redirect_uris
     []
   end

--- a/db/migrate/20190110145734_add_pkce_to_service_provider.rb
+++ b/db/migrate/20190110145734_add_pkce_to_service_provider.rb
@@ -1,0 +1,9 @@
+class AddPkceToServiceProvider < ActiveRecord::Migration[5.1]
+  def up
+    add_column :service_providers, :pkce, :boolean
+  end
+
+  def down
+    remove_column :service_providers, :pkce
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181122100307) do
+ActiveRecord::Schema.define(version: 20190110145734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 20181122100307) do
     t.integer "ial"
     t.boolean "piv_cac", default: false
     t.boolean "piv_cac_scoped_by_email", default: false
+    t.boolean "pkce"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe OpenidConnectTokenForm do
           expect(form.errors).to be_blank
         end
 
+        it 'is true, and has no errors when the sp is set to jwt only mode' do
+          allow_any_instance_of(ServiceProvider).to receive(:pkce).and_return(false)
+          expect(valid?).to eq(true)
+          expect(form.errors).to be_blank
+        end
+
+        it 'is false, and has errors if the sp is set for pkce only mode' do
+          allow_any_instance_of(ServiceProvider).to receive(:pkce).and_return(true)
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).
+            to include(t('openid_connect.token.errors.invalid_authentication'))
+        end
+
         context 'with a trailing slash in the audience url' do
           before { jwt_payload[:aud] = 'http://www.example.com/api/openid_connect/token/' }
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -206,6 +206,19 @@ RSpec.describe OpenidConnectTokenForm do
           expect(valid?).to eq(true)
           expect(form.errors).to be_blank
         end
+
+        it 'is true, and has no errors if the sp is set for pkce only mode' do
+          allow_any_instance_of(ServiceProvider).to receive(:pkce).and_return(true)
+          expect(valid?).to eq(true)
+          expect(form.errors).to be_blank
+        end
+
+        it 'is false, and has errors if the sp is set for jwt only mode' do
+          allow_any_instance_of(ServiceProvider).to receive(:pkce).and_return(false)
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).
+            to include(t('openid_connect.token.errors.invalid_authentication'))
+        end
       end
 
       context 'with a code_challenge that is not the SHA256 of the code_verifier' do


### PR DESCRIPTION
**Why**: To prevent downgrade from JWT to the less secure PKCE by enforcing a single mode per SP

**How**: Add a pkce three state boolean column to service_providers.  This will allow us to support existing sps (null) while forcing future sps and migrated legacy sps to use the new required field in their configuration. Add code to the validation logic which checks for pkce or jwt to also check that the sp's configuration matches the current mode.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
