### PR TITLE
LG-2498 Set remember device as default for MFA

### DIFF
--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -29,7 +29,7 @@
               form_class: 'inline-block') %>
 
   <inline-block class="span" style="white-space:nowrap">
-    <%= check_box_tag 'remember_device', true, false, class: 'my2 ml2 mr1' %>
+    <%= check_box_tag 'remember_device', true, true, class: 'my2 ml2 mr1' %>
     <%= label_tag 'remember_device',
                 t('forms.messages.remember_device'),
                 class: 'blue' %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -11,7 +11,7 @@ h1.h3.my0 = @presenter.header
       pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'number',
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
   .border.border-light-blue.rounded-lg.py1.mt2.mb4.sm-my2.col-12.sm-col-7
-    = check_box_tag 'remember_device', true, false, class: 'mr1 ml2'
+    = check_box_tag 'remember_device', true, true, class: 'mr1 ml2'
     = label_tag 'remember_device',
       t('forms.messages.remember_device'),
       class: 'blue mr2'

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -52,7 +52,7 @@
       <%= t('two_factor_authentication.webauthn_verified.info') %>
     </p>
     <div class="border border-light-blue rounded-lg px2 py1 mt3">
-      <%= check_box_tag 'remember_device', true, false, class: 'mr1' %>
+      <%= check_box_tag 'remember_device', true, true, class: 'mr1' %>
       <%= label_tag 'remember_device',
         t('forms.messages.remember_device'),
         class: 'blue mt-1p' %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -62,7 +62,7 @@
           </div>
         </div>
         <div class="border border-light-blue rounded-lg px2 py1 mt3">
-          <%= check_box_tag 'remember_device', true, false, class: 'mr1' %>
+          <%= check_box_tag 'remember_device', true, true, class: 'mr1' %>
           <%= label_tag 'remember_device', t('forms.messages.remember_device'), class: 'blue mt-1p' %>
         </div>
       </div>

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -27,7 +27,7 @@
             class: 'block col-12 field monospace', size: 16, maxlength: 20,
             'aria-labelledby': 'totp-label' %>
      <div class='border border-light-blue rounded-lg px2 py1 mt3'>
-       <%= check_box_tag 'remember_device', true, false, class: 'mr1' %>
+       <%= check_box_tag 'remember_device', true, true, class: 'mr1' %>
        <%= label_tag 'remember_device',
          t('forms.messages.remember_device'),
          class: 'blue mt-1p' %>

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -143,6 +143,9 @@ feature 'disavowing an action' do
   end
 
   def disavow_last_action_and_reset_password
+    # Don't want to 'remember device'
+    Capybara.reset_session!
+
     open_last_email
     click_email_link_matching(%r{events\/disavow})
 

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -143,8 +143,7 @@ feature 'disavowing an action' do
   end
 
   def disavow_last_action_and_reset_password
-    # Don't want to 'remember device'
-    Capybara.reset_session!
+    set_new_browser_session
 
     open_last_email
     click_email_link_matching(%r{events\/disavow})

--- a/spec/features/multiple_emails/sign_in_spec.rb
+++ b/spec/features/multiple_emails/sign_in_spec.rb
@@ -7,6 +7,7 @@ feature 'sign in with any email address' do
     email1, email2 = user.reload.email_addresses.map(&:email)
 
     signin(email1, user.password)
+    uncheck(t('forms.messages.remember_device'))
     fill_in_code_with_last_phone_otp
     click_submit_default
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'OpenID Connect' do
   include IdvHelper
   include CloudhsmMocks
-  include RememberDeviceConcern
 
   context 'with client_secret_jwt' do
     it 'succeeds with prompt select_account and no prior session' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'OpenID Connect' do
   include IdvHelper
   include CloudhsmMocks
+  include RememberDeviceConcern
 
   context 'with client_secret_jwt' do
     it 'succeeds with prompt select_account and no prior session' do
