### PR TITLE
Cleanup webpack output on setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -71,6 +71,10 @@ Dir.chdir APP_ROOT do
   run 'bin/rake db:create RAILS_ENV=test'
   run 'bin/rake db:reset RAILS_ENV=test'
 
+  puts "\n== Cleaning up old assets =="
+  run "rake assets:clobber"
+  run "RAILS_ENV=test rake assets:clobber"
+
   puts "\n== Removing old logs and tempfiles =="
   run "rm -f log/*"
   run "rm -rf tmp/cache"


### PR DESCRIPTION
**Why**: The webpack output pollutes the public folder every time the
javascript is recompiled. This commit adds `rake asset:clobber` calls to
the setup script to clean those up when `make setup` is run.
