### PR TITLE
LG-1611: SP's can optionally request signed auth response message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,10 +43,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: f0c4a98952ca24e3c356293dd74fd4885d96ff37
+  revision: 95366bbb24088660eadc54ba49f56399cf8b17b4
   branch: master
   specs:
-    saml_idp (0.8.0.pre.18f)
+    saml_idp (0.9.0.pre.18f)
       activesupport
       builder
       httparty
@@ -167,7 +167,7 @@ GEM
       debug_inspector (>= 0.0.1)
     brakeman (4.7.1)
     browser (2.6.1)
-    builder (3.2.3)
+    builder (3.2.4)
     bullet (6.0.2)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
@@ -199,7 +199,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     cose (0.10.0)
       cbor (~> 0.5.9)
@@ -300,10 +300,10 @@ GEM
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
-    httparty (0.17.1)
+    httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.7.0)
+    i18n (1.7.1)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.29)
       activesupport (>= 4.0.2)
@@ -350,12 +350,12 @@ GEM
     maxminddb (0.1.22)
     memory_profiler (0.9.14)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mustermann (1.0.3)
@@ -384,7 +384,7 @@ GEM
       ast (~> 2.4.0)
     pg (1.1.4)
     phonelib (0.6.39)
-    pkcs11 (0.2.7)
+    pkcs11 (0.3.2)
     premailer (1.11.1)
       addressable
       css_parser (>= 1.6.0)
@@ -610,7 +610,7 @@ GEM
       rotp (>= 3.2.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module SamlIdpAuthConcern
   extend ActiveSupport::Concern
 
@@ -94,6 +95,7 @@ module SamlIdpAuthConcern
       reference_id: active_identity.session_uuid,
       encryption: current_service_provider.encryption_opts,
       signature: saml_response_signature_options,
+      signed_response_message: current_service_provider.signed_response_message_requested,
     )
   end
 
@@ -126,3 +128,4 @@ module SamlIdpAuthConcern
     url.to_s
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -210,7 +210,6 @@ test:
         fr: ""
     allow_prompt_login: true
 
-
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':
     agency_id: 2

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -40,6 +40,46 @@ test:
       - zipcode
     allow_prompt_login: true
 
+  'test_saml_sp_not_requesting_signed_response_message':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP requesting signed response message'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 1
+    attribute_bundle:
+      - email
+    allow_prompt_login: true
+    block_encryption: 'none'
+    signed_response_message_requested: false
+
+  'test_saml_sp_requesting_signed_response_message':
+    agency_id: 2
+    acs_url: 'http://example.com/test/saml/decode_assertion'
+    assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
+    sp_initiated_login_url: 'https://example.com/auth/saml/login'
+    failure_to_proof_url: 'https://example.com/'
+    redirect_uris:
+      - 'http://example.com/'
+      - 'http://example.com/auth/result'
+      - 'http://example.com/logout'
+    friendly_name: 'Test SP requesting signed response message'
+    cert: 'saml_test_sp'
+    logo: 'generic.svg'
+    ial: 1
+    attribute_bundle:
+      - email
+    allow_prompt_login: true
+    block_encryption: 'none'
+    signed_response_message_requested: true
+
   'https://rp2.serviceprovider.com/auth/saml/metadata':
     acs_url: 'http://example.com/test/saml/decode_assertion'
     assertion_consumer_logout_service_url: 'http://example.com/test/saml/decode_slo_request'
@@ -169,6 +209,7 @@ test:
         es: ""
         fr: ""
     allow_prompt_login: true
+
 
 development:
   'https://rp1.serviceprovider.com/auth/saml/metadata':

--- a/db/migrate/20200221215702_add_signed_response_message_requested_to_service_provider.rb
+++ b/db/migrate/20200221215702_add_signed_response_message_requested_to_service_provider.rb
@@ -1,0 +1,10 @@
+class AddSignedResponseMessageRequestedToServiceProvider < ActiveRecord::Migration[5.1]
+  def up
+    add_column :service_providers, :signed_response_message_requested, :boolean
+    change_column_default :service_providers, :signed_response_message_requested, false
+  end
+
+  def down
+    remove_column :service_providers, :signed_response_message_requested
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200210235313) do
+ActiveRecord::Schema.define(version: 20200221215702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(version: 20200210235313) do
     t.string "push_notification_url"
     t.jsonb "help_text", default: {"sign_in"=>{}, "sign_up"=>{}, "forgot_password"=>{}}
     t.boolean "allow_prompt_login", default: false
+    t.boolean "signed_response_message_requested", default: false
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe SamlIdpController do
+  include SamlAuthHelper
+
+  before do
+    # All the tests here were written prior to the interstitial
+    # authorization confirmation page so let's force the system
+    # to skip past that page
+    allow(controller).to receive(:auth_count).and_return(2)
+  end
+
+  render_views
+
+  describe 'GET /api/saml/auth' do
+    # let(:xmldoc) { SamlResponseDoc.new('controller', 'response_assertion', response) }
+
+    context "SP's can have signed_response_message_requested set" do
+      context 'with signed_response_message_requested true' do
+        it 'finds a Signature in the message' do
+          user = create(:user, :signed_up)
+          generate_saml_response(user, sp_requesting_signed_saml_response_settings)
+          saml_response_encoded = response.body.match(/.*id=\"SAMLResponse\" value=\"(.*)\" \/><input type=\"submit\"/)[1]
+          saml_response_text = Base64.decode64(saml_response_encoded)
+          saml_response = ::REXML::Document.new(saml_response_text)
+          signature_count = REXML::XPath.match(saml_response, '//ds:Signature').length
+
+          expect(signature_count).to eq 2
+        end
+      end
+
+      context 'with signed_response_message_requested false' do
+        it 'does not find Signature in the message' do
+          user = create(:user, :signed_up)
+          generate_saml_response(user, sp_not_requesting_signed_saml_response_settings)
+          saml_response_encoded = response.body.match(/.*id=\"SAMLResponse\" value=\"(.*)\" \/><input type=\"submit\"/)[1]
+          saml_response_text = Base64.decode64(saml_response_encoded)
+          saml_response = ::REXML::Document.new(saml_response_text)
+          signature_count = REXML::XPath.match(saml_response, '//ds:Signature').length
+
+          expect(signature_count).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -32,6 +32,7 @@ describe SamlIdpController do
           expect(signature_count).to eq 2
         end
 
+        # rubocop:disable Metrics/LineLength
         it 'finds a Signature referencing the Response' do
           response_id = REXML::XPath.match(saml_response, '//samlp:Response').first.attributes['ID']
           signature_ref = REXML::XPath.match(saml_response, '//ds:Reference').first.attributes['URI'][1..-1]
@@ -57,6 +58,7 @@ describe SamlIdpController do
 
           expect(signature_ref).to eq assertion_id
         end
+        # rubocop:enable Metrics/LineLength
       end
     end
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -101,6 +101,18 @@ module SamlAuthHelper
     settings
   end
 
+  def sp_not_requesting_signed_saml_response_settings
+    settings = saml_settings.dup
+    settings.issuer = 'test_saml_sp_not_requesting_signed_response_message'
+    settings
+  end
+
+  def sp_requesting_signed_saml_response_settings
+    settings = saml_settings.dup
+    settings.issuer = 'test_saml_sp_requesting_signed_response_message'
+    settings
+  end
+
   def email_nameid_saml_settings_for_allowed_issuer
     settings = saml_settings.dup
     settings.name_identifier_format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'


### PR DESCRIPTION
Note: to try this out, you will need to use the accompanying PR in the saml_idp gem (https://github.com/18F/saml_idp/pull/25)