### PR TITLE
Give readonly db user access to schemas after migration

### DIFF
--- a/deploy/migrate
+++ b/deploy/migrate
@@ -17,7 +17,7 @@ which bundle
 export RAILS_ENV=production
 export MIGRATION_STATEMENT_TIMEOUT=60000
 
-bundle exec rake db:create db:migrate db:seed --trace
+bundle exec rake db:create db:migrate db:seed db:grant_readonly_access --trace
 
 set +x
 

--- a/lib/tasks/db_grant_readonly_access.rake
+++ b/lib/tasks/db_grant_readonly_access.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc 'Create a readonly database user'
+  task grant_readonly_access: :environment do
+    username = Figaro.env.database_readonly_username
+
+    if username.blank?
+      warn 'Skipping readonly db setup because read only user is not present'
+      next
+    end
+
+    sql = "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}"
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end


### PR DESCRIPTION
**Why**: To make sure that the readonly database user always has access to the latest schema. This means we should not need to set the console write access flag to make read-only queries anymore.

cc: @lauraGgit & @MacHu-GWU
