### PR TITLE
Change rubocop rules for commas in multiline method calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -281,7 +281,7 @@ Style/TrailingCommaInArguments:
   # parenthesized method calls where each argument is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,7 @@ class AccountsController < ApplicationController
     @view_model = AccountShow.new(
       decrypted_pii: cacher.fetch,
       personal_key: flash[:personal_key],
-      decorated_user: current_user.decorate
+      decorated_user: current_user.decorate,
     )
 
     @login_presenter = LoginPresenter.new(user: current_user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
       sp: current_sp,
       view_context: view_context,
       sp_session: sp_session,
-      service_provider_request: service_provider_request
+      service_provider_request: service_provider_request,
     ).call
   end
 
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
   # https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes
   def add_new_relic_trace_attributes
     ::NewRelic::Agent.add_custom_attributes(
-      amzn_trace_id: request.headers['X-Amzn-Trace-Id']
+      amzn_trace_id: request.headers['X-Amzn-Trace-Id'],
     )
   end
 
@@ -145,7 +145,7 @@ class ApplicationController < ActionController::Base
     analytics.track_event(
       Analytics::INVALID_AUTHENTICITY_TOKEN,
       controller: controller_info,
-      user_signed_in: user_signed_in?
+      user_signed_in: user_signed_in?,
     )
     flash[:error] = t('errors.invalid_authenticity_token')
     redirect_back fallback_location: new_user_session_url

--- a/app/controllers/concerns/account_reactivation_concern.rb
+++ b/app/controllers/concerns/account_reactivation_concern.rb
@@ -9,7 +9,7 @@ module AccountReactivationConcern
   def reactivate_account_session
     @_reactivate_account_session ||= ReactivateAccountSession.new(
       user: current_user,
-      user_session: user_session
+      user_session: user_session,
     )
   end
 end

--- a/app/controllers/concerns/idv/phone_otp_rate_limitable.rb
+++ b/app/controllers/concerns/idv/phone_otp_rate_limitable.rb
@@ -23,7 +23,7 @@ module Idv
         attributes: {
           second_factor_attempts_count: 0,
           second_factor_locked_at: nil,
-        }
+        },
       ).call
     end
 
@@ -40,7 +40,7 @@ module Idv
     def handle_max_attempts(type)
       presenter = TwoFactorAuthCode::MaxAttemptsReachedPresenter.new(
         type,
-        decorated_user
+        decorated_user,
       )
       sign_out
       render_full_width('shared/_failure', locals: { presenter: presenter })

--- a/app/controllers/concerns/idv/phone_otp_sendable.rb
+++ b/app/controllers/concerns/idv/phone_otp_sendable.rb
@@ -28,7 +28,7 @@ module Idv
       @send_phone_confirmation_otp_service ||= Idv::SendPhoneConfirmationOtp.new(
         user: current_user,
         idv_session: idv_session,
-        locale: user_locale
+        locale: user_locale,
       )
     end
 

--- a/app/controllers/concerns/idv_failure_concern.rb
+++ b/app/controllers/concerns/idv_failure_concern.rb
@@ -16,7 +16,7 @@ module IdvFailureConcern
     Idv::MaxAttemptsFailurePresenter.new(
       decorated_session: decorated_session,
       step_name: step,
-      view_context: view_context
+      view_context: view_context,
     )
   end
 
@@ -25,7 +25,7 @@ module IdvFailureConcern
       reason: reason,
       remaining_attempts: remaining_step_attempts,
       step_name: step,
-      view_context: view_context
+      view_context: view_context,
     )
   end
 end

--- a/app/controllers/concerns/idv_session.rb
+++ b/app/controllers/concerns/idv_session.rb
@@ -27,7 +27,7 @@ module IdvSession
     @_idv_session ||= Idv::Session.new(
       user_session: user_session,
       current_user: current_user,
-      issuer: sp_session[:issuer]
+      issuer: sp_session[:issuer],
     )
   end
 

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -23,7 +23,7 @@ module PersonalKeyConcern
     analytics.track_event(
       Analytics::INVALID_AUTHENTICITY_TOKEN,
       controller: controller_info,
-      user_signed_in: user_signed_in?
+      user_signed_in: user_signed_in?,
     )
     sign_out
     flash[:alert] = t('errors.invalid_authenticity_token')

--- a/app/controllers/concerns/phone_confirmation.rb
+++ b/app/controllers/concerns/phone_confirmation.rb
@@ -6,7 +6,7 @@ module PhoneConfirmation
     redirect_to otp_send_url(
       otp_delivery_selection_form: {
         otp_delivery_preference: otp_delivery_method(id, phone, selected_delivery_method),
-      }
+      },
     )
   end
 

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -14,7 +14,7 @@ module RememberDeviceConcern
     return if remember_device_cookie.nil?
     return unless remember_device_cookie.valid_for_user?(
       user: current_user,
-      expiration_interval: decorated_session.mfa_expiration_interval
+      expiration_interval: decorated_session.mfa_expiration_interval,
     )
 
     handle_valid_remember_device_cookie
@@ -24,7 +24,7 @@ module RememberDeviceConcern
     remember_device_cookie_contents = cookies.encrypted[:remember_device]
     return if remember_device_cookie_contents.blank?
     @remember_device_cookie ||= RememberDeviceCookie.from_json(
-      remember_device_cookie_contents
+      remember_device_cookie_contents,
     )
   end
 
@@ -34,7 +34,7 @@ module RememberDeviceConcern
 
     !remember_device_cookie.valid_for_user?(
       user: current_user,
-      expiration_interval: decorated_session.mfa_expiration_interval
+      expiration_interval: decorated_session.mfa_expiration_interval,
     )
   end
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -15,7 +15,7 @@ module SamlIdpAuthConcern
     @result = @saml_request_validator.call(
       service_provider: current_service_provider,
       authn_context: requested_authn_context,
-      nameid_format: saml_request.name_id_format
+      nameid_format: saml_request.name_id_format,
     )
 
     return if @result.success?
@@ -29,7 +29,7 @@ module SamlIdpAuthConcern
       url: request.original_url,
       session: session,
       protocol_request: saml_request,
-      protocol: FederatedProtocols::Saml
+      protocol: FederatedProtocols::Saml,
     ).call
   end
 
@@ -71,7 +71,7 @@ module SamlIdpAuthConcern
       user: principal,
       service_provider: current_service_provider,
       authn_request: saml_request,
-      decrypted_pii: decrypted_pii
+      decrypted_pii: decrypted_pii,
     )
   end
 
@@ -91,7 +91,7 @@ module SamlIdpAuthConcern
       authn_context_classref: requested_authn_context,
       reference_id: active_identity.session_uuid,
       encryption: current_service_provider.encryption_opts,
-      signature: rotation_signature_opts
+      signature: rotation_signature_opts,
     )
   end
 

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -67,7 +67,7 @@ module SamlIdpLogoutConcern
       saml_idp_config.base_saml_location,
       saml_request.response_url,
       saml_request.request_id,
-      saml_idp_config.algorithm
+      saml_idp_config.algorithm,
     )
   end
 
@@ -102,7 +102,7 @@ module SamlIdpLogoutConcern
     render_template_for(
       Base64.strict_encode64(slo_session[:logout_response]),
       slo_session[:logout_response_url],
-      'SAMLResponse'
+      'SAMLResponse',
     )
 
     sign_out if user_signed_in?

--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -13,7 +13,7 @@ module SecureHeadersConcern
 
     override_content_security_policy_directives(
       form_action: ["'self'", redirect_uri].compact,
-      preserve_schemes: true
+      preserve_schemes: true,
     )
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -37,7 +37,7 @@ module TwoFactorAuthenticatable
   def handle_max_attempts(type)
     presenter = TwoFactorAuthCode::MaxAttemptsReachedPresenter.new(
       type,
-      decorated_user
+      decorated_user,
     )
     sign_out
     render_full_width('shared/_failure', locals: { presenter: presenter })
@@ -67,7 +67,7 @@ module TwoFactorAuthenticatable
       attributes: {
         second_factor_attempts_count: 0,
         second_factor_locked_at: nil,
-      }
+      },
     ).call
   end
 
@@ -115,7 +115,7 @@ module TwoFactorAuthenticatable
 
     UpdateUser.new(
       user: current_user,
-      attributes: attributes
+      attributes: attributes,
     ).call
   end
 
@@ -157,7 +157,7 @@ module TwoFactorAuthenticatable
     UpdateUser.new(
       user: current_user,
       attributes: { phone_id: user_session[:phone_id], phone: user_session[:unconfirmed_phone],
-                    phone_confirmed_at: Time.zone.now }
+                    phone_confirmed_at: Time.zone.now },
     ).call
   end
 
@@ -291,7 +291,7 @@ module TwoFactorAuthenticatable
 
     TwoFactorAuthCode.const_get("#{type}_delivery_presenter".classify).new(
       data: data,
-      view: view_context
+      view: view_context,
     )
   end
 

--- a/app/controllers/concerns/verify_sp_attributes_concern.rb
+++ b/app/controllers/concerns/verify_sp_attributes_concern.rb
@@ -12,10 +12,10 @@ module VerifySPAttributesConcern
   def update_verified_attributes
     IdentityLinker.new(
       current_user,
-      sp_session[:issuer]
+      sp_session[:issuer],
     ).link_identity(
       ial: sp_session_ial,
-      verified_attributes: sp_session[:requested_attributes]
+      verified_attributes: sp_session[:requested_attributes],
     )
   end
 

--- a/app/controllers/health/abstract_health_controller.rb
+++ b/app/controllers/health/abstract_health_controller.rb
@@ -7,7 +7,7 @@ module Health
 
       # Add health check summary data to New Relic traces.
       ::NewRelic::Agent.add_custom_attributes(
-        health_check_summary: summary.as_json
+        health_check_summary: summary.as_json,
       )
 
       render json: summary, status: (summary.healthy? ? :ok : :internal_error)

--- a/app/controllers/idv/jurisdiction_controller.rb
+++ b/app/controllers/idv/jurisdiction_controller.rb
@@ -31,7 +31,7 @@ module Idv
       presenter = Idv::JurisdictionFailurePresenter.new(
         reason: params[:reason],
         jurisdiction: idv_session.selected_jurisdiction,
-        view_context: view_context
+        view_context: view_context,
       )
       render_full_width('shared/_failure', locals: { presenter: presenter })
     end

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -60,7 +60,7 @@ module Idv
     def phone_confirmation_otp_verification_form
       @phone_confirmation_otp_verification_form ||= PhoneConfirmationOtpVerificationForm.new(
         user: current_user,
-        idv_session: idv_session
+        idv_session: idv_session,
       )
     end
   end

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -69,7 +69,7 @@ module Idv
     def set_idv_form
       @idv_form ||= Idv::PhoneForm.new(
         user: current_user,
-        previous_params: idv_session.previous_phone_step_params
+        previous_params: idv_session.previous_phone_step_params,
       )
     end
 

--- a/app/controllers/idv/sessions_controller.rb
+++ b/app/controllers/idv/sessions_controller.rb
@@ -89,7 +89,7 @@ module Idv
     def set_idv_form
       @idv_form ||= Idv::ProfileForm.new(
         user: current_user,
-        previous_params: idv_session.previous_profile_step_params
+        previous_params: idv_session.previous_profile_step_params,
       )
     end
 

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -47,7 +47,7 @@ module Idv
       confirmation_maker = UspsConfirmationMaker.new(
         pii: Pii::Cacher.new(current_user, user_session).fetch,
         issuer: sp_session[:issuer],
-        profile: current_user.decorate.pending_profile
+        profile: current_user.decorate.pending_profile,
       )
       confirmation_maker.perform
 

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -28,7 +28,7 @@ class IdvController < ApplicationController
   def fail
     redirect_to idv_url and return unless idv_attempter.exceeded?
     presenter = Idv::IdvFailurePresenter.new(
-      view_context: view_context
+      view_context: view_context,
     )
     render_full_width('shared/_failure', locals: { presenter: presenter })
   end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -59,7 +59,7 @@ module OpenidConnect
     def apply_secure_headers_override
       override_content_security_policy_directives(
         form_action: ["'self'", authorization_params[:redirect_uri]].compact,
-        preserve_schemes: true
+        preserve_schemes: true,
       )
     end
 
@@ -104,7 +104,7 @@ module OpenidConnect
         url: request.original_url,
         session: session,
         protocol_request: @authorize_form,
-        protocol: FederatedProtocols::Oidc
+        protocol: FederatedProtocols::Oidc,
       ).call
     end
   end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -77,7 +77,7 @@ class SamlIdpController < ApplicationController
     SamlIdp::MetadataBuilder.new(
       config,
       SamlCertRotationManager.new_certificate,
-      SamlCertRotationManager.new_secret_key
+      SamlCertRotationManager.new_secret_key,
     )
   end
 
@@ -94,7 +94,7 @@ class SamlIdpController < ApplicationController
   def capture_analytics
     analytics_payload = @result.to_h.merge(
       idv: identity_needs_verification?,
-      finish_profile: profile_needs_verification?
+      finish_profile: profile_needs_verification?,
     )
     analytics.track_event(Analytics::SAML_AUTH, analytics_payload)
   end
@@ -116,7 +116,7 @@ class SamlIdpController < ApplicationController
     render(
       template: 'saml_idp/shared/saml_post_binding',
       locals: { action_url: action_url, message: message, type: type },
-      layout: false
+      layout: false,
     )
   end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -11,7 +11,7 @@ module SignUp
       @view_model = view_model
       if show_completions_page?
         track_agency_handoff(
-          Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT
+          Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
         )
       else
         redirect_to account_url
@@ -20,7 +20,7 @@ module SignUp
 
     def update
       track_agency_handoff(
-        Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE
+        Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
       )
       update_verified_attributes
       clear_verify_attributes_sessions
@@ -43,7 +43,7 @@ module SignUp
         loa3_requested: loa3?,
         decorated_session: decorated_session,
         current_user: current_user,
-        handoff: new_service_provider_attributes
+        handoff: new_service_provider_attributes,
       )
     end
 
@@ -61,7 +61,7 @@ module SignUp
 
     def decider
       CompletionsDecider.new(
-        user_agent: request.user_agent, request_url: sp_session[:request_url]
+        user_agent: request.user_agent, request_url: sp_session[:request_url],
       )
     end
 
@@ -69,7 +69,7 @@ module SignUp
       sign_out
       flash[:notice] = t(
         'instructions.go_back_to_mobile_app',
-        friendly_name: view_model.decorated_session.sp_name
+        friendly_name: view_model.decorated_session.sp_name,
       )
       redirect_to new_user_session_url
     end
@@ -77,7 +77,7 @@ module SignUp
     def track_agency_handoff(analytic)
       analytics.track_event(
         analytic,
-        service_provider_attributes
+        service_provider_attributes,
       )
     end
   end

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -15,7 +15,7 @@ module SignUp
         process_valid_confirmation_token
         request_id = params.fetch(:_request_id, '')
         redirect_to sign_up_enter_password_url(
-          request_id: request_id, confirmation_token: @confirmation_token
+          request_id: request_id, confirmation_token: @confirmation_token,
         )
       else
         process_confirmed_user

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -36,7 +36,7 @@ module SignUp
       render(
         :new,
         locals: { request_id: request_id, confirmation_token: @confirmation_token },
-        formats: :html
+        formats: :html,
       )
     end
 
@@ -49,7 +49,7 @@ module SignUp
       password = permitted_params[:password]
       UpdateUser.new(
         user: @user,
-        attributes: { reset_requested_at: nil, password: password }
+        attributes: { reset_requested_at: nil, password: password },
       ).call
       PasswordMetricsIncrementer.new(password).increment_password_metrics
       sign_in_and_redirect_user

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -54,7 +54,7 @@ module SignUp
       session[:email] = @register_user_email_form.email
 
       redirect_to sign_up_verify_email_url(
-        resend: resend_confirmation, request_id: permitted_params[:request_id]
+        resend: resend_confirmation, request_id: permitted_params[:request_id],
       )
     end
 

--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -24,7 +24,7 @@ class SmsController < ApplicationController
 
     analytics.track_event(
       Analytics::TWILIO_SMS_INBOUND_MESSAGE_RECEIVED,
-      result.to_h
+      result.to_h,
     )
 
     head :accepted
@@ -33,7 +33,7 @@ class SmsController < ApplicationController
   def process_failure(result)
     analytics.track_event(
       Analytics::TWILIO_SMS_INBOUND_MESSAGE_VALIDATION_FAILED,
-      result.to_h
+      result.to_h,
     )
 
     if !@message.signature_valid?

--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -40,7 +40,7 @@ module Test
     def render_template_for(validity, response)
       render(
         template: 'test/saml_test/decode_response.html.slim',
-        locals: { is_valid: validity, response: response }
+        locals: { is_valid: validity, response: response },
       )
     end
   end

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -10,7 +10,7 @@ module TwoFactorAuthentication
       )
       @presenter = TwoFactorAuthCode::BackupCodePresenter.new(
         view: view_context,
-        data: { current_user: current_user }
+        data: { current_user: current_user },
       )
       @backup_code_form = BackupCodeVerificationForm.new(current_user)
     end
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     def presenter_for_two_factor_authentication_method
       TwoFactorAuthCode::BackupCodePresenter.new(
         view: view_context,
-        data: { current_user: current_user }
+        data: { current_user: current_user },
       )
     end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -53,7 +53,7 @@ module TwoFactorAuthentication
 
       flash[:error] = t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: capabilities.unsupported_location
+        location: capabilities.unsupported_location,
       )
       redirect_to login_two_factor_url(otp_delivery_preference: 'sms', reauthn: reauthn?)
     end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -30,7 +30,7 @@ module TwoFactorAuthentication
       clear_piv_cac_nonce
       save_piv_cac_information(
         subject: piv_cac_verfication_form.x509_dn,
-        presented: true
+        presented: true,
       )
 
       handle_valid_otp_for_authentication_context
@@ -73,7 +73,7 @@ module TwoFactorAuthentication
       @piv_cac_verification_form ||= UserPivCacVerificationForm.new(
         user: current_user,
         token: params[:token],
-        nonce: piv_cac_nonce
+        nonce: piv_cac_nonce,
       )
     end
 
@@ -86,7 +86,7 @@ module TwoFactorAuthentication
     def presenter_for_two_factor_authentication_method
       TwoFactorAuthCode::PivCacAuthenticationPresenter.new(
         view: view_context,
-        data: piv_cac_view_data
+        data: piv_cac_view_data,
       )
     end
 

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -43,7 +43,7 @@ module TwoFactorAuthentication
     def presenter_for_two_factor_authentication_method
       TwoFactorAuthCode::WebauthnAuthenticationPresenter.new(
         view: view_context,
-        data: { credential_ids: credential_ids }
+        data: { credential_ids: credential_ids },
       )
     end
 

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -41,7 +41,7 @@ module Users
     def user_phone_form_params
       params.require(:user_phone_form).permit(
         :international_code,
-        :phone
+        :phone,
       )
     end
   end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -70,7 +70,7 @@ module Users
       @user_piv_cac_form ||= UserPivCacSetupForm.new(
         user: current_user,
         token: params[:token],
-        nonce: piv_cac_nonce
+        nonce: piv_cac_nonce,
       )
     end
 
@@ -78,7 +78,7 @@ module Users
       flash[:success] = t('notices.piv_cac_configured')
       save_piv_cac_information(
         subject: user_piv_cac_form.x509_dn,
-        presented: true
+        presented: true,
       )
       redirect_to next_step
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,7 @@ module Users
       analytics.track_event(
         Analytics::SIGN_IN_PAGE_VISIT,
         flash: flash[:alert],
-        stored_location: session['user_return_to']
+        stored_location: session['user_return_to'],
       )
       super
     end
@@ -44,7 +44,7 @@ module Users
       flash[:notice] = t(
         'notices.session_timedout',
         app: APP_NAME,
-        minutes: Figaro.env.session_timeout_in_minutes
+        minutes: Figaro.env.session_timeout_in_minutes,
       )
       redirect_to root_url(request_id: request_id)
     end
@@ -74,7 +74,7 @@ module Users
     def process_locked_out_user
       presenter = TwoFactorAuthCode::MaxAttemptsReachedPresenter.new(
         'generic_login_attempts',
-        current_user.decorate
+        current_user.decorate,
       )
       sign_out
       render_full_width('shared/_failure', locals: { presenter: presenter })

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -55,7 +55,7 @@ module Users
       OtpDeliveryPreferenceUpdater.new(
         user: current_user,
         preference: delivery_params[:otp_delivery_preference],
-        phone_id: user_session[:phone_id]
+        phone_id: user_session[:phone_id],
       ).call
     end
 
@@ -79,7 +79,7 @@ module Users
       flash[:error] = t('errors.messages.phone_unsupported')
       redirect_to login_two_factor_url(
         otp_delivery_preference: phone_configuration.delivery_preference,
-        reauthn: reauthn?
+        reauthn: reauthn?,
       )
     end
 

--- a/app/controllers/users/verify_account_controller.rb
+++ b/app/controllers/users/verify_account_controller.rb
@@ -29,7 +29,7 @@ module Users
     def build_verify_account_form
       VerifyAccountForm.new(
         user: current_user,
-        otp: params_otp
+        otp: params_otp,
       )
     end
 

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -10,7 +10,7 @@ module Users
       @verify_password_form = VerifyPasswordForm.new(
         user: current_user,
         password: '',
-        decrypted_pii: decrypted_pii
+        decrypted_pii: decrypted_pii,
       )
     end
 
@@ -46,7 +46,7 @@ module Users
       VerifyPasswordForm.new(
         user: current_user,
         password: params.require(:user).permit(:password)[:password],
-        decrypted_pii: decrypted_pii
+        decrypted_pii: decrypted_pii,
       )
     end
   end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -9,7 +9,7 @@ module Users
     def new
       @personal_key_form = VerifyPersonalKeyForm.new(
         user: current_user,
-        personal_key: ''
+        personal_key: '',
       )
     end
 
@@ -45,7 +45,7 @@ module Users
     def personal_key_form
       VerifyPersonalKeyForm.new(
         user: current_user,
-        personal_key: params.permit(:personal_key)[:personal_key]
+        personal_key: params.permit(:personal_key)[:personal_key],
       )
     end
   end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -66,7 +66,7 @@ module Users
       analytics.track_event(
         Analytics::WEBAUTHN_DELETED,
         success: success,
-        mfa_method_counts: counts_hash
+        mfa_method_counts: counts_hash,
       )
     end
 

--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -47,8 +47,8 @@ module Voice
       BasicAuthUrl.build(
         voice_otp_url(
           encrypted_code: encrypted_code,
-          repeat_count: repeat_count - 1
-        )
+          repeat_count: repeat_count - 1,
+        ),
       )
     end
 

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -92,7 +92,7 @@ class ServiceProviderSessionDecorator
       URIService.add_params(
         oidc_redirect_uri,
         error: 'access_denied',
-        state: request_params[:state]
+        state: request_params[:state],
       )
     else
       sp.return_to_sp_url

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -66,7 +66,7 @@ class OpenidConnectAuthorizeForm
       rails_session_id: rails_session_id,
       ial: ial,
       scope: scope.join(' '),
-      code_challenge: code_challenge
+      code_challenge: code_challenge,
     )
   end
 
@@ -132,7 +132,7 @@ class OpenidConnectAuthorizeForm
       uri,
       error: 'invalid_request',
       error_description: errors.full_messages.join(' '),
-      state: state
+      state: state,
     )
   end
 end

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -90,7 +90,7 @@ class OpenidConnectLogoutForm
       uri,
       error: 'invalid_request',
       error_description: errors.full_messages.join(' '),
-      state: state
+      state: state,
     )
   end
 end

--- a/app/forms/sms_form.rb
+++ b/app/forms/sms_form.rb
@@ -13,7 +13,7 @@ class SmsForm
     FormResponse.new(
       success: success,
       errors: errors.messages,
-      extra: message.extra_analytics_attributes
+      extra: message.extra_analytics_attributes,
     )
   end
 

--- a/app/forms/user_phone_form.rb
+++ b/app/forms/user_phone_form.rb
@@ -49,7 +49,7 @@ class UserPhoneForm
     self.submitted_phone = params[:phone]
     self.phone = PhoneFormatter.format(
       submitted_phone,
-      country_code: international_code
+      country_code: international_code,
     )
 
     tfa_prefs = params[:otp_delivery_preference]

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -13,7 +13,7 @@ class UserPivCacSetupForm
     FormResponse.new(
       success: success && process_valid_submission,
       errors: {},
-      extra: extra_analytics_attributes
+      extra: extra_analytics_attributes,
     )
   end
 

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -55,7 +55,7 @@ class WebauthnSetupForm
   def valid_attestation_response?(protocol)
     @attestation_response = ::WebAuthn::AuthenticatorAttestationResponse.new(
       attestation_object: Base64.decode64(@attestation_object),
-      client_data_json: Base64.decode64(@client_data_json)
+      client_data_json: Base64.decode64(@client_data_json),
     )
     safe_response("#{protocol}#{self.class.domain_name}")
   end

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -44,7 +44,7 @@ class WebauthnVerificationForm
       authenticator_data: Base64.decode64(@authenticator_data),
       client_data_json: Base64.decode64(@client_data_json),
       signature: Base64.decode64(@signature),
-      credential_id: Base64.decode64(@credential_id)
+      credential_id: Base64.decode64(@credential_id),
     )
     original_origin = "#{protocol}#{self.class.domain_name}"
     assertion_response.valid?(@challenge.pack('c*'), original_origin,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
       image_tag(asset_url('tooltip.svg'), width: 16, class: 'px1 img-tooltip'), \
       class: 'hint--top hint--no-animate', \
       'aria-label': text, \
-      'tabindex': '0'
+      'tabindex': '0',
     )
   end
 

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -14,7 +14,7 @@ module SessionTimeoutWarningHelper
   def timeout_refresh_path
     URIService.add_params(
       request.original_fullpath,
-      timeout: true
+      timeout: true,
     )&.html_safe # rubocop:disable Rails/OutputSafety
   end
 
@@ -39,7 +39,7 @@ module SessionTimeoutWarningHelper
       render(
         partial: 'session_timeout/expire_session',
         formats: [:js],
-        locals: { session_timeout_in: session_timeout_in }
+        locals: { session_timeout_in: session_timeout_in },
       )
     end
   end

--- a/app/jobs/sms_account_reset_cancellation_notifier_job.rb
+++ b/app/jobs/sms_account_reset_cancellation_notifier_job.rb
@@ -6,8 +6,8 @@ class SmsAccountResetCancellationNotifierJob < ApplicationJob
       to: phone,
       body: I18n.t(
         'jobs.sms_account_reset_cancel_job.message',
-        app: APP_NAME
-      )
+        app: APP_NAME,
+      ),
     )
   end
 end

--- a/app/jobs/sms_account_reset_notifier_job.rb
+++ b/app/jobs/sms_account_reset_notifier_job.rb
@@ -8,8 +8,8 @@ class SmsAccountResetNotifierJob < ApplicationJob
       body: I18n.t(
         'jobs.sms_account_reset_notifier_job.message',
         app: APP_NAME,
-        cancel_link: account_reset_cancel_url(token: token)
-      )
+        cancel_link: account_reset_cancel_url(token: token),
+      ),
     )
   end
 end

--- a/app/jobs/sms_otp_sender_job.rb
+++ b/app/jobs/sms_otp_sender_job.rb
@@ -28,8 +28,8 @@ class SmsOtpSenderJob < ApplicationJob
       to: phone,
       body: I18n.t(
         message,
-        code: code, app: APP_NAME, expiration: otp_valid_for_minutes
-      )
+        code: code, app: APP_NAME, expiration: otp_valid_for_minutes,
+      ),
     )
   end
 

