### PR TITLE
Enable doc auth in local dev and production

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,7 +41,7 @@ cloudhsm_pin: user:password
 cloudhsm_saml_key_label: key1
 database_statement_timeout: '2500'
 disallow_ial2_recovery:
-doc_auth_exclusive: 'false'
+doc_auth_enabled: 'true'
 doc_capture_request_valid_for_minutes: '15'
 email_from: no-reply@login.gov
 enable_load_testing_mode: 'false'
@@ -144,7 +144,7 @@ development:
   database_username: ''
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
-  doc_auth_enabled: 'false'
+  doc_auth_exclusive: 'true'
   domain_name: localhost:3000
   email_deletion_enabled: 'true'
   enable_rate_limiting: 'false'
@@ -246,7 +246,7 @@ production:
   database_username:
   disable_email_sending: 'false'
   disallow_all_web_crawlers: 'false'
-  doc_auth_enabled: 'false'
+  doc_auth_exclusive: 'true'
   domain_name: login.gov
   email_deletion_enabled: 'false'
   enable_rate_limiting: 'true'
@@ -347,7 +347,7 @@ test:
   database_username: ''
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
-  doc_auth_enabled: 'true'
+  doc_auth_exclusive: 'false'
   domain_name: www.example.com
   email_deletion_enabled: 'true'
   enable_rate_limiting: 'true'


### PR DESCRIPTION
**Why**: It is enabled in all of the deployed envs so there is not reason to keep it disabled in app.yml