### PR TITLE
Remove the tests that test international OTP confirmation

### DIFF
--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -10,11 +10,6 @@ describe 'phone otp confirmation' do
     it_behaves_like 'phone otp confirmation', :sms
     it_behaves_like 'phone otp confirmation', :voice
 
-    context 'with an international phone number' do
-      let(:phone) { '+81543543643' }
-      it_behaves_like 'phone otp confirmation', :sms
-    end
-
     def visit_otp_confirmation(delivery_method)
       select_2fa_option(:phone)
       fill_in :user_phone_form_phone, with: phone
@@ -44,11 +39,6 @@ describe 'phone otp confirmation' do
 
     it_behaves_like 'phone otp confirmation', :sms
     it_behaves_like 'phone otp confirmation', :voice
-
-    context 'with an international phone number' do
-      let(:phone) { '+81543543643' }
-      it_behaves_like 'phone otp confirmation', :sms
-    end
 
     def visit_otp_confirmation(delivery_method)
       select_2fa_option(:phone)
@@ -87,15 +77,6 @@ describe 'phone otp confirmation' do
     it_behaves_like 'phone otp confirmation', :sms
     it_behaves_like 'phone otp confirmation', :voice
 
-    context 'with an international phone number' do
-      before do
-        user.phone_configurations.first.update!(phone: formatted_phone)
-      end
-
-      let(:phone) { '+81543543643' }
-      it_behaves_like 'phone otp confirmation', :sms
-    end
-
     def visit_otp_confirmation(delivery_method)
       user.phone_configurations.first.update!(delivery_preference: delivery_method)
       sign_in_user(user)
@@ -117,11 +98,6 @@ describe 'phone otp confirmation' do
 
     it_behaves_like 'phone otp confirmation', :sms
     it_behaves_like 'phone otp confirmation', :voice
-
-    context 'with an international phone number' do
-      let(:phone) { '+81543543643' }
-      it_behaves_like 'phone otp confirmation', :sms
-    end
 
     def visit_otp_confirmation(delivery_method)
       sign_in_live_with_2fa(user)


### PR DESCRIPTION
**Why**: We moved the branches for sending OTPs to international numbers into the telephony gem and we test it in there. That made these tests effectively duplicates of the domestic SMS tests.