### PR TITLE
Whitelist SP redirect in CSP on piv cac setup after sign in action

### DIFF
--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -1,8 +1,10 @@
 module Users
   class PivCacSetupFromSignInController < ApplicationController
     include PivCacConcern
+    include SecureHeadersConcern
 
     before_action :confirm_two_factor_authenticated
+    before_action :apply_secure_headers_override, only: %i[prompt success]
 
     def prompt
       if params.key?(:token)


### PR DESCRIPTION
**Why**: This screen can redirect to the service provider so the redirect uri needs to be one of the permitted form actions