### PR TITLE
LG-2059 Fix 500 error verifying images in doc auth

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -54,7 +54,7 @@ module Idv
 
       def verify_back_image(reset_step:)
         back_image_verified, data, analytics_hash = assure_id_results
-        data[:notice] = I18n.t('errors.doc_auth.general_info')
+        data[:notice] = I18n.t('errors.doc_auth.general_info') if data.class == Hash
         return failure(data, analytics_hash) unless back_image_verified
 
         return [nil, data] if process_good_result(data)

--- a/app/views/idv/doc_auth/_error_messages.html.slim
+++ b/app/views/idv/doc_auth/_error_messages.html.slim
@@ -2,4 +2,5 @@
   .alert.alert-error
     = flow_session[:error_message]
     = render 'idv/doc_auth/in_person_proofing_option'
-  .alert.alert-notice == flow_session[:notice]
+  - if flow_session[:notice].present?
+    .alert.alert-notice == flow_session[:notice]

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -18,13 +18,13 @@ en:
       token_missing: token missing
     confirm_password_incorrect: Incorrect password.
     doc_auth:
-      acuant_network_error: Sorry we are experiencing technical difficulties.  Please
+      acuant_network_error: Sorry we are experiencing technical difficulties. Please
         try again later.
       acuant_throttle: To prevent abuse we limit the number of times you can attempt
         to validate a document.  Please try again later.
       consent_form: Before you can continue, you must give us permission. Please check
         the box below and then click continue.
-      general_error: Your state issued ID could not be verified.  Please try using
+      general_error: Your state issued ID could not be verified. Please try using
         different images starting with the front of your state issued ID.
       general_info: |-
         <div class="bold">If you are using a camera please ensure</div>

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'back image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_auth_steps_before_back_image_step(user)
       mock_assure_id_ok
@@ -59,9 +59,11 @@ shared_examples 'back image step' do |simulate|
       attach_image
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_front_image_step) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_error')) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_info')) unless simulate
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
+        expect(page).to have_content(strip_tags(I18n.t('errors.doc_auth.general_info'))[0..32])
+      end
     end
 
     it 'throttles calls to acuant and allows attempts after the attempt window' do
@@ -100,7 +102,7 @@ shared_examples 'back image step' do |simulate|
       end
     end
 
-    it 'catches network timeout errors' do
+    it 'catches network timeout errors posting back image' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_back_image).
         and_raise(Faraday::TimeoutError)
 
@@ -112,10 +114,22 @@ shared_examples 'back image step' do |simulate|
         expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
       end
     end
+
+    it 'catches network timeout errors verifying results' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
+        and_raise(Faraday::TimeoutError)
+
+      attach_image
+      click_idv_continue
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
   end
 end
 
 feature 'doc auth back image' do
-  it_behaves_like 'back image step', 'false'
-  it_behaves_like 'back image step', 'true'
+  it_behaves_like 'back image step', false
+  it_behaves_like 'back image step', true
 end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'back image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_back_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'back image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_back_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'back image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_back_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'front image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_front_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'front image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_front_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'front image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_auth_steps_before_front_image_step(user)
       mock_assure_id_ok
@@ -93,34 +93,8 @@ shared_examples 'front image step' do |simulate|
       end
     end
 
-    it 'catches network connection errors on results' do
-      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
-        and_raise(Faraday::ConnectionFailed.new('error'))
-
-      attach_image
-      click_idv_continue
-
-      unless simulate
-        expect(page).to have_current_path(idv_doc_auth_front_image_step)
-        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
-      end
-    end
-
     it 'catches network timeout errors on post_front_image' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:post_front_image).
-        and_raise(Faraday::TimeoutError)
-
-      attach_image
-      click_idv_continue
-
-      unless simulate
-        expect(page).to have_current_path(idv_doc_auth_front_image_step)
-        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
-      end
-    end
-
-    it 'catches network timeout errors on results' do
-      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
         and_raise(Faraday::TimeoutError)
 
       attach_image
@@ -135,6 +109,6 @@ shared_examples 'front image step' do |simulate|
 end
 
 feature 'doc auth front image' do
