### PR TITLE
Re-add New Relic alert for faraday connection error on GA call

### DIFF
--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -21,7 +21,7 @@ class GoogleAnalyticsMeasurement
       request.body = request_body
     end
   rescue Faraday::ConnectionFailed => err
-    Rails.logger.info err.inspect
+    NewRelic::Agent.notice_error(err)
   end
 
   private


### PR DESCRIPTION
**Why**: So that errors talking to Google Analytics will be reported to New Relic and we will know about issues tracking analytics