### PR TITLE
LG-1458 Fix logic to show sign up completed page

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -6,17 +6,15 @@ module SignUp
     before_action :confirm_two_factor_authenticated
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
+    before_action :redirect_to_account_if_no_issuer
+    before_action :redirect_to_sp_if_user_has_identity_for_issuer
 
     def show
       @view_model = view_model
-      if show_completions_page?
-        analytics.track_event(
-          Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
-          analytics_attributes(''),
+      analytics.track_event(
+        Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
+        analytics_attributes(''),
         )
-      else
-        return_to_account
-      end
     end
 
     def update
@@ -31,14 +29,20 @@ module SignUp
 
     private
 
-    def handle_verified_attributes
-      update_verified_attributes
-      clear_verify_attributes_sessions
+    def redirect_to_account_if_no_issuer
+      redirect_to account_url if sp_session[:issuer].blank?
     end
 
-    def show_completions_page?
-      service_providers = sp_session[:issuer].present? || @view_model.user_has_identities?
-      user_fully_authenticated? && service_providers
+    def redirect_to_sp_if_user_has_identity_for_issuer
+      redirect_to after_sign_in_url if user_has_identity_for_issuer?(sp_session[:issuer])
+    end
+
+    def user_has_identity_for_issuer?(issuer)
+      current_user.identities.where(service_provider: issuer).any?
+    end
+
+    def after_sign_in_url
+      after_sign_in_path_for(current_user)
     end
 
     def view_model

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -6,8 +6,8 @@ module SignUp
     before_action :confirm_two_factor_authenticated
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
-    before_action :redirect_to_account_if_no_issuer, only: :show
-    before_action :redirect_to_account_if_user_has_identity_for_issuer, only: :show
+    before_action :redirect_to_after_sign_in_url_if_no_issuer
+    before_action :redirect_to_after_sign_in_url_if_user_has_identity_for_issuer
 
     def show
       @view_model = view_model
@@ -34,16 +34,20 @@ module SignUp
       clear_verify_attributes_sessions
     end
 
-    def redirect_to_account_if_no_issuer
-      redirect_to account_url if sp_session[:issuer].blank?
+    def redirect_to_after_sign_in_url_if_no_issuer
+      redirect_to after_sign_in_url if sp_session[:issuer].blank?
     end
 
-    def redirect_to_account_if_user_has_identity_for_issuer
-      redirect_to account_url if user_has_identity_for_issuer?(sp_session[:issuer])
+    def redirect_to_after_sign_in_url_if_user_has_identity_for_issuer
+      redirect_to after_sign_in_url if user_has_identity_for_issuer?(sp_session[:issuer])
     end
 
     def user_has_identity_for_issuer?(issuer)
       current_user.identities.where(service_provider: issuer).any?
+    end
+
+    def after_sign_in_url
+      after_sign_in_path_for(current_user)
     end
 
     def view_model

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -14,7 +14,7 @@ module SignUp
       analytics.track_event(
         Analytics::USER_REGISTRATION_AGENCY_HANDOFF_PAGE_VISIT,
         analytics_attributes(''),
-        )
+      )
     end
 
     def update

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -29,6 +29,11 @@ module SignUp
 
     private
 
+    def handle_verified_attributes
+      update_verified_attributes
+      clear_verify_attributes_sessions
+    end
+
     def redirect_to_account_if_no_issuer
       redirect_to account_url if sp_session[:issuer].blank?
     end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -7,7 +7,7 @@ module SignUp
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
     before_action :redirect_to_account_if_no_issuer
-    before_action :redirect_to_account_if_user_has_identity_for_issuer
+    before_action :redirect_to_sp_if_user_has_identity_for_issuer
 
     def show
       @view_model = view_model
@@ -38,8 +38,8 @@ module SignUp
       redirect_to account_url if sp_session[:issuer].blank?
     end
 
-    def redirect_to_account_if_user_has_identity_for_issuer
-      redirect_to account_url if user_has_identity_for_issuer?(sp_session[:issuer])
+    def redirect_to_sp_if_user_has_identity_for_issuer
+      redirect_to sp_session[:request_url] if user_has_identity_for_issuer?(sp_session[:issuer])
     end
 
     def user_has_identity_for_issuer?(issuer)

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -7,7 +7,7 @@ module SignUp
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
     before_action :redirect_to_account_if_no_issuer
