### PR TITLE
LG-2587 IAL2 SP User Quota Tracking

### DIFF
--- a/app/services/db/identity/sp_user_counts.rb
+++ b/app/services/db/identity/sp_user_counts.rb
@@ -3,7 +3,7 @@ module Db
     class SpUserCounts
       def self.call
         sql = <<~SQL
-          SELECT service_provider as issuer,count(user_id) AS total
+          SELECT service_provider as issuer,count(user_id) AS total, count(user_id)-count(verified_at) AS ial1_total, count(verified_at) AS ial2_total
           FROM identities
           GROUP BY issuer ORDER BY issuer
         SQL

--- a/app/services/db/identity/sp_user_counts.rb
+++ b/app/services/db/identity/sp_user_counts.rb
@@ -3,9 +3,28 @@ module Db
     class SpUserCounts
       def self.call
         sql = <<~SQL
-          SELECT service_provider as issuer,count(user_id) AS total, count(user_id)-count(verified_at) AS ial1_total, count(verified_at) AS ial2_total
+          SELECT
+            service_providers.issuer,
+            total,
+            ial1_total,
+            ial2_total,
+            CAST(
+              (CASE WHEN ial2_quota IS NULL
+              THEN 0
+              ELSE ROUND(ial2_total * 100.0 / ial2_quota)
+              END)
+              AS INTEGER
+            ) AS percent_ial2_quota
+          FROM service_providers, 
+          (SELECT
+            service_provider AS issuer,
+            count(user_id) AS total,
+            count(user_id)-count(verified_at) AS ial1_total,
+            count(verified_at) AS ial2_total
           FROM identities
-          GROUP BY issuer ORDER BY issuer
+          GROUP BY issuer ORDER BY issuer)
+          AS TBL
+          WHERE TBL.issuer = service_providers.issuer
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end

--- a/app/services/db/identity/sp_user_counts.rb
+++ b/app/services/db/identity/sp_user_counts.rb
@@ -5,27 +5,12 @@ module Db
       def self.call
         sql = <<~SQL
           SELECT
-            service_providers.issuer,
-            total,
-            ial1_total,
-            ial2_total,
-            CAST(
-              (CASE WHEN ial2_quota IS NULL
-              THEN 0
-              ELSE ROUND(ial2_total * 100.0 / ial2_quota)
-              END)
-              AS INTEGER
-            ) AS percent_ial2_quota
-          FROM service_providers,
-          (SELECT
             service_provider AS issuer,
             count(user_id) AS total,
             count(user_id)-count(verified_at) AS ial1_total,
             count(verified_at) AS ial2_total
           FROM identities
-          GROUP BY issuer ORDER BY issuer)
-          AS TBL
-          WHERE TBL.issuer = service_providers.issuer
+          GROUP BY issuer ORDER BY issuer
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end

--- a/app/services/db/identity/sp_user_counts.rb
+++ b/app/services/db/identity/sp_user_counts.rb
@@ -1,6 +1,7 @@
 module Db
   module Identity
     class SpUserCounts
+      # rubocop:disable Metrics/MethodLength
       def self.call
         sql = <<~SQL
           SELECT
@@ -15,7 +16,7 @@ module Db
               END)
               AS INTEGER
             ) AS percent_ial2_quota
