### PR TITLE
LG-2564 LG-2565 IALMAX for SAML and OIDC

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -43,6 +43,7 @@ module SignUp
         decorated_session: decorated_session,
         current_user: current_user,
         handoff: new_service_provider_attributes,
+        ialmax_requested: ialmax?,
       )
     end
 
@@ -52,6 +53,10 @@ module SignUp
 
     def ial2?
       sp_session[:ial2] == true
+    end
+
+    def ialmax?
+      sp_session[:ialmax] == true
     end
 
     def return_to_account

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -166,9 +166,10 @@ class OpenidConnectAuthorizeForm
   end
 
   def validate_privileges
-    return unless ial2_requested? && service_provider.ial != 2
-    return unless ialmax_requested? && service_provider.ial != 2
-    errors.add(:acr_values, t('openid_connect.authorization.errors.no_auth'))
+    if (ial2_requested? && service_provider.ial != 2) ||
+       (ialmax_requested? && service_provider.ial != 2)
+      errors.add(:acr_values, t('openid_connect.authorization.errors.no_auth'))
+    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -58,7 +58,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def ialmax_requested?
-    ial == 0
+    ial.zero?
   end
 
   def service_provider

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -161,7 +161,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def scopes
-    return OpenidConnectAttributeScoper::VALID_SCOPES if ial2_requested? || ialmax_requested?
+    return OpenidConnectAttributeScoper::VALID_SCOPES if ialmax_requested? || ial2_requested?
     OpenidConnectAttributeScoper::VALID_IAL1_SCOPES
   end
 

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -58,7 +58,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def ialmax_requested?
-    ial.zero?
+    ial&.zero?
   end
 
   def service_provider

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -95,7 +95,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ialmax_session?
-    identity.ial.zero?
+    identity.ial&.zero?
   end
 
   def x509_data

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -82,7 +82,7 @@ class OpenidConnectUserInfoPresenter
 
   def ial2_data
     @ial2_data ||= begin
-      if ial2_session?
+      if ial2_session? || ialmax_session?
         Pii::SessionStore.new(identity.rails_session_id).load
       else
         Pii::Attributes.new_from_hash({})
@@ -92,6 +92,10 @@ class OpenidConnectUserInfoPresenter
 
   def ial2_session?
     identity.ial == 2
+  end
+
+  def ialmax_session?
+    identity.ial == 0
   end
 
   def x509_data

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -95,7 +95,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def ialmax_session?
-    identity.ial == 0
+    identity.ial.zero?
   end
 
   def x509_data

--- a/app/presenters/saml_request_presenter.rb
+++ b/app/presenters/saml_request_presenter.rb
@@ -20,7 +20,7 @@ class SamlRequestPresenter
   end
 
   def requested_attributes
-    return [:email] unless ial2_authn_context?
+    return [:email] unless ial2_authn_context? || ialmax_authn_context?
     bundle.map { |attr| ATTRIBUTE_TO_FRIENDLY_NAME_MAP[attr] }.compact.uniq
   end
 
@@ -30,6 +30,10 @@ class SamlRequestPresenter
 
   def ial2_authn_context?
     Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include? authn_context
+  end
+
+  def ialmax_authn_context?
+    Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == authn_context
   end
 
   def authn_context

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -51,6 +51,8 @@ class IdTokenBuilder
   def acr
     ial = identity.ial
     case ial
+    when 0
+      Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
     when 1
       Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
     when 2

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -51,12 +51,9 @@ class IdTokenBuilder
   def acr
     ial = identity.ial
     case ial
-    when 0
-      Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
-    when 1
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
-    when 2
-      Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+    when 0 then Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+    when 1 then Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+    when 2 then Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     else
       raise "Unknown ial #{ial}"
     end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -32,6 +32,7 @@ class StoreSpMetadataInSession
     session[:sp] = {
       issuer: sp_request.issuer,
       ial2: ial2_requested?,
+      ialmax: ial2_requested?,
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
@@ -39,6 +40,10 @@ class StoreSpMetadataInSession
   end
 
   def ial2_requested?
+    Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == sp_request.ial
+  end
+
+  def ialmax_requested?
     Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include? sp_request.ial
   end
 end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -39,11 +39,11 @@ class StoreSpMetadataInSession
     }
   end
 
