### PR TITLE
Use separate controllers for adding and editting phones

### DIFF
--- a/app/controllers/users/add_phone_controller.rb
+++ b/app/controllers/users/add_phone_controller.rb
@@ -1,0 +1,30 @@
+module Users
+  class AddPhoneController
+    include PhoneConfirmation
+
+    before_action :confirm_two_factor_authenticated
+
+    def new
+      @add_phone_form = AddPhoneForm.new(current_user)
+    end
+
+    def create
+      @add_phone_form = AddPhoneForm.new(current_user, nil)
+      if @add_phone_form.submit(user_params).success?
+        confirm_phone
+        bypass_sign_in current_user
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def confirm_phone
+      flash[:notice] = t('devise.registrations.phone_update_needs_confirmation')
+      prompt_to_confirm_phone(id: nil, phone: @add_phone_form.phone,
+                              selected_delivery_method: @add_phone_form.otp_delivery_preference,
+                              selected_default_number: @add_phone_form.otp_make_default_number)
+    end
+  end
+end

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -9,17 +9,17 @@ module Users
     before_action :set_setup_presenter
 
     def index
-      @user_phone_form = UserPhoneForm.new(current_user, nil)
+      @add_phone_form = AddPhoneForm.new(current_user, nil)
       analytics.track_event(Analytics::USER_REGISTRATION_PHONE_SETUP_VISIT)
     end
 
     def create
-      @user_phone_form = UserPhoneForm.new(current_user, nil)
+      @add_phone_form = AddPhoneForm.new(current_user, nil)
       result = @user_phone_form.submit(user_phone_form_params)
       analytics.track_event(Analytics::MULTI_FACTOR_AUTH_PHONE_SETUP, result.to_h)
 
       if result.success?
-        handle_create_success(@user_phone_form.phone)
+        handle_create_success(@add_phone_form.phone)
       else
         render :index
       end
@@ -34,8 +34,8 @@ module Users
     def handle_create_success(phone)
       if MfaContext.new(current_user).phone_configurations.map(&:phone).index(phone).nil?
         prompt_to_confirm_phone(id: nil,
-                                phone: @user_phone_form.phone,
-                                selected_delivery_method: @user_phone_form.otp_delivery_preference)
+                                phone: @add_phone_form.phone,
+                                selected_delivery_method: @add_phone_form.otp_delivery_preference)
       else
         flash[:error] = t('errors.messages.phone_duplicate')
         redirect_to phone_setup_url
@@ -47,7 +47,7 @@ module Users
     end
 
     def user_phone_form_params
