### PR TITLE
Fix a bug where EventUserCreator returned nil instead of an event

### DIFF
--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -42,6 +42,7 @@ class UserEventCreator
     return event unless user_has_multiple_devices
 
     send_new_device_notificaiton(user: user, event: event, device: device)
+    event
   end
 
   def assign_device_cookie(device_cookie)

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -30,6 +30,7 @@ class UserEventCreator
     create_event_for_device(event_type: event_type, user: user, device: device)
   end
 
+  # :reek:TooManyStatements
   def create_event_for_new_device(event_type:, user:)
     user_has_multiple_devices = UserDecorator.new(user).devices?
 

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -59,8 +59,9 @@ describe UserEventCreator do
         allow(UserAlerts::AlertUserAboutNewDevice).to receive(:call)
         create(:device, user: user)
 
-        subject.create_user_event(event_type, user)
+        event = subject.create_user_event(event_type, user)
 
+        expect(event).to be_a(Event)
         expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
           with(user, user.events.first.device, instance_of(String))
       end
@@ -84,8 +85,9 @@ describe UserEventCreator do
         allow(UserAlerts::AlertUserAboutNewDevice).to receive(:call)
         create(:device, user: user)
 
-        subject.create_user_event(event_type, user)
+        event = subject.create_user_event(event_type, user)
 
+        expect(event).to be_a(Event)
         expect(UserAlerts::AlertUserAboutNewDevice).to have_received(:call).
           with(user, user.events.first.device, instance_of(String))
       end


### PR DESCRIPTION
**Why**: The consumers of `EventUserCreator#create_event_with_disavowal` expect it to return an event. In the case where the event was initiated from a new device, it returned `nil`. This commit fixes that.
