### PR TITLE
Refactor OMB report S3 bucket, add functions for disabling recurring jobs.

### DIFF
--- a/app/services/job_runner/runner.rb
+++ b/app/services/job_runner/runner.rb
@@ -1,7 +1,53 @@
 module JobRunner
+  # The Runner class manages the list of known configurations and is
+  # responsible for running all of them in turn when {#run} is called.
   class Runner
+    # The list of known job configurations. Calling {#run} will execute these
+    # jobs according to their schedules. Add new configurations to this list by
+    # calling {.add_config} aka {.add_configuration}.
+    #
+    # @return [Array<JobRunner::JobConfiguration>]
+    #
     def self.configurations
       @configurations ||= []
+      # dup and freeze so that callers have to use add_config to add jobs
+      @configurations.dup.freeze
+    end
+
+    # Empty the job configurations list.
+    def self.clear_configurations
+      @configurations = []
+    end
+
+    # Load the disabled job list from config. Provides a way to disable jobs
+    # without changing code.
+    def self.disabled_jobs
+      @disabled_jobs ||= JSON.parse(Figaro.env.recurring_jobs_disabled_names!)
+    end
+
+    # Add a new job configuration to the list of jobs to run. This is the
+    # primary entrypoint for users to add new jobs.
+    #
+    # @param [JobRunner::JobConfiguration] job_config
+    #
+    # @see .configurations
+    #
+    def self.add_configuration(job_config)
+      unless job_config.is_a?(JobRunner::JobConfiguration)
+        raise ArgumentError, 'job_config must be a JobRunner::JobConfiguration'
+      end
+
+      if disabled_jobs.include?(job_config.name)
+        Rails.logger.warn("JobRunner: skipping disabled job: #{job_config.name.inspect}")
+        return false
+      end
+
+      @configurations ||= []
+      @configurations << job_config
+    end
+
+    class << self
+      alias add_config add_configuration
     end
 
     def run

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -49,6 +49,9 @@ queue_health_check_frequency_seconds: '30'
 # The number of words in the personal key phrase
 recovery_code_length: '4'
 
+# add JSON job configuration names here to disable them from running
+recurring_jobs_disabled_names: '[]'
+
 # How long (in seconds) to wait for requests before dropping them (via the rack_timeout gem).
 # Note that the key name must be capitalized because the gem looks for
 # ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'], and Figaro does not automatically make lowercase keys
@@ -443,6 +446,7 @@ test:
   recaptcha_enabled_percent: '0'
   recaptcha_site_key: 'key1'
   recaptcha_secret_key: 'key2'
+  recurring_jobs_disabled_names: '["disabled job"]'
   redis_url: 'redis://localhost:6379/0'
   redis_throttle_url: 'redis://localhost:6379/1'
   remember_device_expiration_hours_aal_1: '720'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -205,6 +205,7 @@ development:
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'
   requests_per_ip_track_only_mode: 'false'
+  s3_reports_enabled: 'false'
   saml_endpoint_configs: '[{"suffix":"","secret_key_passphrase":"trust-but-verify"},{"suffix":"2018","secret_key_passphrase":"asdf1234"}]'
   scrypt_cost: '10000$8$1$' # These values are in hex for N, r, and p.
   secret_key_base: 'development_secret_key_base'
@@ -326,6 +327,8 @@ production:
   requests_per_ip_limit: '300'
   requests_per_ip_period: '300'
   requests_per_ip_track_only_mode: 'false'
+  s3_report_bucket_prefix: 'login-gov.reports'
+  s3_reports_enabled: 'true'
   saml_endpoint_configs:
   scrypt_cost: '10000$8$1$' # These values are in hex for N, r, and p.
   secret_key_base: # generate via `rake secret`
@@ -454,6 +457,7 @@ test:
   requests_per_ip_limit: '4'
   requests_per_ip_period: '60'
   requests_per_ip_track_only_mode: 'false'
+  s3_reports_enabled: 'false'
   saml_endpoint_configs: '[{"suffix":"2019","secret_key_passphrase":"trust-but-verify"},{"suffix":"2018","secret_key_passphrase":"asdf1234"},{"suffix":"cloudhsm","cloudhsm_key_label":"key1"}]'
   scrypt_cost: '800$8$1$' # SCrypt::Engine.calibrate(max_time: 0.01)
   secret_key_base: 'test_secret_key_base'

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -1,5 +1,5 @@
 # Daily GPO letter mailings