-  def ial2_requested?
+  def ialmax_requested?
     Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF == sp_request.ial
   end
 
-  def ialmax_requested?
+  def ial2_requested?
     Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include? sp_request.ial
   end
 end

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -32,7 +32,7 @@ class StoreSpMetadataInSession
     session[:sp] = {
       issuer: sp_request.issuer,
       ial2: ial2_requested?,
-      ialmax: ial2_requested?,
+      ialmax: ialmax_requested?,
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -70,7 +70,8 @@ class SignUpCompletionsShow
   end
 
   def sorted_attribute_mapping
-    ial2_requested || ialmax_requested ? SORTED_IAL2_ATTRIBUTE_MAPPING : SORTED_IAL1_ATTRIBUTE_MAPPING
+    return SORTED_IAL2_ATTRIBUTE_MAPPING if ial2_requested || ialmax_requested
+    SORTED_IAL1_ATTRIBUTE_MAPPING
   end
 
   def identities_partial

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -1,14 +1,15 @@
 class SignUpCompletionsShow
   include ActionView::Helpers::TagHelper
 
-  def initialize(ial2_requested:, decorated_session:, current_user:, handoff:)
+  def initialize(ial2_requested:, decorated_session:, current_user:, handoff:, ialmax_requested:)
     @ial2_requested = ial2_requested
     @decorated_session = decorated_session
     @current_user = current_user
     @handoff = handoff
+    @ialmax_requested = ialmax_requested
   end
 
-  attr_reader :ial2_requested, :decorated_session
+  attr_reader :ial2_requested, :ialmax_requested, :decorated_session
 
   SORTED_IAL2_ATTRIBUTE_MAPPING = [
     [%i[given_name family_name], :full_name],
@@ -69,7 +70,7 @@ class SignUpCompletionsShow
   end
 
   def sorted_attribute_mapping
-    ial2_requested ? SORTED_IAL2_ATTRIBUTE_MAPPING : SORTED_IAL1_ATTRIBUTE_MAPPING
+    ial2_requested || ialmax_requested ? SORTED_IAL2_ATTRIBUTE_MAPPING : SORTED_IAL1_ATTRIBUTE_MAPPING
   end
 
   def identities_partial

--- a/app/views/sign_up/completions/_requested_attributes.html.slim
+++ b/app/views/sign_up/completions/_requested_attributes.html.slim
@@ -1,5 +1,6 @@
 ul.mb3.list-reset.border-bottom.success-bullets.requested-attributes
   - view_model.requested_attributes_sorted.each do |attribute|
+    - next if @pii[attribute].blank?
     li.border-top
       span.bold
         = t("help_text.requested_attributes.#{attribute}")

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -121,7 +121,7 @@ unauthorized_scope_enabled: 'false'
 usps_download_sftp_timeout: '5'
 usps_upload_enabled: 'false'
 usps_upload_sftp_timeout: '5'
-valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2"]'
+valid_authn_contexts: '["http://idmanagement.gov/ns/assurance/loa/1", "http://idmanagement.gov/ns/assurance/loa/3", "http://idmanagement.gov/ns/assurance/ial/1", "http://idmanagement.gov/ns/assurance/ial/2", "http://idmanagement.gov/ns/assurance/ial/0"]'
 
 development:
   aamva_private_key: 123abc

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -6,6 +6,7 @@ module Saml
       LOA3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'.freeze
       IAL1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/1'.freeze
       IAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/2'.freeze
+      IALMAX_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/ial/0'.freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
         expect(session[:sp]).to eq(
           ial2: false,
+          ialmax: false,
           issuer: 'urn:gov:gsa:openidconnect:test',
           request_id: sp_request_id,
           request_url: request.original_url,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -306,6 +306,7 @@ describe SamlIdpController do
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
           ial2: false,
+          ialmax: false,
           request_url: @stored_request_url,
           request_id: sp_request_id,
           requested_attributes: ['email'],
@@ -325,6 +326,7 @@ describe SamlIdpController do
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
           ial2: false,
+          ialmax: false,
           request_url: @saml_request.request.original_url,
           request_id: sp_request_id,
           requested_attributes: ['email'],

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -808,6 +808,39 @@ feature 'Sign in' do
     end
   end
 
+  context 'saml sp requests ialmax' do
+    it 'returns ial1 info for a non-verified user' do
+      user = create(:user, :signed_up)
+      visit_idp_from_saml_sp_with_ialmax
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_content(user.email)
+
+      click_continue
+
+      expect(current_url).to eq @saml_authn_request
+    end
+
+    it 'returns ial2 info for a verified user' do
+      user = create(:profile, :active, :verified,
+                    pii: { first_name: 'John', ssn: '111223333' }).user
+      visit_idp_from_saml_sp_with_ialmax
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_content('111223333')
+
+      click_continue
+
+      expect(current_url).to eq @saml_authn_request
+    end
+  end
+
   def perform_steps_to_get_to_add_piv_cac_during_sign_up
     user = create(:user, :signed_up, :with_phone)
     visit_idp_from_sp_with_ial1(:oidc)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -24,6 +24,12 @@ feature 'Sign in' do
     expect(page).to_not have_content t('devise.registrations.start.accordion')
   end
 
+  scenario 'user signs in as ialmax and does not see ial2 help text' do
+    visit_idp_from_oidc_sp_with_ialmax
+
+    expect(page).to_not have_content t('devise.registrations.start.accordion')
+  end
+
   scenario 'user signs in as ial2 and does see ial2 help text' do
     visit_idp_from_sp_with_ial2(:oidc)
 
@@ -766,6 +772,39 @@ feature 'Sign in' do
       click_submit_default
 
       expect(current_url).to eq account_url
+    end
+  end
+
+  context 'oidc sp requests ialmax' do
+    it 'returns ial1 info for a non-verified user' do
+      user = create(:user, :signed_up)
+      visit_idp_from_oidc_sp_with_ialmax
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_content(user.email)
+
+      click_continue
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
+    end
+
+    it 'returns ial2 info for a verified user' do
+      user = create(:profile, :active, :verified,
+                    pii: { first_name: 'John', ssn: '111223333' }).user
+      visit_idp_from_oidc_sp_with_ialmax
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_content('111223333')
+
+      click_continue
+
+      expect(current_url).to start_with('http://localhost:7654/auth/result')
     end
   end
 

--- a/spec/services/remote_settings_service_spec.rb
+++ b/spec/services/remote_settings_service_spec.rb
@@ -4,7 +4,7 @@ describe RemoteSettingsService do
   subject(:service) { RemoteSettingsService }
 
   describe '.load_yml_erb' do
-    xit 'loads the remote location' do
+    it 'loads the remote location' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).to_return(body: Rails.root.join('config', 'agencies.yml').read)
 
@@ -64,7 +64,7 @@ describe RemoteSettingsService do
   end
 
   describe '.update_setting' do
-    xit 'it creates a setting if it does not exist' do
+    it 'it creates a setting if it does not exist' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).
         to_return(body: Rails.root.join('config', 'agencies.localdev.yml'))
@@ -73,7 +73,7 @@ describe RemoteSettingsService do
       expect(RemoteSetting.find_by(name: 'agencies.yml').url).to eq(location)
     end
 
-    xit 'it updates the setting if it exists' do
+    it 'it updates the setting if it exists' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).
         to_return(body: Rails.root.join('config', 'agencies.localdev.yml'))

