### PR TITLE
Remove typo in authenticator setup screen

### DIFF
--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -36,7 +36,7 @@
             <%= t('links.copy') %>
           </div>
         </div>
-        <div class="py2 center bold"><%= t('instructions.mfa.authenticator.or') %>></div>
+        <div class="py2 center bold"><%= t('instructions.mfa.authenticator.or') %></div>
         <%= accordion('totp-info', t('instructions.mfa.authenticator.accordion_header'),
                       wrapper_css: 'mb2 col-12 fs-16p') do %>
           <div class="center">


### PR DESCRIPTION
**Why**
Typo in authentication app set up step 3