### PR TITLE
Add encryption context to KMS calls

### DIFF
--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -1,0 +1,98 @@
+module Encryption
+  class ContextlessKmsClient
+    include Encodable
+
+    KEY_TYPE = {
+      KMS: 'KMSx',
+    }.freeze
+
+    def encrypt(plaintext)
+      return encrypt_kms(plaintext) if FeatureManagement.use_kms?
+      encrypt_local(plaintext)
+    end
+
+    def decrypt(ciphertext)
+      return decrypt_kms(ciphertext) if use_kms?(ciphertext)
+      decrypt_local(ciphertext)
+    end
+
+    def self.looks_like_kms?(ciphertext)
+      ciphertext.start_with?(KEY_TYPE[:KMS])
+    end
+
+    private
+
+    def use_kms?(ciphertext)
+      FeatureManagement.use_kms? && self.class.looks_like_kms?(ciphertext)
+    end
+
+    def encrypt_kms(plaintext)
+      if plaintext.bytesize > 4096
+        encrypt_in_chunks(plaintext)
+      else
+        KEY_TYPE[:KMS] + encrypt_raw_kms(plaintext)
+      end
+    end
+
+    # chunk plaintext into ~4096 byte chunks, but not less than 1024 bytes in a chunk if chunking.
+    # we do this by counting how many chunks we have and adding one.
+    # :reek:FeatureEnvy
+    def encrypt_in_chunks(plaintext)
+      plain_size = plaintext.bytesize
+      number_chunks = plain_size / 4096
+      chunk_size = plain_size / (1 + number_chunks)
+      ciphertext_set = plaintext.scan(/.{1,#{chunk_size}}/m).map(&method(:encrypt_raw_kms))
+      KEY_TYPE[:KMS] + ciphertext_set.map { |chunk| Base64.strict_encode64(chunk) }.to_json
+    end
+
+    def encrypt_raw_kms(plaintext)
+      raise ArgumentError, 'kms plaintext exceeds 4096 bytes' if plaintext.bytesize > 4096
+      aws_client.encrypt(
+        key_id: Figaro.env.aws_kms_key_id,
+        plaintext: plaintext,
+      ).ciphertext_blob
+    end
+
+    # :reek:DuplicateMethodCall
+    def decrypt_kms(ciphertext)
+      raw_ciphertext = ciphertext.sub(KEY_TYPE[:KMS], '')
+      if raw_ciphertext[0] == '[' && raw_ciphertext[-1] == ']'
+        decrypt_chunked_kms(raw_ciphertext)
+      else
+        decrypt_raw_kms(raw_ciphertext)
+      end
+    end
+
+    def decrypt_chunked_kms(raw_ciphertext)
+      ciphertext_set = JSON.parse(raw_ciphertext).map { |chunk| Base64.strict_decode64(chunk) }
+      ciphertext_set.map(&method(:decrypt_raw_kms)).join('')
+    rescue JSON::ParserError, ArgumentError
+      decrypt_raw_kms(raw_ciphertext)
+    end
+
+    def decrypt_raw_kms(raw_ciphertext)
+      aws_client.decrypt(ciphertext_blob: raw_ciphertext).plaintext
+    rescue Aws::KMS::Errors::InvalidCiphertextException
+      raise EncryptionError, 'Aws::KMS::Errors::InvalidCiphertextException'
+    end
+
+    def encrypt_local(plaintext)
+      encryptor.encrypt(plaintext, Figaro.env.password_pepper)
+    end
+
+    def decrypt_local(ciphertext)
+      encryptor.decrypt(ciphertext, Figaro.env.password_pepper)
+    end
+
+    def aws_client
+      @aws_client ||= Aws::KMS::Client.new(
+        instance_profile_credentials_timeout: 1, # defaults to 1 second
+        instance_profile_credentials_retries: 5, # defaults to 0 retries
+      )
+    end
+
+    def encryptor
+      @encryptor ||= Encryptors::AesEncryptor.new
+    end
+  end
+end

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -37,18 +37,22 @@ module Encryption
         @kms_client = KmsClient.new
       end
 
-      def encrypt(plaintext)
+      def encrypt(plaintext, user_uuid: nil)
         salt = SecureRandom.hex(32)
         cost = Figaro.env.scrypt_cost
         aes_encryption_key = scrypt_password_digest(salt: salt, cost: cost)
         aes_encrypted_ciphertext = aes_cipher.encrypt(plaintext, aes_encryption_key)
-        kms_encrypted_ciphertext = kms_client.encrypt(aes_encrypted_ciphertext)
+        kms_encrypted_ciphertext = kms_client.encrypt(
+          aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
+        )
         Ciphertext.new(kms_encrypted_ciphertext, salt, cost).to_s
       end
 
-      def decrypt(ciphertext_string)
+      def decrypt(ciphertext_string, user_uuid: nil)
         ciphertext = Ciphertext.parse_from_string(ciphertext_string)
-        aes_encrypted_ciphertext = kms_client.decrypt(ciphertext.encrypted_data)
+        aes_encrypted_ciphertext = kms_client.decrypt(
+          ciphertext.encrypted_data, kms_encryption_context(user_uuid: user_uuid)
+        )
         aes_encryption_key = scrypt_password_digest(salt: ciphertext.salt, cost: ciphertext.cost)
         aes_cipher.decrypt(aes_encrypted_ciphertext, aes_encryption_key)
       end
@@ -56,6 +60,13 @@ module Encryption
       private
 
       attr_reader :password, :aes_cipher, :kms_client
+
+      def kms_encryption_context(user_uuid:)
+        {
+          'context' => 'pii-encryption',
+          'user_uuid' => user_uuid,
+        }
+      end
 
       def scrypt_password_digest(salt:, cost:)
         scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)

--- a/app/services/encryption/encryptors/session_encryptor.rb
+++ b/app/services/encryption/encryptors/session_encryptor.rb
@@ -5,12 +5,12 @@ module Encryption
 
       def encrypt(plaintext)
         aes_ciphertext = AesEncryptor.new.encrypt(plaintext, aes_encryption_key)
-        kms_ciphertext = KmsClient.new.encrypt(aes_ciphertext)
+        kms_ciphertext = ContextlessKmsClient.new.encrypt(aes_ciphertext)
         encode(kms_ciphertext)
       end
 
       def decrypt(ciphertext)
-        aes_ciphertext = KmsClient.new.decrypt(decode(ciphertext))
+        aes_ciphertext = ContextlessKmsClient.new.decrypt(decode(ciphertext))
         aes_encryptor.decrypt(aes_ciphertext, aes_encryption_key)
       end
 

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -1,25 +1,35 @@
 require 'base64'
 
 module Encryption
-  class KmsClient
+  class KmsClient # rubocop:disable Metrics/ClassLength
     include Encodable
 
     KEY_TYPE = {
-      KMS: 'KMSx',
+      KMS: 'KMSc',
+      LOCAL_KEY: 'LOCc',
     }.freeze
 
-    def encrypt(plaintext)
-      return encrypt_kms(plaintext) if FeatureManagement.use_kms?
-      encrypt_local(plaintext)
+    def encrypt(plaintext, encryption_context)
+      return encrypt_kms(plaintext, encryption_context) if FeatureManagement.use_kms?
+      encrypt_local(plaintext, encryption_context)
     end
 
-    def decrypt(ciphertext)
-      return decrypt_kms(ciphertext) if use_kms?(ciphertext)
-      decrypt_local(ciphertext)
+    def decrypt(ciphertext, encryption_context)
+      return decrypt_contextless_kms(ciphertext) if self.class.looks_like_contextless?(ciphertext)
+      return decrypt_kms(ciphertext, encryption_context) if use_kms?(ciphertext)
+      decrypt_local(ciphertext, encryption_context)
     end
 
     def self.looks_like_kms?(ciphertext)
       ciphertext.start_with?(KEY_TYPE[:KMS])
+    end
+
+    def self.looks_like_local_key?(ciphertext)
+      ciphertext.start_with?(KEY_TYPE[:LOCAL_KEY])
+    end
+
+    def self.looks_like_contextless?(ciphertext)
+      !looks_like_kms?(ciphertext) && !looks_like_local_key?(ciphertext)
     end
 
     private
@@ -28,62 +38,86 @@ module Encryption
       FeatureManagement.use_kms? && self.class.looks_like_kms?(ciphertext)
     end
 
-    def encrypt_kms(plaintext)
-      if plaintext.bytesize > 4096
-        encrypt_in_chunks(plaintext)
-      else
-        KEY_TYPE[:KMS] + encrypt_raw_kms(plaintext)
-      end
+    def encrypt_kms(plaintext, encryption_context)
+      KEY_TYPE[:KMS] + chunk_plaintext(plaintext).map do |chunk|
+        Base64.strict_encode64(
+          encrypt_raw_kms(chunk, encryption_context),
+        )
+      end.to_json
+    end
+
+    def encrypt_raw_kms(plaintext, encryption_context)
+      raise ArgumentError, 'kms plaintext exceeds 4096 bytes' if plaintext.bytesize > 4096
+      aws_client.encrypt(
+        key_id: Figaro.env.aws_kms_key_id,
+        plaintext: plaintext,
+        encryption_context: encryption_context,
+      ).ciphertext_blob
+    end
+
+    def decrypt_kms(ciphertext, encryption_context)
+      clipped_ciphertext = ciphertext.gsub(/\A#{KEY_TYPE[:KMS]}/, '')
+      ciphertext_chunks = JSON.parse(clipped_ciphertext)
+      ciphertext_chunks.map do |chunk|
+        decrypt_raw_kms(
+          Base64.strict_decode64(chunk),
+          encryption_context,
+        )
+      end.join('')
+    rescue JSON::ParserError, ArgumentError => error
+      raise EncryptionError, "Failed to parse KMS ciphertext: #{error}"
+    end
+
+    def decrypt_raw_kms(ciphertext, encryption_context)
+      aws_client.decrypt(
+        ciphertext_blob: ciphertext,
+        encryption_context: encryption_context,
+      ).plaintext
+    rescue Aws::KMS::Errors::InvalidCiphertextException
+      raise EncryptionError, 'Aws::KMS::Errors::InvalidCiphertextException'
+    end
+
+    def encrypt_local(plaintext, encryption_context)
+      KEY_TYPE[:LOCAL_KEY] + chunk_plaintext(plaintext).map do |chunk|
+        Base64.strict_encode64(
+          encryptor.encrypt(chunk, local_encryption_key(encryption_context)),
+        )
+      end.to_json
+    end
+
+    def decrypt_local(ciphertext, encryption_context)
+      clipped_ciphertext = ciphertext.gsub(/\A#{KEY_TYPE[:LOCAL_KEY]}/, '')
+      ciphertext_chunks = JSON.parse(clipped_ciphertext)
+      ciphertext_chunks.map do |chunk|
+        encryptor.decrypt(
+          Base64.strict_decode64(chunk),
+          local_encryption_key(encryption_context),
+        )
+      end.join('')
+    rescue JSON::ParserError, ArgumentError => error
+      raise EncryptionError, "Failed to parse local ciphertext: #{error}"
+    end
+
+    def local_encryption_key(encryption_context)
+      OpenSSL::HMAC.digest(
+        'sha256',
+        Figaro.env.password_pepper,
+        (encryption_context.keys + encryption_context.values).sort.join(''),
+      )
+    end
+
+    def decrypt_contextless_kms(ciphertext)
+      ContextlessKmsClient.new.decrypt(ciphertext)
     end
 
     # chunk plaintext into ~4096 byte chunks, but not less than 1024 bytes in a chunk if chunking.
     # we do this by counting how many chunks we have and adding one.
     # :reek:FeatureEnvy
-    def encrypt_in_chunks(plaintext)
+    def chunk_plaintext(plaintext)
       plain_size = plaintext.bytesize
       number_chunks = plain_size / 4096
       chunk_size = plain_size / (1 + number_chunks)
-      ciphertext_set = plaintext.scan(/.{1,#{chunk_size}}/m).map(&method(:encrypt_raw_kms))
-      KEY_TYPE[:KMS] + ciphertext_set.map { |chunk| Base64.strict_encode64(chunk) }.to_json
-    end
-
-    def encrypt_raw_kms(plaintext)
-      raise ArgumentError, 'kms plaintext exceeds 4096 bytes' if plaintext.bytesize > 4096
-      aws_client.encrypt(
-        key_id: Figaro.env.aws_kms_key_id,
-        plaintext: plaintext,
-      ).ciphertext_blob
-    end
-
-    # :reek:DuplicateMethodCall
-    def decrypt_kms(ciphertext)
-      raw_ciphertext = ciphertext.sub(KEY_TYPE[:KMS], '')
-      if raw_ciphertext[0] == '[' && raw_ciphertext[-1] == ']'
-        decrypt_chunked_kms(raw_ciphertext)
-      else
-        decrypt_raw_kms(raw_ciphertext)
-      end
-    end
-
-    def decrypt_chunked_kms(raw_ciphertext)
-      ciphertext_set = JSON.parse(raw_ciphertext).map { |chunk| Base64.strict_decode64(chunk) }
-      ciphertext_set.map(&method(:decrypt_raw_kms)).join('')
-    rescue JSON::ParserError, ArgumentError
-      decrypt_raw_kms(raw_ciphertext)
-    end
-
-    def decrypt_raw_kms(raw_ciphertext)
-      aws_client.decrypt(ciphertext_blob: raw_ciphertext).plaintext
-    rescue Aws::KMS::Errors::InvalidCiphertextException
-      raise EncryptionError, 'Aws::KMS::Errors::InvalidCiphertextException'
-    end
-
-    def encrypt_local(plaintext)
-      encryptor.encrypt(plaintext, Figaro.env.password_pepper)
-    end
-
-    def decrypt_local(ciphertext)
-      encryptor.decrypt(ciphertext, Figaro.env.password_pepper)
+      plaintext.scan(/.{1,#{chunk_size}}/m)
     end
 
     def aws_client

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -81,7 +81,7 @@ module Encryption
     end
 
     def kms_client
-      KmsClient.new
+      ContextlessKmsClient.new
     end
 
     def split_scrypt_digest(digest)

--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -18,12 +18,6 @@ module Pii
       attrs
     end
 
-    def self.new_from_encrypted(encrypted, password:)
-      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-      decrypted = encryptor.decrypt(encrypted)
-      new_from_json(decrypted)
-    end
-
     def self.new_from_json(pii_json)
       return new if pii_json.blank?
       pii = JSON.parse(pii_json, symbolize_names: true)
@@ -33,11 +27,6 @@ module Pii
     def initialize(*args)
       super
       assign_all_members
-    end
-
-    def encrypted(password)
-      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-      encryptor.encrypt(to_json)
     end
 
     def eql?(other)

--- a/config/initializers/new_relic_tracers.rb
+++ b/config/initializers/new_relic_tracers.rb
@@ -66,6 +66,12 @@ Encryption::KmsClient.class_eval do
   add_method_tracer :encrypt, "Custom/#{name}/encrypt"
 end
 
+Encryption::ContextlessKmsClient.class_eval do
+  include ::NewRelic::Agent::MethodTracer
+  add_method_tracer :decrypt, "Custom/#{name}/decrypt"
+  add_method_tracer :encrypt, "Custom/#{name}/encrypt"
+end
+
 TwilioService::Utils.class_eval do
   include ::NewRelic::Agent::MethodTracer
   add_method_tracer :place_call, "Custom/#{name}/place_call"

--- a/lib/tasks/add_context_to_pii_bundles.rake
+++ b/lib/tasks/add_context_to_pii_bundles.rake
@@ -1,0 +1,43 @@
+namespace :adhoc do
+  desc 'Add KMS encryption context to existing PII bundles'
+  task add_context_to_pii_bundles: :environment do
+    Rails.logger = Logger.new(STDOUT)
+
+    @kms_client = Encryption::KmsClient.new
+
+    batch_count = 0
+    # rubocop:disable Metrics/MethodLength
+    def add_context_to_encrypted_pii(encrypted_pii, user_uuid)
+      ciphertext = Encryption::Encryptors::PiiEncryptor::Ciphertext.parse_from_string(
+        encrypted_pii,
+      )
+      return unless @kms_client.class.looks_like_contextless?(ciphertext.encrypted_data)
+      ciphertext.encrypted_data = @kms_client.encrypt(
+        @kms_client.decrypt(
+          ciphertext.encrypted_data,
+          'context' => 'pii-encryption',
+          'user_uuid' => user_uuid,
+        ),
+        'context' => 'pii-encryption',
+        'user_uuid' => user_uuid,
+      )
+      ciphertext.to_s
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    Profile.includes(:user).find_in_batches do |batch|
+      Rails.logger.info "Processing batch #{batch_count += 1}"
+      batch.each do |profile|
+        updated_pii = add_context_to_encrypted_pii(profile.encrypted_pii, profile.user.uuid)
+        profile.encrypted_pii = updated_pii if updated_pii.present?
+        updated_recovery_pii = add_context_to_encrypted_pii(
+          profile.encrypted_pii_recovery, profile.user.uuid
+        )
+        profile.encrypted_pii_recovery = updated_recovery_pii if updated_recovery_pii.present?
+        profile.save! if profile.changed?
+      end
+      sleep 1
+    end
+    Rails.logger.info('Done!')
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -63,6 +63,14 @@ describe Profile do
 
       expect(decrypted_pii).to eq pii
     end
+
+    it 'fails if the encryption context from the uuid is incorrect' do
+      profile.encrypt_pii(pii, user.password)
+
+      allow(profile.user).to receive(:uuid).and_return('a-different-uuid')
+
+      expect { profile.decrypt_pii(user.password) }.to raise_error(Encryption::EncryptionError)
+    end
   end
 
   describe '#recover_pii' do

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+describe Encryption::ContextlessKmsClient do
+  let(:password_pepper) { '1' * 32 }
+  let(:local_plaintext) { 'local plaintext' }
+  let(:local_ciphertext) { 'local ciphertext' }
+
+  context 'with kms plaintext less than 4k' do
+    let(:kms_plaintext) { 'kms plaintext' }
+    let(:kms_ciphertext) { 'kms ciphertext' }
+    let(:kms_enabled) { true }
+
+    before do
+      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
+
+      encryptor = Encryption::Encryptors::AesEncryptor.new
+      allow(encryptor).to receive(:encrypt).
+        with(local_plaintext, password_pepper).
+        and_return(local_ciphertext)
+      allow(encryptor).to receive(:decrypt).
+        with(local_ciphertext, password_pepper).
+        and_return(local_plaintext)
+      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
+
+      stub_aws_kms_client(kms_plaintext, kms_ciphertext)
+      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    end
+
+    describe '#encrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to encrypt the plaintext' do
+          result = subject.encrypt(kms_plaintext)
+
+          expect(result).to eq('KMSx' + kms_ciphertext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to encrypt the plaintext and signs it' do
+          result = subject.encrypt(local_plaintext)
+
+          expect(result).to eq(local_ciphertext)
+        end
+      end
+    end
+
+    describe '#decrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
+          result = subject.decrypt('KMSx' + kms_ciphertext)
+
+          expect(result).to eq(kms_plaintext)
+        end
+
+        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to decrypt a ciphertext' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+    end
+
+    describe '#looks_like_kms?' do
+      it 'returns true for kms encrypted data' do
+        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
+      end
+
+      it 'returns false for non kms encrypted data' do
+        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      end
+    end
+  end
+
+  context 'with kms plaintext greater than 4k' do
+    let(:long_kms_plaintext) { SecureRandom.random_bytes(4096 * 1.8) }
+    let(:long_kms_plaintext_bytesize) { long_kms_plaintext.bytesize }
+    let(:long_kms_plaintext_chunksize) { long_kms_plaintext_bytesize / 2 }
+    let(:kms_ciphertext) { %w[chunk1 chunk2].map { |c| Base64.strict_encode64(c) }.to_json }
+    let(:kms_enabled) { true }
+
+    before do
+      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
+
+      encryptor = Encryption::Encryptors::AesEncryptor.new
+      allow(encryptor).to receive(:encrypt).
+        with(local_plaintext, password_pepper).
+        and_return(local_ciphertext)
+      allow(encryptor).to receive(:decrypt).
+        with(local_ciphertext, password_pepper).
+        and_return(local_plaintext)
+      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
+
+      stub_mapped_aws_kms_client(
+        long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
+        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2',
+      )
+      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    end
+
+    describe '#encrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to encrypt the plaintext' do
+          result = subject.encrypt(long_kms_plaintext)
+
+          expect(result).to eq('KMSx' + kms_ciphertext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to encrypt the plaintext and signs it' do
+          result = subject.encrypt(local_plaintext)
+
+          expect(result).to eq(local_ciphertext)
+        end
+      end
+    end
+
+    describe '#decrypt' do
+      context 'with KMS enabled' do
+        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
+          result = subject.decrypt('KMSx' + kms_ciphertext)
+
+          expect(result).to eq(long_kms_plaintext)
+        end
+
+        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+
+      context 'without KMS enabled' do
+        let(:kms_enabled) { false }
+
+        it 'uses the password pepper to decrypt a ciphertext' do
+          result = subject.decrypt(local_ciphertext)
+
+          expect(result).to eq(local_plaintext)
+        end
+      end
+    end
+
+    describe '#looks_like_kms?' do
+      it 'returns true for kms encrypted data' do
+        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
+      end
+
+      it 'returns false for non kms encrypted data' do
+        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/encryption/encryptors/pii_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/pii_encryptor_spec.rb
@@ -8,12 +8,12 @@ describe Encryption::Encryptors::PiiEncryptor do
 
   describe '#encrypt' do
     it 'returns encrypted text' do
-      ciphertext = subject.encrypt(plaintext)
+      ciphertext = subject.encrypt(plaintext, user_uuid: 'uuid-123-abc')
 
       expect(ciphertext).to_not match plaintext
     end
 
-    it 'uses the user access key encryptor to encrypt the plaintext' do
+    it 'uses layers KMS and AES to encrypt the plaintext' do
       salt = '0' * 64
       allow(SecureRandom).to receive(:hex).once.with(32).and_return(salt)
 
@@ -30,15 +30,15 @@ describe Encryption::Encryptors::PiiEncryptor do
         with(plaintext, decoded_scrypt_digest).
         and_return('aes_ciphertext')
 
-      kms_client = instance_double(Encryption::KmsClient)
+      kms_client = instance_double(Encryption::ContextlessKmsClient)
       expect(Encryption::KmsClient).to receive(:new).and_return(kms_client)
       expect(kms_client).to receive(:encrypt).
-        with('aes_ciphertext').
+        with('aes_ciphertext', 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc').
         and_return('kms_ciphertext')
 
       expected_ciphertext = Base64.strict_encode64('kms_ciphertext')
 
-      ciphertext = subject.encrypt(plaintext)
+      ciphertext = subject.encrypt(plaintext, user_uuid: 'uuid-123-abc')
 
       expect(ciphertext).to eq({
         encrypted_data: expected_ciphertext,
@@ -50,17 +50,18 @@ describe Encryption::Encryptors::PiiEncryptor do
 
   describe '#decrypt' do
     it 'returns the original text' do
-      ciphertext = subject.encrypt(plaintext)
-      decrypted_ciphertext = subject.decrypt(ciphertext)
+      ciphertext = subject.encrypt(plaintext, user_uuid: 'uuid-123-abc')
+      decrypted_ciphertext = subject.decrypt(ciphertext, user_uuid: 'uuid-123-abc')
 
       expect(decrypted_ciphertext).to eq(plaintext)
     end
 
     it 'requires the same password used for encrypt' do
-      ciphertext = subject.encrypt(plaintext)
+      ciphertext = subject.encrypt(plaintext, user_uuid: 'uuid-123-abc')
       new_encryptor = described_class.new('This is not the passowrd')
 
-      expect { new_encryptor.decrypt(ciphertext) }.to raise_error Encryption::EncryptionError
+      expect { new_encryptor.decrypt(ciphertext, user_uuid: 'uuid-123-abc') }.
+        to raise_error Encryption::EncryptionError
     end
 
     it 'uses layered AES and KMS to decrypt the contents' do
@@ -73,10 +74,10 @@ describe Encryption::Encryptors::PiiEncryptor do
       expect(scrypt_password).to receive(:digest).and_return(scrypt_digest)
       expect(SCrypt::Password).to receive(:new).and_return(scrypt_password)
 
-      kms_client = instance_double(Encryption::KmsClient)
+      kms_client = instance_double(Encryption::ContextlessKmsClient)
       expect(Encryption::KmsClient).to receive(:new).and_return(kms_client)
       expect(kms_client).to receive(:decrypt).
-        with('kms_ciphertext').
+        with('kms_ciphertext', 'context' => 'pii-encryption', 'user_uuid' => 'uuid-123-abc').
         and_return('aes_ciphertext')
 
       cipher = instance_double(Encryption::AesCipher)
@@ -89,7 +90,7 @@ describe Encryption::Encryptors::PiiEncryptor do
         encrypted_data: Base64.strict_encode64('kms_ciphertext'),
         salt: salt,
         cost: '800$8$1$',
-      }.to_json)
+      }.to_json, user_uuid: 'uuid-123-abc')
 
       expect(result).to eq(plaintext)
     end

--- a/spec/services/encryption/encryptors/session_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/session_encryptor_spec.rb
@@ -6,7 +6,7 @@ describe Encryption::Encryptors::SessionEncryptor do
   describe '#encrypt' do
     it 'returns a KMS wrapped AES encrypted ciphertext' do
       aes_encryptor = instance_double(Encryption::Encryptors::AesEncryptor)
-      kms_client = instance_double(Encryption::KmsClient)
+      kms_client = instance_double(Encryption::ContextlessKmsClient)
       allow(aes_encryptor).to receive(:encrypt).
         with(plaintext, Figaro.env.session_encryption_key[0...32]).
         and_return('aes output')
@@ -14,7 +14,7 @@ describe Encryption::Encryptors::SessionEncryptor do
         with('aes output').
         and_return('kms output')
       allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(aes_encryptor)
-      allow(Encryption::KmsClient).to receive(:new).and_return(kms_client)
+      allow(Encryption::ContextlessKmsClient).to receive(:new).and_return(kms_client)
 
       expected_ciphertext = Base64.strict_encode64('kms output')
 

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -1,167 +1,114 @@
 require 'rails_helper'
 
 describe Encryption::KmsClient do
-  let(:password_pepper) { '1' * 32 }
-  let(:local_plaintext) { 'local plaintext' }
-  let(:local_ciphertext) { 'local ciphertext' }
+  before do
+    stub_mapped_aws_kms_client(
+      'a' * 3000 => 'kms1',
+      'b' * 3000 => 'kms2',
+      'c' * 3000 => 'kms3',
+    )
 
-  context 'with kms plaintext less than 4k' do
-    let(:kms_plaintext) { 'kms plaintext' }
-    let(:kms_ciphertext) { 'kms ciphertext' }
-    let(:kms_enabled) { true }
-
-    before do
-      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
-
-      encryptor = Encryption::Encryptors::AesEncryptor.new
+    encryptor = Encryption::Encryptors::AesEncryptor.new
+    {
+      'a' * 3000 => 'local1',
+      'b' * 3000 => 'local2',
+      'c' * 3000 => 'local3',
+    }.each do |plaintext, ciphertext|
       allow(encryptor).to receive(:encrypt).
-        with(local_plaintext, password_pepper).
-        and_return(local_ciphertext)
+        with(plaintext, local_encryption_key).
+        and_return(ciphertext)
       allow(encryptor).to receive(:decrypt).
-        with(local_ciphertext, password_pepper).
-        and_return(local_plaintext)
-      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
-
-      stub_aws_kms_client(kms_plaintext, kms_ciphertext)
-      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+        with(ciphertext, local_encryption_key).
+        and_return(plaintext)
     end
+    allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
 
-    describe '#encrypt' do
-      context 'with KMS enabled' do
-        it 'uses KMS to encrypt the plaintext' do
-          result = subject.encrypt(kms_plaintext)
+    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+  end
 
-          expect(result).to eq('KMSx' + kms_ciphertext)
-        end
-      end
+  let(:plaintext) { 'a' * 3000 + 'b' * 3000 + 'c' * 3000 }
+  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
 
-      context 'without KMS enabled' do
-        let(:kms_enabled) { false }
+  let(:local_encryption_key) do
+    OpenSSL::HMAC.digest(
+      'sha256',
+      Figaro.env.password_pepper,
+      '123-abc-456-defattribute-bundlecontextuser_id',
+    )
+  end
 
-        it 'uses the password pepper to encrypt the plaintext and signs it' do
-          result = subject.encrypt(local_plaintext)
+  let(:kms_ciphertext) do
+    'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
+  end
+  let(:local_ciphertext) do
+    'LOCc' + %w[local1 local2 local3].map { |c| Base64.strict_encode64(c) }.to_json
+  end
 
-          expect(result).to eq(local_ciphertext)
-        end
-      end
-    end
+  let(:kms_enabled) { true }
 
-    describe '#decrypt' do
-      context 'with KMS enabled' do
-        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
-          result = subject.decrypt('KMSx' + kms_ciphertext)
+  describe '#encrypt' do
+    context 'with KMS enabled' do
+      it 'encrypts with KMS' do
+        result = subject.encrypt(plaintext, encryption_context)
 
-          expect(result).to eq(kms_plaintext)
-        end
-
-        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
-          result = subject.decrypt(local_ciphertext)
-
-          expect(result).to eq(local_plaintext)
-        end
-      end
-
-      context 'without KMS enabled' do
-        let(:kms_enabled) { false }
-
-        it 'uses the password pepper to decrypt a ciphertext' do
-          result = subject.decrypt(local_ciphertext)
-
-          expect(result).to eq(local_plaintext)
-        end
+        expect(result).to eq(kms_ciphertext)
       end
     end
 
-    describe '#looks_like_kms?' do
-      it 'returns true for kms encrypted data' do
-        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
-      end
+    context 'with KMS disabled' do
+      let(:kms_enabled) { false }
 
-      it 'returns false for non kms encrypted data' do
-        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      it 'encrypts with a local key' do
+        result = subject.encrypt(plaintext, encryption_context)
+
+        expect(result).to eq(local_ciphertext)
       end
     end
   end
 
-  context 'with kms plaintext greater than 4k' do
-    let(:long_kms_plaintext) { SecureRandom.random_bytes(4096 * 1.8) }
-    let(:long_kms_plaintext_bytesize) { long_kms_plaintext.bytesize }
-    let(:long_kms_plaintext_chunksize) { long_kms_plaintext_bytesize / 2 }
-    let(:kms_ciphertext) { %w[chunk1 chunk2].map { |c| Base64.strict_encode64(c) }.to_json }
-    let(:kms_enabled) { true }
+  describe '#decrypt' do
+    context 'with a ciphertext encrypted with KMS' do
+      it 'decrypts the ciphertext with KMS' do
+        result = subject.decrypt(kms_ciphertext, encryption_context)
 
-    before do
-      allow(Figaro.env).to receive(:password_pepper).and_return(password_pepper)
-
-      encryptor = Encryption::Encryptors::AesEncryptor.new
-      allow(encryptor).to receive(:encrypt).
-        with(local_plaintext, password_pepper).
-        and_return(local_ciphertext)
-      allow(encryptor).to receive(:decrypt).
-        with(local_ciphertext, password_pepper).
-        and_return(local_plaintext)
-      allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
-
-      stub_mapped_aws_kms_client(
-        long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
-        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2',
-      )
-      allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
-    end
-
-    describe '#encrypt' do
-      context 'with KMS enabled' do
-        it 'uses KMS to encrypt the plaintext' do
-          result = subject.encrypt(long_kms_plaintext)
-
-          expect(result).to eq('KMSx' + kms_ciphertext)
-        end
-      end
-
-      context 'without KMS enabled' do
-        let(:kms_enabled) { false }
-
-        it 'uses the password pepper to encrypt the plaintext and signs it' do
-          result = subject.encrypt(local_plaintext)
-
-          expect(result).to eq(local_ciphertext)
-        end
+        expect(result).to eq(plaintext)
       end
     end
 
-    describe '#decrypt' do
-      context 'with KMS enabled' do
-        it 'uses KMS to decrypt a ciphertext encrypted with KMS' do
-          result = subject.decrypt('KMSx' + kms_ciphertext)
+    context 'with a ciphertext encrypted with a local key' do
+      it 'decrypts the ciphertext with a local key' do
+        result = subject.decrypt(local_ciphertext, encryption_context)
 
-          expect(result).to eq(long_kms_plaintext)
-        end
-
-        it 'uses the password pepper to decrypt a legacy ciphertext encrypted without KMS' do
-          result = subject.decrypt(local_ciphertext)
-
-          expect(result).to eq(local_plaintext)
-        end
-      end
-
-      context 'without KMS enabled' do
-        let(:kms_enabled) { false }
-
-        it 'uses the password pepper to decrypt a ciphertext' do
-          result = subject.decrypt(local_ciphertext)
-
-          expect(result).to eq(local_plaintext)
-        end
+        expect(result).to eq(plaintext)
       end
     end
 
-    describe '#looks_like_kms?' do
-      it 'returns true for kms encrypted data' do
-        expect(subject.class.looks_like_kms?('KMSx' + kms_ciphertext)).to eq(true)
+    context 'with a contextless ciphertext' do
+      before do
+        contextless_client = Encryption::ContextlessKmsClient.new
+        allow(contextless_client).to receive(:decrypt).
+          with('KMSx123abc').
+          and_return('plaintext')
+        allow(contextless_client).to receive(:decrypt).
+          with('123abc').
+          and_return('plaintext')
+        allow(Encryption::ContextlessKmsClient).to receive(:new).and_return(contextless_client)
       end
 
-      it 'returns false for non kms encrypted data' do
-        expect(subject.class.looks_like_kms?('abcdef.' + kms_ciphertext)).to eq(false)
+      context 'created with KMS' do
+        it 'delegates to the contextless kms client' do
+          result = subject.decrypt('KMSx123abc', encryption_context)
+
+          expect(result).to eq('plaintext')
+        end
+      end
+
+      context 'created with a local key' do
+        it 'delegates to the contextless kms client' do
+          result = subject.decrypt('123abc', encryption_context)
+
+          expect(result).to eq('plaintext')
+        end
       end
     end
   end

--- a/spec/services/pii/attributes_spec.rb
+++ b/spec/services/pii/attributes_spec.rb
@@ -28,24 +28,6 @@ describe Pii::Attributes do
     end
   end
 
-  describe '#new_from_encrypted' do
-    it 'inflates from encrypted string' do
-      orig_attrs = described_class.new_from_hash(first_name: 'Jane')
-      encrypted_pii = orig_attrs.encrypted(password)
-      pii_attrs = described_class.new_from_encrypted(encrypted_pii, password: password)
-
-      expect(pii_attrs.first_name).to eq 'Jane'
-    end
-
-    it 'allows deprecated attributes that are no longer added to the hash schema' do
-      deprecated_atts = described_class.new_from_hash(otp: '123abc')
-      encrypted_pii = deprecated_atts.encrypted(password)
-      pii_attrs = described_class.new_from_encrypted(encrypted_pii, password: password)
-
-      expect(pii_attrs[:otp]).to eq('123abc')
-    end
-  end
-
   describe '#new_from_json' do
     it 'inflates from JSON string' do
       pii_json = { first_name: 'Jane' }.to_json
@@ -57,15 +39,6 @@ describe Pii::Attributes do
     it 'returns all-nil object when passed blank JSON' do
       expect(described_class.new_from_json(nil)).to be_a Pii::Attributes
       expect(described_class.new_from_json('')).to be_a Pii::Attributes
-    end
-  end
-
-  describe '#encrypted' do
-    it 'returns the object as encrypted string' do
-      pii_attrs = described_class.new_from_hash(first_name: 'Jane')
-
-      encrypted = pii_attrs.encrypted(password)
-      expect(encrypted).to_not match 'Jane'
     end
   end
 


### PR DESCRIPTION
**Why**: So we can use the cloudtrail output to monitor KMS usage.

This commit moves the old KMS client into a new client called
`ContextlessKmsClient`. After moving the PII data out of that KMS client
it can be deprecated and maintained as legacy code with the UAK
password encryptor.

The new KMS client requires a context hash to perform encryption.