### PR TITLE
LG-1100 Limit doc auth image retries/acuant calls

### DIFF
--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -5,4 +5,27 @@ class Throttle < ApplicationRecord
   enum throttle_type: {
     idv_acuant: 1,
   }
+
+  THROTTLE_CONFIG = {
+    idv_acuant: {
+      max_attempts: (Figaro.env.acuant_max_attempts || 3).to_i,
+      attempt_window: (Figaro.env.acuant_attempt_window_in_minutes || 86_400).to_i,
+    },
+  }.freeze
+
+  def expired?
+    return true if attempted_at.blank?
+    _max_attempts, attempt_window_in_minutes = Throttle.config_values(throttle_type)
+    attempted_at + attempt_window_in_minutes.to_i.minutes < Time.zone.now
+  end
+
+  def maxed?
+    max_attempts, _attempt_window_in_minutes = Throttle.config_values(throttle_type)
+    attempts >= max_attempts
+  end
+
+  def self.config_values(throttle_type)
+    config = THROTTLE_CONFIG.with_indifferent_access[throttle_type]
+    [config[:max_attempts], config[:attempt_window]]
+  end
 end

--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -1,4 +1,8 @@
 class Throttle < ApplicationRecord
   belongs_to :user
   validates :user_id, presence: true
+
+  enum throttle_type: {
+    idv_acuant: 1,
+  }
 end

--- a/app/models/throttle.rb
+++ b/app/models/throttle.rb
@@ -1,0 +1,4 @@
+class Throttle < ApplicationRecord
+  belongs_to :user
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,7 @@ class User < ApplicationRecord
   has_many :devices, dependent: :destroy
   has_one :doc_capture, dependent: :destroy
   has_one :account_recovery_request, dependent: :destroy
+  has_many :throttles, dependent: :destroy
 
   validates :x509_dn_uuid, uniqueness: true, allow_nil: true
 

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -89,14 +89,14 @@ module Idv
 
       def throttle_post_front_image
         return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled?
-        assure_id.post_front_image(image.read)
         increment_attempts
+        assure_id.post_front_image(image.read)
       end
 
       def throttle_post_back_image
         return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled?
-        assure_id.post_back_image(image.read)
         increment_attempts
+        assure_id.post_back_image(image.read)
       end
 
       def test_credentials?

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -106,19 +106,11 @@ module Idv
       end
 
       def increment_attempts
-        Throttler::Increment.new(user_id, :idv_acuant).call
+        Throttler::Increment.call(user_id, :idv_acuant)
       end
 
       def throttled?
-        Throttler::IsThrottled.new(user_id, :idv_acuant).call(max_attempts, delay_in_minutes)
-      end
-
-      def max_attempts
-        (Figaro.env.acuant_max_attempts || 3).to_i
-      end
-
-      def delay_in_minutes
-        (Figaro.env.acuant_attempt_window_in_minutes || 86_400).to_i
+        Throttler::IsThrottled.call(user_id, :idv_acuant)
       end
 
       def user_id

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -106,11 +106,11 @@ module Idv
       end
 
       def increment_attempts
-        Throttler::Increment.new(user_id, acuant_throttle).call
+        Throttler::Increment.new(user_id, :idv_acuant).call
       end
 
       def throttled?
-        Throttler::IsThrottled.new(user_id, acuant_throttle).call(max_attempts, delay_in_minutes)
+        Throttler::IsThrottled.new(user_id, :idv_acuant).call(max_attempts, delay_in_minutes)
       end
 
       def max_attempts
@@ -123,10 +123,6 @@ module Idv
 
       def user_id
         current_user ? current_user.id : user_id_from_token
-      end
-
-      def acuant_throttle
-        Throttler::ThrottleTypes::IDV_ACUANT
       end
 
       delegate :idv_session, to: :@flow

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -122,7 +122,7 @@ module Idv
       end
 
       def user_id
-        current_user.id
+        current_user ? current_user.id : user_id_from_token
       end
 
       def acuant_throttle

--- a/app/services/throttler/find_or_create.rb
+++ b/app/services/throttler/find_or_create.rb
@@ -1,16 +1,15 @@
 module Throttler
   class FindOrCreate