-    before_action :redirect_to_sp_if_user_has_identity_for_issuer
+    before_action :redirect_to_account_if_user_has_identity_for_issuer
 
     def show
       @view_model = view_model
@@ -38,8 +38,8 @@ module SignUp
       redirect_to account_url if sp_session[:issuer].blank?
     end
 
-    def redirect_to_sp_if_user_has_identity_for_issuer
-      redirect_to after_sign_in_url if user_has_identity_for_issuer?(sp_session[:issuer])
+    def redirect_to_account_if_user_has_identity_for_issuer
+      redirect_to account_url if user_has_identity_for_issuer?(sp_session[:issuer])
     end
 
     def user_has_identity_for_issuer?(issuer)

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -6,8 +6,8 @@ module SignUp
     before_action :confirm_two_factor_authenticated
     before_action :verify_confirmed, if: :loa3?
     before_action :apply_secure_headers_override, only: :show
-    before_action :redirect_to_account_if_no_issuer
-    before_action :redirect_to_sp_if_user_has_identity_for_issuer
+    before_action :redirect_to_account_if_no_issuer, only: :show
+    before_action :redirect_to_account_if_user_has_identity_for_issuer, only: :show
 
     def show
       @view_model = view_model
@@ -38,16 +38,12 @@ module SignUp
       redirect_to account_url if sp_session[:issuer].blank?
     end
 
-    def redirect_to_sp_if_user_has_identity_for_issuer
-      redirect_to sp_session[:request_url] if user_has_identity_for_issuer?(sp_session[:issuer])
+    def redirect_to_account_if_user_has_identity_for_issuer
+      redirect_to account_url if user_has_identity_for_issuer?(sp_session[:issuer])
     end
 
     def user_has_identity_for_issuer?(issuer)
       current_user.identities.where(service_provider: issuer).any?
-    end
-
-    def after_sign_in_url
-      after_sign_in_path_for(current_user)
     end
 
     def view_model

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -89,7 +89,7 @@ describe SignUp::CompletionsController do
       subject.session[:sp] = {}
       get :show
 
-      expect(response).to render_template(:show)
+      expect(response).to redirect_to(account_url)
     end
   end
 
@@ -100,12 +100,15 @@ describe SignUp::CompletionsController do
       @linker = instance_double(IdentityLinker)
       allow(@linker).to receive(:link_identity).and_return(true)
       allow(IdentityLinker).to receive(:new).and_return(@linker)
+      allow_any_instance_of(SignUp::CompletionsController).to \
+        receive(:user_has_identity_for_issuer?).and_return(false)
     end
 
     context 'LOA1' do
       it 'tracks analytics' do
         stub_sign_in
         subject.session[:sp] = {
+          issuer: 'foo',
           loa3: false,
           request_url: 'http://example.com',
         }
@@ -123,6 +126,7 @@ describe SignUp::CompletionsController do
       it 'updates verified attributes' do
         stub_sign_in
         subject.session[:sp] = {
+          issuer: 'foo',
           loa3: false,
           request_url: 'http://example.com',
           requested_attributes: ['email'],
@@ -137,6 +141,7 @@ describe SignUp::CompletionsController do
         user = create(:user, profiles: [create(:profile, :verified, :active)])
         stub_sign_in(user)
         subject.session[:sp] = {
+          issuer: 'foo',
           loa3: true,
           request_url: 'http://example.com',
         }
@@ -155,6 +160,7 @@ describe SignUp::CompletionsController do
         user = create(:user, profiles: [create(:profile, :verified, :active)])
         stub_sign_in(user)
         subject.session[:sp] = {
+          issuer: 'foo',
           loa3: true,
           request_url: 'http://example.com',
           requested_attributes: %w[email first_name],


### PR DESCRIPTION
**Why**: Users only need to consent to an sp once in IAL1.  This also fixes the analytics.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
