### PR TITLE
LG-1440 Make the phone option say "second phone" after setting up a phone

### DIFF
--- a/app/policies/two_factor_authentication/phone_policy.rb
+++ b/app/policies/two_factor_authentication/phone_policy.rb
@@ -20,6 +20,10 @@ module TwoFactorAuthentication
       true
     end
 
+    def second_phone?
+      mfa_user.phone_configurations.any?
+    end
+
     private
 
     attr_reader :mfa_user

--- a/app/presenters/two_factor_authentication/second_phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/second_phone_selection_presenter.rb
@@ -1,0 +1,24 @@
+module TwoFactorAuthentication
+  class SecondPhoneSelectionPresenter < PhoneSelectionPresenter
+    attr_reader :current_phone_configuration
+
+    def initialize(current_phone_configuration)
+      @current_phone_configuration = current_phone_configuration
+    end
+
+    def method
+      :phone
+    end
+
+    def label
+      t('two_factor_authentication.two_factor_choice_options.second_phone')
+    end
+
+    def info
+      t(
+        'two_factor_authentication.two_factor_choice_options.second_phone_info_html',
+        phone: current_phone_configuration.phone,
+      )
+    end
+  end
+end

--- a/app/presenters/two_factor_authentication/second_phone_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/second_phone_selection_presenter.rb
@@ -17,8 +17,15 @@ module TwoFactorAuthentication
     def info
       t(
         'two_factor_authentication.two_factor_choice_options.second_phone_info_html',
-        phone: current_phone_configuration.phone,
+        phone: masked_number(current_phone_configuration.phone),
       )
+    end
+
+    private
+
+    def masked_number(number)
+      return '' if number.blank?
+      "***-***-#{number[-4..-1]}"
     end
   end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -49,10 +49,14 @@ class TwoFactorOptionsPresenter
   end
 
   def phone_options
-    if TwoFactorAuthentication::PhonePolicy.new(current_user).available?
-      [TwoFactorAuthentication::PhoneSelectionPresenter.new]
+    if TwoFactorAuthentication::PhonePolicy.new(current_user).second_phone?
+      [
+        TwoFactorAuthentication::SecondPhoneSelectionPresenter.new(
+          current_user.phone_configurations.take,
+        ),
+      ]
     else
-      []
+      [TwoFactorAuthentication::PhoneSelectionPresenter.new]
     end
   end
 

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -128,6 +128,9 @@ en:
       phone_info_html: Get your security code via text message (SMS) or phone call
       piv_cac: Government employees
       piv_cac_info_html: Use your PIV/CAC card to secure your account
+      second_phone: Second phone
+      second_phone_info_html: Get a security code by text message (SMS) or phone call
+        to a phone number that is not %{phone}
       sms: Text message / SMS
       sms_info_html: Get your security code via text message / SMS
       voice: Phone call

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -130,7 +130,7 @@ en:
       piv_cac_info_html: Use your PIV/CAC card to secure your account
       second_phone: Second phone
       second_phone_info_html: Get a security code by text message (SMS) or phone call
-        to a phone number that is not %{phone}
+        to a secondary phone number (one that is not %{phone})
       sms: Text message / SMS
       sms_info_html: Get your security code via text message / SMS
       voice: Phone call

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -137,6 +137,9 @@ es:
         / SMS o de una llamada telefónica
       piv_cac: Empleados del Gobierno
       piv_cac_info_html: Use su tarjeta PIV / CAC para asegurar su cuenta
+      second_phone: Segundo telefono
+      second_phone_info_html: Obtenga un código de seguridad por mensaje de texto
+        (SMS) o llame a un número de teléfono que no sea %{phone}
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto
         / SMS

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -49,8 +49,8 @@ es:
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto
         / SMS a <strong>%{phone}</strong>.
-      sms_setup_info_html: Obtenga su código de seguridad a través de mensajes de
-        texto / SMS.
+      sms_setup_info_html: Obtenga un código de seguridad por mensaje de texto (SMS)
+        o llame a un número de teléfono secundario (uno que no sea %{phone})
       voice: Llamada telefónica automatizada
       voice_info_html: Obtenga su código de seguridad a través de una llamada telefónica
         a <strong>%{phone}</strong>. (Solo números de teléfono de América del Norte).

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -49,8 +49,8 @@ es:
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto
         / SMS a <strong>%{phone}</strong>.
