### PR TITLE
Rollback the change to use separate NR accounts for web and bg jobs

### DIFF
--- a/bin/job_runs.sh
+++ b/bin/job_runs.sh
@@ -26,10 +26,6 @@ if [ $# -ge 2 ]; then
   PIDFILE="$2"
 fi
 
-if [[ -f '/etc/login.gov/info/env' && -f '/etc/login.gov/info/domain' ]]; then
-  export NEW_RELIC_APP_NAME="bg.`cat /etc/login.gov/info/env`.`cat /etc/login.gov/info/domain`"
-fi
-
 case $1 in
   start)
     # If PIDFILE is given, fork into background


### PR DESCRIPTION
**Why**: It turns out we do not actually need this to separate alerting. We can do that with NR alert policies.