### PR TITLE
Add disavowals to events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,11 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
                  event_type: event_type)
   end
 
+  def create_user_event_with_disavowal(event_type, user = current_user)
+    event = create_user_event(event_type, user)
+    EventDisavowal::GenerateDisavowalToken.new(event).call
+  end
+
   def create_or_update_device(user)
     cookie = cookies[:device]
     device = DeviceTracking::ManageDevice.call(user, cookie, request.remote_ip, request.user_agent)

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -1,0 +1,61 @@
+class EventDisavowalController < ApplicationController
+  before_action :validate_disavowed_event
+
+  def new
+    # Memoize the form for use in the views
+    password_reset_from_disavowal_form
+    analytics.track_event(
+      Analytics::EVENT_DISAVOWAL,
+      FormResponse.new(
+        success: true,
+        errors: {},
+        extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
+      ).to_h,
+    )
+  end
+
+  def create
+    result = password_reset_from_disavowal_form.submit(password_reset_params)
+    analytics.track_event(Analytics::EVENT_DISAVOWAL_PASSWORD_RESET, result.to_h)
+    if result.success?
+      handle_successful_password_reset
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def password_reset_from_disavowal_form
+    @password_reset_from_disavowal_form ||= EventDisavowal::PasswordResetFromDisavowalForm.new(
+      disavowed_event,
+    )
+  end
+
+  def password_reset_params
+    params.require(:event_disavowal_password_reset_from_disavowal_form).permit(:password)
+  end
+
+  def validate_disavowed_event
+    result = EventDisavowal::ValidateDisavowedEvent.new(disavowed_event).call
+    return if result.success?
+    analytics.track_event(Analytics::EVENT_DISAVOWAL_TOKEN_INVALID, result.to_h)
+    flash[:error] = result.errors[:event].first
+    redirect_to root_url
+  end
+
+  def handle_successful_password_reset
+    EventDisavowal::DisavowEvent.new(disavowed_event).call
+    flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
+    redirect_to new_user_session_url
+  end
+
+  def disavowal_token
+    @disavowal_token ||= params[:disavowal_token]
+  end
+
+  def disavowed_event
+    return if disavowal_token.nil?
+    @disavowed_event ||= EventDisavowal::FindDisavowedEvent.new(disavowal_token).call
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -30,11 +30,18 @@ module Users
     end
 
     def handle_valid_password
-      create_user_event(:password_changed)
+      create_event_and_notify_user_about_password_change
       bypass_sign_in current_user
 
       flash[:personal_key] = @update_user_password_form.personal_key
       redirect_to account_url, notice: t('notices.password_changed')
+    end
+
+    def create_event_and_notify_user_about_password_change
+      disavowal_token = create_user_event_with_disavowal(:password_changed)
+      current_user.confirmed_email_addresses.each do |email_address|
+        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
+      end
     end
 
     def handle_invalid_password

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -108,7 +108,7 @@ module Users
     end
 
     def handle_successful_password_reset
-      create_user_event(:password_changed, resource)
+      create_reset_event_and_send_notification
       flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
       redirect_to new_user_session_url
     end
@@ -122,6 +122,13 @@ module Users
       end
 
       render :edit
+    end
+
+    def create_reset_event_and_send_notification
+      disavowal_token = create_user_event_with_disavowal(:password_changed, resource)
+      resource.confirmed_email_addresses.each do |email_address|
+        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
+      end
     end
 
     def user_params

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -1,5 +1,5 @@
 module Users
-  class ResetPasswordsController < Devise::PasswordsController
+  class ResetPasswordsController < Devise::PasswordsController # rubocop:disable Metrics/ClassLength
     include RecaptchaConcern
 
     def new

--- a/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
+++ b/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
@@ -1,0 +1,41 @@
+module EventDisavowal
+  class PasswordResetFromDisavowalForm
+    include ActiveModel::Model
+    include FormPasswordValidator
+
+    attr_reader :event, :user
+
+    def initialize(event)
+      @event = event
+      @user = event.user
+    end
+
+    def submit(params)
+      self.password = params[:password]
+
+      success = valid?
+      handle_valid_password if success
+      FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+    end
+
+    private
+
+    def handle_valid_password
+      update_user
+      mark_profile_inactive
+    end
+
+    def update_user
+      attributes = { password: password }
+      UpdateUser.new(user: user, attributes: attributes).call
+    end
+
+    def mark_profile_inactive
+      user.active_profile&.deactivate(:password_reset)
+    end
+
+    def extra_analytics_attributes
+      EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(event)
+    end
+  end
+end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -38,7 +38,6 @@ class ResetPasswordForm
   def handle_valid_password
     update_user
     mark_profile_inactive
