### PR TITLE
LG-2392 Add rate limit screen for doc auth image upload Part 2

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -137,8 +137,13 @@ module Idv
       end
 
       def throttled
-        redirect_to idv_session_errors_throttled_url
+        redirect_to throttled_url
         [false, I18n.t('errors.doc_auth.acuant_throttle')]
+      end
+
+      def throttled_url
+        return idv_session_errors_throttled_url unless @flow.class == Idv::Flows::RecoveryFlow
+        idv_session_errors_recovery_throttled_url
       end
 
       def test_credentials?

--- a/app/views/idv/session_errors/recovery_throttled.html.erb
+++ b/app/views/idv/session_errors/recovery_throttled.html.erb
@@ -1,0 +1,20 @@
+<% title t('errors.doc_auth.acuant_throttle') %>
+
+<%= image_tag('alert/fail-x.svg', width: 54) %>
+
+<h1 class="h3 mb1 mt3 my0"><%= t('errors.doc_auth.acuant_throttle') %></h1>
+
+<div class="col-2"><hr class="mt3 mb2 bw4 rounded border-red" /></div>
+
+<h2 class="h4 mb2 mt3 my0"><%= t('headings.lock_failure') %></h2>
+
+<%= render 'idv/shared/reset_your_account' %>
+
+<p>
+  <%= t('idv.failure.errors.text_html',
+    link: link_to(t('idv.failure.errors.link'), MarketingSite.contact_url)) %>
+</p>
+
+<%= render 'idv/shared/back_to_sp_link' %>
+
+<%= render 'idv/doc_auth/in_person_proofing_option' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ Rails.application.routes.draw do
       get '/session/errors/throttled' => 'session_errors#throttled'
       get '/session/errors/recovery_failure' => 'session_errors#recovery_failure'
       get '/session/errors/recovery_warning' => 'session_errors#recovery_warning'
+      get '/session/errors/recovery_throttled' => 'session_errors#recovery_throttled'
       delete '/session' => 'sessions#destroy'
       get '/jurisdiction' => 'jurisdiction#new'
       post '/jurisdiction' => 'jurisdiction#create'


### PR DESCRIPTION
**Why**: So the user can reset their account if they are throttled during recovery