### PR TITLE
add new relic tracers for backgroud jobs

### DIFF
--- a/app/services/job_runner/lock_referee.rb
+++ b/app/services/job_runner/lock_referee.rb
@@ -22,6 +22,14 @@ module JobRunner
       log_done_message
     end
 
+    def log_executing_job_message
+      Rails.logger.info("#{job_configuration}: Executing job")
+    end
+
+    def log_done_message
+      Rails.logger.debug("#{job_configuration}: Done")
+    end
+
     private
 
     def run_needed?
@@ -38,14 +46,6 @@ module JobRunner
     def log_race_lost_message
       race_lost_message = "#{job_configuration}: Due for run, but someone else won the race"
       Rails.logger.info(race_lost_message)
-    end
-
-    def log_executing_job_message
-      Rails.logger.info("#{job_configuration}: Executing job")
-    end
-
-    def log_done_message
-      Rails.logger.debug("#{job_configuration}: Done")
     end
 
     def log_run_not_needed_message(last_run)

--- a/config/initializers/new_relic_tracers.rb
+++ b/config/initializers/new_relic_tracers.rb
@@ -3,6 +3,7 @@
 require 'new_relic/agent/method_tracer'
 require 'aws/ses'
 require 'cloudhsm_jwt'
+require 'newrelic_rpm'
 
 Aws::SES::Base.class_eval do
   include ::NewRelic::Agent::MethodTracer
@@ -80,4 +81,19 @@ TwilioService::Utils.class_eval do
   include ::NewRelic::Agent::MethodTracer
   add_method_tracer :place_call, "Custom/#{name}/place_call"
   add_method_tracer :send_sms, "Custom/#{name}/send_sms"
+end
+
+JobRunner::LockReferee.class_eval do
+  include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+  add_transaction_tracer :log_executing_job_message, :category => :task
+end
+
+JobRunner::LockReferee.class_eval do
+  include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+  add_transaction_tracer :log_done_message, :category => :task
+end
+
+UspsConfirmationUploader.class_eval do
+  include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+  add_transaction_tracer :run, :category => :task
 end


### PR DESCRIPTION
WHY: So Background Jobs are reported to New Relic

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
