### PR TITLE
Fix 500 errors on doc auth when no phone used for 2fa

### DIFF
--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -19,7 +19,7 @@ module Idv
 
       def extract_pii_from_doc(data)
         pii_from_doc = Idv::Utils::PiiFromDoc.new(data).call(
-          current_user.phone_configurations.first.phone,
+          current_user&.phone_configurations&.first&.phone,
         )
         flow_session[:pii_from_doc] = pii_from_doc
       end

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -24,7 +24,7 @@ module Idv
 
       def extract_pii_from_doc(data)
         pii_from_doc = Idv::Utils::PiiFromDoc.new(data).call(
-          current_user.phone_configurations.first.phone,
+          current_user&.phone_configurations&.first&.phone,
         )
         flow_session[:pii_from_doc] = pii_from_doc
       end

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -19,7 +19,7 @@ module Idv
 
       def extract_pii_from_doc(data)
         pii_from_doc = Idv::Utils::PiiFromDoc.new(data).call(
-          current_user.phone_configurations.first.phone,
+          current_user&.phone_configurations&.first&.phone,
         )
         flow_session[:pii_from_doc] = pii_from_doc
       end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -24,6 +24,14 @@ shared_examples 'back image step' do |simulate|
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
+    it 'proceeds to the next page if the user does not have a phone' do
+      complete_doc_auth_steps_before_back_image_step(create(:user, :with_piv_or_cac))
+      attach_image
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_doc_auth_ssn_step)
+    end
+
     it 'does not proceed to the next page with invalid info' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
         and_return([false, ''])

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -28,6 +28,13 @@ shared_examples 'link sent step' do |simulate|
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
+    it 'proceeds to the next page if the user does not have a phone' do
+      complete_doc_auth_steps_before_link_sent_step(create(:user, :with_piv_or_cac))
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_doc_auth_ssn_step)
+    end
+
     it 'does not proceed to the next page with invalid info' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
         and_return([false, ''])

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -24,6 +24,14 @@ shared_examples 'mobile back image step' do |simulate|
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
+    it 'proceeds to the next page if the user does not have a phone' do
+      complete_doc_auth_steps_before_mobile_back_image_step(create(:user, :with_piv_or_cac))
+      attach_image
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_doc_auth_ssn_step)
+    end
+
     it 'does not proceed to the next page with invalid info' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
         and_return([false, ''])


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
