### PR TITLE
Use export to set the NewRelic app name for background jobs

### DIFF
--- a/bin/job_runs.sh
+++ b/bin/job_runs.sh
@@ -26,9 +26,8 @@ if [ $# -ge 2 ]; then
   PIDFILE="$2"
 fi
 
-NEW_RELIC_APP_NAME=
 if [[ -f '/etc/login.gov/info/env' && -f '/etc/login.gov/info/domain' ]]; then
-  NEW_RELIC_APP_NAME="bg.`cat /etc/login.gov/info/env`.`cat /etc/login.gov/info/domain`"
+  export NEW_RELIC_APP_NAME="bg.`cat /etc/login.gov/info/env`.`cat /etc/login.gov/info/domain`"
 fi
 
 case $1 in


### PR DESCRIPTION
**Why**: Setting it in the job_runs script environment does not seem to be enough. It looks like we need to export it for it to be picked up.