### PR TITLE
Stop sorting backup codes by ID

### DIFF
--- a/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/backup_code_selection_presenter.rb
@@ -2,7 +2,7 @@ module TwoFactorAuthentication
   class BackupCodeSelectionPresenter < SelectionPresenter
     def initialize(user)
       @user = user
-      super(user&.backup_code_configurations&.first)
+      super(user&.backup_code_configurations&.take)
     end
 
     def method


### PR DESCRIPTION
**Why**: This causes the backup code query to run super slow