-      sms_setup_info_html: Obtenga un código de seguridad por mensaje de texto (SMS)
-        o llame a un número de teléfono secundario (uno que no sea %{phone})
+      sms_setup_info_html: Obtenga su código de seguridad a través de mensajes de
+        texto / SMS.
       voice: Llamada telefónica automatizada
       voice_info_html: Obtenga su código de seguridad a través de una llamada telefónica
         a <strong>%{phone}</strong>. (Solo números de teléfono de América del Norte).
@@ -139,7 +139,7 @@ es:
       piv_cac_info_html: Use su tarjeta PIV / CAC para asegurar su cuenta
       second_phone: Segundo telefono
       second_phone_info_html: Obtenga un código de seguridad por mensaje de texto
-        (SMS) o llame a un número de teléfono que no sea %{phone}
+        (SMS) o por llamada a un número de teléfono secundario (uno que no es %{phone})
       sms: Mensaje de texto / SMS
       sms_info_html: Obtenga su código de seguridad a través de mensajes de texto
         / SMS

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -137,7 +137,7 @@ fr:
       piv_cac_info_html: Utilisez votre carte PIV / CAC pour sécuriser votre compte
       second_phone: Deuxième téléphone
       second_phone_info_html: Recevez un code de sécurité par SMS ou appel téléphonique
-        à un numéro de téléphone autre que %{phone}
+        vers un numéro de téléphone secondaire (autre que le %{phone})
       sms: SMS
       sms_info_html: Obtenez votre code de sécurité par SMS
       voice: Appel téléphonique

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -135,6 +135,9 @@ fr:
       phone_info_html: Obtenez votre code de sécurité par SMS ou par appel téléphonique
       piv_cac: Employés du gouvernement
       piv_cac_info_html: Utilisez votre carte PIV / CAC pour sécuriser votre compte
+      second_phone: Deuxième téléphone
+      second_phone_info_html: Recevez un code de sécurité par SMS ou appel téléphonique
+        à un numéro de téléphone autre que %{phone}
       sms: SMS
       sms_info_html: Obtenez votre code de sécurité par SMS
       voice: Appel téléphonique

--- a/spec/features/backup_mfa/second_phone_spec.rb
+++ b/spec/features/backup_mfa/second_phone_spec.rb
@@ -24,7 +24,7 @@ feature 'setting up a second phone as backup MFA' do
     expect(page).to have_content(
       t(
         'two_factor_authentication.two_factor_choice_options.second_phone_info_html',
-        phone: '+1 202-555-1234',
+        phone: '***-***-1234',
       ),
     )
 

--- a/spec/features/backup_mfa/second_phone_spec.rb
+++ b/spec/features/backup_mfa/second_phone_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+feature 'setting up a second phone as backup MFA' do
+  scenario 'seeing "second phone" as the phone option' do
+    create(:user, :unconfirmed)
+    confirm_last_user
+    fill_in 'password_form_password', with: 'salty pickles'
+    click_button t('forms.buttons.continue')
+
+    expect(page).to have_content(t('two_factor_authentication.two_factor_choice_options.phone'))
+    expect(page).to have_content(
+      t('two_factor_authentication.two_factor_choice_options.phone_info_html'),
+    )
+
+    select_2fa_option(:phone)
+    fill_in :user_phone_form_phone, with: '2025551234'
+    click_send_security_code
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(page).to have_content(
+      t('two_factor_authentication.two_factor_choice_options.second_phone'),
+    )
+    expect(page).to have_content(
+      t(
+        'two_factor_authentication.two_factor_choice_options.second_phone_info_html',
+        phone: '+1 202-555-1234',
+      ),
+    )
+
+    select_2fa_option(:phone)
+    fill_in :user_phone_form_phone, with: '2025555678'
+    click_send_security_code
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(page).to have_current_path(account_path)
+  end
+end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -31,9 +31,9 @@ describe TwoFactorOptionsPresenter do
     context 'with a user with a phone configured' do
       let(:user) { build(:user, :with_phone) }
 
-      it 'supplies all the options' do
+      it 'supplies all the options with second phone options' do
         expect(presenter.options.map(&:class)).to eq [
-          TwoFactorAuthentication::PhoneSelectionPresenter,
+          TwoFactorAuthentication::SecondPhoneSelectionPresenter,
           TwoFactorAuthentication::AuthAppSelectionPresenter,
           TwoFactorAuthentication::WebauthnSelectionPresenter,
           TwoFactorAuthentication::BackupCodeSelectionPresenter,


### PR DESCRIPTION
**Why**: So that users will know they cannot user the same phone number as they did for their first one if they selection this option