### PR TITLE
LG-2372: new version of saml_idp doesn't sign saml logout response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 3977fa36c90b28ec2c2533fe02df0146e69efba6
+  revision: f0c4a98952ca24e3c356293dd74fd4885d96ff37
   branch: master
   specs:
     saml_idp (0.8.0.pre.18f)

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -33,15 +33,8 @@ feature 'SAML logout' do
         expect(xmldoc.issuer_nodeset.length).to eq(1)
         expect(xmldoc.issuer_nodeset[0].content).to eq "https://#{Figaro.env.domain_name}/api/saml"
 
-        # It should contain a SHA256 signature nodeset
-        expect(xmldoc.signature_nodeset.length).to eq(1)
-        expect(xmldoc.signature_method_nodeset[0].attr('Algorithm')).
-          to eq('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256')
-
-        # It should contain a SHA256 digest method nodeset
-        expect(xmldoc.digest_method_nodeset.length).to eq(1)
-        expect(xmldoc.digest_method_nodeset[0].attr('Algorithm')).
-          to eq('http://www.w3.org/2001/04/xmlenc#sha256')
+        # It should not contain a SHA256 signature nodeset
+        expect(xmldoc.signature_nodeset.length).to eq(0)
 
         # The user should be signed out
         visit account_path


### PR DESCRIPTION
This picks up an updated version of the saml_idp gem that does not sign SAMLLogoutResponse 