### PR TITLE
LG-2532 Switch to cleave.js for field formatting

### DIFF
--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -36,6 +36,7 @@ function formatForm() {
       numericOnly: true,
       blocks: [5, 4],
       delimiter: '-',
+      delimiterLazyShow: true,
     });
   }
 

--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -1,5 +1,6 @@
 import Cleave from 'cleave.js';
 
+/* eslint-disable no-new */
 function formatForm() {
   if (document.querySelector('.dob')) {
     new Cleave('.dob', {

--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -16,8 +16,8 @@ function formatForm() {
     });
   }
 
-  if (document.querySelector('.backup_code')) {
-    new Cleave('.backup_code', {
+  if (document.querySelector('.backup-code')) {
+    new Cleave('.backup-code', {
       blocks: [4, 4, 4],
       delimiter: '-',
     });

--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -1,37 +1,49 @@
-import { SocialSecurityNumberFormatter, TextField } from 'field-kit';
-import DateFormatter from './modules/date-formatter';
-import NumericFormatter from './modules/numeric-formatter';
-import PersonalKeyFormatter from './modules/personal-key-formatter';
-import ZipCodeFormatter from './modules/zip-code-formatter';
-
+import Cleave from 'cleave.js';
 
 function formatForm() {
-  const formats = [
-    ['.dob', new DateFormatter()],
-    ['.mfa', new NumericFormatter()],
-    ['.personal-key', new PersonalKeyFormatter()],
-    ['.ssn', new SocialSecurityNumberFormatter()],
-    ['.zipcode', new ZipCodeFormatter()],
-  ];
+  if (document.querySelector('.dob')) {
+    new Cleave('.dob', {
+      date: true,
+      datePattern: ['m', 'd', 'Y'],
+    });
+  }
 
-  formats.forEach(function(f) {
-    const [el, formatter] = f;
-    const input = document.querySelector(el);
-    if (input) {
-      /* eslint-disable no-new, no-shadow */
-      const field = new TextField(input, formatter);
+  if (document.querySelector('.personal-key')) {
+    new Cleave('.personal-key', {
+      blocks: [4, 4, 4, 4],
+      delimiter: '-',
+    });
+  }
 
-      // add date format placeholders only to .dob fields
-      if (el === '.dob') {
-        field.setFocusedPlaceholder('');
-        field.setUnfocusedPlaceholder('mm/dd/yyyy');
-      }
+  if (document.querySelector('.backup_code')) {
+    new Cleave('.backup_code', {
+      blocks: [4, 4, 4],
+      delimiter: '-',
+    });
+  }
 
-      // removes focus set by field-kit bug https://github.com/square/field-kit/issues/62
-      if (el !== '.mfa') document.activeElement.blur();
-    }
-  });
+  if (document.querySelector('.ssn')) {
+    new Cleave('.ssn', {
+      numericOnly: true,
+      blocks: [3, 2, 4],
+      delimiter: '-',
+    });
+  }
+
+  if (document.querySelector('.zipcode')) {
+    new Cleave('.zipcode', {
+      numericOnly: true,
+      blocks: [5, 4],
+      delimiter: '-',
+    });
+  }
+
+  if (document.querySelector('.mfa')) {
+    new Cleave('.mfa', {
+      numericOnly: true,
+      blocks: [6],
+    });
+  }
 }
-
 
 document.addEventListener('DOMContentLoaded', formatForm);

--- a/app/views/partials/backup_code/_entry_fields.html.slim
+++ b/app/views/partials/backup_code/_entry_fields.html.slim
@@ -3,7 +3,7 @@
     label: t('simple_form.required.html') + t('forms.two_factor.backup_code'),
     input_html: { autocapitalize: 'none',
       autocomplete: 'off',
-      class: 'caps',
+      class: 'caps backup_code',
       maxlength: 14,
       required: true,
       spellcheck: 'false' }

--- a/app/views/partials/backup_code/_entry_fields.html.slim
+++ b/app/views/partials/backup_code/_entry_fields.html.slim
@@ -3,7 +3,7 @@
     label: t('simple_form.required.html') + t('forms.two_factor.backup_code'),
     input_html: { autocapitalize: 'none',
       autocomplete: 'off',
-      class: 'caps backup_code',
+      class: 'caps backup-code',
       maxlength: 14,
       required: true,
       spellcheck: 'false' }

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -15,8 +15,7 @@
   <div class="col-12 sm-col-5 mb2 sm-mb0 sm-mr-20p inline-block">
     <%= text_field_tag(:code, '', value: @presenter.code_value, required: true, autofocus: true,
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-                       type: 'number') %>
+                       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length) %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number', @presenter.otp_make_default_number %>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -15,7 +15,8 @@
   <div class="col-12 sm-col-5 mb2 sm-mb0 sm-mr-20p inline-block">
     <%= text_field_tag(:code, '', value: @presenter.code_value, required: true, autofocus: true,
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length) %>
+                       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
+                       type: 'tel') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number', @presenter.otp_make_default_number %>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "classlist.js": "^1.1.20150312",
     "clipboard": "^1.6.1",
     "coffeescript": "1.12.7",
-    "field-kit": "^2.1.0",
     "focus-trap": "^2.3.0",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "base32-crockford-browser": "^1.0.0",
     "basscss-sass": "^3.0.0",
     "classlist.js": "^1.1.20150312",
+    "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
     "coffeescript": "1.12.7",
     "focus-trap": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,14 +3022,6 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-field-kit@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/field-kit/-/field-kit-2.1.0.tgz#e68ede5f4e3051b2dc4258105a495c541a3b2d7f"
-  integrity sha1-5o7eX04wUbLcQlgQWklcVBo7LX8=
-  dependencies:
-    input-sim "^3.0.1"
-    stround "0.3.1"
-
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -3734,11 +3726,6 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-input-sim@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/input-sim/-/input-sim-3.1.0.tgz#83f9c214f4d6d8c8e9094d3457979591ea88cc2c"
-  integrity sha1-g/nCFPTW2MjpCU00V5eVkeqIzCw=
 
 inquirer@^3.0.6:
   version "3.3.0"
@@ -7077,11 +7064,6 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-stround@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stround/-/stround-0.3.1.tgz#be5f2e1dd7f5b6a1468682548ac87461b8d66454"
-  integrity sha1-vl8uHdf1tqFGhoJUish0YbjWZFQ=
 
 style-loader@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,6 +1923,11 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+cleave.js@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.5.3.tgz#1ef36e1375dea289bffeefe8ebb1e3ef2ee23240"
+  integrity sha512-tLum0abk+NRUZtMxpqLQS0jE9k2KYzsUlnMAqfMd2LAf8bb5xTHLHXTtPyI+dCk6DThtmWER3EzKfUi4NHdR7A==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"


### PR DESCRIPTION
**Why:** The field-kit module was outdated and causing a bug where in some browsers, backspace would not work in certain input fields (like MFA OTP). After considering just getting rid of field-kit and giving up the delightful formatting, I found cleave.js as a more modern alternative to field-kit. This way, we can fix the backspace bug _and_  keep our formatting.