### PR TITLE
Allow users to disavow personal key sign ins

### DIFF
--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -29,7 +29,8 @@ module TwoFactorAuthentication
 
     def handle_result(result)
       if result.success?
-        create_user_event(:personal_key_used)
+        event = create_user_event_with_disavowal(:personal_key_used)
+        UserAlerts::AlertUserAboutPersonalKeySignIn.call(current_user, event.disavowal_token)
         generate_new_personal_key
         handle_valid_otp
       else

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -38,10 +38,8 @@ module Users
     end
 
     def create_event_and_notify_user_about_password_change
-      disavowal_token = create_user_event_with_disavowal(:password_changed).disavowal_token
-      current_user.confirmed_email_addresses.each do |email_address|
-        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
-      end
+      event = create_user_event_with_disavowal(:password_changed)
+      UserAlerts::AlertUserAboutPasswordChange.call(current_user, event.disavowal_token)
     end
 
     def handle_invalid_password

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -125,12 +125,8 @@ module Users
     end
 
     def create_reset_event_and_send_notification
-      disavowal_token = create_user_event_with_disavowal(
-        :password_changed, resource
-      ).disavowal_token
-      resource.confirmed_email_addresses.each do |email_address|
-        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
-      end
+      event = create_user_event_with_disavowal(:password_changed, resource)
+      UserAlerts::AlertUserAboutPasswordChange.call(resource, event.disavowal_token)
     end
 
     def user_params

--- a/app/forms/personal_key_form.rb
+++ b/app/forms/personal_key_form.rb
@@ -15,7 +15,6 @@ class PersonalKeyForm
     @success = valid?
 
     reset_sensitive_fields unless success
-    send_personal_key_sign_in_notification if success
 
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
@@ -32,14 +31,5 @@ class PersonalKeyForm
 
   def reset_sensitive_fields
     self.personal_key = nil
-  end
-
-  def send_personal_key_sign_in_notification
-    user.confirmed_email_addresses.each do |email_address|
-      UserMailer.personal_key_sign_in(email_address.email).deliver_now
-    end
-    MfaContext.new(user).phone_configurations.each do |phone_configuration|
-      SmsPersonalKeySignInNotifierJob.perform_now(phone: phone_configuration.phone)
-    end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -28,7 +28,8 @@ class UserMailer < ActionMailer::Base
     mail(to: email, subject: t('user_mailer.account_does_not_exist.subject'))
   end
 
-  def personal_key_sign_in(email)
+  def personal_key_sign_in(email, disavowal_token:)
+    @disavowal_token = disavowal_token
     mail(to: email, subject: t('user_mailer.personal_key_sign_in.subject'))
   end
 

--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -35,6 +35,7 @@ module UserAccessKeyOverrides
   end
 
   def personal_key=(new_personal_key)
