### PR TITLE
Fix doc auth unauthenticated 500 errors

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -1,5 +1,7 @@
 module Idv
   class DocAuthController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
     include IdvSession # remove if we retire the non docauth LOA3 flow
     include Flow::FlowStateMachine
 
@@ -9,7 +11,5 @@ module Idv
       flow: Idv::Flows::DocAuthFlow,
       analytics_id: Analytics::DOC_AUTH,
     }.freeze
-
-    before_action :confirm_two_factor_authenticated
   end
 end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -12,11 +12,19 @@ describe Idv::DocAuthController do
     end
   end
 
-  before do
+  before do |example|
     enable_doc_auth
-    stub_sign_in
+    stub_sign_in unless example.metadata[:skip_sign_in]
     stub_analytics
     allow(@analytics).to receive(:track_event)
+  end
+
+  describe 'unauthenticated', :skip_sign_in do
+    it 'redirects to the root url' do
+      get :index
+
+      expect(response).to redirect_to root_url
+    end
   end
 
   describe '#index' do


### PR DESCRIPTION
Fix 500 errors when doc auth paths are hit unauthenticated due to a misplaced before hook.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
