### PR TITLE
Fixing 2FA SMS code not autopopulating in Safari

### DIFF
--- a/app/views/idv/otp_verification/show.html.slim
+++ b/app/views/idv/otp_verification/show.html.slim
@@ -12,7 +12,7 @@ p == @presenter.phone_number_message
     = text_field_tag(:code, '', value: @code, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-      autocomplete: 'off', type: 'tel')
+      type: 'number')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12'
   br
   br

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -16,7 +16,7 @@
     <%= text_field_tag(:code, '', value: @presenter.code_value, required: true, autofocus: true,
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
                        'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-                       autocomplete: 'off', type: 'tel') %>
+                       type: 'number') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number', @presenter.otp_make_default_number %>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -8,8 +8,8 @@ h1.h3.my0 = @presenter.header
     class: 'block bold'
   .col-12.sm-col-5.mb1.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', value: @code, required: true, autofocus: true,
-      pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
-      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length, autocomplete: 'off'
+      pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'number',
+      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
   .border.border-light-blue.rounded-lg.py1.mt2.mb4.sm-my2.col-12.sm-col-7
     = check_box_tag 'remember_device', true, false, class: 'mr1 ml2'
     = label_tag 'remember_device',

--- a/spec/support/shared_examples_for_otp_forms.rb
+++ b/spec/support/shared_examples_for_otp_forms.rb
@@ -1,10 +1,4 @@
 shared_examples_for 'an otp form' do
-  it 'disables autocomplete' do
-    render
-
-    expect(rendered).to have_css('input[autocomplete=off]')
-  end
-
   describe 'tertiary form actions' do
     it 'allows the user to cancel out of the sign in process' do
       render


### PR DESCRIPTION
**Why**:
- 2FA code field does not sugguest the code received via SMS
in Safari browser both on mobile and on desktop. This is to fix
the issue by removing autocomplete off and setting the type of
the input to number.

**How**:
- Removing autocomplete set to off
- Making the 2FA code input field to be number type instead of tel

Fixes #3492