### PR TITLE
LG-1285 Prevent sign in with an unconfirmed email address

### DIFF
--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -5,16 +5,21 @@ module UserEncryptedAttributeOverrides
     # override this Devise method to support our use of encrypted_email
     def find_first_by_auth_conditions(tainted_conditions, _opts = {})
       email = tainted_conditions[:email]
-      return find_with_email(email) if email
+      return find_with_confirmed_email(email) if email.present?
 
       find_by(tainted_conditions)
     end
 
     # :reek:UtilityFunction
     def find_with_email(email)
-      email = EmailAddress.where.not(confirmed_at: nil).find_with_email(email) ||
-              EmailAddress.where(confirmed_at: nil).find_with_email(email)
-      email&.user
+      email_address = EmailAddress.where.not(confirmed_at: nil).find_with_email(email) ||
+                      EmailAddress.where(confirmed_at: nil).find_with_email(email)
+      email_address&.user
+    end
+
+    def find_with_confirmed_email(email)
+      email_address = EmailAddress.where.not(confirmed_at: nil).find_with_email(email)
+      email_address&.user
     end
   end
 

--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -17,6 +17,7 @@ module UserEncryptedAttributeOverrides
       email_address&.user
     end
 
+    # :reek:UtilityFunction
     def find_with_confirmed_email(email)
       email_address = EmailAddress.where.not(confirmed_at: nil).find_with_email(email)
       email_address&.user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,6 +31,29 @@ FactoryBot.define do
       end
     end
 
+    trait :with_multiple_emails do
+      after(:build) do |user, _evaluator|
+        until user.email_addresses.many?
+          user.email_addresses << build(
+            :email_address,
+            email: Faker::Internet.safe_email,
+            confirmed_at: user.confirmed_at,
+            user_id: -1,
+          )
+        end
+      end
+      after(:stub) do |user, _evaluator|
+        until user.email_addresses.many?
+          user.email_addresses << build(
+            :email_address,
+            email: Faker::Internet.safe_email,
+            confirmed_at: user.confirmed_at,
+            user_id: -1,
+          )
+        end
+      end
+    end
+
     trait :with_webauthn do
       after(:build) do |user, evaluator|
         next unless user.webauthn_configurations.empty?

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 feature 'sign in with any email address' do
-  scenario 'signing in any email address' do
+  scenario 'signing in with any email address' do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
 
-    user = create(:user, :signed_up)
-    create(:email_address, user: user)
+    user = create(:user, :signed_up, :with_multiple_emails)
 
     email1, email2 = user.reload.email_addresses.map(&:email)
 
@@ -20,5 +19,19 @@ feature 'sign in with any email address' do
     click_submit_default
 
     expect(page).to have_current_path(account_path)
+  end
+
+  scenario 'signing in with an unconfirmed email results in an error' do
+    user = create(:user, :signed_up, :with_multiple_emails)
+
+    email_address = user.email_addresses.first
+    email_address.update!(confirmed_at: nil)
+
+    signin(email_address.email, user.password)
+
+    error_message = t('devise.failure.invalid_html', link: t('devise.failure.invalid_link_text'))
+
+    expect(page).to have_content(error_message)
+    expect(page).to have_current_path(new_user_session_path)
   end
 end


### PR DESCRIPTION
**Why**: So that users can't add an email address and use it to sign in without confirming it.
