### PR TITLE
Make the email attribute in the factories transient

### DIFF
--- a/spec/controllers/account_reset/recover_controller_spec.rb
+++ b/spec/controllers/account_reset/recover_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AccountReset::RecoverController do
   let(:profile) { build(:profile, :active, :verified) }
-  let(:user) { create(:user, :with_authentication_app, :with_email, profiles: [profile]) }
+  let(:user) { create(:user, :with_authentication_app, profiles: [profile]) }
 
   describe '#show' do
     it 'renders the page' do
@@ -55,7 +55,7 @@ describe AccountReset::RecoverController do
     end
 
     it 'logs sms user in the analytics' do
-      user = create(:user, :signed_up, :with_email, profiles: [profile])
+      user = create(:user, :signed_up, profiles: [profile])
       stub_sign_in_before_2fa(user)
 
       stub_analytics
@@ -73,7 +73,7 @@ describe AccountReset::RecoverController do
     end
 
     it 'logs PIV/CAC user in the analytics' do
-      user = create(:user, :with_piv_or_cac, :with_email, profiles: [profile])
+      user = create(:user, :with_piv_or_cac, profiles: [profile])
       stub_sign_in_before_2fa(user)
 
       stub_analytics

--- a/spec/controllers/account_reset/request_controller_spec.rb
+++ b/spec/controllers/account_reset/request_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe AccountReset::RequestController do
-  let(:user) { create(:user, :with_authentication_app, :with_email) }
+  let(:user) { create(:user, :with_authentication_app) }
   describe '#show' do
     it 'renders the page' do
       stub_sign_in_before_2fa(user)
@@ -53,7 +53,7 @@ describe AccountReset::RequestController do
     end
 
     it 'logs sms user in the analytics' do
-      user = create(:user, :signed_up, :with_email)
+      user = create(:user, :signed_up)
       stub_sign_in_before_2fa(user)
 
       stub_analytics
@@ -71,7 +71,7 @@ describe AccountReset::RequestController do
     end
 
     it 'logs PIV/CAC user in the analytics' do
-      user = create(:user, :with_piv_or_cac, :with_backup_code, :with_email)
+      user = create(:user, :with_piv_or_cac, :with_backup_code)
       stub_sign_in_before_2fa(user)
 
       stub_analytics

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,33 +2,32 @@ FactoryBot.define do
   Faker::Config.locale = :en
 
   factory :user do
-    transient do
-      with { {} }
-    end
-
-    confirmed_at { Time.zone.now }
-    email { Faker::Internet.safe_email }
     password { '!1a Z@6s' * 16 } # Maximum length password.
 
-    trait :with_email do
-      after(:build) do |user, _evaluator|
-        next unless user.email_addresses.empty?
-        user.email_addresses << build(
-          :email_address,
-          email: user.email,
-          confirmed_at: user.confirmed_at,
-          user_id: -1,
-        )
-      end
+    transient do
+      with { {} }
+      email { Faker::Internet.safe_email }
+      confirmed_at { Time.zone.now }
+    end
 
-      after(:stub) do |user, _evaluator|
-        next unless user.email_addresses.empty?
-        user.email_addresses << build(
-          :email_address,
-          email: user.email,
-          confirmed_at: user.confirmed_at,
-        )
-      end
+    after(:build) do |user, evaluator|
+      next unless user.email_addresses.empty?
+      user.email_addresses.build(
+        email: evaluator.email,
+        confirmed_at: evaluator.confirmed_at,
+      )
+      user.email = evaluator.email
+      user.confirmed_at = evaluator.confirmed_at
+    end
+
+    after(:stub) do |user, evaluator|
+      next unless user.email_addresses.empty?
+      user.email_addresses.build(
+        email: evaluator.email,
+        confirmed_at: evaluator.confirmed_at,
+      )
+      user.email = evaluator.email
+      user.confirmed_at = evaluator.confirmed_at
     end
 
     trait :with_multiple_emails do

--- a/spec/features/multiple_emails/email_management_spec.rb
+++ b/spec/features/multiple_emails/email_management_spec.rb
@@ -21,7 +21,7 @@ feature 'managing email address' do
 
   context 'allows deletion of email address' do
     it 'does not allow last confirmed email to be deleted' do
-      user = create(:user, :signed_up, :with_email, email: 'test@example.com ')
+      user = create(:user, :signed_up, email: 'test@example.com ')
       confirmed_email = user.confirmed_email_addresses.first
       unconfirmed_email = create(:email_address, user: user, confirmed_at: nil)
       user.email_addresses.reload
@@ -37,7 +37,7 @@ feature 'managing email address' do
     end
 
     it 'Allows delete when more than one confirmed email exists' do