-    def initialize(user_id, throttle_type)
-      @user_id = user_id
-      @throttle_type = throttle_type
+    def self.call(user_id, throttle_type)
+      throttle = Throttle.find_or_create_by(user_id: user_id, throttle_type: throttle_type)
+      reset_if_expired(throttle)
     end
 
-    def call
-      Throttle.find_or_create_by(user_id: user_id, throttle_type: throttle_type)
+    def self.reset_if_expired(throttle)
+      return throttle unless throttle.expired? && throttle.attempts.zero?
+      throttle.update(attempts: 0)
+      throttle
     end
-
-    private
-
-    attr_accessor :user_id, :throttle_type
+    private_class_method :reset_if_expired
   end
 end

--- a/app/services/throttler/find_or_create.rb
+++ b/app/services/throttler/find_or_create.rb
@@ -1,0 +1,16 @@
+module Throttler
+  class FindOrCreate
+    def initialize(user_id, throttle_type)
+      @user_id = user_id
+      @throttle_type = throttle_type
+    end
+
+    def call
+      Throttle.find_or_create_by(user_id: user_id, throttle_type: throttle_type)
+    end
+
+    private
+
+    attr_accessor :user_id, :throttle_type
+  end
+end

--- a/app/services/throttler/increment.rb
+++ b/app/services/throttler/increment.rb
@@ -1,0 +1,17 @@
+module Throttler
+  class Increment
+    def initialize(user_id, throttle_type)
+      @user_id = user_id
+      @throttle_type = throttle_type
+    end
+
+    def call
+      throttler = Throttler::FindOrCreate.new(user_id, throttle_type).call
+      throttler.update(attempts: throttler.attempts + 1, attempted_at: Time.zone.now)
+    end
+
+    private
+
+    attr_accessor :user_id, :throttle_type
+  end
+end

--- a/app/services/throttler/increment.rb
+++ b/app/services/throttler/increment.rb
@@ -1,17 +1,8 @@
 module Throttler
   class Increment
-    def initialize(user_id, throttle_type)
-      @user_id = user_id
-      @throttle_type = throttle_type
-    end
-
-    def call
-      throttler = Throttler::FindOrCreate.new(user_id, throttle_type).call
+    def self.call(user_id, throttle_type)
+      throttler = Throttler::FindOrCreate.call(user_id, throttle_type)
       throttler.update(attempts: throttler.attempts + 1, attempted_at: Time.zone.now)
     end
-
-    private
-
-    attr_accessor :user_id, :throttle_type
   end
 end

--- a/app/services/throttler/is_throttled.rb
+++ b/app/services/throttler/is_throttled.rb
@@ -1,0 +1,32 @@
+module Throttler
+  class IsThrottled
+    def initialize(user_id, throttle_type)
+      @user_id = user_id
+      @throttle_type = throttle_type
+    end
+
+    def call(max_attempts, attempt_window_in_minutes)
+      throttle = Throttler::FindOrCreate.new(user_id, throttle_type).call
+      expired = window_expired?(throttle, attempt_window_in_minutes)
+      return if expired
+
+      # too many attempts in the window
+      return unless throttle.attempts >= max_attempts && !expired
+      throttle
+    end
+
+    private
+
+    attr_accessor :user_id, :throttle_type
+
+    def window_expired?(throttle, attempt_window_in_minutes)
+      attempted_at = throttle.attempted_at
+
+      # never attempted
+      return true if attempted_at.blank?
+
+      # last attempted in the past outside the window
+      attempted_at + attempt_window_in_minutes.to_i.minutes < Time.zone.now
+    end
+  end
+end

--- a/app/services/throttler/is_throttled.rb
+++ b/app/services/throttler/is_throttled.rb
@@ -1,32 +1,12 @@
 module Throttler
   class IsThrottled
-    def initialize(user_id, throttle_type)
-      @user_id = user_id
-      @throttle_type = throttle_type
-    end
-
-    def call(max_attempts, attempt_window_in_minutes)
-      throttle = Throttler::FindOrCreate.new(user_id, throttle_type).call
-      expired = window_expired?(throttle, attempt_window_in_minutes)
+    def self.call(user_id, throttle_type)
+      throttle = FindOrCreate.call(user_id, throttle_type)
+      expired = throttle.expired?
       return if expired
 
