### PR TITLE
Lg 2310 run locally with piv_cac - fixed CSP header issue

### DIFF
--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -56,14 +56,22 @@ module PivCacService
 
     def token_decoded(token)
       return decode_test_token(token) if token.start_with?('TEST:')
-
       return { 'error' => 'service.disabled' } if FeatureManagement.identity_pki_disabled?
-
-      uri = URI(piv_cac_verify_token_link)
-      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
-        http.request(decode_request(uri, token))
-      end
+      res = token_response(token)
       decode_token_response(res)
+    end
+
+    def token_response(token)
+      http = Net::HTTP.new(verify_token_uri.hostname, verify_token_uri.port)
+      http.use_ssl = verify_token_uri.scheme == 'https'
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if FeatureManagement.identity_pki_local_dev?
+      http.start do |post|
+        post.request(decode_request(verify_token_uri, token))
+      end
+    end
+
+    def verify_token_uri
+      URI(piv_cac_verify_token_link)
     end
 
     def decode_request(uri, token)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -51,6 +51,7 @@ google_analytics_key:
 google_analytics_timeout: '5'
 ial2_recovery_request_valid_for_minutes: '15'
 identity_pki_disabled: 'true'
+identity_pki_local_dev: 'false'
 idv_attempt_window_in_hours: '24'
 idv_max_attempts: '3'
 idv_send_link_attempt_window_in_minutes: '10'
@@ -68,7 +69,6 @@ logins_per_email_and_ip_bantime: '60'
 logins_per_email_and_ip_period: '60'
 logins_per_ip_period: '60'
 mailer_domain_name: http://localhost:3000
-max_auth_apps_per_account: '2'
 max_emails_per_account: '12'
 max_mail_events_window_in_days: '30'
 max_piv_cac_per_account: '2'
@@ -180,6 +180,8 @@ development:
   otp_delivery_blocklist_maxretry: '10'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
+  identity_pki_disabled: 'false'
+  identity_pki_local_dev: 'true'
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: ee7f20f44cdc2ba0c6830f70470d1d1d059e1279cdb58134db92b35947b1528ef5525ece5910cf4f2321ab989a618feea12ef95711dbc62b9601e8520a34ee12
   piv_cac_verify_token_url: https://localhost:8443/

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -69,6 +69,7 @@ logins_per_email_and_ip_bantime: '60'
 logins_per_email_and_ip_period: '60'
 logins_per_ip_period: '60'
 mailer_domain_name: http://localhost:3000
+max_auth_apps_per_account: '2'
 max_emails_per_account: '12'
 max_mail_events_window_in_days: '30'
 max_piv_cac_per_account: '2'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,7 +6,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
-  # On the development environment only we allow 'https://*' to hop over to identity-pki 
+  # On the development environment only we allow 'https://*' to hop over to identity-pki
   form_action = Rails.env.development? ? ["'self'", 'https://*'] : ["'self'"]
   default_csp_config = {
     default_src: ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,11 +6,12 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
+  form_action = Rails.env.development? ? ["'self'", 'https://*'] : ["'self'"]
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
-    form_action: ["'self'"], # CSP 2.0 only
+    form_action: form_action,
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: [
       "'self'",

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,6 +6,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
+  # On the development environment only we allow 'https://*' to hop over to identity-pki 
   form_action = Rails.env.development? ? ["'self'", 'https://*'] : ["'self'"]
   default_csp_config = {
     default_src: ["'self'"],

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -117,4 +117,10 @@ class FeatureManagement
   def self.usps_upload_enabled?
     Figaro.env.usps_upload_enabled == 'true'
   end
+
+  def self.identity_pki_local_dev?
+    # This option should only be used in the development environment
+    # it controls if we hop over to identity-pki on a developers local machins
+    Rails.env.development? && Figaro.env.identity_pki_local_dev == 'true'
+  end
 end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -381,4 +381,42 @@ describe 'FeatureManagement', type: :feature do
       expect(FeatureManagement.disallow_ial2_recovery?).to eq(false)
     end
   end
+
+  describe '#identity_pki_local_dev?' do
+    context 'when in development mode' do
+      before(:each) do
+        allow(Rails.env).to receive(:development?).and_return(true)
+      end
+
+      it 'returns true when Figaro setting is true' do
+        allow(Figaro.env).to receive(:identity_pki_local_dev) { 'true' }
+
+        expect(FeatureManagement.identity_pki_local_dev?).to eq(true)
+      end
+
+      it 'returns false when Figaro setting is false' do
+        allow(Figaro.env).to receive(:identity_pki_local_dev) { 'false' }
+
+        expect(FeatureManagement.identity_pki_local_dev?).to eq(false)
+      end
+    end
+
+    context 'when in non-development mode' do
+      before(:each) do
+        allow(Rails.env).to receive(:development?).and_return(false)
+      end
+
+      it 'returns false when Figaro setting is true' do
+        allow(Figaro.env).to receive(:identity_pki_local_dev) { 'true' }
+
+        expect(FeatureManagement.identity_pki_local_dev?).to eq(false)
+      end
+
+      it 'returns false when Figaro setting is false' do
+        allow(Figaro.env).to receive(:identity_pki_local_dev) { 'false' }
+
+        expect(FeatureManagement.identity_pki_local_dev?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/piv_cac_service_spec.rb
+++ b/spec/services/piv_cac_service_spec.rb
@@ -94,6 +94,47 @@ describe PivCacService do
         end
       end
 
+      describe 'when configured to contact piv_cac service for local development' do
+        before(:each) do
+          allow(Figaro.env).to receive(:identity_pki_local_dev) { 'true' }
+          allow(Figaro.env).to receive(:identity_pki_disabled) { 'false' }
+          allow(Figaro.env).to receive(:piv_cac_verify_token_url) { 'http://localhost:8443/' }
+        end
+
+        let!(:request) do
+          stub_request(:post, 'localhost:8443').
+            with(
+              body: 'token=foo',
+              headers: { 'Authentication' => /^hmac\s+:.+:.+$/ },
+            ).
+            to_return(
+              status: [200, 'Ok'],
+              body: '{"subject":"dn","uuid":"uuid"}',
+            )
+        end
+
+        it 'sends the token to the target service' do
+          PivCacService.decode_token('foo')
+          expect(request).to have_been_requested.once
+        end
+
+        it 'returns the decoded JSON from the target service' do
+          expect(PivCacService.decode_token('foo')).to eq(
+            'subject' => 'dn',
+            'uuid' => 'uuid',
+          )
+        end
+
+        describe 'with test data' do
+          it 'returns an error' do
+            token = 'TEST:{"uuid":"hijackedUUID","subject":"hijackedDN"}'
+            expect(PivCacService.decode_token(token)).to eq(
+              'error' => 'token.bad',
+            )
+          end
+        end
+      end
+
       describe 'when configured to contact remote service' do
         before(:each) do
           allow(Figaro.env).to receive(:identity_pki_disabled) { 'false' }


### PR DESCRIPTION
Why:
Allow developers to run the piv_cac server locally with the idp.

I fixed CSP header issue by using uri.hostname instead of uri.host in the Net::HTTP call.