### PR TITLE
Permit any node version between v8 and v12 inclusive

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": "~8.x.x",
-    "npm": "~5.x.x"
+    "node": ">=8 <=12",
+    "npm": ">=5 <= 6"
   },
   "scripts": {
     "test": "NODE_ENV=test `npm bin`/mocha --require @babel/register --require spec/javascripts/spec_helper.js spec/javascripts/**/**_spec.js",


### PR DESCRIPTION
**Why**: So that the IdP can run alongside the devops code with either node v8 or node v12