### PR TITLE
Add reset password create accounts to registration logs

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -43,7 +43,6 @@ module SignUp
       user = @register_user_email_form.user
       unless @register_user_email_form.email_taken?
         create_user_event(:account_created, user)
-        Funnel::Registration::Create.call(user.id)
       end
 
       resend_confirmation = params[:user][:resend]

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -66,6 +66,7 @@ class RegisterUserEmailForm
   def process_successful_submission(request_id, instructions)
     self.success = true
     user.save!
+    Funnel::Registration::Create.call(user.id)
     SendSignUpEmailConfirmation.new(user).call(request_id: request_id, instructions: instructions)
   end
 

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -19,7 +19,9 @@ describe RequestPasswordReset do
         )
 
         RequestPasswordReset.new(email).perform
-        expect(User.find_with_email(email)).to be_present
+        user = User.find_with_email(email)
+        expect(user).to be_present
+        expect(RegistrationLog.first.user_id).to eq(user.id)
       end
     end
 


### PR DESCRIPTION
Moving the call to the form takes care of create account and password resets that also create accounts.