-      # too many attempts in the window
-      return unless throttle.attempts >= max_attempts && !expired
+      return unless throttle.maxed? && !expired
       throttle
-    end
-
-    private
-
-    attr_accessor :user_id, :throttle_type
-
-    def window_expired?(throttle, attempt_window_in_minutes)
-      attempted_at = throttle.attempted_at
-
-      # never attempted
-      return true if attempted_at.blank?
-
-      # last attempted in the past outside the window
-      attempted_at + attempt_window_in_minutes.to_i.minutes < Time.zone.now
     end
   end
 end

--- a/app/services/throttler/reset.rb
+++ b/app/services/throttler/reset.rb
@@ -1,0 +1,17 @@
+module Throttler
+  class Reset
+    def initialize(user_id, throttle_type)
+      @user_id = user_id
+      @throttle_type = throttle_type
+    end
+
+    def call
+      throttler = FindOrCreate.new(user_id, throttle_type).call
+      throttler.update(attempts: 0)
+    end
+
+    private
+
+    attr_accessor :user_id, :throttle_type
+  end
+end

--- a/app/services/throttler/reset.rb
+++ b/app/services/throttler/reset.rb
@@ -1,17 +1,9 @@
 module Throttler
   class Reset
-    def initialize(user_id, throttle_type)
-      @user_id = user_id
-      @throttle_type = throttle_type
+    def self.call(user_id, throttle_type)
+      throttle = Throttle.find_or_create_by(user_id: user_id, throttle_type: throttle_type)
+      throttle.update(attempts: 0)
+      throttle
     end
-
-    def call
-      throttler = FindOrCreate.new(user_id, throttle_type).call
-      throttler.update(attempts: 0)
-    end
-
-    private
-
-    attr_accessor :user_id, :throttle_type
   end
 end

--- a/app/services/throttler/throttle_types.rb
+++ b/app/services/throttler/throttle_types.rb
@@ -1,0 +1,5 @@
+module Throttler
+  class ThrottleTypes
+    IDV_ACUANT = 1
+  end
+end

--- a/app/services/throttler/throttle_types.rb
+++ b/app/services/throttler/throttle_types.rb
@@ -1,5 +1,0 @@
-module Throttler
-  class ThrottleTypes
-    IDV_ACUANT = 1
-  end
-end

--- a/app/views/idv/capture_doc/back_image.html.slim
+++ b/app/views/idv/capture_doc/back_image.html.slim
@@ -8,7 +8,7 @@ h1.h3.my0 = t('doc_auth.headings.upload_back')
   .clearfix.mxn1
     .sm-col.sm-col-8.px1.mt2
       = f.input :image, label: false, as: 'file', required: true
-  p = flow_session[:error_message]
+  p.red.bold = flow_session[:error_message]
   .mb4 id= 'target'
   .mt2
     button type='submit' class='btn btn-primary btn-wide sm-col-6 col-12'

--- a/app/views/idv/capture_doc/capture_mobile_back_image.html.slim
+++ b/app/views/idv/capture_doc/capture_mobile_back_image.html.slim
@@ -15,7 +15,7 @@ ul
     .sm-col.sm-col-9.px1
       = f.input :image, label: false, as: 'file', required: true
 
-  p = flow_session[:error_message]
+  p.red.bold = flow_session[:error_message]
 
   div id= 'target'
   br

--- a/app/views/idv/doc_auth/back_image.html.slim
+++ b/app/views/idv/doc_auth/back_image.html.slim
@@ -8,7 +8,7 @@ h1.h3.my0 = t('doc_auth.headings.upload_back')
   .clearfix.mxn1
     .sm-col.sm-col-8.px1.mt2
       = f.input :image, label: false, as: 'file', required: true
-  p = flow_session[:error_message]
+  p.red.bold = flow_session[:error_message]
   .mb4 id= 'target'
   .mt2
     button type='submit' class='btn btn-primary btn-wide sm-col-6 col-12'

