### PR TITLE
LG-2062 Fix erroneous error counts reported in doc auth funnel

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -19,7 +19,8 @@ class Analytics
 
   def register_doc_auth_step_from_analytics_event(event, attributes)
     return unless user && user.class != AnonymousUser
-    Funnel::DocAuth::RegisterStepFromAnalyticsEvent.call(user.id, event, attributes[:success])
+    success = attributes.blank? || attributes[:success] == 'success'
+    Funnel::DocAuth::RegisterStepFromAnalyticsEvent.call(user.id, event, success)
   end
 
   # :reek:FeatureEnvy

--- a/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_submit_event.rb
@@ -8,7 +8,7 @@ module Funnel
       def self.call(user_id, event, result)
         token = ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN[event]
         return unless token
-        Funnel::DocAuth::RegisterStep.call(user_id, token, :update, result == 'success')
+        Funnel::DocAuth::RegisterStep.call(user_id, token, :update, result)
       end
     end
   end

--- a/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
+++ b/app/services/funnel/doc_auth/register_step_from_analytics_view_event.rb
@@ -10,7 +10,7 @@ module Funnel
 
       def self.call(user_id, event, result)
         token = ANALYTICS_EVENT_TO_DOC_AUTH_LOG_TOKEN[event]
-        Funnel::DocAuth::RegisterStep.call(user_id, token, :view, result == 'success') if token
+        Funnel::DocAuth::RegisterStep.call(user_id, token, :view, result) if token
       end
     end
   end


### PR DESCRIPTION
**Why**: Some analytics events don't report a result.  Those should default to success (usps letter sent)