### PR TITLE
LG-1263 Add a trait for multiple emails to the user factory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -127,14 +127,6 @@ FactoryBot.define do
       otp_secret_key { ROTP::Base32.random_base32 }
     end
 
-    trait :admin do
-      role { :admin }
-    end
-
-    trait :tech_support do
-      role { :tech }
-    end
-
     trait :signed_up do
       with_phone
       with_personal_key

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,6 +31,29 @@ FactoryBot.define do
       end
     end
 
+    trait :with_multiple_emails do
+      after(:build) do |user, _evaluator|
+        until user.email_addresses.many?
+          user.email_addresses << build(
+            :email_address,
+            email: Faker::Internet.safe_email,
+            confirmed_at: user.confirmed_at,
+            user_id: -1,
+          )
+        end
+      end
+      after(:stub) do |user, _evaluator|
+        until user.email_addresses.many?
+          user.email_addresses << build(
+            :email_address,
+            email: Faker::Internet.safe_email,
+            confirmed_at: user.confirmed_at,
+            user_id: -1,
+          )
+        end
+      end
+    end
+
     trait :with_webauthn do
       after(:build) do |user, evaluator|
         next unless user.webauthn_configurations.empty?
@@ -102,6 +125,14 @@ FactoryBot.define do
 
     trait :with_authentication_app do
       otp_secret_key { ROTP::Base32.random_base32 }
+    end
+
+    trait :admin do
+      role { :admin }
+    end
+
+    trait :tech_support do
+      role { :tech }
     end
 
     trait :signed_up do

--- a/spec/features/multiple_emails/email_management_spec.rb
+++ b/spec/features/multiple_emails/email_management_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 feature 'managing email address' do
   context 'show one email address if only one is configured' do
     scenario 'shows one email address for a user with only one' do
-      user = create(:user, :with_authentication_app, :with_phone)
+      user = create(:user, :signed_up, :with_multiple_emails)
       sign_in_and_2fa_user(user)
 
       expect(page).to have_content(user.email_addresses.first.email)
     end
 
     scenario 'shows all email address for a user with multiple emails' do
-      user = create(:user, :with_authentication_app, :with_phone)
-      create(:email_address, user: user)
+      user = create(:user, :signed_up, :with_multiple_emails)
       email1, email2 = user.reload.email_addresses.map(&:email)
       sign_in_and_2fa_user(user)
 


### PR DESCRIPTION
**Why**: So that we can quickly create users for testing accounts with multiple emails.