### PR TITLE
Index email addresses on confirmation_token

### DIFF
--- a/db/migrate/20190620204206_add_confirmation_token_index_to_email_address.rb
+++ b/db/migrate/20190620204206_add_confirmation_token_index_to_email_address.rb
@@ -1,0 +1,7 @@
+class AddConfirmationTokenIndexToEmailAddress < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :email_addresses, :confirmation_token, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190620204206_add_confirmation_token_index_to_email_address.rb
+++ b/db/migrate/20190620204206_add_confirmation_token_index_to_email_address.rb
@@ -2,6 +2,6 @@ class AddConfirmationTokenIndexToEmailAddress < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
-    add_index :email_addresses, :confirmation_token, algorithm: :concurrently
+    add_index :email_addresses, :confirmation_token, algorithm: :concurrently, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190604110233) do
+ActiveRecord::Schema.define(version: 20190620204206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 20190604110233) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_sign_in_at"
+    t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_all_email_fingerprints"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
     t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20190620204206) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_sign_in_at"
-    t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token"
+    t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token", unique: true
     t.index ["email_fingerprint"], name: "index_email_addresses_on_all_email_fingerprints"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
     t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }


### PR DESCRIPTION
**Why**: So that user's confirming email addresses won't result in statement timeouts.
