### PR TITLE
Reduce capybara wait time

### DIFF
--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -458,7 +458,7 @@ feature 'Two Factor Authentication' do
           signin(user.email, user.password)
 
           expect(page).to have_content t('titles.account_locked')
-          expect(page).to have_content(five_minute_countdown_regex)
+          expect(page).to have_content(five_minute_countdown_regex, wait: 2)
         end
       end
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -99,7 +99,7 @@ feature 'Sign in' do
     end
 
     scenario 'user sees warning before session times out' do
-      expect(page).to have_css('#session-timeout-msg')
+      expect(page).to have_css('#session-timeout-msg', wait: 5)
 
       time1 = page.text[/14:5[0-9]/]
       expect(page).to have_content(time1)
@@ -109,13 +109,13 @@ feature 'Sign in' do
     end
 
     scenario 'user can continue browsing' do
-      find_link(t('notices.timeout_warning.signed_in.continue')).click
+      find_link(t('notices.timeout_warning.signed_in.continue'), wait: 5).click
 
       expect(current_path).to eq account_path
     end
 
     scenario 'user has option to sign out' do
-      click_link(t('notices.timeout_warning.signed_in.sign_out'))
+      click_link(t('notices.timeout_warning.signed_in.sign_out'), wait: 5)
 
       expect(page).to have_content t('devise.sessions.signed_out')
       expect(current_path).to eq new_user_session_path
@@ -133,7 +133,7 @@ feature 'Sign in' do
       sign_in_user(user)
       visit user_two_factor_authentication_path
 
-      expect(page).to have_css('#session-timeout-msg')
+      expect(page).to have_css('#session-timeout-msg', wait: 5)
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.continue'))
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.sign_out'))
     end
@@ -148,6 +148,7 @@ feature 'Sign in' do
 
       expect(page).to have_content(
         t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes),
+        wait: 5,
       )
       expect(page).to have_field('Email', with: '')
       expect(current_url).to match Regexp.escape(sign_up_email_path(request_id: '123abc'))

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 feature 'Sign in' do
+  before(:all) do
+    @original_capyabar_wait = Capybara.default_max_wait_time
+    Capybara.default_max_wait_time = 5
+  end
+
+  after(:all) do
+    Capybara.default_max_wait_time = @original_capyabar_wait
+  end
+
   include SessionTimeoutWarningHelper
   include ActionView::Helpers::DateHelper
   include PersonalKeyHelper
@@ -99,7 +108,7 @@ feature 'Sign in' do
     end
 
     scenario 'user sees warning before session times out' do
-      expect(page).to have_css('#session-timeout-msg', wait: 5)
+      expect(page).to have_css('#session-timeout-msg')
 
       time1 = page.text[/14:5[0-9]/]
       expect(page).to have_content(time1)
@@ -109,13 +118,13 @@ feature 'Sign in' do
     end
 
     scenario 'user can continue browsing' do
-      find_link(t('notices.timeout_warning.signed_in.continue'), wait: 5).click
+      find_link(t('notices.timeout_warning.signed_in.continue')).click
 
       expect(current_path).to eq account_path
     end
 
     scenario 'user has option to sign out' do
-      click_link(t('notices.timeout_warning.signed_in.sign_out'), wait: 5)
+      click_link(t('notices.timeout_warning.signed_in.sign_out'))
 
       expect(page).to have_content t('devise.sessions.signed_out')
       expect(current_path).to eq new_user_session_path
@@ -133,7 +142,7 @@ feature 'Sign in' do
       sign_in_user(user)
       visit user_two_factor_authentication_path
 
-      expect(page).to have_css('#session-timeout-msg', wait: 5)
+      expect(page).to have_css('#session-timeout-msg')
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.continue'))
       expect(page).to have_content(t('notices.timeout_warning.partially_signed_in.sign_out'))
     end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,7 +16,7 @@ end
 Capybara.javascript_driver = :headless_chrome
 Chromedriver.set_version '2.38'
 
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = 0.5
 Capybara::Screenshot.autosave_on_failure = false
 Capybara.asset_host = ENV['RAILS_ASSET_HOST'] || 'http://localhost:3000'
 


### PR DESCRIPTION
**Why**: We have a lot of tests that expect content to be absent. Having
a 5 second wait time means that each time we run one of those
expectations it takes 5 seconds. This commit reduces it to a half second
which is a little more reasonable.
