### PR TITLE
Show a flash message when backup codes are configured

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -28,6 +28,7 @@ module Users
     def edit; end
 
     def continue
+      flash[:success] = t('notices.backup_codes_configured')
       redirect_to two_2fa_setup
     end
 

--- a/config/locales/notices/en.yml
+++ b/config/locales/notices/en.yml
@@ -2,6 +2,7 @@
 en:
   notices:
     account_reactivation: Great! You have your personal key.
+    backup_codes_configured: Backup codes configured successfully.
     dap_participation: We participate in the US government’s analytics program. See
       the data at analytics.usa.gov.
     forgot_password:

--- a/config/locales/notices/es.yml
+++ b/config/locales/notices/es.yml
@@ -2,6 +2,7 @@
 es:
   notices:
     account_reactivation: "¡Estupendo! Tiene su clave personal."
+    backup_codes_configured: Códigos de respaldo configurados con éxito.
     dap_participation: Participamos en el programa analítico del Gobierno de Estados
       Unidos. Vea los datos en analytics.usa.gov (en inglés).
     forgot_password:

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -2,6 +2,7 @@
 fr:
   notices:
     account_reactivation: Excellent! Vous avez votre clé personnelle.
+    backup_codes_configured: Codes de sauvegarde configurés avec succès.
     dap_participation: Nous participons au programme d'analytique du gouvernement
       des États-Unis. Consultez les données à analytics.usa.gov.
     forgot_password:

--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -13,7 +13,13 @@ feature 'Backup codes' do
       old_backup_code = user.backup_code_configurations.sample
       click_link t('forms.backup_code.regenerate'), href: backup_code_regenerate_path
       click_on t('account.index.backup_code_confirm_regenerate')
+
       expect(BackupCodeConfiguration.where(id: old_backup_code.id).any?).to eq(false)
+
+      click_continue
+
+      expect(page).to have_content(t('notices.backup_codes_configured'))
+      expect(page).to have_current_path(account_path)
     end
   end
 
@@ -42,6 +48,8 @@ feature 'Backup codes' do
 
       expected_message = "#{t('account.index.backup_codes_exist')}\n#{formatted_generated_at}"
 
+      expect(page).to have_content(t('notices.backup_codes_configured'))
+      expect(page).to have_current_path(account_path)
       expect(page).to have_content(expected_message)
     end
   end

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -17,6 +17,7 @@ feature 'sign up with backup code' do
     click_on 'Continue'
     click_continue
 
+    expect(page).to have_content(t('notices.backup_codes_configured'))
     expect(current_path).to eq account_path
     expect(FirstMfaEnabledForUser.call(user)).to eq(:backup_code)
     expect(user.backup_code_configurations.count).to eq(10)
@@ -54,6 +55,7 @@ feature 'sign up with backup code' do
         expect(user.backup_code_configurations.count).to eq(10)
         click_on 'Continue'
 
+        expect(page).to have_content(t('notices.backup_codes_configured'))
         expect(current_path).to eq account_path
         expect(user.backup_code_configurations.count).to eq(10)
       else


### PR DESCRIPTION
**Why**: So the user has the same experience for setting up all of the methods