### PR TITLE
fix country combo for screen readers

### DIFF
--- a/app/javascript/app/intl-tel-input.js
+++ b/app/javascript/app/intl-tel-input.js
@@ -1,0 +1,24 @@
+function intlTelInput() {
+  const flagContainer = document.querySelectorAll('.flag-container');
+  if (flagContainer) {
+    [].slice.call(flagContainer).forEach((element) => {
+      element.setAttribute('aria-label', 'Country code');
+    });
+  }
+  const selectedFlag = document.querySelectorAll('.flag-container .selected-flag');
+  if (selectedFlag) {
+    [].slice.call(selectedFlag).forEach((element) => {
+      element.setAttribute('aria-haspopup', 'true');
+      element.setAttribute('role', 'button');
+    });
+  }
+  const country = document.querySelectorAll('.flag-container .country');
+  if (country) {
+    [].slice.call(country).forEach((element) => {
+      element.setAttribute('tabindex', '-1');
+    });
+  }
+}
+
+
+document.addEventListener('DOMContentLoaded', intlTelInput);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,3 +10,4 @@ require('../app/phone-validation');
 require('../app/print-personal-key');
 require('../app/i18n-dropdown');
 require('../app/platform-authenticator');
+require('../app/intl-tel-input');


### PR DESCRIPTION
Why: JAWS is unable to read that the country code selection control is a country code selection control on the enter phone screen.