### PR TITLE
Fix utf8 errors in headers and cookies and invalid parameter errors

### DIFF
--- a/lib/rack_request_parser.rb
+++ b/lib/rack_request_parser.rb
@@ -6,7 +6,7 @@ class RackRequestParser
   end
 
   def values_to_check
-    param_values + ahoy_headers + ahoy_cookies + [host_header]
+    param_values + header_values + cookie_values
   end
 
   private
@@ -15,35 +15,19 @@ class RackRequestParser
     all_values(request.params)
   end
 
+  def header_values
+    header_values = []
+    request.env.each do |key, value|
+      header_values.push(value) if key.start_with? 'HTTP_'
+    end
+    header_values
+  end
+
+  def cookie_values
+    request.cookies.values
+  end
+
   def all_values(hash)
     hash.values.flat_map { |value| value.is_a?(Hash) ? all_values(value) : [value] }
-  end
-
-  def ahoy_headers
-    [ahoy_visit_header, ahoy_visitor_header]
-  end
-
-  def ahoy_visit_header
-    request.fetch_header('HTTP_AHOY_VISIT') { '' }
-  end
-
-  def ahoy_visitor_header
-    request.fetch_header('HTTP_AHOY_VISITOR') { '' }
-  end
-
-  def ahoy_cookies
-    [ahoy_visit_cookie, ahoy_visitor_cookie]
-  end
-
-  def ahoy_visit_cookie
-    request.cookies['ahoy_visit']
-  end
-
-  def ahoy_visitor_cookie
-    request.cookies['ahoy_visitor']
-  end
-
-  def host_header
-    request.fetch_header('HTTP_HOST') { '' }
   end
 end

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -6,6 +6,8 @@ class Utf8Sanitizer
     @app = app
   end
 
+  # :reek:DuplicateMethodCall
+  # :reek:TooManyStatements
   def call(env)
     parser = RackRequestParser.new(Rack::Request.new(env))
     values_to_check = parser.values_to_check

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -7,17 +7,19 @@ class Utf8Sanitizer
   end
 
   def call(env)
-    request = Rack::Request.new(env)
-    parser = RackRequestParser.new(request)
+    parser = RackRequestParser.new(Rack::Request.new(env))
     values_to_check = parser.values_to_check
 
     if invalid_strings(values_to_check)
-      Rails.logger.info(event_attributes(env, parser.request))
+      Rails.logger.info(invalid_utf8_event(env, parser.request))
 
       return [400, {}, ['Bad request']]
     end
 
     @app.call(env)
+  rescue Rack::QueryParser::InvalidParameterError => err
+    Rails.logger.info(invalid_parameter_event(err))
+    [400, {}, ['Bad request']]
   end
 
   private
@@ -34,14 +36,14 @@ class Utf8Sanitizer
     !string.force_encoding('UTF-8').valid_encoding?
   end
 
-  def event_attributes(env, request)
+  def invalid_utf8_event(env, request)
     {
       event: 'Invalid UTF-8 encoding',
       user_uuid: env['warden']&.user&.uuid || AnonymousUser.new.uuid,
       ip: remote_ip(request),
-      user_agent: request.user_agent,
+      user_agent: sanitized_user_agent(request),
       timestamp: Time.zone.now,
-      hostname: request.host,
+      hostname: sanitized_hostname(request),
       visitor_id: sanitized_visitor_id(request),
       content_type: env['CONTENT_TYPE'],
     }.to_json
@@ -51,8 +53,23 @@ class Utf8Sanitizer
     @remote_ip ||= (request.env['action_dispatch.remote_ip'] || request.ip).to_s
   end
 
+  def sanitized_hostname(request)
+    Utf8Cleaner.new(request.host).remove_invalid_utf8_bytes
+  end
+
+  def sanitized_user_agent(request)
+    Utf8Cleaner.new(request.user_agent).remove_invalid_utf8_bytes
+  end
+
   def sanitized_visitor_id(request)
     string_to_clean = request.cookies['ahoy_visitor']
     Utf8Cleaner.new(string_to_clean).remove_invalid_utf8_bytes
+  end
+
+  def invalid_parameter_event(error)
+    {
+      event: 'Invalid parameter error',
+      message: error.message,
+    }
   end
 end

--- a/spec/requests/openid_connect_cors_spec.rb
+++ b/spec/requests/openid_connect_cors_spec.rb
@@ -161,7 +161,8 @@ RSpec.describe 'CORS headers for OpenID Connect endpoints' do
   describe 'domain name as the origin' do
     it 'does not load any ServiceProvider objects' do
       stub_const 'ServiceProvider', double
-      get openid_connect_configuration_path, headers: { 'HTTP_ORIGIN' => Figaro.env.domain_name }
+      get openid_connect_configuration_path,
+          headers: { 'HTTP_ORIGIN' => Figaro.env.domain_name.dup }
 
       aggregate_failures do
         expect(response).to be_ok


### PR DESCRIPTION
**Why**: So that these errors will render a 400 instead of a 500.