--- a/app/jobs/sms_personal_key_regeneration_notifier_job.rb
+++ b/app/jobs/sms_personal_key_regeneration_notifier_job.rb
@@ -7,8 +7,8 @@ class SmsPersonalKeyRegenerationNotifierJob < ApplicationJob
       to: phone,
       body: I18n.t(
         'jobs.sms_personal_key_regeneration_notifier_job.message',
-        app: APP_NAME
-      )
+        app: APP_NAME,
+      ),
     )
   end
 end

--- a/app/jobs/sms_personal_key_sign_in_notifier_job.rb
+++ b/app/jobs/sms_personal_key_sign_in_notifier_job.rb
@@ -7,8 +7,8 @@ class SmsPersonalKeySignInNotifierJob < ApplicationJob
       to: phone,
       body: I18n.t(
         'jobs.sms_personal_key_sign_in_notifier_job.message',
-        app: APP_NAME
-      )
+        app: APP_NAME,
+      ),
     )
   end
 end

--- a/app/jobs/voice_otp_sender_job.rb
+++ b/app/jobs/voice_otp_sender_job.rb
@@ -27,10 +27,10 @@ class VoiceOtpSenderJob < ApplicationJob
       url: BasicAuthUrl.build(
         voice_otp_url(
           encrypted_code: cipher.encrypt(code),
-          locale: locale_url_param
-        )
+          locale: locale_url_param,
+        ),
       ),
-      record: Figaro.env.twilio_record_voice == 'true'
+      record: Figaro.env.twilio_record_voice == 'true',
     )
   end
 

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -2,7 +2,7 @@ class AnonymousUser
   EMPTY_EMAIL_ADDRESS = OpenStruct.new(
     email: nil,
     confirmed?: false,
-    confirmed_at: nil
+    confirmed_at: nil,
   ).freeze
 
   def uuid

--- a/app/models/concerns/email_address_callback.rb
+++ b/app/models/concerns/email_address_callback.rb
@@ -25,7 +25,7 @@ module EmailAddressCallback
       confirmation_token: confirmation_token,
       confirmed_at: confirmed_at,
       confirmation_sent_at: confirmation_sent_at,
-      email_fingerprint: email_fingerprint
+      email_fingerprint: email_fingerprint,
     )
   end
 
@@ -36,7 +36,7 @@ module EmailAddressCallback
       confirmation_token: confirmation_token,
       confirmed_at: confirmed_at,
       confirmation_sent_at: confirmation_sent_at,
-      email_fingerprint: email_fingerprint
+      email_fingerprint: email_fingerprint,
     )
     email_addresses.reload
   end

--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -10,7 +10,7 @@ module UserAccessKeyOverrides
   def valid_password?(password)
     result = Encryption::PasswordVerifier.verify(
       password: password,
-      digest: encrypted_password_digest
+      digest: encrypted_password_digest,
     )
     log_password_verification_failure unless result
     result
@@ -25,7 +25,7 @@ module UserAccessKeyOverrides
   def valid_personal_key?(normalized_personal_key)
     Encryption::PasswordVerifier.verify(
       password: normalized_personal_key,
-      digest: encrypted_recovery_code_digest
+      digest: encrypted_recovery_code_digest,
     )
   end
 
@@ -40,7 +40,7 @@ module UserAccessKeyOverrides
   def authenticatable_salt
     return if encrypted_password_digest.blank?
     Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
-      encrypted_password_digest
+      encrypted_password_digest,
     ).password_salt
   end
 

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -14,7 +14,7 @@ module FederatedProtocols
 
     def requested_attributes
       @_attributes ||= SamlRequestPresenter.new(
-        request: request, service_provider: current_service_provider
+        request: request, service_provider: current_service_provider,
       ).requested_attributes
     end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -31,7 +31,7 @@ class Identity < ApplicationRecord
   def piv_cac_available?
     PivCacService.piv_cac_available_for_sp?(
       ServiceProvider.from_issuer(service_provider),
-      user.email_addresses.map(&:email)
+      user.email_addresses.map(&:email),
     )
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -36,14 +36,14 @@ class Profile < ApplicationRecord
   def decrypt_pii(password)
     Pii::Attributes.new_from_encrypted(
       encrypted_pii,
-      password: password
+      password: password,
     )
   end
 
   def recover_pii(personal_key)
     Pii::Attributes.new_from_encrypted(
       encrypted_pii_recovery,
-      password: personal_key
+      password: personal_key,
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
     :timeoutable,
     :trackable,
     :two_factor_authenticatable,
-    authentication_keys: [:email]
+    authentication_keys: [:email],
   )
 
   include EncryptableAttribute

--- a/app/models/usps_confirmation_code.rb
+++ b/app/models/usps_confirmation_code.rb
@@ -5,7 +5,7 @@ class UspsConfirmationCode < ApplicationRecord
     find do |usps_confirmation_code|
       Pii::Fingerprinter.verify(
         Base32::Crockford.normalize(otp),
-        usps_confirmation_code.otp_fingerprint
+        usps_confirmation_code.otp_fingerprint,
       )
     end
   end

--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -10,12 +10,12 @@ class ConfirmationEmailPresenter
     elsif user.confirmed_at.present?
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.confirmed',
-        app: app_link, confirmation_period: confirmation_period
+        app: app_link, confirmation_period: confirmation_period,
       )
     else
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.unconfirmed',
-        app: app_link, confirmation_period: confirmation_period
+        app: app_link, confirmation_period: confirmation_period,
       )
     end
   end

--- a/app/presenters/eastern_time_presenter.rb
+++ b/app/presenters/eastern_time_presenter.rb
@@ -7,7 +7,7 @@ class EasternTimePresenter
     # i18n-tasks-use t('date.month_names')
     I18n.t(
       'event_types.eastern_timestamp',
-      timestamp: I18n.l(eastern_timestamp, format: :event_timestamp)
+      timestamp: I18n.l(eastern_timestamp, format: :event_timestamp),
     )
   end
 

--- a/app/presenters/login_presenter.rb
+++ b/app/presenters/login_presenter.rb
@@ -19,7 +19,7 @@ class LoginPresenter
       'account.index.sign_in_timestamp',
       timestamp: time_ago_in_words(
         timestamp, highest_measures: 2, two_words_connector: two_words_connector
-      )
+      ),
     )
   end
 
@@ -29,7 +29,7 @@ class LoginPresenter
       'account.index.sign_in_timestamp',
       timestamp: time_ago_in_words(
         timestamp, highest_measures: 2, two_words_connector: two_words_connector
-      )
+      ),
     )
   end
 

--- a/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
+++ b/app/presenters/two_factor_auth_code/max_attempts_reached_presenter.rb
@@ -53,7 +53,7 @@ module TwoFactorAuthCode
     def read_about_two_factor_authentication
       link = link_to(
         t('read_about_two_factor_authentication.link', scope: T_SCOPE),
-        MarketingSite.help_url
+        MarketingSite.help_url,
       )
 
       t('read_about_two_factor_authentication.text_html', scope: T_SCOPE, link: link)

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -1,7 +1,7 @@
 module TwoFactorAuthCode
   class PhoneDeliveryPresenter < TwoFactorAuthCode::GenericDeliveryPresenter
     attr_reader(
-      :otp_delivery_preference
+      :otp_delivery_preference,
     )
 
     def header
@@ -46,7 +46,7 @@ module TwoFactorAuthCode
       :unconfirmed_phone,
       :account_reset_token,
       :confirmation_for_phone_change,
-      :voice_otp_delivery_unsupported
+      :voice_otp_delivery_unsupported,
     )
 
     def account_reset_link

--- a/app/presenters/two_factor_authentication/phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/phone_selection_presenter.rb
@@ -12,7 +12,7 @@ module TwoFactorAuthentication
       if configuration.present?
         t(
           "two_factor_authentication.#{option_mode}.#{method}_info_html",
-          phone: masked_number(configuration.phone)
+          phone: masked_number(configuration.phone),
         )
       else
         t("two_factor_authentication.#{option_mode}.#{method}_info")

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -57,7 +57,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
     t('two_factor_authentication.account_reset.text_html',
       link: @view.link_to(
         t('two_factor_authentication.account_reset.link'),
-        account_reset_request_path(locale: LinkLocaleResolver.locale)
+        account_reset_request_path(locale: LinkLocaleResolver.locale),
       ))
   end
 
@@ -65,7 +65,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
     t('two_factor_authentication.account_reset.pending_html',
       cancel_link: @view.link_to(
         t('two_factor_authentication.account_reset.cancel_link'),
-        account_reset_cancel_url(token: account_reset_token)
+        account_reset_cancel_url(token: account_reset_token),
       ))
   end
 

--- a/app/services/account_reset/create_request.rb
+++ b/app/services/account_reset/create_request.rb
@@ -21,7 +21,7 @@ module AccountReset
         requested_at: Time.zone.now,
         cancelled_at: nil,
         granted_at: nil,
-        granted_token: nil
+        granted_token: nil,
       )
       request
     end
@@ -37,7 +37,7 @@ module AccountReset
       return unless phone
       SmsAccountResetNotifierJob.perform_now(
         phone: phone,
-        token: user.account_reset_request.request_token
+        token: user.account_reset_request.request_token,
       )
     end
   end

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -4,7 +4,7 @@ module AccountReset
       notifications_sent = 0
       AccountResetRequest.where(
         sql_query_for_users_eligible_to_delete_their_accounts,
-        tvalue: Time.zone.now - Figaro.env.account_reset_wait_period_days.to_i.days
+        tvalue: Time.zone.now - Figaro.env.account_reset_wait_period_days.to_i.days,
       ).order('requested_at ASC').each do |arr|
         notifications_sent += 1 if grant_request_and_send_email(arr)
       end

--- a/app/services/decorated_session.rb
+++ b/app/services/decorated_session.rb
@@ -12,7 +12,7 @@ class DecoratedSession
         sp: sp,
         view_context: view_context,
         sp_session: sp_session,
-        service_provider_request: service_provider_request
+        service_provider_request: service_provider_request,
       )
     else
       SessionDecorator.new(view_context: view_context)

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -25,7 +25,7 @@ module Encryption
         def self.extract_encrypted_data(parsed_json)
           encoded_encrypted_data = parsed_json['encrypted_data']
           raise EncryptionError, 'ciphertext invalid' unless valid_base64_encoding?(
-            encoded_encrypted_data
+            encoded_encrypted_data,
           )
           decode(encoded_encrypted_data)
         end

--- a/app/services/encryption/encryptors/user_access_key_encryptor.rb
+++ b/app/services/encryption/encryptors/user_access_key_encryptor.rb
@@ -37,7 +37,7 @@ module Encryption
       def encryption_key_from_ciphertext(ciphertext)
         encoded_encryption_key = ciphertext.split(DELIMITER).first
         raise EncryptionError, 'ciphertext is invalid' unless valid_base64_encoding?(
-          encoded_encryption_key
+          encoded_encryption_key,
         )
         decode(encoded_encryption_key)
       end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -51,7 +51,7 @@ module Encryption
       raise ArgumentError, 'kms plaintext exceeds 4096 bytes' if plaintext.bytesize > 4096
       aws_client.encrypt(
         key_id: Figaro.env.aws_kms_key_id,
-        plaintext: plaintext
+        plaintext: plaintext,
       ).ciphertext_blob
     end
 

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -4,7 +4,7 @@ module Encryption
       :encrypted_password,
       :encryption_key,
       :password_salt,
-      :password_cost
+      :password_cost,
     ) do
       def self.parse_from_string(digest_string)
         data = JSON.parse(digest_string, symbolize_names: true)
@@ -12,7 +12,7 @@ module Encryption
           data[:encrypted_password],
           data[:encryption_key],
           data[:password_salt],
-          data[:password_cost]
+          data[:password_cost],
         )
       rescue JSON::ParserError, TypeError
         raise EncryptionError, 'digest contains invalid json'
@@ -36,7 +36,7 @@ module Encryption
         uak.encrypted_password,
         uak.encryption_key,
         salt,
-        uak.cost
+        uak.cost,
       ).to_s
     end
 

--- a/app/services/idv/acuant/assure_id.rb
+++ b/app/services/idv/acuant/assure_id.rb
@@ -21,7 +21,7 @@ module Idv
 
         options = default_options.merge(
           headers: content_type_json,
-          body: image_params
+          body: image_params,
         )
 
         status, @instance_id = post(url, options) { |body| body.delete('"') }
@@ -40,7 +40,7 @@ module Idv
         url = "/AssureIDService/Document/#{instance_id}"
 
         options = default_options.merge(
-          headers: accept_json
+          headers: accept_json,
         )
 
         get(url, options, &JSON.method(:parse))
@@ -59,7 +59,7 @@ module Idv
 
         options = default_options.merge(
           headers: accept_json,
-          body: image
+          body: image,
         )
 
         post(url, options)

--- a/app/services/idv/attempter.rb
+++ b/app/services/idv/attempter.rb
@@ -11,14 +11,17 @@ module Idv
     def increment
       UpdateUser.new(
         user: current_user,
-        attributes: { idv_attempts: current_user.idv_attempts + 1, idv_attempted_at: Time.zone.now }
+        attributes: {
+          idv_attempts: current_user.idv_attempts + 1,
+          idv_attempted_at: Time.zone.now,
+        },
       ).call
     end
 
     def reset
       UpdateUser.new(
         user: current_user,
-        attributes: { idv_attempts: 0 }
+        attributes: { idv_attempts: 0 },
       ).call
     end
 

--- a/app/services/idv/cancel_verification_attempt.rb
+++ b/app/services/idv/cancel_verification_attempt.rb
@@ -10,7 +10,7 @@ module Idv
       user.profiles.verification_pending.each do |profile|
         profile.update!(
           active: false,
-          deactivation_reason: :verification_cancelled
+          deactivation_reason: :verification_cancelled,
         )
       end
     end

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -29,7 +29,7 @@ module Idv
 
     def applicant
       @applicant ||= idv_session.applicant.merge(
-        phone: normalized_phone
+        phone: normalized_phone,
       )
     end
 
@@ -63,7 +63,7 @@ module Idv
 
     def user_phones
       MfaContext.new(
-        idv_session.current_user
+        idv_session.current_user,
       ).phone_configurations.map do |phone_configuration|
         PhoneFormatter.format(phone_configuration.phone)
       end.compact

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -11,7 +11,7 @@ module Idv
     def save_profile
       profile = Profile.new(
         deactivation_reason: :verification_pending,
-        user: user
+        user: user,
       )
       profile.encrypt_pii(pii_attributes, user_password)
       profile.save!

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -34,7 +34,7 @@ module Idv
       FormResponse.new(
         success: false,
         errors: {},
-        extra: extra_analytics_attributes
+        extra: extra_analytics_attributes,
       )
     end
 
@@ -66,7 +66,7 @@ module Idv
         phone: phone,
         otp_created_at: idv_session.phone_confirmation_otp_sent_at,
         message: 'jobs.sms_otp_sender_job.verify_message',
-        locale: locale
+        locale: locale,
       )
     end
 
@@ -75,7 +75,7 @@ module Idv
         code: idv_session.phone_confirmation_otp,
         phone: phone,
         otp_created_at: idv_session.phone_confirmation_otp_sent_at,
-        locale: locale
+        locale: locale,
       )
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -132,7 +132,7 @@ module Idv
       Idv::ProfileMaker.new(
         applicant: applicant,
         user: current_user,
-        user_password: user_password
+        user_password: user_password,
       )
     end
   end

--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -19,7 +19,7 @@ module Idv
 
       def extract_pii_from_doc(data)
         pii_from_doc = Idv::Utils::PiiFromDoc.new(data).call(
-          current_user.phone_configurations.first.phone
+          current_user.phone_configurations.first.phone,
         )
         flow_session[:pii_from_doc] = pii_from_doc
       end

--- a/app/services/idv/steps/ssn_step.rb
+++ b/app/services/idv/steps/ssn_step.rb
@@ -41,7 +41,7 @@ module Idv
       def perform_resolution(pii_from_doc)
         idv_result = Idv::Agent.new(pii_from_doc).proof(:resolution)
         FormResponse.new(
-          success: idv_result[:success], errors: idv_result[:errors]
+          success: idv_result[:success], errors: idv_result[:errors],
         )
       end
     end

--- a/app/services/key_rotator/attribute_encryption.rb
+++ b/app/services/key_rotator/attribute_encryption.rb
@@ -21,7 +21,7 @@ module KeyRotator
         next unless plain_attribute
 
         result[:"encrypted_#{attribute}"] = EncryptedAttribute.new_from_decrypted(
-          plain_attribute
+          plain_attribute,
         ).encrypted
       end
     end

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -40,7 +40,7 @@ class MarketingSite
       locale_segment,
       'help',
       'privacy-and-security',
-      'how-does-logingov-protect-my-data'
+      'how-does-logingov-protect-my-data',
     ).to_s
   end
 end

--- a/app/services/phone_number_capabilities.rb
+++ b/app/services/phone_number_capabilities.rb
@@ -1,6 +1,6 @@
 class PhoneNumberCapabilities
   INTERNATIONAL_CODES = YAML.load_file(
-    Rails.root.join('config', 'country_dialing_codes.yml')
+    Rails.root.join('config', 'country_dialing_codes.yml'),
   ).freeze
 
   attr_reader :phone

--- a/app/services/phone_verification.rb
+++ b/app/services/phone_verification.rb
@@ -69,7 +69,7 @@ class PhoneVerification
       code: error_code,
       message: error_message,
       status: response.status,
-      response: response.body
+      response: response.body,
     )
   end
 
@@ -78,7 +78,7 @@ class PhoneVerification
       code: 4_815_162_342,
       message: "Twilio Verify: #{exception.class}",
       status: 0,
-      response: ''
+      response: '',
     )
   end
 

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -32,7 +32,7 @@ module Pii
       KeyRotator::HmacFingerprinter.new.rotate(
         user: user,
         profile: profile,
-        pii_attributes: fetch
+        pii_attributes: fetch,
       )
     end
 

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -92,7 +92,7 @@ module PivCacService
       return '' if secret.blank?
       nonce = SecureRandom.hex(10)
       hmac = Base64.urlsafe_encode64(
-        OpenSSL::HMAC.digest('SHA256', secret, [token, nonce].join('+'))
+        OpenSSL::HMAC.digest('SHA256', secret, [token, nonce].join('+')),
       )
       "hmac :#{nonce}:#{hmac}"
     end

--- a/app/services/remember_device_cookie.rb
+++ b/app/services/remember_device_cookie.rb
@@ -13,7 +13,7 @@ class RememberDeviceCookie
     check_cookie_role(parsed_json)
     new(
       user_id: parsed_json['user_id'],
-      created_at: Time.zone.parse(parsed_json['created_at'])
+      created_at: Time.zone.parse(parsed_json['created_at']),
     )
   end
 

--- a/app/services/request_key_manager.rb
+++ b/app/services/request_key_manager.rb
@@ -2,7 +2,7 @@ class RequestKeyManager
   def self.read_key_file(key_file, passphrase)
     OpenSSL::PKey::RSA.new(
       File.read(key_file),
-      passphrase
+      passphrase,
     )
   rescue OpenSSL::PKey::RSAError
     raise OpenSSL::PKey::RSAError, "Failed to load #{key_file.inspect}. Bad passphrase?"

--- a/app/services/saml_cert_rotation_manager.rb
+++ b/app/services/saml_cert_rotation_manager.rb
@@ -2,7 +2,7 @@ class SamlCertRotationManager
   def self.new_certificate
     filepath = Rails.root.join(
       'certs',
-      Figaro.env.saml_secret_rotation_certificate
+      Figaro.env.saml_secret_rotation_certificate,
     )
     File.read(filepath)
   end
@@ -12,7 +12,7 @@ class SamlCertRotationManager
     return env.saml_secret_rotation_cloudhsm_saml_key_label if FeatureManagement.use_cloudhsm?
     filepath = Rails.root.join(
       'keys',
-      env.saml_secret_rotation_secret_key
+      env.saml_secret_rotation_secret_key,
     )
     load_secret_key_at_path(filepath).to_pem
   end
@@ -30,7 +30,7 @@ class SamlCertRotationManager
   def self.load_secret_key_at_path(filepath)
     OpenSSL::PKey::RSA.new(
       File.read(filepath),
-      Figaro.env.saml_secret_rotation_secret_key_password
+      Figaro.env.saml_secret_rotation_secret_key_password,
     )
   end
   private_class_method :load_secret_key_at_path

--- a/app/services/saml_request_parser.rb
+++ b/app/services/saml_request_parser.rb
@@ -20,7 +20,7 @@ class SamlRequestParser
       doc.xpath(
         '//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef',
         samlp: Saml::XML::Namespaces::PROTOCOL,
-        saml: Saml::XML::Namespaces::ASSERTION
+        saml: Saml::XML::Namespaces::ASSERTION,
       ).select do |node|
         node.content =~ /#{Regexp.escape(URI_PATTERN)}/
       end

--- a/app/services/single_logout_handler.rb
+++ b/app/services/single_logout_handler.rb
@@ -17,7 +17,7 @@ SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user) do
     Base64.strict_encode64(slo_request_builder(
       sp_metadata,
       identity.uuid,
-      identity.session_uuid
+      identity.session_uuid,
     ).signed)
   end
 
@@ -66,7 +66,7 @@ SingleLogoutHandler = Struct.new(:saml_response, :saml_request, :user) do
       saml_idp_config.base_saml_location,
       sp_data[:assertion_consumer_logout_service_url],
       name_id,
-      saml_idp_config.algorithm
+      saml_idp_config.algorithm,
     )
   end
 

--- a/app/services/test/single_logout_service.rb
+++ b/app/services/test/single_logout_service.rb
@@ -28,7 +28,7 @@ module Test
         settings,
         logout_request.id,
         nil,
-        RelayState: params[:RelayState]
+        RelayState: params[:RelayState],
       )
     end
 

--- a/app/services/test/slo_response_decoder.rb
+++ b/app/services/test/slo_response_decoder.rb
@@ -8,7 +8,7 @@ module Test
     def response
       @response ||= OneLogin::RubySaml::Response.new(
         params[:SAMLResponse],
-        settings: settings
+        settings: settings,
       )
     end
 

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -26,7 +26,7 @@ module TwilioService
     def send_sms(params = {})
       sanitize_errors do
         params = params.reverse_merge(
-          messaging_service_sid: Figaro.env.twilio_messaging_service_sid
+          messaging_service_sid: Figaro.env.twilio_messaging_service_sid,
         )
         client.messages.create(params)
       end

--- a/app/services/twilio_service/sms/request.rb
+++ b/app/services/twilio_service/sms/request.rb
@@ -36,7 +36,7 @@ module TwilioService
       # https://github.com/twilio/twilio-ruby/wiki/Request-Validator
       def signature_valid?
         Twilio::Security::RequestValidator.new(
-          Figaro.env.twilio_auth_token
+          Figaro.env.twilio_auth_token,
         ).validate(url, params, signature)
       end
 

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -13,7 +13,7 @@ class UspsConfirmationMaker
     UspsConfirmation.create!(entry: attributes)
     UspsConfirmationCode.create!(
       profile: profile,
-      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
   end
 

--- a/app/validators/form_password_validator.rb
+++ b/app/validators/form_password_validator.rb
@@ -25,7 +25,7 @@ module FormPasswordValidator
   def password_score
     @password_score = ZXCVBN_TESTER.test(
       password,
-      user.email_addresses.flat_map { |address| ForbiddenPasswords.new(address.email).call }
+      user.email_addresses.flat_map { |address| ForbiddenPasswords.new(address.email).call },
     )
   end
 

--- a/app/validators/otp_delivery_preference_validator.rb
+++ b/app/validators/otp_delivery_preference_validator.rb
@@ -17,8 +17,8 @@ module OtpDeliveryPreferenceValidator
       :phone,
       I18n.t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: phone_number_capabilities.unsupported_location
-      )
+        location: phone_number_capabilities.unsupported_location,
+      ),
     )
   end
 

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -32,7 +32,7 @@ class SignUpCompletionsShow
     safe_join([I18n.t(
       'titles.sign_up.completion_html',
       accent: content_tag(:strong, I18n.t('titles.sign_up.loa1')),
-      app: APP_NAME
+      app: APP_NAME,
     ).html_safe])
   end
   # rubocop:enable Rails/OutputSafety
@@ -44,7 +44,7 @@ class SignUpCompletionsShow
       I18n.t(
         'titles.sign_up.completion_html',
         accent: I18n.t('titles.sign_up.loa1'),
-        app: APP_NAME
+        app: APP_NAME,
       )
     end
   end
@@ -78,7 +78,7 @@ class SignUpCompletionsShow
   def identities
     if @current_user
       @identities ||= @current_user.identities.order(
-        last_authenticated_at: :desc
+        last_authenticated_at: :desc,
       ).limit(MAX_RECENT_IDENTITIES).map(&:decorate)
     else
       false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,10 +35,10 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = true
     Bullet.add_whitelist(
-      type: :n_plus_one_query, class_name: 'User', association: :phone_configurations
+      type: :n_plus_one_query, class_name: 'User', association: :phone_configurations,
     )
     Bullet.add_whitelist(
-      type: :n_plus_one_query, class_name: 'User', association: :email_addresses
+      type: :n_plus_one_query, class_name: 'User', association: :email_addresses,
     )
   end
 

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,5 @@
 Aws.config.update(
   region: Figaro.env.aws_region,
   http_open_timeout: Figaro.env.aws_http_timeout.to_i,
-  http_read_timeout: Figaro.env.aws_http_timeout.to_i
+  http_read_timeout: Figaro.env.aws_http_timeout.to_i,
 )

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -9,7 +9,7 @@ ExceptionNotification.configure do |config|
     sender_address: %("Exception Notifier" <notifier@#{LoginGov::Hostdata.domain}>),
     exception_recipients: EXCEPTION_RECIPIENTS,
     error_grouping: true,
-    sections: %w[request backtrace session]
+    sections: %w[request backtrace session],
   )
 
   config.ignored_exceptions << 'ActionController::BadRequest'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -52,7 +52,7 @@ Figaro.require_keys(
   'twilio_messaging_service_sid',
   'twilio_timeout',
   'use_kms',
-  'valid_authn_contexts'
+  'valid_authn_contexts',
 )
 
 ConfigValidator.new.validate

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -2,5 +2,5 @@ Geocoder.configure(
   ip_lookup: :geoip2,
   geoip2: {
     file: Rails.root.join('geo_data', 'GeoLite2-City.mmdb'),
-  }
+  },
 )

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -26,7 +26,7 @@ module Rack
 
     cache = Readthis::Cache.new(
       expires_in: 2.weeks.to_i,
-      redis: { url: Figaro.env.redis_throttle_url, driver: :hiredis }
+      redis: { url: Figaro.env.redis_throttle_url, driver: :hiredis },
     )
 
     Rack::Attack.cache.store = cache
@@ -58,7 +58,7 @@ module Rack
       track(
         'req/ip',
         limit: Figaro.env.requests_per_ip_limit.to_i,
-        period: Figaro.env.requests_per_ip_period.to_i
+        period: Figaro.env.requests_per_ip_period.to_i,
       ) do |req|
         req.remote_ip unless req.path.starts_with?('/assets') || req.path.starts_with?('/packs')
       end
@@ -66,7 +66,7 @@ module Rack
       throttle(
         'req/ip',
         limit: Figaro.env.requests_per_ip_limit.to_i,
-        period: Figaro.env.requests_per_ip_period.to_i
+        period: Figaro.env.requests_per_ip_period.to_i,
       ) do |req|
         req.remote_ip unless req.path.starts_with?('/assets') || req.path.starts_with?('/packs')
       end