-          FROM service_providers, 
+          FROM service_providers,
           (SELECT
             service_provider AS issuer,
             count(user_id) AS total,
@@ -28,6 +29,7 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/db/identity/sp_user_quotas.rb
+++ b/app/services/db/identity/sp_user_quotas.rb
@@ -1,0 +1,32 @@
+module Db
+  module Identity
+    class SpUserQuotas
+      # rubocop:disable Metrics/MethodLength
+      def self.call(start_date)
+        sql = <<~SQL
+          SELECT
+            service_providers.issuer,
+            ial2_total,
+            CAST(
+              (CASE WHEN ial2_quota IS NULL
+              THEN 0
+              ELSE ROUND(ial2_total * 100.0 / ial2_quota)
+              END)
+              AS INTEGER
+            ) AS percent_ial2_quota
+          FROM service_providers,
+          (SELECT
+            service_provider AS issuer,
+            count(verified_at) AS ial2_total
+          FROM identities
+          WHERE '#{start_date}' <= verified_at
+          GROUP BY issuer ORDER BY issuer)
+          AS TBL
+          WHERE TBL.issuer = service_providers.issuer
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -8,7 +8,7 @@ class IdentityLinker
   end
 
   def link_identity(**extra_attrs)
-    @ial =  extra_attrs[:ial]
+    process_ial
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
     AgencyIdentityLinker.new(identity).link_identity
@@ -20,6 +20,12 @@ class IdentityLinker
   end
 
   private
+
+  def process_ial
+    @ial =  extra_attrs[:ial]
+    return unless @ial == 2 && identity.verified_at.nil?
+    identity.verified_at = Time.zone.now
+  end
 
   def identity
     @identity ||= find_or_create_identity_with_costing

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -8,7 +8,7 @@ class IdentityLinker
   end
 
   def link_identity(**extra_attrs)
-    process_ial
+    process_ial(extra_attrs)
     attributes = merged_attributes(extra_attrs)
     identity.update!(attributes)
     AgencyIdentityLinker.new(identity).link_identity
@@ -21,7 +21,7 @@ class IdentityLinker
 
   private
 
-  def process_ial
+  def process_ial(extra_attrs)
     @ial =  extra_attrs[:ial]
     return unless @ial == 2 && identity.verified_at.nil?
     identity.verified_at = Time.zone.now

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -22,7 +22,7 @@ class IdentityLinker
   private
 
   def process_ial(extra_attrs)
-    @ial =  extra_attrs[:ial]
+    @ial = extra_attrs[:ial]
     return unless @ial == 2 && identity.verified_at.nil?
     identity.verified_at = Time.zone.now
   end

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -4,6 +4,15 @@ module Reports
   class BaseReport
     private
 
+    def fiscal_start_date
+      now = Time.zone.now
+      if now.strftime('%m').to_i >= 9
+        now.strftime('09-01-%Y')
+      else
+        "09-01-#{now.strftime('%Y').to_i - 1}"
+      end
+    end
+
     def first_of_this_month
       Time.zone.today.strftime('%m-01-%Y')
     end

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -7,9 +7,9 @@ module Reports
     def fiscal_start_date
       now = Time.zone.now
       if now.strftime('%m').to_i >= 9
-        now.strftime('09-01-%Y')
+        now.strftime('10-01-%Y')
       else
-        "09-01-#{now.strftime('%Y').to_i - 1}"
+        "10-01-#{now.strftime('%Y').to_i - 1}"
       end
     end
 

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -6,10 +6,10 @@ module Reports
 
     def fiscal_start_date
       now = Time.zone.now
-      if now.strftime('%m').to_i >= 10
+      if now.month >= 10
         now.strftime('10-01-%Y')
       else
-        "10-01-#{now.strftime('%Y').to_i - 1}"
+        "10-01-#{now.year - 1}"
       end
     end
 

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -6,7 +6,7 @@ module Reports
 
     def fiscal_start_date
       now = Time.zone.now
-      if now.strftime('%m').to_i >= 9
+      if now.strftime('%m').to_i >= 10
         now.strftime('10-01-%Y')
       else
         "10-01-#{now.strftime('%Y').to_i - 1}"

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -14,7 +14,7 @@ module Reports
     end
 
     def first_of_this_month
-      Time.zone.today.strftime('%m-01-%Y')
+      Time.zone.today.beginning_of_month.strftime('%m-%d-%Y')
     end
 
     def end_of_today

--- a/app/services/reports/sp_user_quotas_report.rb
+++ b/app/services/reports/sp_user_quotas_report.rb
@@ -1,0 +1,14 @@
+require 'login_gov/hostdata'
+
+module Reports
+  class SpUserQuotasReport < BaseReport
+    REPORT_NAME = 'sp-user-quotas-report'.freeze
+
+    def call
+      user_counts = transaction_with_timeout do
+        Db::Identity::SpUserQuotas.call(fiscal_start_date)
+      end
+      save_report(REPORT_NAME, user_counts.to_json)
+    end
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -66,6 +66,14 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   callback: -> { Reports::SpUserCountsReport.new.call },
 )
 
+# Send Sp User Quotas Report to S3
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
+  name: 'SP user quotas report',
+  interval: 24 * 60 * 60, # 24 hours
+  timeout: 300,
+  callback: -> { Reports::SpUserQuotasReport.new.call },
+)
+
 # Send Doc Auth Funnel Report to S3
 JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   name: 'Doc Auth Funnel Report',

