### PR TITLE
LG-1402 Fix 500 errors on metadata endpoint with a format extension

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   # SAML secret rotation paths
   SamlEndpoint.suffixes.each do |suffix|
-    get "/api/saml/metadata#{suffix}" => 'saml_idp#metadata'
+    get "/api/saml/metadata#{suffix}" => 'saml_idp#metadata', format: false
     match "/api/saml/logout#{suffix}" => 'saml_idp#logout', via: %i[get post delete]
     match "/api/saml/auth#{suffix}" => 'saml_idp#auth', via: %i[get post]
   end

--- a/spec/features/saml/multiple_endpoints_spec.rb
+++ b/spec/features/saml/multiple_endpoints_spec.rb
@@ -64,6 +64,12 @@ shared_examples 'a saml endpoint' do
   end
 
   context 'for a metadata request' do
+    it 'does not throw a 404 error with an extension' do
+      visit endpoint_metadata_path + '.xml'
+
+      expect(page.status_code).to eq 404
+    end
+
     it 'includes the cert' do
       visit endpoint_metadata_path
       document = REXML::Document.new(page.html)

--- a/spec/features/saml/multiple_endpoints_spec.rb
+++ b/spec/features/saml/multiple_endpoints_spec.rb
@@ -64,7 +64,7 @@ shared_examples 'a saml endpoint' do
   end
 
   context 'for a metadata request' do
-    it 'does not throw a 404 error with an extension' do
+    it 'throws a 404 error with an extension' do
       visit endpoint_metadata_path + '.xml'
 
       expect(page.status_code).to eq 404


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
