### PR TITLE
LG-1478 Bug fix - Webauthn not visible on sign in

### DIFF
--- a/app/javascript/packs/webauthn-unhide-signin.js
+++ b/app/javascript/packs/webauthn-unhide-signin.js
@@ -4,12 +4,12 @@ function unhideWebauthn() {
   if (WebAuthn.isWebAuthnEnabled()) {
     const elem = document.getElementById('select_webauthn');
     if (elem) {
-      elem.classList.remove('hidden');
+      elem.classList.remove('hide');
     }
   } else {
     const checkboxes = document.querySelectorAll('input[name="two_factor_options_form[selection]"]');
     for (let i = 0, len = checkboxes.length; i < len; i += 1) {
-      if (!checkboxes[i].classList.contains('hidden')) {
+      if (!checkboxes[i].classList.contains('hide')) {
         checkboxes[i].checked = true;
         break;
       }

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -1,23 +1,55 @@
 require 'rails_helper'
 
 describe 'webauthn hide' do
-  context 'with javascript enabled', :js do
-    it 'displays the security key option' do
-      sign_up_and_set_password
-      webauthn_option = page.find('label[for=two_factor_options_form_selection_webauthn]')
+  context 'on sign up' do
+    context 'with javascript enabled', :js do
+      it 'displays the security key option' do
+        sign_up_and_set_password
 
-      expect(webauthn_option).to be_visible
+        expect(webauthn_option_hidden?).to eq(false)
+      end
+    end
+
+    context 'with javascript disabled' do
+      it 'does not display the security key option' do
+        sign_up_and_set_password
+
+        expect(webauthn_option_hidden?).to eq(true)
+      end
+    end
+
+    def webauthn_option_hidden?
+      page.find(
+        'label[for=two_factor_options_form_selection_webauthn]',
+      )[:class].include?('hide')
     end
   end
 
-  context 'with javascript disabled' do
-    it 'does not display the security key option' do
-      sign_up_and_set_password
-      webauthn_option = page.find(
-        'label[for=two_factor_options_form_selection_webauthn]',
-      )
+  context 'on sign in' do
+    let(:user) { create(:user, :signed_up, :with_webauthn) }
 
-      expect(webauthn_option[:class]).to include('hide')
+    context 'with javascript enabled', :js do
+      it 'displays the security key option' do
+        sign_in_user(user)
+        click_on t('two_factor_authentication.login_options_link_text')
+
+        expect(webauthn_option_hidden?).to eq(false)
+      end
+    end
+
+    context 'with javascript disabled' do
+      it 'does not display the security key option' do
+        sign_in_user(user)
+        click_on t('two_factor_authentication.login_options_link_text')
+
+        expect(webauthn_option_hidden?).to eq(true)
+      end
+    end
+
+    def webauthn_option_hidden?
+      page.find(
+        'label[for=two_factor_options_form_selection_webauthn]',
+      ).find(:xpath, '..')[:class].include?('hide')
     end
   end
 end


### PR DESCRIPTION
Fixed bug where webauthn is not visible to users on sign in

**Why**: So that users who set up webauthn as a method are able to sign in using webauthn