--- a/db/migrate/20200220230641_add_ial2_quota_to_service_providers.rb
+++ b/db/migrate/20200220230641_add_ial2_quota_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddQuotaToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :ial2_quota, :integer
+  end
+end

--- a/db/migrate/20200220230641_add_ial2_quota_to_service_providers.rb
+++ b/db/migrate/20200220230641_add_ial2_quota_to_service_providers.rb
@@ -1,4 +1,4 @@
-class AddQuotaToServiceProviders < ActiveRecord::Migration[5.1]
+class AddIal2QuotaToServiceProviders < ActiveRecord::Migration[5.1]
   def change
     add_column :service_providers, :ial2_quota, :integer
   end

--- a/db/migrate/20200220235113_add_verified_at_to_identities.rb
+++ b/db/migrate/20200220235113_add_verified_at_to_identities.rb
@@ -1,0 +1,5 @@
+class AddIal2QuotaToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :ial2_quota, :integer
+  end
+end

--- a/db/migrate/20200220235113_add_verified_at_to_identities.rb
+++ b/db/migrate/20200220235113_add_verified_at_to_identities.rb
@@ -1,5 +1,5 @@
-class AddIal2QuotaToServiceProviders < ActiveRecord::Migration[5.1]
+class AddVerifiedAtToIdentities < ActiveRecord::Migration[5.1]
   def change
-    add_column :service_providers, :ial2_quota, :integer
+    add_column :identities, :verified_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 20200221215702) do
     t.string "code_challenge"
     t.string "rails_session_id"
     t.json "verified_attributes"
+    t.datetime "verified_at"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true
@@ -405,6 +406,7 @@ ActiveRecord::Schema.define(version: 20200221215702) do
     t.jsonb "help_text", default: {"sign_in"=>{}, "sign_up"=>{}, "forgot_password"=>{}}
     t.boolean "allow_prompt_login", default: false
     t.boolean "signed_response_message_requested", default: false
+    t.integer "ial2_quota"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/config/initializers/job_configurations.rb
+++ b/spec/config/initializers/job_configurations.rb
@@ -99,6 +99,18 @@ describe JobRunner::Runner do
       expect(job.callback.call).to eq 'the report test worked'
     end
 
+    it 'runs the sp user quotas report job' do
+      job = JobRunner::Runner.configurations.find { |c| c.name == 'SP user quotas report' }
+      expect(job).to be_instance_of(JobRunner::JobConfiguration)
+      expect(job.interval).to eq 24 * 60 * 60
+
+      service = instance_double(Reports::SpUserQuotasReport)
+      expect(Reports::SpUserQuotasReport).to receive(:new).and_return(service)
+      expect(service).to receive(:call).and_return('the report test worked')
+
+      expect(job.callback.call).to eq 'the report test worked'
+    end
+
     it 'runs the sp success rate report job' do
       job = JobRunner::Runner.configurations.find { |c| c.name == 'SP success rate report' }
       expect(job).to be_instance_of(JobRunner::JobConfiguration)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -12,7 +12,7 @@ describe Db::Identity::SpUserCounts do
   it 'returns the total user counts per sp' do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }.to_json
 
     expect(subject.call.ntuples).to eq(1)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -10,10 +10,11 @@ describe Db::Identity::SpUserCounts do
   end
 
   it 'returns the total user counts per sp' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }.to_json
+    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, percent_ial2_quota: 0 }.to_json
 
     expect(subject.call.ntuples).to eq(1)
     expect(subject.call[0].to_json).to eq(result)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -12,8 +12,8 @@ describe Db::Identity::SpUserCounts do
   it 'returns the total user counts per sp' do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-
-    result = { issuer: issuer, total: 2 }.to_json
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
+    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1}.to_json
 
     expect(subject.call.ntuples).to eq(1)
     expect(subject.call[0].to_json).to eq(result)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -10,7 +10,7 @@ describe Db::Identity::SpUserCounts do
     expect(subject.call.ntuples).to eq(0)
   end
 
