### PR TITLE
cac proofing rejects_non-dod certs

### DIFF
--- a/app/controllers/idv/cac_controller.rb
+++ b/app/controllers/idv/cac_controller.rb
@@ -24,7 +24,7 @@ module Idv
       return unless request.path == idv_cac_step_path(:present_cac) && token
       data = PivCacService.decode_token(token)
       cn_array = PivCac::CnFieldsFromSubject.call(data['dn'])
-      if cn_array.size > 2
+      if cn_array.size > 2 && data['card_type'] == 'cac'
         process_cac_success(cn_array)
       else
         process_cac_fail

--- a/spec/features/idv/cac/present_cac_step_spec.rb
+++ b/spec/features/idv/cac/present_cac_step_spec.rb
@@ -22,6 +22,7 @@ feature 'cac proofing present cac step' do
 
   it 'proceeds to the next page' do
     allow(PivCacService).to receive(:decode_token).and_return(decoded_token)
+
     click_link t('forms.buttons.cac')
 
     expect(page.current_url.include?("/\?nonce=")).to eq(true)
@@ -42,7 +43,7 @@ feature 'cac proofing present cac step' do
     expect(page).to have_link(t('cac_proofing.errors.state_id'), href: idv_doc_auth_path)
   end
 
-  it 'does not proceed to the next page if not CAC card_type and allows doc auth' do
+  it 'does not proceed to the next page if card_type is not CAC' do
     decoded_token_piv = {
       'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
       'card_type' => 'piv',

--- a/spec/features/idv/cac/present_cac_step_spec.rb
+++ b/spec/features/idv/cac/present_cac_step_spec.rb
@@ -3,7 +3,13 @@ require 'rails_helper'
 feature 'cac proofing present cac step' do
   include CacProofingHelper
 
-  let(:decoded_token) { { 'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234' } }
+  let(:decoded_token) do
+    {
+      'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+      'card_type' => 'cac',
+    }
+  end
+
   before do
     enable_cac_proofing
     sign_in_and_2fa_user
@@ -26,6 +32,23 @@ feature 'cac proofing present cac step' do
   end
 
   it 'does not proceed to the next page with a bad CAC and allows doc auth' do
+    click_link t('forms.buttons.cac')
+
+    expect(page.current_url.include?("/\?nonce=")).to eq(true)
+
+    visit idv_cac_step_path(step: :present_cac, token: 'foo')
+
+    expect(page.current_path).to eq(idv_cac_proofing_present_cac_step)
+    expect(page).to have_link(t('cac_proofing.errors.state_id'), href: idv_doc_auth_path)
+  end
+
+  it 'does not proceed to the next page if not CAC card_type and allows doc auth' do
+    decoded_token_piv = {
+      'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+      'card_type' => 'piv',
+    }
+    allow(PivCacService).to receive(:decode_token).and_return(decoded_token_piv)
+
     click_link t('forms.buttons.cac')
 
     expect(page.current_url.include?("/\?nonce=")).to eq(true)

--- a/spec/support/features/cac_proofing_helper.rb
+++ b/spec/support/features/cac_proofing_helper.rb
@@ -44,7 +44,10 @@ module CacProofingHelper
   def complete_cac_proofing_steps_before_enter_info_step
     complete_cac_proofing_steps_before_present_cac_step
     click_link t('forms.buttons.cac')
-    decoded_token = { 'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234' }
+    decoded_token = {
+      'dn' => 'C=US, O=U.S. Government, OU=DoD, OU=PKI, CN=DOE.JOHN.1234',
+      'card_type' => 'cac',
+    }
     allow(PivCacService).to receive(:decode_token).and_return(decoded_token)
     visit idv_cac_step_path(step: :present_cac, token: 'foo')
   end


### PR DESCRIPTION
WHY:
Change the IdP to reject non-DoD certs