### PR TITLE
Remove OTP prefilling mocking unless we are testing OTP prefilling

### DIFF
--- a/spec/features/backup_mfa/bypass_backup_mfa_spec.rb
+++ b/spec/features/backup_mfa/bypass_backup_mfa_spec.rb
@@ -53,7 +53,6 @@ end
 
 describe 'attempting to bypass backup mfa setup' do
   before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('9999')
   end
 
@@ -63,6 +62,7 @@ describe 'attempting to bypass backup mfa setup' do
     end
 
     def complete_mfa
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 

--- a/spec/features/backup_mfa/no_duplicate_phone_numbers_spec.rb
+++ b/spec/features/backup_mfa/no_duplicate_phone_numbers_spec.rb
@@ -6,15 +6,14 @@ feature 'OTP delivery selection' do
 
     before do
       sign_in_user(user)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
     it 'should fail if using the same number as backup MFA voice' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('voice')
       expect(page).to have_content t('titles.phone_setup.voice')
@@ -29,6 +28,7 @@ feature 'OTP delivery selection' do
 
     it 'should prevent changing one phone to the other number' do
       choose_phone_as_backup_mfa
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_path).to eq(account_path)
@@ -43,7 +43,6 @@ feature 'OTP delivery selection' do
     end
 
     def choose_phone_as_backup_mfa
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('voice')
       expect(page).to have_content t('titles.phone_setup.voice')

--- a/spec/features/backup_mfa/otp_delivery_selection_spec.rb
+++ b/spec/features/backup_mfa/otp_delivery_selection_spec.rb
@@ -4,15 +4,14 @@ feature 'OTP delivery selection' do
   context 'set up voice as 2FA' do
     before do
       sign_in_user
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
     it 'allows the user to setup SMS for backup MFA' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('sms')
       expect(page).to have_content t('titles.phone_setup.sms')
@@ -27,15 +26,14 @@ feature 'OTP delivery selection' do
   context 'set up SMS as 2FA' do
     before do
       sign_in_user
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('sms')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
     it 'allows the user to voice for backup MFA' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       expect(page).to have_current_path(two_factor_options_path)
       select_2fa_option('voice')
       expect(page).to have_content t('titles.phone_setup.voice')
@@ -49,10 +47,10 @@ feature 'OTP delivery selection' do
 
   it 'allows the user to select a backup delivery method and then change that selection' do
     sign_in_user
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     select_2fa_option(:sms)
     fill_in :user_phone_form_phone, with: '202-555-1212'
     click_send_security_code
+    fill_in_code_with_last_phone_otp
     click_submit_default
     select_2fa_option(:voice)
 
@@ -62,14 +60,19 @@ feature 'OTP delivery selection' do
     select_2fa_option(:sms)
 
     expect(page).to have_content(t('titles.phone_setup.sms'))
-    expect(SmsOtpSenderJob).to receive(:perform_now)
-    expect(VoiceOtpSenderJob).to_not receive(:perform_now)
+
+    Twilio::FakeCall.calls = []
+    Twilio::FakeMessage.messages = []
 
     fill_in :user_phone_form_phone, with: '202-555-1313'
     click_send_security_code
 
+    expect(Twilio::FakeCall.calls.length).to eq(0)
+    expect(Twilio::FakeMessage.messages.length).to eq(1)
+
     expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
 
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     expect(page).to have_current_path(account_path)

--- a/spec/features/backup_mfa/sign_up_spec.rb
+++ b/spec/features/backup_mfa/sign_up_spec.rb
@@ -42,6 +42,7 @@ shared_examples 'setting up backup mfa on sign up' do
     select_2fa_option('sms')
     fill_in 'user_phone_form[phone]', with: '202-555-1111'
     click_send_security_code
+    fill_in_code_with_last_phone_otp
     click_submit_default
   end
 
@@ -57,15 +58,12 @@ feature 'backup mfa setup on sign up' do
   include SamlAuthHelper
   include WebAuthnHelper
 
-  before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-  end
-
   context 'sms sign up' do
     def choose_and_confirm_mfa
       select_2fa_option('sms')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
@@ -77,6 +75,7 @@ feature 'backup mfa setup on sign up' do
       select_2fa_option('voice')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -115,8 +115,6 @@ feature 'idv phone step' do
     end
 
     it 'is not re-entrant after confirming OTP' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
       user = user_with_2fa
 
       start_idv_from_sp
