### PR TITLE
LG-1720: Split job health into normal vs critical checks.

### DIFF
--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -7,7 +7,7 @@ module Health
         database: DatabaseHealthChecker,
         account_reset: AccountResetHealthChecker,
       }
-      checkers[:job_runner] = JobRunner::HealthChecker if job_run_healthchecks_enabled?
+      checkers[:job_runner_critical] = JobRunner::HealthCheckerCritical if job_run_healthchecks_enabled?
       MultiHealthChecker.new(**checkers)
     end
 

--- a/app/controllers/health/jobs_controller.rb
+++ b/app/controllers/health/jobs_controller.rb
@@ -1,0 +1,9 @@
+module Health
+  class JobsController < AbstractHealthController
+    private
+
+    def health_checker
+      JobRunner::HealthChecker
+    end
+  end
+end

--- a/app/services/job_runner/health_checker.rb
+++ b/app/services/job_runner/health_checker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JobRunner
   class HealthChecker
     Summary = Struct.new(:healthy, :result) do
@@ -10,8 +12,12 @@ module JobRunner
 
     class << self
       def check
-        result = Runner.configurations.map do |job_configuration|
-          [job_configuration.name, successful_job_run_within_2_intervals?(job_configuration)]
+        jobs = Runner.configurations.select do |job_configuration|
+          job_selected_for_checking?(job_configuration)
+        end
+
+        result = jobs.map do |job_configuration|
+          [job_configuration.name, successful_recent_job_run?(job_configuration)]
         end.to_h
         healthy = !result.value?(false)
         Summary.new(healthy, result)
@@ -19,10 +25,26 @@ module JobRunner
 
       private
 
-      def successful_job_run_within_2_intervals?(job_configuration)
-        interval_window = (job_configuration.interval * 2).seconds.ago
+      # Override this method to filter out some jobs as not checked.
+      # By default, return true always and check all jobs
+      #
+      # @return Boolean
+      #
+      def job_selected_for_checking?(_job_configuration)
+        true
+      end
+
+      # Return whether there has been a succesful run of the given job
+      # configuration in the last N runs, where N is the job configuration's
+      # defined `failures_before_alarm`.
+      #
+      # @param [JobConfiguration] job_configuration
+      # @return [Boolean]
+      #
+      def successful_recent_job_run?(job_configuration)
+        interval_window = job_configuration.interval * job_configuration.failures_before_alarm
         JobRun.where(job_name: job_configuration.name, error: nil).
-          where('created_at > ?', interval_window).
+          where('created_at > ?', interval_window.seconds.ago).
           any?
       end
     end

--- a/app/services/job_runner/health_checker_critical.rb
+++ b/app/services/job_runner/health_checker_critical.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module JobRunner
+  # A subclass of the standard HealthChecker that only looks at job
+  # configurations that are marked with `health_critical: true`.
+  class HealthCheckerCritical < HealthChecker
+    # Select only jobs with #health_critical? => true.
+    def self.job_selected_for_checking?(job_configuration)
+      job_configuration.health_critical?
+    end
+  end
+end

--- a/app/services/job_runner/job_configuration.rb
+++ b/app/services/job_runner/job_configuration.rb
@@ -4,17 +4,39 @@ module JobRunner
     attr_reader :interval
     attr_reader :timeout
     attr_reader :callback
+    attr_reader :failures_before_alarm
 
+    # @param [String] name The name of the job
+    # @param [Integer] interval How often a job should run (seconds)
+    # @param [Integer, nil] timeout How long to wait for a job to run before
+    #   assuming it has timed out (seconds)
+    # @param [Callable] callback The actual job code
+    # @param [Boolean] health_critical Whether this job is critical enough to
+    #   be incorporated in the main app health check.
+    # @param [Integer] failures_before_alarm The number of acceptable failed
+    #   runs before the health check should alarm.
+    #
     # :reek:ControlParameter
-    def initialize(name:, interval:, timeout: nil, callback:)
+    def initialize(name:, interval:, timeout: nil, callback:, health_critical: false,
+                   failures_before_alarm: 1)
       @name = name
       @interval = interval
       @timeout = timeout || interval
       @callback = callback
+      @health_critical = health_critical
+      @failures_before_alarm = failures_before_alarm
     end
 
     def to_s
       "JobConfiguration #{name.inspect}"
+    end
+
+    def health_critical?
+      if @health_critical
+        true
+      else
+        false
+      end
     end
 
     def run_if_needed

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -14,6 +14,8 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   interval: 5 * 60, # 5 minutes
   timeout: 4 * 60,
   callback: -> { AccountReset::GrantRequestsAndSendEmails.new.call },
