### PR TITLE
LG-2044 Add a PIV/CAC during sign in flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,9 +131,13 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     @service_provider_request ||= ServiceProviderRequest.from_uuid(params[:request_id])
   end
 
+  def add_piv_cac_setup_url
+    session[:x509_dn] ? login_add_piv_cac_prompt_url : nil
+  end
+
   def after_sign_in_path_for(_user)
-    user_session.delete(:stored_location) || sp_session_request_url_without_prompt_login ||
-      signed_in_url
+    add_piv_cac_setup_url || user_session.delete(:stored_location) ||
+      sp_session_request_url_without_prompt_login || signed_in_url
   end
 
   def signed_in_url

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,7 +132,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   def add_piv_cac_setup_url
-    session[:x509_dn] ? login_add_piv_cac_prompt_url : nil
+    session[:needs_to_setup_piv_cac_after_sign_in] ? login_add_piv_cac_prompt_url : nil
   end
 
   def after_sign_in_path_for(_user)

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -7,12 +7,17 @@ module SignUp
     before_action :stop_if_invalid_token
 
     def create
+      clear_setup_piv_cac_from_sign_in
       process_confirmation
     rescue ActiveRecord::RecordNotUnique
       process_already_confirmed_user
     end
 
     private
+
+    def clear_setup_piv_cac_from_sign_in
+      session.delete(:x509_dn)
+    end
 
     def process_successful_confirmation
       process_valid_confirmation_token

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -16,7 +16,7 @@ module SignUp
     private
 
     def clear_setup_piv_cac_from_sign_in
-      session.delete(:x509_dn)
+      session.delete(:needs_to_setup_piv_cac_after_sign_in)
     end
 
     def process_successful_confirmation

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -86,6 +86,7 @@ module Users
 
     def process_invalid_submission
       if piv_cac_login_form.valid_token?
+        session[:x509_dn] = piv_cac_login_form.data['dn']
         redirect_to login_piv_cac_account_not_found_url
       else
         process_token_with_error

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -86,7 +86,7 @@ module Users
 
     def process_invalid_submission
       if piv_cac_login_form.valid_token?
-        session[:x509_dn] = true
+        session[:needs_to_setup_piv_cac_after_sign_in] = true
         redirect_to login_piv_cac_account_not_found_url
       else
         process_token_with_error

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -86,7 +86,7 @@ module Users
 
     def process_invalid_submission
       if piv_cac_login_form.valid_token?
-        session[:x509_dn] = piv_cac_login_form.data['dn']
+        session[:x509_dn] = true
         redirect_to login_piv_cac_account_not_found_url
       else
         process_token_with_error

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -57,7 +57,6 @@ module Users
 
     def process_valid_submission
       session.delete(:x509_dn)
-      flash[:success] = t('notices.piv_cac_configured')
       save_piv_cac_information(
         subject: user_piv_cac_form.x509_dn,
         presented: true,

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -55,6 +55,19 @@ module Users
       )
     end
 