@@ -124,6 +122,7 @@ feature 'idv phone step' do
       fill_out_phone_form_ok
       click_idv_continue
       choose_idv_otp_delivery_method_sms
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       visit idv_phone_path
@@ -151,8 +150,6 @@ feature 'idv phone step' do
   end
 
   it 'requires the user to complete the profile step before completing' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
     start_idv_from_sp
     complete_idv_steps_before_profile_step
     # Try to advance ahead to the phone step

--- a/spec/features/mfa_enrollability_spec.rb
+++ b/spec/features/mfa_enrollability_spec.rb
@@ -1,13 +1,9 @@
 require 'rails_helper'
 
-describe 'TOTP enrollability' do
-  before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-  end
-
+describe 'MFA enrollability' do
   let(:user) { create(:user, :signed_up, :with_authentication_app) }
 
-  it 'is not available for selection as backup auth method once it is chosen as primary' do
+  it 'backup codes are not available for backup mfa after being chosen as primary' do
     sign_up_and_set_password
 
     select_2fa_option('backup_code')

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 feature 'sign in with any email address' do
   scenario 'signing in with any email address' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
     user = create(:user, :signed_up, :with_multiple_emails)
 
     email1, email2 = user.reload.email_addresses.map(&:email)
 
     signin(email1, user.password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     expect(page).to have_current_path(account_path)
@@ -16,6 +15,7 @@ feature 'sign in with any email address' do
     first(:link, t('links.sign_out')).click
 
     signin(email2, user.password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     expect(page).to have_current_path(account_path)

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -4,8 +4,6 @@ feature 'signing into an SP with multiple emails enabled' do
   include SamlAuthHelper
 
   scenario 'signing in with OIDC sends the email address used to sign in' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
     user = create(:user, :signed_up, :with_multiple_emails)
     emails = user.reload.email_addresses.map(&:email)
 
@@ -14,7 +12,7 @@ feature 'signing into an SP with multiple emails enabled' do
     emails.each do |email|
       visit_idp_from_oidc_sp
       signin(email, user.password)
-
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue if current_path == sign_up_completed_path
 
@@ -25,8 +23,6 @@ feature 'signing into an SP with multiple emails enabled' do
   end
 
   scenario 'signing in with SAML sends the email address used to sign in' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
     user = create(:user, :signed_up, :with_multiple_emails)
     emails = user.reload.email_addresses.map(&:email)
 
@@ -35,6 +31,7 @@ feature 'signing into an SP with multiple emails enabled' do
     emails.each do |email|
       visit authn_request
       signin(email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue if current_path == sign_up_completed_path
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -72,12 +72,12 @@ describe 'OpenID Connect' do
         prompt: 'select_account',
       )
 
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)
 
       expect(page.response_headers['Content-Security-Policy']).
         to(include('form-action \'self\' http://localhost:7654'))
 
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')
@@ -102,7 +102,6 @@ describe 'OpenID Connect' do
         prompt: 'select_account',
       )
 
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)
 
       expect(page.response_headers['Content-Security-Policy']).
@@ -114,6 +113,8 @@ describe 'OpenID Connect' do
       expect(page).to have_content(t('two_factor_authentication.invalid_otp'))
       expect(page.response_headers['Content-Security-Policy']).
         to(include('form-action \'self\' http://localhost:7654'))
+
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')
@@ -304,12 +305,11 @@ describe 'OpenID Connect' do
 
   context 'canceling sign in with active identities present' do
     it 'signs the user out and returns to the home page' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
       user = create(:user, :signed_up)
 
       visit_idp_from_sp_with_loa1
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       visit destroy_user_session_url
 

--- a/spec/features/openid_connect/redirect_uri_validation_spec.rb
+++ b/spec/features/openid_connect/redirect_uri_validation_spec.rb
@@ -92,10 +92,10 @@ describe 'redirect_uri validation' do
 
   context 'when the user is already signed in via an SP' do
     it 'displays error instead of redirecting' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
       visit_idp_from_sp_with_loa1_with_valid_redirect_uri
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 
@@ -124,10 +124,10 @@ describe 'redirect_uri validation' do
 
   context 'when the SP has multiple registered redirect_uris and the second one is requested' do
     it 'considers the request valid and redirects to the one requested' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
       visit_idp_from_sp_with_loa1_with_second_valid_redirect_uri
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 
@@ -141,7 +141,6 @@ describe 'redirect_uri validation' do
 
   context 'when the SP does not have any registered redirect_uris' do
     it 'considers the request invalid and does not redirect if the user signs in' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
       visit_idp_from_sp_that_does_not_have_redirect_uris
       current_host = URI.parse(page.current_url).host
