### PR TITLE
Upgrade rubocop to 0.72.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -83,7 +83,7 @@ plugins:
     - 'lib/rspec/formatters/user_flow_formatter.rb'
   rubocop:
     enabled: true
-    channel: rubocop-0-58
+    channel: rubocop-0-72
   scss-lint:
     enabled: true
     checks:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 # https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
 # https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml
+require: rubocop-rails
 
 AllCops:
   Exclude:
@@ -188,7 +189,7 @@ Style/IfUnlessModifier:
   Enabled: true
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -217,9 +218,6 @@ Layout/MultilineOperationIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
-
-Style/FormatStringToken:
-  Enabled: false
 
 Style/PercentLiteralDelimiters:
   # Specify the default preferred delimiter for all types with the 'default' key
@@ -275,14 +273,24 @@ Style/TrailingCommaInHashLiteral:
     - consistent_comma
     - no_comma
 
+Naming/UncommunicativeMethodParamName:
+  MinNameLength: 2
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+
 Style/SingleLineBlockParams:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
-  MinNameLength: 2
-
-Style/ExpandPathArguments:
+Naming/RescuedExceptionsVariableName:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,8 @@ group :development do
   gem 'rack-mini-profiler', require: false
   gem 'rails-erd'
   gem 'reek'
-  gem 'rubocop', '~> 0.58.0', require: false
+  gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ group :development do
   gem 'rack-mini-profiler', require: false
   gem 'rails-erd'
   gem 'reek'
-  gem 'rubocop', require: false
+  gem 'rubocop', '~> 0.72.0', require: false
   gem 'rubocop-rails', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -750,7 +750,7 @@ DEPENDENCIES
   rotp (~> 3.3.1)
   rqrcode
   rspec-rails (~> 3.7)
-  rubocop
+  rubocop (~> 0.72.0)
   rubocop-rails
   ruby-progressbar
   ruby-saml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,6 @@ GEM
     pg (1.1.4)
     phonelib (0.6.36)
     pkcs11 (0.2.7)
-    powerpack (0.1.2)
     premailer (1.11.1)
       addressable
       css_parser (>= 1.6.0)
@@ -497,14 +496,16 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    rubocop (0.58.2)
+    rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby-saml (1.10.2)
@@ -749,7 +750,8 @@ DEPENDENCIES
   rotp (~> 3.3.1)
   rqrcode
   rspec-rails (~> 3.7)
-  rubocop (~> 0.58.0)
+  rubocop
+  rubocop-rails
   ruby-progressbar
   ruby-saml
   safe_target_blank

--- a/app/helpers/session_timeout_warning_helper.rb
+++ b/app/helpers/session_timeout_warning_helper.rb
@@ -31,6 +31,7 @@ module SessionTimeoutWarningHelper
     end
   end
 
+  # rubocop:disable Rails/HelperInstanceVariable
   def auto_session_expired_js
     return if @skip_session_expiration
 
@@ -43,6 +44,7 @@ module SessionTimeoutWarningHelper
       )
     end
   end
+  # rubocop:enable Rails/HelperInstanceVariable
 
   def time_left_in_session
     distance_of_time_in_words(warning)

--- a/app/services/idv/acuant/assure_id.rb
+++ b/app/services/idv/acuant/assure_id.rb
@@ -86,7 +86,7 @@ module Idv
           Type: {
             Manufacturer: 'Login.gov',
             Model: 'Doc Auth 1.0',
-            SensorType: '3' # mobile
+            SensorType: '3', # mobile
           },
         }
       end

--- a/app/services/remember_device_cookie.rb
+++ b/app/services/remember_device_cookie.rb
@@ -23,13 +23,13 @@ class RememberDeviceCookie
     raise "RememberDeviceCookie role '#{role}' did not match '#{COOKIE_ROLE}'"
   end
 
-  def to_json
+  def to_json(*args)
     {
       user_id: user_id,
       created_at: created_at.iso8601,
       role: COOKIE_ROLE,
       entropy: SecureRandom.base64(32),
-    }.to_json
+    }.to_json(*args)
   end
 
   def valid_for_user?(user:, expiration_interval:)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -137,7 +137,7 @@ module Rack
       [
         429, # status
         { 'Content-Type' => 'text/html' }, # headers
-        [::File.read('public/429.html')] # body
+        [::File.read('public/429.html')], # body
       ]
     end
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -49,7 +49,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
     samesite: {
-      lax: true # SameSite setting.
+      lax: true, # SameSite setting.
     },
   }
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -69,7 +69,7 @@ namespace :dev do
             first_name: 'Test',
             last_name: "User #{num_created}",
             dob: '1970-05-01',
-            ssn: "666-#{num_created}" # doesn't need to be legit 9 digits, just unique
+            ssn: "666-#{num_created}", # doesn't need to be legit 9 digits, just unique
           )
           personal_key = profile.encrypt_pii(pii, pw)
           profile.verified_at = Time.zone.now

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -20,7 +20,7 @@ describe 'IdvStepConcern' do
         render plain: 'Hello'
       end
 
-      def failure_url(__)
+      def failure_url(_arg)
         'foobar'
       end
     end

--- a/spec/controllers/idv/otp_delivery_method_controller_spec.rb
+++ b/spec/controllers/idv/otp_delivery_method_controller_spec.rb
@@ -220,7 +220,7 @@ describe Idv::OtpDeliveryMethodController do
             code: 60_033,
             message: 'error',
             status: 400,
-            response:  '{"error_code":"60004"}',
+            response: '{"error_code":"60004"}',
           )
         end
 

--- a/spec/controllers/idv/resend_otp_controller_spec.rb
+++ b/spec/controllers/idv/resend_otp_controller_spec.rb
@@ -99,7 +99,7 @@ describe Idv::ResendOtpController do
             code: 60_033,
             message: 'error',
             status: 400,
-            response:  '{"error_code":"60004"}',
+            response: '{"error_code":"60004"}',
           )
         end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe OpenidConnect::AuthorizationController do
     {
       acr_values: Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
       client_id: client_id,
-      nonce:  SecureRandom.hex,
+      nonce: SecureRandom.hex,
       prompt: 'select_account',
       redirect_uri: 'gov.gsa.openidconnect.test://result',
       response_type: 'code',
       scope: 'openid profile',
-      state:  SecureRandom.hex,
+      state: SecureRandom.hex,
     }
   end
 

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -45,7 +45,7 @@ feature 'doc auth send link step' do
       code: 60_033,
       message: 'error',
       status: 400,
-      response:  '{"error_code":"60004"}',
+      response: '{"error_code":"60004"}',
     )
     allow(SmsDocAuthLinkJob).to receive(:perform_now).and_raise(generic_exception)
     fill_in :doc_auth_phone, with: '415-555-0199'

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -1,6 +1,6 @@
 module DocAuthHelper
   ACUANT_RESULTS = {
-    'Result' =>  1,
+    'Result' => 1,
     'Fields' => [
       { 'Name' => 'First Name', 'Value' => 'Jane' },
       { 'Name' => 'Middle Name', 'Value' => 'Ann' },


### PR DESCRIPTION
**Why**: To get fixes for linters, a few new linters, and get rubocop working in VSCode again.