### PR TITLE
LG-1322 Report for total number of unqiue auths per SP in a month

### DIFF
--- a/app/services/auths_per_sp_report.rb
+++ b/app/services/auths_per_sp_report.rb
@@ -1,14 +1,13 @@
 class AuthsPerSpReport
   def self.call(days_ago)
     report_sql = <<~SQL
-      SELECT agency, friendly_name, service_provider, cnt
-      FROM service_providers,
-      (SELECT service_provider, COUNT(*) as cnt
-      FROM identities
+      SELECT agency, friendly_name, service_provider, cnt FROM service_providers,
+      (SELECT service_provider, COUNT(*) as cnt FROM identities WHERE last_authenticated_at > '%s'
       GROUP BY service_provider) as sps_n_counts
       WHERE service_providers.issuer = sps_n_counts.service_provider
       ORDER BY cnt DESC
     SQL
-    ActiveRecord::Base.connection.execute(format(report_sql, days_ago.days.ago))
+    sql = format(report_sql, days_ago.days.ago)
+    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/app/services/auths_per_sp_report.rb
+++ b/app/services/auths_per_sp_report.rb
@@ -1,0 +1,14 @@
+class AuthsPerSpReport
+  def self.call(days_ago)
+    report_sql = <<~SQL
+      SELECT agency, friendly_name, service_provider, cnt
+      FROM service_providers,
+      (SELECT service_provider, COUNT(*) as cnt
+      FROM identities
+      GROUP BY service_provider) as sps_n_counts
+      WHERE service_providers.issuer = sps_n_counts.service_provider
+      ORDER BY cnt DESC
+    SQL
+    ActiveRecord::Base.connection.execute(format(report_sql, days_ago.days.ago))
+  end
+end

--- a/lib/tasks/auths_per_sp.rake
+++ b/lib/tasks/auths_per_sp.rake
@@ -1,0 +1,11 @@
+namespace :auths_per_sp do
+  task :report, %i[days_ago] => [:environment] do |_task, args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 0')
+    puts 'agency, friendly_name, service_provider: count'
+    rows = AuthsPerSpReport.call(args[:days_ago].to_i)
+    rows.each do |row|
+      puts "#{row['agency']}, #{row['friendly_name']}, #{row['service_provider']}: #{row['cnt']}"
+    end
+  end
+end
+# rake "auths_per_sp:report[30]"

--- a/spec/services/auths_per_sp_report_spec.rb
+++ b/spec/services/auths_per_sp_report_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe AuthsPerSpReport do
+  describe '#call' do
+    let(:days_ago) { 30 }
+
+    it 'prints the report with zero records when there are no identities' do
+      rows = AuthsPerSpReport.call(days_ago)
+
+      expect(rows.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
**Why**:  So that agency customers can see the total number of authentications by users at Login.gov so that they can track traffic to their applications over time

**How**: Create a service class to generate the report from identities and service_providers and a rake task to run the report.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
