### PR TITLE
LG-2484 Increase timeouts for Acuant results API call

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Metrics/ClassLength
+# rubocop:disable Style/ColonMethodCall
 # :reek:TooManyMethods
 # :reek:RepeatedConditional
 module Idv
@@ -142,14 +143,18 @@ module Idv
       end
 
       def rescue_network_errors
-        yield
-      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => exception
+        Timeout::timeout(Figaro.env.acuant_timeout.to_i) { yield }
+      rescue Timeout::Error, Faraday::TimeoutError, Faraday::ConnectionFailed => exception
         NewRelic::Agent.notice_error(exception)
         [
           false,
           I18n.t('errors.doc_auth.acuant_network_error'),
           { acuant_network_error: exception.message },
         ]
+      end
+
+      def acuant_timeout
+        Figaro.env
       end
 
       def friendly_failure(message, data)
@@ -173,4 +178,5 @@ module Idv
     end
   end
 end
+# rubocop:enable Style/ColonMethodCall
 # rubocop:enable Metrics/ClassLength

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -143,7 +143,7 @@ module Idv
       end
 
       def rescue_network_errors
-        Timeout::timeout(Figaro.env.acuant_timeout.to_i) { yield }
+        Timeout::timeout(acuant_timeout) { yield }
       rescue Timeout::Error, Faraday::TimeoutError, Faraday::ConnectionFailed => exception
         NewRelic::Agent.notice_error(exception)
         [
@@ -154,7 +154,7 @@ module Idv
       end
 
       def acuant_timeout
-        Figaro.env
+        Figaro.env.acuant_timeout.to_i
       end
 
       def friendly_failure(message, data)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -29,6 +29,7 @@ acuant_assure_id_subscription_id: ''
 acuant_assure_id_username: ''
 acuant_attempt_window_in_minutes: '1440'
 acuant_facial_match_license_key: ''
+acuant_timeout: '45'
 add_email_link_valid_for_hours: '24'
 allow_doc_auth_test_credentials:
 asset_host:

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -5,6 +5,8 @@ module Rack
       '/verify/doc_auth/back_image',
       '/verify/doc_auth/mobile_back_image',
       '/verify/capture_doc/capture_mobile_back_image',
+      '/verify/recovery/back_image',
+      '/verify/recovery/mobile_back_image',
     ]
 
     class << self

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,25 @@
+# :reek:InstanceVariableAssumption
+module Rack
+  class Timeout
+    @excludes = [
+      '/verify/doc_auth/back_image',
+      '/verify/doc_auth/mobile_back_image',
+      '/verify/capture_doc/capture_mobile_back_image',
+    ]
+
+    class << self
+      attr_accessor :excludes
+    end
+
+    def call_with_excludes(env)
+      if self.class.excludes.any? { |exclude_uri| /\A#{exclude_uri}/ =~ env['REQUEST_URI'] }
+        @app.call(env)
+      else
+        call_without_excludes(env)
+      end
+    end
+
+    alias call_without_excludes call
+    alias call call_with_excludes
+  end
+end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -2,10 +2,15 @@
 module Rack
   class Timeout
     @excludes = [
+      '/verify/doc_auth/front_image',
       '/verify/doc_auth/back_image',
+      '/verify/doc_auth/mobile_front_image',
       '/verify/doc_auth/mobile_back_image',
+      '/verify/capture_doc/mobile_front_image',
       '/verify/capture_doc/capture_mobile_back_image',
+      '/verify/recovery/front_image',
       '/verify/recovery/back_image',
+      '/verify/recovery/mobile_front_image',
       '/verify/recovery/mobile_back_image',
     ]
 

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -143,6 +143,18 @@ shared_examples 'back image step' do |simulate|
       end
     end
 
+    it 'catches acuant timeout errors verifying results' do
+      allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
+        and_raise(Timeout::Error)
+
+      attach_image
+      click_idv_continue
+      unless simulate
+        expect(page).to have_current_path(idv_doc_auth_back_image_step)
+        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
+      end
+    end
+
     it 'notifies newrelic when acuant goes over the rack timeout' do
       allow_any_instance_of(Idv::Acuant::AssureId).to receive(:results).
         and_raise(Rack::Timeout::RequestTimeoutException.new(nil))


### PR DESCRIPTION
**Why** : So users don't timeout with the rack timeout before the proofing call completes.
**How**: Monkey patch rack timeout to exclude the acuant proofing endpoints.  Cap the response time of API calls using a standard timeout