### PR TITLE
LG-1077 Slight change to the wording in the location notification

### DIFF
--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -25,7 +25,7 @@ en:
       reactivation:
         instructions: Your profile was recently deactivated due to a password reset.
         link: Reactivate your profile now.
-      sign_in_location_and_ip: 'From %{location} (IP address: %{ip})'
+      sign_in_location_and_ip: 'From %{ip} (IP address potentially located in %{location})'
       ssn: Social Security Number
       unknown_location: unknown location
       verification:

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -25,7 +25,7 @@ en:
       reactivation:
         instructions: Your profile was recently deactivated due to a password reset.
         link: Reactivate your profile now.
-      sign_in_location_and_ip: 'From %{ip} (IP address potentially located in %{location})'
+      sign_in_location_and_ip: From %{ip} (IP address potentially located in %{location})
       ssn: Social Security Number
       unknown_location: unknown location
       verification:

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -25,7 +25,8 @@ es:
       reactivation:
         instructions: Su perfil ha sido desactivado debido a un cambio de contraseña.
         link: Reactive su perfil ahora.
-      sign_in_location_and_ip: 'Desde %{location} (Dirección IP: %{ip})'
+      sign_in_location_and_ip: Desde %{ip} (la dirección IP probablemente se encuentra
+        en %{location})
       ssn: Número de Seguro Social
       unknown_location: ubicación desconocida
       verification:

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -27,7 +27,7 @@ fr:
           de mot passe. Vous pouvez utiliser votre clé personnelle pour réactiver
           votre profil.
         link: Réactivez votre profil maintenant.
-      sign_in_location_and_ip: "{ip} (adresse IP probablement située dans %{location})"
+      sign_in_location_and_ip: "%{ip} (adresse IP probablement située dans %{location})"
       ssn: Numéro d'assurance sociale
       unknown_location: lieu inconnu
       verification:

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -27,7 +27,7 @@ fr:
           de mot passe. Vous pouvez utiliser votre clé personnelle pour réactiver
           votre profil.
         link: Réactivez votre profil maintenant.
-      sign_in_location_and_ip: "%{location} (Adresse IP: %{ip})"
+      sign_in_location_and_ip: "{ip} (adresse IP probablement située dans %{location})"
       ssn: Numéro d'assurance sociale
       unknown_location: lieu inconnu
       verification:

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -23,7 +23,7 @@ describe 'New device tracking' do
           user.email_addresses.first,
           device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),
-          'From United States (IP address: 127.0.0.1)',
+          'From 127.0.0.1 (IP address potentially located in United States)',
           instance_of(String),
         )
       expect(SmsNewDeviceSignInNotifierJob).to have_received(:perform_now).
@@ -66,7 +66,7 @@ describe 'New device tracking' do
           user.email_addresses.first,
           device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),
-          'From United States (IP address: 127.0.0.1)',
+          'From 127.0.0.1 (IP address potentially located in United States)',
           instance_of(String),
         )
       expect(SmsNewDeviceSignInNotifierJob).to_not have_received(:perform_now)


### PR DESCRIPTION
**Why**:
To make it clearer to the user that the location is being determined by the IP and may not be the same as the user's location, such as is often the case with mobile users.