@@ -354,12 +355,14 @@ describe 'OpenID Connect' do
 
       visit_idp_from_sp_with_ial1
       fill_in_credentials_and_submit(user.email, user.password)
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
       visit destroy_user_session_url
 
       visit_idp_from_sp_with_ial1
       fill_in_credentials_and_submit(user.email, user.password)
+      uncheck(t('forms.messages.remember_device'))
       sp_request_id = ServiceProviderRequest.last.uuid
       sp = ServiceProvider.from_issuer('urn:gov:gsa:openidconnect:sp:server')
       click_link t('links.cancel')

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -8,13 +8,13 @@ describe 'default phone selection' do
                                  created_at: Time.zone.now + 1.hour)
   end
 
-  describe 'sms delivery prefrence' do
+  describe 'sms delivery preference' do
     context 'when the user has not set a default phone number' do
       it 'uses the first phone created as the default' do
         sign_in_before_2fa(user)
-        t('instructions.mfa.sms.number_message_html',
-          number: '***-***-1212',
-          expiration: Figaro.env.otp_valid_for)
+        expect(page).to have_content t('instructions.mfa.sms.number_message_html',
+                                       number: '***-***-1212',
+                                       expiration: Figaro.env.otp_valid_for)
       end
     end
 
@@ -35,7 +35,10 @@ describe 'default phone selection' do
         expect(page).to have_current_path(account_path)
         expect(page).to have_content t('account.index.default')
 
-        sign_out_sign_in(user)
+        # Don't want to 'remember device'
+        Capybara.reset_session!
+
+        sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.sms.number_message_html',
                                        number: '***-***-3434',
                                        expiration: Figaro.env.otp_valid_for)
@@ -71,7 +74,10 @@ describe 'default phone selection' do
         parent = node.first(:xpath, './/..')
         expect(parent).to have_content t('account.index.default')
 
-        sign_out_sign_in(user)
+        # Don't want to 'remember device'
+        Capybara.reset_session!
+
+        sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.sms.number_message_html',
                                        number: '***-***-3111',
                                        expiration: Figaro.env.otp_valid_for)
@@ -98,17 +104,15 @@ describe 'default phone selection' do
         expect(page).to have_current_path(account_path)
         expect(page).to have_content t('account.index.default')
 
-        sign_out_sign_in(user)
+        # Don't want to 'remember device'
+        Capybara.reset_session!
+
+        sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.voice.number_message_html',
                                        number: '***-***-3434',
                                        expiration: Figaro.env.otp_valid_for)
       end
     end
-  end
-
-  def sign_out_sign_in(user)
-    first(:link, t('links.sign_out')).click
-    sign_in_before_2fa(user)
   end
 
   def submit_prefilled_otp_code(user, delivery_preference)

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -35,9 +35,7 @@ describe 'default phone selection' do
         expect(page).to have_current_path(account_path)
         expect(page).to have_content t('account.index.default')
 
-        # Don't want to 'remember device'
-        Capybara.reset_session!
-
+        set_new_browser_session
         sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.sms.number_message_html',
                                        number: '***-***-3434',
@@ -74,9 +72,7 @@ describe 'default phone selection' do
         parent = node.first(:xpath, './/..')
         expect(parent).to have_content t('account.index.default')
 
-        # Don't want to 'remember device'
-        Capybara.reset_session!
-
+        set_new_browser_session
         sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.sms.number_message_html',
                                        number: '***-***-3111',
@@ -104,9 +100,7 @@ describe 'default phone selection' do
         expect(page).to have_current_path(account_path)
         expect(page).to have_content t('account.index.default')
 
-        # Don't want to 'remember device'
-        Capybara.reset_session!
-
+        set_new_browser_session
         sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.voice.number_message_html',
                                        number: '***-***-3434',

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -120,8 +120,7 @@ feature 'IAL1 Single Sign On' do
     it 'it immediately returns to the SP after signing in again' do
       click_continue
 