@@ -88,7 +88,7 @@ module Rack
       track(
         'logins/ip',
         limit: Figaro.env.logins_per_ip_limit.to_i,
-        period: Figaro.env.logins_per_ip_period.to_i
+        period: Figaro.env.logins_per_ip_period.to_i,
       ) do |req|
         req.remote_ip if req.path == '/' && req.post?
       end
@@ -96,7 +96,7 @@ module Rack
       throttle(
         'logins/ip',
         limit: Figaro.env.logins_per_ip_limit.to_i,
-        period: Figaro.env.logins_per_ip_period.to_i
+        period: Figaro.env.logins_per_ip_period.to_i,
       ) do |req|
         req.remote_ip if req.path == '/' && req.post?
       end

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -6,7 +6,7 @@ SamlIdp.configure do |config|
   api_base = protocol + Figaro.env.domain_name + '/api'
 
   config.x509_certificate = OpenSSL::X509::Certificate.new(
-    File.read(Rails.root.join('certs', 'saml.crt'))
+    File.read(Rails.root.join('certs', 'saml.crt')),
   ).to_pem
 
   SamlIdpEncryptionConfigurator.configure(config, FeatureManagement.use_cloudhsm?)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -39,7 +39,7 @@ SecureHeaders::Configuration.default do |config|
   config.csp = if !Rails.env.production?
                  default_csp_config.merge(
                    script_src: ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
-                   style_src: ["'self'", "'unsafe-inline'"]
+                   style_src: ["'self'", "'unsafe-inline'"],
                  )
                else
                  default_csp_config

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     devise_for(
       :users,
       skip: %i[confirmations sessions registrations two_factor_authentication],
-      controllers: { passwords: 'users/reset_passwords' }
+      controllers: { passwords: 'users/reset_passwords' },
     )
 
     # Additional device controller routes.

--- a/lib/custom_devise_failure_app.rb
+++ b/lib/custom_devise_failure_app.rb
@@ -33,7 +33,7 @@ class CustomDeviseFailureApp < Devise::FailureApp
     prefix = "devise.failure.#{message}"
     link = helper.link_to(
       I18n.t("#{prefix}_link_text"),
-      new_user_password_url(locale: locale_url_param, request_id: sp_session[:request_id])
+      new_user_password_url(locale: locale_url_param, request_id: sp_session[:request_id]),
     )
     I18n.t("#{prefix}_html", link: link)
   end

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -25,7 +25,7 @@ module Deploy
 
     def download_application_yml_from_s3
       LoginGov::Hostdata.s3(logger: logger, s3_client: s3_client).download_configs(
-        '/%<env>s/idp/v1/application.yml' => env_yaml_path
+        '/%<env>s/idp/v1/application.yml' => env_yaml_path,
       )
     end
 
@@ -45,7 +45,7 @@ module Deploy
         env: nil,
         region: ec2_region,
         logger: logger,
-        s3_client: s3_client
+        s3_client: s3_client,
       ).download_configs('/common/GeoLite2-City.mmdb' => geolocation_db_path)
     end
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -20,7 +20,7 @@ namespace :dev do
       ssn: '660-00-1234',
       dob: '1920-01-01',
       first_name: 'Some',
-      last_name: 'One'
+      last_name: 'One',
     )
     personal_key = profile.encrypt_pii(pii, pw)
     profile.verified_at = Time.zone.now
@@ -50,7 +50,7 @@ namespace :dev do
       progress = ProgressBar.create(
         title: 'Users',
         total: num_users,
-        format: '%t: |%B| %j%% [%a / %e]'
+        format: '%t: |%B| %j%% [%a / %e]',
       )
     end
 

--- a/lib/tasks/rotate.rake
+++ b/lib/tasks/rotate.rake
@@ -34,7 +34,7 @@ namespace :rotate do
     ProgressBar.create(
       title: label,
       total: num,
-      format: '%t: |%B| %j%% [%a / %e]'
+      format: '%t: |%B| %j%% [%a / %e]',
     )
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -5,7 +5,7 @@ describe AccountsController do
     it 'includes before_actions from AccountStateChecker' do
       expect(subject).to have_actions(
         :before,
-        :confirm_two_factor_authenticated
+        :confirm_two_factor_authenticated,
       )
     end
   end
@@ -17,7 +17,7 @@ describe AccountsController do
         user = create(:user, :signed_up)
         user.identities << Identity.create(
           service_provider: 'http://localhost:3000',
-          last_authenticated_at: Time.zone.now
+          last_authenticated_at: Time.zone.now,
         )
 
         sign_in user
@@ -35,7 +35,7 @@ describe AccountsController do
         user = create(
           :user,
           :signed_up,
-          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })]
+          profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
         )
         user.active_profile.deactivate(:password_reset)
 
@@ -44,7 +44,7 @@ describe AccountsController do
         view_model = AccountShow.new(
           decrypted_pii: nil,
           personal_key: nil,
-          decorated_user: user.decorate
+          decorated_user: user.decorate,
         )
         allow(subject).to receive(:view_model).and_return(view_model)
 

--- a/spec/controllers/idv/confirmations_controller_spec.rb
+++ b/spec/controllers/idv/confirmations_controller_spec.rb
@@ -8,14 +8,14 @@ describe Idv::ConfirmationsController do
     idv_session = Idv::Session.new(
       user_session: subject.user_session,
       current_user: user,
-      issuer: nil
+      issuer: nil,
     )
     idv_session.applicant = applicant
     idv_session.resolution_successful = true
     profile_maker = Idv::ProfileMaker.new(
       applicant: applicant,
       user: user,
-      user_password: password
+      user_password: password,
     )
     profile = profile_maker.save_profile
     idv_session.pii = profile_maker.pii_attributes
@@ -44,7 +44,7 @@ describe Idv::ConfirmationsController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_vendor_session_started
+        :confirm_idv_vendor_session_started,
       )
     end
 

--- a/spec/controllers/idv/jurisdiction_controller_spec.rb
+++ b/spec/controllers/idv/jurisdiction_controller_spec.rb
@@ -7,7 +7,7 @@ describe Idv::JurisdictionController do
         :before,
         :confirm_two_factor_authenticated,
         :confirm_idv_attempts_allowed,
-        :confirm_idv_needed
+        :confirm_idv_needed,
       )
     end
   end
@@ -25,7 +25,7 @@ describe Idv::JurisdictionController do
     it 'tracks analytics' do
       get :new
       expect(@analytics).to have_received(:track_event).with(
-        Analytics::IDV_JURISDICTION_VISIT
+        Analytics::IDV_JURISDICTION_VISIT,
       )
     end
 

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -212,7 +212,7 @@ describe Idv::OtpDeliveryMethodController do
             error: 'error',
             code: 60_033,
             status: 400,
-            response: '{"error_code":"60004"}'
+            response: '{"error_code":"60004"}',
           )
         end
         let(:twilio_error) do
@@ -220,7 +220,7 @@ describe Idv::OtpDeliveryMethodController do
             code: 60_033,
             message: 'error',
             status: 400,
-            response:  '{"error_code":"60004"}'
+            response:  '{"error_code":"60004"}',
           )
         end
 

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -48,7 +48,7 @@ describe Idv::OtpVerificationController do
       get :show
 
       expect(@analytics).to have_received(:track_event).with(
-        Analytics::IDV_PHONE_CONFIRMATION_OTP_VISIT
+        Analytics::IDV_PHONE_CONFIRMATION_OTP_VISIT,
       )
     end
   end
@@ -87,7 +87,7 @@ describe Idv::OtpVerificationController do
 
       expect(@analytics).to have_received(:track_event).with(
         Analytics::IDV_PHONE_CONFIRMATION_OTP_SUBMITTED,
-        expected_result
+        expected_result,
       )
     end
   end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -14,7 +14,7 @@ describe Idv::PhoneController do
       expect(subject).to have_actions(
         :before,
         :confirm_two_factor_authenticated,
-        :confirm_idv_session_started
+        :confirm_idv_session_started,
       )
     end
   end

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -53,7 +53,7 @@ describe Idv::ResendOtpController do
 
       expect(@analytics).to have_received(:track_event).with(
         Analytics::IDV_PHONE_CONFIRMATION_OTP_RESENT,
-        expected_result
+        expected_result,
       )
     end
 
@@ -91,7 +91,7 @@ describe Idv::ResendOtpController do
             error: 'error',
             code: 60_033,
             status: 400,
-            response: '{"error_code":"60004"}'
+            response: '{"error_code":"60004"}',
           )
         end
         let(:twilio_error) do
@@ -99,7 +99,7 @@ describe Idv::ResendOtpController do
             code: 60_033,
             message: 'error',
             status: 400,
-            response:  '{"error_code":"60004"}'
+            response:  '{"error_code":"60004"}',
           )
         end
 

--- a/spec/controllers/idv/review_controller_spec.rb
+++ b/spec/controllers/idv/review_controller_spec.rb
@@ -6,7 +6,7 @@ describe Idv::ReviewController do
       :user,
       :signed_up,
       password: ControllerHelper::VALID_PASSWORD,
-      email: 'old_email@example.com'
+      email: 'old_email@example.com',
     )
   end
   let(:zipcode) { '66044' }
@@ -28,7 +28,7 @@ describe Idv::ReviewController do
     idv_session = Idv::Session.new(
       user_session: subject.user_session,
       current_user: user,
-      issuer: nil
+      issuer: nil,
     )
     idv_session.profile_confirmation = true
     idv_session.vendor_phone_confirmation = true
@@ -42,7 +42,7 @@ describe Idv::ReviewController do
         :before,
         :confirm_two_factor_authenticated,
         :confirm_idv_session_started,
-        :confirm_idv_steps_complete
+        :confirm_idv_steps_complete,
       )
     end
   end
@@ -205,7 +205,7 @@ describe Idv::ReviewController do
 
         expect(flash.now[:success]).to eq(
           t('idv.messages.review.info_verified_html',
-            phone_message: "<strong>#{t('idv.messages.phone.phone_of_record')}</strong>")
+            phone_message: "<strong>#{t('idv.messages.phone.phone_of_record')}</strong>"),
         )
       end
     end
@@ -219,7 +219,7 @@ describe Idv::ReviewController do
         get :new
 
         expect(flash.now[:success]).to eq(
-          t('idv.messages.mail_sent')
+          t('idv.messages.mail_sent'),
         )
       end
     end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -29,7 +29,7 @@ describe Idv::SessionsController do
         :confirm_two_factor_authenticated,
         :confirm_idv_attempts_allowed,
         :confirm_idv_needed,
-        :confirm_step_needed
+        :confirm_step_needed,
       )
     end
   end

--- a/spec/controllers/idv/usps_controller_spec.rb
+++ b/spec/controllers/idv/usps_controller_spec.rb
@@ -9,7 +9,7 @@ describe Idv::UspsController do
         :before,
         :confirm_two_factor_authenticated,
         :confirm_idv_needed,
-        :confirm_mail_not_spammed
+        :confirm_mail_not_spammed,
       )
     end
   end

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -29,7 +29,7 @@ describe IdvController do
     it 'redirects to failure page if number of attempts has been exceeded' do
       profile = create(
         :profile,
-        user: create(:user, idv_attempts: 3, idv_attempted_at: Time.zone.now)
+        user: create(:user, idv_attempts: 3, idv_attempted_at: Time.zone.now),
       )
 
       stub_sign_in(profile.user)
@@ -125,7 +125,7 @@ describe IdvController do
       it 'allows direct access' do
         profile = create(
           :profile,
-          user: create(:user, idv_attempts: 3, idv_attempted_at: Time.zone.now)
+          user: create(:user, idv_attempts: 3, idv_attempted_at: Time.zone.now),
         )
 
         stub_sign_in(profile.user)

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             it 'redirects to the redirect_uri immediately' do
               IdentityLinker.new(user, client_id).link_identity(ial: 3)
               user.identities.last.update!(
-                verified_attributes: %w[given_name family_name birthdate]
+                verified_attributes: %w[given_name family_name birthdate],
               )
               action
 
@@ -194,7 +194,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
           issuer: 'urn:gov:gsa:openidconnect:test',
           request_id: sp_request_id,
           request_url: request.original_url,
-          requested_attributes: %w[given_name family_name birthdate]
+          requested_attributes: %w[given_name family_name birthdate],
         )
       end
     end

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OpenidConnect::LogoutController do
     IdTokenBuilder.new(
       identity: identity,
       code: code,
-      custom_expiration: 1.day.from_now.to_i
+      custom_expiration: 1.day.from_now.to_i,
     ).id_token
   end
 

--- a/spec/controllers/reactivate_account_controller_spec.rb
+++ b/spec/controllers/reactivate_account_controller_spec.rb
@@ -9,7 +9,7 @@ describe ReactivateAccountController do
   describe 'before_actions' do
     it 'requires the user to be logged in' do
       expect(subject).to have_actions(
-        :confirm_two_factor_authenticated
+        :confirm_two_factor_authenticated,
       )
     end
   end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -63,7 +63,7 @@ describe SamlIdpController do
       it 'finishes SLO at the IdP' do
         user.identities << Identity.create(
           service_provider: 'foo',
-          last_authenticated_at: Time.zone.now
+          last_authenticated_at: Time.zone.now,
         )
         sign_in user
 
@@ -160,7 +160,7 @@ describe SamlIdpController do
           first_name: 'Some',
           last_name: 'One',
           ssn: '666666666',
-          zipcode: '12345'
+          zipcode: '12345',
         )
       end
       let(:this_authn_request) do
@@ -172,7 +172,7 @@ describe SamlIdpController do
           user: user,
           service_provider: ServiceProvider.from_issuer(loa3_saml_settings.issuer),
           authn_request: this_authn_request,
-          decrypted_pii: pii
+          decrypted_pii: pii,
         )
       end
 
@@ -180,7 +180,7 @@ describe SamlIdpController do
         stub_sign_in(user)
         IdentityLinker.new(user, loa3_saml_settings.issuer).link_identity(ial: 3)
         user.identities.last.update!(
-          verified_attributes: %w[given_name family_name social_security_number address]
+          verified_attributes: %w[given_name family_name social_security_number address],
         )
         allow(subject).to receive(:attribute_asserter) { asserter }
       end
@@ -213,7 +213,7 @@ describe SamlIdpController do
         end
 
         expect(xmldoc.attribute_value_for('verified_at')).to eq(
-          user.active_profile.verified_at.iso8601
+          user.active_profile.verified_at.iso8601,
         )
       end
     end
@@ -354,7 +354,7 @@ describe SamlIdpController do
           loa3: false,
           request_url: @saml_request.request.original_url,
           request_id: sp_request_id,
-          requested_attributes: ['email']
+          requested_attributes: ['email'],
         )
       end
 
@@ -391,7 +391,7 @@ describe SamlIdpController do
 
         it 'does not redirect after verifying attributes' do
           IdentityLinker.new(@user, saml_settings.issuer).link_identity(
-            verified_attributes: ['email']
+            verified_attributes: ['email'],
           )
           saml_get_auth(saml_settings)
 
@@ -825,7 +825,7 @@ describe SamlIdpController do
         let(:subject) do
           xmldoc.saml_document.at(
             '//ds:AuthnStatement/ds:AuthnContext',
-            ds: Saml::XML::Namespaces::ASSERTION
+            ds: Saml::XML::Namespaces::ASSERTION,
           )
         end
 
@@ -837,7 +837,7 @@ describe SamlIdpController do
           let(:subject) do
             xmldoc.saml_document.at(
               '//ds:AuthnStatement/ds:AuthnContext/ds:AuthnContextClassRef',
-              ds: Saml::XML::Namespaces::ASSERTION
+              ds: Saml::XML::Namespaces::ASSERTION,
             )
           end
 
@@ -857,7 +857,7 @@ describe SamlIdpController do
         it 'includes the saml:AttributeStatement element' do
           attribute_statement = xmldoc.saml_document.at(
             '//*/saml:AttributeStatement',
-            saml: Saml::XML::Namespaces::ASSERTION
+            saml: Saml::XML::Namespaces::ASSERTION,
           )
 
           expect(attribute_statement.class).to eq(Nokogiri::XML::Element)
@@ -986,7 +986,7 @@ describe SamlIdpController do
         :disable_caching,
         :validate_saml_request,
         :validate_service_provider_and_authn_context,
-        :store_saml_request
+        :store_saml_request,
       )
     end
   end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -17,7 +17,7 @@ describe SignUp::CompletionsController do
 
           expect(@analytics).to have_received(:track_event).with(
             Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
-            loa3: false, service_provider_name: subject.decorated_session.sp_name
+            loa3: false, service_provider_name: subject.decorated_session.sp_name,
           )
         end
       end
@@ -32,7 +32,7 @@ describe SignUp::CompletionsController do
 
           expect(@analytics).to have_received(:track_event).with(
             Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
-            loa3: true, service_provider_name: subject.decorated_session.sp_name
+            loa3: true, service_provider_name: subject.decorated_session.sp_name,
           )
         end
       end
@@ -110,7 +110,7 @@ describe SignUp::CompletionsController do
 
         expect(@analytics).to have_received(:track_event).with(
           Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
-          loa3: false, service_provider_name: subject.decorated_session.sp_name
+          loa3: false, service_provider_name: subject.decorated_session.sp_name,
         )
       end
 
@@ -139,7 +139,7 @@ describe SignUp::CompletionsController do
 
         expect(@analytics).to have_received(:track_event).with(
           Analytics::USER_REGISTRATION_AGENCY_HANDOFF_COMPLETE,
-          loa3: true, service_provider_name: subject.decorated_session.sp_name
+          loa3: true, service_provider_name: subject.decorated_session.sp_name,
         )
       end
 

--- a/spec/controllers/sign_up/email_confirmations_controller_spec.rb
+++ b/spec/controllers/sign_up/email_confirmations_controller_spec.rb
@@ -94,7 +94,7 @@ describe SignUp::EmailConfirmationsController do
       user = create(:user, :unconfirmed)
       UpdateUser.new(
         user: user,
-        attributes: { confirmation_token: 'foo', confirmation_sent_at: Time.zone.now - 2.days }
+        attributes: { confirmation_token: 'foo', confirmation_sent_at: Time.zone.now - 2.days },
       ).call
 
       analytics_hash = {
@@ -142,7 +142,7 @@ describe SignUp::EmailConfirmationsController do
         :signed_up,
         confirmation_token: 'foo',
         confirmation_sent_at: Time.zone.now,
-        unconfirmed_email: 'test@example.com'
+        unconfirmed_email: 'test@example.com',
       )
 
       stub_analytics

--- a/spec/controllers/sign_up/personal_keys_controller_spec.rb
+++ b/spec/controllers/sign_up/personal_keys_controller_spec.rb
@@ -7,7 +7,7 @@ describe SignUp::PersonalKeysController do
       stub_sign_in
 
       expect(@analytics).to receive(:track_event).with(
-        Analytics::USER_REGISTRATION_PERSONAL_KEY_VISIT
+        Analytics::USER_REGISTRATION_PERSONAL_KEY_VISIT,
       )
 
       get :show

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -24,7 +24,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
 
         form = instance_double(BackupCodeVerificationForm)
         response = FormResponse.new(
-          success: true, errors: {}, extra: { multi_factor_auth_method: 'backup_code' }
+          success: true, errors: {}, extra: { multi_factor_auth_method: 'backup_code' },
         )
         allow(BackupCodeVerificationForm).to receive(:new).
           with(subject.current_user).and_return(form)
@@ -48,7 +48,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
         stub_sign_in_before_2fa(build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
         form = instance_double(BackupCodeVerificationForm)
         response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'backup_code' }
+          success: false, errors: {}, extra: { multi_factor_auth_method: 'backup_code' },
         )
         allow(BackupCodeVerificationForm).to receive(:new).
           with(subject.current_user).and_return(form)
@@ -67,7 +67,7 @@ describe TwoFactorAuthentication::BackupCodeVerificationController do
         stub_sign_in_before_2fa(build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
         form = instance_double(BackupCodeVerificationForm)
         response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'backup_code' }
+          success: false, errors: {}, extra: { multi_factor_auth_method: 'backup_code' },
         )
         allow(BackupCodeVerificationForm).to receive(:new).
           with(subject.current_user).and_return(form)

--- a/spec/controllers/two_factor_authentication/options_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/options_controller_spec.rb
@@ -30,7 +30,7 @@ describe TwoFactorAuthentication::OptionsController do
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
 
       expect(response).to redirect_to otp_send_url( \
-        otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
+        otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
       )
 
       piv_cac_webauthn_enabled('true')
@@ -40,7 +40,7 @@ describe TwoFactorAuthentication::OptionsController do
       post :create, params: { two_factor_options_form: { selection: 'sms' } }
 
       expect(response).to redirect_to otp_send_url( \
-        otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
+        otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
       )
     end
 
@@ -48,7 +48,7 @@ describe TwoFactorAuthentication::OptionsController do
       post :create, params: { two_factor_options_form: { selection: 'voice' } }
 
       expect(response).to redirect_to otp_send_url( \
-        otp_delivery_selection_form: { otp_delivery_preference: 'voice' }
+        otp_delivery_selection_form: { otp_delivery_preference: 'voice' },
       )
     end
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -12,7 +12,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
           presenter_data = attributes_for(:generic_otp_presenter)
           TwoFactorAuthCode::PhoneDeliveryPresenter.new(
             data: presenter_data,
-            view: ActionController::Base.new.view_context
+            view: ActionController::Base.new.view_context,
           )
           allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
 
@@ -195,7 +195,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               code: subject.current_user.direct_otp,
               otp_delivery_preference: 'sms',
               remember_device: 'true',
-            }
+            },
           )
 
           expect(cookies.encrypted[:remember_device]).to eq('asdf1234')
@@ -209,7 +209,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             params: {
               code: subject.current_user.direct_otp,
               otp_delivery_preference: 'sms',
-            }
+            },
           )
 
           expect(cookies[:remember_device]).to be_nil
@@ -223,7 +223,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         lockout_period = Figaro.env.lockout_period_in_minutes.to_i.minutes
         subject.current_user.update(
           second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
-          second_factor_attempts_count: 3
+          second_factor_attempts_count: 3,
         )
       end
 
@@ -288,7 +288,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               params: {
                 code: subject.current_user.direct_otp,
                 otp_delivery_preference: 'sms',
-              }
+              },
             )
           end
 
@@ -370,7 +370,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               params: {
                 code: subject.current_user.direct_otp,
                 otp_delivery_preference: 'sms',
-              }
+              },
             )
           end
 
@@ -412,7 +412,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
               code: subject.current_user.direct_otp,
               otp_delivery_preference: 'sms',
               remember_device: 'true',
-            }
+            },
           )
 
           expect(cookies.encrypted[:remember_device]).to eq('asdf1234')
@@ -426,7 +426,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             params: {
               code: subject.current_user.direct_otp,
               otp_delivery_preference: 'sms',
-            }
+            },
           )
 
           expect(cookies[:remember_device]).to be_nil

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -34,7 +34,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
 
         form = instance_double(PersonalKeyForm)
         response = FormResponse.new(
-          success: true, errors: {}, extra: { multi_factor_auth_method: 'personal key' }
+          success: true, errors: {}, extra: { multi_factor_auth_method: 'personal key' },
         )
         allow(PersonalKeyForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)
@@ -70,7 +70,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         stub_sign_in_before_2fa(build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
         form = instance_double(PersonalKeyForm)
         response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal key' }
+          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal key' },
         )
         allow(PersonalKeyForm).to receive(:new).
           with(subject.current_user, '').and_return(form)
@@ -90,7 +90,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
         stub_sign_in_before_2fa(build(:user, :with_phone, with: { phone: '+1 (703) 555-1212' }))
         form = instance_double(PersonalKeyForm)
         response = FormResponse.new(
-          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal key' }
+          success: false, errors: {}, extra: { multi_factor_auth_method: 'personal key' },
         )
         allow(PersonalKeyForm).to receive(:new).
           with(subject.current_user, 'foo').and_return(form)

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -16,22 +16,22 @@ describe TwoFactorAuthentication::PivCacVerificationController do
     allow(PivCacService).to receive(:decode_token).with('good-token').and_return(
       'uuid' => user.x509_dn_uuid,
       'subject' => x509_subject,
-      'nonce' => nonce
+      'nonce' => nonce,
     )
     allow(PivCacService).to receive(:decode_token).with('good-other-token').and_return(
       'uuid' => user.x509_dn_uuid + 'X',
       'subject' => x509_subject + 'X',
-      'nonce' => nonce
+      'nonce' => nonce,
     )
     allow(PivCacService).to receive(:decode_token).with('bad-token').and_return(
       'uuid' => 'bad-uuid',
       'subject' => 'bad-dn',
-      'nonce' => nonce
+      'nonce' => nonce,
     )
     allow(PivCacService).to receive(:decode_token).with('bad-nonce').and_return(
       'uuid' => user.x509_dn_uuid,
       'subject' => x509_subject,
-      'nonce' => 'bad-' + nonce
+      'nonce' => 'bad-' + nonce,
     )
   end
 
@@ -58,7 +58,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
         mock_piv_cac_configuration = mock_mfa.piv_cac_configuration
         allow(mock_piv_cac_configuration).to receive(:mfa_confirmed?).and_return(true)
         allow(mock_mfa).to receive(:piv_cac_configuration).and_return(
-          mock_piv_cac_configuration
+          mock_piv_cac_configuration,
         )
         allow(MfaContext).to receive(:new).with(subject.current_user).and_return(mock_mfa)
         expect(subject.current_user.reload.second_factor_attempts_count).to eq 0
@@ -75,7 +75,7 @@ describe TwoFactorAuthentication::PivCacVerificationController do
       it 'resets the second_factor_attempts_count' do
         UpdateUser.new(
           user: subject.current_user,
-          attributes: { second_factor_attempts_count: 1 }
+          attributes: { second_factor_attempts_count: 1 },
         ).call
 
         get :show, params: { token: 'good-token' }

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -21,7 +21,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
       it 'resets the second_factor_attempts_count' do
         UpdateUser.new(
           user: subject.current_user,
-          attributes: { second_factor_attempts_count: 1 }
+          attributes: { second_factor_attempts_count: 1 },
         ).call
 
         post :create, params: { code: generate_totp_code(@secret) }
@@ -92,7 +92,7 @@ describe TwoFactorAuthentication::TotpVerificationController do
           :user,
           :signed_up,
           second_factor_locked_at: Time.zone.now - lockout_period - 1.second,
-          second_factor_attempts_count: 3
+          second_factor_attempts_count: 3,
         )
         sign_in_before_2fa(user)
         @secret = subject.current_user.generate_totp_secret

--- a/spec/controllers/users/delete_controller_spec.rb
+++ b/spec/controllers/users/delete_controller_spec.rb
@@ -31,7 +31,7 @@ describe Users::DeleteController do
       user = stub_signed_in_user
       user.identities << Identity.create(
         service_provider: 'foo',
-        last_authenticated_at: Time.zone.now
+        last_authenticated_at: Time.zone.now,
       )
       expect(Identity.where(user_id: user.id).length).to eq(1)
       post :delete

--- a/spec/controllers/users/phone_setup_controller_spec.rb
+++ b/spec/controllers/users/phone_setup_controller_spec.rb
@@ -77,13 +77,13 @@ describe Users::PhoneSetupController do
           params: {
             user_phone_form: { phone: '703-555-0100',
                                international_code: 'US' },
-          }
+          },
         )
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'voice' }
-          )
+            otp_delivery_selection_form: { otp_delivery_preference: 'voice' },
+          ),
         )
 
         expect(subject.user_session[:context]).to eq 'confirmation'