--- a/app/views/idv/doc_auth/mobile_back_image.html.slim
+++ b/app/views/idv/doc_auth/mobile_back_image.html.slim
@@ -15,7 +15,7 @@ ul
     .sm-col.sm-col-9.px1
       = f.input :image, label: false, as: 'file', required: true
 
-  p = flow_session[:error_message]
+  p.red.bold = flow_session[:error_message]
 
   div id= 'target'
   br

--- a/app/views/idv/doc_auth/mobile_front_image.html.slim
+++ b/app/views/idv/doc_auth/mobile_front_image.html.slim
@@ -14,6 +14,7 @@ ul
   .clearfix.mxn1
     .sm-col.sm-col-8.px1
       = f.input :image, label: false, as: 'file', required: true
+  p.red.bold = flow_session[:error_message]
   div id= 'target'
   br
   .mt0

--- a/app/views/idv/doc_auth/ssn.html.slim
+++ b/app/views/idv/doc_auth/ssn.html.slim
@@ -18,5 +18,4 @@ h1.h3.my0 = t('doc_auth.headings.ssn')
     button type='submit' class='btn btn-primary btn-wide sm-col-6 col-12'
       = t('forms.buttons.continue')
 
-.mt2.pt1.border-top
-  = link_to t('links.cancel'), idv_cancel_path, class: 'h5'
+= render 'idv/doc_auth/start_over_or_cancel'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -15,6 +15,9 @@
 # Make sure any new entries you add are enclosed in single quotes.
 # Figaro requires all values to be explicit strings.
 
+acuant_max_attempts: '10'
+acuant_attempt_window_in_minutes: '86400'
+
 email_from: 'no-reply@login.gov'
 idv_max_attempts: '3'
 idv_attempt_window_in_hours: '24'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -355,6 +355,8 @@ test:
   acuant_facial_match_license_key: ''
   acuant_facial_match_url: 'https://example.com'
   acuant_simulator: 'false'
+  acuant_max_attempts: '4'
+  acuant_attempt_window_in_minutes: '86400'
   async_job_refresh_interval_seconds: '1'
   async_job_refresh_max_wait_seconds: '15'
   attribute_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,6 +18,8 @@ en:
       token_missing: token missing
     confirm_password_incorrect: Incorrect password.
     doc_auth:
+      acuant_throttle: To prevent abuse we limit the amount of times you can attempt
+        to validate a document.  Please try again later.
       general_error: Your state issued ID could not be verified.  Please try uploading
         different images starting with the front of your state issued ID.
     invalid_authenticity_token: Oops, something went wrong. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -18,6 +18,8 @@ es:
       token_missing: falta el token
     confirm_password_incorrect: La contraseña es incorrecta.
     doc_auth:
+      acuant_throttle: To prevent abuse we limit the amount of times you can attempt
+        to validate a document.  Please try again later.
       general_error: Su identificación emitida por el estado no pudo ser verificada.
         Por favor, intente cargar diferentes imágenes comenzando con el frente de
         su identificación emitida por el estado.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -18,6 +18,8 @@ fr:
       token_missing: jeton manquant
     confirm_password_incorrect: Mot de passe incorrect.
     doc_auth:
+      acuant_throttle: To prevent abuse we limit the amount of times you can attempt
+        to validate a document.  Please try again later.
       general_error: Votre identité émise par l'état n'a pas pu être vérifiée. S'il
         vous plaît essayez de télécharger des images différentes en commençant par
         le devant de votre ID émis par l'État.