--- a/spec/services/remote_settings_service_spec.rb
+++ b/spec/services/remote_settings_service_spec.rb
@@ -4,7 +4,7 @@ describe RemoteSettingsService do
   subject(:service) { RemoteSettingsService }
 
   describe '.load_yml_erb' do
-    it 'loads the remote location' do
+    xit 'loads the remote location' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).to_return(body: Rails.root.join('config', 'agencies.yml').read)
 
@@ -64,7 +64,7 @@ describe RemoteSettingsService do
   end
 
   describe '.update_setting' do
-    it 'it creates a setting if it does not exist' do
+    xit 'it creates a setting if it does not exist' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).
         to_return(body: Rails.root.join('config', 'agencies.localdev.yml'))
@@ -73,7 +73,7 @@ describe RemoteSettingsService do
       expect(RemoteSetting.find_by(name: 'agencies.yml').url).to eq(location)
     end
 
-    it 'it updates the setting if it exists' do
+    xit 'it updates the setting if it exists' do
       location = 'https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml'
       stub_request(:get, location).
         to_return(body: Rails.root.join('config', 'agencies.localdev.yml'))

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -41,6 +41,7 @@ describe StoreSpMetadataInSession do
         app_session_hash = {
           issuer: 'issuer',
           ial2: false,
+          ialmax: false,
           request_url: 'http://issuer.gov',
           request_id: request_id,
           requested_attributes: %w[email],

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -126,6 +126,22 @@ module SamlAuthHelper
     settings
   end
 
+  def ialmax_saml_settings
+    settings = sp1_saml_settings.dup
+    settings.authn_context = Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF
+    settings
+  end
+
+  def ialmax_with_bundle_saml_settings
+    settings = ialmax_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+    ]
+    settings
+  end
+
   def ial2_with_bundle_saml_settings
     settings = ial2_saml_settings
     settings.authn_context = [
@@ -278,5 +294,10 @@ module SamlAuthHelper
       prompt: 'login',
       nonce: nonce,
     )
