### PR TITLE
LG-2383 Raise an error if migrations are pending in bin/activate

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,10 @@ module Upaya
       event.payload.except(:params, :headers)
     end
 
+    # Refuse to run if migraitons are pending. Migrations should be run out
+    # of band from launching the app
+    config.active_record.migration_error = :page_load
+
     # Use a custom log formatter to get timestamp
     config.log_formatter = Upaya::UpayaLogFormatter.new
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,6 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.active_support.deprecation = :log
-  config.active_record.migration_error = :page_load
   config.assets.debug = true
   config.assets.digest = true
   config.assets.raise_runtime_errors = true

--- a/deploy/activate
+++ b/deploy/activate
@@ -16,6 +16,7 @@ id
 which bundle
 
 bundle exec bin/activate
+bundle exec rake db:check_for_pending_migrations
 
 set +x
 

--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -1,0 +1,6 @@
+namespace :db do
+  desc 'Raise an error if migrations are pending'
+  task check_for_pending_migrations: :environment do
+    ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+  end
+end


### PR DESCRIPTION
**Why**: So that new hosts will not launch if there are pending migrations

This commit also renders an error on page load if migrations are pending in any env