### PR TITLE
Show a flash when the user successfully sets up a phone

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -119,6 +119,14 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     user_session[:authn_at] = Time.zone.now
     Funnel::Registration::AddMfa.call(current_user.id, 'phone')
     assign_phone
+    flash[:success] = t('notices.phone_confirmed') if should_show_phone_confirmed_message?
+  end
+
+  def should_show_phone_confirmed_message?
+    # If the user's only MFA method is the one they just setup, then they will be redirected to
+    # the mfa option screen which will show them the first MFA success message. In that case we
+    # do not want to show this additional flash message here.
+    MfaPolicy.new(current_user).multiple_factors_enabled?
   end
 
   def handle_valid_otp_for_authentication_context

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -14,6 +14,7 @@ en:
         link: create a new account
         text_html: Or, %{link} using a different email address.
     password_changed: You changed your password.
+    phone_confirmed: Phone confirmed successfully.
     piv_cac_configured: PIV/CAC card linked successfully.
     piv_cac_disabled: PIV/CAC card unlinked successfully.
     resend_confirmation_email:

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -14,6 +14,7 @@ es:
         link: crear una cuenta nueva
         text_html: O, %{link} utilizando un email diferente.
     password_changed: Ha cambiado su contraseña.
+    phone_confirmed: Teléfono confirmado con éxito.
     piv_cac_configured: Tarjeta PIV/CAC vinculada con éxito.
     piv_cac_disabled: Tarjeta PIV/CAC desvinculada con éxito.
     resend_confirmation_email:

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -15,6 +15,7 @@ fr:
         link: Créer un nouveau compte
         text_html: Ou, %{link} en utilisant une adresse courriel différente.
     password_changed: Vous avez changé votre mot de passe.
+    phone_confirmed: Téléphone confirmé avec succès.
     piv_cac_configured: Carte PIV/CAC liée avec succès.
     piv_cac_disabled: Carte PIV/CAC dissociée avec succès.
     resend_confirmation_email:

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -23,6 +23,9 @@ describe 'phone otp confirmation' do
     end
 
     def expect_successful_otp_confirmation(delivery_method)
+      # When setting up a method as a first MFA the user will see a success screen. The success
+      # flash for phone should not display because it would be duplicative.
+      expect(page).to_not have_content(t('notices.phone_confirmed'))
       select_2fa_option(:backup_code)
       click_continue
 
@@ -67,6 +70,7 @@ describe 'phone otp confirmation' do
     end
 
     def expect_successful_otp_confirmation(delivery_method)
+      expect(page).to have_content(t('notices.phone_confirmed'))
       expect(page).to have_current_path(account_path)
       expect(phone_configuration.confirmed_at).to_not be_nil
       expect(phone_configuration.delivery_preference.to_s).to eq(delivery_method.to_s)
@@ -132,6 +136,8 @@ describe 'phone otp confirmation' do
     end
 
     def expect_successful_otp_confirmation(delivery_method)
+      expect(page).to have_content(t('notices.phone_confirmed'))
+      expect(page).to have_current_path(account_path)
       expect(phone_configuration.confirmed_at).to_not be_nil
       expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
     end


### PR DESCRIPTION
**Why**: So the user has the same experience for setting up all of the methods