@@ -110,13 +110,13 @@ describe Users::PhoneSetupController do
           params: {
             user_phone_form: { phone: '703-555-0100',
                                international_code: 'US' },
-          }
+          },
         )
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
-          )
+            otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
+          ),
         )
 
         expect(subject.user_session[:context]).to eq 'confirmation'
@@ -142,13 +142,13 @@ describe Users::PhoneSetupController do
           params: {
             user_phone_form: { phone: '703-555-0100',
                                international_code: 'US' },
-          }
+          },
         )
 
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
-          )
+            otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
+          ),
         )
 
         expect(subject.user_session[:context]).to eq 'confirmation'
@@ -161,7 +161,7 @@ describe Users::PhoneSetupController do
       expect(subject).to have_actions(
         :before,
         :authenticate_user,
-        :authorize_user
+        :authorize_user,
       )
     end
   end

--- a/spec/controllers/users/phones_controller_spec.rb
+++ b/spec/controllers/users/phones_controller_spec.rb
@@ -26,14 +26,14 @@ describe Users::PhonesController do
       it 'lets user know they need to confirm their new phone' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
         expect(
-          MfaContext.new(user).phone_configurations.reload.first.phone
+          MfaContext.new(user).phone_configurations.reload.first.phone,
         ).to_not eq '+1 202-555-4321'
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
-          )
+            otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
+          ),
         )
         expect(subject.user_session[:context]).to eq 'confirmation'
       end
@@ -71,14 +71,14 @@ describe Users::PhonesController do
       it 'processes successfully and informs user' do
         expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
         expect(MfaContext.new(user).phone_configurations.reload.first.phone).to_not eq(
-          MfaContext.new(second_user).phone_configurations.first.phone
+          MfaContext.new(second_user).phone_configurations.first.phone,
         )
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PHONE_CHANGE_REQUESTED)
         expect(response).to redirect_to(
           otp_send_path(
-            otp_delivery_selection_form: { otp_delivery_preference: 'sms' }
-          )
+            otp_delivery_selection_form: { otp_delivery_preference: 'sms' },
+          ),
         )
         expect(subject.user_session[:context]).to eq 'confirmation'
       end
@@ -240,7 +240,7 @@ describe Users::PhonesController do
       }
       expect(flash[:notice]).to eq t('devise.registrations.phone_update_needs_confirmation')
       expect(
-        MfaContext.new(user).phone_configurations.reload.first.phone
+        MfaContext.new(user).phone_configurations.reload.first.phone,
       ).to_not eq '+1 202-555-4321'
       expect(response).to redirect_to(otp_send_path(otp_delivery_selection_form:
                                                       { otp_delivery_preference: 'sms' }))

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -86,7 +86,7 @@ describe Users::ResetPasswordsController, devise: true do
           :user,
           :signed_up,
           reset_password_sent_at: Time.zone.now - Devise.reset_password_within - 1.hour,
-          reset_password_token: db_confirmation_token
+          reset_password_token: db_confirmation_token,
         )
 
         params = { password: 'short', reset_password_token: raw_reset_token }
@@ -121,7 +121,7 @@ describe Users::ResetPasswordsController, devise: true do
           :user,
           :signed_up,
           reset_password_token: db_confirmation_token,
-          reset_password_sent_at: Time.zone.now
+          reset_password_sent_at: Time.zone.now,
         )
         form_params = { password: 'short', reset_password_token: raw_reset_token }
         analytics_hash = {
@@ -151,7 +151,7 @@ describe Users::ResetPasswordsController, devise: true do
           :user,
           :unconfirmed,
           reset_password_token: db_confirmation_token,
-          reset_password_sent_at: Time.zone.now
+          reset_password_sent_at: Time.zone.now,
         )
         form_params = { password: 'a really long passw0rd', reset_password_token: raw_reset_token }
 
@@ -176,7 +176,7 @@ describe Users::ResetPasswordsController, devise: true do
             :user,
             :signed_up,
             reset_password_token: db_confirmation_token,
-            reset_password_sent_at: Time.zone.now
+            reset_password_sent_at: Time.zone.now,
           )
           old_confirmed_at = user.reload.confirmed_at
           allow(user).to receive(:active_profile).and_return(nil)
@@ -217,7 +217,7 @@ describe Users::ResetPasswordsController, devise: true do
         user = create(
           :user,
           reset_password_token: db_confirmation_token,
-          reset_password_sent_at: Time.zone.now
+          reset_password_sent_at: Time.zone.now,
         )
         _profile = create(:profile, :active, :verified, user: user)
 
@@ -256,7 +256,7 @@ describe Users::ResetPasswordsController, devise: true do
           :user,
           :unconfirmed,
           reset_password_token: db_confirmation_token,
-          reset_password_sent_at: Time.zone.now
+          reset_password_sent_at: Time.zone.now,
         )
 
         stub_user_mailer(user)
@@ -290,7 +290,7 @@ describe Users::ResetPasswordsController, devise: true do
         :user,
         :unconfirmed,
         reset_password_token: db_confirmation_token,
-        reset_password_sent_at: Time.zone.now
+        reset_password_sent_at: Time.zone.now,
       )
 
       stub_user_mailer(user)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -126,7 +126,7 @@ describe Users::SessionsController, devise: true do
       expect(flash[:notice]).to eq t(
         'notices.session_timedout',
         app: APP_NAME,
-        minutes: Figaro.env.session_timeout_in_minutes
+        minutes: Figaro.env.session_timeout_in_minutes,
       )
 
       expect(subject.current_user).to be_nil
@@ -211,7 +211,7 @@ describe Users::SessionsController, devise: true do
       user = create(
         :user,
         :signed_up,
-        second_factor_locked_at: Time.zone.now
+        second_factor_locked_at: Time.zone.now,
       )
 
       stub_analytics
@@ -298,7 +298,7 @@ describe Users::SessionsController, devise: true do
         user = create(:user, :signed_up)
         profile = create(:profile, :active, :verified, user: user, pii: { ssn: '1234' })
         profile.update!(
-          encrypted_pii: { encrypted_data: Base64.strict_encode64('nonsense') }.to_json
+          encrypted_pii: { encrypted_data: Base64.strict_encode64('nonsense') }.to_json,
         )
 
         stub_analytics
@@ -463,7 +463,7 @@ describe Users::SessionsController, devise: true do
         profile = create(
           :profile,
           deactivation_reason: :verification_pending,
-          pii: { ssn: '6666', dob: '1920-01-01' }
+          pii: { ssn: '6666', dob: '1920-01-01' },
         )
         user = profile.user
 

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -6,7 +6,7 @@ describe Users::TotpSetupController, devise: true do
       expect(subject).to have_actions(
         :before,
         :authenticate_user!,
-        [:confirm_two_factor_authenticated, if: :two_factor_enabled?]
+        [:confirm_two_factor_authenticated, if: :two_factor_enabled?],
       )
     end
   end
@@ -31,7 +31,7 @@ describe Users::TotpSetupController, devise: true do
 
       it 'can be used to generate a qrcode with UserDecorator#qrcode' do
         expect(
-          subject.current_user.decorate.qrcode(subject.user_session[:new_totp_secret])
+          subject.current_user.decorate.qrcode(subject.user_session[:new_totp_secret]),
         ).not_to be_nil
       end
 
@@ -73,7 +73,7 @@ describe Users::TotpSetupController, devise: true do
 
       it 'can be used to generate a qrcode with UserDecorator#qrcode' do
         expect(
-          subject.current_user.decorate.qrcode(subject.user_session[:new_totp_secret])
+          subject.current_user.decorate.qrcode(subject.user_session[:new_totp_secret]),
         ).not_to be_nil
       end
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -11,7 +11,7 @@ describe Users::TwoFactorAuthenticationController do
         [:require_current_password, if: :current_password_required?],
         :check_already_authenticated,
         :reset_attempt_count_if_user_no_longer_locked_out,
-        :apply_secure_headers_override
+        :apply_secure_headers_override,
       )
     end
   end
@@ -74,7 +74,7 @@ describe Users::TwoFactorAuthenticationController do
         user = build(:user)
         stub_sign_in_before_2fa(user)
         allow_any_instance_of(
-          TwoFactorAuthentication::PivCacPolicy
+          TwoFactorAuthentication::PivCacPolicy,
         ).to receive(:enabled?).and_return(true)
 
         get :show
@@ -88,7 +88,7 @@ describe Users::TwoFactorAuthenticationController do
         user = build(:user)
         stub_sign_in_before_2fa(user)
         allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy
+          TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(true)
 
         get :show
@@ -102,7 +102,7 @@ describe Users::TwoFactorAuthenticationController do
         stub_sign_in_before_2fa(build(:user, :with_webauthn))
 
         allow_any_instance_of(
-          TwoFactorAuthentication::WebauthnPolicy
+          TwoFactorAuthentication::WebauthnPolicy,
         ).to receive(:enabled?).and_return(true)
 
         get :show
@@ -159,12 +159,12 @@ describe Users::TwoFactorAuthenticationController do
           phone: MfaContext.new(subject.current_user).phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.login_message',
-          locale: nil
+          locale: nil,
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
         expect(response).to redirect_to(
-          login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false)
+          login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false),
         )
       end
 
@@ -176,7 +176,7 @@ describe Users::TwoFactorAuthenticationController do
           phone: MfaContext.new(subject.current_user).phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.login_message',
-          locale: nil
+          locale: nil,
         )
       end
 
@@ -203,7 +203,7 @@ describe Users::TwoFactorAuthenticationController do
         otp_rate_limiter = instance_double(OtpRateLimiter)
         allow(OtpRateLimiter).to receive(:new).with(
           phone: MfaContext.new(@user).phone_configurations.first.phone,
-          user: @user
+          user: @user,
         ).and_return(otp_rate_limiter)
 
         expect(otp_rate_limiter).to receive(:exceeded_otp_send_limit?).twice
@@ -242,12 +242,12 @@ describe Users::TwoFactorAuthenticationController do
           code: subject.current_user.direct_otp,
           phone: MfaContext.new(subject.current_user).phone_configurations.first.phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
-          locale: nil
+          locale: nil,
         )
         expect(subject.current_user.direct_otp).not_to eq(@old_otp)
         expect(subject.current_user.direct_otp).not_to be_nil
         expect(response).to redirect_to(
-          login_two_factor_path(otp_delivery_preference: 'voice', reauthn: false)
+          login_two_factor_path(otp_delivery_preference: 'voice', reauthn: false),
         )
       end
 
@@ -292,7 +292,7 @@ describe Users::TwoFactorAuthenticationController do
           phone: @unconfirmed_phone,
           otp_created_at: subject.current_user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.verify_message',
-          locale: nil
+          locale: nil,
         )
       end
 
@@ -393,7 +393,7 @@ describe Users::TwoFactorAuthenticationController do
         response = '{"error_code":"60004"}'
         status = 400
         verify_error = PhoneVerification::VerifyError.new(
-          code: code, message: error_message, status: status, response: response
+          code: code, message: error_message, status: status, response: response,
         )
 
         allow(SmsOtpSenderJob).to receive(:perform_now).and_raise(verify_error)

--- a/spec/controllers/users/verify_account_controller_spec.rb
+++ b/spec/controllers/users/verify_account_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Users::VerifyAccountController do
     create(
       :usps_confirmation_code,
       profile: pending_profile,
-      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
     allow(decorated_user).to receive(:pending_profile_requires_verification?).
       and_return(has_pending_profile)
@@ -53,7 +53,7 @@ RSpec.describe Users::VerifyAccountController do
           verify_account_form: {
             otp: submitted_otp,
           },
-        }
+        },
       )
     end
 

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -8,7 +8,7 @@ describe Users::WebauthnSetupController do
       expect(subject).to have_actions(
         :before,
         :authenticate_user!,
-        [:confirm_two_factor_authenticated, if: :two_factor_enabled?]
+        [:confirm_two_factor_authenticated, if: :two_factor_enabled?],
       )
     end
   end

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceProviderSessionDecorator do
       sp: sp,
       view_context: view_context,
       sp_session: {},
-      service_provider_request: ServiceProviderRequest.new
+      service_provider_request: ServiceProviderRequest.new,
     )
   end
   let(:sp) { build_stubbed(:service_provider) }
@@ -16,7 +16,7 @@ RSpec.describe ServiceProviderSessionDecorator do
   it 'has the same public API as SessionDecorator' do
     SessionDecorator.public_instance_methods.each do |method|
       expect(
-        described_class.public_method_defined?(method)
+        described_class.public_method_defined?(method),
       ).to be(true), "expected #{described_class} to have ##{method}"
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe ServiceProviderSessionDecorator do
   describe '#return_to_service_provider_partial' do
     it 'returns the correct partial' do
       expect(subject.return_to_service_provider_partial).to eq(
-        'devise/sessions/return_to_service_provider'
+        'devise/sessions/return_to_service_provider',
       )
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe ServiceProviderSessionDecorator do
   describe '#verification_method_choice' do
     it 'returns the correct string' do
       expect(subject.verification_method_choice).to eq(
-        I18n.t('idv.messages.select_verification_with_sp', sp_name: sp_name)
+        I18n.t('idv.messages.select_verification_with_sp', sp_name: sp_name),
       )
     end
   end
@@ -96,7 +96,7 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp: sp,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       )
       expect(subject.sp_name).to eq sp.agency
       expect(subject.sp_name).to_not be_nil
@@ -115,7 +115,7 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp: sp,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       )
       expect(subject.sp_agency).to eq sp.friendly_name
       expect(subject.sp_agency).to_not be_nil
@@ -132,7 +132,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           sp: sp,
           view_context: view_context,
           sp_session: {},
-          service_provider_request: ServiceProviderRequest.new
+          service_provider_request: ServiceProviderRequest.new,
         )
 
         expect(subject.sp_logo).to eq sp_logo
@@ -147,7 +147,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           sp: sp,
           view_context: view_context,
           sp_session: {},
-          service_provider_request: ServiceProviderRequest.new
+          service_provider_request: ServiceProviderRequest.new,
         )
 
         expect(subject.sp_logo).to eq 'generic.svg'
@@ -165,7 +165,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           sp: sp,
           view_context: view_context,
           sp_session: {},
-          service_provider_request: ServiceProviderRequest.new
+          service_provider_request: ServiceProviderRequest.new,
         )
 
         expect(subject.sp_logo_url).to end_with("/sp-logos/#{sp_logo}")
@@ -180,7 +180,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           sp: sp,
           view_context: view_context,
           sp_session: {},
-          service_provider_request: ServiceProviderRequest.new
+          service_provider_request: ServiceProviderRequest.new,
         )
 
         expect(subject.sp_logo_url).to match(%r{/sp-logos/generic-.+\.svg})
@@ -196,7 +196,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           sp: sp,
           view_context: view_context,
           sp_session: {},
-          service_provider_request: ServiceProviderRequest.new
+          service_provider_request: ServiceProviderRequest.new,
         )
 
         expect(subject.sp_logo_url).to eq(logo)
@@ -210,7 +210,7 @@ RSpec.describe ServiceProviderSessionDecorator do
         sp: sp,
         view_context: view_context,
         sp_session: { request_id: 'foo' },
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       )
     end
 

--- a/spec/decorators/session_decorator_spec.rb
+++ b/spec/decorators/session_decorator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SessionDecorator do
   describe '#verification_method_choice' do
     it 'returns the correct string' do
       expect(subject.verification_method_choice).to eq(
-        I18n.t('idv.messages.select_verification_without_sp')
+        I18n.t('idv.messages.select_verification_without_sp'),
       )
     end
   end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -62,7 +62,7 @@ describe UserDecorator do
       user.identities << create(
         :identity,
         service_provider: sp.issuer,
-        session_uuid: SecureRandom.uuid
+        session_uuid: SecureRandom.uuid,
       )
 
       user_decorator = UserDecorator.new(user)
@@ -120,12 +120,12 @@ describe UserDecorator do
           :profile,
           deactivation_reason: :verification_pending,
           created_at: 1.day.ago,
-          user: user
+          user: user,
         )
         new_profile = create(
           :profile,
           deactivation_reason: :verification_pending,
-          user: user
+          user: user,
         )
         user_decorator = UserDecorator.new(user)
 
@@ -140,12 +140,12 @@ describe UserDecorator do
           :profile,
           deactivation_reason: :password_reset,
           created_at: 1.day.ago,
-          user: user
+          user: user,
         )
         create(
           :profile,
           deactivation_reason: :encryption_error,
-          user: user
+          user: user,
         )
         user_decorator = UserDecorator.new(user)
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,13 +43,13 @@ FactoryBot.define do
           if user.id.present?
             create(:webauthn_configuration,
                    { user: user }.merge(
-                     evaluator.with.slice(:name, :credential_id, :credential_public_key)
+                     evaluator.with.slice(:name, :credential_id, :credential_public_key),
                    ))
             user.webauthn_configurations.reload
           else
             user.webauthn_configurations << build(
               :webauthn_configuration,
-              evaluator.with.slice(:name, :credential_id, :credential_public_key)
+              evaluator.with.slice(:name, :credential_id, :credential_public_key),
             )
           end
         end
@@ -59,7 +59,7 @@ FactoryBot.define do
         if user.webauthn_configurations.empty?
           create(:webauthn_configuration,
                  { user: user }.merge(
-                   evaluator.with.slice(:name, :credential_id, :credential_public_key)
+                   evaluator.with.slice(:name, :credential_id, :credential_public_key),
                  ))
           user.webauthn_configurations.reload
         end
@@ -69,7 +69,7 @@ FactoryBot.define do
         if user.webauthn_configurations.empty?
           user.webauthn_configurations << build(
             :webauthn_configuration,
-            evaluator.with.slice(:name, :credential_id, :credential_public_key)
+            evaluator.with.slice(:name, :credential_id, :credential_public_key),
           )
         end
       end
@@ -82,15 +82,20 @@ FactoryBot.define do
           if user.id.present?
             create(:phone_configuration,
                    { user: user, delivery_preference: user.otp_delivery_preference }.merge(
-                     evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
+                     evaluator.with.slice(
+                       :phone,
+                       :confirmed_at,
+                       :delivery_preference,
+                       :mfa_enabled,
+                     ),
                    ))
             user.phone_configurations.reload
           else
             user.phone_configurations << build(
               :phone_configuration,
               { delivery_preference: user.otp_delivery_preference }.merge(
-                evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
-              )
+                evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
+              ),
             )
           end
         end
@@ -100,7 +105,7 @@ FactoryBot.define do
         if user.phone_configurations.empty?
           create(:phone_configuration,
                  { user: user, delivery_preference: user.otp_delivery_preference }.merge(
-                   evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
+                   evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
                  ))
           user.phone_configurations.reload
         end
@@ -111,8 +116,8 @@ FactoryBot.define do
           user.phone_configurations << build(
             :phone_configuration,
             { delivery_preference: user.otp_delivery_preference }.merge(
-              evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled)
-            )
+              evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
+            ),
           )
         end
       end

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -8,7 +8,7 @@ describe 'Account connected applications' do
       :active,
       user: user,
       created_at: Time.zone.now - 80.days,
-      service_provider: 'http://localhost:3000'
+      service_provider: 'http://localhost:3000',
     )
   end
   let(:identity_without_link) do
@@ -17,7 +17,7 @@ describe 'Account connected applications' do
       :active,
       user: user,
       created_at: Time.zone.now - 50.days,
-      service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata'
+      service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata',
     )
   end
   let(:identity_with_link_timestamp) { identity_with_link.decorate.created_at_in_words }
@@ -33,12 +33,15 @@ describe 'Account connected applications' do
     expect(page).to have_content(t('headings.account.connected_apps'))
 
     expect(page).to have_content( \
-      t('event_types.authenticated_at', service_provider: identity_without_link.display_name)
+      t('event_types.authenticated_at', service_provider: identity_without_link.display_name),
     )
     expect(page).to_not have_link(identity_without_link.display_name)
 
     expect(page).to have_content( \
-      t('event_types.authenticated_at_html', service_provider_link: identity_with_link.display_name)
+      t(
+        'event_types.authenticated_at_html',
+        service_provider_link: identity_with_link.display_name,
+      ),
     )
     expect(page).to have_link( \
       identity_with_link.display_name, href: 'http://localhost:3000'

--- a/spec/features/account_history_spec.rb
+++ b/spec/features/account_history_spec.rb
@@ -12,7 +12,7 @@ describe 'Account history' do
       :active,
       user: user,
       last_authenticated_at: Time.zone.now - 80.days,
-      service_provider: 'http://localhost:3000'
+      service_provider: 'http://localhost:3000',
     )
   end
   let(:usps_mail_sent_again_event) do
@@ -24,7 +24,7 @@ describe 'Account history' do
       :active,
       user: user,
       last_authenticated_at: Time.zone.now - 50.days,
-      service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata'
+      service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata',
     )
   end
   let(:account_created_timestamp) { account_created_event.decorate.happened_at_in_words }
@@ -62,12 +62,15 @@ describe 'Account history' do
     end
 
     expect(page).to have_content(
-      t('event_types.authenticated_at', service_provider: identity_without_link.display_name)
+      t('event_types.authenticated_at', service_provider: identity_without_link.display_name),
     )
     expect(page).to_not have_link(identity_without_link.display_name)
 
     expect(page).to have_content(
-      t('event_types.authenticated_at_html', service_provider_link: identity_with_link.display_name)
+      t(
+        'event_types.authenticated_at_html',
+        service_provider_link: identity_with_link.display_name,
+      ),
     )
     expect(page).to have_link(
       identity_with_link.display_name, href: 'http://localhost:3000'

--- a/spec/features/account_reset/cancel_request_spec.rb
+++ b/spec/features/account_reset/cancel_request_spec.rb
@@ -48,7 +48,7 @@ describe 'Account Reset Request: Cancellation' do
 
         expect(page).
           to have_current_path(
-            login_two_factor_path(otp_delivery_preference: 'sms', reauthn: 'false')
+            login_two_factor_path(otp_delivery_preference: 'sms', reauthn: 'false'),
           )
       end
     end

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -17,7 +17,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       expect(page).
         to have_content strip_tags(
-          t('account_reset.confirm_request.instructions', email: user_email)
+          t('account_reset.confirm_request.instructions', email: user_email),
         )
       expect(page).to have_content t('account_reset.confirm_request.security_note')
       expect(page).to have_content t('account_reset.confirm_request.close_window')
@@ -39,9 +39,9 @@ describe 'Account Reset Request: Delete Account', email: true do
             t(
               'account_reset.confirm_delete_account.info',
               email: user_email,
-              link: t('account_reset.confirm_delete_account.link_text')
-            )
-          )
+              link: t('account_reset.confirm_delete_account.link_text'),
+            ),
+          ),
         )
         expect(page).to have_current_path(account_reset_confirm_delete_account_path)
         expect(User.where(id: user.id)).to be_empty
@@ -65,7 +65,7 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       expect(page).
         to have_content strip_tags(
-          t('account_reset.confirm_request.instructions', email: user_email)
+          t('account_reset.confirm_request.instructions', email: user_email),
         )
       expect(page).to_not have_content t('account_reset.confirm_request.security_note')
       expect(page).to have_content t('account_reset.confirm_request.close_window')
@@ -83,7 +83,7 @@ describe 'Account Reset Request: Delete Account', email: true do
         :profile,
         :active,
         :verified,
-        pii: { first_name: 'John', ssn: '111223333' }
+        pii: { first_name: 'John', ssn: '111223333' },
       ).user
     end
 

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -61,7 +61,7 @@ feature 'phone otp rate limiting', :idv_job do
     def expect_max_otp_request_rate_limiting
       expect(page).to have_content t('titles.account_locked')
       expect(page).to have_content t(
-        'two_factor_authentication.max_otp_requests_reached'
+        'two_factor_authentication.max_otp_requests_reached',
       )
 
       expect_rate_limit_circumvention_to_be_disallowed(user)

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -77,7 +77,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
         redirect_uri: 'http://localhost:7654/auth/result',
         state: SecureRandom.hex,
         nonce: SecureRandom.hex,
-        prompt: 'select_account'
+        prompt: 'select_account',
       )
 
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
@@ -107,7 +107,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
         redirect_uri: 'http://localhost:7654/auth/result',
         state: SecureRandom.hex,
         nonce: SecureRandom.hex,
-        prompt: 'select_account'
+        prompt: 'select_account',
       )
 
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
@@ -151,7 +151,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
         prompt: 'select_account',
         nonce: nonce,
         code_challenge: code_challenge,
-        code_challenge_method: 'S256'
+        code_challenge_method: 'S256',
       )
 
       _user = sign_in_live_with_2fa(user)
@@ -195,7 +195,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
           nonce: SecureRandom.hex,
           prompt: 'select_account',
           code_challenge: Digest::SHA256.base64digest(SecureRandom.hex),
-          code_challenge_method: 'S256'
+          code_challenge_method: 'S256',
         )
 
         sp_content = [
@@ -252,7 +252,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
         redirect_uri: 'http://localhost:7654/auth/result',
         state: SecureRandom.hex,
         nonce: SecureRandom.hex,
-        prompt: 'select_account'
+        prompt: 'select_account',
       )
       visit oidc_path
 
@@ -298,7 +298,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
       visit openid_connect_logout_path(
         post_logout_redirect_uri: 'gov.gsa.openidconnect.test://result/logout',
         state: state,
-        id_token_hint: id_token
+        id_token_hint: id_token,
       )
 
       current_url_no_port = URI(current_url).tap { |uri| uri.port = nil }.to_s
@@ -366,7 +366,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -382,7 +382,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -407,7 +407,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
       prompt: 'select_account',
       nonce: nonce,
       code_challenge: code_challenge,
-      code_challenge_method: 'S256'
+      code_challenge_method: 'S256',
     )
 
     _user = sign_in_live_with_2fa(user)
@@ -439,7 +439,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
   def client_private_key
     @client_private_key ||= begin
       OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys', 'saml_test_sp.key'))
+        File.read(Rails.root.join('keys', 'saml_test_sp.key')),
       )
     end
   end
@@ -548,7 +548,7 @@ shared_examples 'OpenID Connect' do |cloudhsm_enabled|
     allow(MockSession).to receive_message_chain(:find_objects, :first).and_return(true)
     allow(MockSession).to receive(:sign) do |_algorithm, _key, input|
       JWT::Algos::Rsa.sign(
-        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key)
+        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key),
       )
     end
   end

--- a/spec/features/openid_connect/redirect_uri_validation_spec.rb
+++ b/spec/features/openid_connect/redirect_uri_validation_spec.rb
@@ -173,7 +173,7 @@ describe 'redirect_uri validation' do
       redirect_uri: 'https://example.com.evil.com/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -189,7 +189,7 @@ describe 'redirect_uri validation' do
       redirect_uri: ':aaaa',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -205,7 +205,7 @@ describe 'redirect_uri validation' do
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -221,7 +221,7 @@ describe 'redirect_uri validation' do
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -237,7 +237,7 @@ describe 'redirect_uri validation' do
       redirect_uri: 'https://example.com',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 
@@ -253,7 +253,7 @@ describe 'redirect_uri validation' do
       redirect_uri: 'http://test.host',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 end

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -71,7 +71,7 @@ feature 'LOA3 Single Sign On' do
         :profile,
         deactivation_reason: :verification_pending,
         phone_confirmed: phone_confirmed,
-        pii: { ssn: '6666', dob: '1920-01-01' }
+        pii: { ssn: '6666', dob: '1920-01-01' },
       )
     end
 

