### PR TITLE
LG-2308 validate prompt login

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -37,6 +37,7 @@ class OpenidConnectAuthorizeForm
   validate :validate_scope
   validate :validate_unauthorized_scope
   validate :validate_privileges
+  validate :validate_prompt
 
   def initialize(params)
     @acr_values = parse_to_values(params[:acr_values], Saml::Idp::Constants::VALID_AUTHN_CONTEXTS)
@@ -111,6 +112,13 @@ class OpenidConnectAuthorizeForm
   def validate_unauthorized_scope
     return unless @unauthorized_scope && Figaro.env.unauthorized_scope_enabled == 'true'
     errors.add(:scope, t('openid_connect.authorization.errors.unauthorized_scope'))
+  end
+
+  def validate_prompt
+    return if prompt == 'select_account'
+    if prompt == 'login'
+      service_provider.allow_prompt_login ? return : errors.add(:prompt, t('openid_connect.authorization.errors.prompt_invalid'))
+    end
   end
 
   def ial

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -116,9 +116,8 @@ class OpenidConnectAuthorizeForm
 
   def validate_prompt
     return if prompt == 'select_account'
-    if prompt == 'login'
-      service_provider.allow_prompt_login ? return : errors.add(:prompt, t('openid_connect.authorization.errors.prompt_invalid'))
-    end
+    return if prompt == 'login' && service_provider.allow_prompt_login
+    errors.add(:prompt, t('openid_connect.authorization.errors.prompt_invalid'))
   end
 
   def ial

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -29,7 +29,7 @@ class OpenidConnectAuthorizeForm
   validates :nonce, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
 
   validates :response_type, inclusion: { in: %w[code] }
-  validates :prompt, presence: true, allow_nil: true, inclusion: { in: %w[login select_account] }
+  validates :prompt, presence: true, inclusion: { in: %w[login select_account] }
   validates :code_challenge_method, inclusion: { in: %w[S256] }, if: :code_challenge
 
   validate :validate_acr_values

--- a/config/locales/openid_connect/en.yml
+++ b/config/locales/openid_connect/en.yml
@@ -7,6 +7,7 @@ en:
         no_auth: The acr_values are not authorized
         no_valid_acr_values: No acceptable acr_values found
         no_valid_scope: No valid scope values found
+        prompt_invalid: No valid prompt values found
         redirect_uri_invalid: redirect_uri is invalid
         redirect_uri_no_match: redirect_uri does not match registered redirect_uri
         unauthorized_scope: Unauthorized scope

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -7,6 +7,7 @@ es:
         no_auth: Los acr_values no están autorizados
         no_valid_acr_values: acr_valores encontrados no aceptables
         no_valid_scope: No se han encontrado valores de magnitud válidos
+        prompt_invalid: Prompt no es válido
         redirect_uri_invalid: Redirect_uri no es válido
         redirect_uri_no_match: Redirect_uri no coincide con redirect_uri registrado
         unauthorized_scope: Alcance no autorizado

--- a/config/locales/openid_connect/fr.yml
+++ b/config/locales/openid_connect/fr.yml
@@ -7,6 +7,7 @@ fr:
         no_auth: Les acr_values ne sont pas autorisées
         no_valid_acr_values: Valeurs acr_values inacceptables trouvées
         no_valid_scope: Aucune étendue de données valide trouvée
+        prompt_invalid: prompt est non valide
         redirect_uri_invalid: redirect_uri est non valide
         redirect_uri_no_match: redirect_uri ne correspond pas au redirect_uri enregistré
         unauthorized_scope: Portée non autorisée

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -16,6 +16,7 @@ test:
     attribute_bundle:
       - email
       - phone
+    allow_prompt_login: true
 
   'https://rp1.serviceprovider.com/auth/saml/metadata':
     agency_id: 2
@@ -37,6 +38,7 @@ test:
       - last_name
       - ssn
       - zipcode
+    allow_prompt_login: true
 
   'https://rp2.serviceprovider.com/auth/saml/metadata':
     acs_url: 'http://example.com/test/saml/decode_assertion'
@@ -44,6 +46,7 @@ test:
     block_encryption: 'aes256-cbc'
     cert: 'saml_test_sp'
     friendly_name: 'Test SP'
+    allow_prompt_login: true
 
   'http://test.host':
     acs_url: 'http://test.host/test/saml/decode_assertion'
@@ -51,6 +54,7 @@ test:
     metadata_url: 'http://test.host/test/saml/metadata'
     sp_initiated_login_url: 'http://test.host/test/saml'
     friendly_name: 'Test SP'
+    allow_prompt_login: true
 
   'urn:gov:gsa:openidconnect:test':
     redirect_uris:
@@ -71,12 +75,13 @@ test:
       - 'gov.gsa.openidconnect.test://result'
       - 'gov.gsa.openidconnect.test://result/signout'
     cert: 'saml_test_sp'
