### PR TITLE
Disable bullet in unit tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,10 @@ Rails.application.configure do
   config.lograge.enabled = true
 
   config.after_initialize do
-    Bullet.enable = true
+    # Having bullet enabled in the test environment causes issues with unit
+    # tests that may not make user of eager loaded values. We disable it by
+    # default here and then re-enable it in feature tests.
+    Bullet.enable = false
     Bullet.bullet_logger = true
     Bullet.raise = true
     Bullet.add_whitelist(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,4 +80,10 @@ RSpec.configure do |config|
   config.before(:each, type: :feature) do
     allow_any_instance_of(Geocoder::Result::Test).to receive(:language=)
   end
+
+  config.around(:each, type: :feature) do |example|
+    Bullet.enable = true
+    example.run
+    Bullet.enable = false
+  end
 end


### PR DESCRIPTION
**Why**: Bullet will auto-detect attributes that are eager loaded but not used. In unit tests that eager load things, but don't use them right away, this causes issues. This commit disables bullet in unit tests so it will only run in feature tests where slow queries are more accurately identified.