-      user = create(:user, :signed_up, :with_email, email: 'test@example.com ')
+      user = create(:user, :signed_up, email: 'test@example.com ')
       confirmed_email1 = user.confirmed_email_addresses.first
       confirmed_email2 = create(:email_address, user: user,
                                                 confirmed_at: Time.zone.now)
@@ -54,7 +54,7 @@ feature 'managing email address' do
 
     it 'sends notification to all confirmed emails when email address is deleted' do
       allow(UserMailer).to receive(:email_deleted).and_call_original
-      user = create(:user, :signed_up, :with_email, email: 'test@example.com ')
+      user = create(:user, :signed_up, email: 'test@example.com ')
       confirmed_email1 = user.confirmed_email_addresses.first
       create(:email_address, user: user, confirmed_at: Time.zone.now)
       user.email_addresses.reload

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe DeleteUserEmailForm do
   describe '#submit' do
     context 'with only a single email address' do
-      let(:user) { create(:user, :with_email, email: 'test@example.com ') }
+      let(:user) { create(:user, email: 'test@example.com ') }
       let(:email_address) { user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
       let!(:result) { form.submit }

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -52,7 +52,7 @@ describe ResetPasswordForm, type: :model do
 
     context 'when both the password and token are valid' do
       it 'sets the user password to the submitted password' do
-        user = create(:user, :with_email, uuid: '123')
+        user = create(:user, uuid: '123')
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
         form = ResetPasswordForm.new(user)

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UpdateUserPasswordForm, type: :model do
-  let(:user) { build(:user, :with_email, password: 'old strong password') }
+  let(:user) { build(:user, password: 'old strong password') }
   let(:user_session) { {} }
   let(:password) { 'salty new password' }
   let(:params) { { password: password } }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UserMailer, type: :mailer do
-  let(:user) { build(:user, :with_email) }
+  let(:user) { build(:user) }
   let(:email_address) { user.email_addresses.first }
 
   describe 'email_deleted' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,7 +33,7 @@ describe User do
     end
 
     it 'mirrors the info from the user object on creation' do
-      user = create(:user, :with_email)
+      user = create(:user)
       email_address = user.email_addresses.first
       expect(email_address).to be_present
       expect(email_address.encrypted_email).to eq user.encrypted_email
@@ -42,7 +42,7 @@ describe User do
     end
 
     it 'mirrors the info from an unconfirmed user object' do
-      user = create(:user, :unconfirmed, :with_email)
+      user = create(:user, :unconfirmed)
       email_address = user.email_addresses.first
       expect(email_address).to be_present
       expect(email_address.encrypted_email).to eq user.encrypted_email
@@ -78,7 +78,7 @@ describe User do
     end
 
     it 'uses a DB index to enforce uniqueness' do
-      user1 = create(:user, :with_email)
+      user1 = create(:user)
       user1.save
       user2 = create(:user, email: "mkuniqu.#{user1.email}")
       user2.uuid = user1.uuid

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   let(:identity) do
     build(:identity,
           rails_session_id: rails_session_id,
-          user: create(:user, :with_email),
+          user: create(:user),
           scope: scope)
   end
 

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IdTokenBuilder do
           # this is a known value from an example developer guide
           # https://www.pingidentity.com/content/developer/en/resources/openid-connect-developers-guide.html
           access_token: 'dNZX1hEZ9wBCzNL40Upu646bdzQA',
-          user: create(:user, :with_email))
+          user: create(:user))
   end
 
   let(:custom_expiration) { 5.minutes.from_now.to_i }

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -25,7 +25,7 @@ describe RequestPasswordReset do
 
     context 'when the user is found and confirmed' do
       it 'sends password reset instructions' do
-        user = create(:user, :with_email)
+        user = create(:user)
         email = user.email_addresses.first.email
 
         allow(User).to receive(:find_with_email).with(email).and_return(user)

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -99,7 +99,7 @@ shared_examples 'strong password' do |form_class|
   end
 
   it 'does not allow a password that is the user email' do
-    user = build_stubbed(:user, :with_email, email: 'custom@benevolent.com', uuid: '123')
+    user = build_stubbed(:user, email: 'custom@benevolent.com', uuid: '123')
     allow(user).to receive(:reset_password_period_valid?).and_return(true)
     form = form_class.constantize.new(user)
     password = 'custom@benevolent.com'

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'accounts/show.html.erb' do
-  let(:user) { create(:user, :signed_up, :with_email) }
+  let(:user) { create(:user, :signed_up) }
   let(:decorated_user) { user.decorate }
 
   before do
@@ -37,7 +37,7 @@ describe 'accounts/show.html.erb' do
   end
 
   context 'when user is TOTP enabled' do
-    let(:user) { create(:user, :signed_up, :with_email, otp_secret_key: '123') }
+    let(:user) { create(:user, :signed_up, otp_secret_key: '123') }
 
     before do
       assign(


### PR DESCRIPTION
**Why**: To make it easier to quit writing to the `email` column in the users table