### PR TITLE
Stop using pkey generator in user factory

### DIFF
--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe AccountReset::RequestController do
-  let(:user) { build(:user, :with_authentication_app, :with_email) }
+  let(:user) { create(:user, :with_authentication_app, :with_email) }
   describe '#show' do
     it 'renders the page' do
       stub_sign_in_before_2fa(user)
@@ -54,7 +54,7 @@ describe AccountReset::RequestController do
 
     it 'logs sms user in the analytics' do
       TwilioService::Utils.telephony_service = FakeSms
-      user = build(:user, :signed_up, :with_email)
+      user = create(:user, :signed_up, :with_email)
       stub_sign_in_before_2fa(user)
 
       stub_analytics

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -62,7 +62,7 @@ describe MfaConfirmationController do
   describe 'password attempts counter' do
     context 'max password attempts reached' do
       it 'signs the user out' do
-        user = build(:user, :signed_up)
+        user = create(:user, :signed_up)
         sign_in user
         session[:password_attempts] = 0
         stub_analytics

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -384,7 +384,7 @@ describe Users::ResetPasswordsController, devise: true do
       it 'sends password reset email to user and tracks event' do
         stub_analytics
 
-        user = build(:user, :signed_up, role: :user, email: 'test@example.com')
+        user = create(:user, :signed_up, role: :user, email: 'test@example.com')
 
         captcha_h = mock_captcha(enabled: true, present: true, valid: true)
         analytics_hash = {

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -34,7 +34,7 @@ describe Users::WebauthnSetupController do
   describe 'when signed in and not account creation' do
     before do
       stub_analytics
-      user = build(:user, :signed_up, :with_authentication_app)
+      user = create(:user, :signed_up, :with_authentication_app)
       stub_sign_in(user)
     end
 

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -165,7 +165,7 @@ describe MfaContext do
     end
 
     context 'with 1 phone and 2 webauthn configurations' do
-      let(:user) { build(:user, :signed_up) }
+      let(:user) { create(:user, :signed_up) }
 
       it 'returns 1 for phone and 2 for webauthn' do
         create_list(:webauthn_configuration, 2, user: user)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -129,7 +129,7 @@ FactoryBot.define do
 
     trait :with_personal_key do
       after :build do |user|
-        PersonalKeyGenerator.new(user).create
+        user.personal_key = RandomPhrase.new(num_words: 4).to_s
       end
     end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -646,7 +646,7 @@ feature 'Two Factor Authentication' do
 
     scenario 'attempting to reuse a TOTP code results in an error' do
       secret = 'abcdefghi'
-      user = build(:user, :signed_up, otp_secret_key: secret)
+      user = create(:user, :signed_up, otp_secret_key: secret)
       otp = generate_totp_code(secret)
 
       Timecop.freeze do

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -14,7 +14,7 @@ describe EmailNotifier do
 
     context 'when the user has changed and confirmed their new email' do
       it 'notifies the old email address of the email change' do
-        user = build(:user, :signed_up)
+        user = create(:user, :signed_up)
         old_email = user.email
         UpdateUser.new(user: user, attributes: { email: 'new@example.com' }).call
         user.confirm


### PR DESCRIPTION
**Why**: The personal key generator calls `User#save!` which causes a db
write regardless of whether you use `build` or `create`.
