### PR TITLE
As config fmcsa help text

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -16,7 +16,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
     'FMCSA National Registry' => {
       i18n_name: 'fmcsa_natl_registry',
       learn_more: 'https://login.gov/help/',
-      exclude_paths: ['/es','/fr'],
+      exclude_paths: ['/es', '/fr'],
     },
   }.freeze
 

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -2,17 +2,23 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
   include ActionView::Helpers::TranslationHelper
 
   DEFAULT_LOGO = 'generic.svg'.freeze
-  CUSTOM_ALERT_SP_NAMES = ['CBP Trusted Traveler Programs'].freeze
+  CUSTOM_ALERT_SP_NAMES = ['CBP Trusted Traveler Programs',
+                           'FMCSA National Registry'].freeze
   DEFAULT_ALERT_SP_NAMES = ['USAJOBS', 'SAM', 'HOMES.mil', 'HOMES.mil - test', 'Rule 19d-1'].freeze
 
   # These are SPs that are migrating users and require special help messages
   CUSTOM_SP_ALERTS = {
     'CBP Trusted Traveler Programs' => {
-      i18n_name: 'trusted_traveler',
-      learn_more: 'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/',
-      exclude_paths: ['/sign_up/enter_email'],
-    },
-  }.freeze
+        i18n_name: 'trusted_traveler',
+        learn_more: 'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/',
+        exclude_paths: ['/sign_up/enter_email'],
+      },
+    'FMCSA National Registry' => {
+        i18n_name: 'fmcsa_natl_registry',
+        learn_more: 'https://login.gov/help/',
+        exclude_paths: [],
+      }
+    }.freeze
 
   def initialize(sp:, view_context:, sp_session:, service_provider_request:)
     @sp = sp

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -9,16 +9,16 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
   # These are SPs that are migrating users and require special help messages
   CUSTOM_SP_ALERTS = {
     'CBP Trusted Traveler Programs' => {
-        i18n_name: 'trusted_traveler',
-        learn_more: 'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/',
-        exclude_paths: ['/sign_up/enter_email'],
-      },
+      i18n_name: 'trusted_traveler',
+      learn_more: 'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/',
+      exclude_paths: ['/sign_up/enter_email'],
+    },
     'FMCSA National Registry' => {
-        i18n_name: 'fmcsa_natl_registry',
-        learn_more: 'https://login.gov/help/',
-        exclude_paths: [],
-      }
-    }.freeze
+      i18n_name: 'fmcsa_natl_registry',
+      learn_more: 'https://login.gov/help/',
+      exclude_paths: [],
+    },
+  }.freeze
 
   def initialize(sp:, view_context:, sp_session:, service_provider_request:)
     @sp = sp

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -16,7 +16,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
     'FMCSA National Registry' => {
       i18n_name: 'fmcsa_natl_registry',
       learn_more: 'https://login.gov/help/',
-      exclude_paths: [],
+      exclude_paths: ['/es','/fr'],
     },
   }.freeze
 

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -29,7 +29,7 @@ en:
         body: |-
           Reminder: please use the same email address as your primary email address
           for your National Registry account when creating your Login.gov account.
-      header: First time here from %{sp_name}?
+      header: First time here from FMCSA National Registry?
     learn_more: Learn more.
     trusted_traveler:
       account_page:

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -12,6 +12,24 @@ en:
         body: Please create a login.gov account using the same email address you use
           for %{sp_name}
       header: First time here from %{sp_name}?
+    fmcsa_natl_registry:
+      account_page:
+        body: |-
+          If you do not have a Login.gov account, you must create one to access the
+          National Registry. To do so, select "Create an account" and use the same
+          email address that is your primary email address for your National Registry
+          account.
+      body_html: |-
+        If you do not have a Login.gov account, you must create one to access the
+        National Registry. To do so, select "Create an account" and use the same
+        email address that is your primary email address for your National Registry
+        account.
+      create_account_link: create a login.gov account
+      create_account_page:
+        body: |-
+          Reminder: please use the same email address as your primary email address
+          for your National Registry account when creating your Login.gov account.
+      header: First time here from %{sp_name}?
     learn_more: Learn more.
     trusted_traveler:
       account_page:
