### PR TITLE
LG-1384 Fix phone configurations index

### DIFF
--- a/db/migrate/20190604110233_fix_phone_configuration_index.rb
+++ b/db/migrate/20190604110233_fix_phone_configuration_index.rb
@@ -1,0 +1,22 @@
+class FixPhoneConfigurationIndex < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index(
+      :phone_configurations,
+      %i[user_id made_default_at created_at],
+      algorithm: :concurrently,
+      name: 'index_phone_configurations_on_made_default_at',
+    )
+    remove_index :phone_configurations, %i[made_default_at created_at]
+  end
+
+  def down
+    remove_index :phone_configurations, %i[user_id made_default_at created_at]
+    add_index(
+      :phone_configurations,
+      %i[made_default_at created_at],
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190529120309) do
+ActiveRecord::Schema.define(version: 20190604110233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -200,7 +200,7 @@ ActiveRecord::Schema.define(version: 20190529120309) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "made_default_at"
-    t.index ["made_default_at", "created_at"], name: "index_phone_configurations_on_made_default_at_and_created_at"
+    t.index ["user_id", "made_default_at", "created_at"], name: "index_phone_configurations_on_made_default_at"
     t.index ["user_id"], name: "index_phone_configurations_on_user_id"
   end
 


### PR DESCRIPTION
**Why**: To prevent full table scans and db outages

**How**: Add new index prefixed with user_id to phone_configurations.  Drop old index.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