--- a/spec/features/saml/redirect_uri_validation_spec.rb
+++ b/spec/features/saml/redirect_uri_validation_spec.rb
@@ -8,7 +8,7 @@ describe 'redirect_uri validation' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
       visit api_saml_auth_path(
-        SAMLRequest: CGI.unescape(saml_request(saml_settings)), redirect_uri: 'http://evil.com'
+        SAMLRequest: CGI.unescape(saml_request(saml_settings)), redirect_uri: 'http://evil.com',
       )
       sp = ServiceProvider.find_by(issuer: 'http://localhost:3000')
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -155,7 +155,7 @@ shared_examples 'saml api' do |cloudhsm_enabled|
         allow(Figaro.env).to receive(:dashboard_url).and_return(fake_dashboard_url)
         stub_request(:get, fake_dashboard_url).to_return(
           status: 200,
-          body: dashboard_service_providers.to_json
+          body: dashboard_service_providers.to_json,
         )
       end
 
@@ -222,7 +222,7 @@ shared_examples 'saml api' do |cloudhsm_enabled|
         decoded_response = Base64.decode64(response_node.value)
         saml_response = OneLogin::RubySaml::Response.new(
           decoded_response,
-          settings: new_cert_saml_settings
+          settings: new_cert_saml_settings,
         )
         saml_response.soft = false
 
@@ -248,7 +248,7 @@ shared_examples 'saml api' do |cloudhsm_enabled|
         decoded_response = Base64.decode64(response_node.value)
         saml_response = OneLogin::RubySaml::Logoutresponse.new(
           decoded_response,
-          new_cert_saml_settings
+          new_cert_saml_settings,
         )
         expect(saml_response.validate).to eq(true)
       end

--- a/spec/features/saml/sp_initiated_slo_spec.rb
+++ b/spec/features/saml/sp_initiated_slo_spec.rb
@@ -319,7 +319,7 @@ feature 'SP-initiated logout' do
 
     it 'completes logout at IdP' do
       allow_any_instance_of(ServiceProvider).to receive(:metadata).and_return(
-        service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata'
+        service_provider: 'https://rp1.serviceprovider.com/auth/saml/metadata',
       )
 
       visit destroy_user_session_url

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -36,7 +36,7 @@ feature 'Changing authentication factor' do
       expect(page).to have_link t('links.cancel'), href: account_path
       expect(page).to have_link t('forms.two_factor.try_again'), href: manage_phone_path
       expect(page).not_to have_content(
-        t('two_factor_authentication.personal_key_fallback.text_html')
+        t('two_factor_authentication.personal_key_fallback.text_html'),
       )
 
       enter_incorrect_otp_code
@@ -54,7 +54,7 @@ feature 'Changing authentication factor' do
       expect(mailer).to have_received(:deliver_later)
       expect(page).to have_content new_phone
       expect(
-        MfaContext.new(user).phone_configurations.reload.first.confirmed_at
+        MfaContext.new(user).phone_configurations.reload.first.confirmed_at,
       ).to_not eq(@previous_phone_confirmed_at)
 
       visit login_two_factor_path(otp_delivery_preference: 'sms')
@@ -100,7 +100,7 @@ feature 'Changing authentication factor' do
             phone: old_phone,
             otp_created_at: user.reload.direct_otp_sent_at.to_s,
             message: 'jobs.sms_otp_sender_job.login_message',
-            locale: nil
+            locale: nil,
           )
 
         expect(page).to have_content UserDecorator.new(user).masked_two_factor_phone_number
@@ -126,7 +126,7 @@ feature 'Changing authentication factor' do
               phone: old_phone,
               otp_created_at: user.reload.direct_otp_sent_at.to_s,
               message: 'jobs.sms_otp_sender_job.login_message',
-              locale: nil
+              locale: nil,
             )
 
           expect(current_path).
@@ -216,7 +216,7 @@ feature 'Changing authentication factor' do
     click_button t('forms.buttons.continue')
 
     expect(current_path).to eq login_two_factor_path(
-      otp_delivery_preference: user.otp_delivery_preference
+      otp_delivery_preference: user.otp_delivery_preference,
     )
   end
 

--- a/spec/features/two_factor_authentication/remember_device_sp_expiration_spec.rb
+++ b/spec/features/two_factor_authentication/remember_device_sp_expiration_spec.rb
@@ -84,11 +84,11 @@ feature 'remember device sp expiration' do
 
     ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server').update!(
       aal: aal,
-      ial: ial
+      ial: ial,
     )
     ServiceProvider.from_issuer('http://localhost:3000').update!(
       aal: aal,
-      ial: ial
+      ial: ial,
     )
   end
 

--- a/spec/features/two_factor_authentication/remember_device_spec.rb
+++ b/spec/features/two_factor_authentication/remember_device_spec.rb
@@ -91,7 +91,7 @@ feature 'Remembering a 2FA device' do
     it 'requires 2FA and does not offer the option to remember device' do
       expect(current_path).to eq(idv_otp_verification_path)
       expect(page).to_not have_content(
-        t('forms.messages.remember_device')
+        t('forms.messages.remember_device'),
       )
     end
   end
@@ -108,7 +108,7 @@ feature 'Remembering a 2FA device' do
       sign_in_user(user)
       expect(current_path).to eq(login_two_factor_authenticator_path)
       expect(page).to_not have_content(
-        t('forms.messages.remember_device')
+        t('forms.messages.remember_device'),
       )
     end
   end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -68,7 +68,7 @@ feature 'Two Factor Authentication' do
         expect(current_path).to eq phone_setup_path
         expect(page).to have_content t(
           'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-          location: 'Bahamas'
+          location: 'Bahamas',
         )
 
         click_on t('two_factor_authentication.choose_another_option')
@@ -123,7 +123,7 @@ feature 'Two Factor Authentication' do
           phone: '+212 661-289324',
           otp_created_at: user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.verify_message',
-          locale: 'ar'
+          locale: 'ar',
         )
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end
@@ -269,7 +269,7 @@ feature 'Two Factor Authentication' do
           user: user,
           attributes: {
             second_factor_locked_at: Time.zone.now - (lockout_period + 1.minute),
-          }
+          },
         ).call
 
         sign_in_user(user)
@@ -352,7 +352,7 @@ feature 'Two Factor Authentication' do
         expect(current_path).to eq account_path
 
         phone_fingerprint = Pii::Fingerprinter.fingerprint(
-          MfaContext.new(user).phone_configurations.first.phone
+          MfaContext.new(user).phone_configurations.first.phone,
         )
         rate_limited_phone = OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint)
 
@@ -391,7 +391,7 @@ feature 'Two Factor Authentication' do
         sign_in_before_2fa(second_user)
         click_link t('links.two_factor_authentication.get_another_code')
         phone_fingerprint = Pii::Fingerprinter.fingerprint(
-          MfaContext.new(first_user).phone_configurations.first.phone
+          MfaContext.new(first_user).phone_configurations.first.phone,
         )
         rate_limited_phone = OtpRequestsTracker.find_by(phone_fingerprint: phone_fingerprint)
 
@@ -565,7 +565,7 @@ feature 'Two Factor Authentication' do
           phone: '+212 661-289324',
           otp_created_at: user.direct_otp_sent_at.to_s,
           message: 'jobs.sms_otp_sender_job.login_message',
-          locale: 'ar'
+          locale: 'ar',
         )
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
       end

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -35,7 +35,7 @@ feature 'Signing in via one-time use personal key' do
       click_submit_default
 
       expect(page).to have_content(
-        t('two_factor_authentication.max_personal_key_login_attempts_reached')
+        t('two_factor_authentication.max_personal_key_login_attempts_reached'),
       )
     end
   end

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -14,7 +14,7 @@ feature 'PIV/CAC Management' do
     context 'with an account allowed to use piv/cac' do
       before(:each) do
         allow_any_instance_of(
-          TwoFactorAuthentication::PivCacPolicy
+          TwoFactorAuthentication::PivCacPolicy,
         ).to receive(:available?).and_return(true)
       end
 
@@ -114,7 +114,7 @@ feature 'PIV/CAC Management' do
     context 'with an account not allowed to use piv/cac' do
       before(:each) do
         allow_any_instance_of(
-          TwoFactorAuthentication::PivCacPolicy
+          TwoFactorAuthentication::PivCacPolicy,
         ).to receive(:available?).and_return(false)
       end
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -171,7 +171,7 @@ def expect_to_be_back_on_manage_personal_key_page_with_continue_button_in_focus
     "//div[@id='personal-key-confirm'][@class='display-none']", visible: false
   )
   expect(page.evaluate_script('document.activeElement.value')).to eq(
-    t('forms.buttons.continue')
+    t('forms.buttons.continue'),
   )
 end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -148,7 +148,7 @@ feature 'Sign in' do
       fill_in 'Email', with: 'test@example.com'
 
       expect(page).to have_content(
-        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes),
       )
       expect(page).to have_field('Email', with: '')
       expect(current_url).to match Regexp.escape(sign_up_email_path(request_id: '123abc'))
@@ -159,7 +159,7 @@ feature 'Sign in' do
 
       visit root_path
       expect(page).to_not have_content(
-        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes),
       )
     end
   end
@@ -199,7 +199,7 @@ feature 'Sign in' do
       fill_in 'Password', with: user.password
 
       expect(page).to have_content(
-        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+        t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes),
       )
       expect(find_field('Email').value).to be_blank
       expect(find_field('Password').value).to be_blank
@@ -332,7 +332,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'Bermuda'
+        location: 'Bermuda',
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end
@@ -353,7 +353,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India'
+        location: 'India',
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end
@@ -367,7 +367,7 @@ feature 'Sign in' do
                     otp_delivery_preference: 'sms', with: { phone: '+91 1234567890' })
       signin(user.email, user.password)
       visit otp_send_path(
-        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true }
+        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true },
       )
 
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
@@ -376,7 +376,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India'
+        location: 'India',
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end
@@ -390,7 +390,7 @@ feature 'Sign in' do
                     otp_delivery_preference: 'voice', with: { phone: '+91 1234567890' })
       signin(user.email, user.password)
       visit otp_send_path(
-        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true }
+        otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true },
       )
 
       expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
@@ -399,7 +399,7 @@ feature 'Sign in' do
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
         'two_factor_authentication.otp_delivery_preference.phone_unsupported',
-        location: 'India'
+        location: 'India',
       )
       expect(user.reload.otp_delivery_preference).to eq 'sms'
     end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -139,7 +139,7 @@ feature 'Sign Up' do
 
     expect(page).to have_current_path two_factor_options_path
     expect(page).not_to have_content(
-      t('two_factor_authentication.two_factor_choice_options.piv_cac')
+      t('two_factor_authentication.two_factor_choice_options.piv_cac'),
     )
   end
 

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -9,7 +9,7 @@ feature 'verify profile with OTP' do
       :profile,
       deactivation_reason: :verification_pending,
       pii: { ssn: '666-66-1234', dob: '1920-01-01', phone: '+1 703-555-9999' },
-      user: user
+      user: user,
     )
     otp_fingerprint = Pii::Fingerprinter.fingerprint(otp)
     create(:usps_confirmation_code, profile: profile, otp_fingerprint: otp_fingerprint)

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -28,13 +28,13 @@ feature 'Email confirmation during sign up' do
       expect { sign_up_with(email) }.
         to change { ActionMailer::Base.deliveries.count }.by(1)
       expect(last_email.html_part.body).to have_content(
-        t('devise.mailer.confirmation_instructions.subject')
+        t('devise.mailer.confirmation_instructions.subject'),
       )
 
       expect { sign_up_with(email) }.
         to change { ActionMailer::Base.deliveries.count }.by(1)
       expect(last_email.html_part.body).to have_content(
-        t('devise.mailer.confirmation_instructions.subject')
+        t('devise.mailer.confirmation_instructions.subject'),
       )
     end
   end
@@ -47,10 +47,10 @@ feature 'Email confirmation during sign up' do
         to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(last_email.html_part.body).to have_content(
-        t('devise.mailer.confirmation_instructions.subject')
+        t('devise.mailer.confirmation_instructions.subject'),
       )
       expect(page).to have_content(
-        t('notices.resend_confirmation_email.success')
+        t('notices.resend_confirmation_email.success'),
       )
     end
   end

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -88,7 +88,7 @@ feature 'Internationalization' do
       %w[en es fr].each do |locale|
         expect(page).to_not have_link(
           t("i18n.locale.#{locale}"),
-          href: "http://test.com/#{locale}"
+          href: "http://test.com/#{locale}",
         )
       end
     end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -21,8 +21,8 @@ feature 'Password Recovery' do
       expect(last_email.html_part.body).to have_content(
         t(
           'mailer.reset_password.footer',
-          expires: (Devise.reset_password_within / 3600)
-        )
+          expires: (Devise.reset_password_within / 3600),
+        ),
       )
 
       open_last_email

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -15,7 +15,7 @@ feature 'Phone confirmation during sign up' do
         phone: '+1 703-555-5555',
         otp_created_at: @user.direct_otp_sent_at.to_s,
         message: 'jobs.sms_otp_sender_job.verify_message',
-        locale: nil
+        locale: nil,
       )
     end
 

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -42,7 +42,7 @@ feature 'Visitor signs up with email address' do
         to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(last_email.html_part.body).to have_content(
-        t('user_mailer.signup_with_your_email.intro', app: APP_NAME)
+        t('user_mailer.signup_with_your_email.intro', app: APP_NAME),
       )
     end
   end

--- a/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
+++ b/spec/forms/idv/phone_confirmation_otp_verification_form_spec.rb
@@ -16,7 +16,7 @@ describe Idv::PhoneConfirmationOtpVerificationForm do
   describe '#submit' do
     def try_submit(code)
       described_class.new(
-        user: user, idv_session: idv_session
+        user: user, idv_session: idv_session,
       ).submit(code: code)
     end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
       scope: scope,
       state: state,
       code_challenge: code_challenge,
-      code_challenge_method: code_challenge_method
+      code_challenge_method: code_challenge_method,
     )
   end
 

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenidConnectLogoutForm do
     IdTokenBuilder.new(
       identity: identity,
       code: code,
-      custom_expiration: 1.day.from_now.to_i
+      custom_expiration: 1.day.from_now.to_i,
     ).id_token
   end
 
@@ -26,7 +26,7 @@ RSpec.describe OpenidConnectLogoutForm do
     OpenidConnectLogoutForm.new(
       id_token_hint: id_token_hint,
       post_logout_redirect_uri: post_logout_redirect_uri,
-      state: state
+      state: state,
     )
   end
 
@@ -120,7 +120,7 @@ RSpec.describe OpenidConnectLogoutForm do
           IdTokenBuilder.new(
             identity: identity,
             code: code,
-            custom_expiration: 5.days.ago.to_i
+            custom_expiration: 5.days.ago.to_i,
           ).id_token
         end
 

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe OpenidConnectTokenForm do
         nonce: nonce,
         rails_session_id: SecureRandom.hex,
         ial: 1,
-        code_challenge: code_challenge
+        code_challenge: code_challenge,
       )
   end
 
@@ -118,7 +118,7 @@ RSpec.describe OpenidConnectTokenForm do
           it 'is invalid' do
             expect(valid?).to eq(false)
             expect(form.errors[:client_assertion]).to include(
-              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url)
+              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url),
             )
           end
         end
@@ -129,7 +129,7 @@ RSpec.describe OpenidConnectTokenForm do
           it 'is invalid' do
             expect(valid?).to eq(false)
             expect(form.errors[:client_assertion]).to include(
-              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url)
+              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url),
             )
           end
         end
@@ -140,7 +140,7 @@ RSpec.describe OpenidConnectTokenForm do
           it 'is invalid' do
             expect(valid?).to eq(false)
             expect(form.errors[:client_assertion]).to include(
-              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url)
+              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url),
             )
           end
         end

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -6,7 +6,7 @@ describe OtpDeliverySelectionForm do
     OtpDeliverySelectionForm.new(
       build_stubbed(:user),
       phone_to_deliver_to,
-      'authentication'
+      'authentication',
     )
   end
 
@@ -57,7 +57,7 @@ describe OtpDeliverySelectionForm do
         subject = OtpDeliverySelectionForm.new(
           build_stubbed(:user),
           nil,
-          'authentication'
+          'authentication',
         )
 
         expect(FormResponse).to receive(:new).
@@ -72,7 +72,7 @@ describe OtpDeliverySelectionForm do
         form = OtpDeliverySelectionForm.new(
           user,
           '+12423270143',
-          'authentication'
+          'authentication',
         )
         attributes = { otp_delivery_preference: 'sms' }
 
@@ -92,7 +92,7 @@ describe OtpDeliverySelectionForm do
         form = OtpDeliverySelectionForm.new(
           user,
           '+17035551212',
-          'authentication'
+          'authentication',
         )
 
         expect(UpdateUser).to_not receive(:new)

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -23,7 +23,7 @@ describe PersonalKeyForm do
           :user,
           :with_phone,
           email: 'jonny.hoops@gsa.gov',
-          with: { phone: '+1 (202) 345-6789' }
+          with: { phone: '+1 (202) 345-6789' },
         )
         raw_code = PersonalKeyGenerator.new(user).create
 

--- a/spec/forms/sms_form_spec.rb
+++ b/spec/forms/sms_form_spec.rb
@@ -8,7 +8,7 @@ describe SmsForm do
     before do
       # Only testing our validation here; service spec tests Twilio msg failing
       allow_any_instance_of(Twilio::Security::RequestValidator).to(
-        receive(:validate).and_return(true)
+        receive(:validate).and_return(true),
       )
     end
 

--- a/spec/forms/two_factor_authentication/phone_deletion_form_spec.rb
+++ b/spec/forms/two_factor_authentication/phone_deletion_form_spec.rb
@@ -19,7 +19,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
           configuration_present: true,
           configuration_id: configuration.id,
           configuration_owner: user.uuid,
-          mfa_method_counts: { phone: 1 }
+          mfa_method_counts: { phone: 1 },
         )
       end
 
@@ -44,7 +44,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
           configuration_present: true,
           configuration_id: configuration.id,
           configuration_owner: user.uuid,
-          mfa_method_counts: { piv_cac: 1 }
+          mfa_method_counts: { piv_cac: 1 },
         )
       end
 
@@ -66,7 +66,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
           configuration_present: false,
           configuration_id: nil,
           configuration_owner: nil,
-          mfa_method_counts: { phone: 1, piv_cac: 1 }
+          mfa_method_counts: { phone: 1, piv_cac: 1 },
         )
       end
 
@@ -89,7 +89,7 @@ describe TwoFactorAuthentication::PhoneDeletionForm do
           configuration_present: true,
           configuration_id: configuration.id,
           configuration_owner: other_user.uuid,
-          mfa_method_counts: { phone: 1, piv_cac: 1 }
+          mfa_method_counts: { phone: 1, piv_cac: 1 },
         )
       end
 

--- a/spec/forms/two_factor_login_options_form_spec.rb
+++ b/spec/forms/two_factor_login_options_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe TwoFactorLoginOptionsForm do
   subject do
     TwoFactorLoginOptionsForm.new(
-      build_stubbed(:user)
+      build_stubbed(:user),
     )
   end
 

--- a/spec/forms/two_factor_options_form_spec.rb
+++ b/spec/forms/two_factor_options_form_spec.rb
@@ -27,7 +27,7 @@ describe TwoFactorOptionsForm do
           to receive(:new).
           with(
             user: user,
-            attributes: { otp_delivery_preference: 'voice' }
+            attributes: { otp_delivery_preference: 'voice' },
           ).
           and_return(user_updater)
         expect(user_updater).to receive(:call)

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -66,7 +66,7 @@ describe UserPhoneForm do
         result = subject.submit(params)
 
         expect(result.extra).to eq(
-          otp_delivery_preference: params[:otp_delivery_preference]
+          otp_delivery_preference: params[:otp_delivery_preference],
         )
       end
 

--- a/spec/forms/verify_account_form_spec.rb
+++ b/spec/forms/verify_account_form_spec.rb
@@ -18,7 +18,7 @@ describe VerifyAccountForm do
       :usps_confirmation_code,
       otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
       code_sent_at: code_sent_at,
-      profile: pending_profile
+      profile: pending_profile,
     )
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,7 +34,7 @@ describe ApplicationHelper do
       context 'current path is email confirmation path' do
         it 'returns true' do
           allow(helper).to receive(:current_page?).with(
-            controller: 'sign_up/passwords', action: 'new'
+            controller: 'sign_up/passwords', action: 'new',
           ).and_return(true)
 
           expect(helper.session_with_trust?).to eq true
@@ -44,10 +44,10 @@ describe ApplicationHelper do
       context 'current path is reset password path' do
         it 'returns true' do
           allow(helper).to receive(:current_page?).with(
-            controller: 'sign_up/passwords', action: 'new'
+            controller: 'sign_up/passwords', action: 'new',
           ).and_return(true)
           allow(helper).to receive(:current_page?).with(
-            controller: 'users/reset_passwords', action: 'edit'
+            controller: 'users/reset_passwords', action: 'edit',
           ).and_return(true)
 
           expect(helper.session_with_trust?).to eq true

--- a/spec/helpers/session_timeout_warning_helper_spec.rb
+++ b/spec/helpers/session_timeout_warning_helper_spec.rb
@@ -26,8 +26,8 @@ describe SessionTimeoutWarningHelper do
         ActionDispatch::Request.new(
           'HTTP_HOST' => http_host,
           'PATH_INFO' => path_info,
-          'rack.url_scheme' => 'https'
-        )
+          'rack.url_scheme' => 'https',
+        ),
       )
     end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'I18n' do
   it 'does not have missing keys' do
     expect(missing_keys).to(
       be_empty,
-      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them",
     )
   end
 
   it 'does not have unused keys' do
     expect(unused_keys).to(
       be_empty,
-      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them",
     )
   end
 

--- a/spec/jobs/sms_account_reset_cancellation_notifier_job_spec.rb
+++ b/spec/jobs/sms_account_reset_cancellation_notifier_job_spec.rb
@@ -12,7 +12,7 @@ describe SmsAccountResetCancellationNotifierJob do
 
     subject(:perform) do
       SmsAccountResetCancellationNotifierJob.perform_now(
-        phone: '+1 (888) 555-5555'
+        phone: '+1 (888) 555-5555',
       )
     end
 

--- a/spec/jobs/sms_account_reset_notifier_job_spec.rb
+++ b/spec/jobs/sms_account_reset_notifier_job_spec.rb
@@ -14,7 +14,7 @@ describe SmsAccountResetNotifierJob do
     subject(:perform) do
       SmsAccountResetNotifierJob.perform_now(
         phone: '+1 (888) 555-5555',
-        token: 'UUID1'
+        token: 'UUID1',
       )
     end
 

--- a/spec/jobs/sms_otp_sender_job_spec.rb
+++ b/spec/jobs/sms_otp_sender_job_spec.rb
@@ -15,7 +15,7 @@ describe SmsOtpSenderJob do
         code: '1234',
         phone: '+1 (888) 555-5555',
         message: 'jobs.sms_otp_sender_job.login_message',
-        otp_created_at: otp_created_at
+        otp_created_at: otp_created_at,
       )
     end
 
@@ -38,7 +38,7 @@ describe SmsOtpSenderJob do
       expect(msg.to).to eq('+1 (888) 555-5555')
       expect(msg.body).to eq(
         I18n.t('jobs.sms_otp_sender_job.login_message',
-               code: '1234', app: APP_NAME, expiration: '10')
+               code: '1234', app: APP_NAME, expiration: '10'),
       )
     end
 
@@ -51,7 +51,7 @@ describe SmsOtpSenderJob do
         code: '1234',
         phone: '+1 (888) 555-5555',
         message: 'jobs.sms_otp_sender_job.verify_message',
-        otp_created_at: otp_created_at
+        otp_created_at: otp_created_at,
       )
 
       messages = FakeSms.messages
@@ -126,7 +126,7 @@ describe SmsOtpSenderJob do
           phone: phone,
           otp_created_at: otp_created_at,
           message: nil,
-          locale: locale
+          locale: locale,
         )
       end
     end
@@ -143,8 +143,8 @@ describe SmsOtpSenderJob do
           to: phone,
           body: I18n.t(
             'jobs.sms_otp_sender_job.login_message',
-            code: code, app: APP_NAME, expiration: Devise.direct_otp_valid_for.to_i / 60
-          )
+            code: code, app: APP_NAME, expiration: Devise.direct_otp_valid_for.to_i / 60,
+          ),
         )
 
         SmsOtpSenderJob.perform_now(
@@ -152,7 +152,7 @@ describe SmsOtpSenderJob do
           phone: phone,
           otp_created_at: otp_created_at,
           message: 'jobs.sms_otp_sender_job.login_message',
-          locale: 'fr'
+          locale: 'fr',
         )
       end
     end

--- a/spec/jobs/sms_reply_sender_job_spec.rb
+++ b/spec/jobs/sms_reply_sender_job_spec.rb
@@ -17,7 +17,7 @@ describe SmsReplySenderJob do
     subject(:perform) do
       SmsReplySenderJob.perform_now(
         to: phone,
-        body: body
+        body: body,
       )
     end
 

--- a/spec/jobs/voice_otp_sender_job_spec.rb
+++ b/spec/jobs/voice_otp_sender_job_spec.rb
@@ -16,7 +16,7 @@ describe VoiceOtpSenderJob do
         VoiceOtpSenderJob.perform_now(
           code: '1234',
           phone: '555-5555',
-          otp_created_at: Time.zone.now.to_s
+          otp_created_at: Time.zone.now.to_s,
         )
       end
 
@@ -41,7 +41,7 @@ describe VoiceOtpSenderJob do
         VoiceOtpSenderJob.perform_now(
           code: '1234',
           phone: '555-5555',
-          otp_created_at: Time.zone.now.to_s
+          otp_created_at: Time.zone.now.to_s,
         )
       end
 
@@ -71,7 +71,7 @@ describe VoiceOtpSenderJob do
       VoiceOtpSenderJob.perform_now(
         code: '1234',
         phone: '555-5555',
-        otp_created_at: otp_expiration_period.ago.to_s
+        otp_created_at: otp_expiration_period.ago.to_s,
       )
 
       calls = FakeVoiceCall.calls

--- a/spec/lib/aws/ses_spec.rb
+++ b/spec/lib/aws/ses_spec.rb
@@ -5,7 +5,7 @@ describe Aws::SES::Base do
     Mail.new(
       to: 'asdf@example.com',
       cc: 'ghjk@example.com',
-      body: 'asdf1234'
+      body: 'asdf1234',
     )
   end
   let(:ses_response) do
@@ -29,7 +29,7 @@ describe Aws::SES::Base do
       expect(ses_client).to have_received(:send_raw_email).with(
         raw_message: {
           data: raw_mail_data,
-        }
+        },
       )
     end
 

--- a/spec/lib/cloudhsm_jwt_spec.rb
+++ b/spec/lib/cloudhsm_jwt_spec.rb
@@ -56,7 +56,7 @@ describe CloudhsmJwt do
     allow(MockSession).to receive_message_chain(:find_objects, :first).and_return(true)
     allow(MockSession).to receive(:sign) do |_algorithm, _key, input|
       JWT::Algos::Rsa.sign(
-        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key)
+        JWT::Signature::ToSign.new('RS256', input, RequestKeyManager.private_key),
       )
     end
     allow(SamlIdp).

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -10,7 +10,7 @@ describe ConfigValidator do
         'other_bad_key' => 'no',
         'up_bad_key' => 'YES   ',
         'cap_bad_key' => ' No',
-        'noncandidate_key' => 'yes'
+        'noncandidate_key' => 'yes',
       )
 
       mimic_figaro
