### PR TITLE
LG-2370 Apply the secure headers override during webauthn setup

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -1,11 +1,12 @@
 module Users
   class WebauthnSetupController < ApplicationController
-    include RememberDeviceConcern
     include MfaSetupConcern
     include RememberDeviceConcern
+    include SecureHeadersConcern
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
+    before_action :apply_secure_headers_override, only: :new
     before_action :set_webauthn_setup_presenter
 
     def new


### PR DESCRIPTION
**Why**: There is a flow now where a user can add a WebAuthn device and be immediatly redirected to an SP. This was introduced when we added the personal key upgrade flow.