### PR TITLE
LG-1411 Add error message when attempting to add email you already have

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -17,6 +17,7 @@ module Users
       if result.success?
         process_successful_creation
       else
+        flash.now[:error] = t('email_addresses.add.duplicate') if duplicate_email?
         render :show
       end
     end
@@ -76,6 +77,10 @@ module Users
     end
 
     private
+
+    def duplicate_email?
+      @register_user_email_form.email_taken?
+    end
 
     def authorize_user_to_edit_email
       return render_not_found if email_address.user != current_user

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -17,7 +17,6 @@ module Users
       if result.success?
         process_successful_creation
       else
-        flash.now[:error] = t('email_addresses.add.duplicate') if duplicate_email?
         render :show
       end
     end
@@ -77,10 +76,6 @@ module Users
     end
 
     private
-
-    def duplicate_email?
-      @register_user_email_form.email_taken?
-    end
 
     def authorize_user_to_edit_email
       return render_not_found if email_address.user != current_user

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -43,7 +43,7 @@ class AddUserEmailForm
   attr_reader :success, :email_address
 
   def valid_form?
-    @allow && valid? && !email_taken?
+    @allow && valid?
   end
 
   def process_successful_submission
@@ -54,7 +54,6 @@ class AddUserEmailForm
 
   def extra_analytics_attributes
     {
-      email_already_exists: email_taken?,
       user_id: existing_user.uuid,
       domain_name: email&.split('@')&.last,
     }.merge(@recaptcha_h)

--- a/app/validators/form_add_email_validator.rb
+++ b/app/validators/form_add_email_validator.rb
@@ -27,6 +27,7 @@ module FormAddEmailValidator
 
   def email_is_available_to_user
     email_address = EmailAddress.find_with_email(email)
-    @email_taken = true if email_address&.user_id == @user.id
+    return unless email_address&.user_id == @user.id
+    errors.add(:email, I18n.t('email_addresses.add.duplicate'))
   end
 end

--- a/config/locales/email_addresses/en.yml
+++ b/config/locales/email_addresses/en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   email_addresses:
+    add:
+      duplicate: This email address is already registered to your account.
     delete:
       confirm: Are you sure you want to delete %{email}?
       failure: Unable to delete this email address.

--- a/config/locales/email_addresses/es.yml
+++ b/config/locales/email_addresses/es.yml
@@ -1,6 +1,8 @@
 ---
 es:
   email_addresses:
+    add:
+      duplicate: Esta dirección de correo electrónico ya está registrada en su cuenta.
     delete:
       confirm: "¿Estas seguro que quieres borrarlo %{email}?"
       failure: No se puede eliminar esta dirección de correo electrónico.

--- a/config/locales/email_addresses/fr.yml
+++ b/config/locales/email_addresses/fr.yml
@@ -1,6 +1,8 @@
 ---
 fr:
   email_addresses:
+    add:
+      duplicate: Cette adresse e-mail est déjà enregistrée sur votre compte.
     delete:
       confirm: Etes-vous sûr que vous voulez supprimer %{email}?
       failure: Impossible de supprimer cette adresse email.

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -133,6 +133,21 @@ feature 'adding email address' do
       expect(page).to have_current_path(add_email_path)
     end
 
+    it 'stays on form and gives an error message when adding an email already on the account' do
+      user = create(:user, :signed_up)
+      sign_in_and_2fa_user(user)
+      visit account_path
+      click_link t('account.index.email_add')
+
+      expect(page).to have_current_path(add_email_path)
+
+      fill_in 'Email', with: user.email_addresses.first.email
+      click_button t('forms.buttons.submit.default')
+
+      expect(page).to have_current_path(add_email_path)
+      expect(page).to have_content(I18n.t('email_addresses.add.duplicate'))
+    end
+
     it 'does not show verify screen without an email in session from add email' do
       user = create(:user, :signed_up)
       sign_in_and_2fa_user(user)


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
