### PR TITLE
LG-2392 Add rate limit screen for doc auth image upload

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -121,7 +121,7 @@ module Idv
       end
 
       def throttle_post_front_image
-        return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled_else_increment
+        return throttled if throttled_else_increment
         rescue_network_errors do
           result = assure_id.post_front_image(image.read)
           add_cost(:acuant_front_image)
@@ -130,12 +130,17 @@ module Idv
       end
 
       def throttle_post_back_image
-        return [false, I18n.t('errors.doc_auth.acuant_throttle')] if throttled_else_increment
+        return throttled if throttled_else_increment
         rescue_network_errors do
           result = assure_id.post_back_image(image.read)
           add_cost(:acuant_back_image)
           result
         end
+      end
+
+      def throttled
+        redirect_to idv_session_errors_throttled_url
+        [false, I18n.t('errors.doc_auth.acuant_throttle')]
       end
 
       def test_credentials?

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -4,13 +4,9 @@
 
 <h1 class="h3 mb1 mt3 my0"><%= t('errors.doc_auth.acuant_throttle') %></h1>
 
-<div class="col-2">
-  <hr class="mt3 mb2 bw4 rounded border-red" />
-</div>
+<div class="col-2"><hr class="mt3 mb2 bw4 rounded border-red" /></div>
 
-<h2 class="h4 mb2 mt3 my0">
-  <%= t('headings.lock_failure') %>
-</h2>
+<h2 class="h4 mb2 mt3 my0"><%= t('headings.lock_failure') %></h2>
 
 <hr>
 

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,10 +1,8 @@
-<% title t("idv.failure.sessions.heading") %>
+<% title t('errors.doc_auth.acuant_throttle') %>
 
 <%= image_tag('alert/fail-x.svg', width: 54) %>
 
-<h1 class="h3 mb1 mt3 my0"><%= t("idv.failure.sessions.heading") %></h1>
-
-<p><%= t('errors.doc_auth.acuant_throttle') %></p>
+<h1 class="h3 mb1 mt3 my0"><%= t('errors.doc_auth.acuant_throttle') %></h1>
 
 <div class="col-2">
   <hr class="mt3 mb2 bw4 rounded border-red" />

--- a/app/views/idv/session_errors/throttled.html.erb
+++ b/app/views/idv/session_errors/throttled.html.erb
@@ -1,0 +1,26 @@
+<% title t("idv.failure.sessions.heading") %>
+
+<%= image_tag('alert/fail-x.svg', width: 54) %>
+
+<h1 class="h3 mb1 mt3 my0"><%= t("idv.failure.sessions.heading") %></h1>
+
+<p><%= t('errors.doc_auth.acuant_throttle') %></p>
+
+<div class="col-2">
+  <hr class="mt3 mb2 bw4 rounded border-red" />
+</div>
+
+<h2 class="h4 mb2 mt3 my0">
+  <%= t('headings.lock_failure') %>
+</h2>
+
+<hr>
+
+<p>
+  <%= t('idv.failure.errors.text_html',
+    link: link_to(t('idv.failure.errors.link'), MarketingSite.contact_url)) %>
+</p>
+
+<%= render 'idv/shared/back_to_sp_link' %>
+
+<%= render 'idv/doc_auth/in_person_proofing_option' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,7 @@ Rails.application.routes.draw do
       get '/session/errors/timeout' => 'session_errors#timeout'
       get '/session/errors/jobfail' => 'session_errors#jobfail'
       get '/session/errors/failure' => 'session_errors#failure'
+      get '/session/errors/throttled' => 'session_errors#throttled'
       delete '/session' => 'sessions#destroy'
       get '/jurisdiction' => 'jurisdiction#new'
       post '/jurisdiction' => 'jurisdiction#create'

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -91,6 +91,7 @@ shared_examples 'back image step' do |simulate|
         click_idv_continue
 
         expect(page).to have_current_path(idv_doc_auth_ssn_step)
+
         click_on t('doc_auth.buttons.start_over')
         complete_doc_auth_steps_before_back_image_step
       end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -95,10 +95,7 @@ shared_examples 'back image step' do |simulate|
         complete_doc_auth_steps_before_back_image_step
       end
 
-      attach_image
-      click_idv_continue
-
-      expect(page).to have_current_path(idv_doc_auth_front_image_step)
+      expect(page).to have_current_path(idv_session_errors_throttled_path)
 
       Timecop.travel((Figaro.env.acuant_attempt_window_in_minutes.to_i + 1).minutes.from_now) do
         sign_in_and_2fa_user(user)

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -70,7 +70,7 @@ shared_examples 'front image step' do |simulate|
       attach_image
       click_idv_continue
 
-      expect(page).to have_current_path(idv_doc_auth_front_image_step)
+      expect(page).to have_current_path(idv_session_errors_throttled_path)
 
       Timecop.travel(Figaro.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
         sign_in_and_2fa_user(user)


### PR DESCRIPTION
**Why**: So users don't attempt to upload the document again and ignore the flash message
**How**: Hook into the code that checks the throttled state and issue a redirect to the new error page