-  it_behaves_like 'front image step', 'false'
-  it_behaves_like 'front image step', 'true'
+  it_behaves_like 'front image step', false
+  it_behaves_like 'front image step', true
 end

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'front image step' do |simulate|
     let(:user) { user_with_2fa }
     let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_front_image_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'link sent step' do |simulate|
     let(:user) { user_with_2fa }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_link_sent_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'link sent step' do |simulate|
     let(:user) { user_with_2fa }
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_link_sent_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'link sent step' do |simulate|
     let(:user) { user_with_2fa }
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_link_sent_step(user)
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'link sent step' do |simulate|
     let(:user) { user_with_2fa }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_auth_steps_before_link_sent_step(user)
       mock_assure_id_ok
@@ -44,9 +44,10 @@ shared_examples 'link sent step' do |simulate|
     end
 
     it 'does not proceed to the next page with invalid info' do
+      DocCapture.first.update(acuant_token: nil)
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_back_image_step) unless simulate
+      expect(page).to have_current_path(idv_doc_auth_link_sent_step)
     end
 
     it 'does not proceed to the next page with result=2' do
@@ -54,12 +55,12 @@ shared_examples 'link sent step' do |simulate|
         and_return([true, assure_id_results_with_result_2])
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_back_image_step) unless simulate
+      expect(page).to have_current_path(idv_doc_auth_send_link_step) unless simulate
     end
   end
 end
 
 feature 'doc auth link sent' do
-  it_behaves_like 'link sent step', 'false'
-  it_behaves_like 'link sent step', 'true'
+  it_behaves_like 'link sent step', false
+  it_behaves_like 'link sent step', true
 end

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'doc auth mobile back image step' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_back_image_step
       mock_assure_id_ok
@@ -49,14 +49,16 @@ shared_examples 'doc auth mobile back image step' do |simulate|
       attach_image
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_mobile_front_image_step) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_error')) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_info')) unless simulate
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_mobile_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
+        expect(page).to have_content(strip_tags(I18n.t('errors.doc_auth.general_info'))[0..32])
+      end
     end
   end
 end
 
 feature 'doc auth back image' do
-  it_behaves_like 'doc auth mobile back image step', 'false'
-  it_behaves_like 'doc auth mobile back image step', 'true'
+  it_behaves_like 'doc auth mobile back image step', false
+  it_behaves_like 'doc auth mobile back image step', true
 end

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'doc auth mobile back image step' do |simulate|
     include DocAuthHelper
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'doc auth mobile back image step' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'doc auth mobile back image step' do |simulate|
     include DocAuthHelper
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'mobile front image step' do |simulate|
     include DocAuthHelper
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'mobile front image step' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'mobile front image step' do |simulate|
     include DocAuthHelper
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'mobile front image step' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_auth_steps_before_mobile_front_image_step
       mock_assure_id_ok
@@ -35,6 +35,6 @@ shared_examples 'mobile front image step' do |simulate|
 end
 
 feature 'doc auth front image' do
-  it_behaves_like 'mobile front image step', 'false'
-  it_behaves_like 'mobile front image step', 'true'
+  it_behaves_like 'mobile front image step', false
+  it_behaves_like 'mobile front image step', true
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'test credentials' do |simulate|
     include DocAuthHelper
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
     end
 

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'test credentials' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
     end
 
@@ -63,5 +63,5 @@ shared_examples 'test credentials' do |simulate|
 end
 
 feature 'doc auth test credentials' do
-  it_behaves_like 'test credentials', 'false'
+  it_behaves_like 'test credentials', false
 end

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'test credentials' do |simulate|
     include DocAuthHelper
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
     end
 

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'test credentials' do |simulate|
     include DocAuthHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
     end
 

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'doc capture mobile back image step' do |simulate|
     include DocCaptureHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       complete_doc_capture_steps_before_mobile_back_image_step
       mock_assure_id_ok
@@ -31,7 +31,7 @@ shared_examples 'doc capture mobile back image step' do |simulate|
       attach_image
       click_idv_continue
 
-      expect(page).to have_current_path(idv_capture_doc_capture_complete_step) unless simulate
+      expect(page).to have_current_path(idv_capture_doc_capture_complete_step) if simulate
     end
 
     it 'does not proceed to the next page with result=2' do
@@ -41,13 +41,13 @@ shared_examples 'doc capture mobile back image step' do |simulate|
       click_idv_continue
 
       unless simulate
