### PR TITLE
Cleanup 404 rendering around events controller

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,8 @@ class EventsController < ApplicationController
       decorated_user: current_user.decorate,
     )
     device_and_events
-    return render_device_not_found if @device.blank?
+  rescue ActiveRecord::RecordNotFound, ActiveModel::RangeError
+    render_device_not_found
   end
 
   private
@@ -21,7 +22,7 @@ class EventsController < ApplicationController
     user_id = current_user.id
     @events = DeviceTracking::ListDeviceEvents.call(user_id, device_id, 0, EVENTS_PAGE_SIZE).
               map(&:decorate)
-    @device = Device.find_by(user_id: user_id, id: device_id)
+    @device = Device.where(user_id: user_id).find(device_id)
   end
 
   def render_device_not_found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ Rails.application.routes.draw do
         as: :openid_connect_configuration
 
     get '/account' => 'accounts#show'
-    get '/account/events' => 'events#show'
+    get '/account/devices/:id/events' => 'events#show', as: :account_events
     get '/account/delete' => 'users/delete#show', as: :account_delete
     delete '/account/delete' => 'users/delete#delete'
     get '/account/reactivate/start' => 'reactivate_account#index', as: :reactivate_account


### PR DESCRIPTION
**Why**: To cleanup the code and cover the ActiveModel range error that
happens when device ids are out of range. This commit also uses the
`#find` method on the active record relation to make ActiveRecord raise
when there is an issue finding a device. It rescues the error and
renders a 404.

It also changes the route so that the id is in the URL instead of in a
param. This limits the types of value that the device id can take on.
