### PR TITLE
Show a flash when a user sets up webauthn

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -85,7 +85,15 @@ module Users
       mark_user_as_fully_authenticated
       save_remember_device_preference
       Funnel::Registration::AddMfa.call(current_user.id, 'webauthn')
+      flash[:success] = t('notices.webauthn_configured') if should_show_webauthn_configured_message?
       redirect_to two_2fa_setup
+    end
+
+    def should_show_webauthn_configured_message?
+      # If the user's only MFA method is the one they just setup, then they will be redirected to
+      # the mfa option screen which will show them the first MFA success message. In that case we
+      # do not want to show this additional flash message here.
+      MfaPolicy.new(current_user).multiple_factors_enabled?
     end
 
     def process_invalid_webauthn(form)

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -50,4 +50,5 @@ en:
     use_diff_email:
       link: use a different email address
       text_html: Or, %{link}
+    webauthn_configured: You enabled a security key.
     webauthn_deleted: You removed a security key.

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -50,4 +50,5 @@ es:
     use_diff_email:
       link: use un email diferente
       text_html: O %{link}
+    webauthn_configured: Ha permitido una clave de seguridad.
     webauthn_deleted: Has eliminado una clave de seguridad.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -53,4 +53,5 @@ fr:
     use_diff_email:
       link: utilisez une adresse courriel différente
       text_html: Or, %{link}
+    webauthn_configured: Ha permitido una clé de sécurité.
     webauthn_deleted: Vous avez supprimé une clé de sécurité.

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -15,6 +15,7 @@ describe 'webauthn management' do
   end
 
   def expect_webauthn_setup_success
+    expect(page).to have_content(t('notices.webauthn_configured'))
     expect(page).to have_current_path(account_path)
   end
 

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -11,6 +11,10 @@ feature 'webauthn sign up' do
     end
 
     def expect_webauthn_setup_success
+      # When setting up a method as a first MFA the user will see a success screen. The success
+      # flash for webauthn should not display because it would be duplicative.
+      expect(page).to_not have_content(t('notices.webauthn_configured'))
+
       expect(current_path).to eq two_factor_options_success_path
       click_continue
 
@@ -43,6 +47,7 @@ feature 'webauthn sign up' do
     end
 
     def expect_webauthn_setup_success
+      expect(page).to have_content(t('notices.webauthn_configured'))
       expect(page).to have_current_path(account_path)
     end
 


### PR DESCRIPTION
**Why**: So the user has the same experience for setting up all of the methods