### PR TITLE
LG-1381 Show users which MFA method they setup on 2nd MFA screen

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ Metrics/MethodLength:
   Exclude:
   - 'db/migrate/*'
   - spec/**/*
+  - 'app/services/first_mfa_enabled_for_user.rb'
 
 Metrics/ModuleLength:
   CountComments: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,6 @@ Metrics/MethodLength:
   Exclude:
   - 'db/migrate/*'
   - spec/**/*
-  - 'app/services/first_mfa_enabled_for_user.rb'
 
 Metrics/ModuleLength:
   CountComments: false

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -39,7 +39,7 @@ class TwoFactorOptionsPresenter
   private
 
   def first_mfa_enabled
-    FirstMfaEnabledForUser.call(current_user)
+    t("two_factor_authentication.devices.#{FirstMfaEnabledForUser.call(current_user)}")
   end
 
   def recovery

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -32,7 +32,15 @@ class TwoFactorOptionsPresenter
     MfaPolicy.new(current_user).no_factors_enabled?
   end
 
+  def first_mfa_successfully_enabled_message
+    t('two_factor_authentication.first_factor_enabled', device: first_mfa_enabled)
+  end
+
   private
+
+  def first_mfa_enabled
+    FirstMfaEnabledForUser.call(current_user)
+  end
 
   def recovery
     no_factors_enabled? ? '' : 'recovery_'

--- a/app/services/first_mfa_enabled_for_user.rb
+++ b/app/services/first_mfa_enabled_for_user.rb
@@ -1,4 +1,5 @@
 class FirstMfaEnabledForUser
+  # rubocop:disable MethodLength
   def self.call(user)
     if TwoFactorAuthentication::PivCacPolicy.new(user).enabled?
       :piv_cac
@@ -14,4 +15,5 @@ class FirstMfaEnabledForUser
       :error
     end
   end
+  # rubocop:enable MethodLength
 end

--- a/app/services/first_mfa_enabled_for_user.rb
+++ b/app/services/first_mfa_enabled_for_user.rb
@@ -1,0 +1,10 @@
+class FirstMfaEnabledForUser
+  def self.call(user)
+    return :piv_cac if TwoFactorAuthentication::PivCacPolicy.new(user).enabled?
+    return :webauthn if TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
+    return :auth_app if TwoFactorAuthentication::AuthAppPolicy.new(user).enabled?
+    return :phone if TwoFactorAuthentication::PhonePolicy.new(user).enabled?
+    return :backup_code if TwoFactorAuthentication::BackupCodePolicy.new(user).enabled?
+    :error
+  end
+end

--- a/app/services/first_mfa_enabled_for_user.rb
+++ b/app/services/first_mfa_enabled_for_user.rb
@@ -1,10 +1,17 @@
 class FirstMfaEnabledForUser
   def self.call(user)
-    return :piv_cac if TwoFactorAuthentication::PivCacPolicy.new(user).enabled?
-    return :webauthn if TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
-    return :auth_app if TwoFactorAuthentication::AuthAppPolicy.new(user).enabled?
-    return :phone if TwoFactorAuthentication::PhonePolicy.new(user).enabled?
-    return :backup_code if TwoFactorAuthentication::BackupCodePolicy.new(user).enabled?
-    :error
+    if TwoFactorAuthentication::PivCacPolicy.new(user).enabled?
+      :piv_cac
+    elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
+      :webauthn
+    elsif TwoFactorAuthentication::AuthAppPolicy.new(user).enabled?
+      :auth_app
+    elsif TwoFactorAuthentication::PhonePolicy.new(user).enabled?
+      :phone
+    elsif TwoFactorAuthentication::BackupCodePolicy.new(user).enabled?
+      :backup_code
+    else
+      :error
+    end
   end
 end

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -1,5 +1,5 @@
 <% if !@presenter.no_factors_enabled? %>
