### PR TITLE
Remove Devise confirmable from the user model

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -44,11 +44,10 @@ module SignUp
     end
 
     def process_successful_password_creation
-      @user.confirm
       password = permitted_params[:password]
       UpdateUser.new(
         user: @user,
-        attributes: { password: password },
+        attributes: { password: password, confirmed_at: Time.zone.now },
       ).call
       Funnel::Registration::AddPassword.call(@user.id)
       sign_in_and_redirect_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   include NonNullUuid
 
   devise(
-    :confirmable,
+    #:confirmable,
     :database_authenticatable,
     :recoverable,
     :registerable,
@@ -47,8 +47,6 @@ class User < ApplicationRecord
   has_many :throttles, dependent: :destroy
   has_one :registration_log, dependent: :destroy
   has_one :proofing_component, dependent: :destroy
-
-  skip_callback :create, :before, :generate_confirmation_token
 
   attr_accessor :asserted_attributes
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ApplicationRecord
   include NonNullUuid
 
   devise(
-    #:confirmable,
     :database_authenticatable,
     :recoverable,
     :registerable,

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -109,7 +109,6 @@ namespace :dev do
 
   def setup_user(user, args)
     user.encrypted_email = args[:ee].encrypted
-    user.skip_confirmation!
     user.reset_password(args[:pw], args[:pw])
     MfaContext.new(user).phone_configurations.create(phone_configuration_data(user, args))
     Event.create(user_id: user.id, event_type: :account_created)
@@ -117,7 +116,6 @@ namespace :dev do
 
   def setup_totp_user(user, args)
     user.encrypted_email = args[:ee].encrypted
-    user.skip_confirmation!
     user.reset_password(args[:pw], args[:pw])
     user.otp_secret_key = ROTP::Base32.random_base32
     Event.create(user_id: user.id, event_type: :account_created)

--- a/spec/services/email_notifier_spec.rb
+++ b/spec/services/email_notifier_spec.rb
@@ -17,7 +17,6 @@ describe EmailNotifier do
         user = create(:user, :signed_up)
         old_email = user.email
         UpdateUser.new(user: user, attributes: { email: 'new@example.com' }).call
-        user.confirm
 
         expect(UserMailer).to receive(:email_changed).with(old_email).and_return(mailer)
         expect(mailer).to receive(:deliver_later)


### PR DESCRIPTION
**Why**: We use our own confirmation logic which we have moved to the email address table. This code is no longer needed.