### PR TITLE
LG-2400 Allow any SAML SP to use email addresses as NameIDs

### DIFF
--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -3,9 +3,6 @@ class SamlRequestValidator
 
   validate :authorized_service_provider
   validate :authorized_authn_context
-  validate :authorized_email_nameid_format
-
-  ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').freeze
 
   def call(service_provider:, authn_context:, nameid_format:)
     self.service_provider = service_provider
@@ -38,20 +35,5 @@ class SamlRequestValidator
          service_provider.ial != 2)
       errors.add(:authn_context, :unauthorized_authn_context)
     end
-  end
-
-  def authorized_email_nameid_format
-    return unless email_nameid_format?
-    return if service_provider_allowed_to_use_email_nameid_format?
-
-    errors.add(:nameid_format, :unauthorized_nameid_format)
-  end
-
-  def email_nameid_format?
-    nameid_format == 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-  end
-
-  def service_provider_allowed_to_use_email_nameid_format?
-    ISSUERS_WITH_EMAIL_NAMEID_FORMAT.include?(service_provider.issuer)
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -160,7 +160,6 @@ development:
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["11111111111111111111111111111111", "22222222222222222222222222222222"]'
-  issuers_with_email_nameid_format: ''
   lockout_period_in_minutes: '10'
   login_with_piv_cac: 'true'
   logins_per_email_and_ip_limit: '5'
@@ -259,7 +258,6 @@ production:
   expired_letters_auth_token:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue:
-  issuers_with_email_nameid_format: sp1,sp2
   lockout_period_in_minutes: '10'
   login_with_piv_cac: 'false'
   logins_per_email_and_ip_limit: '5'
@@ -357,7 +355,6 @@ test:
   expired_letters_auth_token: abc123
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
-  issuers_with_email_nameid_format: https://rp1.serviceprovider.com/auth/saml/metadata
   lockout_period_in_minutes: '5'
   login_with_piv_cac: 'true'
   logins_per_email_and_ip_limit: '2'

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -10,7 +10,6 @@ Figaro.require_keys(
   'enable_usps_verification',
   'exception_recipients',
   'hmac_fingerprinter_key',
-  'issuers_with_email_nameid_format',
   'logins_per_ip_limit',
   'logins_per_ip_period',
   'logins_per_ip_track_only_mode',

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -84,7 +84,6 @@ en:
         <a href="https://status.twilio.com/" target='_blank'>our messaging service
         provider</a>.
       unauthorized_authn_context: Unauthorized authentication context
-      unauthorized_nameid_format: Unauthorized nameID format
       unauthorized_service_provider: Unauthorized Service Provider
       usps_otp_expired: Your confirmation code has expired. Please request another
         letter for a new code.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -85,7 +85,6 @@ es:
         el estado con <a href="https://status.twilio.com/" target='_blank'>nuestro
         proveedor de servicios de mensajes</a>.
       unauthorized_authn_context: Contexto de autenticación no autorizado
-      unauthorized_nameid_format: Formato de ID de nombre no autorizado
       unauthorized_service_provider: Proveedor de servicio no autorizado
       usps_otp_expired: Tu código de confirmación ha caducado. Vuelve a solicitar
         otra carta para recibir un nuevo código.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -91,7 +91,6 @@ fr:
         le statut avec <a href="https://status.twilio.com/" target='_blank'>notre
         fournisseur de service de messages</a>.
       unauthorized_authn_context: Contexte d'authentification non autorisé
-      unauthorized_nameid_format: Format non autorisé du nom d'identification
       unauthorized_service_provider: Fournisseur de service non autorisé
       usps_otp_expired: Votre code de confirmation a expiré. Veuillez solliciter une
         autre lettre afin d'obtenir un nouveau code.

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -409,29 +409,6 @@ describe SamlIdpController do
       end
     end
 
-    context 'service provider uses email NameID format but is not allowed to use email' do
-      it 'returns an error' do
-        stub_analytics
-        allow(@analytics).to receive(:track_event)
-
-        saml_get_auth(email_nameid_saml_settings_for_disallowed_issuer)
-
-        expect(controller).to render_template('saml_idp/auth/error')
-        expect(response.status).to eq(400)
-        expect(response.body).to include(t('errors.messages.unauthorized_nameid_format'))
-
-        analytics_hash = {
-          success: false,
-          errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
-          authn_context: 'http://idmanagement.gov/ns/assurance/loa/1',
-          service_provider: 'http://localhost:3000',
-        }
-
-        expect(@analytics).to have_received(:track_event).
-          with(Analytics::SAML_AUTH, analytics_hash)
-      end
-    end
-
     describe 'HEAD /api/saml/auth', type: :request do
       it 'responds with "403 Forbidden"' do
         head '/api/saml/auth2019?SAMLRequest=bang!'

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -47,30 +47,6 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'valid authentication context and unauthorized nameid format' do
-      it 'returns FormResponse with success: false' do
-        sp = ServiceProvider.from_issuer('http://localhost:3000')
-        authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-        allow(FormResponse).to receive(:new)
-        extra = {
-          authn_context: authn_context,
-          service_provider: sp.issuer,
-        }
-        errors = {
-          nameid_format: [t('errors.messages.unauthorized_nameid_format')],
-        }
-
-        SamlRequestValidator.new.call(
-          service_provider: sp,
-          authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-        )
-
-        expect(FormResponse).to have_received(:new).
-          with(success: false, errors: errors, extra: extra)
-      end
-    end
-
     context 'valid authentication context and authorized nameid format for SP' do
       it 'returns FormResponse with success: true' do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')


### PR DESCRIPTION
**Why**: There are a lot of SPs using COTS SAML implementations that require them to use the email address as the NameID

We required SPs to be added to a list to use the email address as the NameID in the past. This was to encourage SPs to use the UUID unless they absolutely could not. As we add more SPs this list may become difficult to manage.

This commit allows any SP to use the email address as the NameID and prevents us from having to manage a list of permitted SPs.