### PR TITLE
LG-1086 Clicking "send another letter" renders a 500

### DIFF
--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -101,7 +101,7 @@ module Idv
     end
 
     def resend_letter
-      confirmation_maker_perform
+      confirmation_maker = confirmation_maker_perform
       send_reminder
       return unless FeatureManagement.reveal_usps_code?
       session[:last_usps_confirmation_code] = confirmation_maker.otp
@@ -114,6 +114,7 @@ module Idv
         profile: current_user.decorate.pending_profile,
       )
       confirmation_maker.perform
+      confirmation_maker
     end
 
     def idv_form

--- a/spec/controllers/idv/usps_controller_spec.rb
+++ b/spec/controllers/idv/usps_controller_spec.rb
@@ -69,17 +69,17 @@ describe Idv::UspsController do
       end
 
       it 'calls the UspsConfirmationMaker to send another letter and redirects' do
-        resend_letter(otp: false)
+        expect_resend_letter_to_send_letter_and_redirect(otp: false)
       end
 
       it 'calls UspsConfirmationMaker to send another letter with reveal_usps_code on' do
         allow(FeatureManagement).to receive(:reveal_usps_code?).and_return(true)
-        resend_letter(otp: true)
+        expect_resend_letter_to_send_letter_and_redirect(otp: true)
       end
     end
   end
 
-  def resend_letter(otp:)
+  def expect_resend_letter_to_send_letter_and_redirect(otp:)
     pii = { first_name: 'Samuel', last_name: 'Sampson' }
     pii_cacher = instance_double(Pii::Cacher)
     allow(pii_cacher).to receive(:fetch).and_return(pii)


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