--- a/db/migrate/20190407103634_create_throttles.rb
+++ b/db/migrate/20190407103634_create_throttles.rb
@@ -1,0 +1,13 @@
+class CreateThrottles < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    create_table :throttles do |t|
+      t.integer :user_id, null: false
+      t.integer :throttle_type, null: false
+      t.datetime :attempted_at
+      t.integer :attempts, default: 0
+    end
+    add_index :throttles, %i[user_id throttle_type], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190306143757) do
+ActiveRecord::Schema.define(version: 20190407103634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -252,6 +252,14 @@ ActiveRecord::Schema.define(version: 20190306143757) do
     t.boolean "piv_cac_scoped_by_email", default: false
     t.boolean "pkce"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
+  end
+
+  create_table "throttles", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "throttle_type", null: false
+    t.datetime "attempted_at"
+    t.integer "attempts", default: 0
+    t.index ["user_id", "throttle_type"], name: "index_throttles_on_user_id_and_throttle_type"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -5,10 +5,12 @@ shared_examples 'back image step' do |simulate|
     include IdvStepHelper
     include DocAuthHelper
 
+    let(:user) { user_with_2fa }
+    let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
       allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
       enable_doc_auth
-      complete_doc_auth_steps_before_back_image_step
+      complete_doc_auth_steps_before_back_image_step(user)
       mock_assure_id_ok
     end
 
@@ -49,6 +51,29 @@ shared_examples 'back image step' do |simulate|
 
       expect(page).to have_current_path(idv_doc_auth_front_image_step) unless simulate
       expect(page).to have_content(I18n.t('errors.doc_auth.general_error')) unless simulate
+    end
+
+    it 'throttles calls to acuant and allows retry after the attempt window' do
+      (max_attempts / 2).times do
+        attach_image
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_ssn_step)
+        click_on t('doc_auth.buttons.start_over')
+        complete_doc_auth_steps_before_back_image_step(user)
+      end
+
+      attach_image
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_doc_auth_front_image_step)
+
+      Timecop.travel((Figaro.env.acuant_attempt_window_in_minutes.to_i + 1).minutes.from_now) do
+        complete_doc_auth_steps_before_back_image_step(user)
+        attach_image
+        click_idv_continue
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+      end
     end
   end
 end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -53,7 +53,7 @@ shared_examples 'back image step' do |simulate|
       expect(page).to have_content(I18n.t('errors.doc_auth.general_error')) unless simulate
     end
 
-    it 'throttles calls to acuant and allows retry after the attempt window' do
+    it 'throttles calls to acuant and allows attempts after the attempt window' do
       (max_attempts / 2).times do
         attach_image
         click_idv_continue

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -5,10 +5,12 @@ shared_examples 'front image step' do |simulate|
     include IdvStepHelper
     include DocAuthHelper
 
+    let(:user) { user_with_2fa }
+    let(:max_retries) { 3 }
     before do
       allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
       enable_doc_auth
-      complete_doc_auth_steps_before_front_image_step
+      complete_doc_auth_steps_before_front_image_step(user)
       mock_assure_id_ok
     end
 
@@ -30,6 +32,31 @@ shared_examples 'front image step' do |simulate|
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_front_image_step)
+    end
+
+    it 'throttles calls to acuant and allows retry after the attempt window' do
+      allow(Figaro.env).to receive(:acuant_max_attempts).and_return(max_retries)
+      max_retries.times do
+        attach_image
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+        click_on t('doc_auth.buttons.start_over')
+        complete_doc_auth_steps_before_front_image_step(user)
+      end
+
+      attach_image
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_doc_auth_front_image_step)
+
+      Timecop.travel(Figaro.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
+        complete_doc_auth_steps_before_front_image_step(user)
+        attach_image
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+      end
     end
   end
 end

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'front image step' do |simulate|
     include DocAuthHelper
 
     let(:user) { user_with_2fa }
-    let(:max_retries) { 3 }
+    let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
       allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
       enable_doc_auth
@@ -35,8 +35,8 @@ shared_examples 'front image step' do |simulate|
     end
 
     it 'throttles calls to acuant and allows retry after the attempt window' do
-      allow(Figaro.env).to receive(:acuant_max_attempts).and_return(max_retries)
-      max_retries.times do
+      allow(Figaro.env).to receive(:acuant_max_attempts).and_return(max_attempts)
+      max_attempts.times do
         attach_image
         click_idv_continue
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,7 @@ describe User do
     it { is_expected.to have_one(:doc_auth) }
     it { is_expected.to have_one(:doc_capture) }
     it { is_expected.to have_one(:account_recovery_request) }
+    it { is_expected.to have_many(:throttles) }
   end
 
   it 'does not send an email when #create is called' do

--- a/spec/services/throttler/increment_spec.rb
+++ b/spec/services/throttler/increment_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe Throttler::Increment do
   let(:user_id) { 1 }
   let(:throttle_type) { :idv_acuant }
-  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:subject) { described_class }
   let(:throttle) { Throttle.all.first }
 
   it 'creates and increments a throttle if one does not exist' do
