### PR TITLE
LG-2417 Hide the IAL2 recovery entry point if IAL2 recovery is disabled

### DIFF
--- a/app/views/two_factor_authentication/options/index.html.slim
+++ b/app/views/two_factor_authentication/options/index.html.slim
@@ -26,7 +26,7 @@ p.mt-tiny.mb3 = @presenter.info
 
 br
 - if @presenter.should_display_account_reset_or_cancel_link?
-  - if current_user.decorate.identity_verified?
+  - if current_user.decorate.identity_verified? && !FeatureManagement.disallow_ial2_recovery?
     p = @presenter.reverify_link
   - else
     p = @presenter.account_reset_or_cancel_link

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -150,6 +150,7 @@ development:
   database_username: ''
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
+  disallow_ial2_recovery: 'false'
   doc_auth_exclusive: 'true'
   domain_name: localhost:3000
   email_deletion_enabled: 'true'
@@ -249,6 +250,7 @@ production:
   database_username:
   disable_email_sending: 'false'
   disallow_all_web_crawlers: 'false'
+  disallow_ial2_recovery: 'true'
   doc_auth_exclusive: 'true'
   domain_name: login.gov
   email_deletion_enabled: 'false'
@@ -347,6 +349,7 @@ test:
   database_username: ''
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
+  disallow_ial2_recovery: 'false'
   doc_auth_exclusive: 'false'
   domain_name: www.example.com
   email_deletion_enabled: 'true'


### PR DESCRIPTION
**Why**: So we can disable the IAL2 recovery flow without having a broken link