### PR TITLE
LG-1459 Fix logic to go to sign up completed page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,11 +243,11 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   def user_needs_sign_up_completed_page?
     issuer = sp_session[:issuer]
     return false unless issuer
-    !user_has_identity_for_issuer?(issuer)
+    !user_has_ial1_identity_for_issuer?(issuer)
   end
 
-  def user_has_identity_for_issuer?(issuer)
-    current_user.identities.where(service_provider: issuer).any?
+  def user_has_ial1_identity_for_issuer?(issuer)
+    current_user.identities.where(service_provider: issuer, ial: 1).any?
   end
 
   def analytics_exception_info(exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   def after_multiple_2fa_sign_up
-    if session[:sp]
+    if user_needs_sign_up_completed_page?
       sign_up_completed_url
     elsif current_user.decorate.password_reset_profile.present?
       reactivate_account_url
@@ -238,6 +238,16 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
 
   def render_full_width(template, **opts)
     render template, **opts, layout: 'base'
+  end
+
+  def user_needs_sign_up_completed_page?
+    issuer = sp_session[:issuer]
+    return false unless issuer
+    !user_has_identity_for_issuer?(issuer)
+  end
+
+  def user_has_identity_for_issuer?(issuer)
+    current_user.identities.where(service_provider: issuer).any?
   end
 
   def analytics_exception_info(exception)

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -59,7 +59,7 @@ module SignUp
     end
 
     def return_to_account
-      track_completion_event('account-page')
+      track_completion_event('account-page') if user_needs_sign_up_completed_page?
       redirect_to account_url
     end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -20,7 +20,7 @@ module SignUp
     end
 
     def update
-      track_completion_event('agency-page')
+      track_completion_event('agency-page') if user_needs_sign_up_completed_page?
       handle_verified_attributes
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app

--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -29,7 +29,7 @@ module SignUp
     end
 
     def next_step
-      if session[:sp]
+      if user_needs_sign_up_completed_page?
         sign_up_completed_url
       elsif current_user.decorate.password_reset_profile.present?
         reactivate_account_url

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -36,7 +36,7 @@ module Users
     def next_step
       if current_user.decorate.password_reset_profile.present?
         reactivate_account_url
-      elsif session[:sp] && user_has_not_visited_any_sp_yet?
+      elsif user_needs_sign_up_completed_page?
         sign_up_completed_url
       else
         after_sign_in_path_for(current_user)

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -36,7 +36,7 @@ module Users
     def next_step
       if current_user.decorate.password_reset_profile.present?
         reactivate_account_url
-      elsif user_needs_sign_up_completed_page?
+      elsif session[:sp] && user_has_not_visited_any_sp_yet?
         sign_up_completed_url
       else
         after_sign_in_path_for(current_user)

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -107,6 +107,7 @@ describe SignUp::CompletionsController do
         stub_sign_in
         subject.session[:sp] = {
           loa3: false,
+          issuer: 'foo',
           request_url: 'http://example.com',
         }
 
@@ -137,6 +138,7 @@ describe SignUp::CompletionsController do
         user = create(:user, profiles: [create(:profile, :verified, :active)])
         stub_sign_in(user)
         subject.session[:sp] = {
+          issuer: 'foo',
           loa3: true,
           request_url: 'http://example.com',
         }

--- a/spec/controllers/sign_up/personal_keys_controller_spec.rb
+++ b/spec/controllers/sign_up/personal_keys_controller_spec.rb
@@ -32,7 +32,8 @@ describe SignUp::PersonalKeysController do
   describe '#update' do
     context 'sp present' do
       it 'redirects to the sign up completed url' do
-        subject.session[:sp] = 'true'
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        subject.session[:sp] = { issuer: sp.issuer, request_id: '123' }
         stub_sign_in
 
         patch :update
@@ -52,7 +53,8 @@ describe SignUp::PersonalKeysController do
     end
 
     it 'tracks CSRF errors' do
-      subject.session[:sp] = 'true'
+      sp = ServiceProvider.from_issuer('http://localhost:3000')
+      subject.session[:sp] = { issuer: sp.issuer, request_id: '123' }
       stub_sign_in
       stub_analytics
       analytics_hash = {


### PR DESCRIPTION
**Why**: Users only need to consent to an sp once in IAL1.  This also fixes the analytics.

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