@@ -20,7 +20,7 @@ describe ConfigValidator do
 
       expect { ConfigValidator.new.validate(env) }.to raise_error(
         RuntimeError,
-        %r{You have invalid values \(yes\/no\) for #{list}}
+        %r{You have invalid values \(yes\/no\) for #{list}},
       )
     end
 

--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -35,7 +35,7 @@ describe Deploy::Activate do
       s3_client.put_object(
         bucket: 'login-gov.app-secrets.12345-us-west-1',
         key: '/int/idp/v1/application.yml',
-        body: application_yml
+        body: application_yml,
       )
 
       FileUtils.mkdir_p('/etc/login.gov/info')

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -19,7 +19,7 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.email_changed.intro', app: APP_NAME)
+        t('user_mailer.email_changed.intro', app: APP_NAME),
       )
       expect_email_body_to_have_help_and_contact_links
     end
@@ -40,7 +40,7 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.password_changed.intro', app: APP_NAME)
+        t('user_mailer.password_changed.intro', app: APP_NAME),
       )
       expect_email_body_to_have_help_and_contact_links
     end
@@ -61,7 +61,7 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.personal_key_sign_in.intro')
+        t('user_mailer.personal_key_sign_in.intro'),
       )
     end
   end
@@ -81,7 +81,7 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.personal_key_regenerated.intro')
+        t('user_mailer.personal_key_regenerated.intro'),
       )
     end
   end
@@ -103,8 +103,8 @@ describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to have_content(
         I18n.t(
           'user_mailer.signup_with_your_email.intro',
-          app: APP_NAME
-        )
+          app: APP_NAME,
+        ),
       )
       expect_email_body_to_have_help_and_contact_links
     end
@@ -133,7 +133,7 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.phone_changed.intro', app: APP_NAME)
+        t('user_mailer.phone_changed.intro', app: APP_NAME),
       )
       expect_email_body_to_have_help_and_contact_links
     end
@@ -154,11 +154,11 @@ describe UserMailer, type: :mailer do
 
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
-        t('user_mailer.account_does_not_exist.intro', app: APP_NAME)
+        t('user_mailer.account_does_not_exist.intro', app: APP_NAME),
       )
       expect(mail.html_part.body).to have_link(
         t('user_mailer.account_does_not_exist.link_text', app: APP_NAME),
-        href: sign_up_email_url(request_id: 'request_id')
+        href: sign_up_email_url(request_id: 'request_id'),
       )
     end
   end
@@ -190,8 +190,8 @@ describe UserMailer, type: :mailer do
       reset_text = t('user_mailer.account_reset_granted.cancel_link_text')
       expect(mail.html_part.body).to have_content(
         strip_tags(
-          t('user_mailer.account_reset_request.intro', cancel_account_reset: reset_text)
-        )
+          t('user_mailer.account_reset_request.intro', cancel_account_reset: reset_text),
+        ),
       )
     end
   end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -5,7 +5,7 @@ describe Identity do
   let(:identity) do
     Identity.create(
       user_id: user.id,
-      service_provider: 'externalapp'
+      service_provider: 'externalapp',
     )
   end
   subject { identity }
@@ -88,7 +88,7 @@ describe Identity do
   let(:identity_with_sp) do
     Identity.create(
       user_id: user.id,
-      service_provider: service_provider.issuer
+      service_provider: service_provider.issuer,
     )
   end
 

--- a/spec/models/otp_requests_tracker_spec.rb
+++ b/spec/models/otp_requests_tracker_spec.rb
@@ -10,7 +10,7 @@ describe OtpRequestsTracker do
         OtpRequestsTracker.create(
           phone_fingerprint: phone_fingerprint,
           otp_send_count: 3,
-          otp_last_sent_at: Time.zone.now - 1.hour
+          otp_last_sent_at: Time.zone.now - 1.hour,
         )
 
         existing = OtpRequestsTracker.where(phone_fingerprint: phone_fingerprint).first
@@ -54,7 +54,7 @@ describe OtpRequestsTracker do
       old_ort = OtpRequestsTracker.create(
         phone_fingerprint: phone_fingerprint,
         otp_send_count: 3,
-        otp_last_sent_at: Time.zone.now - 1.hour
+        otp_last_sent_at: Time.zone.now - 1.hour,
       )
       new_ort = OtpRequestsTracker.atomic_increment(old_ort.id)
       expect(new_ort.otp_last_sent_at).to be > old_ort.otp_last_sent_at
@@ -64,7 +64,7 @@ describe OtpRequestsTracker do
       old_ort = OtpRequestsTracker.create(
         phone_fingerprint: phone_fingerprint,
         otp_send_count: 3,
-        otp_last_sent_at: Time.zone.now
+        otp_last_sent_at: Time.zone.now,
       )
       new_ort = OtpRequestsTracker.atomic_increment(old_ort.id)
       expect(new_ort.otp_send_count - 1).to eq(old_ort.otp_send_count)

--- a/spec/models/password_metric_spec.rb
+++ b/spec/models/password_metric_spec.rb
@@ -16,7 +16,7 @@ describe PasswordMetric do
         PasswordMetric.create(
           metric: 'length',
           value: 9.0,
-          count: 2
+          count: 2,
         )
       end
 
@@ -33,7 +33,7 @@ describe PasswordMetric do
         PasswordMetric.create(
           metric: 'length',
           value: 10.0,
-          count: 1
+          count: 1,
         )
       end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -9,7 +9,7 @@ describe Profile do
       dob: '1920-01-01',
       ssn: '666-66-1234',
       first_name: 'Jane',
-      last_name: 'Doe'
+      last_name: 'Doe',
     )
   end
 

--- a/spec/models/service_provider_request_spec.rb
+++ b/spec/models/service_provider_request_spec.rb
@@ -5,7 +5,7 @@ describe ServiceProviderRequest do
     context 'when the record exists' do
       it 'returns the record matching the uuid' do
         sp_request = ServiceProviderRequest.create(
-          uuid: '123', issuer: 'foo', url: 'http://bar.com', loa: '1'
+          uuid: '123', issuer: 'foo', url: 'http://bar.com', loa: '1',
         )
 
         expect(ServiceProviderRequest.from_uuid('123')).to eq sp_request

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -59,7 +59,7 @@ describe ServiceProvider do
         }
 
         yaml_attributes = ServiceProviderConfig.new(
-          issuer: 'http://localhost:3000'
+          issuer: 'http://localhost:3000',
         ).sp_attributes
 
         expect(service_provider.metadata).to eq yaml_attributes.merge!(fingerprint)
@@ -88,7 +88,7 @@ describe ServiceProvider do
 
       it 'calls with the user email' do
         expect(PivCacService).to receive(
-          :piv_cac_available_for_sp?
+          :piv_cac_available_for_sp?,
         ).with(service_provider, user.email_addresses.map(&:email))
 
         service_provider.piv_cac_available?(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -128,7 +128,7 @@ describe User do
 
       it 'is true when the correct valud is provided' do
         expect(
-          MfaContext.new(user).piv_cac_configuration.mfa_confirmed?(user.x509_dn_uuid)
+          MfaContext.new(user).piv_cac_configuration.mfa_confirmed?(user.x509_dn_uuid),
         ).to be_truthy
       end
     end
@@ -146,7 +146,7 @@ describe User do
 
       it 'is false when the user x509_dn_uuid value is provided' do
         expect(
-          MfaContext.new(user).piv_cac_configuration.mfa_confirmed?(user.x509_dn_uuid)
+          MfaContext.new(user).piv_cac_configuration.mfa_confirmed?(user.x509_dn_uuid),
         ).to be_falsey
       end
     end
@@ -231,12 +231,12 @@ describe User do
       user.identities << Identity.create(
         service_provider: 'first',
         last_authenticated_at: Time.zone.now - 1.hour,
-        session_uuid: SecureRandom.uuid
+        session_uuid: SecureRandom.uuid,
       )
       user.identities << Identity.create(
         service_provider: 'last',
         last_authenticated_at: Time.zone.now,
-        session_uuid: SecureRandom.uuid
+        session_uuid: SecureRandom.uuid,
       )
     end
 
@@ -269,7 +269,7 @@ describe User do
     it 'does not delete identities when the user is destroyed preventing uuid reuse' do
       user = create(:user, :signed_up)
       user.identities << Identity.create(
-        service_provider: 'entity_id', session_uuid: SecureRandom.uuid
+        service_provider: 'entity_id', session_uuid: SecureRandom.uuid,
       )
       user_id = user.id
       user.destroy!

--- a/spec/models/usps_confirmation_code_spec.rb
+++ b/spec/models/usps_confirmation_code_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UspsConfirmationCode do
       create(:usps_confirmation_code)
       good_confirmation_code = create(
         :usps_confirmation_code,
-        otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+        otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
       )
 
       expect(described_class.first_with_otp(otp)).to eq(good_confirmation_code)
@@ -18,7 +18,7 @@ RSpec.describe UspsConfirmationCode do
     it 'normalizes the entered otp before searching' do
       confirmation_code = create(
         :usps_confirmation_code,
-        otp_fingerprint: Pii::Fingerprinter.fingerprint('ABC000')
+        otp_fingerprint: Pii::Fingerprinter.fingerprint('ABC000'),
       )
 
       expect(described_class.first_with_otp('abcooo')).to eq(confirmation_code)
@@ -35,7 +35,7 @@ RSpec.describe UspsConfirmationCode do
     it 'returns false for a valid otp' do
       confirmation_code = build(
         :usps_confirmation_code,
-        code_sent_at: Time.zone.now
+        code_sent_at: Time.zone.now,
       )
 
       expect(confirmation_code.expired?).to eq(false)
@@ -44,7 +44,7 @@ RSpec.describe UspsConfirmationCode do
     it 'returns true for an expired otp' do
       confirmation_code = build(
         :usps_confirmation_code,
-        code_sent_at: (Figaro.env.usps_confirmation_max_days.to_i + 1).days.ago
+        code_sent_at: (Figaro.env.usps_confirmation_max_days.to_i + 1).days.ago,
       )
 
       expect(confirmation_code.expired?).to eq(true)

--- a/spec/models/webauthn_configuration_spec.rb
+++ b/spec/models/webauthn_configuration_spec.rb
@@ -16,7 +16,7 @@ describe WebauthnConfiguration do
       presenters = subject.selection_presenters
       expect(presenters.count).to eq 1
       expect(presenters.first).to be_instance_of(
-        TwoFactorAuthentication::WebauthnSelectionPresenter
+        TwoFactorAuthentication::WebauthnSelectionPresenter,
       )
     end
   end

--- a/spec/policies/two_factor_authentication/piv_cac_policy_spec.rb
+++ b/spec/policies/two_factor_authentication/piv_cac_policy_spec.rb
@@ -27,7 +27,7 @@ describe TwoFactorAuthentication::PivCacPolicy do
         let(:identity_with_sp) do
           Identity.create(
             user_id: user.id,
-            service_provider: service_provider.issuer
+            service_provider: service_provider.issuer,
           )
         end
 
@@ -75,7 +75,7 @@ describe TwoFactorAuthentication::PivCacPolicy do
 
         before(:each) do
           allow(PivCacService).to receive(:piv_cac_available_for_email?).with(
-            user.email_addresses.map(&:email)
+            user.email_addresses.map(&:email),
           ).and_return(true)
         end
 
@@ -89,7 +89,7 @@ describe TwoFactorAuthentication::PivCacPolicy do
 
         before(:each) do
           allow(PivCacService).to receive(:piv_cac_available_for_email?).with(
-            user.email_addresses.map(&:email)
+            user.email_addresses.map(&:email),
           ).and_return(false)
         end
 

--- a/spec/presenters/eastern_time_presenter_spec.rb
+++ b/spec/presenters/eastern_time_presenter_spec.rb
@@ -7,7 +7,7 @@ describe EasternTimePresenter do
       timestamp = Time.zone.parse(str)
 
       expect(EasternTimePresenter.new(timestamp).to_s).to eq(
-        'April 12, 2017 at 2:19 PM (Eastern)'
+        'April 12, 2017 at 2:19 PM (Eastern)',
       )
     end
   end

--- a/spec/presenters/idv/attempt_failure_presenter_spec.rb
+++ b/spec/presenters/idv/attempt_failure_presenter_spec.rb
@@ -6,7 +6,7 @@ describe Idv::AttemptFailurePresenter do
   let(:presenter) do
     described_class.new(
       remaining_attempts: remaining_attempts,
-      step_name: step_name
+      step_name: step_name,
     )
   end
 

--- a/spec/presenters/idv/usps_presenter_spec.rb
+++ b/spec/presenters/idv/usps_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Idv::UspsPresenter do
     context 'a letter has not been sent' do
       it 'provides text to send' do
         expect(subject.title).to eq(
-          I18n.t('idv.titles.mail.verify')
+          I18n.t('idv.titles.mail.verify'),
         )
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe Idv::UspsPresenter do
       it 'provides text to resend' do
         create_letter_send_event
         expect(subject.title).to eq(
-          I18n.t('idv.titles.mail.resend')
+          I18n.t('idv.titles.mail.resend'),
         )
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Idv::UspsPresenter do
     context 'a letter has not been sent' do
       it 'provides text to send' do
         expect(subject.button).to eq(
-          I18n.t('idv.buttons.mail.send')
+          I18n.t('idv.buttons.mail.send'),
         )
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Idv::UspsPresenter do
       it 'provides text to resend' do
         create_letter_send_event
         expect(subject.button).to eq(
-          I18n.t('idv.buttons.mail.resend')
+          I18n.t('idv.buttons.mail.resend'),
         )
       end
     end

--- a/spec/presenters/idv/warning_presenter_spec.rb
+++ b/spec/presenters/idv/warning_presenter_spec.rb
@@ -10,7 +10,7 @@ describe Idv::WarningPresenter do
       reason: reason,
       remaining_attempts: remaining_attempts,
       step_name: step_name,
-      view_context: view_context
+      view_context: view_context,
     )
   end
 

--- a/spec/presenters/max_attempts_reached_presenter_spec.rb
+++ b/spec/presenters/max_attempts_reached_presenter_spec.rb
@@ -41,7 +41,7 @@ describe TwoFactorAuthCode::MaxAttemptsReachedPresenter do
         [
           presenter.send(:please_try_again),
           presenter.send(:read_about_two_factor_authentication),
-        ]
+        ],
       )
     end
   end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
                 street_address: '123 Fake St Apt 456',
                 locality: 'Washington',
                 region: 'DC',
-                postal_code: '12345'
+                postal_code: '12345',
               )
               expect(user_info[:social_security_number]).to eq('666661234')
             end

--- a/spec/presenters/saml_request_presenter_spec.rb
+++ b/spec/presenters/saml_request_presenter_spec.rb
@@ -35,7 +35,7 @@ describe SamlRequestPresenter do
         service_provider = ServiceProvider.new(
           attribute_bundle: %w[
             email first_name middle_name last_name dob foo ssn phone
-          ]
+          ],
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
         valid_attributes = %i[
@@ -55,7 +55,7 @@ describe SamlRequestPresenter do
         allow(parser).to receive(:requested_attributes).and_return(nil)
 
         service_provider = ServiceProvider.new(
-          attribute_bundle: %w[address1 address2 city state zipcode]
+          attribute_bundle: %w[address1 address2 city state zipcode],
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -20,13 +20,13 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
   let(:presenter) do
     TwoFactorAuthCode::PhoneDeliveryPresenter.new(
       data: data,
-      view: view
+      view: view,
     )
   end
 
   it 'is a subclass of GenericDeliveryPresenter' do
     expect(TwoFactorAuthCode::PhoneDeliveryPresenter.superclass).to(
-      be(TwoFactorAuthCode::GenericDeliveryPresenter)
+      be(TwoFactorAuthCode::GenericDeliveryPresenter),
     )
   end
 
@@ -51,7 +51,7 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       text = t(
         'instructions.mfa.sms.number_message',
         number: "<strong>#{data[:phone_number]}</strong>",
-        expiration: Figaro.env.otp_valid_for
+        expiration: Figaro.env.otp_valid_for,
       )
       expect(presenter.phone_number_message).to eq text
     end

--- a/spec/presenters/two_factor_auth_code/totpable.spec.rb
+++ b/spec/presenters/two_factor_auth_code/totpable.spec.rb
@@ -24,7 +24,7 @@ describe TwoFactorAuthCode::Totpable do
         link = '<a href="/login/two_factor/authenticator">authentication app</a>'
 
         expect(actual).to eq(
-          t('links.phone_confirmation.auth_app_fallback_html', link: link)
+          t('links.phone_confirmation.auth_app_fallback_html', link: link),
         )
       end
     end

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -30,7 +30,7 @@ describe TwoFactorLoginOptionsPresenter do
       t('two_factor_authentication.account_reset.pending_html',
         cancel_link: view.link_to(
           t('two_factor_authentication.account_reset.cancel_link'),
-          account_reset_cancel_url(token: 'foo')
+          account_reset_cancel_url(token: 'foo'),
         ))
   end
 
@@ -42,7 +42,7 @@ describe TwoFactorLoginOptionsPresenter do
       t('two_factor_authentication.account_reset.text_html',
         link: view.link_to(
           t('two_factor_authentication.account_reset.link'),
-          account_reset_request_path(locale: LinkLocaleResolver.locale)
+          account_reset_request_path(locale: LinkLocaleResolver.locale),
         ))
   end
 

--- a/spec/presenters/utc_time_presenter_spec.rb
+++ b/spec/presenters/utc_time_presenter_spec.rb
@@ -10,7 +10,7 @@ describe UtcTimePresenter do
       Time.zone = current_timezone
 
       expect(UtcTimePresenter.new(timestamp).to_s).to eq(
-        'April 12, 2017 at 6:19 PM'
+        'April 12, 2017 at 6:19 PM',
       )
     end
   end

--- a/spec/requests/frontend_analytics_spec.rb
+++ b/spec/requests/frontend_analytics_spec.rb
@@ -33,7 +33,7 @@ describe 'frontend analytics requests' do
       expect(analytics).to have_received(:track_event).
         with(
           Analytics::FRONTEND_BROWSER_CAPABILITIES,
-          hash_including(platform_authenticator: false)
+          hash_including(platform_authenticator: false),
         )
     end
 
@@ -46,7 +46,7 @@ describe 'frontend analytics requests' do
       expect(analytics).to have_received(:track_event).
         with(
           Analytics::FRONTEND_BROWSER_CAPABILITIES,
-          hash_including(platform_authenticator: true)
+          hash_including(platform_authenticator: true),
         ).
         once
     end

--- a/spec/requests/i18n_spec.rb
+++ b/spec/requests/i18n_spec.rb
@@ -15,7 +15,7 @@ describe 'i18n requests' do
 
       post root_path(
         locale: :en,
-        params: { user: { email: 'asdf@gmail.com', passowrd: '123abcdef' } }
+        params: { user: { email: 'asdf@gmail.com', passowrd: '123abcdef' } },
       )
       get response.headers['Location']
 

--- a/spec/requests/openid_connect_authorize_spec.rb
+++ b/spec/requests/openid_connect_authorize_spec.rb
@@ -43,7 +43,7 @@ describe 'user signs in partially and visits openid_connect/authorize' do
     get(
       openid_connect_authorize_path,
       params: params,
-      headers: { 'Accept' => '*/*' }
+      headers: { 'Accept' => '*/*' },
     )
   end
 end

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
           :options,
           api_openid_connect_token_path,
           params: {},
-          headers: { 'HTTP_ORIGIN' => 'https://example.com' }
+          headers: { 'HTTP_ORIGIN' => 'https://example.com' },
         )
 
         aggregate_failures do
@@ -96,7 +96,7 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
           :options,
           api_openid_connect_token_path,
           params: {},
-          headers: { 'HTTP_ORIGIN' => 'https://foo.com' }
+          headers: { 'HTTP_ORIGIN' => 'https://foo.com' },
         )
 
         aggregate_failures do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -90,7 +90,7 @@ describe 'throttling requests' do
             'user[email]' => user.email,
             'user[password]' => user.password,
           },
-          headers: { REMOTE_ADDR: '1.2.3.4' }
+          headers: { REMOTE_ADDR: '1.2.3.4' },
         )
 
         requests_per_ip_limit.times do

--- a/spec/requests/sms_spec.rb
+++ b/spec/requests/sms_spec.rb
@@ -23,13 +23,13 @@ describe 'SMS receiving' do
     context 'with required credentials' do
       it 'returns authorized status' do
         allow(Figaro.env).to(
-          receive(:twilio_http_basic_auth_username).and_return(username)
+          receive(:twilio_http_basic_auth_username).and_return(username),
         )
         allow(Figaro.env).to(
-          receive(:twilio_http_basic_auth_password).and_return(password)
+          receive(:twilio_http_basic_auth_password).and_return(password),
         )
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(true)
+          receive(:validate).and_return(true),
         )
 
         post_message(help_message)
@@ -42,17 +42,17 @@ describe 'SMS receiving' do
   describe 'receiving messages' do
     before do
       allow(Figaro.env).to(
-        receive(:twilio_http_basic_auth_username).and_return(username)
+        receive(:twilio_http_basic_auth_username).and_return(username),
       )
       allow(Figaro.env).to(
-        receive(:twilio_http_basic_auth_password).and_return(password)
+        receive(:twilio_http_basic_auth_password).and_return(password),
       )
     end
 
     context 'when failing' do
       it 'does not send a reply and 403s when signature is invalid' do
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(false)
+          receive(:validate).and_return(false),
         )
 
         expect(SmsReplySenderJob).to_not receive(:perform_later)
@@ -64,7 +64,7 @@ describe 'SMS receiving' do
 
       it 'responds with a 200 status when signature is valid' do
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(true)
+          receive(:validate).and_return(true),
         )
 
         expect(SmsReplySenderJob).to_not receive(:perform_later)
@@ -78,7 +78,7 @@ describe 'SMS receiving' do
     context 'when successful' do
       it 'sends a reply' do
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(true)
+          receive(:validate).and_return(true),
         )
 
         expect(SmsReplySenderJob).to receive(:perform_later)
@@ -96,7 +96,7 @@ describe 'SMS receiving' do
     post(
       api_sms_receive_path,
       params: { Body: body },
-      headers: { 'HTTP_AUTHORIZATION': credentials }
+      headers: { 'HTTP_AUTHORIZATION': credentials },
     )
   end
 end

--- a/spec/services/account_reset/cancel_spec.rb
+++ b/spec/services/account_reset/cancel_spec.rb
@@ -32,9 +32,9 @@ describe AccountReset::Cancel do
         AccountReset::Cancel.new(token).call
 
         expect(
-          SmsAccountResetCancellationNotifierJob
+          SmsAccountResetCancellationNotifierJob,
         ).to have_received(:perform_now).with(
-          phone: MfaContext.new(user).phone_configurations.first.phone
+          phone: MfaContext.new(user).phone_configurations.first.phone,
         )
       end
     end

--- a/spec/services/agency_seeder_spec.rb
+++ b/spec/services/agency_seeder_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AgencySeeder do
       before do
         location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
         RemoteSetting.create(
-          name: 'agencies.yml', url: location, contents: "test:\n  1:\n    name: 'CBP'"
+          name: 'agencies.yml', url: location, contents: "test:\n  1:\n    name: 'CBP'",
         )
       end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -46,7 +46,7 @@ describe Analytics do
       analytics = Analytics.new(
         user: current_user,
         request: FakeRequest.new,
-        sp: 'http://localhost:3000'
+        sp: 'http://localhost:3000',
       )
 
       analytics_hash = {

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -9,14 +9,14 @@ describe AttributeAsserter do
     build(
       :identity,
       service_provider: service_provider.issuer,
-      session_uuid: SecureRandom.uuid
+      session_uuid: SecureRandom.uuid,
     )
   end
   let(:service_provider) do
     instance_double(
       ServiceProvider,
       issuer: 'http://localhost:3000',
-      metadata: {}
+      metadata: {},
     )
   end
   let(:raw_loa1_authn_request) { CGI.unescape sp1_authnrequest.split('SAMLRequest').last }
@@ -36,7 +36,7 @@ describe AttributeAsserter do
           user: user,
           service_provider: service_provider,
           authn_request: loa3_authn_request,
-          decrypted_pii: decrypted_pii
+          decrypted_pii: decrypted_pii,
         )
       end
 
@@ -97,7 +97,7 @@ describe AttributeAsserter do
         context 'authn request specifies bundle' do
           let(:raw_loa3_authn_request) do
             CGI.unescape(
-              auth_request.create(loa3_with_bundle_saml_settings).split('SAMLRequest').last
+              auth_request.create(loa3_with_bundle_saml_settings).split('SAMLRequest').last,
             )
           end
 
@@ -123,7 +123,7 @@ describe AttributeAsserter do
       context 'custom bundle has invalid attribute name' do
         before do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
-            %w[email foo]
+            %w[email foo],
           )
           subject.build
         end
@@ -140,7 +140,7 @@ describe AttributeAsserter do
           user: user,
           service_provider: service_provider,
           authn_request: loa1_authn_request,
-          decrypted_pii: decrypted_pii
+          decrypted_pii: decrypted_pii,
         )
       end
 
@@ -182,7 +182,7 @@ describe AttributeAsserter do
         context 'authn request specifies bundle with first_name, last_name, email, ssn, phone' do
           let(:raw_loa1_authn_request) do
             CGI.unescape(
-              auth_request.create(loa1_with_bundle_saml_settings).split('SAMLRequest').last
+              auth_request.create(loa1_with_bundle_saml_settings).split('SAMLRequest').last,
             )
           end
 
@@ -207,7 +207,7 @@ describe AttributeAsserter do
       context 'custom bundle has invalid attribute name' do
         before do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
-            %w[email foo]
+            %w[email foo],
           )
           subject.build
         end
@@ -222,7 +222,7 @@ describe AttributeAsserter do
       context 'custom bundle does not include email, phone' do
         before do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
-            %w[first_name last_name]
+            %w[first_name last_name],
           )
           subject.build
         end
@@ -235,7 +235,7 @@ describe AttributeAsserter do
       context 'custom bundle includes email, phone' do
         before do
           allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
-            %w[first_name last_name email phone]
+            %w[first_name last_name email phone],
           )
           subject.build
         end
@@ -252,7 +252,7 @@ describe AttributeAsserter do
           user: loa1_user,
           service_provider: service_provider,
           authn_request: loa3_authn_request,
-          decrypted_pii: decrypted_pii
+          decrypted_pii: decrypted_pii,
         )
       end
 
@@ -265,7 +265,7 @@ describe AttributeAsserter do
           user: loa1_user,
           service_provider: service_provider,
           authn_request: loa1_authn_request,
-          decrypted_pii: decrypted_pii
+          decrypted_pii: decrypted_pii,
         )
       end
 

