### PR TITLE
Allow identity-saml-rails SP to receive IAL 2.

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -221,6 +221,7 @@ production:
     friendly_name: 'Demo SP Application'
     logo: 'generic.svg'
     return_to_sp_url: 'https://sp.<%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>'
+    ial: 2
     attribute_bundle:
       - email
 


### PR DESCRIPTION
**Why**: This should have been whitelisted when we rolled out the IAL2
per-SP whitelisting.

**How**: Add `ial: 2` to sp-rails service provider definition.