-    subject.call
+    subject.call(user_id, throttle_type)
 
     expect(throttle.attempts).to eq(1)
     expect(throttle.attempted_at).to be_present
@@ -18,7 +18,7 @@ describe Throttler::Increment do
                     throttle_type: throttle_type,
                     attempts: 1,
                     attempted_at: Time.zone.now)
-    subject.call
+    subject.call(user_id, throttle_type)
 
     expect(throttle.attempts).to eq(2)
     expect(throttle.attempted_at).to be_present

--- a/spec/services/throttler/increment_spec.rb
+++ b/spec/services/throttler/increment_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe Throttler::Increment do
+  let(:user_id) { 1 }
+  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:throttle) { Throttle.all.first }
+
+  it 'creates and increments a throttle if one does not exist' do
+    subject.call
+
+    expect(throttle.attempts).to eq(1)
+    expect(throttle.attempted_at).to be_present
+  end
+
+  it 'it increments a throttle if one exists' do
+    Throttle.create(user_id: user_id,
+                    throttle_type: throttle_type,
+                    attempts: 1,
+                    attempted_at: Time.zone.now)
+    subject.call
+
+    expect(throttle.attempts).to eq(2)
+    expect(throttle.attempted_at).to be_present
+  end
+end

--- a/spec/services/throttler/increment_spec.rb
+++ b/spec/services/throttler/increment_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Throttler::Increment do
   let(:user_id) { 1 }
-  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:throttle_type) { :idv_acuant }
   let(:subject) { described_class.new(user_id, throttle_type) }
   let(:throttle) { Throttle.all.first }
 

--- a/spec/services/throttler/is_throttled_spec.rb
+++ b/spec/services/throttler/is_throttled_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Throttler::IsThrottled do
   let(:user_id) { 1 }
-  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:throttle_type) { :idv_acuant }
   let(:subject) { described_class.new(user_id, throttle_type) }
   let(:throttle) { Throttle.all.first }
   let(:max_attempts) { 3 }

--- a/spec/services/throttler/is_throttled_spec.rb
+++ b/spec/services/throttler/is_throttled_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 describe Throttler::IsThrottled do
   let(:user_id) { 1 }
   let(:throttle_type) { :idv_acuant }
-  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:subject) { described_class }
   let(:throttle) { Throttle.all.first }
-  let(:max_attempts) { 3 }
-  let(:attempt_window_in_minutes) { 5 }
+  let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
+  let(:attempt_window_in_minutes) { Figaro.env.acuant_attempt_window_in_minutes.to_i }
 
   it 'returns throttle if throttled' do
     Throttle.create(user_id: user_id,
                     throttle_type: throttle_type,
                     attempts: max_attempts,
                     attempted_at: Time.zone.now)
-    result = subject.call(max_attempts, attempt_window_in_minutes)
+    result = subject.call(user_id, throttle_type)
 
     expect(result.class).to eq(Throttle)
   end
@@ -23,7 +23,7 @@ describe Throttler::IsThrottled do
                     throttle_type: throttle_type,
                     attempts: max_attempts - 1,
                     attempted_at: Time.zone.now)
-    result = subject.call(max_attempts, attempt_window_in_minutes)
+    result = subject.call(user_id, throttle_type)
 
     expect(result).to be_nil
   end
@@ -32,8 +32,8 @@ describe Throttler::IsThrottled do
     Throttle.create(user_id: user_id,
                     throttle_type: throttle_type,
                     attempts: max_attempts,
-                    attempted_at: Time.zone.now - 6.minutes)
-    result = subject.call(max_attempts, attempt_window_in_minutes)
+                    attempted_at: Time.zone.now - attempt_window_in_minutes.minutes)
+    result = subject.call(user_id, throttle_type)
 
     expect(result).to be_nil
   end