@@ -152,6 +151,7 @@ describe 'redirect_uri validation' do
 
       visit new_user_session_path
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 

--- a/spec/features/remember_device/phone_spec.rb
+++ b/spec/features/remember_device/phone_spec.rb
@@ -4,7 +4,6 @@ feature 'Remembering a phone' do
   include IdvHelper
 
   before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 
@@ -15,6 +14,7 @@ feature 'Remembering a phone' do
       user = user_with_2fa
       sign_in_user(user)
       check :remember_device
+      fill_in_code_with_last_phone_otp
       click_submit_default
       first(:link, t('links.sign_out')).click
       user
@@ -31,12 +31,14 @@ feature 'Remembering a phone' do
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551313'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551212'
       click_send_security_code
       check :remember_device
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       first(:link, t('links.sign_out')).click
@@ -54,6 +56,7 @@ feature 'Remembering a phone' do
       fill_in 'user_phone_form_phone', with: '2022347193'
       click_button t('forms.buttons.submit.confirm_change')
       check :remember_device
+      fill_in_code_with_last_phone_otp
       click_submit_default
       first(:link, t('links.sign_out')).click
       user
@@ -65,6 +68,7 @@ feature 'Remembering a phone' do
       user = user_with_2fa
       sign_in_user(user)
       check :remember_device
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       visit manage_phone_path
@@ -81,6 +85,7 @@ feature 'Remembering a phone' do
     before do
       sign_in_user(user)
       check :remember_device
+      fill_in_code_with_last_phone_otp
       click_submit_default
       visit idv_session_path
       fill_out_idv_form_ok

--- a/spec/features/remember_device/revocation_spec.rb
+++ b/spec/features/remember_device/revocation_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 feature 'taking an action that revokes remember device' do
   before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 
@@ -10,7 +9,7 @@ feature 'taking an action that revokes remember device' do
     let(:user) { create(:user, :signed_up) }
 
     it 'revokes remember device when modified' do
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_link(
@@ -19,6 +18,7 @@ feature 'taking an action that revokes remember device' do
       )
       fill_in 'user_phone_form_phone', with: '7032231000'
       click_button t('forms.buttons.submit.confirm_change')
+      fill_in_code_with_last_phone_otp
       click_submit_default
       first(:link, t('links.sign_out')).click
 
