### PR TITLE
Remove 1st mfa success screen when retiring personal key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,6 +147,8 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   def two_2fa_setup
     if MfaPolicy.new(current_user).sufficient_factors_enabled?
       after_multiple_2fa_sign_up
+    elsif MfaPolicy.new(current_user).retire_personal_key?
+      two_factor_options_path
     else
       two_factor_options_success_url
     end

--- a/spec/features/backup_mfa/personal_key_user_sign_in_spec.rb
+++ b/spec/features/backup_mfa/personal_key_user_sign_in_spec.rb
@@ -6,6 +6,6 @@ describe 'personal key enabled user sign in' do
 
     sign_in_live_with_2fa(user)
 
-    expect(page).to have_current_path(two_factor_options_success_path)
+    expect(page).to have_current_path(two_factor_options_path)
   end
 end


### PR DESCRIPTION
**Why**: The 1st mfa success screen is showing up first before getting the you need to configure a 2nd mfa for users that are retiring personal key