### PR TITLE
LG-1188 New deleted accounts report for service providers

### DIFF
--- a/app/services/deleted_accounts_report.rb
+++ b/app/services/deleted_accounts_report.rb
@@ -1,0 +1,13 @@
+class DeletedAccountsReport
+  def self.call(service_provider, days_ago)
+    report_sql = <<~SQL
+      SELECT uuid,last_authenticated_at
+      FROM identities
+      WHERE user_id not in (SELECT id FROM users)
+      AND service_provider='%s'
+      AND last_authenticated_at > '%s'
+    SQL
+    sql = format(report_sql, service_provider, days_ago.to_i.days.ago)
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/app/services/deleted_accounts_report.rb
+++ b/app/services/deleted_accounts_report.rb
@@ -1,11 +1,12 @@
 class DeletedAccountsReport
   def self.call(service_provider, days_ago)
     report_sql = <<~SQL
-      SELECT uuid,last_authenticated_at
-      FROM identities
-      WHERE user_id not in (SELECT id FROM users)
-      AND service_provider='%s'
-      AND last_authenticated_at > '%s'
+      SELECT last_authenticated_at, identity_uuid FROM
+      (SELECT ids.last_authenticated_at AS last_authenticated_at,
+              ids.uuid AS identity_uuid, us.id AS users_id
+      FROM identities AS ids LEFT JOIN users AS us ON ids.user_id=us.id
+      WHERE service_provider='%s' AND last_authenticated_at > '%s') AS tbl
+      WHERE users_id IS NULL ORDER BY last_authenticated_at ASC
     SQL
     sql = format(report_sql, service_provider, days_ago.to_i.days.ago)
     ActiveRecord::Base.connection.execute(sql)

--- a/lib/tasks/deleted_accounts.rake
+++ b/lib/tasks/deleted_accounts.rake
@@ -1,9 +1,12 @@
 namespace :deleted_accounts do
   task :report, %i[service_provider days_ago] => [:environment] do |_task, args|
-    puts 'uuid, last_authenticated_at'
-    DeletedAccountsReport.call(args[:service_provider], args[:days_ago]).each do |row|
-      puts "#{row['last_authenticated_at']}, #{row['uuid']}"
+    puts 'last_authenticated_at, identity_uuid'
+    days_ago = args[:days_ago].to_i
+    rows = DeletedAccountsReport.call(args[:service_provider], args[:days_ago])
+    rows.each do |row|
+      puts "#{row['last_authenticated_at']}, #{row['identity_uuid']}"
     end
+    puts "Total records=#{rows.count} Date range=#{days_ago.days.ago} - #{Time.zone.now}"
   end
 end
 # rake "deleted_accounts:report[urn:gov:gsa:openidconnect:sp:sinatra,30]"

--- a/lib/tasks/deleted_accounts.rake
+++ b/lib/tasks/deleted_accounts.rake
@@ -1,0 +1,9 @@
+namespace :deleted_accounts do
+  task :report, %i[service_provider days_ago] => [:environment] do |_task, args|
+    puts 'uuid, last_authenticated_at'
+    DeletedAccountsReport.call(args[:service_provider], args[:days_ago]).each do |row|
+      puts "#{row['last_authenticated_at']}, #{row['uuid']}"
+    end
+  end
+end
+# rake "deleted_accounts:report[urn:gov:gsa:openidconnect:sp:sinatra,30]"

--- a/spec/services/deleted_accounts_report_spec.rb
+++ b/spec/services/deleted_accounts_report_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe DeletedAccountsReport do
+  let(:service_provider) { 'urn:gov:gsa:openidconnect:sp:sinatra' }
+  let(:days_ago) { 30 }
+  describe '#call' do
+    it 'prints the report with zero records when no users or identities' do
+      rows = DeletedAccountsReport.call(service_provider, days_ago)
+
+      expect(rows.count).to eq(0)
+    end
+
+    it 'prints the report with zero records when no users are deleted' do
+      user = create(:user)
+      create(:identity, service_provider: service_provider, user: user,
+                        last_authenticated_at: Time.zone.now)
+      rows = DeletedAccountsReport.call(service_provider, days_ago)
+
+      expect(User.count).to eq(1)
+      expect(Identity.count).to eq(1)
+      expect(rows.count).to eq(0)
+    end
+
+    it 'prints the report with one record' do
+      user = create(:user)
+      create(:identity, service_provider: service_provider, user: user,
+                        last_authenticated_at: Time.zone.now)
+      user.destroy!
+      rows = DeletedAccountsReport.call(service_provider, days_ago)
+
+      expect(User.count).to eq(0)
+      expect(Identity.count).to eq(1)
+      expect(rows.count).to eq(1)
+    end
+
+    it 'prints the report with zero records when the last auth date is beyond days ago' do
+      user = create(:user)
+      create(:identity, service_provider: service_provider, user: user,
+                        last_authenticated_at: days_ago + 1)
+      user.destroy!
+      rows = DeletedAccountsReport.call(service_provider, days_ago)
+
+      expect(User.count).to eq(0)
+      expect(Identity.count).to eq(1)
+      expect(rows.count).to eq(0)
+    end
+
+    it 'prints the report with zero records when it is not the correct sp' do
+      user = create(:user)
+      create(:identity, service_provider: 'foo', user: user, last_authenticated_at: Time.zone.now)
+      user.destroy!
+      rows = DeletedAccountsReport.call(service_provider, days_ago)
+
+      expect(User.count).to eq(0)
+      expect(Identity.count).to eq(1)
+      expect(rows.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So service providers can update their data accordingly

**How**: Create a new rake task that calls a service class to print the last auth date and uuids for deleted accounts.  The rake task takes the service provider and the number of days to go back from the current date.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
