### PR TITLE
LG-1896 accept oidc and saml requests with ial in request

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -104,9 +104,11 @@ class OpenidConnectAuthorizeForm
 
   def ial
     case acr_values.sort.max
-    when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF, Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+      when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
       1
-    when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF, Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+      when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
       2
     end
   end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -104,9 +104,9 @@ class OpenidConnectAuthorizeForm
 
   def ial
     case acr_values.sort.max
-    when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+    when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF, Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
       1
-    when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF, Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
       2
     end
   end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -104,11 +104,11 @@ class OpenidConnectAuthorizeForm
 
   def ial
     case acr_values.sort.max
-      when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
+    when Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF
       1
-      when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-          Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
+    when Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::LOA3_AUTHN_CONTEXT_CLASSREF
       2
     end
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -110,7 +110,7 @@ twilio_verify_override_for_intl_sms: 'false'
 usps_download_sftp_timeout: '5'
 usps_upload_enabled: 'false'
 usps_upload_sftp_timeout: '5'
-valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3"]'
+valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2"]'
 
 development:
   aamva_private_key: 123abc

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -5,10 +5,9 @@ module Saml
     module Constants
       LOA1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'.freeze
       LOA3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'.freeze
+      IAL1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/1'.freeze
+      IAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/2'.freeze
 
-      # For now the acr values returned are still LOA
-      IAL1_AUTHN_CONTEXT_CLASSREF = LOA1_AUTHN_CONTEXT_CLASSREF
-      IAL2_AUTHN_CONTEXT_CLASSREF = LOA3_AUTHN_CONTEXT_CLASSREF
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -8,7 +8,6 @@ module Saml
       IAL1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/1'.freeze
       IAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/2'.freeze
 
-
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
       VALID_AUTHN_CONTEXTS = JSON.parse(Figaro.env.valid_authn_contexts).freeze

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -423,7 +423,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
-          authn_context: 'http://idmanagement.gov/ns/assurance/loa/1',
+          authn_context: 'http://idmanagement.gov/ns/assurance/ial/1',
           service_provider: 'http://localhost:3000',
         }
 


### PR DESCRIPTION
**Why:** We want the IdP to allow for IAL1 and IAL2 values in the SAML and OpenID Connect authentication requests.

The examples in the developer docs for such requests have also been updated to reflect this: https://github.com/18F/identity-dev-docs/pull/89