### PR TITLE
LG-2232 Use a separate NewRelic app in the background jobs

### DIFF
--- a/bin/job_runs.sh
+++ b/bin/job_runs.sh
@@ -26,6 +26,11 @@ if [ $# -ge 2 ]; then
   PIDFILE="$2"
 fi
 
+NEW_RELIC_APP_NAME=
+if [[ -f '/etc/login.gov/info/env' && -f '/etc/login.gov/info/domain' ]]; then
+  NEW_RELIC_APP_NAME="bg.`cat /etc/login.gov/info/env`.`cat /etc/login.gov/info/domain`"
+fi
+
 case $1 in
   start)
     # If PIDFILE is given, fork into background
@@ -49,4 +54,3 @@ case $1 in
     usage
     ;;
 esac
-


### PR DESCRIPTION
**Why**: We want to use a app name that is different so that we can collect background job errors in a different app and route alerts differently for things like slow queries.