### PR TITLE
Remove Geolite2 setup from the setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ If you are on a mac, if you receive the following prompt the first time you run 
 JavaScript unit tests run using the mocha test runner. Check out the
 [mocha documentation](https://mochajs.org/) for more details.
 
+### Setting up Geolocation
+
+The app uses MaxMind Geolite2 for geolocation.
+To test geolocation locally you will need to add a copy of the Geolite2-City database to the IdP.
+
+The Geolite2-City database can be downloaded from MaxMind's site at [https://dev.maxmind.com/geoip/geoip2/geolite2/](https://dev.maxmind.com/geoip/geoip2/geolite2/).
+
+Download the GeoIP2 Binary and save it at `geo_data/GeoLite2-City.mmdb`.
+The app will start using that Geolite2 file for geolocation after restart.
+
 ### User flows
 
 We have an automated tool for generating user flows using real views generated from the application. These specs are excluded from our typical spec run because of the overhead of generating screenshots for each view.

--- a/bin/setup
+++ b/bin/setup
@@ -36,12 +36,6 @@ Dir.chdir APP_ROOT do
   run "test -L certs || ln -sv certs.example certs"
   run "test -L keys || ln -sv keys.example keys"
 
-  puts "== Copying GeoLite2 City database =="
-  run "test -L geo_data/GeoLite2-City.mmdb || mkdir -p geo_data && cd geo_data && " \
-      "curl http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xvz"
-  geo_data_file = Dir['geo_data/GeoLite2-City_*/GeoLite2-City.mmdb'].sort.last
-  run "mv #{geo_data_file} geo_data/GeoLite2-City.mmdb"
-
   puts "== Copying sample pwned passwords list =="
   run "cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt"
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,33 @@
-Geocoder.configure(
-  ip_lookup: :geoip2,
-  geoip2: {
-    file: Rails.root.join('geo_data', 'GeoLite2-City.mmdb'),
-  },
-)
+# For some reason the test result class does not impelement the `language=`
+# method. This patches an empty method onto it to prevent NoMethodErrors in
+# the tests
+module Geocoder
+  module Result
+    class Test
+      def language=(_locale); end
+    end
+  end
+end
+
+GEO_DATA_FILEPATH = Rails.root.join('geo_data', 'GeoLite2-City.mmdb').freeze
+
+if !Rails.env.production? && !File.exist?(GEO_DATA_FILEPATH)
+  Geocoder.configure(ip_lookup: :test)
+  Geocoder::Lookup::Test.add_stub(
+    '127.0.0.1', [
+      { 'city' => '', 'country' => 'United States', 'state_code' => '' },
+    ]
+  )
+  Geocoder::Lookup::Test.add_stub(
+    '::1', [
+      { 'city' => '', 'country' => 'United States', 'state_code' => '' },
+    ]
+  )
+else
+  Geocoder.configure(
+    ip_lookup: :geoip2,
+    geoip2: {
+      file: GEO_DATA_FILEPATH,
+    },
+  )
+end

--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -29,24 +29,3 @@ Geocoder::Lookup::Test.add_stub(
     },
   ]
 )
-
-Geocoder::Lookup::Test.add_stub(
-  '127.0.0.1', [
-    {
-      'city' => '',
-      'country' => 'United States',
-      'state_code' => '',
-    },
-  ]
-)
-
-# For some reason the test result class does not impelement the `language=`
-# method. This patches an empty method onto it to prevent NoMethodErrors in
-# the tests
-module Geocoder
-  module Result
-    class Test
-      def language=(_locale); end
-    end
-  end
-end


### PR DESCRIPTION
**Why**: MaxMind has removed public links to the Geolite2 database to comply with CPAA. This broke out setup script which expected the file to be public.

This commit fixes the issue by using the mock in local dev unless a file is present. It also adds instructions to the README on how to download the file to enable geolocation locally.