### PR TITLE
LG-2512 Put the 127.0.0.1 geocoder stub back in the spec file

### DIFF
--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -29,3 +29,13 @@ Geocoder::Lookup::Test.add_stub(
     },
   ]
 )
+
+Geocoder::Lookup::Test.add_stub(
+  '127.0.0.1', [
+    {
+      'city' => '',
+      'country' => 'United States',
+      'state_code' => '',
+    },
+  ]
+)


### PR DESCRIPTION
**Why**: We want this stub created for the tests even if a geolite2 db is present.