### PR TITLE
Updates OpenID Connect ExpressJS sample app

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -248,6 +248,9 @@ production:
     redirect_uris:
       - 'http://localhost:9393/'
       - 'http://localhost:9393/auth/login-gov/callback'
+      - 'http://localhost:9393/auth/login-gov/callback/loa-1'
+      - 'http://localhost:9393/auth/login-gov/callback/loa-3'
+      - 'http://localhost:9393/auth/login-gov/logout'
 
   'urn:gov:gsa:openidconnect:sp:gin':
     agency: 'GSA'


### PR DESCRIPTION
An [update to the sample app](https://github.com/18F/identity-oidc-expressjs/blob/master/routes/auth/login-gov.js#L14-L15) included new routes for LOA1 and LOA3 but these were never updated in the service provider configuration.

Resolves: https://github.com/18F/identity-oidc-expressjs/issues/14

Adds updated redirect URIs for LOA1/3
Adds logout URI


### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
