### PR TITLE
Store signing_up session value in the user session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   def two_2fa_setup
-    if MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+    if MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled?
       after_multiple_2fa_sign_up
     else
       two_factor_options_url
@@ -196,7 +196,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     return redirect_to(new_user_session_url(request_id: id)) if !user_signed_in? && id.present?
     authenticate_user!(force: true)
     return if user_fully_authenticated? &&
-              MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+              MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled?
     return prompt_to_set_up_2fa if user_fully_authenticated? || !two_factor_enabled?
     prompt_to_enter_otp
   end

--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -5,7 +5,7 @@ module MfaSetupConcern
     authenticate_user!(force: true)
     return if user_fully_authenticated?
     return unless MfaPolicy.new(current_user).two_factor_enabled? &&
-                  !session[:signing_up]
+                  !user_session[:signing_up]
     redirect_to user_two_factor_authentication_url
   end
 end

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -42,7 +42,7 @@ module UnconfirmedUserConcern
   def after_confirmation_url_for(user)
     if !user_signed_in?
       new_user_session_url
-    elsif MfaPolicy.new(user, session[:signing_up]).sufficient_factors_enabled?
+    elsif MfaPolicy.new(user, user_session[:signing_up]).sufficient_factors_enabled?
       account_url
     else
       two_factor_options_url

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -15,7 +15,7 @@ module OpenidConnect
     def index
       link_identity_to_service_provider
       return redirect_to two_factor_options_url unless
-        MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+        MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled?
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
       handle_successful_handoff

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -19,7 +19,7 @@ class SamlIdpController < ApplicationController
     link_identity_from_session_data
     capture_analytics
     return redirect_to two_factor_options_url unless
-      MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+      MfaPolicy.new(current_user).sufficient_factors_enabled?
     return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
     return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
     handle_successful_handoff

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -69,7 +69,7 @@ module SignUp
 
     def sign_in_and_redirect_user
       sign_in @user
-      session[:signing_up] = true
+      user_session[:signing_up] = true
       redirect_to after_confirmation_url_for(@user)
     end
   end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -26,7 +26,7 @@ module TwoFactorAuthentication
     def confirm_multiple_factors_enabled
       return if confirmation_context? || phone_enabled?
 
-      if MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled? &&
+      if MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled? &&
          !phone_enabled? && user_signed_in?
         return redirect_to user_two_factor_authentication_url
       end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -44,7 +44,7 @@ module TwoFactorAuthentication
     end
 
     def next_step
-      if MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+      if MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled?
         after_otp_verification_confirmation_url
       else
         two_factor_options_url

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -83,7 +83,7 @@ module Users
     end
 
     def next_step
-      if MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+      if MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled?
         account_url
       else
         two_factor_options_url

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -44,7 +44,7 @@ module Users
 
     def track_event
       properties = {
-        user_signed_up: MfaPolicy.new(current_user, session[:signing_up]).
+        user_signed_up: MfaPolicy.new(current_user, user_session[:signing_up]).
                    sufficient_factors_enabled?,
         totp_secret_present: new_totp_secret.present?,
       }

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -30,13 +30,13 @@ module Users
     private
 
     def two_factor_options_presenter
-      TwoFactorOptionsPresenter.new(current_user, current_sp, session[:signing_up])
+      TwoFactorOptionsPresenter.new(current_user, current_sp, user_session[:signing_up])
     end
 
     def backup_code_only_processing
-      if session[:signing_up] &&
+      if user_session[:signing_up] &&
          @two_factor_options_form.selection == 'backup_code_only'
-        session[:signing_up] = false
+        user_session[:signing_up] = false
         redirect_to account_url
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,8 @@ class UsersController < ApplicationController
   end
 
   def signed_in_user_with_multiple_mfa?
-    current_user && MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled?
+    current_user && MfaPolicy.new(
+      current_user, user_session[:signing_up]
+    ).sufficient_factors_enabled?
   end
 end

--- a/app/views/shared/_cancel_or_back_to_options.html.erb
+++ b/app/views/shared/_cancel_or_back_to_options.html.erb
@@ -1,5 +1,5 @@
 <div class="mt2 pt1 border-top">
-  <% if MfaPolicy.new(current_user, session[:signing_up]).sufficient_factors_enabled? %>
+  <% if MfaPolicy.new(current_user, user_session[:signing_up]).sufficient_factors_enabled? %>
     <%= link_to t('links.cancel'), account_path, class: 'h5' %>
   <% else %>
     <%= link_to t('two_factor_authentication.choose_another_option'), two_factor_options_path %>

--- a/spec/views/users/piv_cac_authentication_setup/new.html.slim_spec.rb
+++ b/spec/views/users/piv_cac_authentication_setup/new.html.slim_spec.rb
@@ -5,6 +5,7 @@ describe 'users/piv_cac_authentication_setup/new.html.slim' do
     it 'renders a link to cancel and go back to the account page' do
       user = create(:user, :signed_up)
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:user_session).and_return(signing_up: false)
       form = OpenStruct.new
       @presenter = PivCacAuthenticationSetupPresenter.new(user, true, form)
 
@@ -18,6 +19,7 @@ describe 'users/piv_cac_authentication_setup/new.html.slim' do
     it 'renders a link to choose a different option' do
       user = create(:user)
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:user_session).and_return(signing_up: true)
       form = OpenStruct.new
       @presenter = PivCacAuthenticationSetupPresenter.new(user, false, form)
 

--- a/spec/views/users/totp_setup/new.html.slim_spec.rb
+++ b/spec/views/users/totp_setup/new.html.slim_spec.rb
@@ -6,6 +6,7 @@ describe 'users/totp_setup/new.html.slim' do
   context 'user has sufficient factors enabled' do
     before do
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:user_session).and_return(signing_up: false)
       @code = 'D4C2L47CVZ3JJHD7'
       @qrcode = 'qrcode.png'
       @presenter = SetupPresenter.new(user, true)
@@ -34,6 +35,7 @@ describe 'users/totp_setup/new.html.slim' do
     it 'renders a link to choose a different option' do
       user = create(:user)
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:user_session).and_return(signing_up: true)
       allow(view).to receive(:user_fully_authenticated?).and_return(false)
       @code = 'D4C2L47CVZ3JJHD7'
       @qrcode = 'qrcode.png'


### PR DESCRIPTION
**Why**: So that it is cleared when the user signs out and does not affect other users.
