### PR TITLE
LG-1324 Remove the phone configuration consideration from 2fa options form

### DIFF
--- a/app/forms/two_factor_options_form.rb
+++ b/app/forms/two_factor_options_form.rb
@@ -36,9 +36,7 @@ class TwoFactorOptionsForm
   end
 
   def user_needs_updating?
-    %w[voice sms].include?(selection) &&
-      selection != MfaContext.new(user).phone_configuration&.delivery_preference &&
-      selection != user.otp_delivery_preference
+    %w[voice sms].include?(selection) && selection != user.otp_delivery_preference
   end
 
   def update_otp_delivery_preference_for_user

--- a/spec/features/backup_mfa/otp_delivery_selection_spec.rb
+++ b/spec/features/backup_mfa/otp_delivery_selection_spec.rb
@@ -11,7 +11,7 @@ feature 'OTP delivery selection' do
       click_submit_default
     end
 
-    it 'then set up SMS as backup MFA' do
+    it 'allows the user to setup SMS for backup MFA' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('sms')
@@ -34,7 +34,7 @@ feature 'OTP delivery selection' do
       click_submit_default
     end
 
-    it 'then set up voice as backup MFA' do
+    it 'allows the user to voice for backup MFA' do
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('voice')
@@ -45,5 +45,33 @@ feature 'OTP delivery selection' do
                                      number: '+1 202-555-1213',
                                      expiration: Figaro.env.otp_valid_for))
     end
+  end
+
+  it 'allows the user to select a backup delivery method and then change that selection' do
+    sign_in_user
+    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
+    select_2fa_option(:sms)
+    fill_in :user_phone_form_phone, with: '202-555-1212'
+    click_send_security_code
+    click_submit_default
+    select_2fa_option(:voice)
+
+    expect(page).to have_content(t('titles.phone_setup.voice'))
+
+    click_on t('two_factor_authentication.choose_another_option')
+    select_2fa_option(:sms)
+
+    expect(page).to have_content(t('titles.phone_setup.sms'))
+    expect(SmsOtpSenderJob).to receive(:perform_now)
+    expect(VoiceOtpSenderJob).to_not receive(:perform_now)
+
+    fill_in :user_phone_form_phone, with: '202-555-1313'
+    click_send_security_code
+
+    expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+
+    click_submit_default
+
+    expect(page).to have_current_path(account_path)
   end
 end


### PR DESCRIPTION
**Why**: Because the 2fa options form is used during sign up and during sign up the delivery preference stored in the users table is used to determine how to send the user an OTP.