### PR TITLE
LG-915 LG-1928 Fix Sign In With PIV/CAC 500 errors

### DIFF
--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -21,6 +21,8 @@ module Users
 
     def did_not_work; end
 
+    def temporary_error; end
+
     private
 
     def two_factor_authentication_method
@@ -86,7 +88,12 @@ module Users
       if piv_cac_login_form.valid_token?
         redirect_to login_piv_cac_account_not_found_url
       else
-        redirect_to login_piv_cac_did_not_work_url
+        redirect_to case piv_cac_login_form.error_type
+                    when 'certificate.timeout', 'certificate.ocsp_error'
+                      login_piv_cac_temporary_error_url
+                    else
+                      login_piv_cac_did_not_work_url
+                    end
       end
     end
 

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.slim
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.slim
@@ -36,6 +36,14 @@ p.mt-tiny.mb3
               = label_tag(:'error_certificate.revoked', 'Revoked certificate')
           label.btn-border.col-12.mb2
             .radio
+              = radio_button_tag(:error, 'certificate.timeout')
+              = label_tag(:'error_certificate.timeout', 'Certificate timeout')
+          label.btn-border.col-12.mb2
+            .radio
+              = radio_button_tag(:error, 'certificate.ocsp_error')
+              = label_tag(:'error_certificate.ocsp_error', 'Certificate OCSP error')
+          label.btn-border.col-12.mb2
+            .radio
               = radio_button_tag(:error, 'certificate.invalid')
               = label_tag(:'error_certificate.invalid', 'Invalid certificate')
           label.btn-border.col-12.mb2

--- a/app/views/users/piv_cac_login/temporary_error.html.slim
+++ b/app/views/users/piv_cac_login/temporary_error.html.slim
@@ -1,0 +1,10 @@
+- title t('headings.piv_cac_login.temporary_error')
+
+h1.h3.my0 = t('headings.piv_cac_login.temporary_error')
+p.mt2.mb2 == t('instructions.mfa.piv_cac.temporary_error',
+               try_again: link_to(I18n.t('instructions.mfa.piv_cac.try_again'), login_piv_cac_url))
+
+.mt3
+  = link_to t('instructions.mfa.piv_cac.back_to_sign_in'), root_url, class: 'usa-button'
+
+= render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_login/temporary_error.html.slim
+++ b/app/views/users/piv_cac_login/temporary_error.html.slim
@@ -1,8 +1,7 @@
 - title t('headings.piv_cac_login.temporary_error')
 
 h1.h3.my0 = t('headings.piv_cac_login.temporary_error')
-p.mt2.mb2 == t('instructions.mfa.piv_cac.temporary_error',
-               try_again: link_to(I18n.t('instructions.mfa.piv_cac.try_again'), login_piv_cac_url))
+p.mt2.mb2 == t('instructions.mfa.piv_cac.temporary_error')
 
 .mt3
   = link_to t('instructions.mfa.piv_cac.back_to_sign_in'), root_url, class: 'usa-button'

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -84,8 +84,10 @@ en:
           your administrator to ensure your certificate is up to date.
         none_html: Please contact your administrator to ensure your certificate is
           up to date.
+        ocsp_error_html: We’re having technical difficulties.  Please try again later.
         revoked_html: Please choose a different certificate from your PIV/CAC or contact
           your administrator to ensure your certificate is up to date.
+        timeout_html: We’re having technical difficulties.  Please try again later.
         unverified_html: Please choose a different certificate from your PIV/CAC or
           contact your administrator to ensure your certificate is up to date.
       choose_different_certificate: Choose a different certificate

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -89,8 +89,12 @@ es:
           con su administrador para asegurarse de que su certificado esté actualizado.
         none_html: Por favor, póngase en contacto con su administrador para asegurarse
           de que su certificado esté actualizado.
