### PR TITLE
LG-1279 List available backup authentication methods on registration

### DIFF
--- a/app/policies/two_factor_authentication/auth_app_policy.rb
+++ b/app/policies/two_factor_authentication/auth_app_policy.rb
@@ -20,6 +20,10 @@ module TwoFactorAuthentication
       true
     end
 
+    def enrollable?
+      available? && !enabled?
+    end
+
     private
 
     attr_reader :user

--- a/app/policies/two_factor_authentication/backup_code_policy.rb
+++ b/app/policies/two_factor_authentication/backup_code_policy.rb
@@ -22,6 +22,10 @@ module TwoFactorAuthentication
       FeatureManagement.backup_codes_enabled?
     end
 
+    def enrollable?
+      available? && !enabled?
+    end
+
     private
 
     attr_reader :user

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -58,8 +58,7 @@ class TwoFactorOptionsPresenter
   end
 
   def totp_option
-    policy = TwoFactorAuthentication::AuthAppPolicy.new(current_user)
-    if available_and_not_enabled?(policy)
+    if TwoFactorAuthentication::AuthAppPolicy.new(current_user).enrollable?
       [TwoFactorAuthentication::AuthAppSelectionPresenter.new]
     else
       []
@@ -74,8 +73,7 @@ class TwoFactorOptionsPresenter
   end
 
   def backup_code_option
-    policy = TwoFactorAuthentication::BackupCodePolicy.new(current_user)
-    if available_and_not_enabled?(policy)
+    if TwoFactorAuthentication::BackupCodePolicy.new(current_user).enrollable?
       [TwoFactorAuthentication::BackupCodeSelectionPresenter.new]
     else
       []

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -79,8 +79,4 @@ class TwoFactorOptionsPresenter
       []
     end
   end
-
-  def available_and_not_enabled?(policy)
-    policy.available? && !policy.enabled?
-  end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -58,7 +58,8 @@ class TwoFactorOptionsPresenter
   end
 
   def totp_option
-    if TwoFactorAuthentication::AuthAppPolicy.new(current_user).available?
+    policy = TwoFactorAuthentication::AuthAppPolicy.new(current_user)
+    if available_and_not_enabled?(policy)
       [TwoFactorAuthentication::AuthAppSelectionPresenter.new]
     else
       []
@@ -74,7 +75,14 @@ class TwoFactorOptionsPresenter
 
   def backup_code_option
     policy = TwoFactorAuthentication::BackupCodePolicy.new(current_user)
-    return [TwoFactorAuthentication::BackupCodeSelectionPresenter.new] if policy.available?
-    []
+    if available_and_not_enabled?(policy)
+      [TwoFactorAuthentication::BackupCodeSelectionPresenter.new]
+    else
+      []
+    end
+  end
+
+  def available_and_not_enabled?(policy)
+    policy.available? && !policy.enabled?
   end
 end

--- a/spec/features/mfa_enrollability_spec.rb
+++ b/spec/features/mfa_enrollability_spec.rb
@@ -7,17 +7,26 @@ describe 'TOTP enrollability' do
 
   let(:user) { create(:user, :signed_up, :with_authentication_app) }
 
-  context 'sign up' do
-    it 'does not allow choosing totp as backup auth method after it is used as primary' do
-      sign_up_and_set_password
+  it 'is not available for selection as backup auth method once it is chosen as primary' do
+    sign_up_and_set_password
 
-      select_2fa_option('auth_app')
-      secret = find('#qr-code').text
-      fill_in 'code', with: generate_totp_code(secret)
-      click_button 'Submit'
+    select_2fa_option('backup_code')
 
-      expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
-      expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
-    end
+    click_on 'Continue'
+
+    expect(page).to have_selector('#two_factor_options_form_selection_backup_code', count: 0)
+    expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
+  end
+
+  it 'does not allow choosing totp as backup auth method after it is used as primary' do
+    sign_up_and_set_password
+
+    select_2fa_option('auth_app')
+    secret = find('#qr-code').text
+    fill_in 'code', with: generate_totp_code(secret)
+    click_button 'Submit'
+
+    expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
+    expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
   end
 end

--- a/spec/features/mfa_enrollability_spec.rb
+++ b/spec/features/mfa_enrollability_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'TOTP enrollability' do
+  before do
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+  end
+
+  let(:user) { create(:user, :signed_up, :with_authentication_app) }
+
+  context 'sign up' do
+    it 'does not allow choosing totp as backup auth method after it is used as primary' do
+      sign_up_and_set_password
+
+      select_2fa_option('auth_app')
+      secret = find('#qr-code').text
+      fill_in 'code', with: generate_totp_code(secret)
+      click_button 'Submit'
+
+      expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
+      expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
+    end
+  end
+end

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -32,6 +32,7 @@ describe 'Remembering a TOTP device' do
       click_button 'Submit'
 
       expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
+      expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
     end
 
     def remember_device_and_sign_out_user

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -23,6 +23,17 @@ describe 'Remembering a TOTP device' do
   end
 
   context 'sign up' do
+    it 'does not allow choosing totp as backup auth method after it is used as primary' do
+      sign_up_and_set_password
+
+      select_2fa_option('auth_app')
+      secret = find('#qr-code').text
+      fill_in 'code', with: generate_totp_code(secret)
+      click_button 'Submit'
+
+      expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
+    end
+
     def remember_device_and_sign_out_user
       user = sign_up_with_backup_codes_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -23,18 +23,6 @@ describe 'Remembering a TOTP device' do
   end
 
   context 'sign up' do
