### PR TITLE
Remove stale password digest rotation

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -14,8 +14,6 @@ module UserAccessKeyOverrides
       user_uuid: uuid,
     )
     log_password_verification_failure unless result
-    password_stale = Encryption::PasswordVerifier.new.stale_digest?(encrypted_password_digest)
-    self.password = password if result && password_stale
     result
   end
 

--- a/spec/features/idv/uak_password_spec.rb
+++ b/spec/features/idv/uak_password_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+feature 'A user with a UAK passwords attempts IdV' do
+  include IdvStepHelper
+
+  context 'before we start writing 2L-KMS passwords' do
+    before do
+      allow(FeatureManagement).to receive(:write_2lkms_passwords?).and_return(true)
+    end
+
+    it 'allows the user to continue to the SP' do
+      user = user_with_2fa
+      user.update!(
+        encrypted_password_digest: Encryption::UakPasswordVerifier.digest(user.password),
+      )
+
+      start_idv_from_sp(:oidc)
+      complete_idv_steps_with_phone_before_confirmation_step(user)
+
+      click_acknowledge_personal_key
+
+      expect(page).to have_current_path(sign_up_completed_path)
+
+      click_on t('forms.buttons.continue')
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+
+  context 'after we start writing 2L-KMS passwords' do
+    it 'allows the user to continue to the SP' do
+      user = user_with_2fa
+      user.update!(
+        encrypted_password_digest: Encryption::UakPasswordVerifier.digest(user.password),
+      )
+
+      start_idv_from_sp(:oidc)
+      complete_idv_steps_with_phone_before_confirmation_step(user)
+
+      click_acknowledge_personal_key
+
+      expect(page).to have_current_path(sign_up_completed_path)
+
+      click_on t('forms.buttons.continue')
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
+    end
+  end
+end

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -1,26 +1,18 @@
 require 'rails_helper'
 
 feature 'legacy passwords' do
-  scenario 'signing in with a password digested by the uak verifier updates the digest' do
+  scenario 'signing in with a password digested by the uak verifier grants access' do
     user = create(:user, :signed_up)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
     )
 
-    expect(
-      Encryption::PasswordVerifier.new.stale_digest?(user.encrypted_password_digest),
-    ).to eq(true)
-
     signin(user.email, 'legacy password')
-    user.reload
 
     expect(page).to have_current_path(
       login_otp_path(otp_delivery_preference: :sms, reauthn: false),
     )
     expect(page).to have_content(t('two_factor_authentication.header_text'))
-    expect(
-      Encryption::PasswordVerifier.new.stale_digest?(user.encrypted_password_digest),
-    ).to eq(false)
   end
 
   scenario 'signing in with an incorrect uak password digest does not grant access' do


### PR DESCRIPTION
**Why**: The password rotation we are doing currently causes issues when it is done anywhere besides sign in. This is because rotating the password digest changes the salt, which Devise uses to verify that the user in the session is the same user that password authed. This causes the user be logged out at any point they verify their password outside of sign in.

We should put something in to the rotate the password of users who have stale digests, but it should only happen on sign in. This commit removes the rotation entirely to fix issues in int while we figure out a better approach.
