### PR TITLE
LG-2713 IAL2 flow with no SP

### DIFF
--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -10,6 +10,7 @@ module VerifyProfileConcern
   end
 
   def account_or_verify_profile_route
+    return 'idv' if session[:ial2_request_with_no_sp] && !current_user.active_profile.present?
     return 'account' unless profile_needs_verification?
     return 'idv_usps' if usps_mail_bounced?
     'verify_account'

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -10,7 +10,7 @@ module VerifyProfileConcern
   end
 
   def account_or_verify_profile_route
-    return 'idv' if session[:ial2_request_with_no_sp] && !current_user.active_profile.present?
+    return 'idv' if session[:ial2_request_with_no_sp] && current_user.active_profile.blank?
     return 'account' unless profile_needs_verification?
     return 'idv_usps' if usps_mail_bounced?
     'verify_account'

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -18,6 +18,7 @@ class IdvController < ApplicationController
 
   def activated
     redirect_to idv_url unless active_profile?
+    redirect_to account_url if session[:ial2_request_with_no_sp]
     idv_session.clear
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,6 +21,7 @@ module Users
       )
 
       @ial = sp_session ? sp_session_ial : 1
+      session[:ial2_request_with_no_sp] = true if sp_session.blank? && params[:ial]=='2'
       super
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ module Users
       )
 
       @ial = sp_session ? sp_session_ial : 1
-      session[:ial2_request_with_no_sp] = true if sp_session.blank? && params[:ial]=='2'
+      session[:ial2_request_with_no_sp] = true if sp_session.blank? && params[:ial] == '2'
       super
     end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -806,22 +806,6 @@ feature 'Sign in' do
 
       expect(current_url).to start_with('http://localhost:7654/auth/result')
     end
-
-    it 'uses ial2 flow with an ial2 param' do
-      user = create(:profile, :active, :verified,
-                    pii: { first_name: 'John', ssn: '111223333' }).user
-      visit_idp_from_oidc_sp_with_ialmax
-      fill_in_credentials_and_submit(user.email, user.password)
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-
-      expect(current_path).to eq sign_up_completed_path
-      expect(page).to have_content('111223333')
-
-      click_continue
-
-      expect(current_url).to start_with('http://localhost:7654/auth/result')
-    end
   end
 
   context 'saml sp requests ialmax' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -864,7 +864,7 @@ feature 'Sign in' do
     end
 
     it 'invokes ial2 flow if the user does not have an ial1 account' do
-      user = register_user('foo@test.com')
+      register_user('foo@test.com')
 
       complete_all_doc_auth_steps
       click_continue

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -842,15 +842,38 @@ feature 'Sign in' do
   end
 
   context 'ial2 param on sign up screen' do
-    it 'invokes ial2 flow' do
+    before do
       enable_doc_auth
-      user = create(:user, :signed_up)
       visit root_path(ial: 2)
+    end
+
+    it 'invokes ial2 flow if the user already has an ial1 account' do
+      user = create(:user, :signed_up)
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq(idv_doc_auth_welcome_step)
+      complete_all_doc_auth_steps
+      click_continue
+      fill_in 'Password', with: user.password
+      click_continue
+      click_acknowledge_personal_key
+      click_continue
+
+      expect(current_path).to eq(account_path)
+    end
+
+    it 'invokes ial2 flow if the user does not have an ial1 account' do
+      user = register_user('foo@test.com')
+
+      complete_all_doc_auth_steps
+      click_continue
+      fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
+      click_continue
+      click_acknowledge_personal_key
+      click_continue
+
+      expect(current_path).to eq(account_path)
     end
   end
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -875,6 +875,16 @@ feature 'Sign in' do
 
       expect(current_path).to eq(account_path)
     end
+
+    it 'goes to the account page if the user is already verified' do
+      user = create(:user, :signed_up)
+      create(:profile, :active, :verified, pii: { ssn: '1234', dob: '1920-01-01' }, user: user)
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq(account_path)
+    end
   end
 
   def perform_steps_to_get_to_add_piv_cac_during_sign_up

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -823,6 +823,22 @@ feature 'Sign in' do
 
       expect(current_url).to eq @saml_authn_request
     end
+
+    it 'returns ial2 info for a verified user' do
+      user = create(:profile, :active, :verified,
+                    pii: { first_name: 'John', ssn: '111223333' }).user
+      visit_idp_from_saml_sp_with_ialmax
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_content('111223333')
+
+      click_continue
+
+      expect(current_url).to eq @saml_authn_request
+    end
   end
 
   context 'ial2 param on sign up screen' do


### PR DESCRIPTION
**Why**: So we can send out a link for users to verify their account without requiring an SP
**How**: If we see an ial param with a value of 2 on the root_path save ial2_request_with_no_sp in session and force an ial2 flow accordingly