### PR TITLE
Change the way the proofing client gems are specified in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,6 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', git: 'git@github.com:18F/identity-aamva-api-client-gem', tag: 'v3.2.2'
-  gem 'lexisnexis', git: 'git@github.com:18F/identity-lexisnexis-api-client-gem', tag: 'v1.2.0'
+  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.2.2'
+  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v1.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:18F/identity-aamva-api-client-gem
+  remote: https://github.com/18F/identity-aamva-api-client-gem.git
   revision: 5268fd1841cd7982f2262544bbe1e0a3f2751e64
   tag: v3.2.2
   specs:
@@ -11,21 +11,21 @@ GIT
       xmldsig
 
 GIT
-  remote: git@github.com:18F/identity-lexisnexis-api-client-gem
-  revision: 29f554ed2ea237c59a20fdbe4a675508b9c8539d
-  tag: v1.2.0
-  specs:
-    lexisnexis (1.2.0)
-      dotenv
-      typhoeus
-
-GIT
   remote: https://github.com/18F/identity-hostdata.git
   revision: b5587588601670f762bbc79f0f4a8468064d9401
   branch: master
   specs:
     identity-hostdata (0.3.3)
       aws-sdk-s3 (~> 1.8)
+
+GIT
+  remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git
+  revision: 29f554ed2ea237c59a20fdbe4a675508b9c8539d
+  tag: v1.2.0
+  specs:
+    lexisnexis (1.2.0)
+      dotenv
+      typhoeus
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git


### PR DESCRIPTION
**Why**: Using the SSH origins will cause problems for people trying to install the gems without GitHub configured to use SSH

This closes #3270 

Shoutout to @laurenancona for the fix to this one.