### PR TITLE
LG-1637 Start supporting the JOIN keyword for inbound SMS responses

### DIFF
--- a/app/services/twilio_service/sms/response.rb
+++ b/app/services/twilio_service/sms/response.rb
@@ -2,7 +2,7 @@ module TwilioService
   module Sms
     class Response
       MESSAGE_STOP_VARIANTS = %w[cancel end quit unsubscribe].freeze
-      MESSAGE_TYPES = %w[help stop].concat(MESSAGE_STOP_VARIANTS).freeze
+      MESSAGE_TYPES = %w[help join stop].concat(MESSAGE_STOP_VARIANTS).freeze
       SIGNATURE_HEADER = 'HTTP_X_TWILIO_SIGNATURE'.freeze
 
       # CTIA short code guidelines require support for multiple stop words
@@ -33,6 +33,15 @@ module TwilioService
 
       def stop
         I18n.t('sms.stop.message')
+      end
+
+      def join
+        I18n.t(
+          'jobs.sms_otp_sender_job.login_message',
+          code: '123456',
+          app: APP_NAME,
+          expiration: Devise.direct_otp_valid_for.to_i / 60,
+        )
       end
     end
   end

--- a/spec/services/twilio_service/sms/response_spec.rb
+++ b/spec/services/twilio_service/sms/response_spec.rb
@@ -59,5 +59,20 @@ describe TwilioService::Sms::Response do
 
       expect(response.reply).to eq(expected)
     end
+
+    it 'calls join and returns  the appropriate message' do
+      message = request.new(url, { Body: 'join', From: number }, signature)
+
+      response = described_class.new(message)
+      expected_message = t(
+        'jobs.sms_otp_sender_job.login_message',
+        code: '123456',
+        app: APP_NAME,
+        expiration: Devise.direct_otp_valid_for.to_i / 60,
+      )
+      expected = { to: number, body: expected_message }
+
+      expect(response.reply).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
**Why**: To have a way for CTIA compliance auditors to assess the compliance of our enrollment message