### PR TITLE
Fix issue with twilio mocks in pkey verification controller

### DIFF
--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -30,7 +30,7 @@ describe TwoFactorAuthentication::PersonalKeyVerificationController do
   describe '#create' do
     context 'when the user enters a valid personal key' do
       it 'tracks the valid authentication event' do
-        sign_in_before_2fa
+        sign_in_before_2fa(create(:user, :with_webauthn))
 
         form = instance_double(PersonalKeyForm)
         response = FormResponse.new(


### PR DESCRIPTION
**Why**: After moving logic to send SMSs out of the pkey verification form, this spec started flickering. It looks like it is because Twilio is not stubbed out properly. This commit works around that issue by signing in with a user that does not have a phone.