### PR TITLE
LG-2095 Accept either an array or a string as a value for OpenID aud claim

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -113,11 +113,23 @@ class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
   end
 
   def validate_aud_claim(payload)
-    normalized_aud = payload['aud'].to_s.chomp('/')
-    return if api_openid_connect_token_url == normalized_aud
+    aud_claim = payload['aud']
+    if aud_claim.is_a?(Array)
+      return true if normalized_aud_array(aud_claim).include?(api_openid_connect_token_url)
+    elsif aud_claim.is_a?(String)
+      return true if normalized_aud_string(aud_claim) == api_openid_connect_token_url
+    end
 
     errors.add(:client_assertion,
                t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url))
+  end
+
+  def normalized_aud_array(auds)
+    auds.map { |aud| aud.to_s.chomp('/') }
+  end
+
+  def normalized_aud_string(aud)
+    aud.to_s.chomp('/')
   end
 
   def service_provider

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -114,22 +114,12 @@ class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
 
   def validate_aud_claim(payload)
     aud_claim = payload['aud']
-    if aud_claim.is_a?(Array)
-      return true if normalized_aud_array(aud_claim).include?(api_openid_connect_token_url)
-    elsif aud_claim.is_a?(String)
-      return true if normalized_aud_string(aud_claim) == api_openid_connect_token_url
-    end
+    aud_as_array = Array.wrap(aud_claim)
+    aud_as_array.map! { |aud| aud.to_s.chomp('/') }
+    return true if aud_as_array.include?(api_openid_connect_token_url)
 
     errors.add(:client_assertion,
                t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url))
-  end
-
-  def normalized_aud_array(auds)
-    auds.map { |aud| aud.to_s.chomp('/') }
-  end
-
-  def normalized_aud_string(aud)
-    aud.to_s.chomp('/')
   end
 
   def service_provider

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -173,6 +173,25 @@ RSpec.describe OpenidConnectTokenForm do
           end
         end
 
+        context 'with a list of audiences including the token url' do
+          before { jwt_payload[:aud] = [api_openid_connect_token_url] }
+
+          it 'is valid' do
+            expect(valid?).to eq(true)
+          end
+        end
+
+        context 'with a list of audiences not including the token url' do
+          before { jwt_payload[:aud] = ['a different audience'] }
+
+          it 'is invalid' do
+            expect(valid?).to eq(false)
+            expect(form.errors[:client_assertion]).to include(
+              t('openid_connect.token.errors.invalid_aud', url: api_openid_connect_token_url),
+            )
+          end
+        end
+
         context 'with a bad issuer' do
           before { jwt_payload[:iss] = 'wrong' }
 


### PR DESCRIPTION
**Why:** The IDP needs to follow the OIDC spec which requires that the audience field can be a string or a list of strings.