### PR TITLE
Add remember device to TOTP

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -240,7 +240,7 @@ module TwoFactorAuthenticatable # rubocop:disable Metrics/ModuleLength
     {
       two_factor_authentication_method: two_factor_authentication_method,
       user_email: current_user.email_addresses.first.email,
-      remember_device_available: false,
+      remember_device_available: true,
     }.merge(generic_data)
   end
 

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -226,7 +226,6 @@ module TwoFactorAuthenticatable # rubocop:disable Metrics/ModuleLength
       voice_otp_delivery_unsupported: voice_otp_delivery_unsupported?,
       reenter_phone_number_path: reenter_phone_number_path,
       unconfirmed_phone: unconfirmed_phone?,
-      remember_device_available: true,
       account_reset_token: account_reset_token,
     }.merge(generic_data)
   end
@@ -240,7 +239,6 @@ module TwoFactorAuthenticatable # rubocop:disable Metrics/ModuleLength
     {
       two_factor_authentication_method: two_factor_authentication_method,
       user_email: current_user.email_addresses.first.email,
-      remember_device_available: true,
     }.merge(generic_data)
   end
 

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -65,7 +65,6 @@ module TwoFactorAuthentication
       {
         two_factor_authentication_method: two_factor_authentication_method,
         user_email: current_user.email_addresses.first.email,
-        remember_device_available: false,
       }.merge(generic_data)
     end
 

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class TotpSetupController < ApplicationController
+    include RememberDeviceConcern
+
     before_action :authenticate_user!
     before_action :confirm_two_factor_authenticated, if: :two_factor_enabled?
 
@@ -53,6 +55,7 @@ module Users
     def process_valid_code
       create_user_event(:authenticator_enabled)
       mark_user_as_fully_authenticated
+      save_remember_device_preference
       flash[:success] = t('notices.totp_configured')
       redirect_to url_after_entering_valid_code
       user_session.delete(:new_totp_secret)

--- a/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/generic_delivery_presenter.rb
@@ -4,7 +4,7 @@ module TwoFactorAuthCode
     include ActionView::Helpers::TranslationHelper
     include Rails.application.routes.url_helpers
 
-    attr_reader :code_value, :remember_device_available
+    attr_reader :code_value
 
     def initialize(data:, view:)
       data.each do |key, value|
@@ -32,10 +32,6 @@ module TwoFactorAuthCode
       else
         'shared/null'
       end
-    end
-
-    def remember_device_available?
-      remember_device_available
     end
 
     private

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -22,12 +22,11 @@ p == @presenter.phone_number_message
     { otp_delivery_preference: @presenter.otp_delivery_preference, resend: true }),
       class: 'btn btn-link btn-border ico ico-refresh text-decoration-none',
       form_class: 'inline-block')
-  - if @presenter.remember_device_available?
-    inline-block.span style="white-space:nowrap;"
-      = check_box_tag 'remember_device', true, false, class: 'my2 ml2 mr1'
-      = label_tag 'remember_device',
-        t('forms.messages.remember_device'),
-        class: 'blue'
+  inline-block.span style="white-space:nowrap;"
+    = check_box_tag 'remember_device', true, false, class: 'my2 ml2 mr1'
+    = label_tag 'remember_device',
+      t('forms.messages.remember_device'),
+      class: 'blue'
 br
 - if @presenter.update_phone_link.present?
     br

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -6,10 +6,15 @@ h1.h3.my0 = @presenter.header
   = render @presenter.reauthn_hidden_field_partial
   = label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'),
     class: 'block bold'
-  .col-12.sm-col-5.mb4.sm-mb0.sm-mr-20p.inline-block
+  .col-12.sm-col-5.mb1.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', value: @code, required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
+  .border.border-light-blue.rounded-lg.py1.mt2.mb4.sm-my2.col-12.sm-col-7
+    = check_box_tag 'remember_device', true, false, class: 'mr1 ml2'
+    = label_tag 'remember_device',
+      t('forms.messages.remember_device'),
+      class: 'blue mr2'
   = submit_tag 'Submit', class: 'btn btn-primary align-top'
 
 = render 'shared/fallback_links', presenter: @presenter

