### PR TITLE
Silence Puma in test environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'knapsack'
-
-Knapsack::Adapters::RSpecAdapter.bind if ENV['CI'] || ENV['KNAPSACK_GENERATE_REPORT']
+Knapsack::Adapters::RSpecAdapter.bind
 
 RSpec.configure do |config|
   # see more settings at spec/rails_helper.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'knapsack'
-Knapsack::Adapters::RSpecAdapter.bind
+
+Knapsack::Adapters::RSpecAdapter.bind if ENV['CI'] || ENV['KNAPSACK_GENERATE_REPORT']
 
 RSpec.configure do |config|
   # see more settings at spec/rails_helper.rb

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ end
 Capybara.javascript_driver = :headless_chrome
 Chromedriver.set_version '2.38'
 
-#Capybara.server = :puma, { Silent: true }
+# Capybara.server = :puma, { Silent: true }
 
 Capybara.default_max_wait_time = 0.5
 Capybara::Screenshot.autosave_on_failure = false

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ end
 Capybara.javascript_driver = :headless_chrome
 Chromedriver.set_version '2.38'
 
-# Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, { Silent: true }
 
 Capybara.default_max_wait_time = 0.5
 Capybara::Screenshot.autosave_on_failure = false

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -12,9 +12,10 @@ Capybara.register_driver :headless_chrome do |app|
                                  browser: :chrome,
                                  desired_capabilities: capabilities
 end
-
 Capybara.javascript_driver = :headless_chrome
 Chromedriver.set_version '2.38'
+
+#Capybara.server = :puma, { Silent: true }
 
 Capybara.default_max_wait_time = 0.5
 Capybara::Screenshot.autosave_on_failure = false


### PR DESCRIPTION
**Why**: So that the Puma output does not pollute the test output.

This cleans up this noise: 
![image](https://user-images.githubusercontent.com/963654/54555990-4e56b600-498e-11e9-8bfb-291218a0088d.png)
