### PR TITLE
Add a feature flag to disable USPS upload in an environment

### DIFF
--- a/app/services/usps_confirmation_uploader.rb
+++ b/app/services/usps_confirmation_uploader.rb
@@ -15,6 +15,7 @@ class UspsConfirmationUploader
   end
 
   def upload_export(export)
+    return unless FeatureManagement.usps_upload_enabled?
     io = StringIO.new(export)
     Net::SFTP.start(*sftp_config) do |sftp|
       sftp.upload!(io, remote_path)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -226,6 +226,7 @@ development:
   usps_download_sftp_username: 'brady'
   usps_download_sftp_password: 'test'
   usps_download_token: '123ABC'
+  usps_upload_enabled: 'false'
   usps_upload_sftp_directory: '/gsa_order'
   usps_upload_sftp_host: 'localhost'
   usps_upload_sftp_username: 'brady'
@@ -345,6 +346,7 @@ production:
   usps_download_sftp_username:
   usps_download_sftp_password:
   usps_download_token:
+  usps_upload_enabled: 'false'
   usps_upload_sftp_directory:
   usps_upload_sftp_host:
   usps_upload_sftp_username:
@@ -471,6 +473,7 @@ test:
   usps_download_sftp_username:
   usps_download_sftp_password:
   usps_download_token: 'test_token'
+  usps_upload_enabled: 'false'
   usps_upload_sftp_directory: '/directory'
   usps_upload_sftp_host: 'example.com'
   usps_upload_sftp_username: 'user'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -121,4 +121,8 @@ class FeatureManagement
   def self.in_person_proofing_enabled?
     Figaro.env.in_person_proofing_enabled == 'true'
   end
+
+  def self.usps_upload_enabled?
+    Figaro.env.usps_upload_enabled == 'true'
+  end
 end

--- a/spec/services/usps_confirmation_uploader_spec.rb
+++ b/spec/services/usps_confirmation_uploader_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe UspsConfirmationUploader do
     it 'does not upload when USPS upload is disabled' do
       allow(Figaro.env).to receive(:usps_upload_enabled).and_return('false')
 
-      expect(Net::SFTP).to_not receive(:start).with(*sftp_options).and_yield(sftp_connection)
+      expect(Net::SFTP).to_not receive(:start)
 
       subject
     end

--- a/spec/services/usps_confirmation_uploader_spec.rb
+++ b/spec/services/usps_confirmation_uploader_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe UspsConfirmationUploader do
     ]
   end
 
+  before do
+    allow(Figaro.env).to receive(:usps_upload_enabled).and_return('true')
+  end
+
   describe '#generate_export' do
     subject { uploader.send(:generate_export, confirmations) }
 
@@ -54,6 +58,14 @@ RSpec.describe UspsConfirmationUploader do
       expect(Net::SFTP).to receive(:start).with(*sftp_options).and_yield(sftp_connection)
       expect(StringIO).to receive(:new).with(export).and_return(string_io)
       expect(sftp_connection).to receive(:upload!).with(string_io, upload_folder)
+
+      subject
+    end
+
+    it 'does not upload when USPS upload is disabled' do
+      allow(Figaro.env).to receive(:usps_upload_enabled).and_return('false')
+
+      expect(Net::SFTP).to_not receive(:start).with(*sftp_options).and_yield(sftp_connection)
 
       subject
     end


### PR DESCRIPTION
**Why**: So that we can have one environment uploading the file so they aren't all overwriting each other.