### PR TITLE
Silence output from CloudHSMKeySharer spec

### DIFF
--- a/spec/lib/cloudhsm/cloudhsm_key_sharer_spec.rb
+++ b/spec/lib/cloudhsm/cloudhsm_key_sharer_spec.rb
@@ -13,6 +13,8 @@ describe CloudhsmKeySharer do
 
   describe '#share_saml_key' do
     it 'shares saml key and generates transcript' do
+      allow(Kernel).to receive(:puts)
+
       greenletters = mock_cloudhsm
 
       subject.share_saml_key


### PR DESCRIPTION
**Why**: So the output from the code does not pollute the test output.
