### PR TITLE
Make the PR age script take draft PRs into account

### DIFF
--- a/bin/fetch_github_metrics
+++ b/bin/fetch_github_metrics
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require_relative '../lib/github_metrics/pr_age_reporter'
+require_relative '../lib/github_metrics'
 
 GithubMetrics::PrAgeReporter.new.call

--- a/lib/github_metrics.rb
+++ b/lib/github_metrics.rb
@@ -1,0 +1,3 @@
+require_relative 'github_metrics/pr_age_reporter'
+require_relative 'github_metrics/pull_request'
+require_relative 'github_metrics/sprint'

--- a/lib/github_metrics/pr_age_reporter.rb
+++ b/lib/github_metrics/pr_age_reporter.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/Date, Rails/TimeZone, Rails/Output
 require 'octokit'
 require 'date'
 
@@ -6,53 +5,26 @@ module GithubMetrics
   class PrAgeReporter
     attr_reader :tot
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Rails/Output
     def call
       numerator = 0
       sprint_pull_requests.each do |pr|
-        pr_open_seconds = (pr.closed_at || pr.merged_at || Time.now).to_i - pr.created_at.to_i
+        pr_open_seconds = pr.done_at_or_current_date - pr.ready_for_review_at
         numerator += pr_open_seconds
-        puts "'#{pr.title}' open for #{seconds_to_hours(pr_open_seconds)} hours"
+        puts "'#{pr.title}' under review for #{seconds_to_hours(pr_open_seconds)} hours"
       end
       puts "Average: #{seconds_to_hours(numerator / sprint_pull_requests.count.to_f)} hours"
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Rails/Output
 
     private
 
-    def sprint_start
-      @sprint_start ||= begin
-        reference_sprint_start = Date.new(2019, 4, 22)
-        days_since_reference = Date.today - reference_sprint_start
-        sprints_since_reference = (days_since_reference / 14).floor
-        (reference_sprint_start + 14 * sprints_since_reference).to_time
-      end
-    end
-
-    def sprint_end
-      (sprint_start + 14).to_time
-    end
-
-    # :reek:FeatureEnvy
-    def pr_open_in_current_sprint?(pr)
-      closed_at_or_current_time = pr.closed_at || pr.merged_at || Time.now
-      return true if pr.created_at > sprint_start || closed_at_or_current_time > sprint_start
-      false
-    end
-
     def sprint_pull_requests
-      github_client.pull_requests('18f/identity-idp', per_page: 100, state: :all).select do |pr|
-        pr_open_in_current_sprint?(pr)
-      end
+      @sprint_pull_requests ||= PullRequest.fetch_pull_requests_for_sprint(Sprint.new)
     end
 
-    def github_client
-      @github_client = Octokit::Client.new
-    end
-
-    def seconds_to_hours(value)
-      (value / 3600.0).round
+    def seconds_to_hours(seconds)
+      (seconds / 3600).round
     end
   end
 end
-# rubocop:enable Rails/Date, Rails/TimeZone, Rails/Output

--- a/lib/github_metrics/pr_age_reporter.rb
+++ b/lib/github_metrics/pr_age_reporter.rb
@@ -9,9 +9,8 @@ module GithubMetrics
     def call
       numerator = 0
       sprint_pull_requests.each do |pr|
-        pr_open_seconds = pr.done_at_or_current_date - pr.ready_for_review_at
-        numerator += pr_open_seconds
-        puts "'#{pr.title}' under review for #{seconds_to_hours(pr_open_seconds)} hours"
+        numerator += pr.ready_for_review_time
+        puts "'#{pr.title}' under review for #{seconds_to_hours(pr.ready_for_review_time)} hours"
       end
       puts "Average: #{seconds_to_hours(numerator / sprint_pull_requests.count.to_f)} hours"
     end

--- a/lib/github_metrics/pr_age_reporter.rb
+++ b/lib/github_metrics/pr_age_reporter.rb
@@ -9,8 +9,9 @@ module GithubMetrics
     def call
       numerator = 0
       sprint_pull_requests.each do |pr|