+    @personal_key = new_personal_key
     return if new_personal_key.blank?
     self.encrypted_recovery_code_digest = Encryption::PasswordVerifier.new.digest(
       password: new_personal_key,

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -1,4 +1,4 @@
-module DeviceTracking
+module UserAlerts
   class AlertUserAboutNewDevice
     def self.call(user, device, disavowal_token)
       send_emails(user, device, disavowal_token)
@@ -20,7 +20,7 @@ module DeviceTracking
 
     def self.send_sms_messages(user)
       return unless FeatureManagement.send_new_device_sms?
-      user.phone_configurations.each do |phone_configuration|
+      MfaContext.new(user).phone_configurations.each do |phone_configuration|
         SmsNewDeviceSignInNotifierJob.perform_now(phone: phone_configuration.phone)
       end
     end

--- a/app/services/user_alerts/alert_user_about_password_change.rb
+++ b/app/services/user_alerts/alert_user_about_password_change.rb
@@ -1,0 +1,9 @@
+module UserAlerts
+  class AlertUserAboutPasswordChange
+    def self.call(user, disavowal_token)
+      user.confirmed_email_addresses.each do |email_address|
+        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/user_alerts/alert_user_about_personal_key_sign_in.rb
+++ b/app/services/user_alerts/alert_user_about_personal_key_sign_in.rb
@@ -1,0 +1,14 @@
+module UserAlerts
+  class AlertUserAboutPersonalKeySignIn
+    def self.call(user, disavowal_token)
+      user.confirmed_email_addresses.each do |email_address|
+        UserMailer.personal_key_sign_in(
+          email_address.email, disavowal_token: disavowal_token
+        ).deliver_now
+      end
+      MfaContext.new(user).phone_configurations.each do |phone_configuration|
+        SmsPersonalKeySignInNotifierJob.perform_now(phone: phone_configuration.phone)
+      end
+    end
+  end
+end

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -50,7 +50,7 @@ class UserEventCreator
 
   def send_new_device_notificaiton(user:, device:, event:)
     disavowal_token = EventDisavowal::GenerateDisavowalToken.new(event).call
-    DeviceTracking::AlertUserAboutNewDevice.call(user, device, disavowal_token)
+    UserAlerts::AlertUserAboutNewDevice.call(user, device, disavowal_token)
   end
 
   def create_event_for_device(event_type:, user:, device:)

--- a/app/views/user_mailer/personal_key_sign_in.html.slim
+++ b/app/views/user_mailer/personal_key_sign_in.html.slim
@@ -12,5 +12,5 @@ table.hr
       | &nbsp;
 
 p == t('.help_html',
-        reset_password_url: forgot_password_url,
+        reset_password_url: event_disavowal_url(disavowal_token: @disavowal_token),
         account_url: account_url)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
 
     trait :with_personal_key do
       after :build do |user|
-        user.personal_key = RandomPhrase.new(num_words: 4).to_s
+        user.personal_key ||= RandomPhrase.new(num_words: 4).to_s
       end
     end
 

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -28,6 +28,17 @@ feature 'disavowing an action' do
     disavow_last_action_and_reset_password
   end
 
+  scenario 'disavowing a personal key sign in' do
+    allow(SmsPersonalKeySignInNotifierJob).to receive(:perform_now)
+
+    signin(user.email, user.password)
+    choose_another_security_option(:personal_key)
+    fill_in :personal_key_form_personal_key, with: user.personal_key
+    click_submit_default
+
+    disavow_last_action_and_reset_password
+  end
+
   scenario 'attempting to disavow an event with an invalid disavowal token' do
     visit event_disavowal_path(disavowal_token: 'this is a totally fake token')
 

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -17,26 +17,6 @@ describe PersonalKeyForm do
         expect(form.submit).to eq result
         expect(user.reload.encrypted_recovery_code_digest).to eq old_code
       end
-
-      it 'sends an email and SMS notification to the user' do
-        user = create(
-          :user,
-          :with_phone,
-          email: 'jonny.hoops@gsa.gov',
-          with: { phone: '+1 (202) 345-6789' },
-        )
-        raw_code = PersonalKeyGenerator.new(user).create
-
-        personal_key_sign_in_mail = double
-        expect(personal_key_sign_in_mail).to receive(:deliver_now)
-        expect(UserMailer).to receive(:personal_key_sign_in).
-          with('jonny.hoops@gsa.gov').
-          and_return(personal_key_sign_in_mail)
-        expect(SmsPersonalKeySignInNotifierJob).to receive(:perform_now).
-          with(phone: '+1 (202) 345-6789')
-
-        PersonalKeyForm.new(user, raw_code).submit
-      end
     end
 
     context 'when the form is invalid' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -50,7 +50,7 @@ describe UserMailer, type: :mailer do
   end
 
   describe 'personal_key_sign_in' do
-    let(:mail) { UserMailer.personal_key_sign_in(user.email) }
+    let(:mail) { UserMailer.personal_key_sign_in(user.email, disavowal_token: 'asdf1234') }
 
     it_behaves_like 'a system email'
 
@@ -65,6 +65,9 @@ describe UserMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.html_part.body).to have_content(
         t('user_mailer.personal_key_sign_in.intro'),
+      )
+      expect(mail.html_part.body).to include(
+        '/events/disavow/asdf1234',
       )
     end
   end

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DeviceTracking::AlertUserAboutNewDevice do
+describe UserAlerts::AlertUserAboutNewDevice do
   describe '#call' do
     before do
       allow(SmsNewDeviceSignInNotifierJob).to receive(:perform_now)