--- a/spec/services/completions_decider_spec.rb
+++ b/spec/services/completions_decider_spec.rb
@@ -30,7 +30,7 @@ describe CompletionsDecider do
       it 'returns true' do
         decider = CompletionsDecider.new(
           user_agent: desktop_user_agent,
-          request_url: request_url_with_app_redirect_uri
+          request_url: request_url_with_app_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq true
@@ -41,7 +41,7 @@ describe CompletionsDecider do
       it 'returns false' do
         decider = CompletionsDecider.new(
           user_agent: desktop_user_agent,
-          request_url: request_url_with_web_redirect_uri
+          request_url: request_url_with_web_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq false
@@ -52,7 +52,7 @@ describe CompletionsDecider do
       it 'returns false' do
         decider = CompletionsDecider.new(
           user_agent: desktop_user_agent,
-          request_url: request_url_without_redirect_uri
+          request_url: request_url_without_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq false
@@ -63,7 +63,7 @@ describe CompletionsDecider do
       it 'returns false' do
         decider = CompletionsDecider.new(
           user_agent: mobile_user_agent,
-          request_url: request_url_without_redirect_uri
+          request_url: request_url_without_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq false
@@ -74,7 +74,7 @@ describe CompletionsDecider do
       it 'returns false' do
         decider = CompletionsDecider.new(
           user_agent: mobile_user_agent,
-          request_url: request_url_with_web_redirect_uri
+          request_url: request_url_with_web_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq false
@@ -85,7 +85,7 @@ describe CompletionsDecider do
       it 'returns false' do
         decider = CompletionsDecider.new(
           user_agent: mobile_user_agent,
-          request_url: request_url_with_app_redirect_uri
+          request_url: request_url_with_app_redirect_uri,
         )
 
         expect(decider.go_back_to_mobile_app?).to eq false

--- a/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/attribute_encryptor_spec.rb
@@ -11,7 +11,7 @@ describe Encryption::Encryptors::AttributeEncryptor do
     allow(Figaro.env).to receive(:attribute_encryption_key).and_return(current_key)
     allow(Figaro.env).to receive(:attribute_cost).and_return(current_cost)
     allow(Figaro.env).to receive(:attribute_encryption_key_queue).and_return(
-      [{ key: retired_key, cost: retired_cost }].to_json
+      [{ key: retired_key, cost: retired_cost }].to_json,
     )
   end
 

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -104,7 +104,7 @@ describe Encryption::KmsClient do
 
       stub_mapped_aws_kms_client(
         long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
-        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2'
+        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2',
       )
       allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
     end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -37,7 +37,7 @@ describe IdentityLinker do
         nonce: nonce,
         ial: ial,
         scope: scope,
-        code_challenge: code_challenge
+        code_challenge: code_challenge,
       )
       user.reload
 

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -93,7 +93,7 @@ describe Idv::Agent do
             messages: [resolution_message, state_id_message],
             success: true,
             exception: nil,
-            timed_out: false
+            timed_out: false,
           )
         end
       end
@@ -107,7 +107,7 @@ describe Idv::Agent do
             messages: [failed_message],
             success: false,
             exception: nil,
-            timed_out: false
+            timed_out: false,
           )
         end
       end
@@ -118,7 +118,7 @@ describe Idv::Agent do
         it 'returns a result where timed out is true' do
           expect(subject.to_h).to include(
             success: false,
-            timed_out: true
+            timed_out: true,
           )
         end
       end
@@ -132,7 +132,7 @@ describe Idv::Agent do
 
           expect(subject.to_h).to include(
             success: false,
-            exception: exception
+            exception: exception,
           )
         end
       end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -10,7 +10,7 @@ describe Idv::ProfileMaker do
       described_class.new(
         applicant: applicant,
         user: user,
-        user_password: user_password
+        user_password: user_password,
       )
     end
 

--- a/spec/services/idv/proofer_spec.rb
+++ b/spec/services/idv/proofer_spec.rb
@@ -23,7 +23,7 @@ describe Idv::Proofer do
 
     original_descendants = Proofer::Base.descendants
     allow(Proofer::Base).to receive(:descendants).and_return(
-      original_descendants + dummy_vendors
+      original_descendants + dummy_vendors,
     )
 
     subject.instance_variable_set(:@vendors, nil)

--- a/spec/services/idv/send_phone_confirmation_otp_spec.rb
+++ b/spec/services/idv/send_phone_confirmation_otp_spec.rb
@@ -48,7 +48,7 @@ describe Idv::SendPhoneConfirmationOtp do
           code: phone_confirmation_otp,
           phone: parsed_phone,
           message: 'jobs.sms_otp_sender_job.verify_message',
-          locale: 'en'
+          locale: 'en',
         )
       end
     end
@@ -71,7 +71,7 @@ describe Idv::SendPhoneConfirmationOtp do
           otp_created_at: idv_session.phone_confirmation_otp_sent_at,
           code: phone_confirmation_otp,
           phone: parsed_phone,
-          locale: 'en'
+          locale: 'en',
         )
       end
     end

--- a/spec/services/marketing_site_spec.rb
+++ b/spec/services/marketing_site_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe MarketingSite do
   describe '.help_authentication_app_url' do
     it 'points to the authentication app section of the help page' do
       expect(MarketingSite.help_authentication_app_url).to eq(
-        'https://www.login.gov/help/signing-in/what-is-an-authentication-app/'
+        'https://www.login.gov/help/signing-in/what-is-an-authentication-app/',
       )
     end
 
@@ -69,7 +69,7 @@ RSpec.describe MarketingSite do
 
       it 'points to the authentication app section of the help page with the locale appended' do
         expect(MarketingSite.help_authentication_app_url).to eq(
-          'https://www.login.gov/es/help/signing-in/what-is-an-authentication-app/'
+          'https://www.login.gov/es/help/signing-in/what-is-an-authentication-app/',
         )
       end
     end

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe OpenidConnectAttributeScoper do
       it 'is only sub and iss' do
         expect(filtered).to eq(
           sub: 'abcdef',
-          iss: 'https://login.gov'
+          iss: 'https://login.gov',
         )
       end
     end

--- a/spec/services/otp_delivery_preference_updater_spec.rb
+++ b/spec/services/otp_delivery_preference_updater_spec.rb
@@ -5,7 +5,7 @@ describe OtpDeliveryPreferenceUpdater do
     OtpDeliveryPreferenceUpdater.new(
       user: build_stubbed(:user, otp_delivery_preference: 'sms'),
       preference: 'sms',
-      phone_id: 1
+      phone_id: 1,
     )
   end
 
@@ -25,7 +25,7 @@ describe OtpDeliveryPreferenceUpdater do
           updater = OtpDeliveryPreferenceUpdater.new(
             user: user,
             preference: 'sms',
-            phone_id: 1
+            phone_id: 1,
           )
           attributes = { otp_delivery_preference: 'sms' }
 
@@ -45,7 +45,7 @@ describe OtpDeliveryPreferenceUpdater do
         updater = OtpDeliveryPreferenceUpdater.new(
           user: nil,
           preference: 'sms',
-          phone_id: 1
+          phone_id: 1,
         )
 
         expect(UpdateUser).to_not receive(:new)

--- a/spec/services/phone_verification_spec.rb
+++ b/spec/services/phone_verification_spec.rb
@@ -61,7 +61,7 @@ describe PhoneVerification do
             'Content-Type' => 'application/x-www-form-urlencoded',
             'User-Agent' => 'Faraday v0.15.3',
             'X-Authy-Api-Key' => Figaro.env.twilio_verify_api_key,
-          }
+          },
         ).
         to_return(status: 200, body: '', headers: {})
 

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -13,7 +13,7 @@ describe Pii::Attributes do
     it 'initializes from complex Hash' do
       pii = described_class.new_from_hash(
         first_name: 'José',
-        last_name: 'Foo'
+        last_name: 'Foo',
       )
 
       expect(pii.first_name.to_s).to eq 'José'

--- a/spec/services/pii/fingerprinter_spec.rb
+++ b/spec/services/pii/fingerprinter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Pii::Fingerprinter do
   before do
     allow(Figaro.env).to receive(:hmac_fingerprinter_key_queue).and_return(
-      '["old-key-one", "old-key-two"]'
+      '["old-key-one", "old-key-two"]',
     )
   end
 

--- a/spec/services/pii/nist_encryption_spec.rb
+++ b/spec/services/pii/nist_encryption_spec.rb
@@ -76,12 +76,12 @@ describe 'NIST Encryption Model' do
       expect(user.valid_password?(password)).to eq true
 
       digest = Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
-        user.encrypted_password_digest
+        user.encrypted_password_digest,
       )
       user_access_key = Encryption::UserAccessKey.new(
         password: password,
         salt: digest.password_salt,
-        cost: digest.password_cost
+        cost: digest.password_cost,
       )
       user_access_key.unlock(digest.encryption_key)
 
@@ -123,7 +123,7 @@ describe 'NIST Encryption Model' do
       hash_E = OpenSSL::Digest::SHA256.hexdigest(user_access_key.z2 + random_R)
 
       user_access_key_encryptor = Encryption::Encryptors::UserAccessKeyEncryptor.new(
-        user_access_key
+        user_access_key,
       )
       encrypted_payload = user_access_key_encryptor.encrypt(pii)
 

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -40,7 +40,7 @@ describe PivCacService do
         token = 'TEST:{"uuid":"hijackedUUID","subject":"hijackedDN"}'
         expect(PivCacService.decode_token(token)).to eq(
           'uuid' => 'hijackedUUID',
-          'subject' => 'hijackedDN'
+          'subject' => 'hijackedDN',
         )
       end
     end
@@ -104,11 +104,11 @@ describe PivCacService do
           stub_request(:post, 'localhost:8443').
             with(
               body: 'token=foo',
-              headers: { 'Authentication' => /^hmac\s+:.+:.+$/ }
+              headers: { 'Authentication' => /^hmac\s+:.+:.+$/ },
             ).
             to_return(
               status: [200, 'Ok'],
-              body: '{"subject":"dn","uuid":"uuid"}'
+              body: '{"subject":"dn","uuid":"uuid"}',
             )
         end
 
@@ -120,7 +120,7 @@ describe PivCacService do
         it 'returns the decoded JSON from the target service' do
           expect(PivCacService.decode_token('foo')).to eq(
             'subject' => 'dn',
-            'uuid' => 'uuid'
+            'uuid' => 'uuid',
           )
         end
 
@@ -128,7 +128,7 @@ describe PivCacService do
           it 'returns an error' do
             token = 'TEST:{"uuid":"hijackedUUID","subject":"hijackedDN"}'
             expect(PivCacService.decode_token(token)).to eq(
-              'error' => 'token.bad'
+              'error' => 'token.bad',
             )
           end
         end
@@ -145,14 +145,14 @@ describe PivCacService do
             with(body: 'token=foo').
             to_return(
               status: [200, 'Ok'],
-              body: 'bad-json'
+              body: 'bad-json',
             )
         end
 
         it 'returns an error' do
           token = 'foo'
           expect(PivCacService.decode_token(token)).to eq(
-            'error' => 'token.bad'
+            'error' => 'token.bad',
           )
         end
       end

--- a/spec/services/reactivate_account_session_spec.rb
+++ b/spec/services/reactivate_account_session_spec.rb
@@ -7,7 +7,7 @@ describe ReactivateAccountSession do
   before do
     @reactivate_account_session = ReactivateAccountSession.new(
       user: user,
-      user_session: user_session
+      user_session: user_session,
     )
   end
 

--- a/spec/services/remember_device_cookie_spec.rb
+++ b/spec/services/remember_device_cookie_spec.rb
@@ -31,7 +31,7 @@ describe RememberDeviceCookie do
 
       expect { described_class.from_json(json) }.to raise_error(
         RuntimeError,
-        "RememberDeviceCookie role 'something_else' did not match 'remember_me'"
+        "RememberDeviceCookie role 'something_else' did not match 'remember_me'",
       )
     end
 
@@ -44,7 +44,7 @@ describe RememberDeviceCookie do
 
       expect { described_class.from_json(json) }.to raise_error(
         RuntimeError,
-        "RememberDeviceCookie role '' did not match 'remember_me'"
+        "RememberDeviceCookie role '' did not match 'remember_me'",
       )
     end
   end
@@ -85,7 +85,7 @@ describe RememberDeviceCookie do
         cookie = described_class.new(user_id: user.id, created_at: created_at)
 
         expect(
-          cookie.valid_for_user?(user: other_user, expiration_interval: expiration_interval)
+          cookie.valid_for_user?(user: other_user, expiration_interval: expiration_interval),
         ).to eq(false)
       end
     end

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -15,7 +15,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -39,7 +39,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -63,7 +63,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -84,7 +84,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -108,7 +108,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -133,7 +133,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
         )
 
         expect(FormResponse).to have_received(:new).

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceProviderSeeder do
         create(
           :service_provider,
           issuer: 'http://test.host',
-          acs_url: 'http://test.host/test/saml/decode_assertion_old'
+          acs_url: 'http://test.host/test/saml/decode_assertion_old',
         )
       end
 

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -63,7 +63,7 @@ describe ServiceProviderUpdater do
       before do
         stub_request(:get, fake_dashboard_url).to_return(
           status: 200,
-          body: dashboard_service_providers.to_json
+          body: dashboard_service_providers.to_json,
         )
       end
 
@@ -174,7 +174,7 @@ describe ServiceProviderUpdater do
       it 'raises an error' do
         stub_request(:get, fake_dashboard_url).to_return(
           status: 200,
-          body: dashboard_service_providers.to_json
+          body: dashboard_service_providers.to_json,
         )
         expect { subject.run }.to raise_error(ActiveRecord::RecordInvalid)
       end

--- a/spec/services/twilio_service/sms/request_spec.rb
+++ b/spec/services/twilio_service/sms/request_spec.rb
@@ -9,7 +9,7 @@ describe TwilioService::Sms::Request do
     context 'when message signature is invalid' do
       it 'returns false' do
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(false)
+          receive(:validate).and_return(false),
         )
 
         message = described_class.new(url, params, signature)
@@ -21,7 +21,7 @@ describe TwilioService::Sms::Request do
     context 'when message signature is valid' do
       before do
         allow_any_instance_of(Twilio::Security::RequestValidator).to(
-          receive(:validate).and_return(true)
+          receive(:validate).and_return(true),
         )
       end
 

--- a/spec/services/twilio_service/sms/response_spec.rb
+++ b/spec/services/twilio_service/sms/response_spec.rb
@@ -8,7 +8,7 @@ describe TwilioService::Sms::Response do
 
   before do
     allow_any_instance_of(Twilio::Security::RequestValidator).to(
-      receive(:validate).and_return(true)
+      receive(:validate).and_return(true),
     )
   end
 

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -26,7 +26,7 @@ describe TwilioService::Utils do
         code: '1234',
         phone: '17035551212',
         message: 'jobs.sms_otp_sender_job.verify_message',
-        otp_created_at: Time.zone.now.to_s
+        otp_created_at: Time.zone.now.to_s,
       )
 
       expect(FakeSms.messages.size).to eq 0
@@ -69,7 +69,7 @@ describe TwilioService::Utils do
 
       service.place_call(
         to: '5555555555',
-        url: 'https://twimlets.com/say?merp'
+        url: 'https://twimlets.com/say?merp',
       )
 
       calls = FakeVoiceCall.calls
@@ -141,7 +141,7 @@ describe TwilioService::Utils do
 
       service.send_sms(
         to: '5555555555',
-        body: '!!CODE1!!'
+        body: '!!CODE1!!',
       )
 
       messages = FakeSms.messages

--- a/spec/services/undeliverable_address_notifier_spec.rb
+++ b/spec/services/undeliverable_address_notifier_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe UndeliverableAddressNotifier do
     create(
       :profile,
       deactivation_reason: :verification_pending,
-      pii: { ssn: '123-45-6789', dob: '1970-01-01' }
+      pii: { ssn: '123-45-6789', dob: '1970-01-01' },
     )
   end
   let(:usps_confirmation_code) do
     create(
       :usps_confirmation_code,
       profile: profile,
-      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
   end
   let(:user) { profile.user }

--- a/spec/services/usps_confirmation_exporter_spec.rb
+++ b/spec/services/usps_confirmation_exporter_spec.rb
@@ -16,7 +16,7 @@ describe UspsConfirmationExporter do
           zipcode: '98021',
           otp: 'ZYX987',
           issuer: issuer,
-        }
+        },
       ),
       UspsConfirmation.new(
         entry: {
@@ -29,7 +29,7 @@ describe UspsConfirmationExporter do
           zipcode: '66666-1234',
           otp: 'ABC123',
           issuer: '',
-        }
+        },
       ),
     ]
   end

--- a/spec/services/usps_confirmation_uploader_spec.rb
+++ b/spec/services/usps_confirmation_uploader_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UspsConfirmationUploader do
           zipcode: '98021',
           otp: 'ZYX987',
           issuer: '',
-        }
+        },
       ),
     ]
   end

--- a/spec/services/x509/attributes_spec.rb
+++ b/spec/services/x509/attributes_spec.rb
@@ -12,7 +12,7 @@ describe X509::Attributes do
 
     it 'initializes from complex Hash' do
       x509 = described_class.new_from_hash(
-        subject: { raw: 'O=US, OU=DoD, CN=José', norm: 'O=US, OU=DoD, CN=Jose' }
+        subject: { raw: 'O=US, OU=DoD, CN=José', norm: 'O=US, OU=DoD, CN=Jose' },
       )
 
       expect(x509.subject.to_s).to eq 'O=US, OU=DoD, CN=José'

--- a/spec/support/account_reset_helper.rb
+++ b/spec/support/account_reset_helper.rb
@@ -7,7 +7,7 @@ module AccountResetHelper
       requested_at: Time.zone.now,
       cancelled_at: nil,
       granted_at: nil,
-      granted_token: nil
+      granted_token: nil,
     )
     request_token
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,7 +5,7 @@ require 'selenium/webdriver'
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu] }
+    chromeOptions: { args: %w[headless disable-gpu] },
   )
 
   Capybara::Selenium::Driver.new app,

--- a/spec/support/fake_sms.rb
+++ b/spec/support/fake_sms.rb
@@ -16,7 +16,7 @@ class FakeSms
     self.class.messages << Message.new(
       opts[:to],
       opts[:body],
-      opts[:messaging_service_sid]
+      opts[:messaging_service_sid],
     )
   end
 

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -67,7 +67,7 @@ module IdvHelper
   def choose_idv_otp_delivery_method_sms
     page.find(
       'label',
-      text: t('two_factor_authentication.otp_delivery_preference.sms')
+      text: t('two_factor_authentication.otp_delivery_preference.sms'),
     ).click
     click_on t('idv.buttons.send_confirmation_code')
   end
@@ -75,7 +75,7 @@ module IdvHelper
   def choose_idv_otp_delivery_method_voice
     page.find(
       'label',
-      text: t('two_factor_authentication.otp_delivery_preference.voice')
+      text: t('two_factor_authentication.otp_delivery_preference.voice'),
     ).click
     click_on t('idv.buttons.send_confirmation_code')
   end
@@ -117,7 +117,7 @@ module IdvHelper
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -123,10 +123,10 @@ module Features
       @raw_confirmation_token, = Devise.token_generator.generate(User, :confirmation_token)
 
       User.last.update(
-        confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.zone.now
+        confirmation_token: @raw_confirmation_token, confirmation_sent_at: Time.zone.now,
       )
       visit sign_up_create_email_confirmation_path(
-        confirmation_token: @raw_confirmation_token
+        confirmation_token: @raw_confirmation_token,
       )
     end
 
@@ -149,7 +149,7 @@ module Features
       stub_piv_cac_service
       visit_piv_cac_service(
         dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-        uuid: user.x509_dn_uuid
+        uuid: user.x509_dn_uuid,
       )
     end
 
@@ -354,7 +354,7 @@ module Features
 
     def attempt_to_confirm_email_with_invalid_token(request_id)
       visit sign_up_create_email_confirmation_url(
-        _request_id: request_id, confirmation_token: 'foo'
+        _request_id: request_id, confirmation_token: 'foo',
       )
     end
 
@@ -420,7 +420,7 @@ module Features
 
       expect(page).to have_current_path two_factor_options_path
       expect(page).to have_content(
-        t('two_factor_authentication.two_factor_choice_options.piv_cac')
+        t('two_factor_authentication.two_factor_choice_options.piv_cac'),
       )
 
       set_up_2fa_with_piv_cac
@@ -490,9 +490,9 @@ module Features
     def link_identity(user, client_id, ial = nil)
       IdentityLinker.new(
         user,
-        client_id
+        client_id,
       ).link_identity(
-        ial: ial
+        ial: ial,
       )
     end
 

--- a/spec/support/features/webauth_verification_helper.rb
+++ b/spec/support/features/webauth_verification_helper.rb
@@ -38,7 +38,7 @@ iwidHlwZSI6IndlYmF1dGhuLmdldCJ9'
       user_id: user.id,
       credential_id: credential_id,
       credential_public_key: public_key,
-      name: 'foo'
+      name: 'foo',
     )
   end
 end

--- a/spec/support/features/webauthn_helper.rb
+++ b/spec/support/features/webauthn_helper.rb
@@ -1,7 +1,7 @@
 module WebauthnHelper
   def mock_challenge
     allow(WebAuthn).to receive(:credential_creation_options).and_return(
-      challenge: challenge.pack('c*')
+      challenge: challenge.pack('c*'),
     )
   end
 

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -27,7 +27,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
 
       expect(page).to have_content t(
         'titles.sign_up.verified',
-        app: APP_NAME
+        app: APP_NAME,
       )
       expect_csp_headers_to_be_present if sp == :oidc
 
@@ -57,7 +57,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
 
       expect(page).to have_content t(
         'titles.sign_up.verified',
-        app: APP_NAME
+        app: APP_NAME,
       )
       expect_csp_headers_to_be_present if sp == :oidc
 
@@ -206,7 +206,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
   def client_private_key
     @client_private_key ||= begin
       OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys', 'saml_test_sp.key'))
+        File.read(Rails.root.join('keys', 'saml_test_sp.key')),
       )
     end
   end

--- a/spec/support/idv_examples/usps_otp_verification_step.rb
+++ b/spec/support/idv_examples/usps_otp_verification_step.rb
@@ -4,14 +4,14 @@ shared_examples 'usps otp verfication step' do |sp|
     create(
       :profile,
       deactivation_reason: :verification_pending,
-      pii: { ssn: '123-45-6789', dob: '1970-01-01' }
+      pii: { ssn: '123-45-6789', dob: '1970-01-01' },
     )
   end
   let(:usps_confirmation_code) do
     create(
       :usps_confirmation_code,
       profile: profile,
-      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp)
+      otp_fingerprint: Pii::Fingerprinter.fingerprint(otp),
     )
   end
   let(:user) { profile.user }

--- a/spec/support/key_rotation_helper.rb
+++ b/spec/support/key_rotation_helper.rb
@@ -3,7 +3,7 @@ module KeyRotationHelper
     env = Figaro.env
     old_hmac_key = env.hmac_fingerprinter_key
     allow(env).to receive(:hmac_fingerprinter_key_queue).and_return(
-      "[\"#{old_hmac_key}\"]"
+      "[\"#{old_hmac_key}\"]",
     )
     allow(env).to receive(:hmac_fingerprinter_key).and_return('4' * 32)
   end
@@ -31,7 +31,7 @@ module KeyRotationHelper
   def rotate_attribute_encryption_key_with_invalid_queue
     env = Figaro.env
     allow(env).to receive(:attribute_encryption_key_queue).and_return(
-      [{ key: 'key-that-was-never-used-in-the-past', cost: '4000$8$2$' }].to_json
+      [{ key: 'key-that-was-never-used-in-the-past', cost: '4000$8$2$' }].to_json,
     )
     allow(env).to receive(:attribute_encryption_key).and_return('4' * 32)
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -32,19 +32,19 @@ module SamlAuthHelper
 
   def sp_fingerprint
     @sp_fingerprint ||= Fingerprinter.fingerprint_cert(
-      OpenSSL::X509::Certificate.new(saml_test_sp_cert)
+      OpenSSL::X509::Certificate.new(saml_test_sp_cert),
     )
   end
 
   def idp_fingerprint
     @idp_fingerprint ||= Fingerprinter.fingerprint_cert(
-      OpenSSL::X509::Certificate.new(saml_test_idp_cert)
+      OpenSSL::X509::Certificate.new(saml_test_idp_cert),
     )
   end
 
   def saml_test_sp_key
     @private_key ||= OpenSSL::PKey::RSA.new(
-      File.read(Rails.root + 'keys/saml_test_sp.key')
+      File.read(Rails.root + 'keys/saml_test_sp.key'),
     ).to_pem
   end
 
@@ -182,10 +182,10 @@ module SamlAuthHelper
 
     IdentityLinker.new(
       user,
-      settings.issuer
+      settings.issuer,
     ).link_identity(
       ial: loa3_requested?(settings) ? true : nil,
-      verified_attributes: ['email']
+      verified_attributes: ['email'],
     )
   end
 
@@ -223,7 +223,7 @@ module SamlAuthHelper
       redirect_uri: 'http://localhost:7654/auth/result',
       state: state,
       prompt: 'select_account',
-      nonce: nonce
+      nonce: nonce,
     )
   end
 end

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -44,7 +44,7 @@ class SamlResponseDoc
   def saml_response(settings)
     @_saml_response ||= OneLogin::RubySaml::Response.new(
       raw_xml_response,
-      settings: settings
+      settings: settings,
     )
   end
 
@@ -58,8 +58,8 @@ class SamlResponseDoc
       Nokogiri::XML(
         OneLogin::RubySaml::Response.new(
           raw_xml_response,
-          settings: sp1_saml_settings
-        ).decrypted_document.to_s
+          settings: sp1_saml_settings,
+        ).decrypted_document.to_s,
       )
     else
       @original_encrypted = false
@@ -79,7 +79,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:Response/saml:Assertion',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     )
   end
 
@@ -87,7 +87,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:Response/saml:Assertion/saml:AuthnStatement/@SessionIndex',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     ).to_s
   end
 
@@ -99,7 +99,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:LogoutRequest',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     )[0]
   end
 
@@ -107,7 +107,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:LogoutResponse/samlp:Status/samlp:StatusCode/@Value',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     ).first.content
   end
 
@@ -115,7 +115,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:LogoutResponse',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     ).first
   end
 
@@ -152,42 +152,42 @@ class SamlResponseDoc
   def signature_method_nodeset
     signature.xpath(
       './ds:SignedInfo/ds:SignatureMethod',
-      ds: Saml::XML::Namespaces::SIGNATURE
+      ds: Saml::XML::Namespaces::SIGNATURE,
     )
   end
 
   def signature_canon_method_nodeset
     signature.xpath(
       './ds:SignedInfo/ds:CanonicalizationMethod',
-      ds: Saml::XML::Namespaces::SIGNATURE
+      ds: Saml::XML::Namespaces::SIGNATURE,
     )
   end
 
   def digest_method_nodeset
     signature.xpath(
       './ds:SignedInfo/ds:Reference/ds:DigestMethod',
-      ds: Saml::XML::Namespaces::SIGNATURE
+      ds: Saml::XML::Namespaces::SIGNATURE,
     )
   end
 
   def transforms_nodeset
     @_transforms ||= response_doc.xpath(
       '//ds:Reference/ds:Transforms',
-      ds: Saml::XML::Namespaces::SIGNATURE
+      ds: Saml::XML::Namespaces::SIGNATURE,
     )
   end
 
   def transform(algorithm)
     @_transform ||= transforms_nodeset[0].xpath(
       "//ds:Transform[@Algorithm='#{algorithm}']",
-      ds: Saml::XML::Namespaces::SIGNATURE
+      ds: Saml::XML::Namespaces::SIGNATURE,
     )[0]
   end
 
   def subject_nodeset
     response_doc.xpath(
       '//ds:Subject',
-      ds: Saml::XML::Namespaces::ASSERTION
+      ds: Saml::XML::Namespaces::ASSERTION,
     )
   end
 
@@ -208,14 +208,14 @@ class SamlResponseDoc
     organization_nodeset[0].
       xpath(
         './ds:OrganizationDisplayName',
-        ds: Saml::XML::Namespaces::METADATA
+        ds: Saml::XML::Namespaces::METADATA,
       ).first.content
   end
 
   def attribute_authority_organization_nodeset
     metadata.xpath(
       './ds:AttributeAuthorityDescriptor/ds:Organization',
-      ds: Saml::XML::Namespaces::METADATA
+      ds: Saml::XML::Namespaces::METADATA,
     )
   end
 
