### PR TITLE
LG-2120 Fix total verified user count in doc auth funnel

### DIFF
--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -2,6 +2,6 @@ class DocAuthLog < ApplicationRecord
   belongs_to :user
 
   def self.verified_users_count
-    DocAuthLog.where.not(verified_view_at: nil).count
+    Profile.where.not(verified_at:nil).count
   end
 end

--- a/app/models/doc_auth_log.rb
+++ b/app/models/doc_auth_log.rb
@@ -2,6 +2,6 @@ class DocAuthLog < ApplicationRecord
   belongs_to :user
 
   def self.verified_users_count
-    Profile.where.not(verified_at:nil).count
+    Profile.where.not(verified_at: nil).count
   end
 end


### PR DESCRIPTION
**Why**: The page that is used to indicate the user has verified is also landed on after sending a GPO letter. 
**How**: Switch to using profile counts for now.