-    it 'does not allow choosing totp as backup auth method after it is used as primary' do
-      sign_up_and_set_password
-
-      select_2fa_option('auth_app')
-      secret = find('#qr-code').text
-      fill_in 'code', with: generate_totp_code(secret)
-      click_button 'Submit'
-
-      expect(page).to have_selector('#two_factor_options_form_selection_auth_app', count: 0)
-      expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
-    end
-
     def remember_device_and_sign_out_user
       user = sign_up_with_backup_codes_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -24,10 +24,8 @@ describe 'Remembering a TOTP device' do
 
   context 'sign up' do
     def remember_device_and_sign_out_user
-      user = sign_up_and_set_password
+      user = sign_up_with_backup_codes_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD
-      select_2fa_option('backup_code')
-      click_continue
       select_2fa_option('auth_app')
       fill_in :code, with: totp_secret_from_page
       check :remember_device

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -26,6 +26,8 @@ describe 'Remembering a TOTP device' do
     def remember_device_and_sign_out_user
       user = sign_up_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD
+      select_2fa_option('backup_code')
+      click_continue
       select_2fa_option('auth_app')
       fill_in :code, with: totp_secret_from_page
       check :remember_device

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -40,6 +40,8 @@ describe 'Remembering a webauthn device' do
       mock_webauthn_setup_challenge
       user = sign_up_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD
+      select_2fa_option('backup_code')
+      click_continue
       select_2fa_option('webauthn')
       fill_in_nickname_and_click_continue
       check :remember_device

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -38,10 +38,8 @@ describe 'Remembering a webauthn device' do
   context 'sign up' do
     def remember_device_and_sign_out_user
       mock_webauthn_setup_challenge
-      user = sign_up_and_set_password
+      user = sign_up_with_backup_codes_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD
-      select_2fa_option('backup_code')
-      click_continue
       select_2fa_option('webauthn')
       fill_in_nickname_and_click_continue
       check :remember_device

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -13,6 +13,16 @@ feature 'sign up with backup code' do
     expect(current_path).to eq two_factor_options_path
   end
 
+  it 'is not available for selection as backup auth method once it is chosen as primary' do
+    sign_up_and_set_password
+
+    select_2fa_option('backup_code')
+
+    click_on 'Continue'
+
+    expect(page).to have_selector('#two_factor_options_form_selection_backup_code', count: 0)
+  end
+
   it 'works for each code and refreshes the codes on the last one' do
     user = create(:user, :signed_up, :with_authentication_app, :with_backup_code)
     old_codes = user.backup_code_configurations.map(&:code)

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -13,17 +13,6 @@ feature 'sign up with backup code' do
     expect(current_path).to eq two_factor_options_path
   end
 
-  it 'is not available for selection as backup auth method once it is chosen as primary' do
-    sign_up_and_set_password
-
-    select_2fa_option('backup_code')
-
-    click_on 'Continue'
-
-    expect(page).to have_selector('#two_factor_options_form_selection_backup_code', count: 0)
-    expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
-  end
-
   it 'works for each code and refreshes the codes on the last one' do
     user = create(:user, :signed_up, :with_authentication_app, :with_backup_code)
     old_codes = user.backup_code_configurations.map(&:code)

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -21,6 +21,7 @@ feature 'sign up with backup code' do
     click_on 'Continue'
 
     expect(page).to have_selector('#two_factor_options_form_selection_backup_code', count: 0)
+    expect(page).to have_selector('#two_factor_options_form_selection_sms', count: 1)
   end
 
   it 'works for each code and refreshes the codes on the last one' do

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -79,7 +79,6 @@ describe TwoFactorOptionsPresenter do
           TwoFactorAuthentication::VoiceSelectionPresenter,
           TwoFactorAuthentication::AuthAppSelectionPresenter,
           TwoFactorAuthentication::WebauthnSelectionPresenter,
-          TwoFactorAuthentication::BackupCodeSelectionPresenter,
         ]
       end
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -54,6 +54,12 @@ module Features
       user
     end
 
+    def sign_up_with_backup_codes
+      user = create(:user, :unconfirmed, :with_backup_code)
+      confirm_last_user
+      user
+    end
+
     def begin_sign_up_with_sp_and_loa(loa3:)
       user = create(:user)
       login_as(user, scope: :user, run_callbacks: false)
@@ -70,6 +76,13 @@ module Features
 
     def sign_up_and_set_password
       user = sign_up
+      fill_in 'password_form_password', with: VALID_PASSWORD
+      click_button t('forms.buttons.continue')
+      user
+    end
+
+    def sign_up_with_backup_codes_and_set_password
+      user = sign_up_with_backup_codes
       fill_in 'password_form_password', with: VALID_PASSWORD
       click_button t('forms.buttons.continue')
       user

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -49,7 +49,7 @@ module Features
     end
 
     def sign_up
-      user = create(:user, :unconfirmed, :with_backup_code)
+      user = create(:user, :unconfirmed)
       confirm_last_user
       user
     end


### PR DESCRIPTION
**Why**: So users do not select an option not available to them and then have to choose another selection.

**How**: Add checks for authenticator and backup codes enabled in TwoFactorOptionsPresenter and conditionally show the options

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
