### PR TITLE
[WIP] Add a new Dockerfile for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ A Identity Management System powering login.gov.
 - [Node.js v12.x.x](https://nodejs.org)
 - [Yarn](https://yarnpkg.com/en/)
 
-#### Setting up and running the app
+#### Running the app with Docker
+
+See the [Docker documentation](./docs/Docker.md) to get up and running
+
+#### Setting up and running the app without Docker
 
 1. Make sure you have a working development environment with all the
   [dependencies](#dependencies) installed. On OS X, the easiest way
@@ -179,41 +183,6 @@ it into the "Index pattern" field, then click the "Next step" button.
 
 12. Refresh the Kibana website. You should now see new events show up in the
 Discover section.
-
-
-#### Using Docker Locally
-
-1. Download, install, and launch [Docker](https://www.docker.com/products/docker-desktop). You should probably bump the memory resources in Docker above the defaults to avoid timeouts. 4 or 8 GB should work well.
-
-1. Build the Docker containers: `docker-compose build`
-
-1. Run `make docker_setup` to copy configuration files and bootstrap the database.
-
-1. Start the Docker containers `docker-compose up` and `open http://localhost:3000`
-
-Please note that the `docker_setup` script will destroy and re-create configuration files that were previously symlinked.  See the script source for more info.
-
-If `Gemfile` or `package.json` change, you'll need to `docker-compose build` again to install those new dependencies. 
-
-More useful Docker commands:
-
-* Run migrations: `docker-compose run --rm web bundle exec rails db:migrate`
-* Force the images to re-build: `docker-compose build --no-cache`. You might have to do this if a "regular build" doesn't seem to correctly install new dependencies.
-* Stop the containers: `docker-compose stop`
-* Stop and remove the containers (`-v` removes Volumes, which includes Postgres data): `docker-compose down`
-* Open a shell in a one-off web container: `docker-compose run --rm web bash`
-* Open a shell in the running web container: `docker-compose exec web bash`
-* Open a psql shell in the running db container: `docker-compose exec db psql -U postgres`
-* `docker image prune` to remove dangling images and free up disk space
-
-#### Running Tests in Docker
-
-* After Docker is set up you can run the entire suite with `docker-compose run web bundle exec rspec`. This takes a while.
-* You can run a one-off test with `docker-compose run web bundle exec rspec spec/file.rb`
-* If the cluster is already running you can run the test on those containers using `exec` instead of `run`: `docker-compose exec web bundle exec rspec spec/file.rb`
-
-
-
 
 ### Viewing the app locally
 

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
+
+def run(command)
+  puts("* Running command: #{command}")
+  abort "command failed (#{$?}): #{command}" unless system command
+end
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts %q[
+   _             _
+  | |           (_)
+  | | ___   __ _ _ _ __    __ _  _____   __
+  | |/ _ \ / _` | | '_ \  / _` |/ _ \ \ / /
+  | | (_) | (_| | | | | || (_| | (_) \ V /
+  |_|\___/ \__, |_|_| |_(_)__, |\___/ \_/
+            __/ |          __/ |
+           |___/          |___/
+  ]
+
+  # Build and tag the base production image
+  puts "== Building the base/production Docker image =="
+  run "docker build . -f production.Dockerfile -t identity-idp-production"
+
+end

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -27,6 +27,9 @@ Dir.chdir APP_ROOT do
   # This file is intended to run after `docker-compose up`
   #  it runs commands that won't work at build time and therefore must be runuted at runtime.
 
+  puts "== Shut down cluster =="
+  run "docker-compose down"
+
   # The app dir is mounted as a volume, so new files also appear in the container.
   #  files copied during build can be overwritten by the mounted Volume.
   puts "== Copying new application.yml if file does not already exist"
@@ -53,15 +56,16 @@ Dir.chdir APP_ROOT do
   run "cp config/service_providers.localdev.yml config/service_providers.yml"
 
   puts "== Creating and migrating dev database =="
-  run "docker-compose run --rm web rake db:create"
+  run "docker-compose run --rm web bundle exec rake db:create"
   # The following pattern prevents a database reset from happening in prod.
-  run "docker-compose run --rm web rake db:environment:set"
-  run "docker-compose run --rm web rake db:reset"
-  run "docker-compose run --rm web rake db:environment:set"
+  run "docker-compose run --rm web bundle exec rake db:environment:set"
+  run "docker-compose run --rm web bundle exec rake db:reset"
+  run "docker-compose run --rm web bundle exec rake db:environment:set"
   # This populates the dev database with sample data
-  run "docker-compose run --rm web rake dev:prime"
+  run "docker-compose run --rm web bundle exec rake dev:prime"
   # Create all parallell test databases
-  run "docker-compose run --rm web rake parallel:setup"
-  # Shut down stack
-  run "docker-compose stop"
+  run "docker-compose run --rm web bundle exec rake parallel:setup"
+
+  puts "== Shut down cluster =="
+  run "docker-compose down"
 end

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -24,8 +24,12 @@ RUN apt-get install -y google-chrome-stable
 # Everything happens here from now on   
 WORKDIR /upaya
 
-# Install dev and test gems
-RUN bundle install --with development test
+# Remove vendored gems from base image
+RUN rm -rf vendor/bundle
+# Install dev and test gems on the system
+RUN bundle install --system --with development test
 
 # Change back to appuser to run the app
 USER appuser
+
+# CMD and EXPOSE are inherited from the base image

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,0 +1,31 @@
+# This is the image we run in our local development docker-compose cluster
+#   it is built on top of the local production.Dockerfile
+FROM identity-idp-production
+
+# Use root for more configuration
+USER root
+
+# Re-install dev dependencies
+RUN apt-get update \
+    && apt-get install -y \
+       build-essential \
+       git \
+       liblzma-dev \
+       patch \
+       ruby-dev \
+       wget 
+
+# Install Chrome for integration tests
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - 
+RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update
+RUN apt-get install -y google-chrome-stable
+
+# Everything happens here from now on   
+WORKDIR /upaya
+
+# Install dev and test gems
+RUN bundle install --with development test
+
+# Change back to appuser to run the app
+USER appuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@
 version: '3'
 services:
   web:
-    build: .
+    build: 
+      context: .
+      dockerfile: development.Dockerfile
     volumes:
       # Mount specific sub-directories into image for local development
       - ./app:/upaya/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,7 @@ services:
       context: .
       dockerfile: development.Dockerfile
     volumes:
-      # Mount specific sub-directories into image for local development
-      - ./app:/upaya/app
-      - ./certs:/upaya/certs
-      - ./config:/upaya/config
-      - ./db:/upaya/db
-      - ./keys:/upaya/keys
-      - ./lib:/upaya/lib
-      - ./log:/upaya/log
-      - ./pwned_passwords:/upaya/pwned_passwords
-      - ./vendor:/upaya/vendor
+       - .:/upaya
     ports:
       - "3000:3000"
     environment:

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,34 @@
+# Docker
+
+## Run the app locally with Docker
+
+1. Download, install, and launch [Docker](https://www.docker.com/products/docker-desktop). You may need to increase memory resources in Docker above the defaults to avoid timeouts.
+
+1. Build the production IDP image, which serves as a base for the development container: `bin/docker_build`
+
+1. Build the development Docker containers: `docker-compose build`
+
+1. Run `make docker_setup` to copy configuration files and bootstrap the database.
+
+1. Start the Docker containers `docker-compose up` and `open http://localhost:3000`
+
+Please note that the `docker_setup` script will destroy and re-create configuration files that were previously symlinked.  See the script source for more info.
+
+If `Gemfile` or `package.json` change, you'll need to `docker-compose build` again to install those new dependencies. 
+
+## More useful Docker commands:
+
+* Run migrations: `docker-compose run --rm web bundle exec rails db:migrate`
+* Force the images to re-build: `docker-compose build --no-cache`. You might have to do this if a "regular build" doesn't seem to correctly install new dependencies.
+* Stop the containers: `docker-compose stop`
+* Stop and remove the containers (`-v` removes Volumes, which includes Postgres data): `docker-compose down`
+* Open a shell in a one-off web container: `docker-compose run --rm web bash`
+* Open a shell in the running web container: `docker-compose exec web bash`
+* Open a psql shell in the running db container: `docker-compose exec db psql -U postgres`
+* `docker image prune` to remove dangling images and free up disk space
+
+## Running Tests in Docker
+
+* After Docker is set up you can run the entire suite with `docker-compose run web bundle exec rspec`. This takes a while.
+* You can run a one-off test with `docker-compose run web bundle exec rspec spec/file.rb`
+* If the cluster is already running you can run the test on those containers using `exec` instead of `run`: `docker-compose exec web bundle exec rspec spec/file.rb`

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -24,8 +24,9 @@ If `Gemfile` or `package.json` change, you'll need to `docker-compose build` aga
 * Stop and remove the containers (`-v` removes Volumes, which includes Postgres data): `docker-compose down`
 * Open a shell in a one-off web container: `docker-compose run --rm web bash`
 * Open a shell in the running web container: `docker-compose exec web bash`
+* Open a shell in the running web container as root: `docker-compose exec --user=root web bash`
 * Open a psql shell in the running db container: `docker-compose exec db psql -U postgres`
-* `docker image prune` to remove dangling images and free up disk space
+* `docker system prune` to remove dangling images and free up disk space
 
 ## Running Tests in Docker
 

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,6 +1,9 @@
 # Use the official Ruby image because the Rails images have been deprecated
 FROM ruby:2.5-slim
 
+# Set necessary ENV
+ENV LC_ALL=C.UTF-8
+
 # Enable package fetch over https and add a few core tools
 RUN apt-get update \
     && apt-get install -y \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
        patch \
        ruby-dev \
     && gem install bundler --conservative \
-    && bundle install --without development test \
+    && bundle install --deployment --without development test \
     && apt-get remove -y \
        build-essential \
        git \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
        patch \
        ruby-dev \
     && gem install bundler --conservative \
-    && bundle install --without deploy production \
+    && bundle install --without development test \
     && apt-get remove -y \
        build-essential \
        git \


### PR DESCRIPTION
**Why**: To keep a limited production container, and still allow extra
tools and dependencies for development

- New script to help build the base/production image
- Only install production gems in base image
- New development Dockerfile installs additional gems/tools
- Moved documentation out of README and into docs folder