### PR TITLE
LG-1499 Update email address column after delete

### DIFF
--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -17,10 +17,19 @@ class DeleteUserEmailForm
 
   private
 
+  def update_user_email_column
+    new_email_address = user.confirmed_email_addresses.take
+    user.update_columns(
+      encrypted_email: new_email_address.encrypted_email,
+      email_fingerprint: new_email_address.email_fingerprint,
+    )
+  end
+
   def email_address_destroyed
     return false unless EmailPolicy.new(@user).can_delete_email?(@email_address)
     return false if email_address.destroy == false
     user.email_addresses.reload
+    update_user_email_column
     true
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -17,6 +17,15 @@ class DeleteUserEmailForm
 
   private
 
+  # When the user deletes an email address, we need to make sure we update the email columns on the
+  # user model with the values from an email address record to make sure they are not occupied by
+  # the email address the user deleted
+  #
+  # In order to do this, we need to update the columns without running the callbacks. Running the
+  # callback will cause the code that updates the email address table when there are changes to
+  # the user model to run
+  #
+  # rubocop:disable Rails/SkipsModelValidations
   def update_user_email_column
     new_email_address = user.confirmed_email_addresses.take
     user.update_columns(
@@ -24,6 +33,7 @@ class DeleteUserEmailForm
       email_fingerprint: new_email_address.email_fingerprint,
     )
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def email_address_destroyed
     return false unless EmailPolicy.new(@user).can_delete_email?(@email_address)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 20190620204206) do
     t.string "encrypted_recovery_code_digest", default: ""
     t.datetime "remember_device_revoked_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"


### PR DESCRIPTION
**Why**: To make sure the email address on the user model is an email the user actually has