-      params.require(:user_phone_form).permit(:phone, :international_code,
+      params.require(:add_phone_form).permit(:phone, :international_code,
                                               :otp_delivery_preference,
                                               :otp_make_default_number)
     end

--- a/app/forms/add_phone_form.rb
+++ b/app/forms/add_phone_form.rb
@@ -1,0 +1,47 @@
+class AddPhoneForm
+  include ActiveModel::Model
+  include FormPhoneValidator
+  include OtpDeliveryPreferenceValidator
+  include RememberDeviceConcern
+
+  validates :otp_delivery_preference, inclusion: { in: %w[voice sms] }
+
+  attr_accessor :phone, :international_code, :otp_delivery_preference,
+                :otp_make_default_number, :user
+
+  def initialize(user)
+    self.user = user
+  end
+
+  def submit(params)
+    ingest_phone_number_params(params)
+
+    success = valid?
+    self.phone = submitted_phone unless success
+
+    revoke_remember_device(user) if success
+
+    FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
+  end
+
+  private
+
+  attr_accessor :submitted_phone
+
+  def ingest_phone_number_params(params)
+    self.otp_delivery_preference = params[:otp_delivery_preference] || 'sms'
+    self.international_code = params[:international_code]
+    self.otp_make_default_number = params[:otp_make_default_number]
+    self.submitted_phone = params[:phone]
+    self.phone = PhoneFormatter.format(
+      params[:phone],
+      country_code: international_code,
+    )
+  end
+
+  def extra_analytics_attributes
+    {
+      otp_delivery_preference: otp_delivery_preference,
+    }
+  end
+end

--- a/app/forms/user_phone_form.rb
+++ b/app/forms/user_phone_form.rb
@@ -44,13 +44,6 @@ class UserPhoneForm
     formatted_user_phone != phone && user.phone_configurations.map(&:phone).include?(phone)
   end
 
-  def phone_config_changed?
-    return true if formatted_user_phone != phone
-    return true if phone_configuration&.delivery_preference != otp_delivery_preference
-    return true if otp_make_default_number && !default_phone_configuration?
-    false
-  end
-
   # :reek:FeatureEnvy
   def masked_number
     phone_number = phone_configuration == nil ? nil : phone_configuration.phone

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,8 +170,8 @@ Rails.application.routes.draw do
     get '/manage/email/confirm_delete/:id' => 'users/emails#confirm_delete',
         as: :manage_email_confirm_delete
 
-    get '/add/phone' => 'users/phones#add'
-    post '/add/phone' => 'users/phones#create'
+    get '/add/phone' => 'users/add_phone#new'
+    post '/add/phone' => 'users/add_phone#create'
     get '/manage/phone' => 'users/phones#edit'
     match '/manage/phone' => 'users/phones#update', via: %i[patch put]
     delete '/manage/phone' => 'users/phones#delete'

--- a/spec/forms/add_phone_form_spec.rb
+++ b/spec/forms/add_phone_form_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe AddPhoneForm do
+  include Shoulda::Matchers::ActiveModel
+
+  let(:user) { create(:user, :signed_up) }
+  let(:params) do
+    {
+      phone: '703-555-5000',
+      international_code: 'US',
+      otp_delivery_preference: 'sms',
+    }
+  end
+
+  subject { described_class.new(user) }
+
+  it_behaves_like 'a phone form'
+  it_behaves_like 'an otp delivery preference form'
+
+  describe 'phone validation' do
+    it do
+      should validate_inclusion_of(:international_code).
+        in_array(PhoneNumberCapabilities::INTERNATIONAL_CODES.keys)
+    end
+
+    it 'validates that the number matches the requested international code' do
+      params[:phone] = '123 123 1234'
+      params[:international_code] = 'MA'
+      result = subject.submit(params)
+
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to eq(false)
+      expect(result.errors).to include(:phone)
+    end
+  end
+
+  it 'is valid when the params are valid' do
+    result = subject.submit(params)
+
+    expect(result).to be_kind_of(FormResponse)
+    expect(result.success?).to eq(true)
+    expect(result.errors).to be_empty
+    expect(result.extra).to eq(
+      otp_delivery_preference: params[:otp_delivery_preference],
+    )
+  end
+
+  it 'revokes the users rememder device sessions' do
+    subject.submit(params)
+
+    expect(user.reload.remember_device_revoked_at).to be_within(1.second).of(Time.zone.now)
+  end
+
+  it 'preserves the format of the submitted phone number if phone is invalid' do
+    params[:phone] = '555-555-5000'
+    params[:international_code] = 'MA'
+
+    result = subject.submit(params)
+
+    expect(result.success?).to eq(false)
+    expect(subject.phone).to eq('555-555-5000')
+  end
+end

--- a/spec/forms/user_phone_form_spec.rb
+++ b/spec/forms/user_phone_form_spec.rb
@@ -14,6 +14,7 @@ describe UserPhoneForm do
   subject { UserPhoneForm.new(user, MfaContext.new(user).phone_configurations.first) }
 
   it_behaves_like 'a phone form'
+  it_behaves_like 'an otp delivery preference form'
 
   it 'loads initial values from the user object' do
     user = build_stubbed(
@@ -92,74 +93,6 @@ describe UserPhoneForm do
       end
     end
 
-    context 'when otp_delivery_preference is voice and phone number does not support voice' do
-      let(:unsupported_phone) { '242-327-0143' }
-      let(:params) do
-        {
-          phone: unsupported_phone,
-          international_code: 'US',
-          otp_delivery_preference: 'voice',
-        }
-      end
-
-      it 'is invalid' do
-        result = subject.submit(params)
-
-        expect(result.success?).to eq(false)
-      end
-    end
-
-    context 'when otp_delivery_preference is not voice or sms' do
-      let(:params) do
-        {
-          phone: '703-555-1212',
-          international_code: 'US',
-          otp_delivery_preference: 'foo',
-        }
-      end
-
-      it 'is invalid' do
-        result = subject.submit(params)
-
-        expect(result.success?).to eq(false)
-        expect(result.errors[:otp_delivery_preference].first).
-          to eq 'is not included in the list'
-      end
-    end
-
-    context 'when otp_delivery_preference is empty' do
-      let(:params) do
-        {
-          phone: '703-555-1212',
-          international_code: 'US',
-          otp_delivery_preference: '',
-        }
-      end
-
-      it 'is invalid' do
-        result = subject.submit(params)
-
-        expect(result.success?).to eq(false)
-        expect(result.errors[:otp_delivery_preference].first).
-          to eq 'is not included in the list'
-      end
-    end
-
-    context 'when otp_delivery_preference param is not present' do
-      let(:params) do
-        {
-          phone: '703-555-1212',
-          international_code: 'US',
-        }
-      end
-
-      it 'is valid' do
-        result = subject.submit(params)
-
-        expect(result.success?).to eq(true)
-      end
-    end
-
     it 'does not raise inclusion errors for Norwegian phone numbers' do
       # ref: https://github.com/18F/identity-private/issues/2392
       params[:phone] = '21 11 11 11'
@@ -175,33 +108,6 @@ describe UserPhoneForm do
       subject.submit(params)
 
       expect(user.reload.remember_device_revoked_at).to be_within(1.second).of(Time.zone.now)
-    end
-  end
-
-  describe '#phone_config_changed?' do
-    it 'returns true if the user phone has changed' do
-      params[:phone] = '+1 504 444 1643'
-      subject.submit(params)
-
-      expect(subject.phone_config_changed?).to eq(true)
-    end
-
-    it 'returns false if the user phone has not changed' do
-      params[:phone] = MfaContext.new(user).phone_configurations.first.phone
-      subject.submit(params)
-
-      expect(subject.phone_config_changed?).to eq(false)
-    end
-
-    context 'when a user has no phone' do
-      it 'returns true' do
-        MfaContext.new(user).phone_configurations.clear
-
-        params[:phone] = '+1 504 444 1643'
-        subject.submit(params)
-
-        expect(subject.phone_config_changed?).to eq(true)
-      end
     end
   end
 end


### PR DESCRIPTION
**Why**: To untangle some of the shared code around adding a phone number and editting a phone configuration