### PR TITLE
Render verified_at on handoff page, even if null

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -127,7 +127,11 @@ module SignUp
 
     def verified_at
       timestamp = current_user.active_profile&.verified_at
-      I18n.l(timestamp, format: :event_timestamp) if timestamp
+      if timestamp
+        I18n.l(timestamp, format: :event_timestamp)
+      else
+        I18n.t('help_text.requested_attributes.verified_at_blank')
+      end
     end
 
     def pii_to_displayable_attributes

--- a/app/presenters/saml_request_presenter.rb
+++ b/app/presenters/saml_request_presenter.rb
@@ -11,6 +11,7 @@ class SamlRequestPresenter
     address2: :address,
     city: :address,
     state: :address,
+    verified_at: :verified_at,
     zipcode: :address,
   }.freeze
 
@@ -20,8 +21,13 @@ class SamlRequestPresenter
   end
 
   def requested_attributes
-    return [:email] unless ial2_authn_context? || ialmax_authn_context?
-    bundle.map { |attr| ATTRIBUTE_TO_FRIENDLY_NAME_MAP[attr] }.compact.uniq
+    if ial2_authn_context? || ialmax_authn_context?
+      bundle.map { |attr| ATTRIBUTE_TO_FRIENDLY_NAME_MAP[attr] }.compact.uniq
+    else
+      attrs = [:email]
+      attrs << :verified_at if bundle.include?(:verified_at)
+      attrs
+    end
   end
 
   private

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -66,7 +66,7 @@ class AttributeAsserter
   end
 
   def verified_at_getter_function
-    ->(principal) { principal.active_profile.verified_at.iso8601 }
+    ->(principal) { principal.active_profile&.verified_at&.iso8601 }
   end
 
   def attribute_getter_function(attr)

--- a/config/locales/help_text/en.yml
+++ b/config/locales/help_text/en.yml
@@ -16,4 +16,5 @@ en:
       phone: Phone number
       social_security_number: Social Security Number
       verified_at: Updated on
+      verified_at_blank: Not yet verified
       x509_subject: PIV/CAC Identity

--- a/config/locales/help_text/es.yml
+++ b/config/locales/help_text/es.yml
@@ -16,4 +16,5 @@ es:
       phone: Teléfono
       social_security_number: Número de Seguro Social
       verified_at: Actualizado en
+      verified_at_blank: Aún no verificado
       x509_subject: Identidad PIV/CAC

--- a/config/locales/help_text/fr.yml
+++ b/config/locales/help_text/fr.yml
@@ -17,4 +17,5 @@ fr:
       phone: Numéro de téléphone
       social_security_number: Numéro de sécurité sociale
       verified_at: Mis à jour le
+      verified_at_blank: Pas encore vérifié
       x509_subject: Identité associée à la carte PIV/CAC

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -187,7 +187,7 @@ describe 'OpenID Connect' do
                     'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
 
     userinfo_response = JSON.parse(page.body).with_indifferent_access
-    expect(userinfo_response[:email]).to eq(user.email)
+    expect(userinfo_response[:email]).to be_present
     expect(userinfo_response[:verified_at]).to be_nil
   end
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -201,4 +201,27 @@ feature 'IAL1 Single Sign On' do
       expect(page).to have_content t('links.back_to_sp', sp: sp.friendly_name)
     end
   end
+
+  context 'requesting verified_at for an IAL1 account' do
+    it 'shows verified_at as a requested attribute, even if blank' do
+      user = create(:user, :signed_up)
+      saml_authn_request = auth_request.create(ial1_with_verified_at_saml_settings)
+
+      visit saml_authn_request
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_url).to match new_user_session_path
+      expect(page).to have_content(t('help_text.requested_attributes.verified_at'))
+      expect(page).to have_content(t('help_text.requested_attributes.verified_at_blank'))
+
+      click_continue
+
+      xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+
+      expect(xmldoc.attribute_node_for('verified_at')).to be_present
+      expect(xmldoc.attribute_value_for('verified_at')).to be_blank
+    end
+  end
 end

--- a/spec/presenters/saml_request_presenter_spec.rb
+++ b/spec/presenters/saml_request_presenter_spec.rb
@@ -14,13 +14,13 @@ describe SamlRequestPresenter do
         allow(parser).to receive(:requested_attributes).and_return(nil)
 
         all_attributes = %w[
-          email first_name middle_name last_name dob ssn
+          email first_name middle_name last_name dob ssn verified_at
           phone address1 address2 city state zipcode foo
         ]
         service_provider = ServiceProvider.new(attribute_bundle: all_attributes)
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
 
-        expect(presenter.requested_attributes).to eq(%i[email])
+        expect(presenter.requested_attributes).to eq(%i[email verified_at])
       end
     end
 
@@ -34,12 +34,12 @@ describe SamlRequestPresenter do
 
         service_provider = ServiceProvider.new(
           attribute_bundle: %w[
-            email first_name middle_name last_name dob foo ssn phone
+            email first_name middle_name last_name dob foo ssn phone verified_at
           ],
         )
         presenter = SamlRequestPresenter.new(request: request, service_provider: service_provider)
         valid_attributes = %i[
-          email given_name name family_name birthdate social_security_number phone
+          email given_name name family_name birthdate social_security_number phone verified_at
         ]
 
         expect(presenter.requested_attributes).to eq(valid_attributes)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -174,6 +174,15 @@ module SamlAuthHelper
     settings
   end
 
+  def ial1_with_verified_at_saml_settings
+    settings = sp1_saml_settings
+    settings.authn_context = [
+      settings.authn_context,
+      "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,verified_at",
+    ]
+    settings
+  end
+
   def ial1_with_bundle_saml_settings
     settings = sp1_saml_settings
     settings.authn_context = [


### PR DESCRIPTION
- Also make sure it renders for SAML

![localhost_3000_sign_up_completed](https://user-images.githubusercontent.com/458784/75924366-aa268300-5e1b-11ea-8071-a2f40cfe8834.png)
