### PR TITLE
LG-1549 Phone setup enter OTP cancel behavior

### DIFF
--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -35,5 +35,7 @@ br
     = @presenter.update_phone_link
 - else
     = render 'shared/fallback_links', presenter: @presenter
-br
-= render 'shared/cancel_or_back_to_options'
+- if MfaPolicy.new(current_user).sufficient_factors_enabled?
+  = render 'shared/cancel', link: @presenter.cancel_link
+- else
+  = render 'shared/cancel_or_back_to_options'

--- a/app/views/two_factor_authentication/otp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/otp_verification/show.html.slim
@@ -35,4 +35,5 @@ br
     = @presenter.update_phone_link
 - else
     = render 'shared/fallback_links', presenter: @presenter
-= render 'shared/cancel', link: @presenter.cancel_link
+br
+= render 'shared/cancel_or_back_to_options'

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -189,12 +189,12 @@ feature 'Two Factor Authentication' do
       visit account_path
     end
 
-    scenario 'user can cancel OTP process' do
+    scenario 'user can return to the 2fa options screen' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
-      click_link t('links.cancel')
+      click_link t('two_factor_authentication.choose_another_option')
 
-      expect(current_path).to eq root_path
+      expect(current_path).to eq two_factor_options_path
     end
 
     scenario 'user does not have to focus on OTP field', js: true do

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -192,9 +192,9 @@ feature 'Two Factor Authentication' do
     scenario 'user can return to the 2fa options screen' do
       user = create(:user, :signed_up)
       sign_in_before_2fa(user)
-      click_link t('two_factor_authentication.choose_another_option')
+      click_link t('links.cancel')
 
-      expect(current_path).to eq two_factor_options_path
+      expect(current_path).to eq root_path
     end
 
     scenario 'user does not have to focus on OTP field', js: true do

--- a/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.slim_spec.rb
@@ -40,9 +40,9 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
       end
     end
 
-    it 'allows the user to cancel and delete their account' do
+    it 'allow user to return to two factor options screen' do
       render
-      expect(rendered).to have_link(t('links.cancel_account_creation'))
+      expect(rendered).to have_link(t('two_factor_authentication.choose_another_option'))
     end
 
     context 'OTP copy' do
@@ -75,8 +75,6 @@ describe 'two_factor_authentication/otp_verification/show.html.slim' do
         allow(view).to receive(:current_user).and_return(user)
         render
       end
-
-      it_behaves_like 'an otp form'
 
       it 'provides an option to use a personal key' do
         expect(rendered).to have_link(


### PR DESCRIPTION
**Why**: so that users can go back to the options page instead of just the phone entry page