### PR TITLE
(LG-2549) Fix PIV/CAC setup page

### DIFF
--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
@@ -8,13 +8,14 @@ p.mt2.mb2 == t('instructions.mfa.piv_cac.add_from_sign_in')
 .mt3
   .inline-block
     = form_tag(submit_new_piv_cac_url) do
-      = label_tag 'code', t('forms.webauthn_setup.nickname'), class: 'block bold'
+      = label_tag 'code', t('forms.piv_cac_setup.nickname'), class: 'block bold'
       = text_field_tag :name, '', required: true, id: 'nickname',
               class: 'block col-12 field monospace', size: 16, maxlength: 20,
               'aria-labelledby': 'totp-label'
-      = submit_tag t('forms.piv_cac_setup.submit'), class: 'btn btn-primary'
-  .inline-block
-    = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
-      class: 'usa-button usa-button--outline'
+      .mt2
+        = submit_tag t('forms.piv_cac_setup.submit'), class: 'btn btn-primary mr1'
+        .inline-block
+          = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
+            class: 'btn btn-secondary'
 
 = render 'shared/cancel', link: new_user_session_url

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -98,6 +98,7 @@ en:
         unverified_html: Please choose a different certificate from your PIV/CAC or
           contact your administrator to ensure your certificate is up to date.
       choose_different_certificate: Choose a different certificate
+      nickname: PIV/CAC nickname
       no_thanks: No thanks
       piv_cac:
         already_associated_html: Please choose a certificate from a different PIV/CAC

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -106,6 +106,7 @@ es:
           contacto con su administrador para asegurarse de que su certificado esté
           actualizado.
       choose_different_certificate: Elija un certificado diferente
+      nickname: Apodo PIV/CAC
       no_thanks: No, gracias
       piv_cac:
         already_associated_html: Elige un certificado de una PIV/CAC distinta o ponte

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -108,6 +108,7 @@ fr:
           ou contactez votre administrateur pour vous assurer que votre certificat
           est à jour.
       choose_different_certificate: Choisissez un certificat différent
+      nickname: Pseudo PIV/CAC
       no_thanks: Non merci
       piv_cac:
         already_associated_html: Veuillez choisir un certificat associé à une autre


### PR DESCRIPTION
**Why**: The copy was misleading and the form styles
were inconsistent


Before
![image-2020-01-24-10-42-52-251](https://user-images.githubusercontent.com/458784/73700817-6dd8f900-469c-11ea-8087-2543757cf3ff.png)


After
<img width="642" alt="Screen Shot 2020-02-03 at 3 34 13 PM" src="https://user-images.githubusercontent.com/458784/73700833-792c2480-469c-11ea-84f4-22a6ce08b691.png">
