### PR TITLE
Render a 404 when a device is not found

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,6 +12,7 @@ class EventsController < ApplicationController
       decorated_user: current_user.decorate,
     )
     device_and_events
+    return render_device_not_found if @device.blank?
     render 'accounts/events/show'
   end
 
@@ -22,6 +23,10 @@ class EventsController < ApplicationController
     @events = DeviceTracking::ListDeviceEvents.call(user_id, device_id, 0, EVENTS_PAGE_SIZE).
               map(&:decorate)
     @device = Device.find_by(user_id: user_id, id: device_id)
+  end
+
+  def render_device_not_found
+    render 'pages/page_not_found', layout: false, status: :not_found, formats: :html
   end
 
   def device_id

--- a/spec/features/device_tracking_spec.rb
+++ b/spec/features/device_tracking_spec.rb
@@ -21,4 +21,12 @@ describe 'Device tracking' do
       expect(page).to have_content(t('event_types.account_created'))
     end
   end
+
+  context 'when the device does not exist' do
+    it 'renders a 404 error' do
+      visit account_events_path(id: 'dne')
+
+      expect(page).to have_content(t('pages.page_not_found.header'))
+    end
+  end
 end


### PR DESCRIPTION
**Why**: So that it does not render a 500 which triggers alerting
