### PR TITLE
Fix the OIDC token form code validation

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -29,10 +29,7 @@ class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
     ATTRS.each do |key|
       instance_variable_set(:"@#{key}", params[key])
     end
-
-    session_expiration = Figaro.env.session_timeout_in_minutes.to_i.minutes.ago
-    @identity = Identity.where(session_uuid: code).
-                where('updated_at >= ?', session_expiration).first
+    @identity = find_identity_with_code
   end
 
   def submit
@@ -59,6 +56,14 @@ class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
   private
 
   attr_reader :identity
+
+  def find_identity_with_code
+    return if code.blank?
+
+    session_expiration = Figaro.env.session_timeout_in_minutes.to_i.minutes.ago
+    @identity = Identity.where(session_uuid: code).
+                where('updated_at >= ?', session_expiration).first
+  end
 
   def pkce?
     pkce_sp && (code_verifier.present? || identity.try(:code_challenge).present?)

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe OpenidConnectTokenForm do
           expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
         end
       end
+
+      context 'code is nil' do
+        before do
+          # Create an identity with a nil session uuid to make sure the form is not
+          # looking up an identity with a nil code and finding this one
+          create(:identity, session_uuid: nil)
+        end
+
+        let(:code) { nil }
+
+        it 'is invalid' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).to include(t('openid_connect.token.errors.invalid_code'))
+        end
+      end
     end
 
     context 'private_key_jwt' do


### PR DESCRIPTION
**Why**: To make it display the correct error in the logs when the code
is nil.