-    notify_user_of_password_change_via_email
   end
 
   def update_user
@@ -49,12 +48,6 @@ class ResetPasswordForm
 
   def mark_profile_inactive
     user.active_profile&.deactivate(:password_reset)
-  end
-
-  def notify_user_of_password_change_via_email
-    user.confirmed_email_addresses.each do |email_address|
-      UserMailer.password_changed(email_address).deliver_later
-    end
   end
 
   def extra_analytics_attributes

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -22,19 +22,12 @@ class UpdateUserPasswordForm
 
   def process_valid_submission
     update_user_password
-    email_user_about_password_change
     encrypt_user_profile_if_active
   end
 
   def update_user_password
     attributes = { password: password }
     UpdateUser.new(user: user, attributes: attributes).call
-  end
-
-  def email_user_about_password_change
-    user.confirmed_email_addresses.each do |email_address|
-      UserMailer.password_changed(email_address).deliver_later
-    end
   end
 
   def encrypt_user_profile_if_active

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,7 +14,8 @@ class UserMailer < ActionMailer::Base
     mail(to: email, subject: t('mailer.email_reuse_notice.subject'))
   end
 
-  def password_changed(email_address)
+  def password_changed(email_address, disavowal_token:)
+    @disavowal_token = disavowal_token
     mail(to: email_address.email, subject: t('devise.mailer.password_updated.subject'))
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -62,6 +62,9 @@ class Analytics # rubocop:disable Metrics/ClassLength
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_CHANGE_REQUEST = 'Email Change Request'.freeze
+  EVENT_DISAVOWAL = 'Event disavowal visited'.freeze
+  EVENT_DISAVOWAL_PASSWORD_RESET = 'Event disavowal password reset'.freeze
+  EVENT_DISAVOWAL_TOKEN_INVALID = 'Event disavowal token invalid'.freeze
   EVENTS_VISIT = 'Events Page Visited'.freeze
   EXPIRED_LETTERS = 'Expired Letters'.freeze
   FRONTEND_BROWSER_CAPABILITIES = 'Frontend: Browser capabilities'.freeze

--- a/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
+++ b/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
@@ -1,0 +1,20 @@
+module EventDisavowal
+  class BuildDisavowedEventAnalyticsAttributes
+    # rubocop:disable MethodLength,
+    def self.call(event)
+      return {} if event.blank?
+
+      device = event.device
+      {
+        event_id: event.id,
+        event_type: event.event_type,
+        event_created_at: event.created_at,
+        event_ip: event.ip,
+        disavowed_device_user_agent: device&.user_agent,
+        disavowed_device_last_ip: device&.last_ip,
+        disavowed_device_last_used_at: device&.last_used_at,
+      }
+    end
+    # rubocop:enable MethodLength
+  end
+end

--- a/app/services/event_disavowal/disavow_event.rb
+++ b/app/services/event_disavowal/disavow_event.rb
@@ -1,0 +1,13 @@
+module EventDisavowal
+  class DisavowEvent
+    attr_reader :event
+
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      event.update!(disavowed_at: Time.zone.now)
+    end
+  end
+end

--- a/app/services/event_disavowal/find_disavowed_event.rb
+++ b/app/services/event_disavowal/find_disavowed_event.rb
@@ -1,0 +1,25 @@
+module EventDisavowal
+  class FindDisavowedEvent
+    attr_reader :disavowal_token
+
+    def initialize(disavowal_token)
+      @disavowal_token = disavowal_token
+    end
+
+    def call
+      @event ||= Event.where(
+        disavowal_token_fingerprint: disavowal_token_fingerprints,
+      ).first
+    end
+
+    private
+
+    def disavowal_token_fingerprints
+      old_keys = KeyRotator::Utils.old_keys(:hmac_fingerprinter_key_queue)
+      previous_key_fingerprints = old_keys.map do |key|
+        Pii::Fingerprinter.fingerprint(disavowal_token, key)
+      end
+      [Pii::Fingerprinter.fingerprint(disavowal_token)] + previous_key_fingerprints
+    end
+  end
+end