+        ocsp_error_html: Estamos teniendo dificultades técnicas. Por favor, inténtelo
+          de nuevo más tarde.
         revoked_html: Elija un certificado diferente de su PIV/CAC o póngase en contacto
           con su administrador para asegurarse de que su certificado esté actualizado.
+        timeout_html: Estamos teniendo dificultades técnicas. Por favor, inténtelo
+          de nuevo más tarde.
         unverified_html: Elija un certificado diferente de su PIV/CAC o póngase en
           contacto con su administrador para asegurarse de que su certificado esté
           actualizado.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -90,9 +90,13 @@ fr:
           à jour.
         none_html: Veuillez contacter votre administrateur pour vous assurer que votre
           certificat est à jour.
+        ocsp_error_html: Nous avons des difficultés techniques. Veuillez réessayer
+          plus tard.
         revoked_html: Veuillez choisir un certificat différent de votre PIV/CAC ou
           contactez votre administrateur pour vous assurer que votre certificat est
           à jour.
+        timeout_html: Nous avons des difficultés techniques. Veuillez réessayer plus
+          tard.
         unverified_html: Veuillez choisir un certificat différent de votre PIV/CAC
           ou contactez votre administrateur pour vous assurer que votre certificat
           est à jour.

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -39,6 +39,7 @@ en:
       account_not_found: Your PIV/CAC is not connected to an account
       did_not_work: Your PIV/CAC did not work
       new: Sign in with your PIV or CAC
+      temporary_error: We are experiencing technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: The certificate you selected is invalid.

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -46,8 +46,9 @@ en:
         expired: The certificate you selected has expired.
         invalid: The certificate you selected is invalid.
         none: We cannot detect a certificate on your PIV/CAC card.
+        ocsp_error: We’re having technical difficulties.  Please try again later.
         revoked: The certificate you selected has been revoked from your card.
-        timeout: We are experiencing technical difficulties.  Please try again later.
+        timeout: We’re having technical difficulties.  Please try again later.
         unverified: The certificate you selected is invalid.
       new: Use your PIV/CAC card to secure your account
       piv_cac:

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -39,7 +39,7 @@ en:
       account_not_found: Your PIV/CAC is not connected to an account
       did_not_work: Your PIV/CAC did not work
       new: Sign in with your PIV or CAC
-      temporary_error: We are experiencing technical difficulties using your PIV/CAC
+      temporary_error: We’re having technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: The certificate you selected is invalid.
@@ -47,6 +47,7 @@ en:
         invalid: The certificate you selected is invalid.
         none: We cannot detect a certificate on your PIV/CAC card.
         revoked: The certificate you selected has been revoked from your card.
+        timeout: We are experiencing technical difficulties.  Please try again later.
         unverified: The certificate you selected is invalid.
       new: Use your PIV/CAC card to secure your account
       piv_cac:

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -40,7 +40,7 @@ es:
       account_not_found: Su PIV / CAC no está conectado a una cuenta
       did_not_work: Su PIV / CAC no funcionó
       new: Use su PIV / CAC para iniciar sesión en su cuenta
-      temporary_error: We are experiencing technical difficulties using your PIV/CAC
+      temporary_error: We’re having technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: El certificado que seleccionaste no es válido.

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -40,6 +40,7 @@ es:
       account_not_found: Su PIV / CAC no está conectado a una cuenta
       did_not_work: Su PIV / CAC no funcionó
       new: Use su PIV / CAC para iniciar sesión en su cuenta
+      temporary_error: We are experiencing technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: El certificado que seleccionaste no es válido.

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -47,7 +47,11 @@ es:
         expired: El certificado que seleccionó ha expirado.
         invalid: El certificado que seleccionaste no es válido.
         none: No podemos detectar un certificado en su tarjeta PIV/CAC.
+        ocsp_error: Estamos teniendo dificultades técnicas. Por favor, inténtelo de
+          nuevo más tarde.
         revoked: El certificado que seleccionó ha sido revocado de su tarjeta.
