### PR TITLE
LG-1965 Reset mobile doc auth properly in hybrid flow

### DIFF
--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -33,6 +33,16 @@ shared_examples 'capture mobile front image step' do |simulate|
 
       expect(page).to have_current_path(idv_capture_doc_mobile_front_image_step(nil))
     end
+
+    it 'resets the session if a link is used again' do
+      attach_image
+      click_idv_continue
+
+      expect(page).to have_current_path(idv_capture_doc_capture_mobile_back_image_step)
+
+      visit idv_capture_doc_mobile_front_image_step(token)
+      expect(page).to have_current_path(idv_capture_doc_mobile_front_image_step(token))
+    end
   end
 end
 


### PR DESCRIPTION
**Why**: The mobile doc capture remains in the state it was left in upon the browser receiving a new link preventing the capture of documents.

**How**: Reset the session if there is a valid token on the url and ensure the token check is before the flow state machine to prevent redirects to the appropriate state of the session