--- a/app/services/event_disavowal/generate_disavowal_token.rb
+++ b/app/services/event_disavowal/generate_disavowal_token.rb
@@ -1,0 +1,27 @@
+module EventDisavowal
+  class GenerateDisavowalToken
+    attr_reader :event, :disavowal_token
+
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      generate_disavowal_token
+      fingerprint_and_save_disavowal_token
+      disavowal_token
+    end
+
+    private
+
+    def generate_disavowal_token
+      @disavowal_token = SecureRandom.urlsafe_base64(32)
+    end
+
+    def fingerprint_and_save_disavowal_token
+      event.update!(
+        disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),
+      )
+    end
+  end
+end

--- a/app/views/event_disavowal/new.html.slim
+++ b/app/views/event_disavowal/new.html.slim
@@ -1,0 +1,17 @@
+- title t('titles.passwords.change')
+
+h1.h3.my0 = t('headings.passwords.change')
+= simple_form_for(@password_reset_from_disavowal_form,
+    url: events_disavowal_url,
+    html: { autocomplete: 'off',
+    method: :post,
+    role: 'form' }) do |f|
+  = f.input :disavowal_token, as: :hidden,
+    input_html: { value: @disavowal_token, name: :disavowal_token }
+  = f.input :password, label: t('forms.passwords.edit.labels.password'), required: true
+  = render 'devise/shared/password_strength'
+  = f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3'
+
+= render 'shared/password_accordion'
+
+== javascript_pack_tag 'pw-strength'

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -12,5 +12,6 @@ table.hr
 
 p == t('.help',
       app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
+      disavowal_link: link_to(t('.disavowal_link'), event_disavowal_url(disavowal_token: @disavowal_token)),
       help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
       contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/app/views/user_mailer/password_changed.html.slim
+++ b/app/views/user_mailer/password_changed.html.slim
@@ -12,6 +12,7 @@ table.hr
 
 p == t('.help',
       app: link_to(APP_NAME, Figaro.env.mailer_domain_name, class: 'gray'),
-      disavowal_link: link_to(t('.disavowal_link'), event_disavowal_url(disavowal_token: @disavowal_token)),
+      disavowal_link: link_to(t('.disavowal_link'),
+        event_disavowal_url(disavowal_token: @disavowal_token)),
       help_link: link_to(t('user_mailer.help_link_text'), MarketingSite.help_url),
       contact_link: link_to(t('user_mailer.contact_link_text'), MarketingSite.contact_url))

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -144,6 +144,7 @@ development:
   enable_rate_limiting: 'false'
   enable_test_routes: 'true'
   enable_usps_verification: 'true'
+  event_disavowal_expiration_hours: '240'
   exception_recipients: 'test1@test.com'
   expired_letters_auth_token: 'abc123'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
@@ -264,6 +265,7 @@ production:
   enable_rate_limiting: 'true'
   enable_test_routes: 'false'
   enable_usps_verification: 'false'
+  event_disavowal_expiration_hours: '240'
   exception_recipients: 'user1@example.com,user2@example.com'
   expired_letters_auth_token:
   google_analytics_key: # 'UA-XXXXXXXXX-YY'
@@ -384,6 +386,7 @@ test:
   enable_rate_limiting: 'true'
   enable_test_routes: 'true'
   enable_usps_verification: 'true'
+  event_disavowal_expiration_hours: '240'
   exception_recipients: 'test1@test.com'
   expired_letters_auth_token: 'abc123'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'

--- a/config/locales/event_disavowals/en.yml
+++ b/config/locales/event_disavowals/en.yml
@@ -4,7 +4,7 @@ en:
     errors:
       event_already_disavowed: You have already used that link to change your password.
         Sign in to change your password.
-      event_disavowal_expired: The link to change your password has expired. Sign in
-        to change your password.
+      event_disavowal_expired: The link to change your password has expired. Sign
+        in to change your password.
       event_not_found: The link to change your password is invalid. Sign in to change
         your password.

--- a/config/locales/event_disavowals/en.yml
+++ b/config/locales/event_disavowals/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  event_disavowals:
+    errors:
+      event_already_disavowed: You have already used that link to change your password.
+        Sign in to change your password.
+      event_disavowal_expired: The link to change your password has expired. Sign in
+        to change your password.
+      event_not_found: The link to change your password is invalid. Sign in to change
+        your password.

--- a/config/locales/event_disavowals/es.yml
+++ b/config/locales/event_disavowals/es.yml
@@ -1,0 +1,7 @@
+---
+es:
+  event_disavowals:
+    errors:
+      event_already_disavowed: Ya has usado ese enlace para cambiar tu contraseña. Inicia sesión para cambiar tu contraseña.
+      event_disavowal_expired: El enlace para cambiar tu contraseña ha caducado. Inicia sesión para cambiar tu contraseña.
+      event_not_found: El enlace para cambiar su contraseña no es válido. Inicia sesión para cambiar tu contraseña.

--- a/config/locales/event_disavowals/es.yml
+++ b/config/locales/event_disavowals/es.yml
@@ -2,6 +2,9 @@
 es:
   event_disavowals:
     errors:
-      event_already_disavowed: Ya has usado ese enlace para cambiar tu contraseña. Inicia sesión para cambiar tu contraseña.
-      event_disavowal_expired: El enlace para cambiar tu contraseña ha caducado. Inicia sesión para cambiar tu contraseña.
-      event_not_found: El enlace para cambiar su contraseña no es válido. Inicia sesión para cambiar tu contraseña.
+      event_already_disavowed: Ya has usado ese enlace para cambiar tu contraseña.
+        Inicia sesión para cambiar tu contraseña.
+      event_disavowal_expired: El enlace para cambiar tu contraseña ha caducado. Inicia
+        sesión para cambiar tu contraseña.
+      event_not_found: El enlace para cambiar su contraseña no es válido. Inicia sesión
+        para cambiar tu contraseña.

--- a/config/locales/event_disavowals/fr.yml
+++ b/config/locales/event_disavowals/fr.yml
@@ -1,0 +1,7 @@
+---
+fr:
+  event_disavowals:
+    errors:
+      event_already_disavowed: Vous avez déjà utilisé ce lien pour changer votre mot de passe. Connectez-vous pour changer votre mot de passe.
+      event_disavowal_expired: Le lien pour changer votre mot de passe a expiré. Connectez-vous pour changer votre mot de passe.
+      event_not_found: Le lien pour changer votre mot de passe est invalide. Connectez-vous pour changer votre mot de passe.

--- a/config/locales/event_disavowals/fr.yml
+++ b/config/locales/event_disavowals/fr.yml
@@ -2,6 +2,9 @@
 fr:
   event_disavowals:
     errors:
-      event_already_disavowed: Vous avez déjà utilisé ce lien pour changer votre mot de passe. Connectez-vous pour changer votre mot de passe.
-      event_disavowal_expired: Le lien pour changer votre mot de passe a expiré. Connectez-vous pour changer votre mot de passe.
-      event_not_found: Le lien pour changer votre mot de passe est invalide. Connectez-vous pour changer votre mot de passe.
+      event_already_disavowed: Vous avez déjà utilisé ce lien pour changer votre mot
+        de passe. Connectez-vous pour changer votre mot de passe.
+      event_disavowal_expired: Le lien pour changer votre mot de passe a expiré. Connectez-vous
+        pour changer votre mot de passe.
+      event_not_found: Le lien pour changer votre mot de passe est invalide. Connectez-vous
+        pour changer votre mot de passe.

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -64,7 +64,7 @@ en:
     password_changed:
       disavowal_link: here
       help: If you did not make this change, you can reset your password %{disavowal_link}.
-        For more help please visit the %{app} %{help_link} or %{contact_link}.
+        For more help, please visit the %{app} %{help_link} or %{contact_link}.
       intro: You have a new password for your %{app} account.
     personal_key_regenerated:
       help_html: <p>Your login.gov account was just issued a new 16-character personal

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -62,8 +62,9 @@ en:
         <p><strong>%{date}<br/>%{location}</strong></p>"
       subject: New sign-in with your Login.gov account
     password_changed:
-      help: If you did not make this change, please visit the %{app} %{help_link}
-        or %{contact_link}.
+      disavowal_link: here
+      help: If you did not make this change, you can reset your password %{disavowal_link}.
+        For more help please visit the %{app} %{help_link} or %{contact_link}.
       intro: You have a new password for your %{app} account.
     personal_key_regenerated:
       help_html: <p>Your login.gov account was just issued a new 16-character personal

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -62,7 +62,9 @@ es:
         <p><strong>%{date}<br/>%{location}</strong></p>"
       subject: Nuevo initio de sesion con su Login.gov cuenta
     password_changed:
-      help: Si no realizó este cambio, visite el %{app} %{help_link} o el %{contact_link}.
+      disavowal_link: aquí
+      help: Si no realizó este cambio puede restablecer su contraseña %{disavowal_link}.
+        Para más ayuda, visite el %{app} %{help_link} o el %{contact_link}.
       intro: Tiene una contraseña nueva para su cuenta de %{app}.
     personal_key_regenerated:
       help_html: <p>Tu cuenta de login.gov acaba de emitir una nueva clave personal

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -65,8 +65,10 @@ fr:
         <p><strong>%{date}<br/>%{location}</strong></p>"
       subject: Nouvelle connexion avec votre compte Login.gov
     password_changed:
-      help: Si vous n'avez pas changé votre mot de passe, veuillez visiter le %{help_link}
-        de %{app} ou %{contact_link}.
+      disavowal_link: ici
+      help: Si vous n'avez pas changé votre mot de passe, vous pouvez réinitialiser
+        votre mot de passe %{disavowal_link}. Pour plus d'aide, veuillez visiter le
+        %{help_link} de %{app} ou %{contact_link}.
       intro: Le mot de passe de votre compte %{app} a été changé.
     personal_key_regenerated:
       help_html: <p>Votre compte login.gov vient de recevoir une nouvelle clé personnelle

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,9 @@ Rails.application.routes.draw do
          as: :create_verify_personal_key
     get '/account_recovery_setup' => 'account_recovery_setup#index'
 
+    get '/events/disavow/:disavowal_token' => 'event_disavowal#new', as: :event_disavowal
+    post '/events/disavow/' => 'event_disavowal#create', as: :events_disavowal
+
     get '/piv_cac' => 'users/piv_cac_authentication_setup#new', as: :setup_piv_cac
     delete '/piv_cac' => 'users/piv_cac_authentication_setup#delete', as: :disable_piv_cac
     get '/present_piv_cac' => 'users/piv_cac_authentication_setup#redirect_to_piv_cac_service', as: :redirect_to_piv_cac_service

--- a/db/migrate/20190306143757_add_disavowal_token_fingerprint_to_events.rb
+++ b/db/migrate/20190306143757_add_disavowal_token_fingerprint_to_events.rb
@@ -1,0 +1,9 @@
+class AddDisavowalTokenFingerprintToEvents < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :events, :disavowed_at, :timestamp
+    add_column :events, :disavowal_token_fingerprint, :string
+    add_index :events, :disavowal_token_fingerprint, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190225005651) do
+ActiveRecord::Schema.define(version: 20190306143757) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -119,7 +120,10 @@ ActiveRecord::Schema.define(version: 20190225005651) do
     t.datetime "updated_at", null: false
     t.integer "device_id"
     t.string "ip"
