### PR TITLE
Increase db migration timeout from 1 minute to 10 minutes.

### DIFF
--- a/deploy/migrate
+++ b/deploy/migrate
@@ -15,7 +15,7 @@ id
 which bundle
 
 export RAILS_ENV=production
-export MIGRATION_STATEMENT_TIMEOUT=60000
+export MIGRATION_STATEMENT_TIMEOUT=600000 # 10 minutes, units are 1/1000 of a second
 
 bundle exec rake db:create db:migrate db:seed db:grant_readonly_access --trace
 


### PR DESCRIPTION
**Why**: The current timeout is 1 minute, which is far too short when
you need to run a migration against a large database. This results in
needing manual recovery steps.

**How**: Change MIGRATION_STATEMENT_TIMEOUT from 60000 to 600000.

https://github.com/18F/identity-devops/issues/1514
