### PR TITLE
Add a service class to handle event creation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,32 +56,10 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     warden.user || AnonymousUser.new
   end
 
-  def create_user_event(event_type, user = current_user)
-    return unless user&.id
-    device = create_or_update_device(user)
-    Event.create(user_id: user.id,
-                 device_id: device.id,
-                 ip: request.remote_ip,
-                 event_type: event_type)
+  def user_event_creator
+    @user_event_creator ||= UserEventCreator.new(request, current_user)
   end
-
-  def create_user_event_with_disavowal(event_type, user = current_user)
-    event = create_user_event(event_type, user)
-    EventDisavowal::GenerateDisavowalToken.new(event).call
-    event
-  end
-
-  def create_or_update_device(user)
-    cookie = cookies[:device]
-    device = DeviceTracking::FindOrCreateDevice.call(
-      user, cookie, request.remote_ip, request.user_agent
-    )
-
-    device_cookie_uuid = device.cookie_uuid
-
-    cookies.permanent[:device] = device_cookie_uuid unless device_cookie_uuid == cookie
-    device
-  end
+  delegate :create_user_event, :create_user_event_with_disavowal, to: :user_event_creator
 
   def decorated_session
     @_decorated_session ||= DecoratedSession.new(

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -1,6 +1,6 @@
 class UserEventCreator
   attr_reader :request, :current_user
-  
+
   def initialize(request, current_user)
     @request = request
     @current_user = current_user
@@ -24,14 +24,18 @@ class UserEventCreator
   private
 
   def create_or_update_device(user)
-    cookie = request.cookie_jar[:device]
+    cookie = cookies[:device]
     device = DeviceTracking::FindOrCreateDevice.call(
       user, cookie, request.remote_ip, request.user_agent
     )
 
     device_cookie_uuid = device.cookie_uuid
 
-    request.cookie_jar.permanent[:device] = device_cookie_uuid unless device_cookie_uuid == cookie
+    cookies.permanent[:device] = device_cookie_uuid unless device_cookie_uuid == cookie
     device
+  end
+
+  def cookies
+    request.cookie_jar
   end
 end

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -1,0 +1,37 @@
+class UserEventCreator
+  attr_reader :request, :current_user
+  
+  def initialize(request, current_user)
+    @request = request
+    @current_user = current_user
+  end
+
+  def create_user_event(event_type, user = current_user)
+    return unless user&.id
+    device = create_or_update_device(user)
+    Event.create(user_id: user.id,
+                 device_id: device.id,
+                 ip: request.remote_ip,
+                 event_type: event_type)
+  end
+
+  def create_user_event_with_disavowal(event_type, user = current_user)
+    event = create_user_event(event_type, user)
+    EventDisavowal::GenerateDisavowalToken.new(event).call
+    event
+  end
+
+  private
+
+  def create_or_update_device(user)
+    cookie = request.cookie_jar[:device]
+    device = DeviceTracking::FindOrCreateDevice.call(
+      user, cookie, request.remote_ip, request.user_agent
+    )
+
+    device_cookie_uuid = device.cookie_uuid
+
+    request.cookie_jar.permanent[:device] = device_cookie_uuid unless device_cookie_uuid == cookie
+    device
+  end
+end


### PR DESCRIPTION
**Why**: Event disavowals requests some orchestration of the event disavowal and device tracking module. Moving to a service class lets us manage this complexity outside of the application controller.
