### PR TITLE
Use bin/rake instead of rake in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -77,8 +77,8 @@ Dir.chdir APP_ROOT do
   run 'bin/rake parallel:setup'
 
   puts "\n== Cleaning up old assets =="
-  run "rake assets:clobber"
-  run "RAILS_ENV=test rake assets:clobber"
+  run "bin/rake assets:clobber"
+  run "RAILS_ENV=test bin/rake assets:clobber"
 
   puts "\n== Removing old logs and tempfiles =="
   run "rm -f log/*"


### PR DESCRIPTION
**Why**: To fix an issue where the bundled rake version and the CLI rake version got out of sync and showed us this error:

> Gem::LoadError: You have already activated rake 12.3.3, but your Gemfile requires rake 12.3.2. Prepending `bundle exec` to your command may solve this.