### PR TITLE
Hide doc auth error and info after new image selected

### DIFF
--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -5,13 +5,15 @@ function imagePreview() {
     document.getElementById('doc_auth_image').click();
   });
   $('#doc_auth_image').on('change', function(event) {
+    $('.simple_form .alert-error').hide();
+    $('.simple_form .alert-notice').hide();
     const files = event.target.files;
     const image = files[0];
     const reader = new FileReader();
     reader.onload = function(file) {
       const img = new Image();
       img.onload = function () {
-        const displayWidth = '500';
+        const displayWidth = '460';
         const ratio = (this.height / this.width);
         img.width = displayWidth;
         img.height = (displayWidth * ratio);


### PR DESCRIPTION
Why: Errors and help info from the previous image should be hidden after the user selects a new image.