### PR TITLE
Don't check for pending migrations on a migration instance

### DIFF
--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -1,6 +1,10 @@
 namespace :db do
   desc 'Raise an error if migrations are pending'
   task check_for_pending_migrations: :environment do
+    instance_role_filename = '/etc/login.gov/info/role'
+    instance_role = File.exist?(instance_role_filename) &&
+                    File.read(instance_role_filename).strip
+    break if instance_role == 'migration'
     ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
   end
 end

--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -4,7 +4,11 @@ namespace :db do
     instance_role_filename = '/etc/login.gov/info/role'
     instance_role = File.exist?(instance_role_filename) &&
                     File.read(instance_role_filename).strip
-    break if instance_role == 'migration'
-    ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+
+    if instance_role == 'migration'
+      warn('Skipping pending migration check on migration instance')
+    else
+      ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+    end
   end
 end


### PR DESCRIPTION
**Why**: Because a migration instance will obviously have pending migrations