### PR TITLE
Do not show TOTP success message if it is the first MFA method

### DIFF
--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -59,9 +59,16 @@ module Users
       create_user_event(:authenticator_enabled)
       mark_user_as_fully_authenticated
       save_remember_device_preference
-      flash[:success] = t('notices.totp_configured')
+      flash[:success] = t('notices.totp_configured') if should_show_totp_configured_message?
       redirect_to url_after_entering_valid_code
       user_session.delete(:new_totp_secret)
+    end
+
+    def should_show_totp_configured_message?
+      # If the user's only MFA method is the one they just setup, then they will be redirected to
+      # the mfa option screen which will show them the first MFA success message. In that case we
+      # do not want to show this additional flash message here.
+      MfaPolicy.new(current_user).multiple_factors_enabled?
     end
 
     def process_successful_disable

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -130,7 +130,6 @@ describe Users::TotpSetupController, devise: true do
 
         it 'redirects to account_path with a success message' do
           expect(response).to redirect_to(account_path)
-          expect(flash[:success]).to eq t('notices.totp_configured')
           expect(subject.user_session[:new_totp_secret]).to be_nil
 
           result = {

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -130,6 +130,7 @@ describe Users::TotpSetupController, devise: true do
 
         it 'redirects to account_path with a success message' do
           expect(response).to redirect_to(account_path)
+          expect(flash[:success]).to eq t('notices.totp_configured')
           expect(subject.user_session[:new_totp_secret]).to be_nil
 
           result = {
@@ -185,7 +186,6 @@ describe Users::TotpSetupController, devise: true do
 
         it 'redirects to setup another factor with a success message' do
           expect(response).to redirect_to(two_factor_options_url)
-          expect(flash[:success]).to eq t('notices.totp_configured')
           expect(subject.user_session[:new_totp_secret]).to be_nil
 
           result = {

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -130,7 +130,6 @@ describe Users::TotpSetupController, devise: true do
 
         it 'redirects to account_path with a success message' do
           expect(response).to redirect_to(account_path)
-          expect(flash[:success]).to eq t('notices.totp_configured')
           expect(subject.user_session[:new_totp_secret]).to be_nil
 
           result = {
@@ -184,8 +183,9 @@ describe Users::TotpSetupController, devise: true do
           patch :confirm, params: { code: generate_totp_code(secret) }
         end
 
-        it 'redirects to setup another factor with a success message' do
+        it 'redirects to setup another factor without a flash message' do
           expect(response).to redirect_to(two_factor_options_url)
+          expect(flash[:success]).to be_nil
           expect(subject.user_session[:new_totp_secret]).to be_nil
 
           result = {

--- a/spec/features/totp/setup_success_message_spec.rb
+++ b/spec/features/totp/setup_success_message_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+feature 'success message for TOTP setup' do
+  context 'the user is setting up TOTP as first MFA method' do
+    it 'shows the fist MFA setup success method' do
+      user = sign_up_and_set_password
+      set_up_2fa_with_authenticator_app
+
+      expect(page).to have_content(
+        t(
+          'two_factor_authentication.first_factor_enabled',
+          device: t('two_factor_authentication.devices.auth_app'),
+        ),
+      )
+      expect(page).to_not have_content(t('notices.totp_configured'))
+    end
+  end
+
+  context 'the user is setting up TOTP as the second MFA method' do
+    it 'shows the TOTP setup success message' do
+      user = sign_up_and_set_password
+      set_up_2fa_with_valid_phone
+      set_up_2fa_with_authenticator_app
+
+      expect(page).to have_content(t('notices.totp_configured'))
+      expect(page).to_not have_content(
+        t(
+          'two_factor_authentication.first_factor_enabled',
+          device: t('two_factor_authentication.devices.auth_app'),
+        ),
+      )
+    end
+  end
+
+  context 'the user is adding TOTP after setting up an account' do
+    it 'shows the TOTP setup success message' do
+      user = create(:user, :signed_up)
+
+      sign_in_live_with_2fa(user)
+
+      click_link t('forms.buttons.enable'), href: authenticator_setup_url
+      secret = find('#qr-code').text
+      fill_in 'code', with: generate_totp_code(secret)
+      click_button 'Submit'
+
+      expect(page).to have_content(t('notices.totp_configured'))
+      expect(page).to_not have_content(
+        t(
+          'two_factor_authentication.first_factor_enabled',
+          device: t('two_factor_authentication.devices.auth_app'),
+        ),
+      )
+    end
+  end
+end

--- a/spec/features/totp/setup_success_message_spec.rb
+++ b/spec/features/totp/setup_success_message_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'success message for TOTP setup' do
   context 'the user is setting up TOTP as first MFA method' do
     it 'shows the fist MFA setup success method' do
-      user = sign_up_and_set_password
+      sign_up_and_set_password
       set_up_2fa_with_authenticator_app
 
       expect(page).to have_content(
@@ -18,7 +18,7 @@ feature 'success message for TOTP setup' do
 
   context 'the user is setting up TOTP as the second MFA method' do
     it 'shows the TOTP setup success message' do
-      user = sign_up_and_set_password
+      sign_up_and_set_password
       set_up_2fa_with_valid_phone
       set_up_2fa_with_authenticator_app
 


### PR DESCRIPTION
**Why**: Because the MFA options screen, which is the next screen in the flow, has it's own separate success message.