+    def process_invalid_submission
+      redirect_to case user_piv_cac_form.error_type
+                  when 'certificate.timeout'
+                    flash[:error] = t('titles.piv_cac_setup.certificate.timeout')
+                    login_piv_cac_temporary_error_url
+                  when 'certificate.ocsp_error'
+                    flash[:error] = t('titles.piv_cac_setup.certificate.ocsp_error')
+                    login_piv_cac_temporary_error_url
+                  else
+                    login_piv_cac_did_not_work_url
+                  end
+    end
+
     def process_valid_submission
       session.delete(:x509_dn)
       save_piv_cac_information(

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -1,0 +1,69 @@
+module Users
+  class PivCacSetupFromSignInController < ApplicationController
+    include PivCacConcern
+
+    before_action :confirm_two_factor_authenticated
+
+    def prompt
+      if params.key?(:token)
+        process_piv_cac_setup
+      elsif flash[:error_type].present?
+        render_error
+      else
+        render_prompt
+      end
+    end
+
+    def success; end
+
+    def next
+      redirect_to after_sign_in_path_for(current_user)
+    end
+
+    def decline
+      session.delete(:x509_dn)
+      redirect_to after_sign_in_path_for(current_user)
+    end
+
+    private
+
+    def render_error
+      @presenter = PivCacAuthenticationSetupErrorPresenter.new(error: flash[:error_type])
+      render :error
+    end
+
+    def render_prompt
+      analytics.track_event(Analytics::USER_REGISTRATION_PIV_CAC_SETUP_VISIT)
+      render :prompt
+    end
+
+    def process_piv_cac_setup
+      result = user_piv_cac_form.submit
+      analytics.track_event(Analytics::MULTI_FACTOR_AUTH_SETUP, result.to_h)
+      if result.success?
+        process_valid_submission
+      else
+        process_invalid_submission
+      end
+    end
+
+    def user_piv_cac_form
+      @user_piv_cac_form ||= UserPivCacSetupForm.new(
+          user: current_user,
+          token: params[:token],
+          nonce: piv_cac_nonce,
+          )
+    end
+
+    def process_valid_submission
+      session.delete(:x509_dn)
+      flash[:success] = t('notices.piv_cac_configured')
+      save_piv_cac_information(
+          subject: user_piv_cac_form.x509_dn,
+          presented: true,
+          )
+      create_user_event(:piv_cac_enabled)
+      redirect_to login_add_piv_cac_success_url
+    end
+  end
+end

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -21,7 +21,7 @@ module Users
     end
 
     def decline
-      session.delete(:x509_dn)
+      session.delete(:needs_to_setup_piv_cac_after_sign_in)
       redirect_to after_sign_in_path_for(current_user)
     end
 
@@ -69,7 +69,7 @@ module Users
     end
 
     def process_valid_submission
-      session.delete(:x509_dn)
+      session.delete(:needs_to_setup_piv_cac_after_sign_in)
       save_piv_cac_information(
         subject: user_piv_cac_form.x509_dn,
         presented: true,

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -49,19 +49,19 @@ module Users
 
     def user_piv_cac_form
       @user_piv_cac_form ||= UserPivCacSetupForm.new(
-          user: current_user,
-          token: params[:token],
-          nonce: piv_cac_nonce,
-          )
+        user: current_user,
+        token: params[:token],
+        nonce: piv_cac_nonce,
+      )
     end
 
     def process_valid_submission
       session.delete(:x509_dn)
       flash[:success] = t('notices.piv_cac_configured')
       save_piv_cac_information(
-          subject: user_piv_cac_form.x509_dn,
-          presented: true,
-          )
+        subject: user_piv_cac_form.x509_dn,
+        presented: true,
+      )
       create_user_event(:piv_cac_enabled)
       redirect_to login_add_piv_cac_success_url
     end

--- a/app/forms/user_piv_cac_login_form.rb
+++ b/app/forms/user_piv_cac_login_form.rb
@@ -2,7 +2,7 @@ class UserPivCacLoginForm
   include ActiveModel::Model
   include PivCacFormHelpers
 
-  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user
+  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user, :data
 
   validates :token, presence: true
   validates :nonce, presence: true

--- a/app/forms/user_piv_cac_login_form.rb
+++ b/app/forms/user_piv_cac_login_form.rb
@@ -2,7 +2,7 @@ class UserPivCacLoginForm
   include ActiveModel::Model
   include PivCacFormHelpers
 
-  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user, :data
+  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user
 
   validates :token, presence: true
   validates :nonce, presence: true

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
@@ -7,6 +7,7 @@ p.mt2.mb2 == t('instructions.mfa.piv_cac.add_from_sign_in')
 
 .mt3
   = link_to t('forms.piv_cac_setup.submit'), redirect_to_piv_cac_service_url, class: 'usa-button'
-  = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url, class: 'usa-button usa-button--outline btn inline-block btn_link'
+  = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
+    class: 'usa-button usa-button--outline btn inline-block btn_link'
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
@@ -1,0 +1,12 @@
+- title t('titles.piv_cac_login.add')
+
+h1.h3.my0 = t('titles.piv_cac_login.add')
+p.mt2.mb2 == t('headings.piv_cac_login.add')
+
+p.mt2.mb2 == t('instructions.mfa.piv_cac.add_from_sign_in')
+
+.mt3
+  = link_to t('forms.piv_cac_setup.submit'), redirect_to_piv_cac_service_url, class: 'usa-button'
+  = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url, class: 'usa-button usa-button--outline btn inline-block btn_link'
+
+= render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
@@ -6,8 +6,10 @@ p.mt2.mb2 == t('headings.piv_cac_login.add')
 p.mt2.mb2 == t('instructions.mfa.piv_cac.add_from_sign_in')
 
 .mt3