-      # Don't want to 'remember device'
-      Capybara.reset_session!
+      set_new_browser_session
 
       sign_in_user(user)
       fill_in_code_with_last_phone_otp

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -120,7 +120,8 @@ feature 'IAL1 Single Sign On' do
     it 'it immediately returns to the SP after signing in again' do
       click_continue
 
-      visit sign_out_url
+      # Don't want to 'remember device'
+      Capybara.reset_session!
 
       sign_in_user(user)
       fill_in_code_with_last_phone_otp

--- a/spec/features/saml/ial3_sso_spec.rb
+++ b/spec/features/saml/ial3_sso_spec.rb
@@ -9,6 +9,7 @@ feature 'IAL2 Single Sign On' do
     saml_authn_request = auth_request.create(ial2_with_bundle_saml_settings)
     visit saml_authn_request
     fill_in_credentials_and_submit(user.email, user.password)
+    uncheck(t('forms.messages.remember_device'))
     fill_in_code_with_last_phone_otp
     click_submit_default
     fill_out_idv_jurisdiction_ok

--- a/spec/features/sign_in/remember_device_default_spec.rb
+++ b/spec/features/sign_in/remember_device_default_spec.rb
@@ -7,7 +7,7 @@ describe 'Remember device checkbox' do
       sign_in_user(user)
 
       expect(page).
-          to have_checked_field t('forms.messages.remember_device')
+        to have_checked_field t('forms.messages.remember_device')
     end
   end
 end

--- a/spec/features/sign_in/remember_device_default_spec.rb
+++ b/spec/features/sign_in/remember_device_default_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'Remember device checkbox' do
+  context 'when the user signs in and arrives at the 2FA page' do
+    it "has a checked 'remember device' box" do
+      user = create(:user, :signed_up)
+      sign_in_user(user)
+
+      expect(page).
+          to have_checked_field t('forms.messages.remember_device')
+    end
+  end
+end

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -18,6 +18,7 @@ feature 'Changing authentication factor' do
       visit manage_password_path
 
       expect(page).to have_content t('help_text.change_factor', factor: 'password')
+
       complete_2fa_confirmation
 
       expect(current_path).to eq manage_password_path

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -18,7 +18,6 @@ feature 'Changing authentication factor' do
       visit manage_password_path
 
       expect(page).to have_content t('help_text.change_factor', factor: 'password')
-
       complete_2fa_confirmation
 
       expect(current_path).to eq manage_password_path

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -330,7 +330,8 @@ feature 'Two Factor Authentication' do
 
         expect(current_path).to eq(account_path)
 
-        first(:link, t('links.sign_out')).click
+        # Don't want to 'remember device'
+        Capybara.reset_session!
 
         sign_in_user(user)
         fill_in 'code', with: otp

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -330,9 +330,7 @@ feature 'Two Factor Authentication' do
 
         expect(current_path).to eq(account_path)
 
-        # Don't want to 'remember device'
-        Capybara.reset_session!
-
+        set_new_browser_session
         sign_in_user(user)
         fill_in 'code', with: otp
         click_submit_default

--- a/spec/services/db/sp_cost/add_sp_cost_spec.rb
+++ b/spec/services/db/sp_cost/add_sp_cost_spec.rb
@@ -43,7 +43,9 @@ feature 'SP Costing' do
   it 'logs the correct costs for an ial1 authentication' do
     create_ial1_user_from_sp(email4)
     SpCost.delete_all
-    visit sign_out_url
+
+    # track costs without dealing with 'remember device'
+    Capybara.reset_session!
 
     visit_idp_from_sp_with_ial1(:oidc)
     fill_in_credentials_and_submit(email4, password)
@@ -57,7 +59,9 @@ feature 'SP Costing' do
   it 'logs the correct costs for an ial2 authentication' do
     create_ial2_user_from_sp(email3)
     SpCost.delete_all
-    visit sign_out_url
+
+    # track costs without dealing with 'remember device'
+    Capybara.reset_session!
 
     visit_idp_from_sp_with_ial2(:oidc)
     fill_in_credentials_and_submit(email3, password)
