### PR TITLE
Don't check for pending migrations on a migration instance (#3445)

### DIFF
--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -1,6 +1,14 @@
 namespace :db do
   desc 'Raise an error if migrations are pending'
   task check_for_pending_migrations: :environment do
-    ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+    instance_role_filename = '/etc/login.gov/info/role'
+    instance_role = File.exist?(instance_role_filename) &&
+                    File.read(instance_role_filename).strip
+
+    if instance_role == 'migration'
+      warn('Skipping pending migration check on migration instance')
+    else
+      ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+    end
   end
 end


### PR DESCRIPTION
* Don't check for pending migrations on a migration instance

**Why**: Because a migration instance will obviously have pending migrations

* Some cleanup