+    t.datetime "disavowed_at"
+    t.string "disavowal_token_fingerprint"
     t.index ["device_id", "created_at"], name: "index_events_on_device_id_and_created_at"
+    t.index ["disavowal_token_fingerprint"], name: "index_events_on_disavowal_token_fingerprint"
     t.index ["user_id", "created_at"], name: "index_events_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_events_on_user_id"
   end

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+describe EventDisavowalController do
+  let(:disavowal_token) { 'asdf1234' }
+  let(:event) do
+    create(
+      :event,
+      disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),
+    )
+  end
+
+  before do
+    stub_analytics
+  end
+
+  describe '#new' do
+    context 'with a valid disavowal_token' do
+      it 'tracks an analytics event' do
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL,
+          build_analytics_hash,
+        )
+
+        get :new, params: { disavowal_token: disavowal_token }
+      end
+    end
+
+    context 'with an invalid disavowal_token' do
+      it 'tracks an analytics event' do
+        event.update!(disavowed_at: Time.zone.now)
+
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL_TOKEN_INVALID,
+          build_analytics_hash(
+            success: false,
+            errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
+          ),
+        )
+
+        get :new, params: { disavowal_token: disavowal_token }
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'with a valid passowrd' do
+      it 'tracks an analytics event' do
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL_PASSWORD_RESET,
+          build_analytics_hash,
+        )
+
+        post :create, params: {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
+        }
+      end
+    end
+
+    context 'with an invalid password' do
+      it 'tracks an analytics event' do
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL_PASSWORD_RESET,
+          build_analytics_hash(
+            success: false,
+            errors: { password: ['is too short (minimum is 12 characters)'] },
+          ),
+        )
+
+        params = {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'too short' },
+        }
+
+        post :create, params: params
+      end
+    end
+
+    context 'with an invalid disavowal_token' do
+      it 'tracks an analytics event' do
+        event.update!(disavowed_at: Time.zone.now)
+
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL_TOKEN_INVALID,
+          build_analytics_hash(
+            success: false,
+            errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
+          ),
+        )
+
+        params = {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
+        }
+
+        post :create, params: params
+      end
+    end
+  end
+
+  # :reek:BooleanParameter
+  def build_analytics_hash(success: true, errors: {})
+    {
+      success: success,
+      errors: errors,
+      event_id: event.id,
+      event_type: event.event_type,
+      event_created_at: event.created_at,
+      event_ip: event.ip,
+      disavowed_device_user_agent: event.device.user_agent,
+      disavowed_device_last_ip: event.device.last_ip,
+      disavowed_device_last_used_at: event.device.last_used_at,
+    }
+  end
+end

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -100,16 +100,16 @@ describe EventDisavowalController do
 
   # :reek:BooleanParameter
   def build_analytics_hash(success: true, errors: {})
