### PR TITLE
Stop saving in user factory traits

### DIFF
--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -72,7 +72,7 @@ describe AccountReset::RequestController do
     end
 
     it 'logs PIV/CAC user in the analytics' do
-      user = build(:user, :with_piv_or_cac, :with_email)
+      user = create(:user, :with_piv_or_cac, :with_email)
       stub_sign_in_before_2fa(user)
 
       stub_analytics

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,114 +12,75 @@ FactoryBot.define do
 
     trait :with_email do
       after(:build) do |user, _evaluator|
-        if user.email.present? && user.email_addresses.empty?
-          user.save!
-          if user.email_addresses.reload.empty?
-            if user.id.present?
-              create(:email_address, user: user, email: user.email, confirmed_at: user.confirmed_at)
-              user.email_addresses.reload
-            else
-              user.email_addresses << build(
-                :email_address, email: user.email, user: user, confirmed_at: user.confirmed_at
-              )
-            end
-          end
-        end
+        next unless user.email_addresses.empty?
+        user.email_addresses << build(
+          :email_address,
+          email: user.email,
+          confirmed_at: user.confirmed_at,
+          user_id: -1,
+        )
       end
 
       after(:stub) do |user, _evaluator|
-        if user.email.present? && user.email_addresses.empty?
-          user.email_addresses << build(
-            :email_address, email: user.email, user: user, confirmed_at: user.confirmed_at
-          )
-        end
+        next unless user.email_addresses.empty?
+        user.email_addresses << build(
+          :email_address,
+          email: user.email,
+          confirmed_at: user.confirmed_at,
+        )
       end
     end
 
     trait :with_webauthn do
       after(:build) do |user, evaluator|
-        if user.webauthn_configurations.empty?
-          user.save!
-          if user.id.present?
-            create(:webauthn_configuration,
-                   { user: user }.merge(
-                     evaluator.with.slice(:name, :credential_id, :credential_public_key),
-                   ))
-            user.webauthn_configurations.reload
-          else
-            user.webauthn_configurations << build(
-              :webauthn_configuration,
-              evaluator.with.slice(:name, :credential_id, :credential_public_key),
-            )
-          end
-        end
-      end
-
-      after(:create) do |user, evaluator|
-        if user.webauthn_configurations.empty?
-          create(:webauthn_configuration,
-                 { user: user }.merge(
-                   evaluator.with.slice(:name, :credential_id, :credential_public_key),
-                 ))
-          user.webauthn_configurations.reload
-        end
+        next unless user.webauthn_configurations.empty?
+        user.webauthn_configurations << build(
+          :webauthn_configuration,
+          {
+            user_id: -1,
+          }.merge(
+            evaluator.with.slice(:name, :credential_id, :credential_public_key),
+          ),
+        )
       end
 
       after(:stub) do |user, evaluator|
-        if user.webauthn_configurations.empty?
-          user.webauthn_configurations << build(
-            :webauthn_configuration,
-            evaluator.with.slice(:name, :credential_id, :credential_public_key),
-          )
-        end
+        next unless user.webauthn_configurations.empty?
+        user.webauthn_configurations << build(
+          :webauthn_configuration,
+          evaluator.with.slice(:name, :credential_id, :credential_public_key),
+        )
       end
     end
 
     trait :with_phone do
       after(:build) do |user, evaluator|
-        if user.phone_configurations.empty?
-          user.save!
-          if user.id.present?
-            create(:phone_configuration,
-                   { user: user, delivery_preference: user.otp_delivery_preference }.merge(
-                     evaluator.with.slice(
-                       :phone,
-                       :confirmed_at,
-                       :delivery_preference,
-                       :mfa_enabled,
-                     ),
-                   ))
-            user.phone_configurations.reload
-          else
-            user.phone_configurations << build(
-              :phone_configuration,
-              { delivery_preference: user.otp_delivery_preference }.merge(
-                evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
-              ),
-            )
-          end
-        end
-      end
-
-      after(:create) do |user, evaluator|
-        if user.phone_configurations.empty?
-          create(:phone_configuration,
-                 { user: user, delivery_preference: user.otp_delivery_preference }.merge(
-                   evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
-                 ))
-          user.phone_configurations.reload
-        end
+        next unless user.phone_configurations.empty?
+        user.phone_configurations << build(
+          :phone_configuration,
+          {
+            delivery_preference: user.otp_delivery_preference,
+            user_id: -1,
+          }.merge(
+            evaluator.with.slice(
+              :phone, :confirmed_at, :delivery_preference, :mfa_enabled
+            ),
+          ),
+        )
       end
 
       after(:stub) do |user, evaluator|
-        if user.phone_configurations.empty?
-          user.phone_configurations << build(
-            :phone_configuration,
-            { delivery_preference: user.otp_delivery_preference }.merge(
-              evaluator.with.slice(:phone, :confirmed_at, :delivery_preference, :mfa_enabled),
+        next unless user.phone_configurations.empty?
+        user.phone_configurations << build(
+          :phone_configuration,
+          {
+            delivery_preference: user.otp_delivery_preference,
+          }.merge(
+            evaluator.with.slice(
+              :phone, :confirmed_at, :delivery_preference, :mfa_enabled
             ),
-          )
-        end
+          ),
+        )
       end
     end
 

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -99,7 +99,7 @@ shared_examples 'strong password' do |form_class|
   end
 
   it 'does not allow a password that is the user email' do
-    user = build(:user, :with_email, email: 'custom@benevolent.com', uuid: '123')
+    user = build_stubbed(:user, :with_email, email: 'custom@benevolent.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
     password = 'custom@benevolent.com'


### PR DESCRIPTION
**Why**: Calling save in a factory triggers writes to the dbs regardless
of whether the factory uses `build` or `create`