+        timeout: Estamos teniendo dificultades técnicas. Por favor, inténtelo de nuevo
+          más tarde.
         unverified: El certificado que seleccionaste no es válido.
       new: Use su tarjeta PIV/CAC para asegurar su cuenta
       piv_cac:

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -40,7 +40,7 @@ es:
       account_not_found: Su PIV / CAC no está conectado a una cuenta
       did_not_work: Su PIV / CAC no funcionó
       new: Use su PIV / CAC para iniciar sesión en su cuenta
-      temporary_error: We’re having technical difficulties using your PIV/CAC
+      temporary_error: Estamos teniendo dificultades técnicas para usar su PIV/CAC
     piv_cac_setup:
       certificate:
         bad: El certificado que seleccionaste no es válido.

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -40,7 +40,7 @@ fr:
       account_not_found: Votre PIV / CAC n'est pas connecté à un compte
       did_not_work: Votre PIV / CAC n'a pas fonctionné
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
-      temporary_error: We are experiencing technical difficulties using your PIV/CAC
+      temporary_error: We’re having technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: Le certificat que vous avez sélectionné n'est pas valide.

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -47,7 +47,10 @@ fr:
         expired: Le certificat que vous avez sélectionné a expiré.
         invalid: Le certificat que vous avez sélectionné n'est pas valide.
         none: Nous ne pouvons pas détecter un certificat sur votre carte PIV/CAC.
+        ocsp_error: Nous avons des difficultés techniques. Veuillez réessayer plus
+          tard.
         revoked: Le certificat que vous avez sélectionné a été retiré de votre carte.
+        timeout: Nous avons des difficultés techniques. Veuillez réessayer plus tard.
         unverified: Le certificat que vous avez sélectionné n'est pas valide.
       new: Utilisez votre carte PIV/CAC pour sécuriser votre compte
       piv_cac:

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -40,6 +40,7 @@ fr:
       account_not_found: Votre PIV / CAC n'est pas connecté à un compte
       did_not_work: Votre PIV / CAC n'a pas fonctionné
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
+      temporary_error: We are experiencing technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:
         bad: Le certificat que vous avez sélectionné n'est pas valide.

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -40,7 +40,7 @@ fr:
       account_not_found: Votre PIV / CAC n'est pas connecté à un compte
       did_not_work: Votre PIV / CAC n'a pas fonctionné
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
-      temporary_error: We’re having technical difficulties using your PIV/CAC
+      temporary_error: Nous rencontrons des difficultés techniques avec votre PIV/CAC
     piv_cac_setup:
       certificate:
         bad: Le certificat que vous avez sélectionné n'est pas valide.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -36,6 +36,8 @@ en:
           agency administrator.
         sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
           set up PIV/CAC</strong> as a two-factor authentication method.
+        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
+          %{try_again} later or use your username and password to sign in now.
         try_again: try again
       sms:
         confirm_code_html: Need another code? %{resend_code_link}. Message rates may

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -36,7 +36,8 @@ en:
           agency administrator.
         sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
           set up PIV/CAC</strong> as a two-factor authentication method.
-        temporary_error: Please try again later or sign in with your email and password instead.
+        temporary_error: Please try again later or sign in with your email and password
+          instead.
         try_again: try again
       sms:
         confirm_code_html: Need another code? %{resend_code_link}. Message rates may

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -36,8 +36,7 @@ en:
           agency administrator.
         sign_in: Make sure <strong>you have a login.gov account</strong> and <strong>you've
           set up PIV/CAC</strong> as a two-factor authentication method.
-        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
-          %{try_again} later or use your username and password to sign in now.
+        temporary_error: Please try again later or sign in with your email and password instead.
         try_again: try again
       sms:
         confirm_code_html: Need another code? %{resend_code_link}. Message rates may

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -37,8 +37,7 @@ es:
           con el administrador de su agencia.
         sign_in: Asegúrese de que <strong>tenga una cuenta login.gov</strong> y <strong>haya
           configurado PIV/CAC</strong> como método de autenticación de dos factores.