-  <div class="alert alert-success" role="alert">Your primary authentication method has been successfully set up.</div>
+  <div class="alert alert-success" role="alert"><%= @presenter.first_mfa_successfully_enabled_message %></div>
 <% end %>
 <% title @presenter.title %>
 <h1 class="h3 my0"><%= @presenter.heading %></h1>

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -21,13 +21,12 @@ en:
       need to use a new key.
     choose_another_option: "‹ Choose another option"
     devices:
-      auth_app: authentication app
-      backup_code: backup codes
-      phone: phone
+      auth_app: Authentication app
+      backup_code: Backup codes
+      phone: Phone
       piv_cac: PIV/CAC
-      webauthn: security key
-    first_factor_enabled: Your primary authentication method %{device} has been successfully
-      set up.
+      webauthn: Security key
+    first_factor_enabled: "%{device} was successfully setup as an authentication method."
     header_text: Enter your security code
     invalid_backup_code: That backup code is invalid.
     invalid_otp: That security code is invalid. You can try entering it again or request

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -26,7 +26,8 @@ en:
       phone: phone
       piv_cac: PIV/CAC
       webauthn: security key
-    first_factor_enabled: Your primary authentication method %{device} has been successfully set up.
+    first_factor_enabled: Your primary authentication method %{device} has been successfully
+      set up.
     header_text: Enter your security code
     invalid_backup_code: That backup code is invalid.
     invalid_otp: That security code is invalid. You can try entering it again or request

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -20,6 +20,13 @@ en:
     backup_code_prompt: You can use this security code once. After you enter it, you'll
       need to use a new key.
     choose_another_option: "‹ Choose another option"
+    devices:
+      auth_app: authentication app
+      backup_code: backup codes
+      phone: phone
+      piv_cac: PIV/CAC
+      webauthn: security key
+    first_factor_enabled: Your primary authentication method %{device} has been successfully set up.
     header_text: Enter your security code
     invalid_backup_code: That backup code is invalid.
     invalid_otp: That security code is invalid. You can try entering it again or request

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -26,7 +26,8 @@ es:
       phone: teléfono
       piv_cac: PIV/CAC
       webauthn: clave de seguridad
-    first_factor_enabled: Su método de autenticación principal %{device} se ha configurado correctamente.
+    first_factor_enabled: Su método de autenticación principal %{device} se ha configurado
+      correctamente.
     header_text: Ingrese su código de seguridad
     invalid_backup_code: Esa código de respaldo no es válida.
     invalid_otp: Ese código de seguridad no es válido. Puede intentar ingresarlo de

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -21,13 +21,13 @@ es:
       need to use a new key.
     choose_another_option: "‹ Elige otra opción"
     devices:
-      auth_app: aplicación de autenticación
-      backup_code: códigos de seguridad personal
-      phone: teléfono
+      auth_app: Aplicación de autenticación
+      backup_code: Códigos de seguridad personal
+      phone: Teléfono
       piv_cac: PIV/CAC
-      webauthn: clave de seguridad
-    first_factor_enabled: Su método de autenticación principal %{device} se ha configurado
-      correctamente.
+      webauthn: Clave de seguridad
+    first_factor_enabled: "%{device} se configuró correctamente como un método de
+      autenticación."
     header_text: Ingrese su código de seguridad
     invalid_backup_code: Esa código de respaldo no es válida.
     invalid_otp: Ese código de seguridad no es válido. Puede intentar ingresarlo de

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -20,6 +20,13 @@ es:
     backup_code_prompt: You can use this security code once. After you enter it, you'll
       need to use a new key.
     choose_another_option: "‹ Elige otra opción"
+    devices:
+      auth_app: aplicación de autenticación
+      backup_code: códigos de seguridad personal
+      phone: teléfono
+      piv_cac: PIV/CAC
+      webauthn: clave de seguridad
+    first_factor_enabled: Su método de autenticación principal %{device} se ha configurado correctamente.
     header_text: Ingrese su código de seguridad
     invalid_backup_code: Esa código de respaldo no es válida.
     invalid_otp: Ese código de seguridad no es válido. Puede intentar ingresarlo de

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -26,7 +26,8 @@ fr:
       phone: téléphone
       piv_cac: PIV/CAC
       webauthn: clé de sécurité
