### PR TITLE
LG-2010 Clean up PIV/CAC error screen

### DIFF
--- a/app/views/users/piv_cac_login/account_not_found.html.erb
+++ b/app/views/users/piv_cac_login/account_not_found.html.erb
@@ -1,6 +1,6 @@
 <% title t('headings.piv_cac_login.account_not_found') %>
 
-<h1 class='h3 font-heading-'><%= t('headings.piv_cac_login.account_not_found') %></h1>
+<h1 class='h3 margin-top-0'><%= t('headings.piv_cac_login.account_not_found') %></h1>
 <p>
   <%=
     t(

--- a/app/views/users/piv_cac_login/account_not_found.html.erb
+++ b/app/views/users/piv_cac_login/account_not_found.html.erb
@@ -1,0 +1,19 @@
+<% title t('headings.piv_cac_login.account_not_found') %>
+
+<h1 class='h3 font-heading-'><%= t('headings.piv_cac_login.account_not_found') %></h1>
+<p>
+  <%=
+    t(
+      'instructions.mfa.piv_cac.account_not_found.paragraph_1_html',
+      sign_in: link_to(t('headings.sign_in_without_sp'), root_url)
+    )
+  %>
+</p>
+<p>
+  <%=
+    t(
+      'instructions.mfa.piv_cac.account_not_found.paragraph_2_html',
+      create_account: link_to(t('links.create_account'), sign_up_email_url)
+    )
+  %>
+</p>

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -1,8 +1,9 @@
 - title t('headings.piv_cac_login.account_not_found')
 
-h1.h3.my0 = t('headings.piv_cac_login.account_not_found', )
-p.mt2.mb2 == t('instructions.mfa.piv_cac.account_not_found',
-        sign_in: link_to(t('headings.sign_in_without_sp'), root_url),
-        create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
+h1.h3.mt0 = t('headings.piv_cac_login.account_not_found', )
+p == t('instructions.mfa.piv_cac.account_not_found.paragraph_1',
+  sign_in: link_to(t('headings.sign_in_without_sp'), root_url))
+p == t('instructions.mfa.piv_cac.account_not_found.paragraph_2',
+  create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/account_not_found.html.slim
+++ b/app/views/users/piv_cac_login/account_not_found.html.slim
@@ -1,9 +1,0 @@
-- title t('headings.piv_cac_login.account_not_found')
-
-h1.h3.mt0 = t('headings.piv_cac_login.account_not_found', )
-p == t('instructions.mfa.piv_cac.account_not_found.paragraph_1',
-  sign_in: link_to(t('headings.sign_in_without_sp'), root_url))
-p == t('instructions.mfa.piv_cac.account_not_found.paragraph_2',
-  create_account: link_to(I18n.t('links.create_account'), sign_up_email_url))
-
-= render 'shared/cancel', link: new_user_session_url

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -26,9 +26,9 @@ en:
         or: or
       piv_cac:
         account_not_found:
-          paragraph_1: "<strong>%{sign_in}</strong> with your email address and password.
+          paragraph_1_html: "<strong>%{sign_in}</strong> with your email address and password.
             Then add your PIV/CAC to your account."
-          paragraph_2: "<strong>Don't have a login.gov account?</strong> %{create_account}"
+          paragraph_2_html: "<strong>Don't have a login.gov account?</strong> %{create_account}"
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -26,8 +26,8 @@ en:
         or: or
       piv_cac:
         account_not_found:
-          paragraph_1_html: "<strong>%{sign_in}</strong> with your email address and password.
-            Then add your PIV/CAC to your account."
+          paragraph_1_html: "<strong>%{sign_in}</strong> with your email address and
+            password. Then add your PIV/CAC to your account."
           paragraph_2_html: "<strong>Don't have a login.gov account?</strong> %{create_account}"
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -25,10 +25,10 @@ en:
           at %{app}.%{tooltip}
         or: or
       piv_cac:
-        account_not_found: "<strong>%{sign_in}</strong> with you email address and
-          password.<br><br>Sign in with your email address and password. Then add
-          your PIV/CAC to your account.<br><br><strong>Don't have a login.gov account?</strong>
-          %{create_account}"
+        account_not_found:
+          paragraph_1: "<strong>%{sign_in}</strong> with your email address and password.
+            Then add your PIV/CAC to your account."
+          paragraph_2: "<strong>Don't have a login.gov account?</strong> %{create_account}"
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -26,10 +26,10 @@ es:
           a %{email} en %{app}.%{tooltip}
         or: o
       piv_cac:
-        account_not_found: "<strong>%{sign_in}</strong> con su dirección de correo
-          electrónico y contraseña.<br><br>Inicie sesión con su dirección de correo
-          electrónico y contraseña. Luego agregue su PIV/CAC a su cuenta.<br><br><strong>¿No
-          tiene una cuenta login.gov?</strong> %{create_account}"
+        account_not_found:
+          paragraph_1: "<strong>%{sign_in}</strong> con su dirección de correo electrónico
+            y contraseña. Luego agregue su PIV/CAC a su cuenta."
+          paragraph_2: "<strong>¿No tiene una cuenta login.gov?</strong> %{create_account}"
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -27,8 +27,8 @@ es:
         or: o
       piv_cac:
         account_not_found:
-          paragraph_1_html: "<strong>%{sign_in}</strong> con su dirección de correo electrónico
-            y contraseña. Luego agregue su PIV/CAC a su cuenta."
+          paragraph_1_html: "<strong>%{sign_in}</strong> con su dirección de correo
+            electrónico y contraseña. Luego agregue su PIV/CAC a su cuenta."
           paragraph_2_html: "<strong>¿No tiene una cuenta login.gov?</strong> %{create_account}"
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -27,9 +27,9 @@ es:
         or: o
       piv_cac:
         account_not_found:
-          paragraph_1: "<strong>%{sign_in}</strong> con su dirección de correo electrónico
+          paragraph_1_html: "<strong>%{sign_in}</strong> con su dirección de correo electrónico
             y contraseña. Luego agregue su PIV/CAC a su cuenta."
-          paragraph_2: "<strong>¿No tiene una cuenta login.gov?</strong> %{create_account}"
+          paragraph_2_html: "<strong>¿No tiene una cuenta login.gov?</strong> %{create_account}"
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -29,9 +29,10 @@ fr:
         or: or
       piv_cac:
         account_not_found:
-          paragraph_1_html: "<strong>%{sign_in}</strong> votre adresse email et votre mot
-            de passe. Ajoutez ensuite votre PIV/CAC à votre compte."
-          paragraph_2_html: "<strong>Vous n'avez pas de compte login.gov?</strong> %{create_account}"
+          paragraph_1_html: "<strong>%{sign_in}</strong> votre adresse email et votre
+            mot de passe. Ajoutez ensuite votre PIV/CAC à votre compte."
+          paragraph_2_html: "<strong>Vous n'avez pas de compte login.gov?</strong>
+            %{create_account}"
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -28,10 +28,10 @@ fr:
           le code correspondant à %{email} à %{app}.%{tooltip}
         or: or
       piv_cac:
-        account_not_found: "<strong>%{sign_in}</strong> votre adresse e-mail et votre
-          mot de passe.<br><br>Connectez-vous avec votre adresse email et votre mot
-          de passe. Ajoutez ensuite votre PIV/CAC à votre compte. <br><br><strong>Vous
-          n'avez pas de compte login.gov?</strong> %{create_account}"
+        account_not_found:
+          paragraph_1: "<strong>%{sign_in}</strong> votre adresse email et votre mot
+            de passe. Ajoutez ensuite votre PIV/CAC à votre compte."
+          paragraph_2: "<strong>Vous n'avez pas de compte login.gov?</strong> %{create_account}"
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -29,9 +29,9 @@ fr:
         or: or
       piv_cac:
         account_not_found:
-          paragraph_1: "<strong>%{sign_in}</strong> votre adresse email et votre mot
+          paragraph_1_html: "<strong>%{sign_in}</strong> votre adresse email et votre mot
             de passe. Ajoutez ensuite votre PIV/CAC à votre compte."
-          paragraph_2: "<strong>Vous n'avez pas de compte login.gov?</strong> %{create_account}"
+          paragraph_2_html: "<strong>Vous n'avez pas de compte login.gov?</strong> %{create_account}"
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.


### PR DESCRIPTION
**Why**: To fix a typo, merge some duplicate content, and break things out into paragraphs instead of using break tags