### PR TITLE
Add the post logout redirect URI for the OIDC SP

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -237,6 +237,7 @@ production:
       - 'http://localhost:9292/auth/result'
       <% if LoginGov::Hostdata.in_datacenter? %>
       - 'https://sp-oidc-sinatra.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/auth/result'
+      - 'https://sp-oidc-sinatra.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>/'
       <% end %>
 
   'urn:gov:gsa:openidconnect:sp:expressjs':


### PR DESCRIPTION
**Why**: This is currently missing which means that logout is broken for
the OIDC Sinatra SP in int.
