### PR TITLE
Show the last signed in email address on the account page

### DIFF
--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -148,7 +148,7 @@ class AccountShow # rubocop:disable Metrics/ClassLength
   def header_personalization
     return decrypted_pii.first_name if decrypted_pii.present?
 
-    decorated_user.email
+    EmailContext.new(decorated_user.user).last_sign_in_email_address.email
   end
 
   def totp_content

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -34,4 +34,24 @@ feature 'sign in with any email address' do
     expect(page).to have_content(error_message)
     expect(page).to have_current_path(new_user_session_path)
   end
+
+  scenario 'it shows the email address used to sign in on the account page' do
+    user = create(:user, :signed_up, :with_multiple_emails)
+
+    email1, email2 = user.reload.email_addresses.map(&:email)
+
+    signin(email1, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(page).to have_content([t('account.welcome'), email1].join(', '))
+
+    Capybara.reset_session!
+
+    signin(email2, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+
+    expect(page).to have_content([t('account.welcome'), email2].join(', '))
+  end
 end

--- a/spec/view_models/account_show_spec.rb
+++ b/spec/view_models/account_show_spec.rb
@@ -169,12 +169,15 @@ describe AccountShow do
     end
 
     context 'AccountShow instance does not have decrypted_pii' do
-      it "returns the user's email" do
-        email = 'john@smith.com'
-        user = build(:user, :with_email, email: email).decorate
-        profile_index = AccountShow.new(decrypted_pii: {}, personal_key: '', decorated_user: user)
+      it 'returns the email the user used to sign in last' do
+        decorated_user = create(:user, :with_multiple_emails).decorate
+        email_address = decorated_user.user.reload.email_addresses.last
+        email_address.update!(last_sign_in_at: 1.minute.from_now)
+        profile_index = AccountShow.new(
+          decrypted_pii: {}, personal_key: '', decorated_user: decorated_user,
+        )
 
-        expect(profile_index.header_personalization).to eq email
+        expect(profile_index.header_personalization).to eq email_address.email
       end
     end
   end


### PR DESCRIPTION
**Why**: To reinforce the idea that the email address the user used to log in as is the one that we use for them and send to SPs.