+  end
+
+  def visit_idp_from_saml_sp_with_ialmax
+    @saml_authn_request = auth_request.create(ialmax_with_bundle_saml_settings)
+    visit @saml_authn_request
   end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -263,4 +263,20 @@ module SamlAuthHelper
       nonce: nonce,
     )
   end
+
+  def visit_idp_from_oidc_sp_with_ialmax
+    state = SecureRandom.hex
+    client_id = 'urn:gov:gsa:openidconnect:sp:server'
+    nonce = SecureRandom.hex
+    visit openid_connect_authorize_path(
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email profile:name social_security_number',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      prompt: 'login',
+      nonce: nonce,
+    )
+  end
 end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -263,20 +263,4 @@ module SamlAuthHelper
       nonce: nonce,
     )
   end
-
-  def visit_idp_from_oidc_sp_with_ialmax
-    state = SecureRandom.hex
-    client_id = 'urn:gov:gsa:openidconnect:sp:server'
-    nonce = SecureRandom.hex
-    visit openid_connect_authorize_path(
-      client_id: client_id,
-      response_type: 'code',
-      acr_values: Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
-      scope: 'openid email profile:name social_security_number',
-      redirect_uri: 'http://localhost:7654/auth/result',
-      state: state,
-      prompt: 'login',
-      nonce: nonce,
-    )
-  end
 end

--- a/spec/view_models/sign_up_completions_show_spec.rb
+++ b/spec/view_models/sign_up_completions_show_spec.rb
@@ -11,6 +11,7 @@ describe SignUpCompletionsShow do
       ial2_requested: false,
       decorated_session: decorated_session,
       handoff: false,
+      ialmax_requested: false,
     )
   end
 

--- a/spec/views/sign_up/completions/show.html.slim_spec.rb
+++ b/spec/views/sign_up/completions/show.html.slim_spec.rb
@@ -37,6 +37,7 @@ describe 'sign_up/completions/show.html.slim' do
         ial2_requested: false,
         decorated_session: SessionDecorator.new,
         handoff: true,
+        ialmax_requested: false,
       )
       create_identities(@user)
     end

--- a/spec/views/sign_up/completions/show.html.slim_spec.rb
+++ b/spec/views/sign_up/completions/show.html.slim_spec.rb
@@ -8,6 +8,7 @@ describe 'sign_up/completions/show.html.slim' do
       ial2_requested: false,
       decorated_session: SessionDecorator.new,
       handoff: false,
+      ialmax_requested: false,
     )
   end
 


### PR DESCRIPTION
**Why**: So partners can get the highest IAL for a user without forcing them to identity proof.
**How**: Use IAL 0 to signify IALMAX since we store IAL as an integer.  Add appropriate support for  http://idmanagement.gov/ns/assurance/ial/0 Only allow IALMAX requests if the sp is set for IAL2.  Allow IAL2 fields to be displayed on the consent screen and sent back if available when IALMAX is requested.  Note that ial2_request? is still false.