### PR TITLE
Make create_user_event_with_disavowal return an event

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   def create_user_event_with_disavowal(event_type, user = current_user)
     event = create_user_event(event_type, user)
     EventDisavowal::GenerateDisavowalToken.new(event).call
+    event
   end
 
   def create_or_update_device(user)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -38,7 +38,7 @@ module Users
     end
 
     def create_event_and_notify_user_about_password_change
-      disavowal_token = create_user_event_with_disavowal(:password_changed)
+      disavowal_token = create_user_event_with_disavowal(:password_changed).disavowal_token
       current_user.confirmed_email_addresses.each do |email_address|
         UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
       end

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -125,7 +125,9 @@ module Users
     end
 
     def create_reset_event_and_send_notification
-      disavowal_token = create_user_event_with_disavowal(:password_changed, resource)
+      disavowal_token = create_user_event_with_disavowal(
+        :password_changed, resource
+      ).disavowal_token
       resource.confirmed_email_addresses.each do |email_address|
         UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
       end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,8 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :device
 
+  attr_accessor :disavowal_token
+
   enum event_type: {
     account_created: 1,
     phone_confirmed: 2,

--- a/app/services/event_disavowal/generate_disavowal_token.rb
+++ b/app/services/event_disavowal/generate_disavowal_token.rb
@@ -9,18 +9,18 @@ module EventDisavowal
     def call
       generate_disavowal_token
       fingerprint_and_save_disavowal_token
-      disavowal_token
+      event.disavowal_token
     end
 
     private
 
     def generate_disavowal_token
-      @disavowal_token = SecureRandom.urlsafe_base64(32)
+      event.disavowal_token = SecureRandom.urlsafe_base64(32)
     end
 
     def fingerprint_and_save_disavowal_token
       event.update!(
-        disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(disavowal_token),
+        disavowal_token_fingerprint: Pii::Fingerprinter.fingerprint(event.disavowal_token),
       )
     end
   end

--- a/spec/services/event_disavowal/generate_disavowal_token_spec.rb
+++ b/spec/services/event_disavowal/generate_disavowal_token_spec.rb
@@ -9,7 +9,9 @@ describe EventDisavowal::GenerateDisavowalToken do
     it 'adds a disavowal token fingerprint to an event and returns the token' do
       token = subject.call
 
+      expect(event.disavowal_token).to eq(token)
       expect(Pii::Fingerprinter.fingerprint(token)).to eq(event.reload.disavowal_token_fingerprint)
+      expect(Event.find(event.id).disavowal_token).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
**Why**: To have a return type that is consistent with `create_user_event`.