-JobRunner::Runner.configurations << JobRunner::JobConfiguration.new(
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'Send GPO letter',
   interval: 24 * 60 * 60,
   timeout: 300,
@@ -9,7 +9,7 @@ JobRunner::Runner.configurations << JobRunner::JobConfiguration.new(
 )
 
 # Send account deletion confirmation notifications
-JobRunner::Runner.configurations << JobRunner::JobConfiguration.new(
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'Account reset notice',
   interval: 5 * 60, # 5 minutes
   timeout: 4 * 60,
@@ -17,7 +17,7 @@ JobRunner::Runner.configurations << JobRunner::JobConfiguration.new(
 )
 
 # Send OMB Fitara report to s3
-JobRunner::Runner.configurations << JobRunner::JobConfiguration.new(
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'OMB Fitara report',
   interval: 24 * 60 * 60, # 5 minutes
   timeout: 300,

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -19,7 +19,7 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
 # Send OMB Fitara report to s3
 JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'OMB Fitara report',
-  interval: 24 * 60 * 60, # 5 minutes
+  interval: 24 * 60 * 60, # 24 hours
   timeout: 300,
   callback: -> { Reports::OmbFitaraReport.new.call },
 )

--- a/spec/features/reports/omb_fitara_report_spec.rb
+++ b/spec/features/reports/omb_fitara_report_spec.rb
@@ -30,4 +30,17 @@ feature 'OMB Fitara compliance officer runs report' do
       expect(Reports::OmbFitaraReport.new.call).to eq(results)
     end
   end
+
+  describe '.generate_s3_path' do
+    it 'generates paths with date or latest prefix' do
+      expect(LoginGov::Hostdata).to receive(:env).twice.and_return('ci')
+
+      Timecop.travel Date.new(2018, 1, 2) do
+        expect(Reports::OmbFitaraReport.generate_s3_path).
+          to eq('ci/omb-fitara-report/2018/2018-01-02.omb-fitara-report.json')
+        expect(Reports::OmbFitaraReport.generate_s3_path(latest: true)).
+          to eq('ci/omb-fitara-report/latest.omb-fitara-report.json')
+      end
+    end
+  end
 end

--- a/spec/services/job_runner/runner_spec.rb
+++ b/spec/services/job_runner/runner_spec.rb
@@ -2,20 +2,72 @@ require 'rails_helper'
 
 describe JobRunner::Runner do
   before do
-    configurations = []
-    configurations << JobRunner::JobConfiguration.new(
+    described_class.clear_configurations
+    described_class.add_config JobRunner::JobConfiguration.new(
       name: 'test job 1',
       interval: 5 * 60,
       timeout: 60,
       callback: -> { 'test job 1 result' },
     )
-    configurations << JobRunner::JobConfiguration.new(
+    described_class.add_config JobRunner::JobConfiguration.new(
       name: 'test job 2',
       interval: 60 * 60,
       timeout: 60 * 30,
       callback: -> { 'test job 2 result' },
     )
-    allow(described_class).to receive(:configurations).and_return(configurations)
+  end
+
+  describe '.configurations' do
+    it 'has the expected configurations' do
+      expect(described_class.configurations.length).to eq 2
+    end
+
+    it 'freezes the result array' do
+      expect { described_class.configurations << 123 }.to raise_error(FrozenError)
+    end
+  end
+
+  describe '.disabled_jobs' do
+    it 'parses disabled job JSON' do
+      expect(described_class.disabled_jobs).to eq ['disabled job']
+    end
+  end
+
+  describe '.add_config' do
+    it 'rejects unexpected classes' do
+      expect { described_class.add_config 123 }.to raise_error(ArgumentError)
+      expect { described_class.add_config 'some job' }.to raise_error(ArgumentError)
+    end
+
+    it 'adds a job to the configurations list' do
+      config = JobRunner::JobConfiguration.new(
+        name: 'test job 3',
+        interval: 60 * 60,
+        timeout: 60 * 30,
+        callback: -> { 'test job 3 result' },
+      )
+
+      expect(described_class.configurations.length).to eq 2
+      described_class.add_config(config)
+      expect(described_class.configurations.length).to eq 3
+      expect(described_class.configurations.last).to eq config
+    end
+
+    it 'is an alias of add_configuration' do
+      expect(described_class.method(:add_config)).to eq described_class.method(:add_configuration)
+    end
+
+    it 'ignores disabled jobs' do
+      disabled_job = JobRunner::JobConfiguration.new(
+        name: 'disabled job',
+        interval: 60,
+        callback: -> { 'blah' },
+      )
+
+      expect(described_class.configurations.length).to eq 2
+      expect(described_class.add_config(disabled_job)).to eq false
+      expect(described_class.configurations.length).to eq 2
+    end
   end
 
   describe '#run' do
@@ -31,7 +83,7 @@ describe JobRunner::Runner do
       expect(second_job.result).to eq('test job 2 result')
     end
 
-    context 'when their are jobs that are not due to run' do
+    context 'when there are jobs that are not due to run' do
       it 'only runs the jobs that are due to run' do
         previous_job_start = 20.minutes.ago
         create(:job_run, job_name: 'test job 2', created_at: previous_job_start)
@@ -48,7 +100,7 @@ describe JobRunner::Runner do
       end
     end
 
-    context 'when their are timed out jobs' do
+    context 'when there are timed out jobs' do
       it 'cleans up the timed out jobs' do
         timed_out_job_start = 120.minutes.ago
         create(:job_run, job_name: 'test job 2', created_at: timed_out_job_start)


### PR DESCRIPTION
## Add a way to disable recurring jobs using config.
**Why**: We may encounter situations where a recurring job is failing
and we need to rapidly disable it, or where a job is failing and we
don't care so we want health checks to stop failing.

**How**: Add a new Figaro key, `recurring_jobs_disabled_names`. This key
is expected to contain JSON representing an array of string job names.
Any job names present in this list will be ignored when
JobRunner::Runner.add_config is called to add a job with a matching
name. This required refactoring the process to add job configs so that
we have an easy place to add such validation.

## Refactor OMB Fitara report to gen S3 bucket name.

**Why**: The existing config methods for the reports had a few
shortcomings. We shouldn't need to set anything in application secrets
in order for this functionality to operate. Any differences between
environments should be encoded in the idp code itself rather than
requiring manual effort from team members anytime a new environment is
created.

In addition, we should use an environment-specific and date-specific
path for the uploaded reports so that we're not overwriting existing
data and so that the IAM permissions can be scoped to prevent
cross-environment interference.

**How**: Add two new Figaro keys, `s3_report_bucket_prefix` and
`s3_reports_enabled`. The latter controls whether we will attempt to
upload to S3 at all (true in production-like envs, false elsewhere). The
former sets the S3 bucket prefix used in all environments. The rest of
the S3 bucket is computed as a function of the environment name, AWS
account ID, and AWS region.

https://github.com/18F/identity-devops/issues/1558

TODO:
- [x] Test in the brody env
- [x] Also copy uploads to a `0-latest.` prefix or similar