### PR TITLE
LG-940 Require 2 MFA methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,6 +138,16 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     user_fully_authenticated? ? account_or_verify_profile_url : user_two_factor_authentication_url
   end
 
+  def after_multiple_2fa_sign_up
+    if session[:sp]
+      sign_up_completed_url
+    elsif current_user.decorate.password_reset_profile.present?
+      reactivate_account_url
+    else
+      after_sign_in_path_for(current_user)
+    end
+  end
+
   def reauthn_param
     params[:reauthn]
   end

--- a/app/controllers/concerns/authorizable.rb
+++ b/app/controllers/concerns/authorizable.rb
@@ -3,7 +3,7 @@ module Authorizable
     return unless TwoFactorAuthentication::PhonePolicy.new(current_user).enabled?
 
     if user_fully_authenticated?
-      redirect_to account_url
+      # redirect_to account_url
     elsif MfaPolicy.new(current_user).two_factor_enabled?
       redirect_to user_two_factor_authentication_url
     end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -189,13 +189,21 @@ module TwoFactorAuthenticatable # rubocop:disable Metrics/ModuleLength
     policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
 
     if policy.show_personal_key_after_initial_2fa_setup?
-      sign_up_personal_key_url
+      two_2fa_setup
     elsif @updating_existing_number
       account_url
     elsif decorated_user.password_reset_profile.present?
       reactivate_account_url
     else
       account_url
+    end
+  end
+
+  def two_2fa_setup
+    if MfaPolicy.new(current_user).multiple_factors_enabled?
+      after_multiple_2fa_sign_up
+    else
+      two_factor_options_path
     end
   end
 

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -18,7 +18,7 @@ module Users
       generator.save(user_session[:backup_codes])
       create_user_event(:backup_codes_added)
       revoke_remember_device
-      redirect_to sign_up_personal_key_url
+      redirect_to after_multiple_2fa_sign_up
     end
 
     def download

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -86,7 +86,7 @@ module Users
       policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
 
       if policy.show_personal_key_after_initial_2fa_setup?
-        sign_up_personal_key_url
+        after_multiple_2fa_sign_up
       else
         idv_jurisdiction_url
       end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -99,7 +99,7 @@ module Users
       return account_url if user_already_has_a_personal_key?
 
       policy = PersonalKeyForNewUserPolicy.new(user: current_user, session: session)
-      return sign_up_personal_key_url if policy.show_personal_key_after_initial_2fa_setup?
+      return after_multiple_2fa_sign_up if policy.show_personal_key_after_initial_2fa_setup?
 
       idv_jurisdiction_url
     end


### PR DESCRIPTION
**Why**: So that if a user forgets one method they have a recovery method to get back into their account

**How**: Redirect previous personal key setup to conditionally either setup an additional second factor or redirect to the flow after the old personal key setup.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
