### PR TITLE
Log faraday connection error instead of reporting it to NR

### DIFF
--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -21,7 +21,7 @@ class GoogleAnalyticsMeasurement
       request.body = request_body
     end
   rescue Faraday::ConnectionFailed => err
-    NewRelic::Agent.notice_error(err)
+    Rails.logger.info err.inspect
   end
 
   private


### PR DESCRIPTION
**Why**: The devops change we need to add the google analytics endpoint to the https proxy has not been deployed yet. This is a patch that we can put in place to keep NR from reporting errors until it does.