### PR TITLE
LG-1821 Add a uniqueness constraint to email address

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -10,6 +10,7 @@ module Users
       @register_user_email_form = AddUserEmailForm.new
     end
 
+    # :reek:DuplicateMethodCall
     def add
       @register_user_email_form = AddUserEmailForm.new
 

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -20,6 +20,9 @@ module Users
       else
         render :show
       end
+    rescue ActiveRecord::RecordNotUnique
+      flash[:error] = t('email_addresses.add.duplicate')
+      render :show
     end
 
     def resend

--- a/db/migrate/20191022134041_add_uniqueness_constraint_to_unconfirmed_emails.rb
+++ b/db/migrate/20191022134041_add_uniqueness_constraint_to_unconfirmed_emails.rb
@@ -1,0 +1,12 @@
+class AddUniquenessConstraintToUnconfirmedEmails < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :email_addresses,
+      %i[email_fingerprint user_id],
+      unique: true,
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191015123431) do
+ActiveRecord::Schema.define(version: 20191022134041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 20191015123431) do
     t.datetime "updated_at", null: false
     t.datetime "last_sign_in_at"
     t.index ["confirmation_token"], name: "index_email_addresses_on_confirmation_token", unique: true
+    t.index ["email_fingerprint", "user_id"], name: "index_email_addresses_on_email_fingerprint_and_user_id", unique: true
     t.index ["email_fingerprint"], name: "index_email_addresses_on_all_email_fingerprints"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
     t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }


### PR DESCRIPTION
**Why**: To make certain that a user can only have 1 email address with a given email