### PR TITLE
LG-1423 Add link to welcome page help text to create an account

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -31,6 +31,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
 
   def sp_msg(section, args = {})
     args = args.merge(sp_name: sp_name)
+    args = args.merge(sp_create_link: sp_create_link)
     return t("service_providers.#{sp_alert_name}.#{section}", args) if custom_alert?
 
     t("service_providers.default.#{section}", args)
@@ -85,8 +86,13 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
     sp_session[:requested_attributes].sort
   end
 
+  def sp_create_link
+    view_context.link_to t('service_providers.default.account_page.create_link'),
+                         view_context.sign_up_email_url(request_id: sp_session[:request_id])
+  end
+
   def sp_name
-    sp.friendly_name || sp.agency
+    'USAJOBS' #sp.friendly_name || sp.agency
   end
 
   def sp_agency

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -92,7 +92,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
   end
 
   def sp_name
-    'USAJOBS' #sp.friendly_name || sp.agency
+    sp.friendly_name || sp.agency
   end
 
   def sp_agency

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -88,7 +88,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
 
   def sp_create_link
     view_context.link_to t('service_providers.default.account_page.create_link'),
-                         view_context.sign_up_email_url(request_id: sp_session[:request_id])
+                         view_context.sign_up_email_path(request_id: sp_session[:request_id])
   end
 
   def sp_name

--- a/app/views/shared/_sp_alert.html.slim
+++ b/app/views/shared/_sp_alert.html.slim
@@ -3,7 +3,7 @@
     .bold = decorated_session.sp_msg('header')
     p.mb1
       - if current_page?(new_user_session_path)
-        = decorated_session.sp_msg('account_page.body')
+        == decorated_session.sp_msg('account_page.body')
       - elsif current_page?(sign_up_email_path)
         = decorated_session.sp_msg('create_account_page.body')
       - else

--- a/config/locales/service_providers/en.yml
+++ b/config/locales/service_providers/en.yml
@@ -3,8 +3,9 @@ en:
   service_providers:
     default:
       account_page:
-        body: Your old %{sp_name} username and password won’t work. Please create
-          a login.gov account using the same email address you use for %{sp_name}.
+        body: Your old %{sp_name} username and password won’t work. Please %{sp_create_link}
+          using the same email address you use for %{sp_name}.
+        create_link: create a login.gov account
       body_html: Your old %{sp_name} username and password won’t work. Please %{link}
         using the same email address you use for %{sp_name}.
       create_account_link: create a login.gov account

--- a/config/locales/service_providers/es.yml
+++ b/config/locales/service_providers/es.yml
@@ -5,7 +5,8 @@ es:
       account_page:
         body: Si tiene un perfil de %{sp_name} existente, favor de usar la dirección
           de correo electrónico primaria o secundaria que usó para %{sp_name} para
-          crear su nueva cuenta de login.gov.
+          %{sp_create_link}.
+        create_link: crear su nueva cuenta de login.gov
       body_html: Si tiene un perfil de %{sp_name} existente, favor de usar la dirección
         de correo electrónico primaria o secundaria que usó para %{sp_name} para %{link}.
       create_account_link: crear su nueva cuenta de login.gov

--- a/config/locales/service_providers/fr.yml
+++ b/config/locales/service_providers/fr.yml
@@ -5,7 +5,8 @@ fr:
       account_page:
         body: Si vous avez déjà un profil %{sp_name}, veuillez utiliser l'adresse
           e-mail principale ou secondaire que vous avez utilisée pour %{sp_name} pour
-          créer votre nouveau compte login.gov.
+          %{sp_create_link}.
+        create_link: créer votre nouveau compte login.gov
       body_html: Si vous avez déjà un profil %{sp_name}, veuillez utiliser l'adresse
         e-mail principale ou secondaire que vous avez utilisée pour %{sp_name} pour
         %{link}.

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe ServiceProviderSessionDecorator do
   end
   let(:sp) { build_stubbed(:service_provider) }
   let(:sp_name) { subject.sp_name }
+  before do
+    allow(view_context).to receive(:sign_up_email_path).
+      and_return('/sign_up/enter_email')
+  end
 
   it 'has the same public API as SessionDecorator' do
     SessionDecorator.public_instance_methods.each do |method|

--- a/spec/views/devise/passwords/new.html.slim_spec.rb
+++ b/spec/views/devise/passwords/new.html.slim_spec.rb
@@ -11,6 +11,8 @@ describe 'devise/passwords/new.html.slim' do
     view_context = ActionController::Base.new.view_context
     allow(view_context).to receive(:new_user_session_url).
       and_return('https://www.example.com/')
+    allow(view_context).to receive(:sign_up_email_path).
+      and_return('/sign_up/enter_email')
 
     @decorated_session = DecoratedSession.new(
       sp: @sp,

--- a/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -61,6 +61,8 @@ describe 'devise/sessions/new.html.slim' do
         service_provider_request: ServiceProviderRequest.new,
       ).call
       allow(view).to receive(:decorated_session).and_return(@decorated_session)
+      allow(view_context).to receive(:sign_up_email_path).
+        and_return('/sign_up/enter_email')
     end
 
     it 'displays a custom header' do


### PR DESCRIPTION
**Why**:  To prevent confusion on how the user actually creates an account

**How**:  Update the service provider session decorator and the view to handle html

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
