### PR TITLE
css fixes for IE 11

### DIFF
--- a/app/assets/stylesheets/components/_personal-key.scss
+++ b/app/assets/stylesheets/components/_personal-key.scss
@@ -48,7 +48,7 @@
   background-color: $blue-lightest;
   background-position: center 3.3rem;
   background-repeat: no-repeat;
-  background-size: 115px;
+  background-size: 145px 145px;
   border-bottom: 1px solid $border-color;
 }
 

--- a/app/views/layouts/base.html.slim
+++ b/app/views/layouts/base.html.slim
@@ -45,7 +45,7 @@ html lang="#{I18n.locale}" class='no-js'
       = render 'shared/newrelic/browser_instrumentation'
 
   body class="#{Rails.env}-env site #{yield(:background_cls)}"
-    .site-wrap
+    .site-wrap.bg-light-blue
       - if FeatureManagement.fake_banner_mode?
         = render 'shared/fake_banner'
       - else


### PR DESCRIPTION
The good news is many of the IE 11 issues I saw previously were corrected by the recent asset paths fix.

Here are the remaining issues that are resolved in this PR:

Footer overlapping main content area:
![image](https://user-images.githubusercontent.com/18326436/64750457-fa64fe00-d4e6-11e9-9b44-3b889596fe22.png)

After the fix:
![image](https://user-images.githubusercontent.com/18326436/64750470-0781ed00-d4e7-11e9-9592-bb22244d80bb.png)

Personal key graphic is incorrect:
![image](https://user-images.githubusercontent.com/18326436/64750517-35ffc800-d4e7-11e9-8a76-f4948e2460ca.png)

After the fix:
![image](https://user-images.githubusercontent.com/18326436/64750530-42842080-d4e7-11e9-997a-f3ee8144e3b1.png)
