### PR TITLE
Fix French translation for "Email addresses"

### DIFF
--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -16,7 +16,7 @@ fr:
       dob: Date de naissance
       email: Adresse courriel
       email_add: "+ Ajouter un email"
-      email_addresses: Adresse courrieles
+      email_addresses: Adresses courriel
       full_name: Nom complet
       login: Information de connexion
       password: Mot de passe


### PR DESCRIPTION
**Why**: So the translation is correct.
