### PR TITLE
Add missing event names

### DIFF
--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -7,6 +7,7 @@ en:
     authenticated_at_html: Signed in at %{service_provider_link}
     authenticator_disabled: Authenticator app disabled
     authenticator_enabled: Authenticator app enabled
+    backup_codes_added: Backup codes added
     eastern_timestamp: "%{timestamp} (Eastern)"
     email_changed: Email address changed
     new_personal_key: Personal key changed

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -7,6 +7,7 @@ es:
     authenticated_at_html: Sesión iniciada en %{service_provider_link}
     authenticator_disabled: La app de autenticación fue suspendida
     authenticator_enabled: App de autenticación permitido
+    backup_codes_added: Códigos de respaldo añadidos
     eastern_timestamp: "%{timestamp} (hora del Este)"
     email_changed: Email cambiado
     new_personal_key: Clave personal cambiado

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -7,6 +7,7 @@ fr:
     authenticated_at_html: Connecté à %{service_provider_link}
     authenticator_disabled: Application d'authentification désactivée
     authenticator_enabled: Application d'authentification activée
+    backup_codes_added: Codes de sauvegarde ajoutés
     eastern_timestamp: "%{timestamp} (Eastern)"
     email_changed: Adresse courriel modifiée
     new_personal_key: Clé personnelle modifié

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -100,7 +100,7 @@ en:
       auth_app_info: Set up an authentication application to get your security code
         without providing a phone number
       backup_code: Backup Codes
-      backup_code_info: Recieve a pre-generated list of security codes to use when
+      backup_code_info: Receive a pre-generated list of security codes to use when
         signing in
       piv_cac: Government employees
       piv_cac_info: Use your PIV/CAC card to secure your account

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -12,4 +12,14 @@ describe Event do
       expect(event).to be_valid
     end
   end
+
+  it 'has a translation for every event type' do
+    missing_translations = Event.event_types.keys.select do |event_type|
+      translation = I18n.t("event_types.#{event_type}", raise: true)
+      translation.empty?
+    rescue I18n::MissingTranslationData
+      true
+    end
+    expect(missing_translations).to be_empty
+  end
 end


### PR DESCRIPTION
**Why**: To clean up missing translation message that appear in event
history.