-        expect(page).to have_current_path(idv_capture_doc_capture_mobile_back_image_step)
+        expect(page).to have_current_path(idv_capture_doc_step_path(step: :mobile_front_image))
       end
     end
   end
 end
 
 feature 'doc capture back image' do
-  it_behaves_like 'doc capture mobile back image step', 'false'
-  it_behaves_like 'doc capture mobile back image step', 'true'
+  it_behaves_like 'doc capture mobile back image step', false
+  it_behaves_like 'doc capture mobile back image step', true
 end

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'doc capture mobile back image step' do |simulate|
     include DocCaptureHelper
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       complete_doc_capture_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'doc capture mobile back image step' do |simulate|
     include DocCaptureHelper
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       complete_doc_capture_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'doc capture mobile back image step' do |simulate|
     include DocCaptureHelper
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       complete_doc_capture_steps_before_mobile_back_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'capture mobile front image step' do |simulate|
 
     token = nil
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       token = complete_doc_capture_steps_before_mobile_front_image_step
       mock_assure_id_ok
@@ -47,6 +47,6 @@ shared_examples 'capture mobile front image step' do |simulate|
 end
 
 feature 'doc capture front image' do
-  it_behaves_like 'capture mobile front image step', 'false'
-  it_behaves_like 'capture mobile front image step', 'true'
+  it_behaves_like 'capture mobile front image step', false
+  it_behaves_like 'capture mobile front image step', true
 end

--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'capture mobile front image step' do |simulate|
 
     token = nil
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       token = complete_doc_capture_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'capture mobile front image step' do |simulate|
 
     token = nil
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       token = complete_doc_capture_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'capture mobile front image step' do |simulate|
 
     token = nil
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       token = complete_doc_capture_steps_before_mobile_front_image_step
       mock_assure_id_ok

--- a/spec/features/idv/recovery/back_image_step_spec.rb
+++ b/spec/features/idv/recovery/back_image_step_spec.rb
@@ -13,7 +13,7 @@ shared_examples 'recovery back image step' do |simulate|
 
     before do |example|
       select_user = example.metadata[:no_phone] ? user_no_phone : user
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_back_image_step(select_user)

--- a/spec/features/idv/recovery/back_image_step_spec.rb
+++ b/spec/features/idv/recovery/back_image_step_spec.rb
@@ -13,7 +13,7 @@ shared_examples 'recovery back image step' do |simulate|
 
     before do |example|
       select_user = example.metadata[:no_phone] ? user_no_phone : user
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_back_image_step(select_user)