-    friendly_name: 'Example app without prompt=login'
+    friendly_name: 'Example app that disallows prompt=login'
     agency: '18F'
     agency_id: 1
     uuid_priority: 20
     logo: 'generic.svg'
     ial: 1
+    allow_prompt_login: false
 
   'urn:gov:gsa:openidconnect:test:loa1':
     redirect_uris:
@@ -88,6 +93,7 @@ test:
     agency_id: 1
     uuid_priority: 20
     logo: 'generic.svg'
+    allow_prompt_login: true
 
   'urn:gov:gsa:openidconnect:sp:server':
     agency_id: 2
@@ -98,6 +104,7 @@ test:
     friendly_name: 'Test SP'
     assertion_consumer_logout_service_url: ''
     ial: 2
+    allow_prompt_login: true
 
   'test_sp_with_default_help_text':
     agency_id: 2
@@ -141,6 +148,7 @@ test:
           l'adresse e-mail principale ou secondaire que vous avez utilisée pour %{sp_name}
           pour <a href=%{sp_create_link}> créer votre nouveau compte login.gov</a>
           <p><a href="https://login.gov/help/">En savoir plus.</a>
+    allow_prompt_login: true
 
   'test_sp_with_custom_help_text':
     agency_id: 2
@@ -160,6 +168,7 @@ test:
         en: ""
         es: ""
         fr: ""
+    allow_prompt_login: true
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -64,6 +64,19 @@ test:
     logo: 'generic.svg'
     ial: 2
     push_notification_url: http://localhost/push_notifications
+    allow_prompt_login: true
+
+  'urn:gov:gsa:openidconnect:test_prompt_login_banned':
+    redirect_uris:
+      - 'gov.gsa.openidconnect.test://result'
+      - 'gov.gsa.openidconnect.test://result/signout'
+    cert: 'saml_test_sp'
+    friendly_name: 'Example app without prompt=login'
+    agency: '18F'
+    agency_id: 1
+    uuid_priority: 20
+    logo: 'generic.svg'
+    ial: 1
 
   'urn:gov:gsa:openidconnect:test:loa1':
     redirect_uris:

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -46,6 +46,22 @@ describe 'OpenID Connect' do
       oidc_end_client_secret_jwt(prompt: 'login')
     end
 
+    it 'fails with prompt login if not allowed for SP' do
+      visit openid_connect_authorize_path(
+        client_id: 'urn:gov:gsa:openidconnect:test_prompt_login_banned',
+        response_type: 'code',
+        acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        scope: 'openid email',
+        redirect_uri: 'http://localhost:7654/auth/result',
+        state: SecureRandom.hex,
+        prompt: 'login',
+        nonce: SecureRandom.hex,
+      )
+
+      expect(current_path).to eq(openid_connect_authorize_path)
+      # TODO Expect an error message
+    end
+
     it 'returns invalid request with bad prompt parameter' do
       oidc_end_client_secret_jwt(prompt: 'aaa', redirs_to: '/auth/result')
       expect(current_url).to include('?error=invalid_request')

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -59,7 +59,7 @@ describe 'OpenID Connect' do
       )
 
       expect(current_path).to eq(openid_connect_authorize_path)
-      # TODO Expect an error message
+      expect(page).to have_content(t('openid_connect.authorization.errors.prompt_invalid'))
     end
 
     it 'returns invalid request with bad prompt parameter' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -167,7 +167,7 @@ describe 'OpenID Connect' do
     expect(page).to have_content(t('headings.sign_in_without_sp'))
   end
 
-  context 'with PCKE', driver: :mobile_rack_test do
+  context 'with PKCE', driver: :mobile_rack_test do
     it 'succeeds with client authentication via PKCE' do
       client_id = 'urn:gov:gsa:openidconnect:test'
       state = SecureRandom.hex

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -148,11 +148,25 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it { expect(valid?).to eq(true) }
     end
 
-    context 'when prompt is login' do
+    context 'when prompt is login and allowed by sp' do
       let(:prompt) { 'login' }
+      before do
+        allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return true
+      end
+
       it { expect(valid?).to eq(true) }
     end
 
+    context 'when prompt is login but not allowed by sp' do
+      let(:prompt) { 'login' }
+      before do
+        allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return false
+      end
+
+      it { expect(valid?).to eq(false) }
+    end
+
+    
     context 'when prompt is blank' do
       let(:prompt) { '' }
       it { expect(valid?).to eq(false) }

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it { expect(valid?).to eq(false) }
     end
 
-    
     context 'when prompt is blank' do
       let(:prompt) { '' }
       it { expect(valid?).to eq(false) }


### PR DESCRIPTION
**Why:* Because we added allow_prompt_login to the service provider object and now we want to use it to validate when prompt = login is allowed to be used.