### PR TITLE
LG-2123 Update AAMVA gem to 3.2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,6 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.2.3'
+  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.2.4'
   gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v1.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/identity-aamva-api-client-gem.git
-  revision: 4e7a644c2ea7c61e3fc8b57bc12d35a075e94df5
-  tag: v3.2.3
+  revision: b48e45089e672f2e201d2946ee42e5ca49cf9415
+  tag: v3.2.4
   specs:
-    aamva (3.2.3)
+    aamva (3.2.4)
       dotenv
       faraday
       hashie


### PR DESCRIPTION
**Why**: To pick up a change that improves the logging on Faraday error messages