### PR TITLE
LG-1789 Update stale password digests as users sign in

### DIFF
--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
 feature 'legacy passwords' do
-  scenario 'signing in with a password digested by the uak verifier grants access' do
+  scenario 'signing in with a password digested by the uak verifier updates the digest' do
     user = create(:user, :signed_up)
     user.update!(
       encrypted_password_digest: Encryption::UakPasswordVerifier.digest('legacy password'),
     )
+
+    expect(
+      Encryption::PasswordVerifier.new.stale_digest?(user.encrypted_password_digest),
+    ).to eq(true)
 
     signin(user.email, 'legacy password')
 
@@ -13,6 +17,9 @@ feature 'legacy passwords' do
       login_otp_path(otp_delivery_preference: :sms, reauthn: false),
     )
     expect(page).to have_content(t('two_factor_authentication.header_text'))
+    expect(
+      Encryption::PasswordVerifier.new.stale_digest?(user.reload.encrypted_password_digest),
+    ).to eq(false)
   end
 
   scenario 'signing in with an incorrect uak password digest does not grant access' do


### PR DESCRIPTION
**Why**: This means that users using digests in legacy formats will have their digests updated to the latest format. This reduces the population of people using legacy formats and makes those legacy formats easier to retire.

This commit uses a devise hook that runs after authentication to rotate the digest. This is necessary because the digest must be rotated between validating the password and saving the user to the session. The user's session depends on the password salt. Re-digesting the password changes the password salt and invalidates the user's session if the user has been saved to the session.