--- a/spec/services/user_alerts/alert_user_about_password_change_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_password_change_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe UserAlerts::AlertUserAboutPasswordChange do
+  describe '#call' do
+    it 'sends an email to all of the users confirmed email addresses' do
+      user = create(:user)
+      disavowal_token = 'asdf1234'
+      user.email_addresses.destroy_all
+      confirmed_email_addresses = create_list(:email_address, 2, user: user)
+      create(:email_address, user: user, confirmed_at: nil)
+
+      allow(UserMailer).to receive(:password_changed).and_call_original
+
+      described_class.call(user, disavowal_token)
+
+      expect(UserMailer).to have_received(:password_changed).twice
+      expect(UserMailer).to have_received(:password_changed).
+        with(confirmed_email_addresses[0], disavowal_token: disavowal_token)
+      expect(UserMailer).to have_received(:password_changed).
+        with(confirmed_email_addresses[1], disavowal_token: disavowal_token)
+    end
+  end
+end

--- a/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe UserAlerts::AlertUserAboutPersonalKeySignIn do
+  describe '#call' do
+    it 'sends sms and emails to confirmed addresses' do
+      user = create(:user)
+      disavowal_token = 'asdf1234'
+      user.email_addresses.destroy_all
+      confirmed_email_addresses = create_list(:email_address, 2, user: user)
+      create(:email_address, user: user, confirmed_at: nil)
+      phone_configurations = [
+        create(:phone_configuration, user: user, phone: '(202) 111-1111'),
+        create(:phone_configuration, user: user, phone: '(202) 222-2222'),
+      ]
+
+      allow(UserMailer).to receive(:personal_key_sign_in).and_call_original
+      allow(SmsPersonalKeySignInNotifierJob).to receive(:perform_now)
+
+      described_class.call(user, disavowal_token)
+
+      expect(UserMailer).to have_received(:personal_key_sign_in).twice
+      expect(UserMailer).to have_received(:personal_key_sign_in).
+        with(confirmed_email_addresses[0].email, disavowal_token: disavowal_token)
+      expect(UserMailer).to have_received(:personal_key_sign_in).
+        with(confirmed_email_addresses[1].email, disavowal_token: disavowal_token)
+      expect(SmsPersonalKeySignInNotifierJob).to have_received(:perform_now).
+        with(phone: phone_configurations[0].phone)
+      expect(SmsPersonalKeySignInNotifierJob).to have_received(:perform_now).
+        with(phone: phone_configurations[1].phone)
+    end
+  end
+end

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -44,7 +44,7 @@ describe UserEventCreator do
       let(:device) { create(:device, cookie_uuid: existing_device_cookie) }
 
       it 'creates a device and creates an event' do
-        expect(DeviceTracking::AlertUserAboutNewDevice).to_not receive(:call)
+        expect(UserAlerts::AlertUserAboutNewDevice).to_not receive(:call)
 
         event = subject.create_user_event(event_type, user)
 
@@ -56,12 +56,12 @@ describe UserEventCreator do
       end
 
       it 'alerts the user if they have other devices' do
-        allow(DeviceTracking::AlertUserAboutNewDevice).to receive(:call)
+        allow(UserAlerts::AlertUserAboutNewDevice).to receive(:call)
         create(:device, user: user)
 
         subject.create_user_event(event_type, user)
 
-        expect(DeviceTracking::AlertUserAboutNewDevice).to have_received(:call).
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
           with(user, user.events.first.device, instance_of(String))
       end
     end
@@ -70,7 +70,7 @@ describe UserEventCreator do
       let(:device) { nil }
 
       it 'creates a device and creates an event' do
-        expect(DeviceTracking::AlertUserAboutNewDevice).to_not receive(:call)
+        expect(UserAlerts::AlertUserAboutNewDevice).to_not receive(:call)
 
         event = subject.create_user_event(event_type, user)
 
@@ -81,12 +81,12 @@ describe UserEventCreator do
       end
 
       it 'alerts the user if they have other devices' do
-        allow(DeviceTracking::AlertUserAboutNewDevice).to receive(:call)
+        allow(UserAlerts::AlertUserAboutNewDevice).to receive(:call)
         create(:device, user: user)
 
         subject.create_user_event(event_type, user)
 
-        expect(DeviceTracking::AlertUserAboutNewDevice).to have_received(:call).
+        expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
           with(user, user.events.first.device, instance_of(String))
       end
     end


### PR DESCRIPTION
**Why**: To allow users to quickly change their password in response to a personal key sign ins
