### PR TITLE
fix redirect from doc auth to idv when browser back clicked

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -84,6 +84,7 @@ module Flow
     end
 
     def redirect_to_step(step)
+      flow_finish and return unless next_step
       redirect_to send(@step_url, step: step)
     end
 

--- a/spec/features/idv/doc_auth/finished_spec.rb
+++ b/spec/features/idv/doc_auth/finished_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'doc auth success step' do
+  include IdvStepHelper
+  include DocAuthHelper
+
+  before do
+    enable_doc_auth
+    complete_all_doc_auth_steps
+  end
+
+  it 'is on the correct page after clicking continue on final step' do
+    expect(page).to have_current_path(idv_phone_path)
+  end
+
+  it 'is on the correct page when using the back button after final step' do
+    expect(page).to have_current_path(idv_phone_path)
+    visit '/verify/doc_auth/doc_success'
+    expect(page).to have_current_path(idv_phone_path)
+  end
+end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -163,6 +163,11 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     click_idv_continue
   end
 
+  def complete_all_doc_auth_steps(user = user_with_2fa)
+    complete_doc_auth_steps_before_doc_success_step(user)
+    click_idv_continue
+  end
+
   def complete_doc_auth_steps_before_address_step(user = user_with_2fa)
     complete_doc_auth_steps_before_verify_step(user)
     click_link t('doc_auth.buttons.change_address')


### PR DESCRIPTION
WHY: To prevent a 500 error from displaying when a user clicks the back button after reaching the verify phone step in Doc Auth flow. 

https://rpm.newrelic.com/accounts/1376370/applications/52136858/filterable_errors#/show/51f5d1c6-e12b-11e9-80c8-0242ac110007_0_15890/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart