### PR TITLE
LG-1240 Add general error for problems connecting to vendors in doc auth

### DIFF
--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -32,6 +32,7 @@ module Flow
 
     def failure(message, extra = {})
       flow_session[:error_message] = message
+      extra ||= {}
       FormResponse.new(success: false, errors: { message: message }, extra: extra)
     end
 

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -33,7 +33,7 @@ module Flow
     def failure(message, extra = nil)
       flow_session[:error_message] = message
       hash = { success: false, errors: { message: message } }
-      hash.merge!(extra: extra) unless extra.nil?
+      hash[:extra] = extra unless extra.nil?
       FormResponse.new(hash)
     end
 

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -32,7 +32,6 @@ module Flow
 
     def failure(message, extra = {})
       flow_session[:error_message] = message
-      extra ||= {}
       FormResponse.new(success: false, errors: { message: message }, extra: extra)
     end
 

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -30,9 +30,11 @@ module Flow
       FormResponse.new(success: true, errors: {})
     end
 
-    def failure(message, extra = {})
+    def failure(message, extra = nil)
       flow_session[:error_message] = message
-      FormResponse.new(success: false, errors: { message: message }, extra: extra)
+      hash = { success: false, errors: { message: message } }
+      hash.merge!(extra: extra) unless extra.nil?
+      FormResponse.new(hash)
     end
 
     def flow_params

--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -2,8 +2,8 @@ module Idv
   module Steps
     class BackImageStep < DocAuthBaseStep
       def call
-        good, data = post_back_image
-        return failure(data) unless good
+        good, data, analytics_hash = post_back_image
+        return failure(data, analytics_hash) unless good
 
         failure_data, data = verify_back_image(reset_step: :front_image)
         return failure_data if failure_data

--- a/app/services/idv/steps/capture_mobile_back_image_step.rb
+++ b/app/services/idv/steps/capture_mobile_back_image_step.rb
@@ -2,8 +2,8 @@ module Idv
   module Steps
     class CaptureMobileBackImageStep < DocAuthBaseStep
       def call
-        good, data = post_back_image
-        return failure(data) unless good
+        good, data, analytics_hash = post_back_image
+        return failure(data, analytics_hash) unless good
 
         failure_data, _data = verify_back_image(reset_step: :mobile_front_image)
         return failure_data if failure_data

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -45,8 +45,8 @@ module Idv
       end
 
       def verify_back_image(reset_step:)
-        back_image_verified, data = assure_id_results
-        return failure(data) unless back_image_verified
+        back_image_verified, data, analytics_hash = assure_id_results
+        return failure(data, analytics_hash) unless back_image_verified
 
         return [nil, data] if data['Result'] == GOOD_RESULT
 
@@ -74,7 +74,7 @@ module Idv
 
       def assure_id_results
         return [true, { 'Result' => GOOD_RESULT }] if test_credentials?
-        assure_id.results
+        rescue_network_errors { assure_id.results }
       end
 
       def post_back_image
@@ -90,13 +90,13 @@ module Idv
       def throttle_post_front_image
         return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled?
         increment_attempts
-        assure_id.post_front_image(image.read)
+        rescue_network_errors { assure_id.post_front_image(image.read) }
       end
 
       def throttle_post_back_image
         return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled?
         increment_attempts
-        assure_id.post_back_image(image.read)
+        rescue_network_errors { assure_id.post_back_image(image.read) }
       end
 
       def test_credentials?
@@ -115,6 +115,17 @@ module Idv
 
       def user_id
         current_user ? current_user.id : user_id_from_token
+      end
+
+      def rescue_network_errors
+        yield
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => exception
+        NewRelic::Agent.notice_error(exception)
+        [
+          false,
+          I18n.t('errors.doc_auth.acuant_network_error'),
+          { acuant_network_error: exception.message },
+        ]
       end
 
       delegate :idv_session, to: :@flow

--- a/app/services/idv/steps/doc_success_step.rb
+++ b/app/services/idv/steps/doc_success_step.rb
@@ -5,6 +5,8 @@ module Idv
         step_successful
       end
 
+      private
+
       def step_successful
         save_doc_auth
         flow_session[:image_verification_data] = {}

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -2,8 +2,8 @@ module Idv
   module Steps
     class FrontImageStep < DocAuthBaseStep
       def call
-        success, instance_id_or_message = assure_id.create_document
-        return failure(instance_id_or_message) unless success
+        success, instance_id_or_message, analytics_hash = assure_id_create_document
+        return failure(instance_id_or_message, analytics_hash) unless success
 
         flow_session[:instance_id] = instance_id_or_message
         upload_front_image
@@ -11,13 +11,17 @@ module Idv
 
       private
 
+      def assure_id_create_document
+        rescue_network_errors { assure_id.create_document }
+      end
+
       def form_submit
         Idv::ImageUploadForm.new.submit(permit(:image))
       end
 
       def upload_front_image
-        success, message = post_front_image
-        return failure(message) unless success
+        success, message, analyics_hash = post_front_image
+        return failure(message, analyics_hash) unless success
       end
     end
   end

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -2,8 +2,8 @@ module Idv
   module Steps
     class MobileBackImageStep < DocAuthBaseStep
       def call
