### PR TITLE
Use 18f logo for service provider session decorator test

### DIFF
--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ServiceProviderSessionDecorator do
   describe '#sp_logo_url' do
     context 'service provider has a logo' do
       it 'returns the logo' do
-        sp_logo = 'real_logo.svg'
+        sp_logo = '18f.svg'
         sp = build_stubbed(:service_provider, logo: sp_logo)
 
         subject = ServiceProviderSessionDecorator.new(
@@ -168,7 +168,7 @@ RSpec.describe ServiceProviderSessionDecorator do
           service_provider_request: ServiceProviderRequest.new,
         )
 
-        expect(subject.sp_logo_url).to end_with("/sp-logos/#{sp_logo}")
+        expect(subject.sp_logo_url).to match(%r{sp-logos\/18f-[0-9a-f]+\.svg$})
       end
     end
 


### PR DESCRIPTION
**Why**: Using a logo that does not exist causes the asset pipeline to fallback to a file that may or may not be in the public directory. This behavior is deprecated and will cause us problems if we keep it around.
