### PR TITLE
Don't use knapsack when running locally

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
-require 'knapsack'
-Knapsack::Adapters::RSpecAdapter.bind
+# Knapsack runs the tests across multiple nodes in CI. We do not need to run it
+# locally unless we are generating a report to help it figure out how to
+# distribute tests across nodes.
+if ENV['CI'] || ENV['KNAPSACK_GENERATE_REPORT']
+  require 'knapsack'
+  Knapsack::Adapters::RSpecAdapter.bind
+end
 
 RSpec.configure do |config|
   # see more settings at spec/rails_helper.rb


### PR DESCRIPTION
**Why**: Knapsack is for use in CI. We do not need it running locally.