-  = link_to t('forms.piv_cac_setup.submit'), redirect_to_piv_cac_service_url, class: 'usa-button'
-  = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
-    class: 'usa-button usa-button--outline btn inline-block btn_link'
+  .inline-block
+    = link_to t('forms.piv_cac_setup.submit'), redirect_to_piv_cac_service_url, class: 'usa-button'
+  .inline-block
+    = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
+      class: 'usa-button usa-button--outline'
 
 = render 'shared/cancel', link: new_user_session_url

--- a/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/success.html.erb
@@ -1,0 +1,11 @@
+<% title t('headings.piv_cac_login.success') %>
+
+<%= image_tag asset_url('alert/success.svg'), width: 90 %>
+
+<h1 class="h3 mb2 mt3 my0"><%= t('headings.piv_cac_login.success') %></h1>
+<br>
+
+<%= button_to t('forms.buttons.continue'), login_add_piv_cac_success_path,
+    class: 'btn btn-primary btn-wide sm-col-6 col-12', method: :post %>
+
+<%= render 'shared/cancel', link: destroy_user_session_path %>

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -91,6 +91,7 @@ en:
         unverified_html: Please choose a different certificate from your PIV/CAC or
           contact your administrator to ensure your certificate is up to date.
       choose_different_certificate: Choose a different certificate
+      no_thanks: No thanks
       piv_cac:
         already_associated_html: Please choose a certificate from a different PIV/CAC
           or contact your administrator to ensure your PIV/CAC is up to date.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -99,6 +99,7 @@ es:
           contacto con su administrador para asegurarse de que su certificado esté
           actualizado.
       choose_different_certificate: Elija un certificado diferente
+      no_thanks: No, gracias
       piv_cac:
         already_associated_html: Elige un certificado de una PIV/CAC distinta o ponte
           en contacto con el administrador para confirmar que tu PIV/CAC está al día.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -101,6 +101,7 @@ fr:
           ou contactez votre administrateur pour vous assurer que votre certificat
           est à jour.
       choose_different_certificate: Choisissez un certificat différent
+      no_thanks: Non merci
       piv_cac:
         already_associated_html: Veuillez choisir un certificat associé à une autre
           carte PIV/CAC ou contactez votre administrateur afin de vérifier que votre

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -37,8 +37,11 @@ en:
     personal_key: Always have access to your account with your personal key
     piv_cac_login:
       account_not_found: Your PIV/CAC is not connected to an account
+      add: Set up your PIV or CAC as a two-factor authentication method so you can
+        use it to sign in.
       did_not_work: Your PIV/CAC did not work
       new: Sign in with your PIV or CAC
+      success: You successfully set up PIV/CAC as an authentication method.
       temporary_error: We’re having technical difficulties using your PIV/CAC
     piv_cac_setup:
       certificate:

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -38,8 +38,11 @@ es:
     personal_key: Siempre tenga acceso a su cuenta con su clave personal
     piv_cac_login:
       account_not_found: Su PIV / CAC no está conectado a una cuenta
+      add: Configure su PIV o CAC como un método de autenticación de dos factores
+        para que pueda usarlo para iniciar sesión.
       did_not_work: Su PIV / CAC no funcionó
       new: Use su PIV / CAC para iniciar sesión en su cuenta
+      success: Configuró correctamente PIV/CAC como método de autenticación.
       temporary_error: Estamos teniendo dificultades técnicas para usar su PIV/CAC
     piv_cac_setup:
       certificate:

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -38,8 +38,11 @@ fr:
     personal_key: Ayez toujours accès à votre compte avec votre clé personnelle
     piv_cac_login:
       account_not_found: Votre PIV / CAC n'est pas connecté à un compte
+      add: Configurez votre PIV ou votre CAC en tant que méthode d'authentification
+        à deux facteurs pour pouvoir l'utiliser pour vous connecter.
       did_not_work: Votre PIV / CAC n'a pas fonctionné
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
+      success: Vous avez correctement configuré PIV/CAC en tant que méthode d’authentification.
       temporary_error: Nous rencontrons des difficultés techniques avec votre PIV/CAC
     piv_cac_setup:
       certificate:

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -29,6 +29,10 @@ en:
           paragraph_1_html: "<strong>%{sign_in}</strong> with your email address and
             password. Then add your PIV/CAC to your account."
           paragraph_2_html: "<strong>Don't have a login.gov account?</strong> %{create_account}"
