### PR TITLE
LG-2430 Track data around profile deactivation and activation with personal key

### DIFF
--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -57,6 +57,7 @@ module TwoFactorAuthentication
     end
 
     def re_encrypt_profile_recovery_pii
+      analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION_SIGN_IN)
       Pii::ReEncryptor.new(pii: pii, profile: password_reset_profile).perform
       user_session[:personal_key] = password_reset_profile.personal_key
     end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -7,6 +7,7 @@ module Users
     before_action :init_account_reactivation, only: [:new]
 
     def new
+      analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION_VISITED)
       @personal_key_form = VerifyPersonalKeyForm.new(
         user: current_user,
         personal_key: '',
@@ -15,7 +16,7 @@ module Users
 
     def create
       result = personal_key_form.submit
-
+      analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION_SUBMITTED, result.to_h)
       if result.success?
         handle_success(result)
       else
@@ -33,6 +34,7 @@ module Users
     end
 
     def handle_success(result)
+      analytics.track_event(Analytics::PERSONAL_KEY_REACTIVATION)
       reactivate_account_session.store_decrypted_pii(result.extra[:decrypted_pii])
       redirect_to verify_password_url
     end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -47,12 +47,19 @@ class ResetPasswordForm
   end
 
   def mark_profile_inactive
-    user.active_profile&.deactivate(:password_reset)
-    Funnel::DocAuth::ResetSteps.call(@user.id)
+    profile = user.active_profile
+    return if profile.blank?
+
+    @profile_deactivated = true
+    profile&.deactivate(:password_reset)
+    Funnel::DocAuth::ResetSteps.call(user.id)
     Db::ProofingComponent::DeleteAll.call(user.id)
   end
 
   def extra_analytics_attributes
-    { user_id: user.uuid }
+    {
+      user_id: user.uuid,
+      profile_deactivated: (@profile_deactivated == true),
+    }
   end
 end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -1,3 +1,4 @@
+# :reek:InstanceVariableAssumption
 class ResetPasswordForm
   include ActiveModel::Model
   include FormPasswordValidator
@@ -46,6 +47,7 @@ class ResetPasswordForm
     UpdateUser.new(user: user, attributes: attributes).call
   end
 
+  # :reek:DuplicateMethodCall
   def mark_profile_inactive
     profile = user.active_profile
     return if profile.blank?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -147,6 +147,10 @@ class Analytics
   PASSWORD_RESET_PASSWORD = 'Password Reset: Password Submitted'.freeze
   PASSWORD_RESET_TOKEN = 'Password Reset: Token Submitted'.freeze
   PASSWORD_RESET_VISIT = 'Password Reset: Email Form Visited'.freeze
+  PERSONAL_KEY_REACTIVATION = 'Personal key reactivation: Account reactivated with personal key'.freeze
+  PERSONAL_KEY_REACTIVATION_SIGN_IN = 'Personal key reactivation: Account reactivated with personal key as MFA'.freeze
+  PERSONAL_KEY_REACTIVATION_SUBMITTED = 'Personal key reactivation: Personal key form submitted'.freeze
+  PERSONAL_KEY_REACTIVATION_VISITED = 'Personal key reactivation: Personal key form visitted'.freeze
   PERSONAL_KEY_VIEWED = 'Personal Key Viewed'.freeze
   PHONE_CHANGE_SUBMITTED = 'Phone Number Change: Form submitted'.freeze
   PHONE_CHANGE_VIEWED = 'Phone Number Change: Visited'.freeze

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -101,6 +101,7 @@ describe Users::ResetPasswordsController, devise: true do
             reset_password_token: ['token_expired'],
           },
           user_id: user.uuid,
+          profile_deactivated: false,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -130,6 +131,7 @@ describe Users::ResetPasswordsController, devise: true do
             password: ["is too short (minimum is #{Devise.password_length.first} characters)"],
           },
           user_id: user.uuid,
+          profile_deactivated: false,
         }
 
         expect(@analytics).to receive(:track_event).
@@ -191,6 +193,7 @@ describe Users::ResetPasswordsController, devise: true do
             success: true,
             errors: {},
             user_id: user.uuid,
+            profile_deactivated: false,
           }
 
           expect(@analytics).to have_received(:track_event).
@@ -231,6 +234,7 @@ describe Users::ResetPasswordsController, devise: true do
           success: true,
           errors: {},
           user_id: user.uuid,
+          profile_deactivated: true,
         }
 
         expect(@analytics).to have_received(:track_event).
@@ -269,6 +273,7 @@ describe Users::ResetPasswordsController, devise: true do
           success: true,
           errors: {},
           user_id: user.uuid,
+          profile_deactivated: false,
         }
 
         expect(@analytics).to have_received(:track_event).

--- a/spec/support/shared_examples/password_strength.rb
+++ b/spec/support/shared_examples/password_strength.rb
@@ -10,16 +10,7 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    if form_class == 'PasswordForm'
-      extra = {
-        user_id: '123',
-        request_id_present: false,
-      }
-    elsif form_class == 'ResetPasswordForm'
-      extra = {
-        user_id: '123',
-      }
-    end
+    extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)
 
     if %w[PasswordForm ResetPasswordForm].include?(form_class)
@@ -42,16 +33,7 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    if form_class == 'PasswordForm'
-      extra = {
-        user_id: '123',
-        request_id_present: false,
-      }
-    elsif form_class == 'ResetPasswordForm'
-      extra = {
-        user_id: '123',
-      }
-    end
+    extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)
 
     if %w[PasswordForm ResetPasswordForm].include?(form_class)
@@ -76,16 +58,8 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    if form_class == 'PasswordForm'
-      extra = {
-        user_id: '123',
-        request_id_present: false,
-      }
-    elsif form_class == 'ResetPasswordForm'
-      extra = {
-        user_id: '123',
-      }
-    end
+
+    extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)
 
     if %w[PasswordForm ResetPasswordForm].include?(form_class)
@@ -108,16 +82,7 @@ shared_examples 'strong password' do |form_class|
         ' Add another word or two.' \
         ' Uncommon words are better'],
     }
-    if form_class == 'PasswordForm'
-      extra = {
-        user_id: '123',
-        request_id_present: false,
-      }
-    elsif form_class == 'ResetPasswordForm'
-      extra = {
-        user_id: '123',
-      }
-    end
+    extra = hash_including(user_id: '123')
     result = instance_double(FormResponse)
 
     if %w[PasswordForm ResetPasswordForm].include?(form_class)


### PR DESCRIPTION
**Why**: So we can determine how many users are saving their personal keys and using them to recover their IAL2 accounts