### PR TITLE
RC 96 Prod - Rename the grant_readonly_access rake task and revert implementation

### DIFF
--- a/lib/tasks/db_readonly_user.rake
+++ b/lib/tasks/db_readonly_user.rake
@@ -1,6 +1,20 @@
 namespace :db do
-  desc 'Create a readonly database user'
+  desc 'Grant readonly database user read access to all tables'
   task grant_readonly_access: :environment do
+    username = Figaro.env.database_readonly_username
+
+    if username.blank?
+      warn 'Skipping readonly db setup because read only user is not present'
+      next
+    end
+
+    sql = "GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{username}"
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  desc 'Create a readonly database user'
+  task create_readonly_user: :environment do
     username = Figaro.env.database_readonly_username
 
     if username.blank?


### PR DESCRIPTION
**Why**: It turns out this is run on migrations instances. When this happens it attempts to create a readonly db user that already exists.