### PR TITLE
Fix copy/paste issue with cert in setup scrpit

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -34,7 +34,7 @@ Dir.chdir APP_ROOT do
   run "test -L keys/saml2018.key.enc || cp keys/saml2018.key.enc.example keys/saml2018.key.enc"
   run "test -L certs/saml.crt || cp certs/saml.crt.example certs/saml.crt"
   run "test -L certs/saml2018.crt || cp certs/saml2018.crt.example certs/saml2018.crt"
-  run "test -L certs/samlcloudhsm.crt || cp certs/saml2018.crt.example certs/samlcloudhsm.crt"
+  run "test -L certs/samlcloudhsm.crt || cp certs/samlcloudhsm.crt.example certs/samlcloudhsm.crt"
 
   puts "== Copying GeoLite2 City database =="
   run "test -L geo_data/GeoLite2-City.mmdb || mkdir -p geo_data && cd geo_data && " \


### PR DESCRIPTION
**Why**: The line in the setup script that copies the cloudhsm cert to
the right place was actually copying the saml2018 cert which was causing
issues for local dev.