-        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
-          %{try_again} later or use your username and password to sign in now.
+        temporary_error: Please try again later or sign in with your email and password instead.
         try_again: inténtalo de nuevo
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -37,7 +37,7 @@ es:
           con el administrador de su agencia.
         sign_in: Asegúrese de que <strong>tenga una cuenta login.gov</strong> y <strong>haya
           configurado PIV/CAC</strong> como método de autenticación de dos factores.
-        temporary_error: Please try again later or sign in with your email and password instead.
+        temporary_error: Vuelve a intentarlo más tarde o inicia sesión con tu correo electrónico y contraseña.
         try_again: inténtalo de nuevo
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -37,6 +37,8 @@ es:
           con el administrador de su agencia.
         sign_in: Asegúrese de que <strong>tenga una cuenta login.gov</strong> y <strong>haya
           configurado PIV/CAC</strong> como método de autenticación de dos factores.
+        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
+          %{try_again} later or use your username and password to sign in now.
         try_again: inténtalo de nuevo
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -37,7 +37,8 @@ es:
           con el administrador de su agencia.
         sign_in: Asegúrese de que <strong>tenga una cuenta login.gov</strong> y <strong>haya
           configurado PIV/CAC</strong> como método de autenticación de dos factores.
-        temporary_error: Vuelve a intentarlo más tarde o inicia sesión con tu correo electrónico y contraseña.
+        temporary_error: Vuelve a intentarlo más tarde o inicia sesión con tu correo
+          electrónico y contraseña.
         try_again: inténtalo de nuevo
       sms:
         confirm_code_html: "¿Necesita otro código? %{resend_code_link}. Puede estar

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -42,7 +42,7 @@ fr:
         sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
           et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
           d'authentification à deux facteurs.
-        temporary_error: Please try again later or sign in with your email and password instead.
+        temporary_error: Veuillez réessayer ultérieurement ou connectez-vous avec votre adresse électronique et votre mot de passe.
         try_again: réessayer
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -42,6 +42,8 @@ fr:
         sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
           et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
           d'authentification à deux facteurs.
+        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
+          %{try_again} later or use your username and password to sign in now.
         try_again: réessayer
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -42,7 +42,8 @@ fr:
         sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
           et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
           d'authentification à deux facteurs.
-        temporary_error: Veuillez réessayer ultérieurement ou connectez-vous avec votre adresse électronique et votre mot de passe.
+        temporary_error: Veuillez réessayer ultérieurement ou connectez-vous avec
+          votre adresse électronique et votre mot de passe.
         try_again: réessayer
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -42,8 +42,7 @@ fr:
         sign_in: Assurez-vous que <strong>vous disposez d'un compte login.gov</strong>
           et que <strong>vous avez configuré PIV/CAC</strong> en tant que méthode
           d'authentification à deux facteurs.
-        temporary_error: We are experiencing technical difficulties using your PIV/CAC.  Please
-          %{try_again} later or use your username and password to sign in now.
+        temporary_error: Please try again later or sign in with your email and password instead.
         try_again: réessayer
       sms:
         confirm_code_html: Vous avez besoin d'un autre code? %{resend_code_link}.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -27,7 +27,9 @@ en:
         expired: PIV/CAC certificate error
         invalid: PIV/CAC certificate error
         none: PIV/CAC certificate error
+        ocsp_error: PIV/CAC certificate error
         revoked: PIV/CAC certificate error
+        timeout: PIV/CAC certificate error
         unverified: PIV/CAC certificate error
       new: Use your PIV/CAC card to secure your account
       piv_cac:

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -28,7 +28,9 @@ es:
         expired: Error de certificado PIV/CAC
         invalid: Error de certificado PIV/CAC
         none: Error de certificado PIV/CAC
+        ocsp_error: Error de certificado PIV/CAC
         revoked: Error de certificado PIV/CAC
