### PR TITLE
LG-1821 Add a uniqueness constratin to email address

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -12,7 +12,6 @@ module Users
 
     def add
       @register_user_email_form = AddUserEmailForm.new
-
       result = @register_user_email_form.submit(current_user, permitted_params)
 
       if result.success?
@@ -20,6 +19,9 @@ module Users
       else
         render :show
       end
+    rescue ActiveRecord::RecordNotUnique
+      flash[:error] = t('email_addresses.add.duplicate')
+      render :show
     end
 
     def resend

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -10,6 +10,7 @@ module Users
       @register_user_email_form = AddUserEmailForm.new
     end
 
+    # :reek:DuplicateMethodCall
     def add
       @register_user_email_form = AddUserEmailForm.new
       result = @register_user_email_form.submit(current_user, permitted_params)

--- a/db/migrate/20190823200349_add_uniqueness_constraint_to_unconfirmed_emails.rb
+++ b/db/migrate/20190823200349_add_uniqueness_constraint_to_unconfirmed_emails.rb
@@ -1,0 +1,12 @@
+class AddUniquenessConstraintToUnconfirmedEmails < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :email_addresses,
+      %i[email_fingerprint user_id],
+      unique: true,
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805215030) do
+ActiveRecord::Schema.define(version: 20190823200349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 20190805215030) do
     t.datetime "updated_at", null: false
     t.datetime "last_sign_in_at"
     t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token", unique: true
+    t.index ["email_fingerprint", "user_id"], name: "index_email_addresses_on_email_fingerprint_and_user_id", unique: true
     t.index ["email_fingerprint"], name: "index_email_addresses_on_all_email_fingerprints"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
     t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -168,6 +168,24 @@ feature 'adding email address' do
     end
   end
 
+  it 'does not raise a 500 if user submits in rapaid succession violating a db constraint' do
+    user = create(:user, :signed_up)
+    sign_in_and_2fa_user(user)
+
+    visit account_path
+    click_link t('account.index.email_add')
+
+    fake_email = instance_double(EmailAddress)
+    expect(fake_email).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+    expect(EmailAddress).to receive(:new).and_return(fake_email)
+
+    fill_in 'Email', with: email
+    click_button t('forms.buttons.submit.default')
+
+    expect(page).to have_current_path(add_email_path)
+    expect(page).to have_content(t('email_addresses.add.duplicate'))
+  end
+
   def sign_in_user_and_add_email(user, add_email = true)
     sign_in_and_2fa_user(user)
 


### PR DESCRIPTION
**Why**: To make certain that a user can only have 1 email address with a given email