### PR TITLE
Log KMS actions to a KMS log file

### DIFF
--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -7,11 +7,13 @@ module Encryption
     }.freeze
 
     def encrypt(plaintext)
+      KmsLogger.log(:encrypt)
       return encrypt_kms(plaintext) if FeatureManagement.use_kms?
       encrypt_local(plaintext)
     end
 
     def decrypt(ciphertext)
+      KmsLogger.log(:decrypt)
       return decrypt_kms(ciphertext) if use_kms?(ciphertext)
       decrypt_local(ciphertext)
     end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -11,13 +11,14 @@ module Encryption
 
     def encrypt(plaintext, encryption_context)
       return ContextlessKmsClient.new.encrypt(plaintext) unless FeatureManagement.use_kms_contexts?
-
+      KmsLogger.log(:encrypt, encryption_context)
       return encrypt_kms(plaintext, encryption_context) if FeatureManagement.use_kms?
       encrypt_local(plaintext, encryption_context)
     end
 
     def decrypt(ciphertext, encryption_context)
       return decrypt_contextless_kms(ciphertext) if self.class.looks_like_contextless?(ciphertext)
+      KmsLogger.log(:decrypt, encryption_context)
       return decrypt_kms(ciphertext, encryption_context) if use_kms?(ciphertext)
       decrypt_local(ciphertext, encryption_context)
     end

--- a/app/services/encryption/kms_logger.rb
+++ b/app/services/encryption/kms_logger.rb
@@ -1,0 +1,18 @@
+module Encryption
+  class KmsLogger
+    def self.log(action, context = nil)
+      output = {
+        kms: {
+          action: action,
+          encryption_context: context,
+        },
+      }
+      logger.info(output.to_json)
+    end
+
+    def self.logger
+      @logger ||= Logger.new('log/kms.log')
+    end
+    private_class_method :logger
+  end
+end

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -127,6 +127,12 @@ describe Encryption::ContextlessKmsClient do
           expect(result).to eq(local_ciphertext)
         end
       end
+
+      it 'logs the encryption' do
+        expect(Encryption::KmsLogger).to receive(:log).with(:encrypt)
+
+        subject.encrypt(long_kms_plaintext)
+      end
     end
 
     describe '#decrypt' do
@@ -152,6 +158,12 @@ describe Encryption::ContextlessKmsClient do
 
           expect(result).to eq(local_plaintext)
         end
+      end
+
+      it 'logs the decryption' do
+        expect(Encryption::KmsLogger).to receive(:log).with(:decrypt)
+
+        subject.decrypt('KMSx' + kms_ciphertext)
       end
     end
 

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -80,6 +80,12 @@ describe Encryption::KmsClient do
         expect(result).to eq('contextless ciphertext')
       end
     end
+
+    it 'logs the context' do
+      expect(Encryption::KmsLogger).to receive(:log).with(:encrypt, encryption_context)
+
+      subject.encrypt(plaintext, encryption_context)
+    end
   end
 
   describe '#decrypt' do
@@ -126,6 +132,12 @@ describe Encryption::KmsClient do
           expect(result).to eq('plaintext')
         end
       end
+    end
+
+    it 'logs the context' do
+      expect(Encryption::KmsLogger).to receive(:log).with(:decrypt, encryption_context)
+
+      subject.decrypt(kms_ciphertext, encryption_context)
     end
   end
 end

--- a/spec/services/encryption/kms_logger_spec.rb
+++ b/spec/services/encryption/kms_logger_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe Encryption::KmsLogger do
+  describe '.log' do
+    context 'with a context' do
+      it 'logs the context' do
+        described_class.log(:encrypt, context: 'pii-encryption', user_uuid: '1234-abc')
+
+        log_contents = File.read('log/kms.log').split("\n")
+        log = log_contents.last
+
+        expect(log).to include(
+          {
+            kms: {
+              action: 'encrypt',
+              encryption_context: { context: 'pii-encryption', user_uuid: '1234-abc' },
+            },
+          }.to_json,
+        )
+      end
+    end
+
+    context 'without a context' do
+      it 'logs that an encryption happened without a context' do
+        described_class.log(:decrypt)
+
+        log_contents = File.read('log/kms.log').split("\n")
+        log = log_contents.last
+
+        expect(log).to include(
+          {
+            kms: {
+              action: 'decrypt',
+              encryption_context: nil,
+            },
+          }.to_json,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that we can match calls to the KMS client to output we see
in the cloudtrail logs.
