### PR TITLE
LG-2418 Don't require reactivation for IAL1 SPs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,11 +157,16 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   def after_multiple_2fa_sign_up
     if needs_completions_screen?
       sign_up_completed_url
-    elsif current_user.decorate.password_reset_profile.present?
+    elsif user_needs_to_reactivate_account?
       reactivate_account_url
     else
       after_sign_in_path_for(current_user)
     end
+  end
+
+  def user_needs_to_reactivate_account?
+    return false if current_user.decorate.password_reset_profile.blank?
+    sp_session[:ial2] == true
   end
 
   def ga_cookie_client_id

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -192,7 +192,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def after_otp_action_required?
-    decorated_user.password_reset_profile.present? ||
+    user_needs_to_reactivate_account? ||
       @updating_existing_number ||
       !MfaPolicy.new(current_user).sufficient_factors_enabled?
   end
@@ -200,7 +200,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def after_otp_action_url
     if @updating_existing_number
       account_url
-    elsif decorated_user.password_reset_profile.present?
+    elsif user_needs_to_reactivate_account?
       reactivate_account_url
     else
       two_2fa_setup

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -17,7 +17,7 @@ module VerifyProfileConcern
 
   def profile_needs_verification?
     return false if current_user.blank?
-    current_user.decorate.pending_profile_requires_verification? && sp_session[:ial2]
+    current_user.decorate.pending_profile_requires_verification?
   end
 
   def usps_mail_bounced?

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -17,7 +17,7 @@ module VerifyProfileConcern
 
   def profile_needs_verification?
     return false if current_user.blank?
-    current_user.decorate.pending_profile_requires_verification?
+    current_user.decorate.pending_profile_requires_verification? && sp_session[:ial2]
   end
 
   def usps_mail_bounced?

--- a/app/controllers/sign_up/personal_keys_controller.rb
+++ b/app/controllers/sign_up/personal_keys_controller.rb
@@ -31,7 +31,7 @@ module SignUp
     def next_step
       if needs_completions_screen?
         sign_up_completed_url
-      elsif current_user.decorate.password_reset_profile.present?
+      elsif user_needs_to_reactivate_account?
         reactivate_account_url
       else
         after_sign_in_path_for(current_user)

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -34,7 +34,7 @@ module Users
     private
 
     def next_step
-      if current_user.decorate.password_reset_profile.present?
+      if user_needs_to_reactivate_account?
         reactivate_account_url
       elsif session[:sp] && user_has_not_visited_any_sp_yet?
         sign_up_completed_url

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -71,7 +71,7 @@ describe Users::PersonalKeysController do
 
     context 'user needs to reactive account' do
       it 'redirects to the sign up completed url for ial 1' do
-        controller.session[:sp] = { ial2: true }
+        controller.session[:sp] = { ial2: false }
 
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -70,7 +70,22 @@ describe Users::PersonalKeysController do
     end
 
     context 'user needs to reactive account' do
-      it 'redirects to the reactiveate_profile_path' do
+      it 'redirects to the sign up completed url for ial 1' do
+        controller.session[:sp] = { ial2: true }
+
+        user = create(:user, :signed_up)
+        create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
+        user.active_profile.deactivate(:password_reset)
+        sign_in user
+
+        patch :update
+
+        expect(response).to redirect_to sign_up_completed_url
+      end
+
+      it 'redirects to the reactivate account url for ial 2' do
+        controller.session[:sp] = { ial2: true }
+
         user = create(:user, :signed_up)
         create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
         user.active_profile.deactivate(:password_reset)

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -47,6 +47,11 @@ feature 'Password recovery via personal key' do
     click_idv_continue
     complete_idv_profile_ok(user, new_password)
     acknowledge_and_confirm_personal_key
+    click_continue
+
+    expect(current_url).to start_with('http://localhost:7654/auth/result')
+
+    visit account_path
 
     expect(page).to have_content(t('headings.account.verified_account'))
     expect(current_path).to eq(account_path)

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -160,11 +160,11 @@ feature 'User profile' do
         complete_idv_profile_ok(user)
         click_acknowledge_personal_key
 
-        expect(current_path).to eq(account_path)
+        expect(current_path).to eq(sign_up_completed_path)
 
-        visit account_path
+        click_continue
 
-        expect(page).not_to have_content(t('account.index.reactivation.instructions'))
+        expect(current_url).to start_with('http://localhost:7654/auth/result')
       end
     end
   end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'Password Recovery' do
+  include IdvHelper
   include PersonalKeyHelper
 
   context 'user enters valid email in forgot password form', email: true do
@@ -115,7 +116,9 @@ feature 'Password Recovery' do
     end
 
     it 'redirects user to profile after signing back in' do
-      reset_password_and_sign_back_in(@user)
+      fill_in t('forms.passwords.edit.labels.password'), with: 'a real secure password'
+      click_button t('forms.passwords.edit.buttons.submit')
+      fill_in_credentials_and_submit(@user.email, 'a real secure password')
       click_button t('forms.buttons.submit.default')
       fill_in 'code', with: @user.reload.direct_otp
       click_button t('forms.buttons.submit.default')

--- a/spec/support/features/personal_key_helper.rb
+++ b/spec/support/features/personal_key_helper.rb
@@ -2,6 +2,7 @@ module PersonalKeyHelper
   def reset_password_and_sign_back_in(user, password = 'a really long password')
     fill_in t('forms.passwords.edit.labels.password'), with: password
     click_button t('forms.passwords.edit.buttons.submit')
+    visit_idp_from_sp_with_ial2(:oidc)
     fill_in_credentials_and_submit(user.email, password)
   end
 

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -107,7 +107,9 @@ shared_examples 'signing in as IAL1 with personal key after resetting password' 
     old_personal_key = PersonalKeyGenerator.new(user).create
     visit_idp_from_sp_with_ial1(sp)
     trigger_reset_password_and_click_email_link(user.email)
-    reset_password_and_sign_back_in(user, new_password)
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+    fill_in_credentials_and_submit(user.email, new_password)
     choose_another_security_option('personal_key')
     enter_personal_key(personal_key: old_personal_key)
     click_submit_default
@@ -127,7 +129,9 @@ shared_examples 'signing in as IAL2 with personal key after resetting password' 
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
     visit_idp_from_sp_with_ial2(sp)
     trigger_reset_password_and_click_email_link(user.email)
-    reset_password_and_sign_back_in(user, new_password)
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+    fill_in_credentials_and_submit(user.email, new_password)
     choose_another_security_option('personal_key')
     enter_personal_key(personal_key: personal_key_for_ial2_user(user, pii))
     click_submit_default


### PR DESCRIPTION
**Why**: A user who has a IAL2 profile that needs to be reactivated does not need to reactivate that profile to continue to a IAL1 SP.