@@ -28,7 +28,7 @@ feature 'taking an action that revokes remember device' do
     it 'revokes remember device when removed' do
       create(:webauthn_configuration, user: user) # The user needs multiple methods to delete phone
 
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_link(
@@ -46,7 +46,7 @@ feature 'taking an action that revokes remember device' do
     let(:user) { create(:user, :signed_up, :with_webauthn) }
 
     it 'revokes remember device when removed' do
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_on t('account.index.webauthn_delete')
@@ -61,7 +61,7 @@ feature 'taking an action that revokes remember device' do
     let(:user) { create(:user, :signed_up, :with_piv_or_cac) }
 
     it 'revokes remember device when removed' do
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_on t('forms.buttons.disable')
@@ -75,7 +75,7 @@ feature 'taking an action that revokes remember device' do
     let(:user) { create(:user, :signed_up, :with_authentication_app) }
 
     it 'revokes remember device when removed' do
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_on t('forms.buttons.disable')
@@ -89,7 +89,7 @@ feature 'taking an action that revokes remember device' do
     let(:user) { create(:user, :signed_up, :with_authentication_app, :with_backup_code) }
 
     it 'revokes remember device when regenerated' do
-      sign_with_remember_device_and_sign_out
+      sign_in_with_remember_device_and_sign_out
 
       sign_in_user(user)
       click_on t('forms.backup_code.regenerate')
@@ -101,10 +101,11 @@ feature 'taking an action that revokes remember device' do
     end
   end
 
-  def sign_with_remember_device_and_sign_out
+  def sign_in_with_remember_device_and_sign_out
     sign_in_user(user)
     choose_another_security_option('sms')
     check :remember_device
+    fill_in_code_with_last_phone_otp
     click_submit_default
     first(:link, t('links.sign_out')).click
   end

--- a/spec/features/remember_device/session_expiration_spec.rb
+++ b/spec/features/remember_device/session_expiration_spec.rb
@@ -4,7 +4,6 @@ describe 'signing in with remember device and idling on the sign in page' do
   include SamlAuthHelper
 
   it 'redirects to the OIDC SP even though session is deleted' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
 
     # We want to simulate a user that has already visited an OIDC SP and that
@@ -14,6 +13,7 @@ describe 'signing in with remember device and idling on the sign in page' do
     user = user_with_2fa
     sign_in_user(user)
     check :remember_device
+    fill_in_code_with_last_phone_otp
     click_submit_default
     first(:link, t('links.sign_out')).click
 

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
         expect(page).to have_content(t('two_factor_authentication.header_text'))
         expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
 
+        fill_in_code_with_last_phone_otp
         click_submit_default
 
         expect(page).to have_current_path(sign_up_completed_path)
@@ -52,6 +53,7 @@ shared_examples 'expiring remember device for an sp config' do |expiration_time,
           expect(page).to have_content(t('two_factor_authentication.header_text'))
           expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
 
+          fill_in_code_with_last_phone_otp
           click_submit_default
         end
 
@@ -71,12 +73,14 @@ feature 'remember device sp expiration' do
     select_2fa_option('sms')
     fill_in :user_phone_form_phone, with: '2025551313'
     click_send_security_code
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     select_2fa_option('sms')
     fill_in :user_phone_form_phone, with: '2025551212'
     click_send_security_code
     check :remember_device
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     first(:link, t('links.sign_out')).click
@@ -84,7 +88,6 @@ feature 'remember device sp expiration' do
   end
 
   before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
 
     ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server').update!(

--- a/spec/features/remember_device/totp_spec.rb
+++ b/spec/features/remember_device/totp_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe 'Remembering a TOTP device' do
   before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 
@@ -29,6 +28,7 @@ describe 'Remembering a TOTP device' do
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       select_2fa_option('auth_app')

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -5,7 +5,6 @@ describe 'Remembering a webauthn device' do
 
   before do
     allow(WebauthnVerificationForm).to receive(:domain_name).and_return('localhost:3000')
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     allow(Figaro.env).to receive(:otp_delivery_blocklist_maxretry).and_return('1000')
   end
 
@@ -43,6 +42,7 @@ describe 'Remembering a webauthn device' do
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551313'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       select_2fa_option('webauthn')

--- a/spec/features/saml/loa1_sso_spec.rb
+++ b/spec/features/saml/loa1_sso_spec.rb
@@ -35,13 +35,12 @@ feature 'LOA1 Single Sign On' do
     end
 
     it 'takes user to the service provider, allows user to visit IDP' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
       user = create(:user, :signed_up)
       saml_authn_request = auth_request.create(saml_settings)
 
       visit saml_authn_request
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 
@@ -78,8 +77,6 @@ feature 'LOA1 Single Sign On' do
     end
 
     it 'after session timeout, signing in takes user back to SP' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
       user = create(:user, :signed_up)
       saml_authn_request = auth_request.create(saml_settings)
 
@@ -90,6 +87,7 @@ feature 'LOA1 Single Sign On' do
       expect(current_url).to eq root_url(request_id: sp_request_id)
 
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 
@@ -102,8 +100,8 @@ feature 'LOA1 Single Sign On' do
     let(:saml_authn_request) { auth_request.create(saml_settings) }
 
     before do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       visit saml_authn_request
     end
@@ -124,6 +122,7 @@ feature 'LOA1 Single Sign On' do
       visit sign_out_url
 
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       visit saml_authn_request

--- a/spec/features/saml/loa3_sso_spec.rb
+++ b/spec/features/saml/loa3_sso_spec.rb
@@ -6,10 +6,10 @@ feature 'LOA3 Single Sign On' do
   include DocAuthHelper
 
   def perform_id_verification_with_usps_without_confirming_code(user)
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
     visit saml_authn_request
     fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
     fill_out_idv_jurisdiction_ok
     click_idv_continue
@@ -43,7 +43,6 @@ feature 'LOA3 Single Sign On' do
   context 'First time registration' do
     let(:email) { 'test@test.com' }
     before do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       @saml_authn_request = auth_request.create(loa3_with_bundle_saml_settings)
     end
 

--- a/spec/features/saml/redirect_uri_validation_spec.rb
+++ b/spec/features/saml/redirect_uri_validation_spec.rb
@@ -5,7 +5,6 @@ describe 'redirect_uri validation' do
 
   context 'when redirect_uri param is included in SAML request' do
     it 'uses the return_to_sp_url URL and not the redirect_uri' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
       visit api_saml_auth2019_path(
         SAMLRequest: CGI.unescape(saml_request(saml_settings)), redirect_uri: 'http://evil.com',
@@ -16,6 +15,7 @@ describe 'redirect_uri validation' do
         to have_link t('links.back_to_sp', sp: sp.friendly_name), href: sp.return_to_sp_url
 
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
       click_submit_default

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -4,7 +4,6 @@ feature 'sign up with backup code' do
   include DocAuthHelper
 
   it 'works' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     sign_up_and_set_password
     select_2fa_option('backup_code')
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -216,6 +216,7 @@ feature 'Changing authentication factor' do
 
   def complete_2fa_confirmation
     complete_2fa_confirmation_without_entering_otp
+    fill_in_code_with_last_phone_otp
     click_submit_default
   end
 
@@ -251,6 +252,7 @@ feature 'Changing authentication factor' do
   end
 
   def submit_correct_otp
+    fill_in_code_with_last_phone_otp
     click_submit_default
   end
 

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -187,7 +187,8 @@ feature 'Two Factor Authentication' do
       expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
 
       check 'remember_device'
-      submit_prefilled_otp_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
 
       expect(current_path).to eq account_path
     end
@@ -196,18 +197,14 @@ feature 'Two Factor Authentication' do
       visit account_path
     end
 
-    def submit_prefilled_otp_code
-      click_button t('forms.buttons.submit.default')
-    end
-
     scenario 'user can resend one-time password (OTP)' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
-      old_code = find('input[@name="code"]').value
+      old_code = last_sms_otp
 
       click_link t('links.two_factor_authentication.get_another_code')
 
-      new_code = find('input[@name="code"]').value
+      new_code = last_sms_otp
 
       expect(old_code).not_to eq(new_code)
     end
@@ -343,6 +340,7 @@ feature 'Two Factor Authentication' do
         (max_attempts - 1).times do
           click_link t('links.two_factor_authentication.get_another_code')
         end
+        fill_in_code_with_last_phone_otp
         click_submit_default
 
         expect(current_path).to eq account_path
@@ -364,6 +362,7 @@ feature 'Two Factor Authentication' do
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
 
+        fill_in_code_with_last_phone_otp
         click_submit_default
 
         expect(current_path).to eq account_path

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -11,13 +11,12 @@ feature 'Password recovery via personal key' do
   let(:pii) { { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' } }
 
   scenario 'resets password and reactivates profile with personal key', email: true, js: true do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
     personal_key = personal_key_from_pii(user, pii)
 
     trigger_reset_password_and_click_email_link(user.email)
 
     reset_password_and_sign_back_in(user, new_password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     expect(current_path).to eq reactivate_account_path
@@ -29,10 +28,10 @@ feature 'Password recovery via personal key' do
   end
 
   scenario 'resets password and reactivates profile with no personal key', email: true, js: true do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     personal_key_from_pii(user, pii)
     trigger_reset_password_and_click_email_link(user.email)
     reset_password_and_sign_back_in(user, new_password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     expect(current_path).to eq(reactivate_account_path)
@@ -78,10 +77,10 @@ feature 'Password recovery via personal key' do
 
   context 'account recovery alternative paths' do
     before do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       personal_key_from_pii(user, pii)
       trigger_reset_password_and_click_email_link(user.email)
       reset_password_and_sign_back_in(user, new_password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -90,7 +90,6 @@ feature 'PIV/CAC Management' do
 
       context 'when the user does not have a 2nd mfa yet' do
         it 'does prompt to set one up after configuring PIV/CAC' do
-          allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
           stub_piv_cac_service
 
           user.update(otp_secret_key: 'secret')

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -126,11 +126,11 @@ feature 'View personal key' do
 end
 
 def sign_up_and_view_personal_key
-  allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
   sign_up_and_set_password
   select_2fa_option('sms')
   fill_in 'user_phone_form_phone', with: '202-555-1212'
   click_send_security_code
+  fill_in_code_with_last_phone_otp
   click_submit_default
 end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -290,11 +290,11 @@ feature 'Sign in' do
 
   context 'invalid request_id' do
     it 'allows the user to sign in and does not try to redirect to any SP' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = create(:user, :signed_up)
 
       visit new_user_session_path(request_id: 'invalid')
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_path).to eq account_path
@@ -485,12 +485,11 @@ feature 'Sign in' do
 
   context 'visiting via SP1, then via SP2, then signing in' do
     it 'redirects to SP2' do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-
       user = create(:user, :signed_up)
       visit_idp_from_sp_with_loa1(:saml)
       visit_idp_from_sp_with_loa1(:oidc)
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
 

--- a/spec/features/visitors/phone_confirmation_spec.rb
+++ b/spec/features/visitors/phone_confirmation_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 feature 'Phone confirmation during sign up' do
   context 'visitor can sign up and confirm a valid phone for OTP' do
     before do
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-      allow(SmsOtpSenderJob).to receive(:perform_now)
+      allow(SmsOtpSenderJob).to receive(:perform_now).and_call_original
       @user = sign_in_before_2fa
 
       select_2fa_option('sms')
@@ -21,6 +20,7 @@ feature 'Phone confirmation during sign up' do
     end
 
     it 'updates phone_confirmed_at and redirects to add another MFA' do
+      fill_in_code_with_last_phone_otp
       click_button t('forms.buttons.submit.default')
 
       expect(MfaContext.new(@user).phone_configurations.reload.first.confirmed_at).to be_present

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -5,10 +5,6 @@ feature 'webauthn sign up' do
 
   let!(:user) { sign_up_and_set_password }
 
-  before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-  end
-
   context 'as first MFA method' do
     def visit_webauthn_setup
       select_2fa_option('webauthn')
@@ -20,6 +16,7 @@ feature 'webauthn sign up' do
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551313'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(page).to have_current_path(account_path)
@@ -33,6 +30,7 @@ feature 'webauthn sign up' do
       select_2fa_option('sms')
       fill_in :user_phone_form_phone, with: '2025551313'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       select_2fa_option('webauthn')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
   config.include AnalyticsHelper
   config.include AwsKmsClientHelper
   config.include KeyRotationHelper
+  config.include TwilioHelper
 
   config.before(:suite) do
     Rails.application.load_seed

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -24,11 +24,11 @@ module Features
     end
 
     def sign_up_and_2fa_loa1_user
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       user = sign_up_and_set_password
       select_2fa_option('sms')
       fill_in 'user_phone_form_phone', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
       select_2fa_option('backup_code')
       click_continue
@@ -94,10 +94,9 @@ module Features
     end
 
     def sign_in_before_2fa(user = create(:user))
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       login_as(user, scope: :user, run_callbacks: false)
 
-      if TwoFactorAuthentication::PhonePolicy.new(user).enabled?
+      if MfaPolicy.new(user).two_factor_enabled?
         Warden.on_next_request do |proxy|
           session = proxy.env['rack.session']
           session['warden.user.user.session'] = {}
@@ -155,8 +154,8 @@ module Features
     end
 
     def sign_in_live_with_2fa(user = user_with_2fa)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       user
     end
@@ -170,6 +169,10 @@ module Features
         dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
         uuid: user.x509_dn_uuid,
       )
+    end
+
+    def fill_in_code_with_last_phone_otp
+      fill_in :code, with: last_phone_otp
     end
 
     def click_submit_default
@@ -265,7 +268,6 @@ module Features
     end
 
     def sign_up_user_from_sp_without_confirming_email(email)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       sp_request_id = ServiceProviderRequest.last.uuid
 
       expect(current_url).to eq new_user_session_url(request_id: sp_request_id)
@@ -394,10 +396,10 @@ module Features
     end
 
     def set_up_2fa_with_valid_phone
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       select_2fa_option('sms')
       fill_in 'user_phone_form[phone]', with: '202-555-1212'
       click_send_security_code
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
@@ -410,7 +412,6 @@ module Features
     end
 
     def confirm_email_and_password(email)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       find_link(t('links.create_account')).click
       submit_form_with_valid_email(email)
       click_confirmation_link_in_email(email)
@@ -463,8 +464,8 @@ module Features
     end
 
     def sign_in_via_branded_page(user)
-      allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
       fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
       click_submit_default
     end
 
@@ -508,13 +509,6 @@ module Features
       ).link_identity(
         ial: ial,
       )
-    end
-
-    def configure_backup_phone
-      select_2fa_option('sms')
-      fill_in 'user_phone_form_phone', with: '202-555-1212'
-      click_send_security_code
-      click_submit_default
     end
   end
 end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -2,10 +2,6 @@ shared_examples 'sp handoff after identity verification' do |sp|
   include SamlAuthHelper
   include IdvHelper
 
-  before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-  end
-
   let(:email) { 'test@test.com' }
 
   context 'sign up' do
@@ -45,6 +41,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     it 'requires idv and hands off successfully' do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_path).to eq idv_jurisdiction_path
@@ -82,6 +79,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     it 'does not require verification and hands off successfully' do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect_csp_headers_to_be_present if sp == :oidc
@@ -99,6 +97,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     before do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       fill_out_idv_jurisdiction_ok
       click_idv_continue
@@ -115,6 +114,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
 
       expect_csp_headers_to_be_present if sp == :oidc
 
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect_successful_oidc_handoff if sp == :oidc

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -2,16 +2,13 @@ shared_examples 'sp requesting attributes' do |sp|
   include SamlAuthHelper
   include IdvHelper
 
-  before do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
-  end
-
   let(:user) { user_with_2fa }
 
   context 'visiting an SP for the first time' do
     it 'requires the user to verify the attributes submitted to the SP' do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(current_path).to eq idv_jurisdiction_path
@@ -38,6 +35,7 @@ shared_examples 'sp requesting attributes' do |sp|
     before do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
       fill_out_idv_jurisdiction_ok
       click_idv_continue
@@ -51,6 +49,7 @@ shared_examples 'sp requesting attributes' do |sp|
     it 'does not require the user to verify attributes' do
       visit_idp_from_sp_with_loa3(sp)
       sign_in_user(user)
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       if sp == :oidc

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -53,6 +53,7 @@ shared_examples 'creating an LOA3 account using authenticator app for 2FA' do |s
     fill_out_phone_form_ok
     click_idv_continue
     choose_idv_otp_delivery_method_sms
+    fill_in_code_with_last_phone_otp
     click_submit_default
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_continue
@@ -76,7 +77,6 @@ end
 
 shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
   it 'redirects to the SP', email: true do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     visit_idp_from_sp_with_loa1(sp)
     register_user_with_piv_cac
 
@@ -87,7 +87,7 @@ shared_examples 'creating an account using PIV/CAC for 2FA' do |sp|
 
     expect(page).to have_current_path(two_factor_options_path)
 
-    configure_backup_phone
+    set_up_2fa_with_valid_phone
 
     if sp == :oidc
       expect(page.response_headers['Content-Security-Policy']).
@@ -125,6 +125,7 @@ shared_examples 'creating an LOA3 account using webauthn for 2FA' do |sp|
     fill_out_phone_form_ok
     click_idv_continue
     choose_idv_otp_delivery_method_sms
+    fill_in_code_with_last_phone_otp
     click_submit_default
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_continue

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -27,6 +27,7 @@ shared_examples 'remember device' do
 
     # Setup remember device as second user
     check :remember_device
+    fill_in_code_with_last_phone_otp
     click_submit_default
 
     # Sign out second user

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -1,6 +1,5 @@
 shared_examples 'signing in with the site in Spanish' do |sp|
   it 'redirects to the SP' do
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     Capybara.current_session.driver.header('Accept-Language', 'es')
 
     user = create(:user, :signed_up)
@@ -12,7 +11,9 @@ shared_examples 'signing in with the site in Spanish' do |sp|
         to(include('form-action \'self\' http://localhost:7654'))
     end
 
+    fill_in_code_with_last_phone_otp
     click_submit_default
+
     expect(current_url).to eq(sign_up_completed_url(locale: 'es'))
 
     click_continue

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -1,6 +1,5 @@
 module SpAuthHelper
   def create_loa1_account_go_back_to_sp_and_sign_out(sp)
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     email = 'test@test.com'
     visit_idp_from_sp_with_loa1(sp)
     click_link t('links.create_account')
@@ -15,10 +14,10 @@ module SpAuthHelper
   end
 
   def create_loa3_account_go_back_to_sp_and_sign_out(sp)
-    allow(FeatureManagement).to receive(:prefill_otp_codes?).and_return(true)
     user = create(:user, :signed_up)
     visit_idp_from_sp_with_loa3(sp)
     fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
     click_submit_default
     fill_out_idv_jurisdiction_ok
     click_idv_continue

--- a/spec/support/twilio/fake_call.rb
+++ b/spec/support/twilio/fake_call.rb
@@ -1,5 +1,5 @@
 module Twilio
-  FakeCall = Struct.new(:to, :from, :url, :record) do
+  FakeCall = Struct.new(:to, :from, :url, :record, :sent_at) do
     cattr_accessor :calls
     self.calls = []
 
@@ -9,13 +9,17 @@ module Twilio
         opts[:from],
         opts[:url],
         opts[:record],
+        Time.zone.now,
       )
     end
 
+    def self.last_call(phone: nil)
+      return calls.last if phone.nil?
+      calls.select { |c| c.to == phone }.last
+    end
+
     def self.last_otp(phone: nil)
-      return calls.last.otp if phone.nil?
-      call = calls.select { |c| c.to == phone }.last
-      call&.otp
+      last_call(phone: phone)&.otp
     end
 
     def otp

--- a/spec/support/twilio/fake_message.rb
+++ b/spec/support/twilio/fake_message.rb
@@ -1,5 +1,5 @@
 module Twilio
-  FakeMessage = Struct.new(:to, :body, :messaging_service_sid) do
+  FakeMessage = Struct.new(:to, :body, :messaging_service_sid, :sent_at) do
     cattr_accessor :messages
     self.messages = []
 
@@ -8,13 +8,17 @@ module Twilio
         opts[:to],
         opts[:body],
         opts[:messaging_service_sid],
+        Time.zone.now,
       )
     end
 
+    def self.last_message(phone: nil)
+      return messages.last if phone.nil?
+      messages.select { |m| m.to == phone }.last
+    end
+
     def self.last_otp(phone: nil)
-      return messages.last&.otp if phone.nil?
-      message = messages.select { |m| m.to == phone }.last
-      message&.otp
+      last_message(phone: phone)&.otp
     end
 
     def otp

--- a/spec/support/twilio/fake_verify_message.rb
+++ b/spec/support/twilio/fake_verify_message.rb
@@ -1,5 +1,5 @@
 module Twilio
-  FakeVerifyMessage = Struct.new(:country_code, :local_number, :code) do
+  FakeVerifyMessage = Struct.new(:country_code, :local_number, :code, :sent_at) do
     cattr_accessor :messages
     self.messages = []
 
@@ -11,10 +11,13 @@ module Twilio
       )
     end
 
+    def self.last_message(phone: nil)
+      return messages.last if phone.nil?
+      messages.select { |m| m.to == phone }.last
+    end
+
     def self.last_otp(phone: nil)
-      return messages.last&.otp if phone.nil?
-      message = messages.select { |m| m.to == phone }.last
-      message&.otp
+      last_message(phone: phone)&.otp
     end
 
     def to

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -1,0 +1,21 @@
+module TwilioHelper
+  def last_sms_otp(phone: nil)
+    Twilio::FakeMessage.last_otp(phone: phone)
+  end
+
+  def last_international_sms_otp(phone: nil)
+    Twilio::FakeVerifyMessage.last_otp(phone: phone)
+  end
+
+  def last_voice_otp(phone: nil)
+    Twilio::FakeCall.last_otp(phone: phone)
+  end
+
+  def last_phone_otp
+    [
+      Twilio::FakeMessage.last_message,
+      Twilio::FakeCall.last_call,
+      Twilio::FakeVerifyMessage.last_message,
+    ].compact.max_by(&:sent_at)&.otp
+  end
+end


### PR DESCRIPTION
**Why**: So that we test submitting the OTP that is actually send by SMS or voice.
