### PR TITLE
Use a well formed blob for the PIV/CAC URL in the CSP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       parallel
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    pg (1.2.2)
+    pg (1.1.4)
     phonelib (0.6.39)
     pkcs11 (0.2.7)
     premailer (1.11.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       parallel
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    pg (1.1.4)
+    pg (1.2.2)
     phonelib (0.6.39)
     pkcs11 (0.2.7)
     premailer (1.11.1)

--- a/app/controllers/concerns/secure_headers_concern.rb
+++ b/app/controllers/concerns/secure_headers_concern.rb
@@ -19,6 +19,7 @@ module SecureHeadersConcern
   end
 
   def csp_uris
+    return ["'self'"] if stored_url_for_user.blank?
     # Returns fully formed CSP array w/"'self'" and redirect_uris
     SecureHeadersWhitelister.csp_with_sp_redirect_uris(
       authorize_params[:redirect_uri],

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -9,7 +9,7 @@ module Users
     before_action :authenticate_user!
     before_action :confirm_user_authenticated_for_2fa_setup, except: :redirect_to_piv_cac_service
     before_action :authorize_piv_cac_disable, only: :delete
-    before_action :apply_secure_headers_override, only: :new
+    before_action :set_piv_cac_setup_csp_form_action_uris, only: :new
     before_action :cap_piv_cac_count, only: %i[new submit_new_piv_cac]
 
     def new

--- a/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
+++ b/app/controllers/users/piv_cac_setup_from_sign_in_controller.rb
@@ -4,7 +4,8 @@ module Users
     include SecureHeadersConcern
 
     before_action :confirm_two_factor_authenticated
-    before_action :apply_secure_headers_override, only: %i[prompt success]
+    before_action :apply_secure_headers_override, only: :success
+    before_action :set_piv_cac_setup_csp_form_action_uris, only: :prompt
 
     def prompt
       if params.key?(:token)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,18 +6,10 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
-  # On the development environment only we allow 'https://*' to hop over to identity-pki
-  form_action = if Rails.env.development?
-                  ["'self'", 'https://*']
-                else
-                  ["'self'",
-                   "https://*.pivcac.#{LoginGov::Hostdata.env}.#{LoginGov::Hostdata.domain}"]
-                end
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
-    form_action: form_action,
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: [
       "'self'",

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,8 +11,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
                   ["'self'", 'https://*']
                 else
                   ["'self'",
-                   'https://*.pivcac.*.identitysandbox.gov',
-                   'https://*.pivcac.*.login.gov']
+                   "https://*.pivcac.#{LoginGov::Hostdata.env}.#{LoginGov::Hostdata.domain}"]
                 end
   default_csp_config = {
     default_src: ["'self'"],

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -19,11 +19,17 @@ feature 'PIV/CAC Management' do
       end
 
       scenario 'allows association of a piv/cac with an account' do
+        allow(LoginGov::Hostdata).to receive(:env).and_return('test')
+        allow(LoginGov::Hostdata).to receive(:domain).and_return('example.com')
+
         stub_piv_cac_service
 
         sign_in_and_2fa_user(user)
         visit account_path
         click_link t('forms.buttons.enable'), href: setup_piv_cac_url
+
+        expect(page.response_headers['Content-Security-Policy']).
+          to(include("form-action https://*.pivcac.test.example.com 'self';"))
 
         nonce = piv_cac_nonce_from_form_action
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -89,8 +89,10 @@ feature 'Sign in' do
 
     perform_steps_to_get_to_add_piv_cac_during_sign_up
 
+    # rubocop:disable Metrics/LineLength
     expected_form_action =
       "form-action https://*.pivcac.test.example.com 'self' http://localhost:7654/auth/result https://example.com;"
+    # rubocop:enable Metrics/LineLength
 
     expect(page.response_headers['Content-Security-Policy']).
       to(include(expected_form_action))

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -83,6 +83,19 @@ feature 'Sign in' do
     expect(current_path).to eq login_piv_cac_did_not_work_path
   end
 
+  scenario 'user opts to add piv/cac card and has piv cac redirect in CSP' do
+    allow(LoginGov::Hostdata).to receive(:env).and_return('test')
+    allow(LoginGov::Hostdata).to receive(:domain).and_return('example.com')
+
+    perform_steps_to_get_to_add_piv_cac_during_sign_up
+
+    expected_form_action =
+      "form-action https://*.pivcac.test.example.com 'self' http://localhost:7654/auth/result https://example.com;"
+
+    expect(page.response_headers['Content-Security-Policy']).
+      to(include(expected_form_action))
+  end
+
   scenario 'user attempts sign in with a PIV/CAC on mobile' do
     allow(DeviceDetector).to receive(:new).and_return(mobile_device)
     visit root_path


### PR DESCRIPTION
**Why**: Apparently having a `*` character in the middle of the blob makes everything break. This commit attempts to fix that.