### PR TITLE
Remove rubocop file exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,43 +33,20 @@ Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Enabled: true
   Max: 25
+  ExcludedMethods:
+    - 'Struct.new'
   Exclude:
     - 'Rakefile'
     - '**/*.rake'
-    - 'app/decorators/identity_decorator.rb'
-    - 'app/decorators/user_decorator.rb'
-    - 'app/services/omniauth_authorizer.rb'
-    - 'app/services/single_logout_handler.rb'
-    - 'app/services/pii/attributes.rb'
-    - 'app/services/x509/attributes.rb'
     - 'config/environments/*.rb'
-    - 'config/initializers/secure_headers.rb'
     - 'config/routes.rb'
     - 'spec/**/*.rb'
-    - 'config/initializers/active_job_logger_patch.rb'
 
 Metrics/ClassLength:
   Description: Avoid classes longer than 100 lines of code.
   Enabled: true
   CountComments: false
   Max: 100
-  Exclude:
-  - spec/**/*
-  - app/controllers/application_controller.rb
-  - app/controllers/openid_connect/authorization_controller.rb
-  - app/controllers/saml_idp_controller.rb
-  - app/controllers/users/confirmations_controller.rb
-  - app/controllers/users/sessions_controller.rb
-  - app/controllers/users/two_factor_authentication_controller.rb
-  - app/decorators/service_provider_session_decorator.rb
-  - app/decorators/user_decorator.rb
-  - app/forms/openid_connect_token_form.rb
-  - app/models/user.rb
-  - app/services/analytics.rb
-  - app/services/idv/session.rb
-  - app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
-  - app/view_models/account_show.rb
-  - lib/cloudhsm/cloudhsm_key_generator.rb
 
 Metrics/LineLength:
   Description: Limit lines to 100 characters.
@@ -100,7 +77,6 @@ Metrics/ModuleLength:
   Enabled: true
   Exclude:
   - spec/**/*
-  - 'app/controllers/concerns/two_factor_authenticatable.rb'
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
@@ -115,15 +91,6 @@ Rails/HttpPositionalArguments:
   Include:
     - 'spec/**/*'
     - 'test/**/*'
-
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - 'app/controllers/concerns/saml_idp_auth_concern.rb'
-    - 'app/controllers/concerns/two_factor_authenticatable.rb'
-
-Rails/OutputSafety:
-  Exclude:
-  - lib/i18n_override.rb
 
 # temporarily disabled until the fix for https://github.com/bbatsov/rubocop/issues/4249
 # is available in a new release
@@ -140,8 +107,6 @@ Rails/TimeZone:
   SupportedStyles:
     - strict
     - flexible
-  Exclude:
-    - 'lib/lambdas/account_reset_lambda.rb'
 
 Layout/AlignParameters:
   # Alignment of parameters in multi-line method calls.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 require 'core_extensions/string/permit'
 
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::Base # rubocop:disable Metrics/ClassLength
   String.include CoreExtensions::String::Permit
   include UserSessionContext
   include VerifyProfileConcern

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -2,9 +2,11 @@ module SamlIdpAuthConcern
   extend ActiveSupport::Concern
 
   included do
+    # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :validate_saml_request, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
     before_action :store_saml_request, only: :auth
+    # rubocop:enable Rails/LexicallyScopedActionFilter
   end
 
   private

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -1,14 +1,16 @@
-module TwoFactorAuthenticatable
+module TwoFactorAuthenticatable # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   include RememberDeviceConcern
   include SecureHeadersConcern
 
   included do
+    # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :authenticate_user
     before_action :require_current_password, if: :current_password_required?
     before_action :check_already_authenticated
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
     before_action :apply_secure_headers_override, only: %i[show create]
