### PR TITLE
LG-1765 Sign in with PIV/CAC feedback on errors

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -17,11 +17,9 @@ module Users
       redirect_to PivCacService.piv_cac_service_link(piv_cac_nonce)
     end
 
-    def account_not_found
-    end
+    def account_not_found; end
 
-    def did_not_work
-    end
+    def did_not_work; end
 
     private
 

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -7,8 +7,6 @@ module Users
     def new
       if params.key?(:token)
         process_piv_cac_login
-      elsif flash[:error_type].present?
-        render_error
       else
         render_prompt
       end
@@ -19,15 +17,16 @@ module Users
       redirect_to PivCacService.piv_cac_service_link(piv_cac_nonce)
     end
 
+    def account_not_found
+    end
+
+    def did_not_work
+    end
+
     private
 
     def two_factor_authentication_method
       'piv_cac'
-    end
-
-    def render_error
-      @presenter = PivCacAuthenticationErrorPresenter.new(error: flash[:error_type])
-      render :error
     end
 
     def render_prompt
@@ -86,8 +85,11 @@ module Users
     end
 
     def process_invalid_submission
-      flash[:error_type] = piv_cac_login_form.error_type
-      redirect_to root_url
+      if piv_cac_login_form.valid_token?
+        redirect_to login_piv_cac_account_not_found_url
+      else
+        redirect_to login_piv_cac_did_not_work_url
+      end
     end
 
     def mark_user_session_authenticated(authentication_type)

--- a/app/presenters/piv_cac_authentication_login_presenter.rb
+++ b/app/presenters/piv_cac_authentication_login_presenter.rb
@@ -23,4 +23,8 @@ class PivCacAuthenticationLoginPresenter
   def heading
     t('headings.piv_cac_login.new')
   end
+
+  def info
+    t('instructions.mfa.piv_cac.sign_in')
+  end
 end

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -4,7 +4,7 @@ h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
 p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
         sign_in: link_to(t('headings.sign_in_without_sp'), root_url),
         add_piv_cac: link_to(t('instructions.mfa.piv_cac.add_piv_cac'),
-          'https://login.gov/help/creating-an-account/two-factor-authentication/)
+          'https://login.gov/help/creating-an-account/two-factor-authentication/'),
         create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -4,7 +4,8 @@ h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
 p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
         sign_in: link_to(t('headings.sign_in_without_sp'), root_url),
         add_piv_cac: link_to(t('instructions.mfa.piv_cac.add_piv_cac'),
-          'https://login.gov/help/creating-an-account/two-factor-authentication/'),
+          'https://login.gov/help/creating-an-account/two-factor-authentication/',
+          target: '_blank'),
         create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -2,7 +2,9 @@
 
 h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
 p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