-        numerator += pr.ready_for_review_time
-        puts "'#{pr.title}' under review for #{seconds_to_hours(pr.ready_for_review_time)} hours"
+        ready_for_review_time = pr.ready_for_review_time
+        numerator += ready_for_review_time
+        puts "'#{pr.title}' under review for #{seconds_to_hours(ready_for_review_time)} hours"
       end
       puts "Average: #{seconds_to_hours(numerator / sprint_pull_requests.count.to_f)} hours"
     end

--- a/lib/github_metrics/pull_request.rb
+++ b/lib/github_metrics/pull_request.rb
@@ -1,0 +1,58 @@
+# rubocop:disable Rails/TimeZone
+module GithubMetrics
+  class PullRequest
+    extend Forwardable
+
+    class << self
+      def fetch_recent_pull_requests
+        github_client.pull_requests(
+          '18f/identity-idp',
+          per_page: 100,
+          state: :all,
+          accept: 'application/vnd.github.shadow-cat-preview+json',
+        ).map do |pr_response|
+          new(pr_response)
+        end
+      end
+
+      def fetch_pull_requests_for_sprint(sprint)
+        fetch_recent_pull_requests.select do |pull_request|
+          sprint.includes_pull_request?(pull_request)
+        end
+      end
+
+      def github_client
+        @github_client ||= Octokit::Client.new
+      end
+    end
+
+    def initialize(pull_request_response)
+      @pull_request_response = pull_request_response
+    end
+
+    def_delegators :pull_request_response, :title, :created_at, :closed_at,
+                   :merged_at, :number, :draft
+
+    def ready_for_review_at
+      timeline = self.class.github_client.issue_timeline(
+        '18f/identity-idp', number, accept: 'application/vnd.github.mockingbird-preview'
+      )
+      timeline.select do |item|
+        item.event == 'ready_for_review'
+      end.first&.created_at || created_at
+    end
+
+    def done_at_or_current_date
+      merged_at || closed_at || Time.now
+    end
+
+    def open_time
+      done_at_or_current_date - ready_for_review_at
+    end
+
+    private
+
+    attr_reader :pull_request_response
+  end
+end
+# rubocop:enable Rails/TimeZone

--- a/lib/github_metrics/pull_request.rb
+++ b/lib/github_metrics/pull_request.rb
@@ -46,7 +46,7 @@ module GithubMetrics
       merged_at || closed_at || Time.now
     end
 
-    def open_time
+    def ready_for_review_time
       done_at_or_current_date - ready_for_review_at
     end
 

--- a/lib/github_metrics/sprint.rb
+++ b/lib/github_metrics/sprint.rb
@@ -1,0 +1,37 @@
+# rubocop:disable Rails/TimeZone
+module GithubMetrics
+  class Sprint
+    attr_reader :sprint_start
+
+    def initialize(sprint_start: nil)
+      @sprint_start = sprint_start
+      @sprint_start ||= current_sprint_start
+    end
+
+    def sprint_end
+      sprint_start + 14 * 24 * 3600
+    end
+
+    def includes_pull_request?(pull_request)
+      return false if pull_request.draft
+      created_at = pull_request.created_at
+      return true if created_at < sprint_end && created_at > sprint_start
+      done_at_or_current_date = pull_request.done_at_or_current_date
+      return true if done_at_or_current_date < sprint_end && done_at_or_current_date > sprint_start
+      false
+    end
+
+    private
+
+    def current_sprint_start
+      @sprint_start ||= begin
+        # 12:00 ET on 4/22/2019 was the start of sprint 83
+        reference_sprint_start = Time.new(2019, 4, 22, 12, 0, 0, -14_400)
+        days_since_reference = (Time.now - reference_sprint_start) / (24 * 3600)
+        sprints_since_reference = (days_since_reference / 14).floor
+        reference_sprint_start + 14 * sprints_since_reference * 24 * 3600
+      end
+    end
+  end
+end
+# rubocop:enable Rails/TimeZone


### PR DESCRIPTION
**Why**: Because we want to measure how long PRs are open for review, and not how long they are open overall.