-        good, data = post_back_image
-        return failure(data) unless good
+        good, data, analytics_hash = post_back_image
+        return failure(data, analytics_hash) unless good
 
         failure_data, data = verify_back_image(reset_step: :mobile_front_image)
         return failure_data if failure_data

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -16,8 +16,8 @@ module Idv
       end
 
       def upload_front_image
-        success, message = post_front_image
-        return failure(message) unless success
+        success, message, analytics_hash = post_front_image
+        return failure(message, analytics_hash) unless success
       end
     end
   end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,7 +18,8 @@ en:
       token_missing: token missing
     confirm_password_incorrect: Incorrect password.
     doc_auth:
-      acuant_network_error: Sorry we are experiencing technical difficulties.  Please try again later.
+      acuant_network_error: Sorry we are experiencing technical difficulties.  Please
+        try again later.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Your state issued ID could not be verified.  Please try uploading

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,6 +18,7 @@ en:
       token_missing: token missing
     confirm_password_incorrect: Incorrect password.
     doc_auth:
+      acuant_network_error: Sorry we are experiencing technical difficulties.  Please try again later.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Your state issued ID could not be verified.  Please try uploading

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -18,7 +18,8 @@ es:
       token_missing: falta el token
     confirm_password_incorrect: La contraseña es incorrecta.
     doc_auth:
-      acuant_network_error: Lo sentimos, estamos experimentando dificultades técnicas. Por favor, inténtelo de nuevo más tarde.
+      acuant_network_error: Lo sentimos, estamos experimentando dificultades técnicas.
+        Por favor, inténtelo de nuevo más tarde.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Su identificación emitida por el estado no pudo ser verificada.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -18,6 +18,7 @@ es:
       token_missing: falta el token
     confirm_password_incorrect: La contraseña es incorrecta.
     doc_auth:
+      acuant_network_error: Lo sentimos, estamos experimentando dificultades técnicas. Por favor, inténtelo de nuevo más tarde.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Su identificación emitida por el estado no pudo ser verificada.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -18,6 +18,7 @@ fr:
       token_missing: jeton manquant
     confirm_password_incorrect: Mot de passe incorrect.
     doc_auth:
+      acuant_network_error: Désolé, nous rencontrons des difficultés techniques. Veuillez réessayer plus tard.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Votre identité émise par l'état n'a pas pu être vérifiée. S'il

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -18,7 +18,8 @@ fr:
       token_missing: jeton manquant
     confirm_password_incorrect: Mot de passe incorrect.
     doc_auth:
-      acuant_network_error: Désolé, nous rencontrons des difficultés techniques. Veuillez réessayer plus tard.
+      acuant_network_error: Désolé, nous rencontrons des difficultés techniques. Veuillez
+        réessayer plus tard.
       acuant_throttle: To prevent abuse we limit the amount of times you can attempt
         to validate a document.  Please try again later.
       general_error: Votre identité émise par l'état n'a pas pu être vérifiée. S'il

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -91,7 +91,7 @@ shared_examples 'back image step' do |simulate|
 
     it 'catches network timeout errors' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
-        and_raise(Faraday::Faraday::TimeoutError)
+        and_raise(Faraday::TimeoutError)
 
       attach_image
       click_idv_continue

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -75,6 +75,32 @@ shared_examples 'back image step' do |simulate|
         expect(page).to have_current_path(idv_doc_auth_back_image_step)
       end
     end
+
+    it 'catches network connection errors' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
+        and_raise(Faraday::ConnectionFailed.new('error'))
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
+
+    it 'catches network timeout errors' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
+        and_raise(Faraday::Faraday::TimeoutError)
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
   end
 end
 

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -59,7 +59,7 @@ shared_examples 'front image step' do |simulate|
       end
     end
 
-    it 'catches network connection errors' do
+    it 'catches network connection errors on post_front_image' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
         and_raise(Faraday::ConnectionFailed.new('error'))
 
@@ -72,8 +72,34 @@ shared_examples 'front image step' do |simulate|
       end
     end
 
-    it 'catches network timeout errors' do
+    it 'catches network connection errors on results' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
+        and_raise(Faraday::ConnectionFailed.new('error'))
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
+
+    it 'catches network timeout errors on post_front_image' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
+        and_raise(Faraday::TimeoutError)
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
+
+    it 'catches network timeout errors on results' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
         and_raise(Faraday::TimeoutError)
 
       attach_image

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -58,6 +58,32 @@ shared_examples 'front image step' do |simulate|
         expect(page).to have_current_path(idv_doc_auth_back_image_step)
       end
     end
+
+    it 'catches network connection errors' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
+        and_raise(Faraday::ConnectionFailed.new('error'))
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
+
+    it 'catches network timeout errors' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
+        and_raise(Faraday::TimeoutError)
+
+      attach_image
+      click_idv_continue
+
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
   end
 end
 


### PR DESCRIPTION
**Why**: So that users don't see a 500 error when doc auth fails to connect or times out communicating with a vendor

**How**: Add a rescue_network_errors wrapper to all networking calls to vendors.  Have this catch various types of network errors, log it, and notify newrelic

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
