### PR TITLE
Deploy RC 84.1 to production w/PR 2971

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,4 +72,8 @@ module ApplicationHelper
       t('links.cancel')
     end
   end
+
+  def desktop_device?
+    DeviceDetector.new(request.user_agent)&.device_type == 'desktop'
+  end
 end

--- a/app/views/users/backup_code_setup/index.html.slim
+++ b/app/views/users/backup_code_setup/index.html.slim
@@ -31,8 +31,9 @@ p.mt-tiny.mb3 == t('forms.backup_code.instructions')
                   br
                   br
         .center.mt1
-          = link_to t('forms.backup_code.download'), backup_code_download_path,
-            class: 'text-decoration-none ico btn-border ico-download'
+          - if desktop_device?
+            = link_to t('forms.backup_code.download'), backup_code_download_path,
+              class: 'text-decoration-none ico btn-border ico-download'
           = link_to t('forms.backup_code.print'), '#',
             data: { print: true },
             class: 'ico ico-print btn-border ml2 text-decoration-none'

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -1,16 +1,29 @@
 require 'rails_helper'
 
 feature 'sign up with backup code' do
+  include DocAuthHelper
+
   it 'works' do
     sign_up_and_set_password
 
     select_2fa_option('backup_code')
 
+    expect(page).to have_link(t('forms.backup_code.download'))
     expect(current_path).to eq backup_code_setup_path
 
     click_on 'Continue'
 
     expect(current_path).to eq two_factor_options_path
+  end
+
+  it 'does not show download button on a mobile device' do
+    allow(DeviceDetector).to receive(:new).and_return(mobile_device)
+
+    sign_up_and_set_password
+
+    select_2fa_option('backup_code')
+
+    expect(page).to_not have_link(t('forms.backup_code.download'))
   end
 
   it 'works for each code and refreshes the codes on the last one' do


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