-    {
+    hash_including(
+      :event_created_at,
+      :disavowed_device_last_used_at,
       success: success,
       errors: errors,
       event_id: event.id,
       event_type: event.event_type,
-      event_created_at: event.created_at,
       event_ip: event.ip,
       disavowed_device_user_agent: event.device.user_agent,
       disavowed_device_last_ip: event.device.last_ip,
-      disavowed_device_last_used_at: event.device.last_used_at,
-    }
+    )
   end
 end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -519,7 +519,9 @@ describe Users::ResetPasswordsController, devise: true do
   def stub_user_mailer(user)
     mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
     user.email_addresses.each do |email_address|
-      allow(UserMailer).to receive(:password_changed).with(email_address).and_return(mailer)
+      allow(UserMailer).to receive(:password_changed).
+        with(email_address, disavowal_token: instance_of(String)).
+        and_return(mailer)
     end
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :event do
     event_type { :account_created }
+    user
 
     after(:build) do |event|
       event.device ||= event.user.devices.first || build(:device, user: event.user)

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+feature 'disavowing an action' do
+  let(:user) { create(:user, :signed_up) }
+
+  scenario 'disavowing a password reset' do
+    perform_disavowable_password_reset
+    disavow_last_action_and_reset_password
+  end
+
+  scenario 'disavowing a password update' do
+    sign_in_and_2fa_user(user)
+    visit manage_password_path
+    fill_in 'New password', with: 'OldVal!dPassw0rd'
+    click_on t('forms.buttons.submit.update')
+    Capybara.reset_sessions!
+
+    disavow_last_action_and_reset_password
+  end
+
+  scenario 'attempting to disavow an event with an invalid disavowal token' do
+    visit event_disavowal_path(disavowal_token: 'this is a totally fake token')
+
+    expect(page).to have_content(t('event_disavowals.errors.event_not_found'))
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario 'returning after disavowing an action but not resetting password' do
+    perform_disavowable_password_reset
+
+    open_last_email
+
+    # Click the disavowal link a first time
+    click_email_link_matching(%r{events\/disavow})
+    expect(page).to have_content(t('headings.passwords.change'))
+
+    # Click the disavowal link a second time and expect it to still work
+    disavow_last_action_and_reset_password
+  end
+
+  scenario 'attempting to reset a password after having already disavowed an action' do
+    disavow_link_regex = %r{/events/disavow/[^\"]*}
+
+    perform_disavowable_password_reset
+    email = open_last_email
+    disavowal_link = email.html.to_s.match(disavow_link_regex).to_s
+    disavow_last_action_and_reset_password
+
+    Capybara.reset_sessions!
+
+    visit disavowal_link
+
+    expect(page).to have_content(t('event_disavowals.errors.event_already_disavowed'))
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario 'attempting to disavow an event after a long time and the disavowal has expired' do
+    perform_disavowable_password_reset
+
+    Timecop.travel 11.days.from_now do
+      open_last_email
+      click_email_link_matching(%r{events\/disavow})
+
+      expect(page).to have_content(t('event_disavowals.errors.event_disavowal_expired'))
+      expect(page).to have_current_path(root_path)
+    end
+  end
+
+  scenario 'disavowing an event and entering an invalid password' do
+    perform_disavowable_password_reset
+
+    open_last_email
+    click_email_link_matching(%r{events\/disavow})
+
+    expect(page).to have_content(t('headings.passwords.change'))
+
+    fill_in 'New password', with: 'invalid'
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    expect(page).to have_content('is too short (minimum is 12 characters)')
+
+    fill_in 'New password', with: 'NewVal!dPassw0rd'
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    expect(page).to have_content(t('devise.passwords.updated_not_active'))
+
+    signin(user.email, 'NewVal!dPassw0rd')
+
+    # We should be on the MFA screen because we logged in with the new password
+    expect(page).to have_content(t('two_factor_authentication.header_text'))
+    expect(page.current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+  end
+
+  def perform_disavowable_password_reset
+    visit forgot_password_path
+    fill_in :password_reset_email_form_email, with: user.email
+    click_continue
+    open_last_email
+    click_email_link_matching(/reset_password_token/)
+    fill_in 'New password', with: 'OldVal!dPassw0rd'
+    click_button t('forms.passwords.edit.buttons.submit')
+  end
+
+  def disavow_last_action_and_reset_password
+    open_last_email
+    click_email_link_matching(%r{events\/disavow})
+
+    expect(page).to have_content(t('headings.passwords.change'))
+
+    fill_in 'New password', with: 'NewVal!dPassw0rd'
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    expect(page).to have_content(t('devise.passwords.updated_not_active'))
+
+    signin(user.email, 'NewVal!dPassw0rd')
+
+    # We should be on the MFA screen because we logged in with the new password
+    expect(page).to have_content(t('two_factor_authentication.header_text'))
+    expect(page.current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+  end
+end

--- a/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
+++ b/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe EventDisavowal::PasswordResetFromDisavowalForm, type: :model do
+  let(:user) { create(:user, password: 'salty pickles') }
+  let(:new_password) { 'saltier pickles' }
+  let(:event) { create(:event, user: user) }
+
+  subject { described_class.new(event) }
+
+  it_behaves_like 'password validation'
+
+  context 'with a valid password' do
+    it 'resets the users password' do
+      subject.submit(password: new_password)
+
+      expect(user.reload.valid_password?(new_password)).to eq(true)
+    end
+  end
+
+  context 'with an invalid password' do
+    let(:new_password) { 'too short' }
+
+    it 'does not reset the users passowrd' do
+      subject.submit(password: new_password)
+
+      expect(user.reload.valid_password?(new_password)).to eq(false)
+    end
+  end
+end

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -33,8 +33,6 @@ describe UpdateUserPasswordForm, type: :model do
 
     context 'when the password is valid' do
       it 'returns FormResponse with success: true' do
-        stub_email_delivery
-
         result = instance_double(FormResponse)
 
         expect(FormResponse).to receive(:new).
@@ -43,8 +41,6 @@ describe UpdateUserPasswordForm, type: :model do
       end
 
       it 'updates the user' do
-        stub_email_delivery
-
         user_updater = instance_double(UpdateUser)
         allow(UpdateUser).to receive(:new).
           with(user: user, attributes: { password: 'salty new password' }).
@@ -63,8 +59,6 @@ describe UpdateUserPasswordForm, type: :model do
 
       it 'encrypts the active profile' do
         allow(user).to receive(:active_profile).and_return(profile)
-
-        stub_email_delivery
 
         encryptor = instance_double(ActiveProfileEncryptor)
         allow(ActiveProfileEncryptor).to receive(:new).

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -55,16 +55,6 @@ describe UpdateUserPasswordForm, type: :model do
 
         expect(user_updater).to have_received(:call)
       end
-
-      it 'sends an email to notify of the password change' do
-        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(UserMailer).to receive(:password_changed).
-          with(user.email_addresses.first).and_return(mailer)
-
-        subject.submit(params)
-
-        expect(mailer).to have_received(:deliver_later)
-      end
     end
 
     context 'when the user has an active profile' do
@@ -89,20 +79,10 @@ describe UpdateUserPasswordForm, type: :model do
 
     context 'when the user does not have an active profile' do
       it 'does not call ActiveProfileEncryptor' do
-        mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        expect(UserMailer).to receive(:password_changed).
-          with(user.email_addresses.first).and_return(mailer)
         expect(ActiveProfileEncryptor).to_not receive(:new)
 
         subject.submit(params)
       end
-    end
-  end
-
-  def stub_email_delivery
-    mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-    user.email_addresses.each do |email_address|
-      allow(UserMailer).to receive(:password_changed).with(email_address).and_return(mailer)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -26,7 +26,7 @@ describe UserMailer, type: :mailer do
   end
 
   describe 'password_changed' do
-    let(:mail) { UserMailer.password_changed(email_address) }
+    let(:mail) { UserMailer.password_changed(email_address, disavowal_token: '123abc') }
 
     it_behaves_like 'a system email'
 
@@ -41,6 +41,9 @@ describe UserMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
         t('user_mailer.password_changed.intro', app: APP_NAME),
+      )
+      expect(mail.html_part.body).to include(
+        '/events/disavow/123abc',
       )
       expect_email_body_to_have_help_and_contact_links
     end

--- a/spec/services/event_disavowal/disavow_event_spec.rb
+++ b/spec/services/event_disavowal/disavow_event_spec.rb
@@ -6,7 +6,7 @@ describe EventDisavowal::DisavowEvent do
       event = create(:event, disavowed_at: nil)
       described_class.new(event).call
 
-      expect(event.reload.disavowed_at).to be_within(1).of(Time.now)
+      expect(event.reload.disavowed_at).to be_within(1).of(Time.zone.now)
     end
   end
 end

--- a/spec/services/event_disavowal/disavow_event_spec.rb
+++ b/spec/services/event_disavowal/disavow_event_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe EventDisavowal::DisavowEvent do
+  describe '#call' do
+    it 'sets disavowed_at' do
+      event = create(:event, disavowed_at: nil)
+      described_class.new(event).call
+
+      expect(event.reload.disavowed_at).to be_within(1).of(Time.now)
+    end
+  end
+end

--- a/spec/services/event_disavowal/find_disavowed_event_spec.rb
+++ b/spec/services/event_disavowal/find_disavowed_event_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe EventDisavowal::FindDisavowedEvent do
+  describe '#call' do
+    let(:disavowal_token) { '1234abcd' }
+
+    subject { described_class.new(disavowal_token) }
+
+    context 'an event exists' do
+      it 'returns the event' do
+        disavowed_event = create(
+          :event,
+          disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),
+        )
+
+        event = subject.call
+
+        expect(event).to eq(disavowed_event)
+      end
+    end
+
+    context 'an event exists with a disavowal token fingerprinted with an old key' do
+      it 'returns the event' do
+        disavowed_event = create(
+          :event,
+          disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),
+        )
+        rotate_hmac_key
+
+        event = subject.call
+
+        expect(event).to eq(disavowed_event)
+      end
+    end
+
+    context 'an event does not exist' do
+      it 'returns nil' do
+        event = subject.call
+
+        expect(event).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/event_disavowal/generate_disavowal_token_spec.rb
+++ b/spec/services/event_disavowal/generate_disavowal_token_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe EventDisavowal::GenerateDisavowalToken do
+  describe '#call' do
+    let(:event) { create(:event) }
+
+    subject { described_class.new(event) }
+
+    it 'adds a disavowal token fingerprint to an event and returns the token' do
+      token = subject.call
+
+      expect(Pii::Fingerprinter.fingerprint(token)).to eq(event.reload.disavowal_token_fingerprint)
+    end
+  end
+end

--- a/spec/services/event_disavowal/validate_disavowed_event_spec.rb
+++ b/spec/services/event_disavowal/validate_disavowed_event_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe EventDisavowal::ValidateDisavowedEvent do
+  let(:event) { create(:event) }
+  subject { described_class.new(event) }
+
+  describe '#call' do
+    let(:result) { subject.call }
+
+    context 'the event is valid' do
+      it 'returns a successful response' do
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'the event is nil' do
+      let(:event) { nil }
+
+      it 'returns an unsuccessful response' do
+        expect(result.success?).to eq(false)
+        expect(result.errors[:event]).to include(t('event_disavowals.errors.event_not_found'))
+      end
+    end
+
+    context 'the event is already disavowed' do
+      let(:event) { create(:event, disavowed_at: 1.day.ago) }
+
+      it 'returns an unsuccessful response' do
+        expect(result.success?).to eq(false)
+        expect(result.errors[:event]).to include(
+          t('event_disavowals.errors.event_already_disavowed'),
+        )
+      end
+    end
+
+    context 'it has been more than 10 days since the event occured' do
+      let(:event) { create(:event, created_at: 11.days.ago) }
+
+      it 'returns an unsuccessful response' do
+        expect(result.success?).to eq(false)
+        expect(result.errors[:event]).to include(
+          t('event_disavowals.errors.event_disavowal_expired'),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that users can quickly and easily reset their password in response to suspicious activity. Additionally, this ties into our backend analytics pipeline which means we can use users reporting suspicious activity in this way to build fraud models.

**How**: This commit adds a `disavowed_at` and `disavowal_token_fingerprint` column to events. When a disavowable event is created, a token is fingerprinted and saved to the event. That fingerprint is added to a link and send in the email.

This commit adds a controller for when a user clicks on of those links. It validates the token, then presents the user with a password reset form. The user uses that form to reset their password. Once the password is reset, the disavowal token is invalidated.

In this commit, disavowals are only setup for password resets and password updates, but the tooling for adding this to other events is built in.
