### PR TITLE
Fix doc auth 500 error on invalid phone exception from Twilio

### DIFF
--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -3,11 +3,15 @@ module Idv
     class SendLinkStep < DocAuthBaseStep
       def call
         capture_doc = CaptureDoc::CreateRequest.call(current_user.id)
-        SmsDocAuthLinkJob.perform_now(
-          phone: permit(:phone),
-          link: link(capture_doc.request_token),
-          app: 'login.gov',
-        )
+        begin
+          SmsDocAuthLinkJob.perform_now(
+            phone: permit(:phone),
+            link: link(capture_doc.request_token),
+            app: 'login.gov',
+          )
+        rescue Twilio::REST::RestError
+          return failure(I18n.t('errors.messages.invalid_phone_number'))
+        end
       end
 
       private

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -9,7 +9,7 @@ module Idv
             link: link(capture_doc.request_token),
             app: 'login.gov',
           )
-        rescue Twilio::REST::RestError
+        rescue Twilio::REST::RestError, PhoneVerification::VerifyError
           return failure(I18n.t('errors.messages.invalid_phone_number'))
         end
       end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -28,4 +28,16 @@ feature 'doc auth send link step' do
 
     expect(page).to have_current_path(idv_doc_auth_send_link_step)
   end
+
+  it 'does not proceed if twilio raises an error on the phone number' do
+    generic_exception = Twilio::REST::RestError.new(
+      '', FakeTwilioErrorResponse.new(123)
+    )
+    allow(SmsDocAuthLinkJob).to receive(:perform_now).and_raise(generic_exception)
+    fill_in :doc_auth_phone, with: '415-555-0199'
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_send_link_step)
+    expect(page).to have_content t('errors.messages.invalid_phone_number')
+  end
 end

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -29,9 +29,24 @@ feature 'doc auth send link step' do
     expect(page).to have_current_path(idv_doc_auth_send_link_step)
   end
 
-  it 'does not proceed if twilio raises an error on the phone number' do
+  it 'does not proceed if Twilio raises a RestError' do
     generic_exception = Twilio::REST::RestError.new(
       '', FakeTwilioErrorResponse.new(123)
+    )
+    allow(SmsDocAuthLinkJob).to receive(:perform_now).and_raise(generic_exception)
+    fill_in :doc_auth_phone, with: '415-555-0199'
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_send_link_step)
+    expect(page).to have_content t('errors.messages.invalid_phone_number')
+  end
+
+  it 'does not proceed if Twilio raises a VerifyError' do
+    generic_exception = PhoneVerification::VerifyError.new(
+      code: 60_033,
+      message: 'error',
+      status: 400,
+      response:  '{"error_code":"60004"}',
     )
     allow(SmsDocAuthLinkJob).to receive(:perform_now).and_raise(generic_exception)
     fill_in :doc_auth_phone, with: '415-555-0199'


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
