### PR TITLE
Pin the style guide version to 2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "field-kit": "^2.1.0",
     "focus-trap": "^2.3.0",
     "hint.css": "^2.3.2",
-    "identity-style-guide": "^2.1.3",
+    "identity-style-guide": "2.1.5",
     "intl-tel-input": "^16.0.7",
     "jquery": "^3.3.1",
     "libphonenumber-js": "^0.4.23",


### PR DESCRIPTION
**Why**: So we can upgrade the node version in the style guide w/o causing issues in the IdP. After the IdP is on node v12 a follow up PR should change this back.