--- a/spec/services/throttler/is_throttled_spec.rb
+++ b/spec/services/throttler/is_throttled_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Throttler::IsThrottled do
+  let(:user_id) { 1 }
+  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:throttle) { Throttle.all.first }
+  let(:max_attempts) { 3 }
+  let(:attempt_window_in_minutes) { 5 }
+
+  it 'returns throttle if throttled' do
+    Throttle.create(user_id: user_id,
+                    throttle_type: throttle_type,
+                    attempts: max_attempts,
+                    attempted_at: Time.zone.now)
+    result = subject.call(max_attempts, attempt_window_in_minutes)
+
+    expect(result.class).to eq(Throttle)
+  end
+
+  it 'returns nil if the attempts < max_attempts' do
+    Throttle.create(user_id: user_id,
+                    throttle_type: throttle_type,
+                    attempts: max_attempts - 1,
+                    attempted_at: Time.zone.now)
+    result = subject.call(max_attempts, attempt_window_in_minutes)
+
+    expect(result).to be_nil
+  end
+
+  it 'returns nil if the attempts <= max_attempts but the window is expired' do
+    Throttle.create(user_id: user_id,
+                    throttle_type: throttle_type,
+                    attempts: max_attempts,
+                    attempted_at: Time.zone.now - 6.minutes)
+    result = subject.call(max_attempts, attempt_window_in_minutes)
+
+    expect(result).to be_nil
+  end
+end

--- a/spec/services/throttler/reset_spec.rb
+++ b/spec/services/throttler/reset_spec.rb
@@ -12,7 +12,7 @@ describe Throttler::Reset do
                     throttle_type: throttle_type,
                     attempts: max_attempts,
                     attempted_at: Time.zone.now)
-    result = subject.call
+    subject.call
 
     expect(throttle.attempts).to eq(0)
   end

--- a/spec/services/throttler/reset_spec.rb
+++ b/spec/services/throttler/reset_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Throttler::Reset do
   let(:user_id) { 1 }
-  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:throttle_type) { :idv_acuant }
   let(:max_attempts) { 3 }
   let(:subject) { described_class.new(user_id, throttle_type) }
   let(:throttle) { Throttle.all.first }

--- a/spec/services/throttler/reset_spec.rb
+++ b/spec/services/throttler/reset_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Throttler::Reset do
+  let(:user_id) { 1 }
+  let(:throttle_type) { Throttler::ThrottleTypes::IDV_ACUANT }
+  let(:max_attempts) { 3 }
+  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:throttle) { Throttle.all.first }
+
+  it 'resets attempt count to 0' do
+    Throttle.create(user_id: user_id,
+                    throttle_type: throttle_type,
+                    attempts: max_attempts,
+                    attempted_at: Time.zone.now)
+    result = subject.call
+
+    expect(throttle.attempts).to eq(0)
+  end
+end

--- a/spec/services/throttler/reset_spec.rb
+++ b/spec/services/throttler/reset_spec.rb
@@ -4,7 +4,7 @@ describe Throttler::Reset do
   let(:user_id) { 1 }
   let(:throttle_type) { :idv_acuant }
   let(:max_attempts) { 3 }
-  let(:subject) { described_class.new(user_id, throttle_type) }
+  let(:subject) { described_class }
   let(:throttle) { Throttle.all.first }
 
   it 'resets attempt count to 0' do
@@ -12,7 +12,7 @@ describe Throttler::Reset do
                     throttle_type: throttle_type,
                     attempts: max_attempts,
                     attempted_at: Time.zone.now)
-    subject.call
+    subject.call(user_id, throttle_type)
 
     expect(throttle.attempts).to eq(0)
   end


### PR DESCRIPTION
**Why**: To keep user data secure and prevent brute force attacks

**How**: Add a generic throttler table/class to handle a variety of throttling use cases and not have to continually add new fields to the user table.  Provide service classes to handle throttling. Add these throttles to the front and back image calls to Acuant.

Usage:
```
return error if Throttler::IsThrottled.call(user_id, :idv_acuant)
Throttler::Increment.call(user_id, :idv_acuant)
```

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
