### PR TITLE
LG-1284 Fix a bug parsing the GA cookie

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -31,7 +31,7 @@ class Analytics
 
   def grab_ga_client_id
     return if ga_cookie.blank?
-    ga_client_id = ga_cookie.match('GA1\.\d\.\d+\.(\d+)')
+    ga_client_id = ga_cookie.match('GA1\.\d\.(\d+\.\d+)')
     return ga_client_id[1] if ga_client_id
   end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -132,7 +132,7 @@ describe Analytics do
 
       client_id = analytics.grab_ga_client_id
 
-      expect(client_id).to eq '1142002911'
+      expect(client_id).to eq '3333333333.1142002911'
     end
   end
 end


### PR DESCRIPTION
**Why**: The client ID that we send to Google needs to have the last 2 numerics instead of just the first one. I was able to figure this out by looking at the frontend code we used that did work and comparing the results against our ruby code that parsed the cookie.