+        timeout: Error de certificado PIV/CAC
         unverified: Error de certificado PIV/CAC
       new: Use su tarjeta PIV/CAC para asegurar su cuenta
       piv_cac:

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -27,7 +27,9 @@ fr:
         expired: Erreur de certificat PIV/CAC
         invalid: Erreur de certificat PIV/CAC
         none: Erreur de certificat PIV/CAC
+        ocsp_error: Erreur de certificat PIV/CAC
         revoked: Erreur de certificat PIV/CAC
+        timeout: Erreur de certificat PIV/CAC
         unverified: Erreur de certificat PIV/CAC
       new: Utilisez votre carte PIV/CAC pour sécuriser votre compte
       piv_cac:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
         get '/login/piv_cac' => 'users/piv_cac_login#new'
         get '/login/piv_cac_account_not_found' => 'users/piv_cac_login#account_not_found'
         get '/login/piv_cac_did_not_work' => 'users/piv_cac_login#did_not_work'
+        get '/login/piv_cac_temporary_error' => 'users/piv_cac_login#temporary_error'
         get '/login/present_piv_cac' => 'users/piv_cac_login#redirect_to_piv_cac_service'
         get '/login/password' => 'password_capture#new', as: :capture_password
         post '/login/password' => 'password_capture#create'

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -32,6 +32,18 @@ feature 'Sign in' do
     expect(current_path).to eq login_piv_cac_account_not_found_path
   end
 
+  scenario 'user cannot sign in with certificate timeout error' do
+    signin_with_piv_error('certificate.timeout')
+
+    expect(current_path).to eq login_piv_cac_temporary_error_path
+  end
+
+  scenario 'user cannot sign in with certificate ocsp error' do
+    signin_with_piv_error('certificate.ocsp_error')
+
+    expect(current_path).to eq login_piv_cac_temporary_error_path
+  end
+
   scenario 'user cannot sign in with an unregistered piv/cac card' do
     signin_with_bad_piv
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -36,12 +36,14 @@ feature 'Sign in' do
     signin_with_piv_error('certificate.timeout')
 
     expect(current_path).to eq login_piv_cac_temporary_error_path
+    expect(page).to have_content t('headings.piv_cac_login.temporary_error')
   end
 
   scenario 'user cannot sign in with certificate ocsp error' do
     signin_with_piv_error('certificate.ocsp_error')
 
     expect(current_path).to eq login_piv_cac_temporary_error_path
+    expect(page).to have_content t('headings.piv_cac_login.temporary_error')
   end
 
   scenario 'user cannot sign in with an unregistered piv/cac card' do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -55,6 +55,23 @@ module Features
       fill_in_piv_cac_credentials_and_submit(user)
     end
 
+    def signin_with_piv_error(error)
+      user = user_with_piv_cac
+      allow(UserMailer).to receive(:new_device_sign_in).and_call_original
+      visit new_user_session_path
+      click_on t('account.login.piv_cac')
+
+      allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
+
+      stub_piv_cac_service
+      nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
+      visit_piv_cac_service(current_url,
+                            nonce: nonce,
+                            uuid: user.x509_dn_uuid,
+                            subject: 'SomeIgnoredSubject',
+                            error: error)
+    end
+
     def signin_with_bad_piv
       allow(UserMailer).to receive(:new_device_sign_in).and_call_original
       visit new_user_session_path

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -57,7 +57,6 @@ module Features
 
     def signin_with_piv_error(error)
       user = user_with_piv_cac
-      allow(UserMailer).to receive(:new_device_sign_in).and_call_original
       visit new_user_session_path
       click_on t('account.login.piv_cac')
 


### PR DESCRIPTION
**Why**: User gets 500 errors with sign in with piv/cac timeout and ocsp errors.

**How**: Update PKI to rescue errors and send them to IDP.  Have IDP show a temporary error screen where the user is notified they should try again later or sign in now with username/password.