### PR TITLE
Add secure headers override to MFA setup views

### DIFF
--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -2,11 +2,13 @@ module Users
   class BackupCodeSetupController < ApplicationController
     include MfaSetupConcern
     include RememberDeviceConcern
+    include SecureHeadersConcern
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :ensure_backup_codes_in_session, only: %i[continue download]
     before_action :set_backup_code_setup_presenter
+    before_action :apply_secure_headers_override
 
     def index
       @presenter = BackupCodeCreatePresenter.new

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -1,13 +1,16 @@
 module Users
+  # rubocop:disable Metrics/ClassLength
   class PivCacAuthenticationSetupController < ApplicationController
     include UserAuthenticator
     include PivCacConcern
     include MfaSetupConcern
     include RememberDeviceConcern
+    include SecureHeadersConcern
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup, except: :redirect_to_piv_cac_service
     before_action :authorize_piv_cac_disable, only: :delete
+    before_action :apply_secure_headers_override, only: :new
 
     def new
       if params.key?(:token)
@@ -117,4 +120,5 @@ module Users
                                             more_than_two_factors_enabled?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -3,10 +3,12 @@ module Users
     include RememberDeviceConcern
     include MfaSetupConcern
     include RememberDeviceConcern
+    include SecureHeadersConcern
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :set_totp_setup_presenter
+    before_action :apply_secure_headers_override
 
     def new
       return redirect_to account_url if current_user.totp_enabled?

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -6,7 +6,7 @@ module Users
 
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup
-    before_action :apply_secure_headers_override, only: :new
+    before_action :apply_secure_headers_override
     before_action :set_webauthn_setup_presenter
 
     def new


### PR DESCRIPTION
**Why**: The personal key upgrade path means you can be redirected to an SP from MFA setup. This means the redirect URI must be set in the CSP header or the user will be stuck on the last step of MFA setup.