### PR TITLE
LG-2556: openid connect spec refactor

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'redis'
+
+begin
+  Redis.current.call 'INFO'
+rescue Redis::CannotConnectError => cce
+  puts "\n\nIt appears Redis is not running, but it is required for (some) specs to run\n\n"
+  puts cce
+  exit 1
+end
+
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails' do

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -1,0 +1,47 @@
+module OidcAuthHelper
+  OIDC_ISSUER = 'urn:gov:gsa:openidconnect:sp:server'.freeze
+
+  def sign_in_oidc_user(user)
+    visit_idp_from_ial1_oidc_sp
+    fill_in_credentials_and_submit(user.email, user.password)
+    click_continue
+  end
+
+  def visit_idp_from_ial1_oidc_sp(**args)
+    params = ial1_params args
+    visit openid_connect_authorize_path params
+  end
+
+  def visit_idp_from_ial2_oidc_sp(**args)
+    params = ial2_params args
+    visit openid_connect_authorize_path params
+  end
+
+  def ial1_params(prompt: nil, state: SecureRandom.hex, nonce: SecureRandom.hex, client_id: OIDC_ISSUER)
+    ial1_params = {
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      nonce: nonce,
+    }
+    ial1_params[:prompt] = prompt if prompt
+    ial1_params
+  end
+
+  def ial2_params(prompt: nil, state: SecureRandom.hex, nonce: SecureRandom.hex, client_id: OIDC_ISSUER)
+    ial2_params = {
+      client_id: client_id,
+      response_type: 'code',
+      acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+      scope: 'openid email profile:name social_security_number',
+      redirect_uri: 'http://localhost:7654/auth/result',
+      state: state,
+      nonce: nonce,
+    }
+    ial2_params[:prompt] = prompt if prompt
+    ial2_params
+  end
+end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -9,12 +9,16 @@ module OidcAuthHelper
 
   def visit_idp_from_ial1_oidc_sp(**args)
     params = ial1_params args
-    visit openid_connect_authorize_path params
+    oidc_path = openid_connect_authorize_path params
+    visit oidc_path
+    oidc_path
   end
 
   def visit_idp_from_ial2_oidc_sp(**args)
     params = ial2_params args
-    visit openid_connect_authorize_path params
+    oidc_path = openid_connect_authorize_path params
+    visit oidc_path
+    oidc_path
   end
 
   def ial1_params(prompt: nil, state: SecureRandom.hex, nonce: SecureRandom.hex, client_id: OIDC_ISSUER)

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -21,7 +21,10 @@ module OidcAuthHelper
     oidc_path
   end
 
-  def ial1_params(prompt: nil, state: SecureRandom.hex, nonce: SecureRandom.hex, client_id: OIDC_ISSUER)
+  def ial1_params(prompt: nil,
+                  state: SecureRandom.hex,
+                  nonce: SecureRandom.hex,
+                  client_id: OIDC_ISSUER)
     ial1_params = {
       client_id: client_id,
       response_type: 'code',
@@ -35,7 +38,10 @@ module OidcAuthHelper
     ial1_params
   end
 
-  def ial2_params(prompt: nil, state: SecureRandom.hex, nonce: SecureRandom.hex, client_id: OIDC_ISSUER)
+  def ial2_params(prompt: nil,
+                  state: SecureRandom.hex,
+                  nonce: SecureRandom.hex,
+                  client_id: OIDC_ISSUER)
     ial2_params = {
       client_id: client_id,
       response_type: 'code',


### PR DESCRIPTION
Why? In working to make new tests on OIDC authorization requests, I found the large openid_connect_spec.rb to be difficult to follow, particularly since many of the tests were just calls into a large method that checked many exceptions. I created a new support module with helper methods to do the most common task, visiting the idp from an oidc sp.

In the end, I did not eliminate the method being called since that would most assuredly have caused this spec file to grow (at least in the first pass), not shrink, and it wasn't always clear to me how much of the logic was necessary to accomplish the goal of any one test.