### PR TITLE
LG-1638 Change the text for the HELP and STOP messages

### DIFF
--- a/config/locales/sms/en.yml
+++ b/config/locales/sms/en.yml
@@ -4,6 +4,6 @@ en:
     help:
       message: Get help at www.login.gov/help or contact us at www.login.gov/contact.
     stop:
-      message: You have unsubscribed from alerts from login.gov. You will no longer
+      message: You've unsubscribed from alerts from login.gov. You will no longer
         receive alerts unless you resubscribe by using this phone number to sign in
         or set up an account. Reply HELP for help of see www.login.gov/help.

--- a/config/locales/sms/en.yml
+++ b/config/locales/sms/en.yml
@@ -2,7 +2,8 @@
 en:
   sms:
     help:
-      message: 'login.gov: Get help at www.login.gov/help or email us at hello@login.gov.'
+      message: Get help at www.login.gov/help or contact us at www.login.gov/contact.
     stop:
-      message: login.gov is not a subscription service. You will only receive security
-        codes when you sign in. Reply HELP for help or see www.login.gov/help.
+      message: You have unsubscribed from alerts from login.gov. You will no longer
+        receive alerts unless you resubscribe by using this phone number to sign in
+        or set up an account. Reply HELP for help of see www.login.gov/help.

--- a/config/locales/sms/en.yml
+++ b/config/locales/sms/en.yml
@@ -4,6 +4,6 @@ en:
     help:
       message: Get help at www.login.gov/help or contact us at www.login.gov/contact.
     stop:
-      message: You've unsubscribed from alerts from login.gov. You will no longer
+      message: You've unsubscribed from login.gov alerts. You will no longer
         receive alerts unless you resubscribe by using this phone number to sign in
         or set up an account. Reply HELP for help or see www.login.gov/help.

--- a/config/locales/sms/en.yml
+++ b/config/locales/sms/en.yml
@@ -6,4 +6,4 @@ en:
     stop:
       message: You've unsubscribed from alerts from login.gov. You will no longer
         receive alerts unless you resubscribe by using this phone number to sign in
-        or set up an account. Reply HELP for help of see www.login.gov/help.
+        or set up an account. Reply HELP for help or see www.login.gov/help.

--- a/config/locales/sms/en.yml
+++ b/config/locales/sms/en.yml
@@ -4,6 +4,6 @@ en:
     help:
       message: Get help at www.login.gov/help or contact us at www.login.gov/contact.
     stop:
-      message: You've unsubscribed from login.gov alerts. You will no longer
-        receive alerts unless you resubscribe by using this phone number to sign in
-        or set up an account. Reply HELP for help or see www.login.gov/help.
+      message: You've unsubscribed from login.gov alerts. You will no longer receive
+        alerts unless you resubscribe by using this phone number to sign in or set
+        up an account. Reply HELP for help or see www.login.gov/help.

--- a/config/locales/sms/es.yml
+++ b/config/locales/sms/es.yml
@@ -2,8 +2,7 @@
 es:
   sms:
     help:
-      message: 'login.gov: obtenga ayuda en www.login.gov/help o envíenos un correo
-        electrónico a hello@login.gov.'
+      message: Obtenga ayuda en www.login.gov/help o contáctenos en www.login.gov/contact.
     stop:
       message: login.gov no es un servicio de suscripción. Solo recibirá códigos de
         seguridad cuando se registre. Responda HELP para obtener ayuda o visite www.login.gov/help.

--- a/config/locales/sms/es.yml
+++ b/config/locales/sms/es.yml
@@ -4,5 +4,7 @@ es:
     help:
       message: Obtenga ayuda en www.login.gov/help o contáctenos en www.login.gov/contact.
     stop:
-      message: login.gov no es un servicio de suscripción. Solo recibirá códigos de
-        seguridad cuando se registre. Responda HELP para obtener ayuda o visite www.login.gov/help.
+      message: Has cancelado la suscripción a las alertas de login.gov. Ya no recibirá
+        alertas a menos que vuelva a suscribirse utilizando este número de teléfono
+        para iniciar sesión o configurar una cuenta. Responda HELP para obtener ayuda
+        o visite www.login.gov/help.

--- a/config/locales/sms/es.yml
+++ b/config/locales/sms/es.yml
@@ -4,7 +4,7 @@ es:
     help:
       message: Obtenga ayuda en www.login.gov/help o contáctenos en www.login.gov/contact.
     stop:
-      message: Has cancelado la suscripción a las alertas de login.gov. Ya no recibirá
+      message: Ha cancelado la suscripción a las alertas de login.gov. Ya no recibirá
         alertas a menos que vuelva a suscribirse utilizando este número de teléfono
         para iniciar sesión o configurar una cuenta. Responda HELP para obtener ayuda
         o visite www.login.gov/help.

--- a/config/locales/sms/fr.yml
+++ b/config/locales/sms/fr.yml
@@ -2,9 +2,10 @@
 fr:
   sms:
     help:
-      message: 'login.gov: Obtenez de l''aide sur www.login.gov/help ou envoyez-nous
-        un courriel à hello@login.gov.'
+      message: Obtenez de l'aide à l'adresse www.login.gov/help ou contactez-nous
+        à l'adresse www.login.gov/contact.
     stop:
-      message: login.gov n'est pas un service d'abonnement. Vous ne recevrez des codes
-        de sécurité que lorsque vous vous connecterez. Aidez HELP pour obtenir de
-        l'aide ou consultez www.login.gov/help.
+      message: Has cancelado la suscripción a las alertas de login.gov. Ya no recibirá
+        alertas a menos que vuelva a suscribirse utilizando este número de teléfono
+        para iniciar sesión o configurar una cuenta. Responda la HELP para obtener
+        ayuda de ver www.login.gov/help.

--- a/config/locales/sms/fr.yml
+++ b/config/locales/sms/fr.yml
@@ -5,7 +5,7 @@ fr:
       message: Obtenez de l'aide à l'adresse www.login.gov/help ou contactez-nous
         à l'adresse www.login.gov/contact.
     stop:
-      message: Has cancelado la suscripción a las alertas de login.gov. Ya no recibirá
-        alertas a menos que vuelva a suscribirse utilizando este número de teléfono
-        para iniciar sesión o configurar una cuenta. Responda la HELP para obtener
-        ayuda de ver www.login.gov/help.
+      message: Vous avez désabonné des alertes de login.gov. Vous ne recevrez plus
+        d'alertes sauf si vous vous réabonnez en utilisant ce numéro de téléphone
+        pour vous connecter ou créer un compte. Répondez à HELP pour obtenir de l'aide
+        ou visitez www.login.gov/help.


### PR DESCRIPTION
**Why**: To stop providing outdated instructions on how to obtain help and to bring the stop response inline with CTIA requirements