### PR TITLE
LG-1486 Add timeout for post to google analytics on backend

### DIFF
--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -1,10 +1,11 @@
 class GoogleAnalyticsMeasurement
-  GA_ENDPOINT = 'https://www.google-analytics.com/collect'.freeze
+  GA_URL = 'https://www.google-analytics.com/collect'.freeze
+  TIMEOUT = Figaro.env.google_analytics_timeout.to_i
 
   attr_reader :category, :event_action, :method, :client_id
 
   cattr_accessor :adapter do
-    Faraday.new(url: GA_ENDPOINT) do |faraday|
+    Faraday.new(url: GA_URL, request: { open_timeout: TIMEOUT, timeout: TIMEOUT }) do |faraday|
       faraday.adapter :typhoeus
     end
   end
@@ -20,7 +21,7 @@ class GoogleAnalyticsMeasurement
     adapter.post do |request|
       request.body = request_body
     end
-  rescue Faraday::ConnectionFailed => err
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
     NewRelic::Agent.notice_error(err)
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -76,6 +76,8 @@ twilio_timeout: '5'
 usps_download_sftp_timeout: '5'
 usps_upload_sftp_timeout: '5'
 
+google_analytics_timeout: '5'
+
 piv_cac_email_domains: >-
   [
     ".eop.gov", ".mil", ".treas.gov", ".dhs.gov",

--- a/spec/services/google_analytics_measurement_spec.rb
+++ b/spec/services/google_analytics_measurement_spec.rb
@@ -48,7 +48,7 @@ describe GoogleAnalyticsMeasurement do
 
     it 'catches network timeout errors' do
       allow(subject.adapter).to receive(:post).
-        and_raise(Faraday::ConnectionFailed.new('error'))
+        and_raise(Faraday::TimeoutError.new('error'))
 
       expect(NewRelic::Agent).to receive(:notice_error)
       subject.send_event

--- a/spec/services/google_analytics_measurement_spec.rb
+++ b/spec/services/google_analytics_measurement_spec.rb
@@ -6,6 +6,17 @@ describe GoogleAnalyticsMeasurement do
     let(:event_action) { 'mfa' }
     let(:method) { 'webAuthn' }
     let(:client_id) { 'a68f8374-0970-4c18-92d9-d18ed63ed430' }
+    let(:expected_req_body) do
+      {
+        v: '1',
+        tid: Figaro.env.google_analytics_key,
+        t: 'event',
+        ec: category,
+        ea: event_action,
+        el: method,
+        cid: client_id,
+      }
+    end
 
     subject do
       GoogleAnalyticsMeasurement.new(
@@ -17,17 +28,7 @@ describe GoogleAnalyticsMeasurement do
     end
 
     it 'sends a properly formatted request' do
-      expected_req_body = {
-        v: '1',
-        tid: Figaro.env.google_analytics_key,
-        t: 'event',
-        ec: category,
-        ea: event_action,
-        el: method,
-        cid: client_id,
-      }
-
-      url = GoogleAnalyticsMeasurement::GA_ENDPOINT
+      url = GoogleAnalyticsMeasurement::GA_URL
       request = stub_request(:post, url).
                 with(body: expected_req_body).
                 to_return(body: '')
@@ -35,6 +36,22 @@ describe GoogleAnalyticsMeasurement do
       subject.send_event
 
       expect(request).to have_been_requested
+    end
+
+    it 'catches network connection errors' do
+      allow(subject.adapter).to receive(:post).
+        and_raise(Faraday::ConnectionFailed.new('error'))
+
+      expect(NewRelic::Agent).to receive(:notice_error)
+      subject.send_event
+    end
+
+    it 'catches network timeout errors' do
+      allow(subject.adapter).to receive(:post).
+        and_raise(Faraday::ConnectionFailed.new('error'))
+
+      expect(NewRelic::Agent).to receive(:notice_error)
+      subject.send_event
     end
   end
 end


### PR DESCRIPTION
**Why**: So users don't get stuck if ga does not respond