### PR TITLE
Redirect users who visit authentication confirmation unauthenticated

### DIFF
--- a/app/controllers/users/authorization_confirmation_controller.rb
+++ b/app/controllers/users/authorization_confirmation_controller.rb
@@ -3,6 +3,7 @@ module Users
     include AuthorizationCountConcern
 
     before_action :bump_auth_count
+    before_action :confirm_two_factor_authenticated
 
     def show
       analytics.track_event(Analytics::AUTHENTICATION_CONFIRMATION)

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -51,6 +51,19 @@ feature 'OIDC Authorization Confirmation' do
 
       expect(current_url).to match('http://localhost:7654/auth/result')
     end
+
+    it 'does not render an error if a user goes back after opting to switch accounts' do
+      sign_in_user(user1)
+      visit_idp_from_oidc_sp
+
+      expect(current_path).to eq(user_authorization_confirmation_path)
+
+      click_button t('user_authorization_confirmation.sign_in')
+      # Simulate clicking the back button by going right back to the original path
+      visit user_authorization_confirmation_path
+
+      expect(current_path).to eq(new_user_session_path)
+    end
   end
 
   def sign_in_oidc_user(user)

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -56,5 +56,18 @@ feature 'SAML Authorization Confirmation' do
 
       expect(current_url).to eq(saml_authn_request)
     end
+
+    it 'does not render an error if a user goes back after opting to switch accounts' do
+      sign_in_user(user1)
+      visit saml_authn_request
+
+      expect(current_path).to eq(user_authorization_confirmation_path)
+
+      click_button t('user_authorization_confirmation.sign_in')
+      # Simulate clicking the back button by going right back to the original path
+      visit user_authorization_confirmation_path
+
+      expect(current_path).to eq(new_user_session_path)
+    end
   end
 end


### PR DESCRIPTION
**Why**: Users should not be able to get to this part of the auth flow unauthenticated. We've seen some 500 errors from users who click the "Switch emails" button. This button logs them out. Then they click the back button and 500 on a call to `current_user.email`.