### PR TITLE
LG-1885 Fix proofing event logging name collision

### DIFF
--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -42,7 +42,7 @@ module Idv
         FormResponse.new(
           success: idv_success(idv_result),
           errors: idv_errors(idv_result),
-          extra: idv_extra(idv_result),
+          extra: { proofing_results: idv_extra(idv_result) },
         )
       end
 


### PR DESCRIPTION
**Why**: The extra hash for proofing results is added to the base hash and the "context" field conflicts with the IDP field for "context":"authentication".  Kibana does not allow field types to change.

**How**: The fix is simply to add one level of indirection to the proofing results {proofing_results:...}