-    first_factor_enabled: Votre méthode d'authentification principale %{device} a été configurée avec succès.
+    first_factor_enabled: Votre méthode d'authentification principale %{device} a
+      été configurée avec succès.
     header_text: Entrez votre code de sécurité
     invalid_backup_code: Ce code de sauvegarde est invalide.
     invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l'entrer

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -21,13 +21,12 @@ fr:
       need to use a new key.
     choose_another_option: "‹ Choisissez une autre option"
     devices:
-      auth_app: application d'authentification
-      backup_code: codes de sécurité personnels
-      phone: téléphone
+      auth_app: Application d'authentification
+      backup_code: Codes de sécurité personnels
+      phone: Téléphone
       piv_cac: PIV/CAC
-      webauthn: clé de sécurité
-    first_factor_enabled: Votre méthode d'authentification principale %{device} a
-      été configurée avec succès.
+      webauthn: Clé de sécurité
+    first_factor_enabled: "%{device} a été configuré avec succès comme méthode d'authentification."
     header_text: Entrez votre code de sécurité
     invalid_backup_code: Ce code de sauvegarde est invalide.
     invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l'entrer

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -20,6 +20,13 @@ fr:
     backup_code_prompt: You can use this security code once. After you enter it, you'll
       need to use a new key.
     choose_another_option: "‹ Choisissez une autre option"
+    devices:
+      auth_app: application d'authentification
+      backup_code: codes de sécurité personnels
+      phone: téléphone
+      piv_cac: PIV/CAC
+      webauthn: clé de sécurité
+    first_factor_enabled: Votre méthode d'authentification principale %{device} a été configurée avec succès.
     header_text: Entrez votre code de sécurité
     invalid_backup_code: Ce code de sauvegarde est invalide.
     invalid_otp: Ce code de sécurité est non valide. Vous pouvez essayer de l'entrer

--- a/spec/features/backup_mfa/sign_up_spec.rb
+++ b/spec/features/backup_mfa/sign_up_spec.rb
@@ -7,9 +7,9 @@ shared_examples 'setting up backup mfa on sign up' do
     fill_in 'password_form_password', with: 'salty pickles'
     click_button t('forms.buttons.continue')
 
-    choose_and_confirm_mfa
+    device = choose_and_confirm_mfa
 
-    expect_back_mfa_setup_to_be_required
+    expect_back_mfa_setup_to_be_required(device)
 
     expect(page).to have_current_path(account_path)
     expect(page).to have_content(t('titles.account'))
@@ -18,9 +18,9 @@ shared_examples 'setting up backup mfa on sign up' do
 
   it 'requires backup mfa on sp sign up' do
     user = visit_idp_from_sp_and_sign_up
-    choose_and_confirm_mfa
+    device = choose_and_confirm_mfa
 
-    expect_back_mfa_setup_to_be_required
+    expect_back_mfa_setup_to_be_required(device)
 
     expect(page).to have_current_path(sign_up_completed_path)
 
@@ -30,14 +30,16 @@ shared_examples 'setting up backup mfa on sign up' do
     expect(user.reload.encrypted_recovery_code_digest).to be_empty
   end
 
-  def expect_back_mfa_setup_to_be_required
+  def expect_back_mfa_setup_to_be_required(device)
     expect(page).to have_current_path(two_factor_options_path)
     expect(page).to have_content t('two_factor_authentication.two_factor_recovery_choice')
+    expect(page).to have_content t('two_factor_authentication.first_factor_enabled', device: device)
 
     visit account_path
 
     expect(page).to have_current_path(two_factor_options_path)
     expect(page).to have_content t('two_factor_authentication.two_factor_recovery_choice')
