### PR TITLE
Make the SP cost specs proper feature specs

### DIFF
--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'SP Costing' do
+feature 'SP Costing', :email do
   include SpAuthHelper
   include SamlAuthHelper
   include IdvHelper
@@ -13,15 +13,11 @@ feature 'SP Costing' do
 
   let(:issuer) { 'urn:gov:gsa:openidconnect:sp:server' }
   let(:agency_id) { 2 }
-  let(:email1) { 'test@test.com' }
-  let(:email2) { 'test2@test.com' }
-  let(:email3) { 'test3@test.com' }
-  let(:email4) { 'test4@test.com' }
-  let(:email5) { 'test5@test.com' }
+  let(:email) { 'test@test.com' }
   let(:password) { Features::SessionHelper::VALID_PASSWORD }
 
   it 'logs the correct costs for an ial1 user creation from sp with oidc' do
-    create_ial1_user_from_sp(email1)
+    create_ial1_user_from_sp(email)
 
     expect_sp_cost_type(0, 1, 'sms')
     expect_sp_cost_type(1, 1, 'user_added')
@@ -29,7 +25,7 @@ feature 'SP Costing' do
   end
 
   it 'logs the correct costs for an ial2 user creation from sp with oidc' do
-    create_ial2_user_from_sp(email2)
+    create_ial2_user_from_sp(email)
 
     expect_sp_cost_type(0, 2, 'sms')
     expect_sp_cost_type(1, 2, 'acuant_front_image')
@@ -41,14 +37,14 @@ feature 'SP Costing' do
   end
 
   it 'logs the correct costs for an ial1 authentication' do
-    create_ial1_user_from_sp(email4)
+    create_ial1_user_from_sp(email)
     SpCost.delete_all
 
     # track costs without dealing with 'remember device'
     Capybara.reset_session!
 
     visit_idp_from_sp_with_ial1(:oidc)
-    fill_in_credentials_and_submit(email4, password)
+    fill_in_credentials_and_submit(email, password)
     fill_in_code_with_last_phone_otp
     click_submit_default
 
@@ -57,14 +53,14 @@ feature 'SP Costing' do
   end
 
   it 'logs the correct costs for an ial2 authentication' do
-    create_ial2_user_from_sp(email3)
+    create_ial2_user_from_sp(email)
     SpCost.delete_all
 
     # track costs without dealing with 'remember device'
     Capybara.reset_session!
 
     visit_idp_from_sp_with_ial2(:oidc)
-    fill_in_credentials_and_submit(email3, password)
+    fill_in_credentials_and_submit(email, password)
     fill_in_code_with_last_phone_otp
     click_submit_default
 
@@ -74,14 +70,14 @@ feature 'SP Costing' do
 
   it 'logs the correct costs for a direct authentication' do
     visit root_path
-    create_ial1_user_directly(email5)
+    create_ial1_user_directly(email)
     SpCost.delete_all
 
     # track costs without dealing with 'remember device'
     Capybara.reset_session!
 
     visit root_path
-    fill_in_credentials_and_submit(email5, password)
+    fill_in_credentials_and_submit(email, password)
     fill_in_code_with_last_phone_otp
     click_submit_default
 


### PR DESCRIPTION
**Why**: The tests were written like feature specs but in the services directory so rspec was treating them like unit tests. This commit moves them into the features directory so RSpec knows they are feature tests.

This commit also adds the `:email` flag to the specs since they use the test inbox which needs to be cleared between examples.