### PR TITLE
LG-2041: logs event on authentication confirmation

### DIFF
--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -5,6 +5,7 @@ module Users
     before_action :bump_auth_count
 
     def show
+      analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION)
       @sp = ServiceProvider.find_by(issuer: sp_session[:issuer]) if sp_session
     end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -72,6 +72,7 @@ class Analytics
   ADD_EMAIL_CONFIRMATION = 'Add Email: Email Confirmation'.freeze
   ADD_EMAIL_CONFIRMATION_RESEND = 'Add Email: Email Confirmation requested due to invalid token'.freeze
   ADD_EMAIL_VISIT = 'Add Email: enter email visited'.freeze
+  AUTHENTICATION_CONFIRMATION = 'Authentication Confirmation'.freeze
   CAC_PROOFING = 'CAC Proofing'.freeze # visited or submitted is appended
   CAPTURE_DOC = 'Capture Doc'.freeze # visited or submitted is appended
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended


### PR DESCRIPTION
A quick PR to log an event when users hit the auth confirmation page so we can track how often we're actually landing here.