### PR TITLE
run piv_cac locally with idp

### DIFF
--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -70,7 +70,7 @@ module PivCacService
       Net::HTTP.start(verify_token_uri.hostname,
                       verify_token_uri.port, use_ssl:
                       verify_token_uri.scheme == 'https') do |http|
-        http.request(decode_request(uri, token))
+        http.request(decode_request(verify_token_uri, token))
       end
     end
 

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -62,7 +62,7 @@ module PivCacService
     end
 
     def token_response(token)
-      return localhost_verify_token(token) if Rails.env.development?
+      return localhost_verify_token(token) if FeatureManagement.identity_pki_local_dev?
       verify_token(token)
     end
 
@@ -76,7 +76,7 @@ module PivCacService
 
     def localhost_verify_token(token)
       http = Net::HTTP.new(verify_token_uri.host, verify_token_uri.port)
-      http.use_ssl = true
+      http.use_ssl = true if Rails.env.development?
       http.ssl_version = :TLSv1_2
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       http.start do |post|

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -51,6 +51,7 @@ google_analytics_key:
 google_analytics_timeout: '5'
 ial2_recovery_request_valid_for_minutes: '15'
 identity_pki_disabled: 'true'
+identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '24'
 idv_max_attempts: '3'
 idv_send_link_attempt_window_in_minutes: '10'
@@ -180,6 +181,7 @@ development:
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
   identity_pki_disabled: 'false'
+  identity_pki_local_dev: 'true'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   piv_cac_verify_token_url: https://localhost:8443/

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -380,6 +380,7 @@ test:
   otp_delivery_blocklist_maxretry: '2'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
+  identity_pki_disabled: 'false'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   piv_cac_verify_token_url: https://localhost:8443/

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -179,6 +179,7 @@ development:
   otp_delivery_blocklist_maxretry: '10'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
+  identity_pki_disabled: 'false'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   piv_cac_verify_token_url: https://localhost:8443/
@@ -380,7 +381,6 @@ test:
   otp_delivery_blocklist_maxretry: '2'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  identity_pki_disabled: 'false'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   piv_cac_verify_token_url: https://localhost:8443/

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,11 +6,12 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
+  form_action = Rails.env.development? ? ["'self'", 'https://*'] : ["'self'"]
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
-    form_action: ["'self'"], # CSP 2.0 only
+    form_action: form_action,
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: [
       "'self'",

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -117,4 +117,8 @@ class FeatureManagement
   def self.usps_upload_enabled?
     Figaro.env.usps_upload_enabled == 'true'
   end
+
+  def self.identity_pki_local_dev?
+    Figaro.env.identity_pki_local_dev == 'true'
+  end
 end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -381,4 +381,18 @@ describe 'FeatureManagement', type: :feature do
       expect(FeatureManagement.disallow_ial2_recovery?).to eq(false)
     end
   end
+
+  describe '#identity_pki_local_dev?' do
+    it 'returns true when Figaro setting is true' do
+      allow(Figaro.env).to receive(:identity_pki_local_dev) { 'true' }
+
+      expect(FeatureManagement.identity_pki_local_dev?).to eq(true)
+    end
+
+    it 'returns false when Figaro setting is false' do
+      allow(Figaro.env).to receive(:identity_pki_local_dev) { 'false' }
+
+      expect(FeatureManagement.identity_pki_local_dev?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Why:
Provide instructions on how to run the piv_cac server locally with the idp.