+  health_critical: true,
+  failures_before_alarm: 2,
 )
 
 # Send OMB Fitara report to s3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   # Non i18n routes. Alphabetically sorted.
   get '/api/health' => 'health/health#index'
   get '/api/health/database' => 'health/database#index'
+  get '/api/health/jobs' => 'health/jobs#index'
   get '/api/openid_connect/certs' => 'openid_connect/certs#index'
   post '/api/openid_connect/token' => 'openid_connect/token#create'
   match '/api/openid_connect/token' => 'openid_connect/token#options', via: :options

--- a/spec/controllers/health/health_controller_spec.rb
+++ b/spec/controllers/health/health_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Health::HealthController do
         allow(DatabaseHealthChecker).to receive(:simple_query).and_return('foo')
         allow(AccountResetHealthChecker).to receive(:check).
           and_return(AccountResetHealthChecker::Summary.new(true, 'foo'))
-        allow(JobRunner::HealthChecker).to receive(:check).
-          and_return(JobRunner::HealthChecker::Summary.new(true, 'foo'))
+        allow(JobRunner::HealthCheckerCritical).to receive(:check).
+          and_return(JobRunner::HealthCheckerCritical::Summary.new(true, 'foo'))
 
         get :index
         json = JSON.parse(response.body, symbolize_names: true)
@@ -21,7 +21,7 @@ RSpec.describe Health::HealthController do
         expect(json[:healthy]).to eq(true)
         expect(json[:statuses][:database][:healthy]).to eq(true)
         expect(json[:statuses][:account_reset][:healthy]).to eq(true)
-        expect(json[:statuses][:job_runner][:healthy]).to eq(true)
+        expect(json[:statuses][:job_runner_critical][:healthy]).to eq(true)
       end
     end
 
@@ -31,8 +31,8 @@ RSpec.describe Health::HealthController do
           and_raise(RuntimeError.new('canceling statement due to statement timeout'))
         allow(AccountResetHealthChecker).to receive(:check).
           and_return(AccountResetHealthChecker::Summary.new(true, 'foo'))
-        allow(JobRunner::HealthChecker).to receive(:check).
-          and_return(JobRunner::HealthChecker::Summary.new(true, 'foo'))
+        allow(JobRunner::HealthCheckerCritical).to receive(:check).
+          and_return(JobRunner::HealthCheckerCritical::Summary.new(true, 'foo'))
 
         get :index
         json = JSON.parse(response.body, symbolize_names: true)
@@ -41,7 +41,7 @@ RSpec.describe Health::HealthController do
         expect(json[:statuses][:database][:result]).
           to include('canceling statement due to statement timeout')
         expect(json[:statuses][:account_reset][:healthy]).to eq(true)
-        expect(json[:statuses][:job_runner][:healthy]).to eq(true)
+        expect(json[:statuses][:job_runner_critical][:healthy]).to eq(true)
         expect(response.status).to eq(500)
       end
     end
@@ -52,8 +52,8 @@ RSpec.describe Health::HealthController do
           and_raise(RuntimeError.new('canceling statement due to statement timeout'))
         allow(AccountResetHealthChecker).to receive(:check).
           and_return(AccountResetHealthChecker::Summary.new(false, 'foo'))
-        allow(JobRunner::HealthChecker).to receive(:check).
-          and_return(JobRunner::HealthChecker::Summary.new(false, 'foo'))
+        allow(JobRunner::HealthCheckerCritical).to receive(:check).
+          and_return(JobRunner::HealthCheckerCritical::Summary.new(false, 'foo'))
 
         get :index
         json = JSON.parse(response.body, symbolize_names: true)
@@ -62,7 +62,7 @@ RSpec.describe Health::HealthController do
         expect(json[:statuses][:database][:result]).
           to include('canceling statement due to statement timeout')
         expect(json[:statuses][:account_reset][:healthy]).to eq(false)
-        expect(json[:statuses][:job_runner][:healthy]).to eq(false)
+        expect(json[:statuses][:job_runner_critical][:healthy]).to eq(false)
         expect(response.status).to eq(500)
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe Health::HealthController do
         expect(json[:healthy]).to eq(true)
         expect(json[:statuses][:database][:healthy]).to eq(true)
         expect(json[:statuses][:account_reset][:healthy]).to eq(true)
-        expect(json[:statuses][:job_runner]).to eq(nil)
+        expect(json[:statuses][:job_runner_critical]).to eq(nil)
       end
     end
   end

