### PR TITLE
Stop stubbing Twilio service in click_send_security_code

### DIFF
--- a/spec/features/backup_mfa/no_duplicate_phone_numbers_spec.rb
+++ b/spec/features/backup_mfa/no_duplicate_phone_numbers_spec.rb
@@ -6,6 +6,7 @@ feature 'OTP delivery selection' do
 
     before do
       sign_in_user(user)
+      stub_twilio_service
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'

--- a/spec/features/backup_mfa/otp_delivery_selection_spec.rb
+++ b/spec/features/backup_mfa/otp_delivery_selection_spec.rb
@@ -4,6 +4,7 @@ feature 'OTP delivery selection' do
   context 'set up voice as 2FA' do
     before do
       sign_in_user
+      stub_twilio_service
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
@@ -27,6 +28,7 @@ feature 'OTP delivery selection' do
   context 'set up SMS as 2FA' do
     before do
       sign_in_user
+      stub_twilio_service
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('sms')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
@@ -49,6 +51,7 @@ feature 'OTP delivery selection' do
 
   it 'allows the user to select a backup delivery method and then change that selection' do
     sign_in_user
+    stub_twilio_service
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     select_2fa_option(:sms)
     fill_in :user_phone_form_phone, with: '202-555-1212'

--- a/spec/features/backup_mfa/sign_up_spec.rb
+++ b/spec/features/backup_mfa/sign_up_spec.rb
@@ -58,6 +58,7 @@ feature 'backup mfa setup on sign up' do
   include WebAuthnHelper
 
   before do
+    stub_twilio_service
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
   end
 
@@ -74,7 +75,6 @@ feature 'backup mfa setup on sign up' do
 
   context 'voice sign up' do
     def choose_and_confirm_mfa
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -35,6 +35,7 @@ feature 'saml api' do
       end
 
       it 'prompts the user to confirm phone after setting up 2FA' do
+        stub_twilio_service
         select_2fa_option('sms')
         fill_in 'user_phone_form_phone', with: '202-555-1212'
         click_send_security_code

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -132,6 +132,7 @@ feature 'Two Factor Authentication' do
     context 'with voice option and US number' do
       it 'sends the code via VoiceOtpSenderJob and redirects to prompt for the code' do
         sign_in_before_2fa
+        stub_twilio_service
         select_2fa_option('voice')
         fill_in 'user_phone_form_phone', with: '7035551212'
         click_send_security_code
@@ -170,6 +171,7 @@ feature 'Two Factor Authentication' do
   end
 
   def submit_2fa_setup_form_with_valid_phone
+    stub_twilio_service
     fill_in 'user_phone_form_phone', with: '703-555-1212'
     click_send_security_code
   end

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -57,6 +57,7 @@ feature 'Phone confirmation during sign up' do
     before do
       @existing_user = create(:user, :signed_up)
       @user = sign_in_before_2fa
+      stub_twilio_service
       select_2fa_option('sms')
       fill_in 'user_phone_form_phone',
               with: MfaContext.new(@existing_user).phone_configurations.detect(&:mfa_enabled?).phone

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -6,6 +6,7 @@ feature 'webauthn sign up' do
   let!(:user) { sign_up_and_set_password }
 
   before do
+    stub_twilio_service
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,7 +66,8 @@ RSpec.configure do |config|
     allow(ValidateEmail).to receive(:mx_valid?).and_return(true)
   end
 
-  config.before(:each, twilio: true) do
+  config.before(:each) do
+    TwilioService::Utils.telephony_service = Twilio::REST::Client
     FakeSms.messages = []
     FakeVoiceCall.calls = []
   end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -24,6 +24,7 @@ module Features
     end
 
     def sign_up_and_2fa_loa1_user
+      stub_twilio_service
       allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = sign_up_and_set_password
       select_2fa_option('sms')
@@ -151,7 +152,6 @@ module Features
     end
 
     def click_send_security_code
-      stub_twilio_service
       click_button t('forms.buttons.send_security_code')
     end
 
@@ -395,6 +395,8 @@ module Features
     end
 
     def set_up_2fa_with_valid_phone
+      stub_twilio_service
+      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('sms')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
@@ -519,6 +521,7 @@ module Features
     end
 
     def configure_backup_phone
+      stub_twilio_service
       select_2fa_option('sms')
       fill_in 'user_phone_form_phone', with: '202-555-1212'
       click_send_security_code


### PR DESCRIPTION
**Why**: Because stubbing a global variable is not an expected side effect of clicking a button.
