### PR TITLE
Fix flickering push notification spec

### DIFF
--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -6,7 +6,6 @@ describe 'Account Reset Request: Delete Account', email: true do
   let(:user) { create(:user, :signed_up) }
   let(:user_email) { user.email_addresses.first.email }
   let(:push_notification_url) { 'http://localhost/push_notifications' }
-  let(:payload) { { uuid: '1234' } }
 
   context 'as an LOA1 user' do
     it 'allows the user to delete their account after 24 hours' do
@@ -71,11 +70,12 @@ describe 'Account Reset Request: Delete Account', email: true do
 
       reset_email
 
-      Timecop.freeze(Time.zone.now + 2.days) do
-        request = stub_request(:post, push_notification_url).
-                  with(headers: push_notification_headers(push_notification_url, payload)).
-                  with(body: '').
-                  to_return(body: '')
+      Timecop.travel(2.days.from_now) do
+        request = stub_push_notification_request(
+          sp_push_notification_endpoint: push_notification_url,
+          topic: 'account_delete',
+          payload: { 'uuid' => '1234' },
+        )
 
         AccountReset::GrantRequestsAndSendEmails.new.call
         open_last_email

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -21,7 +21,6 @@ feature 'User profile' do
 
   context 'loa1 user clicks the delete account button' do
     let(:push_notification_url) { 'http://localhost/push_notifications' }
-    let(:payload) { { uuid: '1234' } }
 
     it 'deletes the account and signs the user out with a flash message' do
       user = sign_in_and_2fa_user
@@ -48,15 +47,14 @@ feature 'User profile' do
 
       click_link(t('account.links.delete_account'))
 
-      Timecop.travel(Time.zone.now) do
-        request = stub_request(:post, push_notification_url).
-                  with(headers: push_notification_headers(push_notification_url, payload)).
-                  with(body: '').
-                  to_return(body: '')
+      request = stub_push_notification_request(
+        sp_push_notification_endpoint: push_notification_url,
+        topic: 'account_delete',
+        payload: { 'uuid' => '1234' },
+      )
 
-        click_button t('users.delete.actions.delete')
-        expect(request).to have_been_requested
-      end
+      click_button t('users.delete.actions.delete')
+      expect(request).to have_been_requested
     end
   end
 

--- a/spec/services/push_notification/account_delete_spec.rb
+++ b/spec/services/push_notification/account_delete_spec.rb
@@ -7,24 +7,21 @@ describe PushNotification::AccountDelete do
   let(:push_notification_url) { 'http://localhost/push_notifications' }
   let(:push_notification_url2) { 'http://localhost:9292/push_notifications' }
   let(:user_id) { 1 }
-  let(:payload) { { uuid: '1234' } }
-  let(:payload2) { { uuid: '4567' } }
 
   before do
     AgencyIdentity.create(user_id: user_id, agency_id: 1, uuid: '1234')
   end
 
   it 'sends updates to one subscriber' do
-    Timecop.freeze(Time.zone.now) do
-      request = stub_request(:post, push_notification_url).
-                with(headers: push_notification_headers(push_notification_url, payload)).
-                with(body: '').
-                to_return(body: '')
+    request = stub_push_notification_request(
+      sp_push_notification_endpoint: push_notification_url,
+      topic: 'account_delete',
+      payload: { 'uuid' => '1234' },
+    )
 
-      subject.call(user_id)
+    subject.call(user_id)
 
-      expect(request).to have_been_requested
-    end
+    expect(request).to have_been_requested
   end
 
   it 'sends updates to two subscribers of the same agency' do
@@ -32,22 +29,22 @@ describe PushNotification::AccountDelete do
     sp.push_notification_url = push_notification_url2
     sp.save!
 
-    Timecop.freeze(Time.zone.now) do
-      request = stub_request(:post, push_notification_url).
-                with(headers: push_notification_headers(push_notification_url, payload)).
-                with(body: '').
-                to_return(body: '')
+    request = stub_push_notification_request(
+      sp_push_notification_endpoint: push_notification_url,
+      topic: 'account_delete',
+      payload: { 'uuid' => '1234' },
+    )
 
