### PR TITLE
LG-2206: encode the logout response with the endpoint signature cert/key

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -22,14 +22,14 @@ module SamlIdpLogoutConcern
   end
 
   def logout_response
-    idp_config = SamlIdp.config
-    SamlIdp::LogoutResponseBuilder.new(
-      UUID.generate,
-      idp_config.base_saml_location,
-      saml_request.response_url,
-      saml_request.request_id,
-      idp_config.algorithm,
-    ).signed
+    response = encode_response(
+      current_user,
+      signature: saml_response_signature_options,
+    )
+    # rubocop:disable Metrics/LineLength
+    Rails.logger.info "#{'~' * 10} Response #{'~' * 10}\n#{response}\n#{'~' * 10} Done with response #{'~' * 10}"
+    # rubocop:enable Metrics/LineLength
+    response
   end
 
   def track_logout_event
@@ -40,5 +40,15 @@ module SamlIdpLogoutConcern
       oidc: false,
       saml_request_valid: sp_initiated ? valid_saml_request? : true,
     )
+  end
+
+  # :reek:FeatureEnvy
+  def saml_response_signature_options
+    endpoint = SamlEndpoint.new(request)
+    {
+      x509_certificate: endpoint.x509_certificate,
+      secret_key: endpoint.secret_key,
+      cloudhsm_key_label: endpoint.cloudhsm_key_label,
+    }
   end
 end

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -21,6 +21,7 @@ module SamlIdpLogoutConcern
     sign_out if user_signed_in?
   end
 
+  # :reek:DuplicateMethodCall
   def logout_response
     response = encode_response(
       current_user,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -16,7 +16,7 @@ describe SamlIdpController do
     end
 
     it 'tracks the event when sp initiated' do
-      allow(controller).to receive(:saml_request).and_return(FakeSamlRequest.new)
+      allow(controller).to receive(:saml_request).and_return(FakeSamlLogoutRequest.new)
       stub_analytics
 
       result = { sp_initiated: true, oidc: false, saml_request_valid: true }

--- a/spec/support/fake_saml_logout_request.rb
+++ b/spec/support/fake_saml_logout_request.rb
@@ -1,4 +1,4 @@
-class FakeSamlRequest
+class FakeSamlLogoutRequest
   def service_provider
     self
   end
@@ -28,11 +28,11 @@ class FakeSamlRequest
   end
 
   def authn_request?
-    true
+    false
   end
 
   def logout_request?
-    false
+    true
   end
 
   def logout_url


### PR DESCRIPTION
*Why?* The logout response was not being encoded in the same fashion as the authn response, specifically not using the appropriate cert/key pair depending on the request path.  This corrects that (in conjunction with https://github.com/18F/saml_idp/pull/22).