### PR TITLE
LG-2010 Remove PIV/CAC instructions link

### DIFF
--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -3,9 +3,6 @@
 h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
 p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
         sign_in: link_to(t('headings.sign_in_without_sp'), root_url),
-        add_piv_cac: link_to(t('instructions.mfa.piv_cac.add_piv_cac'),
-          'https://login.gov/help/creating-an-account/two-factor-authentication/',
-          target: '_blank'),
         create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
 
 = render 'shared/cancel', link: new_user_session_url

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -26,9 +26,9 @@ en:
         or: or
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> with you email address and
-          password.<br><br>%{add_piv_cac}<br><br><strong>Don't have a login.gov account?</strong>
+          password.<br><br>Sign in with your email address and password. Then add
+          your PIV/CAC to your account.<br><br><strong>Don't have a login.gov account?</strong>
           %{create_account}"
-        add_piv_cac: Find out how to add a PIV/CAC to your account.
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -27,9 +27,9 @@ es:
         or: o
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> con su dirección de correo
-          electrónico y contraseña.<br><br>%{add_piv_cac}<br><br><strong>¿No tiene
-          una cuenta login.gov?</strong> %{create_account}"
-        add_piv_cac: Descubra cómo agregar un PIV/CAC a su cuenta.
+          electrónico y contraseña.<br><br>Inicie sesión con su dirección de correo
+          electrónico y contraseña. Luego agregue su PIV/CAC a su cuenta.<br><br><strong>¿No
+          tiene una cuenta login.gov?</strong> %{create_account}"
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -29,9 +29,9 @@ fr:
         or: or
       piv_cac:
         account_not_found: "<strong>%{sign_in}</strong> votre adresse e-mail et votre
-          mot de passe.<br><br>%{add_piv_cac}<br><br><strong>Vous n'avez pas de compte
-          login.gov?</strong> %{create_account}"
-        add_piv_cac: Découvrez comment ajouter un PIV/CAC à votre compte.
+          mot de passe.<br><br>Connectez-vous avec votre adresse email et votre mot
+          de passe. Ajoutez ensuite votre PIV/CAC à votre compte. <br><br><strong>Vous
+          n'avez pas de compte login.gov?</strong> %{create_account}"
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.


### PR DESCRIPTION
**Why**: The old link went to the create account FAQ content. The create account FAQ content does not say anything about PIV/CAC. This is a stop gap until we have content about PIV/CAC ready.