@@ -22,18 +40,3 @@ en:
       create_account_page:
         body: ''
       header: Coming from Trusted Traveler Programs?
-
-    # FMCSA national registry
-    fmcsa_natl_registry:
-      account_page:
-        body: |
-          If you do not have a Login.gov account, you must create one to access the
-          National Registry. To do so, select "Create an account" and be sure to
-          use the same email address that is your primary email address for your
-          National Registry account.
-      create_account_page:
-        body: |
-          Reminder: please be sure to use the same email address that is your
-          primary email address for your National Registry account when creating
-          your Login.gov account.
-      header: First time here from %{sp_name}?

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -32,7 +32,8 @@ en:
           use the same email address that is your primary email address for your
           National Registry account.
       create_account_page:
-        body: Reminder! Please be sure to use the same email address that is your
+        body: |
+          Reminder: please be sure to use the same email address that is your
           primary email address for your National Registry account when creating
           your Login.gov account.
       header: First time here from %{sp_name}?

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -22,3 +22,17 @@ en:
       create_account_page:
         body: ''
       header: Coming from Trusted Traveler Programs?
+
+    # FMCSA national registry
+    fmcsa_natl_registry:
+      account_page:
+        body: |
+          If you do not have a Login.gov account, you must create one to access the
+          National Registry. To do so, select "Create an account" and be sure to
+          use the same email address that is your primary email address for your
+          National Registry account.
+      create_account_page:
+        body: Reminder! Please be sure to use the same email address that is your
+          primary email address for your National Registry account when creating
+          your Login.gov account.
+      header: First time here from %{sp_name}?

--- a/config/locales/service_providers/es.yml
+++ b/config/locales/service_providers/es.yml
@@ -18,7 +18,7 @@ es:
         body: ''
       body_html: ''
       create_account_link: ''
-      create_account_page: 
+      create_account_page:
         body: ''
       header: ''
     learn_more: Obtenga más información.

--- a/config/locales/service_providers/es.yml
+++ b/config/locales/service_providers/es.yml
@@ -13,6 +13,14 @@ es:
         body: Por favor crea un login.gov cuenta usando la misma dirección de correo
           electrónico que utiliza para %{sp_name}.
       header: "¿Ha venido de %{sp_name}?"
+    fmcsa_natl_registry:
+      account_page:
+        body: ''
+      body_html: ''
+      create_account_link: ''
+      create_account_page: 
+        body: ''
+      header: ''
     learn_more: Obtenga más información.
     trusted_traveler:
       account_page:

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -14,6 +14,14 @@ fr:
         body: Veuillez créer un compte login.gov avec la même adresse e-mail que vous
           avez utilisée pour %{sp_name}.
       header: Êtes-vous venu(e) de %{sp_name}?
+    fmcsa_natl_registry:
+      account_page:
+        body: ''
+      body_html: ''
+      create_account_link: ''
+      create_account_page: 
+        body: ''
+      header: ''
     learn_more: En savoir plus.
     trusted_traveler:
       account_page:

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -19,7 +19,7 @@ fr:
         body: ''
       body_html: ''
       create_account_link: ''
-      create_account_page: 
+      create_account_page:
         body: ''
       header: ''
     learn_more: En savoir plus.


### PR DESCRIPTION
## Adds FMCSA help text

<img width="673" alt="Screen Shot 2019-05-09 at 6 38 05 AM" src="https://user-images.githubusercontent.com/1328699/57458013-78598580-7225-11e9-8dd3-d1275c8e1fe9.png">



### Controllers

- [x] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [x] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [x] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [x] Verified that the changes don't affect other apps (such as the dashboard)

- [x] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [x] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [x] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [x] The changes are compatible with data that was encrypted with the old code.

### Routes

- [x] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [x] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [x] Tests added for this feature/bug
- [x] Prefer feature/integration specs over controller specs
- [x] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
