### PR TITLE
Mark local SAML rails SP as IAL2

### DIFF
--- a/config/service_providers.yml
+++ b/config/service_providers.yml
@@ -131,6 +131,7 @@ development:
     return_to_sp_url: 'http://localhost:3003'
     attribute_bundle:
       - email
+    ial: 2
 
   'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard':
     friendly_name: 'Dashboard'


### PR DESCRIPTION
**Why**: Because it is an IAL2 SP