+        add_from_sign_in: <strong>Instructions:</strong> Insert your PIV or CAC on
+          <strong>"ADD PIV/CAC"</strong>. You'll need to <strong>choose a certificate</strong>
+          (the right one likely has your name of it) and <strong>enter your PIN</strong>
+          (your PIN was created when you set up your PIV/CAC).
         back_to_sign_in: Go back to sign in
         confirm_piv_cac_html: Present the PIV/CAC that you associated with your account.
         did_not_work: There may be a problem with your PIV/CAC or PIN.  If you think

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -30,6 +30,10 @@ es:
           paragraph_1_html: "<strong>%{sign_in}</strong> con su dirección de correo
             electrónico y contraseña. Luego agregue su PIV/CAC a su cuenta."
           paragraph_2_html: "<strong>¿No tiene una cuenta login.gov?</strong> %{create_account}"
+        add_from_sign_in: '<strong> Instrucciones: </strong> inserte su PIV o CAC
+          en <strong> "AGREGAR PIV / CAC" </strong>. Tendrá que <strong> elegir un
+          certificado </strong> (el correcto probablemente tenga su nombre) e <strong>
+          ingrese su PIN </strong> (su PIN se creó cuando configuró su PIV / CAC )'
         back_to_sign_in: Regrese para iniciar sesión
         confirm_piv_cac_html: Presenta la PIV/CAC que asociaste con tu cuenta.
         did_not_work: Puede haber un problema con su PIV / CAC o PIN. Si cree que

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -33,6 +33,11 @@ fr:
             mot de passe. Ajoutez ensuite votre PIV/CAC à votre compte."
           paragraph_2_html: "<strong>Vous n'avez pas de compte login.gov?</strong>
             %{create_account}"
+        add_from_sign_in: '<strong> Instructions: </ strong> insérez votre PIV ou
+          votre CAC dans <strong> "AJOUTER PIV / CAC" </ strong>. Vous devez <strong>
+          choisir un certificat </ strong> (le bon en a probablement votre nom) et
+          <strong> saisir votre code confidentiel </ strong> (votre code confidentiel
+          a été créé lors de la configuration de votre PIV / CAC). ).'
         back_to_sign_in: Retourner à vous connecter
         confirm_piv_cac_html: Veuillez présenter la carte PIV/CAC que vous avez associée
           à votre compte.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -20,6 +20,7 @@ en:
     personal_key: Just in case
     phone_setup: Send your security code via text message (SMS) or phone call
     piv_cac_login:
+      add: Add your PIV or CAC
       new: Use your PIV/CAC to sign in to your account
     piv_cac_setup:
       certificate:

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -21,6 +21,7 @@ es:
     phone_setup: Envíe su código de seguridad a través de un mensaje de texto o de
       una llamada telefónica
     piv_cac_login:
+      add: Agregue su PIV o CAC
       new: Use su PIV / CAC para iniciar sesión en su cuenta
     piv_cac_setup:
       certificate:

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -20,6 +20,7 @@ fr:
     personal_key: Juste au cas
     phone_setup: Envoyer votre code de sécurité par SMS ou par appel téléphonique
     piv_cac_login:
+      add: Ajoutez votre PIV ou CAC
       new: Utilisez votre PIV / CAC pour vous connecter à votre compte
     piv_cac_setup:
       certificate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,11 @@ Rails.application.routes.draw do
       post '/login/two_factor/:otp_delivery_preference' => 'two_factor_authentication/otp_verification#create',
            as: :login_otp
 
+      get 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#prompt'
+      post 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#decline'
+      get 'login/add_piv_cac/success' =>  'users/piv_cac_setup_from_sign_in#success'
+      post 'login/add_piv_cac/success' =>  'users/piv_cac_setup_from_sign_in#next'
+
       get '/reauthn' => 'mfa_confirmation#new', as: :user_password_confirm
       post '/reauthn' => 'mfa_confirmation#create', as: :reauthn_user_password
       get '/timeout' => 'users/sessions#timeout'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,8 +111,8 @@ Rails.application.routes.draw do
 
       get 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#prompt'
       post 'login/add_piv_cac/prompt' => 'users/piv_cac_setup_from_sign_in#decline'
