### PR TITLE
Update CBP TTP learn more URL

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -11,7 +11,7 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
   CUSTOM_SP_ALERTS = {
     'CBP Trusted Traveler Programs' => {
       i18n_name: 'trusted_traveler',
-      learn_more: 'https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/',
+      learn_more: 'https://www.login.gov/help/trusted-traveler-programs/cant-sign-in-or-reset-my-password-goes-account/',
       exclude_paths: ['/sign_up/enter_email'],
     },
     'FMCSA National Registry' => {


### PR DESCRIPTION
https://login.gov/help/trusted-traveler-programs/sign-in-doesnt-work/ no longer exists & throws a 404 error when clicking on "Learn More" on the login page for TTP.

Content previously at that URL seems to have been relocated to https://www.login.gov/help/trusted-traveler-programs/cant-sign-in-or-reset-my-password-goes-account/ .

<img width="1440" alt="Screen Shot 2019-09-24 at 3 11 31 PM" src="https://user-images.githubusercontent.com/31887/65542737-ba861980-dedd-11e9-9e2d-6b838ad83472.png">
