### PR TITLE
Fix name collision in doc auth / doc capture shared examples

### DIFF
--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-shared_examples 'mobile back image step' do |simulate|
+shared_examples 'doc auth mobile back image step' do |simulate|
   feature 'doc auth mobile back image step' do
     include IdvStepHelper
     include DocAuthHelper
@@ -53,6 +53,6 @@ shared_examples 'mobile back image step' do |simulate|
 end
 
 feature 'doc auth back image' do
-  it_behaves_like 'mobile back image step', 'false'
-  it_behaves_like 'mobile back image step', 'true'
+  it_behaves_like 'doc auth mobile back image step', 'false'
+  it_behaves_like 'doc auth mobile back image step', 'true'
 end

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-shared_examples 'mobile back image step' do |simulate|
+shared_examples 'doc capture mobile back image step' do |simulate|
   feature 'doc capture mobile back image step' do
     include IdvStepHelper
     include DocAuthHelper
@@ -48,6 +48,6 @@ shared_examples 'mobile back image step' do |simulate|
 end
 
 feature 'doc capture back image' do
-  it_behaves_like 'mobile back image step', 'false'
-  it_behaves_like 'mobile back image step', 'true'
+  it_behaves_like 'doc capture mobile back image step', 'false'
+  it_behaves_like 'doc capture mobile back image step', 'true'
 end


### PR DESCRIPTION
**Why**: The name collision was causing the shared examples to be redefined before the specs ran, meaning that 1 set of the shared examples was run 4 times instead of them both being run 2 times.
