### PR TITLE
Fix rubocop incovation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check: lint test
 
 lint:
 	@echo "--- rubocop ---"
-	bundle exec rubocop -R
+	bundle exec rubocop
 	@echo "--- slim-lint ---"
 	bundle exec slim-lint app/views
 	@echo "--- reek ---"


### PR DESCRIPTION
**Why**: So `make lint` runs without being sad