### PR TITLE
Add tests for phone OTP confirmation

### DIFF
--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+describe 'phone otp confirmation' do
+  let(:phone) { '2025551234' }
+  let(:formatted_phone) { PhoneFormatter.format(phone) }
+
+  context 'on sign up as first MFA' do
+    let!(:user) { sign_up_and_set_password }
+
+    it_behaves_like 'otp confirmation', :sms
+    it_behaves_like 'otp confirmation', :voice
+
+    def visit_otp_confirmation(delivery_method)
+      select_2fa_option(delivery_method)
+      fill_in :user_phone_form_phone, with: phone
+      click_send_security_code
+    end
+
+    def expect_successful_otp_confirmation(delivery_method)
+      select_2fa_option(:backup_code)
+      click_continue
+
+      expect(page).to have_current_path(account_path)
+      expect(phone_configuration.confirmed_at).to_not be_nil
+      expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
+    end
+
+    def expect_failed_otp_confirmation(_delivery_method)
+      visit account_path
+
+      expect(current_path).to eq(two_factor_options_path)
+      expect(phone_configuration).to be_nil
+    end
+  end
+
+  context 'on sign up as second MFA method' do
+    let!(:user) { sign_up_and_set_password }
+
+    it_behaves_like 'otp confirmation', :sms
+    it_behaves_like 'otp confirmation', :voice
+
+    def visit_otp_confirmation(delivery_method)
+      select_2fa_option(:sms)
+      fill_in :user_phone_form_phone, with: '2025551313'
+      click_send_security_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      select_2fa_option(delivery_method)
+      fill_in :user_phone_form_phone, with: phone
+      click_send_security_code
+    end
+
+    def expect_successful_otp_confirmation(delivery_method)
+      expect(page).to have_current_path(account_path)
+      expect(phone_configuration.confirmed_at).to_not be_nil
+      expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
+    end
+
+    def expect_failed_otp_confirmation(_delivery_method)
+      visit account_path
+
+      expect(current_path).to eq(two_factor_options_path)
+      expect(phone_configuration).to be_nil
+    end
+  end
+
+  context 'on sign in' do
+    let(:user) { create(:user, :signed_up) }
+    let(:phone) { user.phone_configurations.first.phone }
+
+    it_behaves_like 'otp confirmation', :sms
+    it_behaves_like 'otp confirmation', :voice
+
+    def visit_otp_confirmation(delivery_method)
+      user.phone_configurations.first.update!(delivery_preference: delivery_method)
+      sign_in_user(user)
+    end
+
+    def expect_successful_otp_confirmation(_delivery_method)
+      expect(page).to have_current_path(account_path)
+    end
+
+    def expect_failed_otp_confirmation(delivery_method)
+      visit account_path
+
+      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: delivery_method))
+    end
+  end
+
+  context 'add phone' do
+    let(:user) { create(:user, :signed_up) }
+
+    it_behaves_like 'otp confirmation', :sms
+    it_behaves_like 'otp confirmation', :voice
+
+    def visit_otp_confirmation(delivery_method)
+      sign_in_live_with_2fa(user)
+      click_on t('account.index.phone_add')
+      fill_in :user_phone_form_phone, with: phone
+      choose "user_phone_form_otp_delivery_preference_#{delivery_method}"
+      click_continue
+    end
+
+    def expect_successful_otp_confirmation(delivery_method)
+      expect(phone_configuration.confirmed_at).to_not be_nil
+      expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
+    end
+
+    def expect_failed_otp_confirmation(_delivery_method)
+      expect(phone_configuration).to be_nil
+    end
+  end
+
+  def phone_configuration
+    user.reload.phone_configurations.detect do |phone_configuration|
+      phone_configuration.phone == formatted_phone
+    end
+  end
+end

--- a/spec/support/shared_examples/phone/otp_confirmation.rb
+++ b/spec/support/shared_examples/phone/otp_confirmation.rb
@@ -1,0 +1,56 @@
+shared_examples 'otp confirmation' do |delivery_method|
+  it 'allows the user to confirm a phone' do
+    visit_otp_confirmation(delivery_method)
+    fill_in :code, with: last_otp(delivery_method)
+    click_submit_default
+    expect_successful_otp_confirmation(delivery_method)
+  end
+
+  it 'renders an error if the user enters an incorrect otp' do
+    visit_otp_confirmation(delivery_method)
+    fill_in :code, with: '123456'
+    click_submit_default
+    expect(page).to have_content(t('two_factor_authentication.invalid_otp'))
+    expect_failed_otp_confirmation(delivery_method)
+  end
+
+  it 'renders an error if the user does not enter an otp' do
+    visit_otp_confirmation(delivery_method)
+    fill_in :code, with: ''
+    click_submit_default
+    expect(page).to have_content(t('two_factor_authentication.invalid_otp'))
+    expect_failed_otp_confirmation(delivery_method)
+  end
+
+  it 'renders an error if the OTP has expired' do
+    visit_otp_confirmation(delivery_method)
+    Timecop.travel 11.minutes.from_now do
+      fill_in :code, with: last_otp(delivery_method)
+      click_submit_default
+      expect(page).to have_content(t('two_factor_authentication.invalid_otp'))
+      expect_failed_otp_confirmation(delivery_method)
+    end
+  end
+
+  it 'allows the user to resend an OTP and confirm with the new OTP' do
+    visit_otp_confirmation(delivery_method)
+    old_code = last_otp(delivery_method)
+    click_on t('links.two_factor_authentication.get_another_code')
+    new_code = last_otp(delivery_method)
+
+    expect(old_code).to_not eq(new_code)
+
+    fill_in :code, with: new_code
+    click_submit_default
+
+    expect_successful_otp_confirmation(delivery_method)
+  end
+
+  def last_otp(delivery_method)
+    if delivery_method == :sms
+      last_sms_otp(phone: formatted_phone)
+    else
+      last_voice_otp(phone: formatted_phone)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that we have tests covering OTP confirmation for phones.