--- a/spec/features/idv/recovery/back_image_step_spec.rb
+++ b/spec/features/idv/recovery/back_image_step_spec.rb
@@ -13,7 +13,7 @@ shared_examples 'recovery back image step' do |simulate|
 
     before do |example|
       select_user = example.metadata[:no_phone] ? user_no_phone : user
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_back_image_step(select_user)
@@ -54,14 +54,16 @@ shared_examples 'recovery back image step' do |simulate|
       attach_image
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_front_image_step) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_error')) unless simulate
-      expect(page).to have_content(I18n.t('errors.doc_auth.general_info')) unless simulate
+      unless simulate
+        expect(page).to have_current_path(idv_recovery_front_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
+        expect(page).to have_content(strip_tags(I18n.t('errors.doc_auth.general_info'))[0..32])
+      end
     end
   end
 end
 
 feature 'recovery back image' do
-  it_behaves_like 'recovery back image step', 'false'
-  it_behaves_like 'recovery back image step', 'true'
+  it_behaves_like 'recovery back image step', false
+  it_behaves_like 'recovery back image step', true
 end

--- a/spec/features/idv/recovery/back_image_step_spec.rb
+++ b/spec/features/idv/recovery/back_image_step_spec.rb
@@ -13,7 +13,7 @@ shared_examples 'recovery back image step' do |simulate|
 
     before do |example|
       select_user = example.metadata[:no_phone] ? user_no_phone : user
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_back_image_step(select_user)

--- a/spec/features/idv/recovery/front_image_step_spec.rb
+++ b/spec/features/idv/recovery/front_image_step_spec.rb
@@ -10,7 +10,7 @@ shared_examples 'recovery front image step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_front_image_step(user)

--- a/spec/features/idv/recovery/front_image_step_spec.rb
+++ b/spec/features/idv/recovery/front_image_step_spec.rb
@@ -10,7 +10,7 @@ shared_examples 'recovery front image step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_front_image_step(user)

--- a/spec/features/idv/recovery/front_image_step_spec.rb
+++ b/spec/features/idv/recovery/front_image_step_spec.rb
@@ -10,7 +10,7 @@ shared_examples 'recovery front image step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_front_image_step(user)
@@ -40,6 +40,6 @@ shared_examples 'recovery front image step' do |simulate|
 end
 
 feature 'recovery front image' do
-  it_behaves_like 'recovery front image step', 'false'
-  it_behaves_like 'recovery front image step', 'true'
+  it_behaves_like 'recovery front image step', false
+  it_behaves_like 'recovery front image step', true
 end

--- a/spec/features/idv/recovery/front_image_step_spec.rb
+++ b/spec/features/idv/recovery/front_image_step_spec.rb
@@ -10,7 +10,7 @@ shared_examples 'recovery front image step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       sign_in_before_2fa(user)
       enable_doc_auth
       complete_recovery_steps_before_front_image_step(user)

--- a/spec/features/idv/recovery/recover_step_spec.rb
+++ b/spec/features/idv/recovery/recover_step_spec.rb
@@ -11,7 +11,7 @@ shared_examples 'recover step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      setup_acuant_simulator(enabed: simulate)
+      setup_acuant_simulator(enabled: simulate)
       enable_doc_auth
       sign_in_before_2fa(user)
       token = complete_recovery_steps_before_recover_step(user)

--- a/spec/features/idv/recovery/recover_step_spec.rb
+++ b/spec/features/idv/recovery/recover_step_spec.rb
@@ -11,7 +11,7 @@ shared_examples 'recover step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate)
+      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
       enable_doc_auth
       sign_in_before_2fa(user)
       token = complete_recovery_steps_before_recover_step(user)
@@ -32,6 +32,6 @@ shared_examples 'recover step' do |simulate|
 end
 
 feature 'recovery step' do
-  it_behaves_like 'recover step', 'false'
-  it_behaves_like 'recover step', 'true'
+  it_behaves_like 'recover step', false
+  it_behaves_like 'recover step', true
 end

--- a/spec/features/idv/recovery/recover_step_spec.rb
+++ b/spec/features/idv/recovery/recover_step_spec.rb
@@ -11,7 +11,7 @@ shared_examples 'recover step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      allow(Figaro.env).to receive(:acuant_simulator).and_return(simulate ? 'true' : 'false')
+      enable_acuant_simulator(simulate)
       enable_doc_auth
       sign_in_before_2fa(user)
       token = complete_recovery_steps_before_recover_step(user)

--- a/spec/features/idv/recovery/recover_step_spec.rb
+++ b/spec/features/idv/recovery/recover_step_spec.rb
@@ -11,7 +11,7 @@ shared_examples 'recover step' do |simulate|
     let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: '1234' }) }
 
     before do
-      enable_acuant_simulator(simulate)
+      setup_acuant_simulator(enabed: simulate)
       enable_doc_auth
       sign_in_before_2fa(user)
       token = complete_recovery_steps_before_recover_step(user)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -227,6 +227,10 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     allow(FeatureManagement).to receive(:doc_auth_exclusive?).and_return(true)
   end
 
+  def enable_acuant_simulator(enabled)
+    allow(Figaro.env).to receive(:acuant_simulator).and_return(enabled ? 'true' : 'false')
+  end
+
   def enable_test_credentials
     allow(FeatureManagement).to receive(:allow_doc_auth_test_credentials?).and_return(true)
   end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -227,7 +227,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     allow(FeatureManagement).to receive(:doc_auth_exclusive?).and_return(true)
   end
 
-  def enable_acuant_simulator(enabled)
+  def setup_acuant_simulator(enabled:)
     allow(Figaro.env).to receive(:acuant_simulator).and_return(enabled ? 'true' : 'false')
   end
 


### PR DESCRIPTION
**Why**: All network errors are handled by a generic routine that returns the error message to display and not a hash.  

**How**: Conditionally add the supplemental info if it's a hash (one line change).  Add coverage for networking errors on assure_id_results (in addition to the existing checks for front and back posts).  Fix a problem with the specs where the string/boolean passed for setting the environment variable for acuant simulator was erroneously being used as a real boolean in the logic.  This was causing code to be inadequately covered.  Fix the specs that were not actually running.