-  it 'returns the total user counts per sp' do
+  it 'returns the total user counts per sp broken down by ial1 and ial2 with percent ial2 quota' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial2_quota: 1)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -14,7 +14,8 @@ describe Db::Identity::SpUserCounts do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, percent_ial2_quota: 0 }.to_json
+    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1,
+               percent_ial2_quota: 0 }.to_json
 
     expect(subject.call.ntuples).to eq(1)
     expect(subject.call[0].to_json).to eq(result)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -20,7 +20,7 @@ describe Db::Identity::SpUserCounts do
     result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1,
                percent_ial2_quota: 0 }.to_json
     result2 = { issuer: issuer2, total: 1, ial1_total: 0, ial2_total: 1,
-               percent_ial2_quota: 100 }.to_json
+                percent_ial2_quota: 100 }.to_json
 
     tuples = subject.call
     expect(tuples.ntuples).to eq(2)

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -4,6 +4,7 @@ describe Db::Identity::SpUserCounts do
   subject { described_class }
 
   let(:issuer) { 'foo' }
+  let(:issuer2) { 'foo2' }
 
   it 'is empty' do
     expect(subject.call.ntuples).to eq(0)
@@ -11,13 +12,19 @@ describe Db::Identity::SpUserCounts do
 
   it 'returns the total user counts per sp' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial2_quota: 1)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
     result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1,
                percent_ial2_quota: 0 }.to_json
+    result2 = { issuer: issuer2, total: 1, ial1_total: 0, ial2_total: 1,
+               percent_ial2_quota: 100 }.to_json
 
-    expect(subject.call.ntuples).to eq(1)
-    expect(subject.call[0].to_json).to eq(result)
+    tuples = subject.call
+    expect(tuples.ntuples).to eq(2)
+    expect(tuples[0].to_json).to eq(result)
+    expect(tuples[1].to_json).to eq(result2)
   end
 end

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -13,7 +13,7 @@ describe Db::Identity::SpUserCounts do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
-    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1}.to_json
+    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }.to_json
 
     expect(subject.call.ntuples).to eq(1)
     expect(subject.call[0].to_json).to eq(result)

--- a/spec/services/db/identity/sp_user_quotas_spec.rb
+++ b/spec/services/db/identity/sp_user_quotas_spec.rb
@@ -1,26 +1,27 @@
 require 'rails_helper'
 
-describe Db::Identity::SpUserCounts do
+describe Db::Identity::SpUserQuotas do
   subject { described_class }
 
   let(:issuer) { 'foo' }
   let(:issuer2) { 'foo2' }
+  let(:fiscal_start_date) { 1.year.ago.strftime('%m-%d-%Y') }
 
   it 'is empty' do
-    expect(subject.call.ntuples).to eq(0)
+    expect(subject.call(fiscal_start_date).ntuples).to eq(0)
   end
 
-  it 'returns the total user counts per sp broken down by ial1 and ial2' do
+  it 'returns the total ial2 user count per fiscal year with percent ial2 quota' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
-    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial2_quota: 1)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4', verified_at: Time.zone.now)
-    result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }.to_json
-    result2 = { issuer: issuer2, total: 1, ial1_total: 0, ial2_total: 1 }.to_json
+    result = { issuer: issuer, ial2_total: 1, percent_ial2_quota: 0 }.to_json
+    result2 = { issuer: issuer2, ial2_total: 1, percent_ial2_quota: 100 }.to_json
 
-    tuples = subject.call
+    tuples = subject.call(fiscal_start_date)
     expect(tuples.ntuples).to eq(2)
     expect(tuples[0].to_json).to eq(result)
     expect(tuples[1].to_json).to eq(result2)

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -9,7 +9,7 @@ describe Reports::SpUserCountsReport do
     expect(subject.call).to eq('[]')
   end
 
-  it 'returns the total user counts per sp' do
+  it 'returns the total user counts per sp broken down by ial1 and ial2 with percent ial2 quota' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -12,7 +12,7 @@ describe Reports::SpUserCountsReport do
   it 'returns the total user counts per sp' do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }].to_json
 
     expect(subject.call).to eq(result)

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -16,7 +16,8 @@ describe Reports::SpUserCountsReport do
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     puts ServiceProvider.count
     puts Identity.count
-    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, percent_ial2_quota: 0 }].to_json
+    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1,
+                percent_ial2_quota: 0 }].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -9,15 +9,14 @@ describe Reports::SpUserCountsReport do
     expect(subject.call).to eq('[]')
   end
 
