### PR TITLE
LG-2351 Write to new PIV/CAC table

### DIFF
--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -41,6 +41,7 @@ module Users
       revoke_remember_device(current_user)
       attributes = { x509_dn_uuid: nil }
       UpdateUser.new(user: current_user, attributes: attributes).call
+      Db::PivCacConfiguration::Delete.call(current_user.id)
     end
 
     def render_prompt

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -1,4 +1,5 @@
 # :reek:RepeatedConditional
+# :reek:TooManyMethods
 
 class MfaContext
   attr_reader :user
@@ -34,6 +35,13 @@ class MfaContext
     else
       BackupCodeConfiguration.none
     end
+  end
+
+  def piv_cac_configuration
+    cfg = user.piv_cac_configurations.first
+    return cfg if cfg
+    return if user&.x509_dn_uuid.blank?
+    PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: 'xxx')
   end
 
   def piv_cac_configurations

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -47,7 +47,8 @@ class MfaContext
 
   def piv_cac_configurations
     if user.present?
-      [piv_cac_configuration]
+      [user.piv_cac_configurations.first ||
+        PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')]
     else
       PivCacConfiguration.none
     end

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -36,7 +36,7 @@ class MfaContext
     end
   end
 
-  def piv_cac_configuration
+  def piv_cac_configurations
     if user.present?
       user.piv_cac_configurations
     else
@@ -54,7 +54,7 @@ class MfaContext
 
   def two_factor_configurations
     phone_configurations + webauthn_configurations + backup_code_configurations +
-      [piv_cac_configuration, auth_app_configuration]
+      piv_cac_configurations + [auth_app_configuration]
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -62,7 +62,7 @@ class MfaContext
     phone_configurations.to_a.select(&:mfa_enabled?).count +
       webauthn_configurations.to_a.select(&:mfa_enabled?).count +
       (backup_code_configurations.any? ? 1 : 0) +
-      (piv_cac_configuration.mfa_enabled? ? 1 : 0) +
+      piv_cac_configurations.to_a.select(&:mfa_enabled?).count +
       (auth_app_configuration.mfa_enabled? ? 1 : 0) +
       personal_key_method_count
   end
@@ -83,7 +83,7 @@ class MfaContext
 
   def unphishable_configuration_count
     webauthn_configurations.to_a.select(&:mfa_enabled?).count +
-      (piv_cac_configuration.mfa_enabled? ? 1 : 0)
+      piv_cac_configurations.to_a.select(&:mfa_enabled?).count
   end
 
   private

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -40,9 +40,7 @@ class MfaContext
   def piv_cac_configuration
     cfg = user.piv_cac_configurations.first if user
     return cfg if cfg
-    cfg = PivCacConfiguration.new(user_id: user&.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
-    cfg.user = user
-    cfg
+    PivCacConfiguration.new(user_id: user&.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
   end
 
   def piv_cac_configurations

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -38,9 +38,9 @@ class MfaContext
   end
 
   def piv_cac_configuration
-    cfg = user.piv_cac_configurations.first
+    cfg = user.piv_cac_configurations.first if user
     return cfg if cfg
-    cfg = PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
+    cfg = PivCacConfiguration.new(user_id: user&.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
     cfg.user = user
     cfg
   end

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -41,7 +41,7 @@ class MfaContext
     cfg = user.piv_cac_configurations.first
     return cfg if cfg
     return if user&.x509_dn_uuid.blank?
-    PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: 'xxx')
+    PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
   end
 
   def piv_cac_configurations

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -47,8 +47,9 @@ class MfaContext
 
   def piv_cac_configurations
     if user.present?
+      user_id = user.class == AnonymousUser ? nil : user.id
       [user.piv_cac_configurations.first ||
-        PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')]
+        PivCacConfiguration.new(user_id: user_id, x509_dn_uuid: user&.x509_dn_uuid, name: '')]
     else
       PivCacConfiguration.none
     end

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -37,7 +37,11 @@ class MfaContext
   end
 
   def piv_cac_configuration
-    PivCacConfiguration.new(user)
+    if user.present?
+      user.piv_cac_configurations
+    else
+      PivCacConfiguration.none
+    end
   end
 
   def auth_app_configuration

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -40,12 +40,14 @@ class MfaContext
   def piv_cac_configuration
     cfg = user.piv_cac_configurations.first
     return cfg if cfg
-    PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
+    cfg = PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
+    cfg.user = user
+    cfg
   end
 
   def piv_cac_configurations
     if user.present?
-      user.piv_cac_configurations
+      [piv_cac_configuration]
     else
       PivCacConfiguration.none
     end

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -40,7 +40,6 @@ class MfaContext
   def piv_cac_configuration
     cfg = user.piv_cac_configurations.first
     return cfg if cfg
-    return if user&.x509_dn_uuid.blank?
     PivCacConfiguration.new(user_id: user.id, x509_dn_uuid: user&.x509_dn_uuid, name: '')
   end
 

--- a/app/forms/user_piv_cac_login_form.rb
+++ b/app/forms/user_piv_cac_login_form.rb
@@ -22,7 +22,7 @@ class UserPivCacLoginForm
   end
 
   def user_found
-    maybe_user = User.find_by(x509_dn_uuid: x509_dn_uuid)
+    maybe_user = Db::PivCacConfiguration::FindUserByX509.call(x509_dn_uuid)
     if maybe_user.present?
       self.user = maybe_user
       true

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -24,6 +24,7 @@ class UserPivCacSetupForm
 
   def process_valid_submission
     revoke_remember_device(user)
+    UpdateUser.new(user: user, attributes: { x509_dn_uuid: x509_dn_uuid }).call
     Db::PivCacConfiguration::Create.call(user.id, x509_dn_uuid)
     true
   rescue PG::UniqueViolation

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -24,8 +24,7 @@ class UserPivCacSetupForm
 
   def process_valid_submission
     revoke_remember_device(user)
-    attributes = { x509_dn_uuid: x509_dn_uuid }
-    UpdateUser.new(user: user, attributes: attributes).call
+    Db::PivCacConfiguration::Create.call(user.id, x509_dn_uuid)
     true
   rescue PG::UniqueViolation
     self.error_type = 'piv_cac.already_associated'
@@ -41,7 +40,7 @@ class UserPivCacSetupForm
   def piv_cac_not_already_associated
     self.x509_dn_uuid = @data['uuid']
     self.x509_dn = @data['subject']
-    if User.find_by(x509_dn_uuid: x509_dn_uuid)
+    if Db::PivCacConfiguration::FindUserByX509.call(x509_dn_uuid)
       self.error_type = 'piv_cac.already_associated'
       false
     else

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -17,7 +17,7 @@ class AnonymousUser
   end
 
   def piv_cac_configurations
-    WebauthnConfiguration.none
+    PivCacConfiguration.none
   end
 
   def webauthn_configurations

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -16,6 +16,10 @@ class AnonymousUser
     nil
   end
 
+  def piv_cac_configurations
+    WebauthnConfiguration.none
+  end
+
   def webauthn_configurations
     WebauthnConfiguration.none
   end

--- a/app/models/piv_cac_configuration.rb
+++ b/app/models/piv_cac_configuration.rb
@@ -1,6 +1,9 @@
-class PivCacConfiguration
-  # This is a wrapping class that lets us interface with the piv/cac configuration in a manner
-  # consistent with phone and webauthn configurations.
+class PivCacConfiguration < ApplicationRecord
+  belongs_to :user, inverse_of: :piv_cac_configurations
+
+  validates :user_id, presence: true
+  validates :name, presence: true
+
   attr_reader :user
 
   def initialize(user)

--- a/app/models/piv_cac_configuration.rb
+++ b/app/models/piv_cac_configuration.rb
@@ -5,7 +5,7 @@ class PivCacConfiguration < ApplicationRecord
   validates :name, presence: true
 
   def mfa_enabled?
-    user&.x509_dn_uuid.present?
+    x509_dn_uuid.present?
   end
 
   def mfa_confirmed?(proposed_uuid)

--- a/app/models/piv_cac_configuration.rb
+++ b/app/models/piv_cac_configuration.rb
@@ -1,14 +1,8 @@
 class PivCacConfiguration < ApplicationRecord
-  belongs_to :user, inverse_of: :piv_cac_configurations
+  belongs_to :user
 
   validates :user_id, presence: true
   validates :name, presence: true
-
-  attr_reader :user
-
-  def initialize(user)
-    @user = user
-  end
 
   def mfa_enabled?
     user&.x509_dn_uuid.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ApplicationRecord
   has_many :phone_configurations, dependent: :destroy, inverse_of: :user
   has_many :email_addresses, dependent: :destroy, inverse_of: :user
   has_many :webauthn_configurations, dependent: :destroy, inverse_of: :user
+  has_many :piv_cac_configurations, dependent: :destroy, inverse_of: :user
   has_one :doc_auth, dependent: :destroy, inverse_of: :user
   has_many :backup_code_configurations, dependent: :destroy
   has_many :devices, dependent: :destroy

--- a/app/services/db/piv_cac_configuration/create.rb
+++ b/app/services/db/piv_cac_configuration/create.rb
@@ -1,7 +1,7 @@
 module Db
   module PivCacConfiguration
     class Create
-      def self.call(user_id, x509_dn_uuid, name = '')
+      def self.call(user_id, x509_dn_uuid, name = x509_dn_uuid)
         user = User.find_by(id: user_id)
         return unless user
         user.x509_dn_uuid = x509_dn_uuid

--- a/app/services/db/piv_cac_configuration/create.rb
+++ b/app/services/db/piv_cac_configuration/create.rb
@@ -2,10 +2,6 @@ module Db
   module PivCacConfiguration
     class Create
       def self.call(user_id, x509_dn_uuid, name = x509_dn_uuid)
-        user = User.find_by(id: user_id)
-        return unless user
-        user.x509_dn_uuid = x509_dn_uuid
-        user.save
         ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: x509_dn_uuid, name: name)
       end
     end

--- a/app/services/db/piv_cac_configuration/create.rb
+++ b/app/services/db/piv_cac_configuration/create.rb
@@ -1,0 +1,13 @@
+module Db
+  module PivCacConfiguration
+    class Create
+      def self.call(user_id, x509_dn_uuid, name = '')
+        user = User.find_by(id: user_id)
+        return unless user
+        user.x509_dn_uuid = x509_dn_uuid
+        user.save
+        ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: x509_dn_uuid, name: name)
+      end
+    end
+  end
+end

--- a/app/services/db/piv_cac_configuration/delete.rb
+++ b/app/services/db/piv_cac_configuration/delete.rb
@@ -1,0 +1,13 @@
+module Db
+  module PivCacConfiguration
+    class Delete
+      def self.call(user_id)
+        user = User.find_by(user_id: user_id)
+        return unless user
+        user.x509_dn_uuid = nil
+        user.save
+        PivCacConfiguration.where(user_id: user_id).delete_all
+      end
+    end
+  end
+end

--- a/app/services/db/piv_cac_configuration/delete.rb
+++ b/app/services/db/piv_cac_configuration/delete.rb
@@ -2,7 +2,7 @@ module Db
   module PivCacConfiguration
     class Delete
       def self.call(user_id)
-        user = User.find_by(user_id: user_id)
+        user = User.find(user_id)
         return unless user
         user.x509_dn_uuid = nil
         user.save

--- a/app/services/db/piv_cac_configuration/delete.rb
+++ b/app/services/db/piv_cac_configuration/delete.rb
@@ -6,7 +6,7 @@ module Db
         return unless user
         user.x509_dn_uuid = nil
         user.save
-        PivCacConfiguration.where(user_id: user_id).delete_all
+        ::PivCacConfiguration.where(user_id: user_id).delete_all
       end
     end
   end

--- a/app/services/db/piv_cac_configuration/find_user_by_x509.rb
+++ b/app/services/db/piv_cac_configuration/find_user_by_x509.rb
@@ -1,0 +1,12 @@
+module Db
+  module PivCacConfiguration
+    class FindUserByX509
+      def self.call(x509_dn_uuid)
+        user = User.find_by(x509_dn_uuid: x509_dn_uuid)
+        return user if user
+        piv_cac_config = ::PivCacConfiguration.find_by(x509_dn_uuid: x509_dn_uuid)
+        piv_cac_config&.user
+      end
+    end
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -677,6 +677,29 @@ feature 'Sign in' do
     end
   end
 
+  context 'multiple piv cacs' do
+    it 'allows you to sign in with either' do
+      user = create(:user, :signed_up, :with_piv_or_cac)
+      user_id = user.id
+      ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: 'foo', name: 'key1')
+      ::PivCacConfiguration.create!(user_id: user_id, x509_dn_uuid: 'bar', name: 'key2')
+
+      visit new_user_session_path
+      click_on t('account.login.piv_cac')
+      fill_in_piv_cac_credentials_and_submit(user, 'foo')
+
+      expect(current_url).to eq account_url
+
+      Capybara.reset_session!
+
+      visit new_user_session_path
+      click_on t('account.login.piv_cac')
+      fill_in_piv_cac_credentials_and_submit(user, 'bar')
+
+      expect(current_url).to eq account_url
+    end
+  end
+
   def perform_steps_to_get_to_add_piv_cac_during_sign_up
     user = create(:user, :signed_up, :with_phone)
     visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -83,14 +83,14 @@ module Features
       fill_in_bad_piv_cac_credentials_and_submit
     end
 
-    def fill_in_piv_cac_credentials_and_submit(user)
+    def fill_in_piv_cac_credentials_and_submit(user, uuid = user.x509_dn_uuid)
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(false)
 
       stub_piv_cac_service
       nonce = get_piv_cac_nonce_from_link(find_link(t('forms.piv_cac_login.submit')))
       visit_piv_cac_service(current_url,
                             nonce: nonce,
-                            uuid: user.x509_dn_uuid,
+                            uuid: uuid,
                             subject: 'SomeIgnoredSubject')
     end
 


### PR DESCRIPTION
**Why**: To support multiple PIV/CACs per user
**How**: Support both legacy user based x509 and multiple piv_cac_configurations to support rollout while providing partial functionality for deletes and adds.  Support the migration of legacy nameless piv/cac cards by using the x509 as the name to signify the user has not chosen one (the displayed name can then be arbitrary)