### PR TITLE
Rescue db not found error in migration check.

### DIFF
--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -5,10 +5,27 @@ namespace :db do
     instance_role = File.exist?(instance_role_filename) &&
                     File.read(instance_role_filename).strip
 
+    begin
+      domain = File.read('/etc/login.gov/info/domain').strip
+    rescue Errno::ENOENT
+      domain = nil
+    end
+
     if instance_role == 'migration'
       warn('Skipping pending migration check on migration instance')
     else
-      ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+      begin
+        ActiveRecord::Migration.check_pending!(ActiveRecord::Base.connection)
+      rescue ActiveRecord::NoDatabaseError => err
+        # This error occurs when the database does not exist.
+        # In personal test environments, that's OK, we should continue and run
+        # database migrations.
+        # In production, this should never happen, so we should bail out.
+        raise if domain == 'login.gov'
+
+        warn('Could not check for migrations. Database does not exist:')
+        warn(err.inspect)
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**:

In new personal test environments, the database will not exist the first
time that the pending migration check runs. This causes bootstrapping to
bail out, preventing the database migration process from creating the
database in the first place.

**How**:

Rescue ActiveRecord::NoDatabaseError in
check_for_pending_migrations.rake, as long as the server's domain is not
`login.gov`. This allows the migration process to complete successfully
even when the database doesn't yet exist, which is necessary for
bootstrapping of personal environments.