### PR TITLE
Track an event when we redirect to an SP

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -33,6 +33,7 @@ module OpenidConnect
     end
 
     def handle_successful_handoff
+      analytics.track_event(Analytics::SP_REDIRECT_INITIATED)
       redirect_to @authorize_form.success_redirect_uri
       delete_branded_experience
     end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -75,6 +75,7 @@ class SamlIdpController < ApplicationController
   end
 
   def handle_successful_handoff
+    analytics.track_event(Analytics::SP_REDIRECT_INITIATED)
     delete_branded_experience
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
   end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -154,6 +154,7 @@ class Analytics
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
+  SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
   TOTP_SETUP_VISIT = 'TOTP Setup Visited'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze
   TWILIO_PHONE_VALIDATION_FAILED = 'Twilio Phone Validation Failed'.freeze

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  client_id: client_id,
                  errors: {},
                  user_fully_authenticated: true)
+          expect(@analytics).to receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
+
+          IdentityLinker.new(user, client_id).link_identity(ial: 1)
+          user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
           action
         end
@@ -143,6 +147,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  client_id: client_id,
                  errors: hash_including(:prompt),
                  user_fully_authenticated: true)
+          expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action
         end
@@ -164,6 +169,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                  client_id: nil,
                  errors: hash_including(:client_id),
                  user_fully_authenticated: true)
+          expect(@analytics).to_not receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
           action
         end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -896,6 +896,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
+        expect(@analytics).to receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
         generate_saml_response(user)
       end
@@ -919,6 +920,7 @@ describe SamlIdpController do
         }
 
         expect(@analytics).to receive(:track_event).with(Analytics::SAML_AUTH, analytics_hash)
+        expect(@analytics).to receive(:track_event).with(Analytics::SP_REDIRECT_INITIATED)
 
         generate_saml_response(user)
       end


### PR DESCRIPTION
**Why**: So it is possible to determine how many people we are successfully redirecting from the event logs