### PR TITLE
Docker: Make bin/setup a little more accomodating

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -24,20 +24,20 @@ Dir.chdir APP_ROOT do
   ]
 
   puts "== Copying application.yml =="
-  run "test -L config/application.yml || cp -v config/application.yml.default config/application.yml"
+  run "test -r config/application.yml || cp -v config/application.yml.default config/application.yml"
 
   puts "== Linking service_providers.yml =="
-  run "test -L config/service_providers.yml || ln -sv service_providers.localdev.yml config/service_providers.yml"
+  run "test -r config/service_providers.yml || ln -sv service_providers.localdev.yml config/service_providers.yml"
 
   puts "== Linking agencies.yml =="
-  run "test -L config/agencies.yml || ln -sv agencies.localdev.yml config/agencies.yml"
+  run "test -r config/agencies.yml || ln -sv agencies.localdev.yml config/agencies.yml"
 
   puts "== Copying logstash.conf =="
   run "cat logstash.conf.example | sed 's/path_to_repo/#{APP_ROOT.to_s.gsub('/', '\/')}/g' > logstash.conf"
 
   puts "== Linking sample certs and keys =="
-  run "test -L certs || ln -sv certs.example certs"
-  run "test -L keys || ln -sv keys.example keys"
+  run "test -r certs || ln -sv certs.example certs"
+  run "test -r keys || ln -sv keys.example keys"
 
   puts "== Copying sample pwned passwords list =="
   run "cp pwned_passwords/pwned_passwords.txt.sample pwned_passwords/pwned_passwords.txt"


### PR DESCRIPTION
**Why**: So it's easier to switch back from running in docker to
running natively/locally

`-L` checks that it's specifically a link but `-r` just checks that it's readable, so the actual copied files that are set up by docker work just as well as symlinks