### PR TITLE
Add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,5 @@ saml_*.shr
 /public/packs-test
 /node_modules
 yarn-debug.log*
+yarn-error.log*
 .yarn-integrity


### PR DESCRIPTION
**Why**: It contains debug messages that we don't want to track in version control.
