### PR TITLE
LG-1470, 1472, 1473 Log user uuid with OIDC token call

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -137,6 +137,7 @@ class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
   def extra_analytics_attributes
     {
       client_id: client_id,
+      user_id: identity&.user&.uuid,
     }
   end
 

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe OpenidConnect::TokenController do
       it 'tracks a successful event in analytics' do
         stub_analytics
         expect(@analytics).to receive(:track_event).
-          with(Analytics::OPENID_CONNECT_TOKEN, success: true, client_id: client_id, errors: {})
+          with(Analytics::OPENID_CONNECT_TOKEN, success: true, client_id: client_id,
+                                                user_id: user.uuid, errors: {})
 
         action
       end
@@ -73,6 +74,7 @@ RSpec.describe OpenidConnect::TokenController do
           with(Analytics::OPENID_CONNECT_TOKEN,
                success: false,
                client_id: client_id,
+               user_id: user.uuid,
                errors: hash_including(:grant_type))
 
         action

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe OpenidConnectTokenForm do
 
         expect(submission).to eq response
         expect(FormResponse).to have_received(:new).
-          with(success: true, errors: {}, extra: { client_id: client_id })
+          with(success: true, errors: {}, extra: { client_id: client_id, user_id: user.uuid })
       end
     end
 
@@ -326,7 +326,8 @@ RSpec.describe OpenidConnectTokenForm do
 
         expect(submission).to eq response
         expect(FormResponse).to have_received(:new).
-          with(success: false, errors: form.errors.messages, extra: { client_id: nil })
+          with(success: false, errors: form.errors.messages, extra: { client_id: nil,
+                                                                      user_id: nil })
       end
     end
   end


### PR DESCRIPTION
**Why**: So login.gov can easily diagnose SP issues after OTP verification and OIDC authorization.  These issues can be:

1.  missing OIDC token call for a particular user where user gets stuck trying to redirect to the SP.    
2.  token errors such as expiration, mixing PKCE or private key jwt, invalid aud, or inavalid code where the user could get routed back to the login.gov sign in screen by the SP

**How**:  The token call is made from the SP's app server and not via the user's browser so historically the value has been anonymous-uuid.  This is not useful when searching for sequences of user interaction.  Specifically it's difficult to trace if a token call was made for a particular user especially with large volume.  There are other request markers that can be used to distinguish that it is not the browser making this call such as visit_id.  To fetch the right user uuid get if off of the user associated with the identity

Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
