### PR TITLE
Drop uniqueness constraint on user email fingerprint

### DIFF
--- a/db/migrate/20190725211433_drop_email_fingerprint_index.rb
+++ b/db/migrate/20190725211433_drop_email_fingerprint_index.rb
@@ -1,0 +1,11 @@
+class DropEmailFingerprintIndex < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :users, :email_fingerprint
+  end
+
+  def down
+    add_index :users, :email_fingerprint, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190720132736) do
+ActiveRecord::Schema.define(version: 20190725211433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -345,7 +345,6 @@ ActiveRecord::Schema.define(version: 20190720132736) do
     t.string "encrypted_recovery_code_digest", default: ""
     t.datetime "remember_device_revoked_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email_fingerprint"], name: "index_users_on_email_fingerprint", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email"


### PR DESCRIPTION
**Why**: So that when we quit writing to user.email the multiple records with a nil value don't violate the constraint