### PR TITLE
LG-2063 Up timeout on hybrid flow link step

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -3,6 +3,7 @@ module Idv
     before_action :confirm_two_factor_authenticated
     before_action :redirect_if_mail_bounced
     before_action :redirect_if_pending_profile
+    before_action :extend_timeout_using_meta_refresh_for_select_paths
 
     include IdvSession # remove if we retire the non docauth LOA3 flow
     include Flow::FlowStateMachine
@@ -20,6 +21,24 @@ module Idv
 
     def redirect_if_pending_profile
       redirect_to verify_account_url if current_user.decorate.pending_profile_requires_verification?
+    end
+
+    def extend_timeout_using_meta_refresh_for_select_paths
+      return unless request.path == idv_doc_auth_step_path(step: :link_sent)
+      max_10min_refreshes = Figaro.env.doc_auth_extend_timeout_by_minutes.to_i / 10
+      return if max_10min_refreshes <= 0
+      meta_refresh_count = flow_session[:meta_refresh_count].to_i
+      return if meta_refresh_count >= max_10min_refreshes
+      do_meta_refresh(meta_refresh_count)
+    end
+
+    def do_meta_refresh(meta_refresh_count)
+      @meta_refresh = 10 * 60
+      flow_session[:meta_refresh_count] = meta_refresh_count + 1
+    end
+
+    def flow_session
+      user_session['idv/doc_auth']
     end
   end
 end

--- a/app/views/idv/doc_auth/link_sent.html.slim
+++ b/app/views/idv/doc_auth/link_sent.html.slim
@@ -1,5 +1,7 @@
 - title t('doc_auth.titles.doc_auth')
 
+- if @meta_refresh
+  - content_for(:meta_refresh) { "#{@meta_refresh}" }
 h1.h3.my0 = t('doc_auth.headings.text_message')
 br
 .clearfix.mxn1

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -44,6 +44,7 @@ database_statement_timeout: '2500'
 disallow_ial2_recovery:
 doc_auth_enabled: 'true'
 doc_capture_request_valid_for_minutes: '15'
+doc_auth_extend_timeout_by_minutes: '40'
 email_from: no-reply@login.gov
 enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -27,12 +27,16 @@ shared_examples 'link sent step' do |simulate|
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
-    it 'refreshes the page 4x with meta refresh extending the regular timeout by 40 minutes' do
+    it 'refreshes page 4x with meta refresh extending timeout by 40 min and can start over' do
       4.times do
         expect(page).to have_css 'meta[http-equiv="refresh"]', visible: false
         visit idv_doc_auth_link_sent_step
       end
       expect(page).to_not have_css 'meta[http-equiv="refresh"]', visible: false
+
+      click_on t('doc_auth.buttons.start_over')
+      complete_doc_auth_steps_before_link_sent_step(user)
+      expect(page).to have_css 'meta[http-equiv="refresh"]', visible: false
     end
 
     it 'proceeds to the next page with valid info and test credentials turned on' do

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -29,10 +29,10 @@ shared_examples 'link sent step' do |simulate|
 
     it 'refreshes the page 4x with meta refresh extending the regular timeout by 40 minutes' do
       4.times do
-        expect(page).to have_css 'meta[http-equiv="refresh"]', :visible => false
+        expect(page).to have_css 'meta[http-equiv="refresh"]', visible: false
         visit idv_doc_auth_link_sent_step
       end
-      expect(page).to_not have_css 'meta[http-equiv="refresh"]', :visible => false
+      expect(page).to_not have_css 'meta[http-equiv="refresh"]', visible: false
     end
 
     it 'proceeds to the next page with valid info and test credentials turned on' do

--- a/spec/features/idv/doc_auth/link_sent_step_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_step_spec.rb
@@ -27,6 +27,14 @@ shared_examples 'link sent step' do |simulate|
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
     end
 
+    it 'refreshes the page 4x with meta refresh extending the regular timeout by 40 minutes' do
+      4.times do
+        expect(page).to have_css 'meta[http-equiv="refresh"]', :visible => false
+        visit idv_doc_auth_link_sent_step
+      end
+      expect(page).to_not have_css 'meta[http-equiv="refresh"]', :visible => false
+    end
+
     it 'proceeds to the next page with valid info and test credentials turned on' do
       enable_test_credentials
       click_idv_continue


### PR DESCRIPTION
**Why**: The hybrid flow desktop screen waits for the mobile flow to complete document capture which sometimes takes users longer than the session timeout of 15minutes to complete.
**How**: Create a hook in doc auth that breaks up the value specified in doc_auth_extend_timeout_by_minutes into 10 minute meta refresh chunks where the count is stored in session