### PR TITLE
LG-2178 Fix IAL2 user counts per SP

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -14,11 +14,11 @@ module OpenidConnect
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
 
     def index
-      link_identity_to_service_provider
       return redirect_to two_factor_options_url unless
         MfaPolicy.new(current_user).sufficient_factors_enabled?
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
+      link_identity_to_service_provider
       handle_successful_handoff
     end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -96,13 +96,12 @@ RSpec.describe OpenidConnect::AuthorizationController do
           it 'redirects verify shared attributes page' do
             action
 
-            expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+            expect(response).to redirect_to(sign_up_completed_url)
           end
 
-          it 'links identity to the user' do
+          it 'does not link identity to the user' do
             action
-            sp = user.identities.last.service_provider
-            expect(sp).to eq(params[:client_id])
+            expect(user.identities.count).to eq(0)
           end
         end
 


### PR DESCRIPTION
**Why**: The identity row is created too early in IAL2.  Cancelling doc auth and then trying to sign in again via IAL2 erroneously creates the row.