-      request2 = stub_request(:post, push_notification_url2).
-                 with(headers: push_notification_headers(push_notification_url2, payload)).
-                 with(body: '').
-                 to_return(body: '')
+    request2 = stub_push_notification_request(
+      sp_push_notification_endpoint: push_notification_url2,
+      topic: 'account_delete',
+      payload: { 'uuid' => '1234' },
+    )
 
-      subject.call(user_id)
+    subject.call(user_id)
 
-      expect(request).to have_been_requested
-      expect(request2).to have_been_requested
-    end
+    expect(request).to have_been_requested
+    expect(request2).to have_been_requested
   end
 
   it 'sends updates to two subscribers for two different agencies' do
@@ -58,22 +55,22 @@ describe PushNotification::AccountDelete do
     sp.agency_id = 2
     sp.save!
 
-    Timecop.freeze(Time.zone.now) do
-      request = stub_request(:post, push_notification_url).
-                with(headers: push_notification_headers(push_notification_url, payload)).
-                with(body: '').
-                to_return(body: '')
+    request = stub_push_notification_request(
+      sp_push_notification_endpoint: push_notification_url,
+      topic: 'account_delete',
+      payload: { 'uuid' => '1234' },
+    )
 
-      request2 = stub_request(:post, push_notification_url2).
-                 with(headers: push_notification_headers(push_notification_url2, payload2)).
-                 with(body: '').
-                 to_return(body: '')
+    request2 = stub_push_notification_request(
+      sp_push_notification_endpoint: push_notification_url2,
+      topic: 'account_delete',
+      payload: { 'uuid' => '4567' },
+    )
 
-      subject.call(user_id)
+    subject.call(user_id)
 
-      expect(request).to have_been_requested
-      expect(request2).to have_been_requested
-    end
+    expect(request).to have_been_requested
+    expect(request2).to have_been_requested
   end
 
   it 'writes failures to the retry table on connection errors' do

--- a/spec/support/features/push_notifications_helper.rb
+++ b/spec/support/features/push_notifications_helper.rb
@@ -1,29 +1,23 @@
 module PushNotificationsHelper
-  def authorization_header(push_to_url, payload)
-    web_push(push_to_url, payload)
+  def stub_push_notification_request(sp_push_notification_endpoint:, topic:, payload:)
+    stub_request(:post, sp_push_notification_endpoint).with do |request|
+      expect(request.body).to eq('')
+
+      headers = request.headers
+      expect(headers['Topic']).to eq(topic)
+      expect(headers['Content-Type']).to eq('application/json')
+
+      parsed_jwt = parse_jwt_from_auth_header(headers['Authorization'])
+      expect(parsed_jwt['aud']).to eq(sp_push_notification_endpoint)
+      expected_expiration = 12.hours.from_now
+      expect(parsed_jwt['exp']).to be_within(2).of(expected_expiration.to_i)
+      expect(parsed_jwt['payload']).to eq(payload)
+      expect(parsed_jwt['sub']).to eq('mailto:partners@login.gov')
+    end.to_return(body: '')
   end
 
-  def jwt_data(push_to_url, push_data_hash)
-    { 'aud': push_to_url,
-      'exp': (Time.zone.now + 12.hours).to_i,
-      'payload': push_data_hash,
-      'sub': 'mailto:partners@login.gov' }
-  end
-
-  def web_push(push_to_url, push_data_hash)
-    payload = jwt_data(push_to_url, push_data_hash)
-    token = JWT.encode(payload, RequestKeyManager.private_key, 'RS256')
-    "WebPush #{token}"
-  end
-
-  def push_notification_headers(push_url, payload)
-    {
-      'Authorization' => authorization_header(push_url, payload),
-      'Content-Length' => '0',
-      'Content-Type' => 'application/json',
-      'Expect' => '',
-      'Topic' => 'account_delete',
-      'User-Agent' => 'Faraday v0.15.4',
-    }
+  def parse_jwt_from_auth_header(auth_header)
+    jwt = auth_header.match(/WebPush (.*)/)[1]
+    JWT.decode(jwt, RequestKeyManager.public_key, true, algorithm: 'RS256').first
   end
 end


### PR DESCRIPTION
**Why**: So the spec does not occassionally fail on CI. This commit also removes the Timecop calls and decodes the JWT to check that it has the expected payload instead of trying to sign a JWT with the exact values and do a comparison.