-        sign_in: link_to(I18n.t('headings.sign_in_without_sp'), root_url),
+        sign_in: link_to(t('headings.sign_in_without_sp'), root_url),
+        add_piv_cac: link_to(t('instructions.mfa.piv_cac.add_piv_cac'),
+          'https://login.gov/help/creating-an-account/two-factor-authentication/)
         create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -1,0 +1,8 @@
+- title t('headings.piv_cac_login.account_not_found')
+
+h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
+p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
+        sign_in: link_to(I18n.t('headings.sign_in_without_sp'), root_url),
+        create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
+
+= render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/did_not_work.html.slim
+++ b/app/views/users/piv_cac_login/did_not_work.html.slim
@@ -4,4 +4,7 @@ h1.h3.my0 = t('headings.piv_cac_login.did_not_work')
 p.mt2.mb2 == t('instructions.mfa.piv_cac.did_not_work',
                try_again: link_to(I18n.t('instructions.mfa.piv_cac.try_again'), login_piv_cac_url))
 
+.mt3
+  = link_to t('instructions.mfa.piv_cac.back_to_sign_in'), root_url, class: 'usa-button'
+
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/did_not_work.html.slim
+++ b/app/views/users/piv_cac_login/did_not_work.html.slim
@@ -1,0 +1,7 @@
+- title t('headings.piv_cac_login.did_not_work')
+
+h1.h3.my0 = t('headings.piv_cac_login.did_not_work')
+p.mt2.mb2 == t('instructions.mfa.piv_cac.did_not_work',
+               try_again: link_to(I18n.t('instructions.mfa.piv_cac.try_again'), login_piv_cac_url))
+
+= render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/new.html.slim
+++ b/app/views/users/piv_cac_login/new.html.slim
@@ -1,6 +1,7 @@
 - title @presenter.title
 
 h1.h3.my0 = @presenter.heading
+p.mt2.mb2 == @presenter.info
 .no-spinner
 
   = link_to @presenter.piv_cac_capture_text,

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -71,7 +71,7 @@ en:
       buttons:
         delete: Remove Phone
     piv_cac_login:
-      submit: Present PIV/CAC card
+      submit: Insert your PIV/CAC
     piv_cac_mfa:
       submit: Present PIV/CAC card
     piv_cac_setup:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -76,7 +76,7 @@ es:
       buttons:
         delete: Eliminar el teléfono
     piv_cac_login:
-      submit: Presentar tarjeta PIV/CAC
+      submit: Inserte su PIV/CAC
     piv_cac_mfa:
       submit: Presentar tarjeta PIV/CAC
     piv_cac_setup:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -75,7 +75,7 @@ fr:
       buttons:
         delete: Supprimer le numéro de teléfono
     piv_cac_login:
-      submit: Veuillez présenter une carte PIV/CAC
+      submit: Insérez votre PIV/CAC
     piv_cac_mfa:
       submit: Veuillez présenter une carte PIV/CAC
     piv_cac_setup:

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -36,7 +36,9 @@ en:
       forgot: Forgot your password?
     personal_key: Always have access to your account with your personal key
     piv_cac_login:
-      new: Use your PIV/CAC to sign in to your account
+      account_not_found: Your PIV/CAC is not connected to an account
+      did_not_work: Your PIV/CAC did not work
+      new: Sign in with your PIV or CAC
     piv_cac_setup:
       certificate:
         bad: The certificate you selected is invalid.

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -37,6 +37,8 @@ es:
       forgot: "¿Olvidó su contraseña?"
     personal_key: Siempre tenga acceso a su cuenta con su clave personal
     piv_cac_login:
+      account_not_found: Your PIV/CAC is not connected to an account
+      did_not_work: Your PIV/CAC did not work
       new: Use su PIV / CAC para iniciar sesión en su cuenta
     piv_cac_setup:
       certificate:

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -37,8 +37,8 @@ es:
       forgot: "¿Olvidó su contraseña?"
     personal_key: Siempre tenga acceso a su cuenta con su clave personal
     piv_cac_login:
-      account_not_found: Your PIV/CAC is not connected to an account
-      did_not_work: Your PIV/CAC did not work
+      account_not_found: Su PIV / CAC no está conectado a una cuenta
+      did_not_work: Su PIV / CAC no funcionó
       new: Use su PIV / CAC para iniciar sesión en su cuenta
     piv_cac_setup:
       certificate:

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -37,6 +37,8 @@ fr:
       forgot: Vous avez oublié votre mot de passe?
     personal_key: Ayez toujours accès à votre compte avec votre clé personnelle
     piv_cac_login:
+      account_not_found: Your PIV/CAC is not connected to an account
+      did_not_work: Your PIV/CAC did not work
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
     piv_cac_setup:
       certificate:

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -37,8 +37,8 @@ fr:
       forgot: Vous avez oublié votre mot de passe?
     personal_key: Ayez toujours accès à votre compte avec votre clé personnelle
     piv_cac_login:
-      account_not_found: Your PIV/CAC is not connected to an account
-      did_not_work: Your PIV/CAC did not work
+      account_not_found: Votre PIV / CAC n'est pas connecté à un compte
+      did_not_work: Votre PIV / CAC n'a pas fonctionné
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
     piv_cac_setup:
       certificate:

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -26,8 +26,9 @@ en:
         or: or
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> with you email address and
-          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
-          have a login.gov account?</strong> %{create_account}"
+          password.<br><br>%{add_piv_cac}<br><br><strong>Don't have a login.gov account?</strong>
+          %{create_account}"
+        add_piv_cac: Find out how to add a PIV/CAC to your account.
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -25,7 +25,17 @@ en:
           at %{app}.%{tooltip}
         or: or
       piv_cac:
+        account_not_found: "<strong>%{sign_in}</strong> with you email address and
+          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
+          have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
+        create_account_link: 
+        did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
+          this is an error, %{try_again}.  If this problem continues, contact your
+          agency administrator.
+        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
+          set up PIV/CAC</strong> as a two-factor authentication method.
+        try_again: try again
       sms:
         confirm_code_html: Need another code? %{resend_code_link}. Message rates may
           apply.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -29,7 +29,6 @@ en:
           password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
           have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
-        create_account_link: 
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
           this is an error, %{try_again}.  If this problem continues, contact your
           agency administrator.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -28,6 +28,7 @@ en:
         account_not_found: "<strong>%{sign_in}</strong> with you email address and
           password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
           have a login.gov account?</strong> %{create_account}"
+        back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
           this is an error, %{try_again}.  If this problem continues, contact your

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -26,17 +26,17 @@ es:
           a %{email} en %{app}.%{tooltip}
         or: o
       piv_cac:
-        account_not_found: "<strong>%{sign_in}</strong> with you email address and
-          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
-          have a login.gov account?</strong> %{create_account}"
-        back_to_sign_in: Go back to sign in
+        account_not_found: "<strong>%{sign_in}</strong> con su dirección de correo
+          electrónico y contraseña.<br><br>Agregue su PIV/CAC a su cuenta.<br><br><strong>¿No
+          tiene una cuenta login.gov?</strong> %{create_account}"
+        back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
-        did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
-          this is an error, %{try_again}.  If this problem continues, contact your
-          agency administrator.
-        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
-          set up PIV/CAC</strong> as a two-factor authentication method.
-        try_again: try again
+        did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que
+          esto es un error, %{try_again}.  Si este problema continúa, comuníquese
+          con el administrador de su agencia.
+        sign_in: Asegúrese de que <strong>tenga una cuenta login.gov</strong> y <strong>haya
+          configurado PIV/CAC</strong> como método de autenticación de dos factores.
+        try_again: inténtalo de nuevo
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar
           sujeto a cargos de mensajería y datos."

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -27,8 +27,9 @@ es:
         or: o
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> con su dirección de correo
-          electrónico y contraseña.<br><br>Agregue su PIV/CAC a su cuenta.<br><br><strong>¿No
-          tiene una cuenta login.gov?</strong> %{create_account}"
+          electrónico y contraseña.<br><br>%{add_piv_cac}<br><br><strong>¿No tiene
+          una cuenta login.gov?</strong> %{create_account}"
+        add_piv_cac: Descubra cómo agregar un PIV/CAC a su cuenta.
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -26,7 +26,17 @@ es:
           a %{email} en %{app}.%{tooltip}
         or: o
       piv_cac:
+        account_not_found: "<strong>%{sign_in}</strong> with you email address and
+          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
+          have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
+        create_account_link: 
+        did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
+          this is an error, %{try_again}.  If this problem continues, contact your
+          agency administrator.
+        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
+          set up PIV/CAC</strong> as a two-factor authentication method.
+        try_again: try again
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar
           sujeto a cargos de mensajería y datos."

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -30,7 +30,6 @@ es:
           password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
           have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
-        create_account_link: 
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
           this is an error, %{try_again}.  If this problem continues, contact your
           agency administrator.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -29,6 +29,7 @@ es:
         account_not_found: "<strong>%{sign_in}</strong> with you email address and
           password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
           have a login.gov account?</strong> %{create_account}"
+        back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
           this is an error, %{try_again}.  If this problem continues, contact your

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -31,6 +31,7 @@ fr:
         account_not_found: "<strong>%{sign_in}</strong> with you email address and
           password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
           have a login.gov account?</strong> %{create_account}"
+        back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -28,8 +28,18 @@ fr:
           le code correspondant à %{email} à %{app}.%{tooltip}
         or: or
       piv_cac:
+        account_not_found: "<strong>%{sign_in}</strong> with you email address and
+          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
+          have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.
+        create_account_link: 
+        did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
+          this is an error, %{try_again}.  If this problem continues, contact your
+          agency administrator.
+        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
+          set up PIV/CAC</strong> as a two-factor authentication method.
+        try_again: try again
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.
           Les frais liés aux messages texte peuvent s'appliquer.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -33,7 +33,6 @@ fr:
           have a login.gov account?</strong> %{create_account}"
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.
-        create_account_link: 
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
           this is an error, %{try_again}.  If this problem continues, contact your
           agency administrator.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -29,8 +29,9 @@ fr:
         or: or
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> votre adresse e-mail et votre
-          mot de passe.<br><br>Ajoutez votre PIV / CAC à votre compte.<br><br><strong>Vous
-          n'avez pas de compte login.gov?</strong> %{create_account}"
+          mot de passe.<br><br>%{add_piv_cac}<br><br><strong>Vous n'avez pas de compte
+          login.gov?</strong> %{create_account}"
+        add_piv_cac: Découvrez comment ajouter un PIV/CAC à votre compte.
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -28,18 +28,19 @@ fr:
           le code correspondant à %{email} à %{app}.%{tooltip}
         or: or
       piv_cac:
-        account_not_found: "<strong>%{sign_in}</strong> with you email address and
-          password.<br><br>Add your PIV/CAC to your account.<br><br><strong>Don't
-          have a login.gov account?</strong> %{create_account}"
-        back_to_sign_in: Go back to sign in
+        account_not_found: "<strong>%{sign_in}</strong> votre adresse e-mail et votre
+          mot de passe.<br><br>Ajoutez votre PIV / CAC à votre compte.<br><br><strong>Vous
+          n'avez pas de compte login.gov?</strong> %{create_account}"
+        back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.
-        did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think
-          this is an error, %{try_again}.  If this problem continues, contact your
-          agency administrator.
-        sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
-          set up PIV/CAC</strong> as a two-factor authentication method.
-        try_again: try again
+        did_not_work: Il peut y avoir un problème avec votre PIV / CAC ou votre code
+          PIN. Si vous pensez que c'est une erreur, %{try_again}.  Si le problème
+          persiste, contactez l'administrateur de votre agence.
+        sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
+          et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
+          d'authentification à deux facteurs.
+        try_again: réessayer
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.
           Les frais liés aux messages texte peuvent s'appliquer.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,8 @@ Rails.application.routes.draw do
 
       if FeatureManagement.allow_piv_cac_login?
         get '/login/piv_cac' => 'users/piv_cac_login#new'
+        get '/login/piv_cac_account_not_found' => 'users/piv_cac_login#account_not_found'
+        get '/login/piv_cac_did_not_work' => 'users/piv_cac_login#did_not_work'
         get '/login/present_piv_cac' => 'users/piv_cac_login#redirect_to_piv_cac_service'
         get '/login/password' => 'password_capture#new', as: :capture_password
         post '/login/password' => 'password_capture#create'

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -33,7 +33,6 @@ feature 'Sign in' do
   end
 
   scenario 'user cannot sign in with an unregistered piv/cac card' do
-    user = build(:user)
     signin_with_bad_piv
 
     expect(current_path).to eq login_piv_cac_did_not_work_path

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -34,7 +34,7 @@ feature 'Sign in' do
 
   scenario 'user cannot sign in with an unregistered piv/cac card' do
     user = build(:user)
-    signin_with_bad_piv(user)
+    signin_with_bad_piv
 
     expect(current_path).to eq login_piv_cac_did_not_work_path
   end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -29,7 +29,7 @@ feature 'Sign in' do
     user = build(:user, x509_dn_uuid: 'unknown-pivcac-uuid')
     signin_with_piv(user)
 
-    expect(current_path).to eq new_user_session_path
+    expect(current_path).to eq login_piv_cac_account_not_found_path
   end
 
   it 'does not throw an exception if the email contains invalid bytes' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -32,6 +32,13 @@ feature 'Sign in' do
     expect(current_path).to eq login_piv_cac_account_not_found_path
   end
 
+  scenario 'user cannot sign in with an unregistered piv/cac card' do
+    user = build(:user)
+    signin_with_bad_piv(user)
+
+    expect(current_path).to eq login_piv_cac_did_not_work_path
+  end
+
   it 'does not throw an exception if the email contains invalid bytes' do
     suppress_output do
       signin("test@\xFFbar\xF8.com", 'Please123!')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -55,6 +55,13 @@ module Features
       fill_in_piv_cac_credentials_and_submit(user)
     end
 
+    def signin_with_bad_piv(user = user_with_piv_cac)
+      allow(UserMailer).to receive(:new_device_sign_in).and_call_original
+      visit new_user_session_path
+      click_on t('account.login.piv_cac')
+      fill_in_bad_piv_cac_credentials_and_submit(user)
+    end
+
     def fill_in_piv_cac_credentials_and_submit(user)
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
@@ -64,6 +71,17 @@ module Features
                             nonce: nonce,
                             uuid: user.x509_dn_uuid,
                             subject: 'SomeIgnoredSubject')
