### PR TITLE
LG-1482 Redirect to SP after backup code only setup

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -37,7 +37,7 @@ module Users
       if user_session[:signing_up] &&
          @two_factor_options_form.selection == 'backup_code_only'
         user_session[:signing_up] = false
-        redirect_to account_url
+        redirect_to two_2fa_setup
       end
     end
 

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'sign up with backup code' do
   include DocAuthHelper
+  include SamlAuthHelper
 
   it 'works' do
     user = sign_up_and_set_password
@@ -63,6 +64,20 @@ feature 'sign up with backup code' do
     select_2fa_option('backup_code_only')
 
     expect(current_path).to eq account_path
+  end
+
+  it 'directs backup code only users to the SP during sign up' do
+    visit_idp_from_sp_with_loa1(:oidc)
+    sign_up_and_set_password
+    select_2fa_option('backup_code')
+    click_on 'Continue'
+    select_2fa_option('backup_code_only')
+
+    expect(page).to have_current_path(sign_up_completed_path)
+
+    click_continue
+
+    expect(current_url).to start_with('http://localhost:7654/auth/result')
   end
 
   def sign_out_user


### PR DESCRIPTION
**Why**: So that users trying to go to an SP land on the SP
