### PR TITLE
Modify GA request params

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -118,7 +118,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // eslint-disable-next-line no-undef
         ga(function (tracker) {
           const clientId = tracker.get('clientId');
-          $('.ga-client-id').val(clientId);
+          const gaClientIdInput = document.getElementById('ga_client_id');
+          gaClientIdInput.value = clientId;
         });
       }
     });

--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -17,7 +17,6 @@ class GoogleAnalyticsMeasurement
   end
 
   def send_event
-    warn request_body
     adapter.post do |request|
       request.body = request_body
     end

--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -17,6 +17,7 @@ class GoogleAnalyticsMeasurement
   end
 
   def send_event
+    warn request_body
     adapter.post do |request|
       request.body = request_body
     end
@@ -31,7 +32,7 @@ class GoogleAnalyticsMeasurement
       v: 1,
       tid: Figaro.env.google_analytics_key,
       t: :event,
-      c: category,
+      ec: category,
       ea: event_action,
       el: method,
       cid: client_id,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -150,6 +150,7 @@ development:
   event_disavowal_expiration_hours: '240'
   exception_recipients: 'test1@test.com'
   expired_letters_auth_token: 'abc123'
+  google_analytics_key: 'UA-XXXXXXXXX-YY'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   ial2_recovery_request_valid_for_minutes: '15'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -150,7 +150,6 @@ development:
   event_disavowal_expiration_hours: '240'
   exception_recipients: 'test1@test.com'
   expired_letters_auth_token: 'abc123'
-  google_analytics_key: 'UA-XXXXXXXXX-YY'
   hmac_fingerprinter_key: 'a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c'
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
   ial2_recovery_request_valid_for_minutes: '15'

--- a/spec/services/google_analytics_measurement_spec.rb
+++ b/spec/services/google_analytics_measurement_spec.rb
@@ -21,7 +21,7 @@ describe GoogleAnalyticsMeasurement do
         v: '1',
         tid: Figaro.env.google_analytics_key,
         t: 'event',
-        c: category,
+        ec: category,
         ea: event_action,
         el: method,
         cid: client_id,


### PR DESCRIPTION
**Why**: After getting the backend GA requests into prod, we discovered a few issues:

1. The `c` param should actually be named `ec`
2. The `cid` was not getting set correctly because the GA client ID was not being set in the form

This commit fixes both of those.
