### PR TITLE
Log the telephony responses

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -135,6 +135,7 @@ module Users
     end
 
     def handle_telephony_result(method:, default:)
+      analytics.track_event(Analytics::TELEPHONY_OTP_SENT, @telephony_result.to_h)
       if @telephony_result.success?
         redirect_to login_two_factor_url(
           otp_delivery_preference: method,

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -169,6 +169,7 @@ class Analytics
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
+  TELEPHONY_OTP_SENT = 'Telephony: OTP sent'.freeze
   TOTP_SETUP_VISIT = 'TOTP Setup Visited'.freeze
   TOTP_USER_DISABLED = 'TOTP: User Disabled TOTP'.freeze
   TWILIO_PHONE_VALIDATION_FAILED = 'Twilio Phone Validation Failed'.freeze

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -180,7 +180,11 @@ describe Users::TwoFactorAuthenticationController do
         }
 
         expect(@analytics).to receive(:track_event).
+          ordered.
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
+        expect(@analytics).to receive(:track_event).
+          ordered.
+          with(Analytics::TELEPHONY_OTP_SENT, hash_including(success: true))
 
         get :send_code, params: { otp_delivery_selection_form: { otp_delivery_preference: 'sms' } }
       end
@@ -252,7 +256,11 @@ describe Users::TwoFactorAuthenticationController do
         }
 
         expect(@analytics).to receive(:track_event).
+          ordered.
           with(Analytics::OTP_DELIVERY_SELECTION, analytics_hash)
+        expect(@analytics).to receive(:track_event).
+          ordered.
+          with(Analytics::TELEPHONY_OTP_SENT, hash_including(success: true))
 
         get :send_code, params: {
           otp_delivery_selection_form: { otp_delivery_preference: 'voice',


### PR DESCRIPTION
**Why**: So that we can use them to collect info when things go wrong. For example, we can provide Pinpoint with the request IDs for a user who reports that they cannot receive an SMS

This was supposed to be done by #3544, but I forgot to add this line.