-  it 'returns the total user counts per sp broken down by ial1 and ial2 with percent ial2 quota' do
+  it 'returns the total user counts per sp broken down by ial1 and ial2' do
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
     puts ServiceProvider.count
     puts Identity.count
-    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1,
-                percent_ial2_quota: 0 }].to_json
+    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -12,7 +12,8 @@ describe Reports::SpUserCountsReport do
   it 'returns the total user counts per sp' do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
-    result = [{ issuer: issuer, total: 2 }].to_json
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
+    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1}].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -10,10 +10,13 @@ describe Reports::SpUserCountsReport do
   end
 
   it 'returns the total user counts per sp' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }].to_json
+    puts ServiceProvider.count
+    puts Identity.count
+    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -13,7 +13,7 @@ describe Reports::SpUserCountsReport do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.now)
-    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1}].to_json
+    result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/reports/sp_user_counts_report_spec.rb
+++ b/spec/services/reports/sp_user_counts_report_spec.rb
@@ -14,8 +14,6 @@ describe Reports::SpUserCountsReport do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    puts ServiceProvider.count
-    puts Identity.count
     result = [{ issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1 }].to_json
 
     expect(subject.call).to eq(result)

--- a/spec/services/reports/sp_user_quotas_report_spec.rb
+++ b/spec/services/reports/sp_user_quotas_report_spec.rb
@@ -14,8 +14,6 @@ describe Reports::SpUserQuotasReport do
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    puts ServiceProvider.count
-    puts Identity.count
     result = [{ issuer: issuer, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
     expect(subject.call).to eq(result)

--- a/spec/services/reports/sp_user_quotas_report_spec.rb
+++ b/spec/services/reports/sp_user_quotas_report_spec.rb
@@ -9,13 +9,23 @@ describe Reports::SpUserQuotasReport do
     expect(subject.call).to eq('[]')
   end
 
-  it 'returns the total ial2 user count per fiscal year with percent ial2 quot' do
+  it 'runs correctly if the current month is before the fiscal start month of October' do
+    expect_report_to_run_correctly_for_fiscal_start_year_month_day(2019, 9, 1)
+  end
+
+  it 'runs correctly if the current month is after the fiscal start month of October' do
+    expect_report_to_run_correctly_for_fiscal_start_year_month_day(2019, 11, 1)
+  end
+
+  def expect_report_to_run_correctly_for_fiscal_start_year_month_day(year, month, day)
     ServiceProvider.create(issuer: issuer, friendly_name: issuer)
     Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
     Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
     Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
-    result = [{ issuer: issuer, ial2_total: 1, percent_ial2_quota: 0 }].to_json
+    results = [{ issuer: issuer, ial2_total: 1, percent_ial2_quota: 0 }].to_json
 
-    expect(subject.call).to eq(result)
+    Timecop.travel Date.new(year, month, day) do
+      expect(subject.call).to eq(results)
+    end
   end
 end

--- a/spec/services/reports/sp_user_quotas_report_spec.rb
+++ b/spec/services/reports/sp_user_quotas_report_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Reports::SpUserQuotasReport do
+  subject { described_class.new }
+
+  let(:issuer) { 'foo' }
+
+  it 'is empty' do
+    expect(subject.call).to eq('[]')
+  end
+
+  it 'returns the total ial2 user count per fiscal year with percent ial2 quot' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1')
+    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2')
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3', verified_at: Time.zone.now)
+    puts ServiceProvider.count
+    puts Identity.count
+    result = [{ issuer: issuer, ial2_total: 1, percent_ial2_quota: 0 }].to_json
+
+    expect(subject.call).to eq(result)
+  end
+end


### PR DESCRIPTION
**Why**: So SP's can limit their cost
**How**: Identity tracks ial unfortunately it changes depending on the last request.  (ie ial2 request it becomes 2 but an ial1 request will make it 1).  Therefore there is no easy way to count the number of IAL2 users per SP without a join.  The verified attributes could be parsed but we wouldn't have a date when the user was verified to do range queries which is what quota tracking needs (it's per fiscal year).  By adding a verified_at on identity we satisfy all these requirements.  Finally each SP will have an optional ial2_quota that we can enforce in a future PR.  Update the user count per sp to include ial1 and ial2 totals as well as the percentage of the ial2 quota used.