@@ -228,28 +228,28 @@ class SamlResponseDoc
     attribute_authority_organization_nodeset[0].
       xpath(
         './ds:OrganizationDisplayName',
-        ds: Saml::XML::Namespaces::METADATA
+        ds: Saml::XML::Namespaces::METADATA,
       ).first.content
   end
 
   def phone_number
     response_doc.at(
       '//ds:Attribute[@Name="phone"]',
-      ds: Saml::XML::Namespaces::ASSERTION
+      ds: Saml::XML::Namespaces::ASSERTION,
     )
   end
 
   def uuid
     response_doc.at(
       '//ds:Attribute[@Name="uuid"]',
-      ds: Saml::XML::Namespaces::ASSERTION
+      ds: Saml::XML::Namespaces::ASSERTION,
     ).children.children.to_s
   end
 
   def attribute_node_for(name)
     response_doc.at(
       %(//ds:Attribute[@Name="#{name}"]),
-      ds: Saml::XML::Namespaces::ASSERTION
+      ds: Saml::XML::Namespaces::ASSERTION,
     )
   end
 
@@ -261,7 +261,7 @@ class SamlResponseDoc
     response_doc.xpath(
       '//samlp:Response/saml:Assertion/saml:AuthnStatement',
       samlp: Saml::XML::Namespaces::PROTOCOL,
-      saml: Saml::XML::Namespaces::ASSERTION
+      saml: Saml::XML::Namespaces::ASSERTION,
     )[0]
   end
 

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -64,7 +64,7 @@ shared_examples 'remember device' do
       scope: 'openid email',
       redirect_uri: 'http://localhost:7654/auth/result',
       state: SecureRandom.hex,
-      nonce: SecureRandom.hex
+      nonce: SecureRandom.hex,
     )
     user = remember_device_and_sign_out_user
 

--- a/spec/support/shared_examples_for_phone_validation.rb
+++ b/spec/support/shared_examples_for_phone_validation.rb
@@ -18,7 +18,7 @@ shared_examples 'a phone form' do
         allow(User).to receive(:exists?).with(
           phone_configuration: {
             phone: MfaContext.new(second_user).phone_configurations.first.phone,
-          }
+          },
         ).and_return(true)
 
         params[:phone] = MfaContext.new(second_user).phone_configurations.first.phone

--- a/spec/view_models/account_show_spec.rb
+++ b/spec/view_models/account_show_spec.rb
@@ -28,7 +28,7 @@ describe AccountShow do
       it 'returns the personal_key partial' do
         user = User.new
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: 'foo', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: 'foo', decorated_user: user.decorate,
         )
 
         expect(profile_index.personal_key_partial).to eq 'accounts/personal_key'
@@ -39,7 +39,7 @@ describe AccountShow do
       it 'returns the shared/null partial' do
         user = User.new
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.personal_key_partial).to eq 'shared/null'
@@ -53,7 +53,7 @@ describe AccountShow do
         user = User.new.decorate
         allow(user).to receive(:password_reset_profile).and_return('profile')
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: 'foo', decorated_user: user
+          decrypted_pii: {}, personal_key: 'foo', decorated_user: user,
         )
 
         expect(profile_index.password_reset_partial).to eq 'accounts/password_reset'
@@ -65,7 +65,7 @@ describe AccountShow do
         user = User.new
         allow(user).to receive(:password_reset_profile).and_return(nil)
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.password_reset_partial).to eq 'shared/null'
@@ -79,7 +79,7 @@ describe AccountShow do
         user = User.new.decorate
         allow(user).to receive(:pending_profile_requires_verification?).and_return(true)
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: 'foo', decorated_user: user
+          decrypted_pii: {}, personal_key: 'foo', decorated_user: user,
         )
 
         expect(profile_index.pending_profile_partial).to eq 'accounts/pending_profile_usps'
@@ -102,7 +102,7 @@ describe AccountShow do
       it 'returns the accounts/password_reset partial' do
         user = User.new.decorate
         profile_index = AccountShow.new(
-          decrypted_pii: { foo: 'bar' }, personal_key: '', decorated_user: user
+          decrypted_pii: { foo: 'bar' }, personal_key: '', decorated_user: user,
         )
 
         expect(profile_index.pii_partial).to eq 'accounts/pii'
@@ -124,14 +124,14 @@ describe AccountShow do
       it 'returns the disable_totp partial' do
         user = User.new
         allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy
+          TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(true)
         allow_any_instance_of(
-          MfaPolicy
+          MfaPolicy,
         ).to receive(:multiple_factors_enabled?).and_return(true)
 
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.totp_partial).to eq 'accounts/actions/disable_totp'
@@ -142,11 +142,11 @@ describe AccountShow do
       it 'returns the enable_totp partial' do
         user = User.new
         allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy
+          TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(false)
 
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.totp_partial).to eq 'accounts/actions/enable_totp'
@@ -161,7 +161,7 @@ describe AccountShow do
         first_name = 'John'
         decrypted_pii = Pii::Attributes.new_from_json({ first_name: first_name }.to_json)
         profile_index = AccountShow.new(
-          decrypted_pii: decrypted_pii, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: decrypted_pii, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.header_personalization).to eq first_name
@@ -184,11 +184,11 @@ describe AccountShow do
       it 'returns localization for auth_app_enabled' do
         user = User.new
         allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy
+          TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(true)
 
         profile_index = AccountShow.new(
-          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate
+          decrypted_pii: {}, personal_key: '', decorated_user: user.decorate,
         )
 
         expect(profile_index.totp_content).to eq t('account.index.auth_app_enabled')
@@ -199,7 +199,7 @@ describe AccountShow do
       it 'returns localization for auth_app_disabled' do
         user = User.new.decorate
         allow_any_instance_of(
-          TwoFactorAuthentication::AuthAppPolicy
+          TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(false)
         profile_index = AccountShow.new(decrypted_pii: {}, personal_key: '', decorated_user: user)
 

--- a/spec/view_models/sign_up_completions_show_spec.rb
+++ b/spec/view_models/sign_up_completions_show_spec.rb
@@ -10,7 +10,7 @@ describe SignUpCompletionsShow do
       current_user: @user,
       loa3_requested: false,
       decorated_session: decorated_session,
-      handoff: false
+      handoff: false,
     )
   end
 
@@ -20,7 +20,7 @@ describe SignUpCompletionsShow do
         sp: build_stubbed(:service_provider),
         view_context: ActionController::Base.new.view_context,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       )
     end
 

--- a/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
+++ b/spec/views/account_reset/confirm_delete_account/show.html.slim_spec.rb
@@ -25,7 +25,7 @@ describe 'account_reset/confirm_delete_account/show.html.slim' do
 
     expect(rendered).to have_link(
       t('account_reset.confirm_delete_account.link_text', app: APP_NAME),
-      href: sign_up_email_path
+      href: sign_up_email_path,
     )
   end
 end

--- a/spec/views/accounts/show.html.slim_spec.rb
+++ b/spec/views/accounts/show.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'accounts/show.html.slim' do
     allow(view).to receive(:current_user).and_return(user)
     assign(
       :view_model,
-      AccountShow.new(decrypted_pii: nil, personal_key: nil, decorated_user: decorated_user)
+      AccountShow.new(decrypted_pii: nil, personal_key: nil, decorated_user: decorated_user),
     )
     assign(:login_presenter, LoginPresenter.new(user: user))
   end
@@ -43,7 +43,7 @@ describe 'accounts/show.html.slim' do
     before do
       assign(
         :view_model,
-        AccountShow.new(decrypted_pii: nil, personal_key: nil, decorated_user: decorated_user)
+        AccountShow.new(decrypted_pii: nil, personal_key: nil, decorated_user: decorated_user),
       )
     end
 
@@ -203,7 +203,7 @@ describe 'accounts/show.html.slim' do
         current_sign_in_at: current_sign_in_at,
         last_sign_in_at: last_sign_in_at,
         current_sign_in_ip: '1.2.3.4',
-        last_sign_in_ip: '159.142.31.80'
+        last_sign_in_ip: '159.142.31.80',
       )
       allow(view).to receive(:current_user).and_return(user)
       assign(:login_presenter, LoginPresenter.new(user: user))
@@ -233,7 +233,7 @@ describe 'accounts/show.html.slim' do
         :user,
         :signed_up,
         :with_email,
-        current_sign_in_ip: '4.3.2.1'
+        current_sign_in_ip: '4.3.2.1',
       )
       assign(:login_presenter, LoginPresenter.new(user: user))
 

--- a/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions.html.slim_spec.rb
@@ -10,8 +10,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     expect(rendered).to have_content(
       t(
         'mailer.confirmation_instructions.footer',
-        confirmation_period: user.decorate.confirmation_period
-      )
+        confirmation_period: user.decorate.confirmation_period,
+      ),
     )
   end
 
@@ -22,7 +22,7 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
 
     expect(rendered).to have_link(
       'http://test.host/sign_up/email/confirm?confirmation_token=foo',
-      href: 'http://test.host/sign_up/email/confirm?confirmation_token=foo'
+      href: 'http://test.host/sign_up/email/confirm?confirmation_token=foo',
     )
   end
 
@@ -36,7 +36,7 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
 
       expect(rendered).to have_link(
         'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo',
-        href: 'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo'
+        href: 'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo',
       )
     end
   end
@@ -51,8 +51,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     expect(rendered).to have_content(
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.confirmed',
-        app: APP_NAME, confirmation_period: presenter.confirmation_period
-      )
+        app: APP_NAME, confirmation_period: presenter.confirmation_period,
+      ),
     )
   end
 
@@ -66,8 +66,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     expect(rendered).to have_content(
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.unconfirmed',
-        app: APP_NAME, confirmation_period: presenter.confirmation_period
-      )
+        app: APP_NAME, confirmation_period: presenter.confirmation_period,
+      ),
     )
   end
 
@@ -81,8 +81,8 @@ describe 'devise/mailer/confirmation_instructions.html.slim' do
     expect(rendered).to have_content(
       I18n.t(
         'mailer.confirmation_instructions.first_sentence.reset_requested',
-        app: APP_NAME
-      )
+        app: APP_NAME,
+      ),
     )
 
     expect(rendered).to have_xpath("//p[contains(@class, 'lead')]/a[text()='#{APP_NAME}']")

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -6,7 +6,7 @@ describe 'devise/passwords/new.html.slim' do
     @sp = build_stubbed(
       :service_provider,
       friendly_name: 'Awesome Application!',
-      return_to_sp_url: 'www.awesomeness.com'
+      return_to_sp_url: 'www.awesomeness.com',
     )
     view_context = ActionController::Base.new.view_context
     allow(view_context).to receive(:sign_up_start_url).
@@ -16,7 +16,7 @@ describe 'devise/passwords/new.html.slim' do
       sp: @sp,
       view_context: view_context,
       sp_session: {},
-      service_provider_request: ServiceProviderRequest.new
+      service_provider_request: ServiceProviderRequest.new,
     ).call
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
   end

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -50,14 +50,14 @@ describe 'devise/sessions/new.html.slim' do
       @sp = build_stubbed(
         :service_provider,
         friendly_name: 'Awesome Application!',
-        return_to_sp_url: 'www.awesomeness.com'
+        return_to_sp_url: 'www.awesomeness.com',
       )
       view_context = ActionController::Base.new.view_context
       @decorated_session = DecoratedSession.new(
         sp: @sp,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
@@ -66,7 +66,7 @@ describe 'devise/sessions/new.html.slim' do
       render
 
       expect(rendered).to have_content(
-        t('headings.sign_in_with_sp', sp: 'Awesome Application!')
+        t('headings.sign_in_with_sp', sp: 'Awesome Application!'),
       )
     end
 
@@ -98,10 +98,10 @@ describe 'devise/sessions/new.html.slim' do
       render
 
       expect(rendered).not_to have_content(
-        t('headings.sign_in_with_sp', sp: 'Awesome Application!')
+        t('headings.sign_in_with_sp', sp: 'Awesome Application!'),
       )
       expect(rendered).not_to have_link(
-        t('links.back_to_sp', sp: 'Awesome Application!')
+        t('links.back_to_sp', sp: 'Awesome Application!'),
       )
     end
   end

--- a/spec/views/idv/come_back_later/show.html.slim_spec.rb
+++ b/spec/views/idv/come_back_later/show.html.slim_spec.rb
@@ -16,7 +16,7 @@ describe 'idv/come_back_later/show.html.slim' do
       render
       expect(rendered).to have_link(
         t('idv.buttons.continue_plain'),
-        href: sp_return_url
+        href: sp_return_url,
       )
     end
 
@@ -25,8 +25,8 @@ describe 'idv/come_back_later/show.html.slim' do
       expect(rendered).to have_content(
         strip_tags(t(
                      'idv.messages.come_back_later_sp_html',
-                     sp: @decorated_session.sp_name
-                   ))
+                     sp: @decorated_session.sp_name,
+                   )),
       )
     end
   end
@@ -38,7 +38,7 @@ describe 'idv/come_back_later/show.html.slim' do
       render
       expect(rendered).to have_link(
         t('idv.buttons.continue_plain', sp: sp_name),
-        href: account_path
+        href: account_path,
       )
     end
   end
@@ -51,7 +51,7 @@ describe 'idv/come_back_later/show.html.slim' do
       render
       expect(rendered).to have_link(
         t('idv.buttons.continue_plain', sp: sp_name),
-        href: account_path
+        href: account_path,
       )
     end
 
@@ -60,8 +60,8 @@ describe 'idv/come_back_later/show.html.slim' do
       expect(rendered).to have_content(
         strip_tags(t(
                      'idv.messages.come_back_later_no_sp_html',
-                     app: APP_NAME
-                   ))
+                     app: APP_NAME,
+                   )),
       )
     end
   end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -10,8 +10,8 @@ describe 'layouts/application.html.slim' do
         sp: nil,
         view_context: nil,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
-      ).call
+        service_provider_request: ServiceProviderRequest.new,
+      ).call,
     )
     allow(view.request).to receive(:original_fullpath).and_return('/foobar')
     allow(view).to receive(:current_user).and_return(User.new)
@@ -116,8 +116,8 @@ describe 'layouts/application.html.slim' do
           sp: nil,
           view_context: nil,
           sp_session: {},
-          service_provider_request: nil
-        ).call
+          service_provider_request: nil,
+        ).call,
       )
       allow(Figaro.env).to receive(:participate_in_dap).and_return('true')
 

--- a/spec/views/layouts/user_mailer.html.slim_spec.rb
+++ b/spec/views/layouts/user_mailer.html.slim_spec.rb
@@ -28,7 +28,7 @@ describe 'layouts/user_mailer.html.slim' do
   it 'includes the support text and link' do
     expect(rendered).to have_content(t('mailer.no_reply'))
     expect(rendered).to have_content(
-      t('mailer.help', app: APP_NAME, link: MarketingSite.nice_help_url)
+      t('mailer.help', app: APP_NAME, link: MarketingSite.nice_help_url),
     )
     expect(rendered).to have_link(MarketingSite.nice_help_url, href: MarketingSite.help_url)
   end

--- a/spec/views/phone_setup/index.html.slim_spec.rb
+++ b/spec/views/phone_setup/index.html.slim_spec.rb
@@ -18,7 +18,7 @@ describe 'users/phone_setup/index.html.slim' do
   it 'renders a link to choose a different option' do
     expect(rendered).to have_link(
       t('two_factor_authentication.choose_another_option'),
-      href: two_factor_options_path
+      href: two_factor_options_path,
     )
   end
 

--- a/spec/views/shared/_address.html.slim_spec.rb
+++ b/spec/views/shared/_address.html.slim_spec.rb
@@ -20,7 +20,7 @@ describe 'shared/_address.html.slim' do
           '123 Fake St',
           'Apt 456',
           'Washington, DC 21234',
-        ]
+        ],
       )
     end
   end

--- a/spec/views/shared/_nav_branded.html.slim_spec.rb
+++ b/spec/views/shared/_nav_branded.html.slim_spec.rb
@@ -12,7 +12,7 @@ describe 'shared/_nav_branded.html.slim' do
         sp: sp_with_logo,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: nil
+        service_provider_request: nil,
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render
@@ -30,7 +30,7 @@ describe 'shared/_nav_branded.html.slim' do
         sp: sp_without_logo,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: nil
+        service_provider_request: nil,
       )
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       render

--- a/spec/views/sign_up/completions/show.html.slim_spec.rb
+++ b/spec/views/sign_up/completions/show.html.slim_spec.rb
@@ -7,7 +7,7 @@ describe 'sign_up/completions/show.html.slim' do
       current_user: @user,
       loa3_requested: false,
       decorated_session: SessionDecorator.new,
-      handoff: false
+      handoff: false,
     )
   end
 
@@ -24,7 +24,7 @@ describe 'sign_up/completions/show.html.slim' do
     identity = create_identities(@user).first
     render
     content = strip_tags(
-      t('idv.messages.agency_login_html', sp: identity.display_name)
+      t('idv.messages.agency_login_html', sp: identity.display_name),
     )
     expect(rendered).to have_content(content)
   end
@@ -35,7 +35,7 @@ describe 'sign_up/completions/show.html.slim' do
         current_user: @user,
         loa3_requested: false,
         decorated_session: SessionDecorator.new,
-        handoff: true
+        handoff: true,
       )
       create_identities(@user)
     end
@@ -52,7 +52,7 @@ describe 'sign_up/completions/show.html.slim' do
       sp = create(
         :service_provider,
         friendly_name: "SP app #{index}",
-        agency: "Agency #{index}"
+        agency: "Agency #{index}",
       )
       create(:identity, service_provider: sp.issuer, user: user)
     end

--- a/spec/views/sign_up/passwords/new.html.slim_spec.rb
+++ b/spec/views/sign_up/passwords/new.html.slim_spec.rb
@@ -18,7 +18,7 @@ describe 'sign_up/passwords/new.html.slim' do
 
   it 'renders the proper help text' do
     expect(rendered).to have_content(
-      t('instructions.password.info.lead', min_length: Devise.password_length.first)
+      t('instructions.password.info.lead', min_length: Devise.password_length.first),
     )
   end
 

--- a/spec/views/sign_up/personal_keys/show.html.slim_spec.rb
+++ b/spec/views/sign_up/personal_keys/show.html.slim_spec.rb
@@ -27,7 +27,7 @@ describe 'sign_up/personal_keys/show.html.slim' do
     it 'displays the date the code was generated' do
       expect(rendered).to have_content(
         t('users.personal_key.generated_on_html',
-          date: I18n.l(Time.zone.today, format: '%B %d, %Y'))
+          date: I18n.l(Time.zone.today, format: '%B %d, %Y')),
       )
     end
   end
@@ -41,7 +41,7 @@ describe 'sign_up/personal_keys/show.html.slim' do
     render
     expect(rendered).to have_content(
       t('instructions.personal_key.info_html',
-        accent: t('instructions.personal_key.accent'))
+        accent: t('instructions.personal_key.accent')),
     )
   end
 

--- a/spec/views/sign_up/registrations/new.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/new.html.slim_spec.rb
@@ -9,7 +9,7 @@ describe 'sign_up/registrations/new.html.slim' do
 
     view_context = ActionController::Base.new.view_context
     @decorated_session = DecoratedSession.new(
-      sp: nil, view_context: view_context, sp_session: {}, service_provider_request: nil
+      sp: nil, view_context: view_context, sp_session: {}, service_provider_request: nil,
     ).call
     allow(view).to receive(:decorated_session).and_return(@decorated_session)
     allow(view_context).to receive(:root_url).and_return('http://www.example.com')
@@ -61,7 +61,7 @@ describe 'sign_up/registrations/new.html.slim' do
       @sp = build_stubbed(
         :service_provider,
         friendly_name: 'SAM',
-        return_to_sp_url: 'www.awesomeness.com'
+        return_to_sp_url: 'www.awesomeness.com',
       )
       view_context = ActionController::Base.new.view_context
       allow(view_context).to receive(:sign_up_start_url).
@@ -70,7 +70,7 @@ describe 'sign_up/registrations/new.html.slim' do
         sp: @sp,
         view_context: view_context,
         sp_session: {},
-        service_provider_request: ServiceProviderRequest.new
+        service_provider_request: ServiceProviderRequest.new,
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end

--- a/spec/views/sign_up/registrations/show.html.slim_spec.rb
+++ b/spec/views/sign_up/registrations/show.html.slim_spec.rb
@@ -10,11 +10,11 @@ describe 'sign_up/registrations/show.html.slim' do
       render
 
       expect(rendered).to have_content(
-        t('headings.create_account_without_sp', sp: nil)
+        t('headings.create_account_without_sp', sp: nil),
       )
 
       expect(rendered).not_to have_link(
-        t('links.back_to_sp', sp: 'Awesome Application!')
+        t('links.back_to_sp', sp: 'Awesome Application!'),
       )
     end
 
@@ -37,11 +37,11 @@ describe 'sign_up/registrations/show.html.slim' do
       @sp = build_stubbed(
         :service_provider,
         friendly_name: 'Awesome Application!',
-        return_to_sp_url: 'www.awesomeness.com'
+        return_to_sp_url: 'www.awesomeness.com',
       )
       view_context = ActionController::Base.new.view_context
       @decorated_session = DecoratedSession.new(
-        sp: @sp, view_context: view_context, sp_session: {}, service_provider_request: nil
+        sp: @sp, view_context: view_context, sp_session: {}, service_provider_request: nil,
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
     end
@@ -62,7 +62,7 @@ describe 'sign_up/registrations/show.html.slim' do
 
       expect(rendered).to have_link(
         t('links.back_to_sp', sp: 'Awesome Application!'),
-        href: @decorated_session.sp_return_url
+        href: @decorated_session.sp_return_url,
       )
     end
 

--- a/spec/views/two_factor_authentication/options/index.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.slim_spec.rb
@@ -11,7 +11,7 @@ describe 'two_factor_authentication/options/index.html.slim' do
 
   it 'has a localized title' do
     expect(view).to receive(:title).with( \
-      t('two_factor_authentication.login_options_title')
+      t('two_factor_authentication.login_options_title'),
     )
 
     render

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -20,7 +20,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
       @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
         data: presenter_data,
-        view: view
+        view: view,
       )
       allow(@presenter).to receive(:reauthn).and_return(false)
     end
@@ -80,7 +80,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       it 'provides an option to use a personal key' do
         expect(rendered).to have_link(
           t('two_factor_authentication.login_options_link_text'),
-          href: login_two_factor_options_path
+          href: login_two_factor_options_path,
         )
       end
     end
@@ -96,13 +96,13 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       it 'provides a cancel link to return to profile' do
         expect(rendered).to have_link(
           t('links.cancel'),
-          href: account_path
+          href: account_path,
         )
       end
 
       it 'renders the reauthn partial' do
         expect(view).to render_template(
-          partial: 'two_factor_authentication/totp_verification/_reauthn'
+          partial: 'two_factor_authentication/totp_verification/_reauthn',
         )
       end
     end
@@ -114,14 +114,14 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         data = presenter_data.merge(confirmation_for_phone_change: true)
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: data,
-          view: view
+          view: view,
         )
 
         render
 
         expect(rendered).to have_link(
           t('links.cancel'),
-          href: account_path
+          href: account_path,
         )
       end
     end
@@ -132,14 +132,14 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: unconfirmed_data,
-          view: view
+          view: view,
         )
 
         render
 
         expect(rendered).not_to have_link(
           t('two_factor_authentication.personal_key_fallback.link'),
-          href: login_two_factor_personal_key_path
+          href: login_two_factor_personal_key_path,
         )
       end
     end
@@ -159,14 +159,14 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         totp_data = presenter_data.merge(totp_enabled: true)
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: totp_data,
-          view: view
+          view: view,
         )
 
         render
 
         expect(rendered).to have_link(
           t('two_factor_authentication.login_options_link_text'),
-          href: login_two_factor_options_path
+          href: login_two_factor_options_path,
         )
       end
     end
@@ -192,7 +192,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         expect(rendered).to have_link(
           t('links.two_factor_authentication.get_another_code'),
-          href: resend_path
+          href: resend_path,
         )
       end
 
@@ -201,7 +201,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         expect(rendered).to have_link(
           t('two_factor_authentication.login_options_link_text'),
-          href: login_two_factor_options_path
+          href: login_two_factor_options_path,
         )
       end
     end
@@ -214,7 +214,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         voice_data = presenter_data.merge(otp_delivery_preference: otp_delivery_preference)
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: voice_data,
-          view: view
+          view: view,
         )
       end
 
@@ -225,12 +225,12 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
           otp_delivery_selection_form: {
             otp_delivery_preference: otp_delivery_preference,
             resend: true,
-          }
+          },
         )
 
         expect(rendered).to have_link(
           t('links.two_factor_authentication.get_another_code'),
-          href: resend_path
+          href: resend_path,
         )
       end
 
@@ -239,7 +239,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         expect(rendered).to have_link(
           t('two_factor_authentication.login_options_link_text'),
-          href: login_two_factor_options_path
+          href: login_two_factor_options_path,
         )
       end
     end
@@ -250,7 +250,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: data,
-          view: view
+          view: view,
         )
 
         render
@@ -265,7 +265,7 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
 
         @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
           data: data,
-          view: view
+          view: view,
         )
 
         render

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -6,14 +6,14 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
     attributes_for(:generic_otp_presenter).merge(
       two_factor_authentication_method: 'authenticator',
       user_email: view.current_user.email,
-      phone_enabled: TwoFactorAuthentication::PhonePolicy.new(user).enabled?
+      phone_enabled: TwoFactorAuthentication::PhonePolicy.new(user).enabled?,
     )
   end
 
   before do
     allow(view).to receive(:current_user).and_return(user)
     @presenter = TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(
-      data: presenter_data, view: ApplicationController.new.view_context
+      data: presenter_data, view: ApplicationController.new.view_context,
     )
     allow(@presenter).to receive(:reauthn).and_return(false)
 
@@ -34,14 +34,14 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
   it 'allows the user to fallback to SMS and voice' do
     expect(rendered).to have_link(
       t('two_factor_authentication.login_options_link_text'),
-      href: login_two_factor_options_path
+      href: login_two_factor_options_path,
     )
   end
 
   it 'provides an option to use a personal key' do
     expect(rendered).to have_link(
       t('two_factor_authentication.login_options_link_text'),
-      href: login_two_factor_options_path
+      href: login_two_factor_options_path,
     )
   end
 
@@ -59,13 +59,13 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
     it 'provides a cancel link to return to profile' do
       expect(rendered).to have_link(
         t('links.cancel'),
-        href: account_path
+        href: account_path,
       )
     end
 
     it 'renders the reauthn partial' do
       expect(view).to render_template(
-        partial: 'two_factor_authentication/totp_verification/_reauthn'
+        partial: 'two_factor_authentication/totp_verification/_reauthn',
       )
     end
   end

--- a/spec/views/users/piv_cac_authentication_setup/new.html.slim_spec.rb
+++ b/spec/views/users/piv_cac_authentication_setup/new.html.slim_spec.rb
@@ -25,7 +25,7 @@ describe 'users/piv_cac_authentication_setup/new.html.slim' do
 
       expect(rendered).to have_link(
         t('two_factor_authentication.choose_another_option'),
-        href: two_factor_options_path
+        href: two_factor_options_path,
       )
     end
   end

--- a/spec/views/users/totp_setup/new.html.slim_spec.rb
+++ b/spec/views/users/totp_setup/new.html.slim_spec.rb
@@ -42,7 +42,7 @@ describe 'users/totp_setup/new.html.slim' do
 
       expect(rendered).to have_link(
         t('two_factor_authentication.choose_another_option'),
-        href: two_factor_options_path
+        href: two_factor_options_path,
       )
     end
   end


### PR DESCRIPTION
**Why**: To make the rule more consistent with the rules for commas in
hashes and array. This commit also goes through and fixes all of the
violations this change caused.
