### PR TITLE
Use factories in device tracking tests

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   belongs_to :user
+  belongs_to :device
 
   enum event_type: {
     account_created: 1,

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -1,13 +1,12 @@
 FactoryBot.define do
   factory :device do
-    id { 1 }
-    user_id { 1 }
-    cookie_uuid { 'foo' }
+    cookie_uuid { SecureRandom.hex(64) }
     user_agent do
       'Google Chrome Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36\
 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
     end
     last_used_at { Time.zone.now }
     last_ip { '127.0.0.1' }
+    user
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :event do
-    user_id { 1 }
     event_type { :account_created }
+
+    after(:build) do |event|
+      event.device ||= event.user.devices.first || build(:device, user: event.user)
+    end
   end
 end

--- a/spec/features/account/device_spec.rb
+++ b/spec/features/account/device_spec.rb
@@ -6,7 +6,7 @@ describe 'Devices' do
     user = create(:user, :signed_up, otp_delivery_preference: 'sms')
     sign_in_and_2fa_user(user)
     create(:device,
-           user_id: user.id,
+           user: user,
            cookie_uuid: 'foo',
            user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) \
 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36',

--- a/spec/features/device_tracking_spec.rb
+++ b/spec/features/device_tracking_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe 'Device tracking' do
   let(:user) { create(:user, :signed_up) }
   let(:now) { Time.zone.now }
-  let(:device) { create(:device, user_id: user.id, last_ip: '4.3.2.1', last_used_at: now) }
+  let(:device) { create(:device, user: user, last_ip: '4.3.2.1', last_used_at: now) }
 
   before do
-    create(:event, device_id: device.id, ip: '4.3.2.1', user: user, created_at: now)
+    create(:event, device: device, ip: '4.3.2.1', user: user, created_at: now)
     sign_in_and_2fa_user(user)
   end
 

--- a/spec/presenters/idv/usps_presenter_spec.rb
+++ b/spec/presenters/idv/usps_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Idv::UspsPresenter do
   end
 
   def create_letter_send_event
-    create(:device, user_id: user.id)
-    create(:event, user_id: user.id, device_id: 1, event_type: :usps_mail_sent)
+    device = create(:device, user: user)
+    create(:event, user: user, device: device, event_type: :usps_mail_sent)
   end
 end

--- a/spec/services/device_tracking/list_device_events_spec.rb
+++ b/spec/services/device_tracking/list_device_events_spec.rb
@@ -2,53 +2,54 @@ require 'rails_helper'
 
 describe DeviceTracking::ListDeviceEvents do
   subject { described_class }
-  let(:now) { Time.zone.now }
-  let(:user) { create(:user, id: 1) }
-  let(:bad_user_id) { 0 }
-  let(:good_user_id) { 1 }
-  let(:device) { create(:device) }
-  let(:bad_device_id) { 0 }
-  let(:good_device_id) { 1 }
-  let(:event1) { create_event(1, 2) }
-  let(:event2) { create_event(2, 3) }
-  let(:event3) { create_event(3, 1) }
+
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:current_device) { create(:device, user: current_user) }
+  let(:other_device) { create(:device) }
+
+  let(:events) do
+    [
+      create(:event, user: current_user, device: current_device, created_at: 2.hours.ago),
+      create(:event, user: current_user, device: current_device, created_at: 3.hours.ago),
+      create(:event, user: current_user, device: current_device, created_at: 1.hour.ago),
+    ]
+  end
 
   before do
-    user
-    device
-    event1
-    event2
-    event3
+    # Memoize records to run creates for specs that query the table
+    current_user
+    other_user
+    current_device
+    other_device
+    events
   end
 
   it 'returns an empty list if the device is not found' do
-    result = subject.call(good_user_id, bad_device_id, 0, 1)
+    result = subject.call(current_user.id, other_device.id, 0, 1)
 
     expect(result).to eq([])
   end
 
   it 'returns an empty list if the device is found but the user is not' do
-    result = subject.call(bad_user_id, good_device_id, 0, 1)
+    result = subject.call(other_user.id, current_device.id, 0, 1)
 
     expect(result).to eq([])
   end
 
   it 'returns a list containing a single most recent event' do
-    result = subject.call(good_user_id, good_device_id, 0, 1)
+    result = subject.call(current_user.id, current_device.id, 0, 1)
 
     expect(result.size).to eq(1)
-    expect(result[0].id).to eq(3)
+    expect(result[0].id).to eq(events[2].id)
   end
 
   it 'returns a list containing multiple most recent events in order and using an offset' do
