### PR TITLE
LG-1964 Confirming email then entering password redirects to sign in

### DIFF
--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -6,6 +6,7 @@ class SendSignUpEmailConfirmation
   end
 
   def call(request_id: nil, instructions: nil)
+    remove_legacy_confirmation_info_on_user
     update_email_address_record
     send_confirmation_email(request_id, instructions)
   end
@@ -42,6 +43,13 @@ class SendSignUpEmailConfirmation
     email_address.update!(
       confirmation_token: confirmation_token,
       confirmation_sent_at: confirmation_sent_at,
+    )
+  end
+
+  def remove_legacy_confirmation_info_on_user
+    email_address.user.update!(
+      confirmation_token: nil,
+      confirmation_sent_at: nil,
     )
   end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -233,7 +233,7 @@ feature 'Sign Up' do
 
   context 'legacy (pre multi email) user w/expired confirmation token on user and email_address' do
     it 'does not return an error and redirect to root after confirming and entering password' do
-      email = 'test@test.com'
+      email = 'test2@test.com'
       User.create!(confirmation_token: 'foo', uuid: 'foo', email: email,
                    confirmation_sent_at: Time.zone.now)
       Timecop.travel 1.year.from_now do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -246,4 +246,16 @@ feature 'Sign Up' do
       end
     end
   end
+
+  it 'does not regenerate a confirmation token if the token is not expired' do
+    email = 'test@test.com'
+
+    visit sign_up_email_path
+    submit_form_with_valid_email(email)
+    token = User.find_with_email(email).email_addresses.first.confirmation_token
+
+    visit sign_up_email_path
+    submit_form_with_valid_email(email)
+    expect(token).to eq(User.find_with_email(email).email_addresses.first.confirmation_token)
+  end
 end

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -230,4 +230,20 @@ feature 'Sign Up' do
       end
     end
   end
+
+  context 'legacy (pre multi email) user w/expired confirmation token on user and email_address' do
+    it 'does not return an error and redirect to root after confirming and entering password' do
+      email = 'test@test.com'
+      User.create!(confirmation_token: 'foo', uuid: 'foo', email: email,
+                   confirmation_sent_at: Time.zone.now)
+      Timecop.travel 1.year.from_now do
+        visit sign_up_email_path
+        submit_form_with_valid_email(email)
+        click_confirmation_link_in_email(email)
+        submit_form_with_valid_password
+
+        expect(page).to have_current_path(two_factor_options_path)
+      end
+    end
+  end
 end

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -70,25 +70,6 @@ describe SendSignUpEmailConfirmation do
         expect(email_address.reload.confirmation_token).to eq(confirmation_token)
         expect(email_address.confirmation_sent_at).to be_within(5.seconds).of(Time.zone.now)
       end
-
-      it 'does not regenerate a token if the token is not expired' do
-        email_address.update!(
-          confirmation_token: old_token,
-          confirmation_sent_at: user.confirmation_sent_at,
-        )
-        user.reload
-
-        mail = double
-        expect(mail).to receive(:deliver_later)
-        expect(UserMailer). to receive(:email_confirmation_instructions).with(
-          user, email_address.email, old_token, instance_of(Hash)
-        ).and_return(mail)
-
-        subject.call
-
-        expect(email_address.reload.confirmation_token).to eq(old_token)
-        expect(email_address.confirmation_sent_at).to be_within(5.seconds).of(5.minutes.ago)
-      end
     end
   end
 end

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -7,6 +7,7 @@ describe SendSignUpEmailConfirmation do
     let(:request_id) { '1234-abcd' }
     let(:instructions) { 'do the things' }
     let(:confirmation_token) { 'confirm-me' }
+    let(:old_token) { 'old-token' }
 
     before do
       allow(Devise).to receive(:friendly_token).once.and_return(confirmation_token)
@@ -72,7 +73,7 @@ describe SendSignUpEmailConfirmation do
 
       it 'does not regenerate a token if the token is not expired' do
         email_address.update!(
-          confirmation_token: user.confirmation_token,
+          confirmation_token: old_token,
           confirmation_sent_at: user.confirmation_sent_at,
         )
         user.reload
@@ -80,12 +81,12 @@ describe SendSignUpEmailConfirmation do
         mail = double
         expect(mail).to receive(:deliver_later)
         expect(UserMailer). to receive(:email_confirmation_instructions).with(
-          user, email_address.email, 'old-token', instance_of(Hash)
+          user, email_address.email, old_token, instance_of(Hash)
         ).and_return(mail)
 
         subject.call
 
-        expect(email_address.reload.confirmation_token).to eq('old-token')
+        expect(email_address.reload.confirmation_token).to eq(old_token)
         expect(email_address.confirmation_sent_at).to be_within(5.seconds).of(5.minutes.ago)
       end
     end

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -7,7 +7,6 @@ describe SendSignUpEmailConfirmation do
     let(:request_id) { '1234-abcd' }
     let(:instructions) { 'do the things' }
     let(:confirmation_token) { 'confirm-me' }
-    let(:old_token) { 'old-token' }
 
     before do
       allow(Devise).to receive(:friendly_token).once.and_return(confirmation_token)


### PR DESCRIPTION
**Why**: After the switch to multiple emails existing users that never confirmed that tried to register their email again would go through the confirm flow and get kicked out and redirected to root after entering a valid new password with: "You need to confirm your email address before continuing"

**How**: Remove the old token info on the user when registering an email that already exists but is not confirmed.