### PR TITLE
LG-1884 Fix 500 error pressing continue before completing mobile capture

### DIFF
--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -17,8 +17,9 @@ module Idv
 
       def check_if_take_photo_with_phone_successful
         dac = DocCapture.find_by(user_id: current_user.id)
-        if dac.acuant_token
-          flow_session[:instance_id] = dac.acuant_token
+        token = dac.acuant_token
+        if token
+          flow_session[:instance_id] = token
           false
         else
           failure(I18n.t('errors.doc_auth.phone_step_incomplete'))

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -2,8 +2,8 @@ module Idv
   module Steps
     class LinkSentStep < DocAuthBaseStep
       def call
-        dac = DocCapture.find_by(user_id: current_user.id)
-        flow_session[:instance_id] = dac.acuant_token
+        error = check_if_take_photo_with_phone_successful
+        return error if error
 
         failure_data, data = verify_back_image(reset_step: :send_link)
         return failure_data if failure_data
@@ -14,6 +14,16 @@ module Idv
       end
 
       private
+
+      def check_if_take_photo_with_phone_successful
+        dac = DocCapture.find_by(user_id: current_user.id)
+        if dac.acuant_token
+          flow_session[:instance_id] = dac.acuant_token
+          false
+        else
+          failure(I18n.t('errors.doc_auth.phone_step_incomplete'))
+        end
+      end
 
       def mark_steps_complete
         %i[send_link link_sent email_sent mobile_front_image mobile_back_image front_image

--- a/app/views/idv/doc_auth/link_sent.html.slim
+++ b/app/views/idv/doc_auth/link_sent.html.slim
@@ -7,7 +7,10 @@ br
   .sm-col.sm-col-9.px1.h1.h2.mb2.mt0.my0 = t('doc_auth.info.link_sent')
 
 .mt0
-br
+- if flow_session[:error_message]
+  p.alert.alert-error = flow_session[:error_message]
+- else
+  br
 = button_to(t('forms.buttons.continue'), url_for, method: :put,
     class: 'btn btn-primary btn-wide sm-col-6 col-12')
 br

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -38,6 +38,8 @@ en:
         <li class="mxn3">The background behind your ID is a solid color</li>
         <li class="mxn3">Background is visible behind the document</li>
         </ul>
+      phone_step_incomplete: You must go to your phone and upload photos of your ID
+        before continuing. We sent you a link with instructions.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You've entered too many incorrect passwords. You

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -39,6 +39,8 @@ es:
         <li class="mxn3">El fondo detrás de su identificación es un color sólido</li>
         <li class="mxn3">El fondo es visible detrás del documento</li>
         </ul>
+      phone_step_incomplete: You must go to your phone and upload photos of your ID
+        before continuing. We sent you a link with instructions.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -39,8 +39,8 @@ es:
         <li class="mxn3">El fondo detrás de su identificación es un color sólido</li>
         <li class="mxn3">El fondo es visible detrás del documento</li>
         </ul>
-      phone_step_incomplete: You must go to your phone and upload photos of your ID
-        before continuing. We sent you a link with instructions.
+      phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
+        antes de continuar. Te enviamos un enlace con instrucciones.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -38,6 +38,8 @@ fr:
         <li class="mxn3">Le fond derrière votre ID est une couleur unie</li>
         <li class="mxn3">Le fond est visible derrière le document</li>
         </ul>
+      phone_step_incomplete: You must go to your phone and upload photos of your ID
+        before continuing. We sent you a link with instructions.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -38,8 +38,9 @@ fr:
         <li class="mxn3">Le fond derrière votre ID est une couleur unie</li>
         <li class="mxn3">Le fond est visible derrière le document</li>
         </ul>
-      phone_step_incomplete: You must go to your phone and upload photos of your ID
-        before continuing. We sent you a link with instructions.
+      phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
+        photos de votre identifiant avant de continuer. Nous vous avons envoyé un
+        lien avec des instructions.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -35,17 +35,15 @@ shared_examples 'link sent step' do |simulate|
     end
 
     it 'proceeds to the next page if the user does not have a phone' do
-      complete_doc_auth_steps_before_link_sent_step(
-        create(:user, :with_authentication_app, :with_piv_or_cac),
-      )
+      user = create(:user, :with_authentication_app, :with_piv_or_cac)
+      mock_doc_captured(user.id)
+      complete_doc_auth_steps_before_link_sent_step(user)
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
     it 'does not proceed to the next page with invalid info' do
-      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
-        and_return([false, ''])
       click_idv_continue
 
       expect(page).to have_current_path(idv_doc_auth_back_image_step) unless simulate


### PR DESCRIPTION
**Why**: Test to not continue mocked the Acuant call but the Acuant call should have not been made.  There should have been a check to see that the token was set from the mobile flow in order to continue.