### PR TITLE
LG-1898: Stop truncating long emails

### DIFF
--- a/app/views/accounts/_emails.html.slim
+++ b/app/views/accounts/_emails.html.slim
@@ -8,9 +8,12 @@
           = link_to t('account.index.email_add'), add_email_path
   - current_user.email_addresses.each do |email|
     .p2.col.col-12.border-top.border-blue-light.account-list-item
-      .col.col-8.sm-6.truncate
-        = email.email
-        span.ml1 = t('email_addresses.unconfirmed') unless email.confirmed_at
+      .col.col-8.sm-6
+        span.break-word
+          = email.email
+          | &nbsp;
+        span
+          = t('email_addresses.unconfirmed') unless email.confirmed_at
       .col.col-4.sm-6.right-align
         - if EmailPolicy.new(current_user).can_delete_email?(email)
           ' &nbsp; &nbsp;

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -9,13 +9,13 @@ feature 'adding email address' do
     sign_in_user_and_add_email(user)
 
     visit account_path
-    expect(page).to have_content email + t('email_addresses.unconfirmed')
+    expect(page).to have_content("#{email} #{t('email_addresses.unconfirmed')}")
 
     click_on_link_in_confirmation_email
 
     expect(page).to have_current_path(account_path)
     expect(page).to have_content(t('devise.confirmations.confirmed'))
-    expect(page).to_not have_content email + t('email_addresses.unconfirmed')
+    expect(page).to_not have_content("#{email} #{t('email_addresses.unconfirmed')}")
     expect(UserMailer).to have_received(:email_added).twice
   end
 


### PR DESCRIPTION
**Why**: So that the "(unconfirmed)" label is visible even
for longer emails


Before

<img width="818" alt="Screen Shot 2020-02-10 at 3 46 19 PM" src="https://user-images.githubusercontent.com/458784/74201103-9a04f480-4c1d-11ea-8b71-b14e6f9a611b.png">


After

<img width="394" alt="Screen Shot 2020-02-10 at 3 52 12 PM" src="https://user-images.githubusercontent.com/458784/74201109-9e311200-4c1d-11ea-812f-dd1273277e36.png">
<img width="823" alt="Screen Shot 2020-02-10 at 3 52 20 PM" src="https://user-images.githubusercontent.com/458784/74201110-9e311200-4c1d-11ea-8696-6248485e71fe.png">
<img width="832" alt="Screen Shot 2020-02-10 at 3 55 43 PM" src="https://user-images.githubusercontent.com/458784/74201178-d5072800-4c1d-11ea-9814-192a7c676f29.png">