--- a/app/views/users/totp_setup/new.html.slim
+++ b/app/views/users/totp_setup/new.html.slim
@@ -42,6 +42,11 @@ ul.list-reset
           .col.col-6.sm-col-5.px1
             = submit_tag t('forms.buttons.submit.default'),
               class: 'col-12 btn btn-primary align-top'
+        .border.border-light-blue.rounded-lg.px2.py1.mt3
+          = check_box_tag 'remember_device', true, false, class: 'mr1'
+          = label_tag 'remember_device',
+            t('forms.messages.remember_device'),
+            class: 'blue mt-1p'
 
 = render 'shared/cancel_or_back_to_options'
 

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -1,18 +1,66 @@
 require 'rails_helper'
 
 describe 'Remembering a TOTP device' do
-  let(:user) do
-    user = build(:user, :signed_up, password: 'super strong password')
-    @secret = user.generate_totp_secret
-    UpdateUser.new(user: user, attributes: { otp_secret_key: @secret }).call
-    user
+  before do
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    allow(SmsOtpSenderJob).to receive(:perform_now)
+    allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 
-  it 'does not offer the option to remember device' do
-    sign_in_user(user)
-    expect(current_path).to eq(login_two_factor_authenticator_path)
-    expect(page).to_not have_content(
-      t('forms.messages.remember_device'),
-    )
+  let(:user) { create(:user, :signed_up, :with_authentication_app) }
+
+  context 'sign in' do
+    def remember_device_and_sign_out_user
+      sign_in_user(user)
+      fill_in :code, with: generate_totp_code(user.otp_secret_key)
+      check :remember_device
+      click_submit_default
+      first(:link, t('links.sign_out')).click
+      user
+    end
+
+    it_behaves_like 'remember device'
+  end
+
+  context 'sign up' do
+    def remember_device_and_sign_out_user
+      user = sign_up_and_set_password
+      user.password = Features::SessionHelper::VALID_PASSWORD
+      select_2fa_option('auth_app')
+      fill_in :code, with: totp_secret_from_page
+      check :remember_device
+      click_submit_default
+      click_acknowledge_personal_key
+      first(:link, t('links.sign_out')).click
+      user
+    end
+
+    it_behaves_like 'remember device'
+  end
+
+  context 'update totp' do
+    after do
+      Timecop.return
+    end
+
+    def remember_device_and_sign_out_user
+      sign_in_and_2fa_user(user)
+      click_on t('forms.buttons.disable')
+      Timecop.travel 5.seconds.from_now # Travel past the revoked at date from disabling the device
+      click_link t('forms.buttons.enable'), href: authenticator_setup_url
+      fill_in :code, with: totp_secret_from_page
+      check :remember_device
+      click_submit_default
+      expect(page).to have_current_path(account_path)
+      first(:link, t('links.sign_out')).click
+      user
+    end
+
+    it_behaves_like 'remember device'
+  end
+
+  def totp_secret_from_page
+    secret = find('#qr-code').text
+    generate_totp_code(secret)
   end
 end

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -3,7 +3,7 @@ shared_examples 'remember device' do
     user = remember_device_and_sign_out_user
     sign_in_user(user)
 
-    expect(current_path).to eq(account_path)
+    expect(page).to have_current_path(account_path)
   end
 
   it 'requires 2FA on sign in after expiration' do
@@ -41,7 +41,7 @@ shared_examples 'remember device' do
 
     # Sign in as second user and expect otp confirmation
     sign_in_user(second_user)
-    expect_mfa_to_be_required_for_user(user)
+    expect_mfa_to_be_required_for_user(second_user)
 
     # Setup remember device as second user
     check :remember_device
@@ -52,7 +52,7 @@ shared_examples 'remember device' do
 
     # Sign in as first user again and expect otp confirmation
     sign_in_user(first_user)
-    expect_mfa_to_be_required_for_user(user)
+    expect_mfa_to_be_required_for_user(first_user)
   end
 
   it 'redirects to an SP from the sign in page' do
@@ -83,6 +83,7 @@ shared_examples 'remember device' do
   end
 
   def expect_mfa_to_be_required_for_user(user)
+    user.reload
     expected_path = if TwoFactorAuthentication::PivCacPolicy.new(user).enabled?
                       login_two_factor_piv_cac_path
                     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?


### PR DESCRIPTION
**Why**: So that users who sign in with a TOTP device can use the remember device functionality