-      get 'login/add_piv_cac/success' =>  'users/piv_cac_setup_from_sign_in#success'
-      post 'login/add_piv_cac/success' =>  'users/piv_cac_setup_from_sign_in#next'
+      get 'login/add_piv_cac/success' => 'users/piv_cac_setup_from_sign_in#success'
+      post 'login/add_piv_cac/success' => 'users/piv_cac_setup_from_sign_in#next'
 
       get '/reauthn' => 'mfa_confirmation#new', as: :user_password_confirm
       post '/reauthn' => 'mfa_confirmation#create', as: :reauthn_user_password

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -56,6 +56,37 @@ feature 'Sign in' do
     expect(current_path).to eq sign_up_completed_path
   end
 
+  scenario 'user opts to add piv/cac card' do
+    user = create(:user, :signed_up, :with_phone)
+    visit_idp_from_sp_with_ial1(:oidc)
+    click_on t('account.login.piv_cac')
+    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
+
+    stub_piv_cac_service
+    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
+    visit_piv_cac_service(current_url,
+                          nonce: nonce,
+                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                          uuid: SecureRandom.uuid,
+                          subject: 'SomeIgnoredSubject')
+
+    expect(current_path).to eq login_piv_cac_account_not_found_path
+    visit new_user_session_path
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    expect(current_path).to eq login_add_piv_cac_prompt_path
+
+    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
+    visit_piv_cac_service(current_url,
+                          nonce: nonce,
+                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                          uuid: SecureRandom.uuid,
+                          subject: 'SomeIgnoredSubject')
+
+    expect(current_path).to eq login_add_piv_cac_success_path
+  end
+
   scenario 'user cannot sign in with certificate timeout error' do
     signin_with_piv_error('certificate.timeout')
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -32,7 +32,7 @@ feature 'Sign in' do
     expect(current_path).to eq login_piv_cac_account_not_found_path
   end
 
-  scenario 'user adds piv/cac card' do
+  scenario 'user opts to not add piv/cac card' do
     user = create(:user, :signed_up, :with_phone)
     visit_idp_from_sp_with_ial1(:oidc)
     click_on t('account.login.piv_cac')
@@ -52,6 +52,8 @@ feature 'Sign in' do
     fill_in_code_with_last_phone_otp
     click_submit_default
     expect(current_path).to eq login_add_piv_cac_prompt_path
+    click_on t('forms.piv_cac_setup.no_thanks')
+    expect(current_path).to eq sign_up_completed_path
   end
 
   scenario 'user cannot sign in with certificate timeout error' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -52,6 +52,19 @@ feature 'Sign in' do
     expect(current_path).to eq sign_up_completed_path
   end
 
+  scenario 'user opts to add piv/cac card but gets an error' do
+    steps_to_get_to_add_piv_cac_during_sign_up
+    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
+    visit_piv_cac_service(current_url,
+                          nonce: nonce,
+                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                          uuid: SecureRandom.uuid,
+                          error: 'certificate.bad',
+                          subject: 'SomeIgnoredSubject')
+
+    expect(current_path).to eq login_piv_cac_did_not_work_path
+  end
+
   scenario 'user cannot sign in with certificate timeout error' do
     signin_with_piv_error('certificate.timeout')
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -33,13 +33,13 @@ feature 'Sign in' do
   end
 
   scenario 'user opts to not add piv/cac card' do
-    steps_to_get_to_add_piv_cac_during_sign_up
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
     click_on t('forms.piv_cac_setup.no_thanks')
     expect(current_path).to eq sign_up_completed_path
   end
 
   scenario 'user opts to add piv/cac card' do
