### PR TITLE
Use AAMVA gem at version 3.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,6 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v3.2.1'
+  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v3.2.2'
   gem 'lexisnexis', git: 'git@github.com:18F/identity-lexisnexis-api-client-gem', tag: 'v1.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: git@github.com:18F/identity-aamva-api-client-gem
-  revision: 03fc2f8c9bfb3218da2a7cb7c309b0650a5bebe5
-  tag: v3.2.1
+  revision: 5268fd1841cd7982f2262544bbe1e0a3f2751e64
+  tag: v3.2.2
   specs:
-    aamva (3.2.1)
+    aamva (3.2.2)
       dotenv
+      faraday
       hashie
       typhoeus
       xmldsig


### PR DESCRIPTION
**Why**: To take advantage of changes to use the Faraday client instead of Typhoeus