### PR TITLE
Stop mocking OTP sender jobs to prevent OTP sends

### DIFF
--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -92,15 +92,16 @@ feature 'phone otp rate limiting', :idv_job do
 
   def expect_rate_limit_circumvention_to_be_disallowed(user)
     # Attempting to send another OTP does not send an OTP and shows lockout message
-    allow(SmsOtpSenderJob).to receive(:perform_now)
-    allow(SmsOtpSenderJob).to receive(:perform_later)
+    Twilio::FakeMessage.messages = []
+    Twilio::FakeCall.calls = []
 
     start_idv_from_sp
     complete_idv_steps_before_phone_otp_delivery_selection_step(user)
 
     expect(page).to have_content t('titles.account_locked')
-    expect(SmsOtpSenderJob).to_not have_received(:perform_now)
-    expect(SmsOtpSenderJob).to_not have_received(:perform_later)
+    expect(Twilio::FakeMessage.messages).to eq([])
+    expect(Twilio::FakeVerifyMessage.messages).to eq([])
+    expect(Twilio::FakeCall.calls).to eq([])
   end
 
   def expect_rate_limit_to_expire(user)

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -5,7 +5,6 @@ feature 'Remembering a phone' do
 
   before do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 

--- a/spec/features/remember_device/revocation_spec.rb
+++ b/spec/features/remember_device/revocation_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 feature 'taking an action that revokes remember device' do
   before do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -5,7 +5,6 @@ describe 'signing in with remember device and idling on the sign in page' do
 
   it 'redirects to the OIDC SP even though session is deleted' do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
 
     # We want to simulate a user that has already visited an OIDC SP and that

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -85,7 +85,6 @@ feature 'remember device sp expiration' do
 
   before do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
 
     ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server').update!(

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'Remembering a TOTP device' do
   before do
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -6,7 +6,6 @@ describe 'Remembering a webauthn device' do
   before do
     allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
     allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-    allow(SmsOtpSenderJob).to receive(:perform_now)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -329,14 +329,13 @@ feature 'Sign in' do
 
   context 'user signs in with Voice OTP delivery preference to an unsupported country' do
     it 'falls back to SMS with an error message' do
-      allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_later)
       user = create(:user, :signed_up,
                     otp_delivery_preference: 'voice', with: { phone: '+1 441-295-9644' })
       signin(user.email, user.password)
 
-      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
-      expect(SmsOtpSenderJob).to have_received(:perform_later)
+      expect(Twilio::FakeCall.calls).to eq([])
+      expect(Twilio::FakeMessage.messages).to eq([])
+      expect(Twilio::FakeVerifyMessage.messages.length).to eq(1)
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
@@ -348,16 +347,15 @@ feature 'Sign in' do
   end
 
   context 'user tries to visit /login/two_factor/voice with an unsupported phone' do
-    it 'displays an error message but does not send an SMS' do
-      allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_later)
+    it 'displays an error message but does not send another SMS' do
       user = create(:user, :signed_up,
                     otp_delivery_preference: 'sms', with: { phone: '+91 1234567890' })
       signin(user.email, user.password)
       visit login_two_factor_path(otp_delivery_preference: 'voice', reauthn: false)
 
-      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
-      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(Twilio::FakeCall.calls).to eq([])
+      expect(Twilio::FakeMessage.messages).to eq([])
+      expect(Twilio::FakeVerifyMessage.messages.length).to eq(1)
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(
@@ -369,9 +367,7 @@ feature 'Sign in' do
   end
 
   context 'user tries to visit /otp/send with voice delivery to an unsupported phone' do
-    it 'displays an error message but does not send an SMS' do
-      allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_later)
+    it 'displays an error message but does not send another SMS' do
       user = create(:user, :signed_up,
                     otp_delivery_preference: 'sms', with: { phone: '+91 1234567890' })
       signin(user.email, user.password)
@@ -379,8 +375,9 @@ feature 'Sign in' do
         otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true },
       )
 
-      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
-      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(Twilio::FakeCall.calls).to eq([])
+      expect(Twilio::FakeMessage.messages).to eq([])
+      expect(Twilio::FakeVerifyMessage.messages.length).to eq(1)
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
       expect(page).to have_content t(
@@ -392,9 +389,7 @@ feature 'Sign in' do
   end
 
   context 'user with voice delivery preference visits /otp/send' do
-    it 'displays an error message but does not send an SMS' do
-      allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_later)
+    it 'displays an error message but does not send another SMS' do
       user = create(:user, :signed_up,
                     otp_delivery_preference: 'voice', with: { phone: '+91 1234567890' })
       signin(user.email, user.password)
@@ -402,8 +397,9 @@ feature 'Sign in' do
         otp_delivery_selection_form: { otp_delivery_preference: 'voice', resend: true },
       )
 
-      expect(VoiceOtpSenderJob).to_not have_received(:perform_later)
-      expect(SmsOtpSenderJob).to have_received(:perform_later).exactly(:once)
+      expect(Twilio::FakeCall.calls).to eq([])
+      expect(Twilio::FakeMessage.messages).to eq([])
+      expect(Twilio::FakeVerifyMessage.messages.length).to eq(1)
       expect(page).
         to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms', reauthn: false))
       expect(page).to have_content t(

--- a/spec/features/users/user_edit_spec.rb
+++ b/spec/features/users/user_edit_spec.rb
@@ -50,9 +50,6 @@ feature 'User edit' do
     end
 
     scenario 'confirms with selected OTP delivery method and updates user delivery preference' do
-      allow(SmsOtpSenderJob).to receive(:perform_later)
-      allow(VoiceOtpSenderJob).to receive(:perform_now)
-
       fill_in 'user_phone_form_phone', with: '703-555-5000'
       choose 'Phone call'
 
@@ -61,8 +58,8 @@ feature 'User edit' do
       user.reload
 
       expect(current_path).to eq(login_otp_path(otp_delivery_preference: :voice))
-      expect(SmsOtpSenderJob).to_not have_received(:perform_later)
-      expect(VoiceOtpSenderJob).to have_received(:perform_now)
+      expect(Twilio::FakeCall.calls.length).to eq(1)
+      expect(Twilio::FakeMessage.messages).to eq([])
       expect(user.otp_delivery_preference).to eq('voice')
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
     allow(TwilioService::Utils).to receive(:telephony_service).and_return(Twilio::FakeRestClient)
     Twilio::FakeMessage.messages = []
     Twilio::FakeCall.calls = []
+    Twilio::FakeVerifyMessage.messages = []
   end
 
   config.around(:each, user_flow: true) do |example|

--- a/spec/support/otp_sender_job_overrides.rb
+++ b/spec/support/otp_sender_job_overrides.rb
@@ -1,0 +1,10 @@
+SmsOtpSenderJob.class_eval do
+  def self.perform_later(*args)
+    perform_now(*args)
+  end
+end
+VoiceOtpSenderJob.class_eval do
+  def self.perform_later(*args)
+    perform_now(*args)
+  end
+end


### PR DESCRIPTION
**Why**: To let the new Twilio service stubs do the work of keeping up with SMS and Voice calls.