### PR TITLE
Read from the email address table to determine if a user is confirmed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,8 +69,12 @@ class User < ApplicationRecord
     # See https://github.com/18F/identity-idp/pull/452 for more details.
   end
 
+  def confirmed?
+    email_addresses.where.not(confirmed_at: nil).any?
+  end
+
   def confirmation_period_expired?
-    confirmation_sent_at.present? && confirmation_sent_at.utc <= self.class.confirm_within.ago
+    super
   end
 
   def last_identity

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -52,7 +52,7 @@ describe ResetPasswordForm, type: :model do
 
     context 'when both the password and token are valid' do
       it 'sets the user password to the submitted password' do
-        user = build_stubbed(:user, :with_email, uuid: '123')
+        user = create(:user, :with_email, uuid: '123')
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
         form = ResetPasswordForm.new(user)

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -48,7 +48,7 @@ describe EmailConfirmationTokenValidator do
 
     context 'confirmation token has already been used' do
       it 'returns FormResponse with success: false' do
-        user = build_stubbed(:user)
+        user = create(:user)
         user.errors.add(:email, :already_confirmed)
 
         response = instance_double(FormResponse)


### PR DESCRIPTION
**Why**: To move reads off of these columns on the user so we can start depending on the email_addresses table to determine confirmation status when users have multiple emails
