### PR TITLE
LG-2386: Shorten the header on the email sent screen in doc auth recovery flow

### DIFF
--- a/app/views/account_reset/recover/email_sent.html.slim
+++ b/app/views/account_reset/recover/email_sent.html.slim
@@ -1,5 +1,7 @@
 - title t('doc_auth.titles.doc_auth')
 
-= image_tag(asset_url('check-email.svg'), width: 96)
+= image_tag(asset_url('check-email.svg'), width: 48)
 
-h1.h3.mb2.mt3.my0 = t('recover.request.email_sent', email: current_user.email)
+h1.h3.mb2.mt3.my0 = t('recover.request.email_check')
+
+p.mt-tiny.mb0 = t('recover.request.email_sent', email: current_user.email)

--- a/app/views/account_reset/recover/email_sent.html.slim
+++ b/app/views/account_reset/recover/email_sent.html.slim
@@ -1,7 +1,5 @@
 - title t('doc_auth.titles.doc_auth')
 
-= image_tag(asset_url('check-email.svg'), width: 48)
+= image_tag(asset_url('check-email.svg'), width: 96)
 
-h1.h3.mb2.mt3.my0 = t('recover.request.email_check')
-
-p.mt-tiny.mb0 = t('recover.request.email_sent', email: current_user.email)
+h1.h3.mb2.mt3.my0 = t('recover.request.email_sent', email: current_user.email)

--- a/config/locales/recover/en.yml
+++ b/config/locales/recover/en.yml
@@ -27,7 +27,8 @@ en:
     request:
       confirm_email: First, let's confirm your email address
       email_check: Check your email
-      email_sent: We sent an email to %{email} with a link to confirm your email address. Follow the link to continue re-verifying your identity.
+      email_sent: We sent an email to %{email} with a link to confirm your email address.
+        Follow the link to continue re-verifying your identity.
       instructions: We'll send an email to the address we have on file for this account.
         Once you receive the email, click the link inside to continue re-verifying
         your account.

--- a/config/locales/recover/en.yml
+++ b/config/locales/recover/en.yml
@@ -26,8 +26,8 @@ en:
       heading: We need to re-verify your identity
     request:
       confirm_email: First, let's confirm your email address
-      email_sent: Link sent to %{email}. Please check your email and follow instructions
-        to re-verify your identity.
+      email_check: Check your email
+      email_sent: We sent an email to %{email} with a link to confirm your email address. Follow the link in the email to continue re-verifying your identity.
       instructions: We'll send an email to the address we have on file for this account.
         Once you receive the email, click the link inside to continue re-verifying
         your account.

--- a/config/locales/recover/en.yml
+++ b/config/locales/recover/en.yml
@@ -27,7 +27,7 @@ en:
     request:
       confirm_email: First, let's confirm your email address
       email_check: Check your email
-      email_sent: We sent an email to %{email} with a link to confirm your email address. Follow the link in the email to continue re-verifying your identity.
+      email_sent: We sent an email to %{email} with a link to confirm your email address. Follow the link to continue re-verifying your identity.
       instructions: We'll send an email to the address we have on file for this account.
         Once you receive the email, click the link inside to continue re-verifying
         your account.

--- a/config/locales/recover/en.yml
+++ b/config/locales/recover/en.yml
@@ -26,8 +26,8 @@ en:
       heading: We need to re-verify your identity
     request:
       confirm_email: First, let's confirm your email address
-      email_check: Check your email
-      email_sent: We sent an email to %{email} with a link to confirm your email address. Follow the link in the email to continue re-verifying your identity.
+      email_sent: Link sent to %{email}. Please check your email and follow instructions
+        to re-verify your identity.
       instructions: We'll send an email to the address we have on file for this account.
         Once you receive the email, click the link inside to continue re-verifying
         your account.

--- a/config/locales/recover/es.yml
+++ b/config/locales/recover/es.yml
@@ -28,6 +28,7 @@ es:
       heading: Necesitamos volver a verificar su identidad
     request:
       confirm_email: Primero, confirmemos tu dirección de correo electrónico
+      email_check: Por favor revise su correo electrónico
       email_sent: Enlace enviado a %{email}. Por favor revise su correo electrónico
         y siga las instrucciones para volver a verificar su identidad.
       instructions: Enviaremos un correo electrónico a la dirección que tenemos registrada

--- a/config/locales/recover/fr.yml
+++ b/config/locales/recover/fr.yml
@@ -28,6 +28,7 @@ fr:
       heading: Nous devons revérifier votre identité
     request:
       confirm_email: D'abord, confirmons votre adresse email
+      email_check: Veuillez vérifier votre courrier électronique
       email_sent: Lien envoyé à %{email}. Veuillez vérifier votre courrier électronique
         et suivez les instructions pour vérifier votre identité.
       instructions: Nous enverrons un courrier électronique à l'adresse indiquée pour


### PR DESCRIPTION
**Why:** As a user verifying my identity to recover my IAL2 account, I want the email sent screen to have a short header and body paragraph, so that it is easier to read at a glance.

**How:** Shorten using the new content

- **Header:** Check your email
- **Body:** We sent an email to name@agency.gov with a link to confirm your email address. Follow the link to continue re-verifying your identity.

Notes:

- Proposed to reduce email icon to match more in visual style with the other 'Step 1 of 4' create your account screen

-----

## Current

![LG-2386-Current](https://user-images.githubusercontent.com/6327082/73989096-425b4600-490a-11ea-8948-bf376c7bdb8a.png)


## Proposed

![LG-2386-Proposed](https://user-images.githubusercontent.com/6327082/73989102-471ffa00-490a-11ea-88bd-3c1173c11874.png)