-    steps_to_get_to_add_piv_cac_during_sign_up
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
     nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
     visit_piv_cac_service(current_url,
                           nonce: nonce,
@@ -53,7 +53,7 @@ feature 'Sign in' do
   end
 
   scenario 'user opts to add piv/cac card but gets an error' do
-    steps_to_get_to_add_piv_cac_during_sign_up
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
     nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
     visit_piv_cac_service(current_url,
                           nonce: nonce,
@@ -646,7 +646,7 @@ feature 'Sign in' do
     end
   end
 
-  def steps_to_get_to_add_piv_cac_during_sign_up
+  def perform_steps_to_get_to_add_piv_cac_during_sign_up
     user = create(:user, :signed_up, :with_phone)
     visit_idp_from_sp_with_ial1(:oidc)
     click_on t('account.login.piv_cac')

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -32,6 +32,28 @@ feature 'Sign in' do
     expect(current_path).to eq login_piv_cac_account_not_found_path
   end
 
+  scenario 'user adds piv/cac card' do
+    user = create(:user, :signed_up, :with_phone)
+    visit_idp_from_sp_with_ial1(:oidc)
+    click_on t('account.login.piv_cac')
+    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
+
+    stub_piv_cac_service
+    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
+    visit_piv_cac_service(current_url,
+                          nonce: nonce,
+                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                          uuid: SecureRandom.uuid,
+                          subject: 'SomeIgnoredSubject')
+
+    expect(current_path).to eq login_piv_cac_account_not_found_path
+    visit new_user_session_path
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    expect(current_path).to eq login_add_piv_cac_prompt_path
+  end
+
   scenario 'user cannot sign in with certificate timeout error' do
     signin_with_piv_error('certificate.timeout')
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -33,50 +33,13 @@ feature 'Sign in' do
   end
 
   scenario 'user opts to not add piv/cac card' do
-    user = create(:user, :signed_up, :with_phone)
-    visit_idp_from_sp_with_ial1(:oidc)
-    click_on t('account.login.piv_cac')
-    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
-
-    stub_piv_cac_service
-    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-    visit_piv_cac_service(current_url,
-                          nonce: nonce,
-                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-                          uuid: SecureRandom.uuid,
-                          subject: 'SomeIgnoredSubject')
-
-    expect(current_path).to eq login_piv_cac_account_not_found_path
-    visit new_user_session_path
-    fill_in_credentials_and_submit(user.email, user.password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    expect(current_path).to eq login_add_piv_cac_prompt_path
+    steps_to_get_to_add_piv_cac_during_sign_up
     click_on t('forms.piv_cac_setup.no_thanks')
     expect(current_path).to eq sign_up_completed_path
   end
 
   scenario 'user opts to add piv/cac card' do
-    user = create(:user, :signed_up, :with_phone)
-    visit_idp_from_sp_with_ial1(:oidc)
-    click_on t('account.login.piv_cac')
-    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
-
-    stub_piv_cac_service
-    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
-    visit_piv_cac_service(current_url,
-                          nonce: nonce,
-                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
-                          uuid: SecureRandom.uuid,
-                          subject: 'SomeIgnoredSubject')
-
-    expect(current_path).to eq login_piv_cac_account_not_found_path
-    visit new_user_session_path
-    fill_in_credentials_and_submit(user.email, user.password)
-    fill_in_code_with_last_phone_otp
-    click_submit_default
-    expect(current_path).to eq login_add_piv_cac_prompt_path
-
+    steps_to_get_to_add_piv_cac_during_sign_up
     nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_setup.submit')))
     visit_piv_cac_service(current_url,
                           nonce: nonce,
@@ -85,6 +48,8 @@ feature 'Sign in' do
                           subject: 'SomeIgnoredSubject')
 
     expect(current_path).to eq login_add_piv_cac_success_path
+    click_continue
+    expect(current_path).to eq sign_up_completed_path
   end
 
   scenario 'user cannot sign in with certificate timeout error' do
@@ -666,5 +631,27 @@ feature 'Sign in' do
       visit_idp_from_oidc_sp_with_loa1_prompt_login
       expect(current_path).to eq(bounced_path)
     end
+  end
+
+  def steps_to_get_to_add_piv_cac_during_sign_up
+    user = create(:user, :signed_up, :with_phone)
+    visit_idp_from_sp_with_ial1(:oidc)
+    click_on t('account.login.piv_cac')
+    allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
+
+    stub_piv_cac_service
+    nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
+    visit_piv_cac_service(current_url,
+                          nonce: nonce,
+                          dn: 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+                          uuid: SecureRandom.uuid,
+                          subject: 'SomeIgnoredSubject')
+
+    expect(current_path).to eq login_piv_cac_account_not_found_path
+    visit new_user_session_path
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    expect(current_path).to eq login_add_piv_cac_prompt_path
   end
 end


### PR DESCRIPTION
**Why**: So users who try to sign in with a PIV/CAC and do not have one associated with their account, can easily add one while signing in.

**How**: When a user attempts to sign in with a good PIV/CAC but they do not have one associated with their account save the condition in session.  When the user then attempts to sign in with username password, check to see if the session state dictates if we should show the user the option of setting up a PIV/CAC.