+    # rubocop:enable Rails/LexicallyScopedActionFilter
   end
 
   DELIVERY_METHOD_MAP = {

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 module Users
-  class SessionsController < Devise::SessionsController
+  class SessionsController < Devise::SessionsController # rubocop:disable Metrics/ClassLength
     include ::ActionView::Helpers::DateHelper
     include SecureHeadersConcern
     include RememberDeviceConcern

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -1,4 +1,5 @@
 module Users
+  # rubocop:disable Metrics/ClassLength
   class TwoFactorAuthenticationController < ApplicationController
     include TwoFactorAuthenticatable
 
@@ -215,4 +216,5 @@ module Users
       redirect_to url if url.present?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,4 +1,4 @@
-class ServiceProviderSessionDecorator
+class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
   include ActionView::Helpers::TranslationHelper
 
   DEFAULT_LOGO = 'generic.svg'.freeze

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,4 +1,4 @@
-class UserDecorator
+class UserDecorator # rubocop:disable Metrics/ClassLength
   include ActionView::Helpers::DateHelper
 
   attr_reader :user

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -1,4 +1,4 @@
-class OpenidConnectTokenForm
+class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,4 +1,4 @@
-class Analytics
+class Analytics # rubocop:disable Metrics/ClassLength
   def initialize(user:, request:, sp:)
     @user = user
     @request = request

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,5 +1,5 @@
 module Idv
-  class Session
+  class Session # rubocop:disable Metrics/ClassLength
     VALID_SESSION_ATTRIBUTES = %i[
       async_result_id
       async_result_started_at

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -1,5 +1,5 @@
 # :reek:TooManyMethods
-class AccountShow
+class AccountShow # rubocop:disable Metrics/ClassLength
   attr_reader :decorated_user, :decrypted_pii, :personal_key
 
   def initialize(decrypted_pii:, personal_key:, decorated_user:)

--- a/config/initializers/active_job_logger_patch.rb
+++ b/config/initializers/active_job_logger_patch.rb
@@ -1,7 +1,7 @@
 # This overrides the ActiveJob logger to remove sensitive info from the logs,
 # such as Devise tokens, OTP codes, phone numbers, emails, and data sent to
 # Google Analytics.
-ActiveSupport.on_load :active_job do
+ActiveSupport.on_load :active_job do # rubocop:disable Metrics/BlockLength
   module ActiveJob
     module Logging
       class LogSubscriber

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,4 +1,4 @@
-SecureHeaders::Configuration.default do |config|
+SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/BlockLength
   config.hsts = "max-age=#{365.days.to_i}; includeSubDomains; preload"
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'

--- a/lib/cloudhsm/cloudhsm_key_generator.rb
+++ b/lib/cloudhsm/cloudhsm_key_generator.rb
@@ -8,7 +8,7 @@ require 'io/console'
 # the program interactively asks for username, password (hidden), idp username,
 # and openssl.conf location
 
-class CloudhsmKeyGenerator
+class CloudhsmKeyGenerator # rubocop:disable Metrics/ClassLength
   KEY_MGMT_UTIL = '/opt/cloudhsm/bin/key_mgmt_util'.freeze
 
   def initialize

--- a/lib/i18n_override.rb
+++ b/lib/i18n_override.rb
@@ -10,7 +10,7 @@ I18n.module_eval do
       key = args.first.to_s
       rtn = i18n_text + i18n_mode_additional_markup(key)
 
-      rtn.html_safe
+      rtn.html_safe # rubocop:disable Rails/OutputSafety
     end
 
     private

--- a/lib/lambdas/account_reset_lambda.rb
+++ b/lib/lambdas/account_reset_lambda.rb
@@ -31,7 +31,8 @@ class AccountResetLambda
   end
 
   def now
-    Time.now.to_f
+    # TimeZone extensions do not apply when running in the lambda environment
+    Time.now.to_f # rubocop:disable Rails/TimeZone
   end
 end
 

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -1,5 +1,6 @@
 require_relative 'saml_auth_helper'
-class SamlResponseDoc
+
+class SamlResponseDoc # rubocop:disable Metrics/ClassLength
   include SamlAuthHelper
 
   attr_reader :original_encrypted


### PR DESCRIPTION
**Why**: Because the file exclusions get stale when they are targetting
a specific file. Disabling rules with comments calls out problems in the
code and means that when the code is changed the disabled rules are in
front of you so you know to re-enable them.