--- a/spec/controllers/health/job_controller_spec.rb
+++ b/spec/controllers/health/job_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+# rubocop:disable Style/BracesAroundHashParameters
+
+RSpec.describe Health::JobsController do
+  describe '#index' do
+    subject(:action) { get :index }
+
+    context 'when jobs are healthy' do
+      it 'returns healthy' do
+        allow(JobRunner::HealthChecker).to receive(:check).
+          and_return(JobRunner::HealthChecker::Summary.new(true, { 'foo' => true }))
+
+        action
+
+        expect(response.status).to eq(200)
+
+        json = JSON.parse(response.body)
+
+        expect(json['healthy']).to eq(true)
+        expect(json['result']).to eq({ 'foo' => true })
+      end
+    end
+
+    context 'when jobs are unhealthy' do
+      before do
+        expect(JobRunner::HealthChecker).to receive(:check).
+          and_return(JobRunner::HealthChecker::Summary.new(false, { 'foo' => false }))
+      end
+
+      it 'is a 500' do
+        action
+
+        expect(response.status).to eq(500)
+      end
+
+      it 'renders the error' do
+        action
+
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json[:healthy]).to eq(false)
+        expect(json[:result]).to eq({ foo: false })
+      end
+    end
+  end
+end
+
+# rubocop:enable Style/BracesAroundHashParameters

--- a/spec/services/job_runner/health_checker_critical_spec.rb
+++ b/spec/services/job_runner/health_checker_critical_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe JobRunner::HealthCheckerCritical do
+  before do
+    configurations = []
+    configurations << JobRunner::JobConfiguration.new(
+      name: 'test job 1',
+      interval: 5 * 60,
+      timeout: 60,
+      callback: -> { 'test job 1 result' },
+      health_critical: true,
+    )
+    configurations << JobRunner::JobConfiguration.new(
+      name: 'test job 2',
+      interval: 60 * 60,
+      timeout: 60 * 30,
+      callback: -> { 'test job 2 result' },
+    )
+    allow(JobRunner::Runner).to receive(:configurations).and_return(configurations)
+  end
+
+  context 'when all of the jobs have run as scheduled' do
+    it 'returns a healthy summary' do
+      create(:job_run, job_name: 'test job 1', created_at: 9.minutes.ago)
+      create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
+
+      expected_summary = { healthy: true, result: { 'test job 1' => true } }
+
+      result = described_class.check
+
+      expect(result.healthy?).to eq(true)
+      expect(result.to_h).to eq(expected_summary)
+      expect(result.as_json).to eq(expected_summary.as_json)
+    end
+  end
+
+  context 'when there is a critical job that has not run' do
+    it 'returns an unhealthy summary' do
+      create(:job_run, job_name: 'test job 1', created_at: 11.minutes.ago)
+      create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
+
+      expected_summary = { healthy: false, result: { 'test job 1' => false } }
+
+      result = described_class.check
+
+      expect(result.healthy?).to eq(false)
+      expect(result.to_h).to eq(expected_summary)
+      expect(result.as_json).to eq(expected_summary.as_json)
+    end
+  end
+
+  context 'when there is a non-critical job that has not run' do
+    it 'returns a healthy summary' do
+      create(:job_run, job_name: 'test job 1', created_at: 5.minutes.ago)
+      create(:job_run, job_name: 'test job 2', created_at: 300.minutes.ago)
+
+      expected_summary = { healthy: true, result: { 'test job 1' => true } }
+
+      result = described_class.check
+
+      expect(result.healthy?).to eq(true)
+      expect(result.to_h).to eq(expected_summary)
+      expect(result.as_json).to eq(expected_summary.as_json)
+    end
+  end
+end

--- a/spec/services/job_runner/health_checker_critical_spec.rb
+++ b/spec/services/job_runner/health_checker_critical_spec.rb
@@ -5,26 +5,35 @@ describe JobRunner::HealthCheckerCritical do
     configurations = []
     configurations << JobRunner::JobConfiguration.new(
       name: 'test job 1',
-      interval: 5 * 60,
+      interval: 5 * 60, # 5 minutes
       timeout: 60,
       callback: -> { 'test job 1 result' },
       health_critical: true,
     )
     configurations << JobRunner::JobConfiguration.new(
-      name: 'test job 2',
+      name: 'normal job',
       interval: 60 * 60,
       timeout: 60 * 30,
-      callback: -> { 'test job 2 result' },
+      callback: -> { 'normal job result' },
+    )
+    configurations << JobRunner::JobConfiguration.new(
+      name: 'test job 3',
+      interval: 60 * 60, # hourly
+      timeout: 60,
+      callback: -> { 'test job 3 result' },
+      health_critical: true,
+      failures_before_alarm: 2,
     )
     allow(JobRunner::Runner).to receive(:configurations).and_return(configurations)
   end
 
-  context 'when all of the jobs have run as scheduled' do
+  context 'when all of the jobs have run within allowed intervals' do
     it 'returns a healthy summary' do
