### PR TITLE
Coerce the device id param into an integer

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,10 +18,16 @@ class EventsController < ApplicationController
   private
 
   def device_and_events
-    id = params[:id]
     user_id = current_user.id
-    @events = DeviceTracking::ListDeviceEvents.call(user_id, id, 0, EVENTS_PAGE_SIZE).
+    @events = DeviceTracking::ListDeviceEvents.call(user_id, device_id, 0, EVENTS_PAGE_SIZE).
               map(&:decorate)
-    @device = Device.find_by(user_id: user_id, id: id.to_i)
+    @device = Device.find_by(user_id: user_id, id: device_id)
+  end
+
+  def device_id
+    @device_id_param ||= begin
+      id = params[:id].try(:to_i)
+      id || 0
+    end
   end
 end


### PR DESCRIPTION
**Why**: So that it does not raise a NoMethodError when we use it like
an integer because it is an array or object of some other class.