+    end
+
+    def fill_in_bad_piv_cac_credentials_and_submit(user)
+      allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
+
+      stub_piv_cac_service
+      nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
+      visit_piv_cac_service(current_url,
+                            nonce: nil,
+                            uuid: nil,
+                            subject: nil)
     end
 
     def fill_in_credentials_and_submit(email, password)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -77,10 +77,7 @@ module Features
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
       stub_piv_cac_service
-      visit_piv_cac_service(current_url,
-                            nonce: nil,
-                            uuid: nil,
-                            subject: nil)
+      visit(current_url + '?token=foo')
     end
 
     def fill_in_credentials_and_submit(email, password)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -55,7 +55,7 @@ module Features
       fill_in_piv_cac_credentials_and_submit(user)
     end
 
-    def signin_with_bad_piv(user = user_with_piv_cac)
+    def signin_with_bad_piv
       allow(UserMailer).to receive(:new_device_sign_in).and_call_original
       visit new_user_session_path
       click_on t('account.login.piv_cac')

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -59,7 +59,7 @@ module Features
       allow(UserMailer).to receive(:new_device_sign_in).and_call_original
       visit new_user_session_path
       click_on t('account.login.piv_cac')
-      fill_in_bad_piv_cac_credentials_and_submit(user)
+      fill_in_bad_piv_cac_credentials_and_submit
     end
 
     def fill_in_piv_cac_credentials_and_submit(user)
@@ -73,11 +73,10 @@ module Features
                             subject: 'SomeIgnoredSubject')
     end
 
-    def fill_in_bad_piv_cac_credentials_and_submit(user)
+    def fill_in_bad_piv_cac_credentials_and_submit
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
       stub_piv_cac_service
-      nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
       visit_piv_cac_service(current_url,
                             nonce: nil,
                             uuid: nil,


### PR DESCRIPTION
**Why**: So user can get feedback if their PIV/CAC is bad or if it's good but not yet linked to an account