-      create(:job_run, job_name: 'test job 1', created_at: 9.minutes.ago)
-      create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
+      create(:job_run, job_name: 'test job 1', created_at: 4.minutes.ago)
+      create(:job_run, job_name: 'normal job', created_at: 20.minutes.ago)
+      create(:job_run, job_name: 'test job 3', created_at: 119.minutes.ago)
 
-      expected_summary = { healthy: true, result: { 'test job 1' => true } }
+      expected_summary = { healthy: true, result: { 'test job 1' => true, 'test job 3' => true } }
 
       result = described_class.check
 
@@ -34,12 +43,14 @@ describe JobRunner::HealthCheckerCritical do
     end
   end
 
-  context 'when there is a critical job that has not run' do
+  context 'when critical jobs are just over allowed threshold' do
     it 'returns an unhealthy summary' do
-      create(:job_run, job_name: 'test job 1', created_at: 11.minutes.ago)
-      create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
+      create(:job_run, job_name: 'test job 1', created_at: 6.minutes.ago)
+      create(:job_run, job_name: 'normal job', created_at: 20.minutes.ago)
+      create(:job_run, job_name: 'test job 3', created_at: 121.minutes.ago)
 
-      expected_summary = { healthy: false, result: { 'test job 1' => false } }
+      expected_summary = { healthy: false,
+                           result: { 'test job 1' => false, 'test job 3' => false } }
 
       result = described_class.check
 
@@ -51,10 +62,11 @@ describe JobRunner::HealthCheckerCritical do
 
   context 'when there is a non-critical job that has not run' do
     it 'returns a healthy summary' do
-      create(:job_run, job_name: 'test job 1', created_at: 5.minutes.ago)
-      create(:job_run, job_name: 'test job 2', created_at: 300.minutes.ago)
+      create(:job_run, job_name: 'test job 1', created_at: 4.minutes.ago)
+      create(:job_run, job_name: 'normal job', created_at: 300.minutes.ago)
+      create(:job_run, job_name: 'test job 3', created_at: 90.minutes.ago)
 
-      expected_summary = { healthy: true, result: { 'test job 1' => true } }
+      expected_summary = { healthy: true, result: { 'test job 1' => true, 'test job 3' => true } }
 
       result = described_class.check
 

--- a/spec/services/job_runner/health_checker_spec.rb
+++ b/spec/services/job_runner/health_checker_spec.rb
@@ -5,13 +5,14 @@ describe JobRunner::HealthChecker do
     configurations = []
     configurations << JobRunner::JobConfiguration.new(
       name: 'test job 1',
-      interval: 5 * 60,
+      interval: 5 * 60, # 5 minutes
       timeout: 60,
       callback: -> { 'test job 1 result' },
+      failures_before_alarm: 3,
     )
     configurations << JobRunner::JobConfiguration.new(
       name: 'test job 2',
-      interval: 60 * 60,
+      interval: 60 * 60, # hourly
       timeout: 60 * 30,
       callback: -> { 'test job 2 result' },
     )
@@ -20,7 +21,7 @@ describe JobRunner::HealthChecker do
 
   context 'when all of the jobs have run as scheduled' do
     it 'returns a healthy summary' do
-      create(:job_run, job_name: 'test job 1', created_at: 9.minutes.ago)
+      create(:job_run, job_name: 'test job 1', created_at: 14.minutes.ago)
       create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
 
       expected_summary = { healthy: true, result: { 'test job 1' => true, 'test job 2' => true } }
@@ -35,7 +36,7 @@ describe JobRunner::HealthChecker do
 
   context 'when there is a job that has not run' do
     it 'returns an unhealthy summary' do
-      create(:job_run, job_name: 'test job 1', created_at: 11.minutes.ago)
+      create(:job_run, job_name: 'test job 1', created_at: 16.minutes.ago)
       create(:job_run, job_name: 'test job 2', created_at: 20.minutes.ago)
 
       expected_summary = { healthy: false, result: { 'test job 1' => false, 'test job 2' => true } }


### PR DESCRIPTION
**Why**: For many recurring jobs that we may run, it's not a big deal if
they don't run exactly on schedule or are failing for a while. For
critical jobs, however, we want to know immediately if they fail.

**How**: Add a `health_critical` boolean parameter that can be passed
when defining a new JobConfiguration. If true, the job will be checked
as part of the main app `/api/health` endpoint and will count toward our
top line SLA. If false, the job will only be checked as part of the new
separate `/api/health/jobs` endpoint. This endpoint is expected to be
noisier but purely internal facing.

https://cm-jira.usa.gov/browse/LG-1720