-    result = subject.call(good_user_id, good_device_id, 1, 2)
+    result = subject.call(current_user.id, current_device.id, 1, 2)
 
     expect(result.size).to eq(2)
-    expect(result[0].id).to eq(1)
-    expect(result[1].id).to eq(2)
-  end
-
-  def create_event(id, ago)
-    create(:event, id: id, user_id: 1, device_id: 1, ip: '4.3.2.1', created_at: now - ago.hour)
+    expect(result[0].id).to eq(events[0].id)
+    expect(result[1].id).to eq(events[1].id)
   end
 end

--- a/spec/services/device_tracking/list_devices_spec.rb
+++ b/spec/services/device_tracking/list_devices_spec.rb
@@ -2,41 +2,43 @@ require 'rails_helper'
 
 describe DeviceTracking::ListDevices do
   subject { described_class }
-  let(:now) { Time.zone.now }
-  let(:user) { create(:user, id: 1) }
-  let(:bad_user_id) { 0 }
-  let(:device1) { create_device(1, 2) }
-  let(:device2) { create_device(2, 3) }
-  let(:device3) { create_device(3, 1) }
+
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:devices) do
+    [
+      create(:device, user: current_user, last_used_at: 2.hours.ago),
+      create(:device, user: current_user, last_used_at: 3.hours.ago),
+      create(:device, user: current_user, last_used_at: 1.hour.ago),
+    ]
+  end
 
   before do
-    device1
-    device2
-    device3
+    # Memoize records to run creates for specs that query the table
+    current_user
+    other_user
+    devices
   end
 
   it 'returns an empty list if the device is not found' do
-    result = subject.call(bad_user_id, 0, 1)
+    result = subject.call(other_user.id, 0, 1)
 
     expect(result).to eq([])
   end
 
   it 'returns a list containing a single most recent device' do
-    result = subject.call(user.id, 0, 1)
+    result = subject.call(current_user.id, 0, 1)
 
     expect(result.size).to eq(1)
-    expect(result[0].id).to eq(3)
+    expect(result[0].id).to eq(devices[2].id)
   end
 
   it 'returns a list containing multiple most recent devices in order and using an offset' do
-    result = subject.call(user.id, 1, 2)
+    result = subject.call(current_user.id, 1, 2)
 
     expect(result.size).to eq(2)
-    expect(result[0].id).to eq(1)
-    expect(result[1].id).to eq(2)
-  end
-
-  def create_device(id, ago)
-    create(:device, id: id, user_id: 1, last_ip: '4.3.2.1', last_used_at: now - ago.hour)
+    expect(result[0].id).to eq(devices[0].id)
+    expect(result[1].id).to eq(devices[1].id)
   end
 end

--- a/spec/services/device_tracking/lookup_device_for_user_spec.rb
+++ b/spec/services/device_tracking/lookup_device_for_user_spec.rb
@@ -2,35 +2,38 @@ require 'rails_helper'
 
 describe DeviceTracking::LookupDeviceForUser do
   subject { described_class }
-  let(:user) { create(:user) }
-  let(:bad_user_id) { 0 }
-  let(:device) { create(:device) }
-  let(:good_uuid) { 'foo' }
-  let(:good_user_id) { 1 }
-  let(:bad_uuid) { 'bar' }
-  let(:bad_user_id) { 2 }
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:device) { create(:device, user: current_user, cookie_uuid: device_uuid) }
+
+  let(:device_uuid) { 'foo' }
+  let(:other_uuid) { 'bar' }
 
   before do
-    user
+    current_user
+    other_user
     device
   end
 
   it 'returns nil if the user is found but the cookie uuid is not' do
-    expect(Device.find_by(user_id: good_user_id)).to be_present
-    result = subject.call(good_user_id, bad_uuid)
+    expect(Device.find_by(user_id: current_user.id)).to be_present
+
+    result = subject.call(current_user.id, other_uuid)
 
     expect(result).to be_nil
   end
 
   it 'returns nil if the user is not found and the cookie uuid is found' do
-    expect(Device.find_by(cookie_uuid: good_uuid)).to be_present
-    result = subject.call(bad_user_id, good_uuid)
+    expect(Device.find_by(cookie_uuid: device_uuid)).to be_present
+
+    result = subject.call(other_user.id, device_uuid)
 
     expect(result).to be_nil
   end
 
   it 'returns the device' do
-    result = subject.call(good_user_id, good_uuid)
+    result = subject.call(current_user.id, device_uuid)
 
     expect(result).to be_present
   end


### PR DESCRIPTION
**Why**: So that we can consolidate factory logic in the factories. This
also served as an opportunity to clean up those factories in light of
changes related to device tracking.
