### PR TITLE
LG-1344 Fix account reset for users with 1 MFA (ie no personal key)

### DIFF
--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -2,7 +2,7 @@ module AccountReset
   class RequestController < ApplicationController
     include TwoFactorAuthenticatable
 
-    before_action :confirm_multiple_factors_enabled
+    before_action :confirm_two_factor_enabled
     before_action :confirm_user_not_verified
 
     def show
@@ -18,8 +18,8 @@ module AccountReset
 
     private
 
-    def confirm_multiple_factors_enabled
-      return if multiple_factors_enabled?
+    def confirm_two_factor_enabled
+      return if MfaPolicy.new(current_user).two_factor_enabled?
 
       redirect_to two_factor_options_url
     end

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe AccountReset::RequestController do
-  let(:user) { create(:user, :with_authentication_app, :with_backup_code, :with_email) }
+  let(:user) { create(:user, :with_authentication_app, :with_email) }
   describe '#show' do
     it 'renders the page' do
       stub_sign_in_before_2fa(user)


### PR DESCRIPTION
Users are using their personal key to sign in, getting routed to setup a 2nd mfa, then abandoning it.  then coming back later, and when they’ve lost their 1st mfa they can’t delete account because it’s checking to see that they completed registration (ie 2 mfas - personal key and phone).  this used to not be an issue because when they’d sign in with personal key before they’d immediately get a new one (ie always have 2 mfas).

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