@@ -72,7 +76,9 @@ feature 'SP Costing' do
     visit root_path
     create_ial1_user_directly(email5)
     SpCost.delete_all
-    visit sign_out_url
+
+    # track costs without dealing with 'remember device'
+    Capybara.reset_session!
 
     visit root_path
     fill_in_credentials_and_submit(email5, password)

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -39,6 +39,7 @@ module Features
       select_2fa_option('phone')
       fill_in 'new_phone_form_phone', with: '202-555-1212'
       click_send_security_code
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
       click_continue
@@ -228,6 +229,7 @@ module Features
 
     def sign_in_live_with_2fa(user = user_with_2fa)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
       user

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -600,5 +600,10 @@ module Features
         ial: ial,
       )
     end
+
+    def set_new_browser_session
+      # For when we want to login from a new browser to avoid the default 'remember device' behavior
+      Capybara.reset_session!
+    end
   end
 end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -97,6 +97,8 @@ shared_examples 'sp handoff after identity verification' do |sp|
     before do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
+
       fill_in_code_with_last_phone_otp
       click_submit_default
       fill_out_idv_jurisdiction_ok
@@ -111,6 +113,7 @@ shared_examples 'sp handoff after identity verification' do |sp|
     it 'does not require idv or requested attribute verification and hands off successfully' do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
 
       expect_csp_headers_to_be_present if sp == :oidc
 

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -42,6 +42,7 @@ shared_examples 'sp requesting attributes' do |sp|
     before do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
       fill_out_idv_jurisdiction_ok
@@ -56,6 +57,7 @@ shared_examples 'sp requesting attributes' do |sp|
     it 'does not require the user to verify attributes' do
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
 
@@ -72,6 +74,7 @@ shared_examples 'sp requesting attributes' do |sp|
       create(:profile, :active, :verified, user: user, pii: saved_pii)
       visit_idp_from_sp_with_ial2(sp)
       sign_in_user(user)
+      uncheck(t('forms.messages.remember_device'))
       fill_in_code_with_last_phone_otp
       click_submit_default
 

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -107,8 +107,7 @@ shared_examples 'signing in as IAL1 with personal key after resetting password' 
   it 'redirects to SP', email: true do
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
 
-    # Don't want to 'remember device'
-    Capybara.reset_session!
+    set_new_browser_session
 
     old_personal_key = PersonalKeyGenerator.new(user).create
     visit_idp_from_sp_with_ial1(sp)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -68,6 +68,8 @@ shared_examples 'signing in as IAL2 with personal key' do |sp|
     user = create_ial2_account_go_back_to_sp_and_sign_out(sp)
     pii = { ssn: '666-66-1234', dob: '1920-01-01', first_name: 'alice' }
 
+    Capybara.reset_sessions!
+
     visit_idp_from_sp_with_ial2(sp)
     fill_in_credentials_and_submit(user.email, user.password)
     choose_another_security_option('personal_key')
@@ -104,6 +106,10 @@ shared_examples 'signing in as IAL1 with personal key after resetting password' 
 
   it 'redirects to SP', email: true do
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
+
+    # Don't want to 'remember device'
+    Capybara.reset_session!
+
     old_personal_key = PersonalKeyGenerator.new(user).create
     visit_idp_from_sp_with_ial1(sp)
     trigger_reset_password_and_click_email_link(user.email)
@@ -242,6 +248,9 @@ def ial1_sign_in_with_personal_key_goes_to_sp(sp)
   Timecop.freeze Time.zone.now do
     user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
     old_personal_key = PersonalKeyGenerator.new(user).create
+
+    Capybara.reset_sessions!
+
     visit_idp_from_sp_with_ial1(sp)
     fill_in_credentials_and_submit(user.email, 'Val!d Pass w0rd')
     choose_another_security_option('personal_key')


### PR DESCRIPTION
**Why**:  We don't want users to have to keep multi-factoring if they are logging in from the same device, to reduce our SMS/phone reliance. So by default, "remember device" should be checked when the user first multi-factor authenticates,