### PR TITLE
WIP Docker image and Compose stack refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,74 @@
 # Use the official Ruby image because the Rails images have been deprecated
-FROM ruby:2.5
+FROM ruby:2.5-slim
 
-# Enable https
-RUN apt-get update
-RUN apt-get install -y apt-transport-https
+# Enable package fetch over https and add a few core tools
+RUN apt-get update \
+    && apt-get install -y \
+       apt-transport-https \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Postgres client
-RUN apt-get install -y --no-install-recommends postgresql-client
-RUN rm -rf /var/lib/apt/lists/*
-
-# Install Chrome for capybara
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - 
-RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update
-RUN apt-get install -y google-chrome-stable
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       postgresql-client \
+       libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Node 12.x
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get install -y nodejs
-RUN ln -s ../node/bin/node /usr/local/bin/
-RUN ln -s ../node/bin/npm /usr/local/bin/
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../node/bin/node /usr/local/bin/ \
+    && ln -s ../node/bin/npm /usr/local/bin/
 
 # Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 # Everything happens here from now on   
 WORKDIR /upaya
 
 # Simple Gem cache.  Success here creates a new layer in the image.
-COPY Gemfile .
-COPY Gemfile.lock .
-RUN gem install bundler --conservative
-RUN bundle install --without deploy production
+# Note - Installs build related debs then removes after use
+COPY Gemfile Gemfile.lock ./
+RUN apt-get update \
+    && apt-get install -y \
+       build-essential \
+       git \
+       liblzma-dev \
+       patch \
+       ruby-dev \
+    && gem install bundler --conservative \
+    && bundle install --without deploy production \
+    && apt-get remove -y \
+       build-essential \
+       git \
+       liblzma-dev \
+       patch \
+       ruby-dev \
+    && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Simple npm cache. Success here creates a new layer in the image.
 COPY package.json .
 COPY yarn.lock .
 RUN NODE_ENV=development yarn install --force
 
-# Copy everything else over
+# Copy in whole source (minus items matched in .dockerignore)
 COPY . .
 
+# Add application user and fix perms
+RUN groupadd -r appuser \
+    && useradd --system --create-home --gid appuser appuser \
+    && chown -R appuser.appuser /upaya
+
 # Up to this point we've been root, change to a lower priv. user
-RUN groupadd -r appuser
-RUN useradd --system --create-home --gid appuser appuser
-RUN chown -R appuser.appuser /upaya
 USER appuser
 
 EXPOSE 3000
-CMD ["rackup", "config.ru", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["bundle", "exec", "rackup", "config.ru", "--host", "0.0.0.0", "--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Simple npm cache. Success here creates a new layer in the image.
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN NODE_ENV=development yarn install --force
 
 # Copy in whole source (minus items matched in .dockerignore)

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -62,5 +62,6 @@ Dir.chdir APP_ROOT do
   run "docker-compose run --rm web rake dev:prime"
   # Create all parallell test databases
   run "docker-compose run --rm web rake parallel:setup"
-
+  # Shut down stack
+  run "docker-compose stop"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,19 @@
+# Docker Compose def for local development
 version: '3'
 services:
   web:
     build: .
     volumes:
-      - .:/upaya
+      # Mount specific sub-directories into image for local development
+      - ./app:/upaya/app
+      - ./certs:/upaya/certs
+      - ./config:/upaya/config
+      - ./db:/upaya/db
+      - ./keys:/upaya/keys
+      - ./lib:/upaya/lib
+      - ./log:/upaya/log
+      - ./pwned_passwords:/upaya/pwned_passwords
+      - ./vendor:/upaya/vendor
     ports:
       - "3000:3000"
     environment:
@@ -25,11 +35,14 @@ services:
       - redis
       - mailcatcher
   db:
-    image: postgres
+    image: postgres:9.6-alpine
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
+    # Trust Docker network - Not suitable for production
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
   redis:
-    image: redis
+    image: redis:5-alpine
   mailcatcher:
     image: rordi/docker-mailcatcher
     container_name: mailcatcher


### PR DESCRIPTION
Test and discussion branch with experiments to reduce Docker image size and resolve some issues when using in directory not previously used for local IdP development.

Shrinks identity-idp_web image from 2.2GB to 1.1GB.

Dockerfile changes:
* IdP base switched to ruby:2.5-slim
* Where possible, collapsed related RUNs into single multiline RUN to reduce layers
* Clear apt cache at end of any RUN using apt
* Run rackup with bundle exec

docker-compose changes:
* Mount a specific set of subdirectories into IdP container to avoid yarn issues/other unintended issues - __Review!  Anything outside of these will require a build to update.__
* PostgreSQL image switched to postgres:9.6-alpine
* PostresSQL configured for network trust
* Redis image switched to redis:5-alpine