+    expect(page).to have_content t('two_factor_authentication.first_factor_enabled', device: device)
 
     select_2fa_option('sms')
     fill_in 'user_phone_form[phone]', with: '202-555-1111'
@@ -65,6 +67,7 @@ feature 'backup mfa setup on sign up' do
       click_send_security_code
       fill_in_code_with_last_phone_otp
       click_submit_default
+      :phone
     end
 
     it_behaves_like 'setting up backup mfa on sign up'
@@ -77,6 +80,7 @@ feature 'backup mfa setup on sign up' do
       click_send_security_code
       fill_in_code_with_last_phone_otp
       click_submit_default
+      :phone
     end
 
     it_behaves_like 'setting up backup mfa on sign up'
@@ -87,6 +91,7 @@ feature 'backup mfa setup on sign up' do
       select_2fa_option('auth_app')
       fill_in :code, with: totp_secret_from_page
       click_submit_default
+      :auth_app
     end
 
     def totp_secret_from_page
@@ -104,6 +109,7 @@ feature 'backup mfa setup on sign up' do
 
     def choose_and_confirm_mfa
       set_up_2fa_with_piv_cac
+      :piv_cac
     end
 
     it_behaves_like 'setting up backup mfa on sign up'
@@ -119,6 +125,7 @@ feature 'backup mfa setup on sign up' do
       fill_in_nickname_and_click_continue
       mock_press_button_on_hardware_key_on_setup
       click_button t('forms.buttons.continue')
+      :webauthn
     end
 
     it_behaves_like 'setting up backup mfa on sign up'

--- a/spec/features/backup_mfa/sign_up_spec.rb
+++ b/spec/features/backup_mfa/sign_up_spec.rb
@@ -33,13 +33,13 @@ shared_examples 'setting up backup mfa on sign up' do
   def expect_back_mfa_setup_to_be_required(device)
     expect(page).to have_current_path(two_factor_options_path)
     expect(page).to have_content t('two_factor_authentication.two_factor_recovery_choice')
-    expect(page).to have_content t('two_factor_authentication.first_factor_enabled', device: device)
+    expect(page).to have_content first_factor_enabled_message(device)
 
     visit account_path
 
     expect(page).to have_current_path(two_factor_options_path)
     expect(page).to have_content t('two_factor_authentication.two_factor_recovery_choice')
-    expect(page).to have_content t('two_factor_authentication.first_factor_enabled', device: device)
+    expect(page).to have_content first_factor_enabled_message(device)
 
     select_2fa_option('sms')
     fill_in 'user_phone_form[phone]', with: '202-555-1111'
@@ -53,6 +53,11 @@ shared_examples 'setting up backup mfa on sign up' do
     visit_idp_from_sp_with_loa1(:oidc)
     confirm_email_and_password(email)
     User.find_with_email(email)
+  end
+
+  def first_factor_enabled_message(device)
+    dmsg = t("two_factor_authentication.devices.#{device}")
+    t('two_factor_authentication.first_factor_enabled', device: dmsg)
   end
 end
 

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -4,7 +4,8 @@ feature 'sign up with backup code' do
   include DocAuthHelper
 
   it 'works' do
-    sign_up_and_set_password
+    user = sign_up_and_set_password
+    expect(FirstMfaEnabledForUser.call(user)).to eq(:error)
     select_2fa_option('backup_code')
 
     expect(page).to have_link(t('forms.backup_code.download'))
@@ -13,6 +14,7 @@ feature 'sign up with backup code' do
     click_on 'Continue'
 
     expect(current_path).to eq account_path
+    expect(FirstMfaEnabledForUser.call(user)).to eq(:backup_code)
   end
 
   it 'does not show download button on a mobile device' do


### PR DESCRIPTION
**Why**:  So a user knows their first method was setup correctly

**How**:  Add a service class FirstMfaEnabledForUser and use the device as the key the message to show to the user in the presenter

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
