### PR TITLE
LG-1498 Fix OIDC prompt=login automatic sign out after sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -229,8 +229,8 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
 
   def sp_session_request_url_without_prompt_login
     # login.gov redirects to the orginal request_url after a user authenticates
-    # strip prompt=login to prevent sign_out
-    # which should only occur once when the user lands on login.gov
+    # replace prompt=login with prompt=select_account to prevent sign_out
+    # which should only every occur once when the user lands on login.gov with prompt=login
     url = sp_session[:request_url]
     url ? url.gsub('prompt=login', 'prompt=select_account') : nil
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,7 +131,8 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   def after_sign_in_path_for(_user)
-    user_session.delete(:stored_location) || sp_session[:request_url] || signed_in_url
+    user_session.delete(:stored_location) || sp_session_request_url_without_prompt_login ||
+      signed_in_url
   end
 
   def signed_in_url
@@ -224,6 +225,13 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
 
   def sp_session
     session.fetch(:sp, {})
+  end
+
+  def sp_session_request_url_without_prompt_login
+    # login.gov redirects to the orginal request_url after a user authenticates
+    # strip prompt=login to prevent sign_out
+    # which should only occur once when the user lands on login.gov
+    sp_session[:request_url].to_s.gsub('prompt=login', 'prompt=select_account')
   end
 
   def render_not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -231,7 +231,8 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     # login.gov redirects to the orginal request_url after a user authenticates
     # strip prompt=login to prevent sign_out
     # which should only occur once when the user lands on login.gov
-    sp_session[:request_url].to_s.gsub('prompt=login', 'prompt=select_account')
+    url = sp_session[:request_url]
+    url ? url.gsub('prompt=login', 'prompt=select_account') : nil
   end
 
   def render_not_found

--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -20,6 +20,6 @@ module SecureHeadersConcern
   private
 
   def stored_url_for_user
-    sp_session[:request_url]
+    sp_session_request_url_without_prompt_login
   end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -7,7 +7,7 @@ module OpenidConnect
 
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :validate_authorize_form, only: [:index]
-    before_action :force_login_if_prompt_param_is_login_and_request_is_external, only: [:index]
+    before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
     before_action :store_request, only: [:index]
     before_action :apply_secure_headers_override, only: [:index]
     before_action :confirm_user_is_authenticated_with_fresh_mfa, only: :index
@@ -88,15 +88,8 @@ module OpenidConnect
       end
     end
 
-    def force_login_if_prompt_param_is_login_and_request_is_external
-      return unless user_signed_in? && @authorize_form.prompt == 'login'
-      sign_out unless referring_host.to_s == Figaro.env.domain_name
-    end
-
-    def referring_host
-      URI.parse(request.referer).host
-    rescue URI::InvalidURIError
-      nil
+    def sign_out_if_prompt_param_is_login_and_user_is_signed_in
+      sign_out if user_signed_in? && @authorize_form.prompt == 'login'
     end
 
     def store_request

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -89,7 +89,8 @@ module OpenidConnect
     end
 
     def sign_out_if_prompt_param_is_login_and_user_is_signed_in
-      sign_out if user_signed_in? && @authorize_form.prompt == 'login'
+      return unless user_signed_in? && @authorize_form.prompt == 'login'
+      sign_out unless sp_session[:request_url] == request.original_url
     end
 
     def store_request

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else
-        redirect_to sp_session[:request_url]
+        redirect_to sp_session_request_url_without_prompt_login
       end
     end
 


### PR DESCRIPTION
Hi! Before submitting your PR for review, and/or before merging it, please
go through the checklists below. These represent the more critical elements
of our code quality guidelines. The rest of the list can be found in
[CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/18F/identity-idp/blob/master/CONTRIBUTING.md#pull-request-guidelines

### Controllers

- [ ] When adding a new controller that requires the user to be fully
authenticated, make sure to add `before_action :confirm_two_factor_authenticated`
as the first callback.

### Database

- [ ] Unsafe migrations are implemented over several PRs and over several
deploys to avoid production errors. The [strong_migrations](https://github.com/ankane/strong_migrations#the-zero-downtime-way) gem
will warn you about unsafe migrations and has great step-by-step instructions
for various scenarios.

- [ ] Indexes were added if necessary. This article provides a good overview
of [indexes in Rails](https://goo.gl/1DARYi).

- [ ] Verified that the changes don't affect other apps (such as the dashboard)

- [ ] When relevant, a rake task is created to populate the necessary DB columns
in the various environments right before deploying, taking into account the users
who might not have interacted with this column yet (such as users who have not
set a password yet)

- [ ] Migrations against existing tables have been tested against a copy of the
production database. See #2127 for an example when a migration caused deployment
issues. In that case, all the migration did was add a new column and an index to
the Users table, which might seem innocuous.

- [ ] When fetching a single record from the database, `#take` is used instead
of `#first` unless there is an `#order` call on the ActiveRecord relations.
This prevents ActiveRecord from sorting by primary key which can result in slow
queries.

### Encryption

- [ ] The changes are compatible with data that was encrypted with the old code.

### Routes

- [ ] GET requests are not vulnerable to CSRF attacks (i.e. they don't change
state or result in destructive behavior).

### Session

- [ ] When adding user data to the session, use the `user_session` helper
instead of the `session` helper so the data does not persist beyond the user's
session.

### Testing

- [ ] Tests added for this feature/bug
- [ ] Prefer feature/integration specs over controller specs
- [ ] When adding code that reads data, write tests for nil values, empty strings,
and invalid inputs.
