### PR TITLE
LG-963 Dynamic doc auth test credentials

### DIFF
--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class BackImageStep < DocAuthBaseStep
       def call
-        good, data = assure_id.post_back_image(image.read)
+        good, data = post_back_image
         return failure(data) unless good
 
         failure_data, data = verify_back_image(reset_step: :front_image)

--- a/app/services/idv/steps/capture_mobile_back_image_step.rb
+++ b/app/services/idv/steps/capture_mobile_back_image_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class CaptureMobileBackImageStep < DocAuthBaseStep
       def call
-        good, data = assure_id.post_back_image(image.read)
+        good, data = post_back_image
         return failure(data) unless good
 
         failure_data, _data = verify_back_image(reset_step: :mobile_front_image)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -88,7 +88,7 @@ module Idv
       end
 
       def test_credentials?
-        FeatureManagement.allow_doc_auth_test_credentials? && image.content_type == 'text/plain'
+        FeatureManagement.allow_doc_auth_test_credentials? && image.content_type == 'text/x-yaml'
       end
 
       delegate :idv_session, to: :@flow

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -88,7 +88,7 @@ module Idv
       end
 
       def test_credentials?
-        FeatureManagment.allow_doc_auth_test_credentials? && image.content_type == 'text/plain'
+        FeatureManagement.allow_doc_auth_test_credentials? && image.content_type == 'text/plain'
       end
 
       delegate :idv_session, to: :@flow

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -1,3 +1,6 @@
+# :reek:TooManyMethods
+# :reek:RepeatedConditional
+
 module Idv
   module Steps
     class DocAuthBaseStep < Flow::BaseStep
@@ -42,7 +45,7 @@ module Idv
       end
 
       def verify_back_image(reset_step:)
-        back_image_verified, data = assure_id.results
+        back_image_verified, data = assure_id_results
         return failure(data) unless back_image_verified
 
         return [nil, data] if data['Result'] == GOOD_RESULT
@@ -52,14 +55,40 @@ module Idv
       end
 
       def extract_pii_from_doc(data)
-        pii_from_doc = Idv::Utils::PiiFromDoc.new(data).call(
+        flow_session[:pii_from_doc] = test_credentials? ? pii_from_test_doc : parse_pii(data)
+      end
+
+      def pii_from_test_doc
+        YAML.safe_load(image.read)['document'].symbolize_keys
+      end
+
+      def parse_pii(data)
+        Idv::Utils::PiiFromDoc.new(data).call(
           current_user&.phone_configurations&.first&.phone,
         )
-        flow_session[:pii_from_doc] = pii_from_doc
       end
 
       def user_id_from_token
         flow_session[:doc_capture_user_id]
+      end
+
+      def assure_id_results
+        return [true, { 'Result' => GOOD_RESULT }] if test_credentials?
+        assure_id.results
+      end
+
+      def post_back_image
+        return [true, ''] if test_credentials?
+        assure_id.post_back_image(image.read)
+      end
+
+      def post_front_image
+        return [true, ''] if test_credentials?
+        assure_id.post_front_image(image.read)
+      end
+
+      def test_credentials?
+        FeatureManagment.allow_doc_auth_test_credentials? && image.content_type == 'text/plain'
       end
 
       delegate :idv_session, to: :@flow

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -16,7 +16,7 @@ module Idv
       end
 
       def upload_front_image
-        success, message = assure_id.post_front_image(image.read)
+        success, message = post_front_image
         return failure(message) unless success
       end
     end

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class MobileBackImageStep < DocAuthBaseStep
       def call
-        good, data = assure_id.post_back_image(image.read)
+        good, data = post_back_image
         return failure(data) unless good
 
         failure_data, data = verify_back_image(reset_step: :mobile_front_image)

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -16,7 +16,7 @@ module Idv
       end
 
       def upload_front_image
-        success, message = assure_id.post_front_image(image.read)
+        success, message = post_front_image
         return failure(message) unless success
       end
     end

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -109,4 +109,8 @@ class FeatureManagement
   def self.disallow_ial2_recovery?
     Figaro.env.disallow_ial2_recovery == 'true'
   end
+
+  def self.allow_doc_auth_test_credentials?
+    Figaro.env.allow_doc_auth_test_credentials == 'true'
+  end
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+shared_examples 'test credentials' do |simulate|
+  feature 'doc auth test credentials' do
+    include IdvStepHelper
+    include DocAuthHelper
+
+    before do
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      enable_doc_auth
+    end
+
+    it 'proceeds to the next page after front_image with valid test credentials' do
+      complete_doc_auth_steps_before_front_image_step
+      enable_test_credentials
+
+      upload_test_credentials_and_continue
+
+      expect(page).to have_current_path(idv_doc_auth_back_image_step)
+    end
+
+    it 'does not proceed to next page from front_image if test credentials are disabled' do
+      complete_doc_auth_steps_before_front_image_step
+
+      upload_test_credentials_and_continue
+
+      expect(page).to have_current_path(idv_doc_auth_front_image_step)
+    end
+
+    it 'proceeds to the next page after back_image with valid test credentials' do
+      complete_doc_auth_steps_before_back_image_step
+      enable_test_credentials
+
+      upload_test_credentials_and_continue
+
+      expect(page).to have_current_path(idv_doc_auth_ssn_step)
+    end
+
+    it 'does not proceed to next page from back_image if test credentials are disabled' do
+      complete_doc_auth_steps_before_back_image_step
+
+      upload_test_credentials_and_continue
+
+      expect(page).to have_current_path(idv_doc_auth_back_image_step)
+    end
+  end
+
+  def upload_test_credentials_and_continue
+    re_mock_assure_id
+
+    attach_file 'doc_auth_image', 'spec/fixtures/ial2_test_credential.yml'
+    click_idv_continue
+  end
+
+  def re_mock_assure_id
+    allow_any_instance_of(Idv::Acuant::AssureId).to receive(:create_document).
+      and_return([true, '123'])
+    allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
+      and_return([false, ''])
+    allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
+      and_return([false, ''])
+  end
+end
+
+feature 'doc auth test credentials' do
+  it_behaves_like 'test credentials', 'false'
+end

--- a/spec/fixtures/ial2_test_credential.yml
+++ b/spec/fixtures/ial2_test_credential.yml
@@ -1,0 +1,11 @@
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  dob: 10/06/1938
+  phone: +1 314-555-1212

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -213,6 +213,10 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     allow(FeatureManagement).to receive(:doc_auth_exclusive?).and_return(true)
   end
 
+  def enable_test_credentials
+    allow(FeatureManagement).to receive(:allow_doc_auth_test_credentials?).and_return(true)
+  end
+
   def attach_image
     attach_file 'doc_auth_image', 'app/assets/images/logo.png'
   end


### PR DESCRIPTION
**Why**: So integrators can simulate any driver's license for testing IAL2 in the integration environment.

**How**: Update the base_step class to handle acuant back_image, front_image, and results calls and have all steps funnel calls through there.  Introduce a new feature flag allow_doc_auth_test_credentials.  Key off of that and whether the user has uploaded a text file to trigger a dynamic test credential.  The test credential is a text file which contains yaml with relevant PII.  This document gets uploaded in place of a driver's license.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
