### PR TITLE
Don't call first on disavowed event lookup query

### DIFF
--- a/app/services/event_disavowal/find_disavowed_event.rb
+++ b/app/services/event_disavowal/find_disavowed_event.rb
@@ -7,9 +7,11 @@ module EventDisavowal
     end
 
     def call
+      # Use `#all` here instead of `#first` to avoid setting a 'LIMIT 1' to the
+      # postgres query which causes it to run slowly.
       @event ||= Event.where(
         disavowal_token_fingerprint: disavowal_token_fingerprints,
-      ).first
+      ).all[0]
     end
 
     private


### PR DESCRIPTION
**Why**: It causes `LIMIT 1` to be added to the query which makes it run super slow and timeout in prod.
