### PR TITLE
Add a box for running migrations to the deploy checklist

### DIFF
--- a/lib/release_management/deploy_checklist.md.erb
+++ b/lib/release_management/deploy_checklist.md.erb
@@ -24,6 +24,7 @@
 - [ ] Backup release manager: Double check the PR and approve it
 - [ ] Merge the deploy pull request
 - [ ] Announce that you are beginning the deploy in `#login-devops`
+- [ ] Run any new migrations on a migration instance
 - [ ] Run the `asg-recycle` script against staging
 - [ ] Use the `ls-servers` script to check the status for the new servers. Wait until they have been up for ~15 minutes
 - [ ] Check that the new code is deployed by looking for the new sha at [https://idp.staging.login.gov/api/deploy.json](https://idp.staging.login.gov/api/deploy.json)
@@ -39,6 +40,7 @@
 - [ ] Backup release manager: Double check the PR and approve it
 - [ ] Merge the deploy pull request
 - [ ] Announce that you are beginning the deploy in `#login-devops`
+- [ ] Run any new migrations on a migration instance
 - [ ] Run the `asg-recycle` script against prod
 - [ ] Use the `ls-servers` script to check the status for the new servers. Wait until they have been up for ~15 minutes
 - [ ] Check that the new code is deployed by looking for the new sha at [https://secure.login.gov/api/deploy.json](https://secure.login.gov/api/deploy.json)


### PR DESCRIPTION
**Why**: To codify running migrations as part of the deploy process