### PR TITLE
LG-2733 Fiscal active users report by SP

### DIFF
--- a/app/services/db/identity/sp_active_user_counts.rb
+++ b/app/services/db/identity/sp_active_user_counts.rb
@@ -6,8 +6,8 @@ module Db
         sql = <<~SQL
           SELECT
             issuer,
-            sum(total_ial1_active) AS total_ial1_active,
-            sum(total_ial2_active) AS total_ial2_active
+            CAST(SUM(total_ial1_active) AS INTEGER) AS total_ial1_active,
+            CAST(SUM(total_ial2_active) AS INTEGER) AS total_ial2_active
           FROM (
             (SELECT
               service_provider AS issuer,

--- a/app/services/db/identity/sp_active_user_counts.rb
+++ b/app/services/db/identity/sp_active_user_counts.rb
@@ -6,7 +6,7 @@ module Db
         sql = <<~SQL
           SELECT
             issuer,
-            sum(total_ial1_active) AS total_ial1_active, 
+            sum(total_ial1_active) AS total_ial1_active,
             sum(total_ial2_active) AS total_ial2_active
           FROM (
             (SELECT

--- a/app/services/db/identity/sp_active_user_counts.rb
+++ b/app/services/db/identity/sp_active_user_counts.rb
@@ -3,6 +3,7 @@ module Db
     class SpActiveUserCounts
       # rubocop:disable Metrics/MethodLength
       def self.call(start_date)
+        quoted_start_date = ActiveRecord::Base.connection.quote(start_date)
         sql = <<~SQL
           SELECT
             issuer,
@@ -14,7 +15,7 @@ module Db
               count(*) AS total_ial1_active,
               0 AS total_ial2_active
             FROM identities
-            WHERE '#{start_date}' <= last_ial1_authenticated_at
+            WHERE #{quoted_start_date} <= last_ial1_authenticated_at
             GROUP BY issuer ORDER BY issuer)
             UNION
             (SELECT
@@ -22,7 +23,7 @@ module Db
               0 AS total_ial1_active,
               count(*) AS total_ial2_active
             FROM identities
-            WHERE '#{start_date}' <= last_ial2_authenticated_at
+            WHERE #{quoted_start_date} <= last_ial2_authenticated_at
             GROUP BY issuer ORDER BY issuer)
           ) AS union_of_ial1_and_ial2_results
           GROUP BY ISSUER ORDER BY issuer

--- a/app/services/db/identity/sp_active_user_counts.rb
+++ b/app/services/db/identity/sp_active_user_counts.rb
@@ -1,0 +1,35 @@
+module Db
+  module Identity
+    class SpActiveUserCounts
+      # rubocop:disable Metrics/MethodLength
+      def self.call(start_date)
+        sql = <<~SQL
+          SELECT
+            issuer,
+            sum(total_ial1_active) AS total_ial1_active, 
+            sum(total_ial2_active) AS total_ial2_active
+          FROM (
+            (SELECT
+              service_provider AS issuer,
+              count(*) AS total_ial1_active,
+              0 AS total_ial2_active
+            FROM identities
+            WHERE '#{start_date}' <= last_ial1_authenticated_at
+            GROUP BY issuer ORDER BY issuer)
+            UNION
+            (SELECT
+              service_provider AS issuer,
+              0 AS total_ial1_active,
+              count(*) AS total_ial2_active
+            FROM identities
+            WHERE '#{start_date}' <= last_ial2_authenticated_at
+            GROUP BY issuer ORDER BY issuer)
+          ) AS union_of_ial1_and_ial2_results
+          GROUP BY ISSUER ORDER BY issuer
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -29,7 +29,7 @@ class IdentityLinker
   end
 
   def process_ial_at(now)
-    if @ial == 2 || (@ial == 0 && identity.verified_at.present?)
+    if @ial == 2 || (@ial&.zero? && identity.verified_at.present?)
       identity.last_ial2_authenticated_at = now
     else
       identity.last_ial1_authenticated_at = now

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -23,8 +23,22 @@ class IdentityLinker
 
   def process_ial(extra_attrs)
     @ial = extra_attrs[:ial]
+    now = Time.zone.now
+    process_ial_at(now)
+    process_verified_at(now)
+  end
+
+  def process_ial_at(now)
+    if @ial == 2 || (@ial == 0 && identity.verified_at.present?)
+      identity.last_ial2_authenticated_at = now
+    else
+      identity.last_ial1_authenticated_at = now
+    end
+  end
+
+  def process_verified_at(now)
     return unless @ial == 2 && identity.verified_at.nil?
-    identity.verified_at = Time.zone.now
+    identity.verified_at = now
   end
 
   def identity

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -29,7 +29,7 @@ class IdentityLinker
   end
 
   def process_ial_at(now)
-    if @ial == 2 || (@ial&.zero? && identity.verified_at.present?)
+    if @ial == 2 || (identity.verified_at.present? && @ial&.zero?)
       identity.last_ial2_authenticated_at = now
     else
       identity.last_ial1_authenticated_at = now

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -6,7 +6,7 @@ module Reports
 
     def fiscal_start_date
       now = Time.zone.now
-      now.change(year: now.month >= 10 ? now.year : now.year - 1, month: 10, day: 1).to_s
+      now.change(year: now.month >= 10 ? now.year : now.year - 1, month: 10, day: 1).to_date.to_s
     end
 
     def first_of_this_month

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -6,7 +6,7 @@ module Reports
 
     def fiscal_start_date
       now = Time.zone.now
-      "10-01-#{now.month >= 10 ? now.year : now.year - 1}"
+      now.change(year: now.month >= 10 ? now.year : now.year - 1, month: 10, day: 1).to_s
     end
 
     def first_of_this_month

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -6,11 +6,7 @@ module Reports
 
     def fiscal_start_date
       now = Time.zone.now
-      if now.month >= 10
-        now.strftime('10-01-%Y')
-      else
-        "10-01-#{now.year - 1}"
-      end
+      "10-01-#{now.month >= 10 ? now.year : now.year - 1}"
     end
 
     def first_of_this_month

--- a/app/services/reports/sp_active_users_report.rb
+++ b/app/services/reports/sp_active_users_report.rb
@@ -1,0 +1,14 @@
+require 'login_gov/hostdata'
+
+module Reports
+  class SpActiveUsersReport < BaseReport
+    REPORT_NAME = 'sp-active-users-report'.freeze
+
+    def call
+      results = transaction_with_timeout do
+        Db::Identity::SpActiveUserCounts.call(fiscal_start_date)
+      end
+      save_report(REPORT_NAME, results.to_json)
+    end
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -121,3 +121,11 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   timeout: 300,
   callback: -> { Reports::TotalSpCostReport.new.call },
 )
+
+# SP Active Users Report to S3
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
+  name: 'SP active users report',
+  interval: 24 * 60 * 60, # 24 hours
+  timeout: 300,
+  callback: -> { Reports::SpActiveUsersReport.new.call },
+)

--- a/db/migrate/20200305201944_add_ial_at_to_identities.rb
+++ b/db/migrate/20200305201944_add_ial_at_to_identities.rb
@@ -1,0 +1,6 @@
+class AddIalAtToIdentities < ActiveRecord::Migration[5.1]
+  def change
+    add_column :identities, :last_ial1_authenticated_at, :datetime
+    add_column :identities, :last_ial2_authenticated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200303202931) do
+ActiveRecord::Schema.define(version: 20200305201944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,8 @@ ActiveRecord::Schema.define(version: 20200303202931) do
     t.json "verified_attributes"
     t.datetime "verified_at"
     t.datetime "last_consented_at"
+    t.datetime "last_ial1_authenticated_at"
+    t.datetime "last_ial2_authenticated_at"
     t.index ["access_token"], name: "index_identities_on_access_token", unique: true
     t.index ["session_uuid"], name: "index_identities_on_session_uuid", unique: true
     t.index ["user_id", "service_provider"], name: "index_identities_on_user_id_and_service_provider", unique: true

--- a/spec/config/initializers/job_configurations.rb
+++ b/spec/config/initializers/job_configurations.rb
@@ -176,5 +176,19 @@ describe JobRunner::Runner do
 
       expect(job.callback.call).to eq 'the report test worked'
     end
+
+    it 'runs the SP active users report job' do
+      job = JobRunner::Runner.configurations.find do |c|
+        c.name == 'SP active users report'
+      end
+      expect(job).to be_instance_of(JobRunner::JobConfiguration)
+      expect(job.interval).to eq 24 * 60 * 60
+
+      service = instance_double(Reports::SpActiveUsersReport)
+      expect(Reports::SpActiveUsersReport).to receive(:new).and_return(service)
+      expect(service).to receive(:call).and_return('the report test worked')
+
+      expect(job.callback.call).to eq 'the report test worked'
+    end
   end
 end

--- a/spec/features/reports/sp_active_users_report_spec.rb
+++ b/spec/features/reports/sp_active_users_report_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature 'sp active users report' do
+  include SamlAuthHelper
+  include IdvHelper
+
+  it 'reports a user as ial1 active for an ial1 sign in' do
+    user = create(:user, :signed_up)
+    visit_idp_from_sp_with_ial1(:oidc)
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    click_continue
+    expect(current_url).to start_with('http://localhost:7654/auth/result')
+
+    results = [{ 'issuer': 'urn:gov:gsa:openidconnect:sp:server',
+                 'total_ial1_active': 1,
+                 'total_ial2_active': 0 }].to_json
+    expect(Db::Identity::SpActiveUserCounts.call('01-01-2019').to_json).to eq(results)
+  end
+
+  it 'reports a user as ial2 active for an ial2 sign in' do
+    user = create(:profile, :active, :verified,
+                  pii: { first_name: 'John', ssn: '111223333' }).user
+    visit_idp_from_sp_with_ial2(:oidc)
+    fill_in_credentials_and_submit(user.email, user.password)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+    click_continue
+    expect(current_url).to start_with('http://localhost:7654/auth/result')
+
+    results = [{ 'issuer': 'urn:gov:gsa:openidconnect:sp:server',
+                 'total_ial1_active': 0,
+                 'total_ial2_active': 1 }].to_json
+    expect(Db::Identity::SpActiveUserCounts.call('01-01-2019').to_json).to eq(results)
+  end
+end

--- a/spec/services/db/identity/sp_active_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_active_user_counts_spec.rb
@@ -4,8 +4,69 @@ describe Db::Identity::SpActiveUserCounts do
   subject { described_class }
 
   let(:fiscal_start_date) { 1.year.ago.strftime('%m-%d-%Y') }
+  let(:issuer) { 'foo' }
+  let(:issuer2) { 'foo2' }
 
   it 'is empty' do
     expect(subject.call(fiscal_start_date).ntuples).to eq(0)
+  end
+
+  it 'returns total active user counts per sp broken down by ial1 and ial2 for ial1 only sps' do
+    now = Time.zone.now
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+                    last_ial1_authenticated_at: now)
+    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+                    last_ial1_authenticated_at: now)
+    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+                    last_ial1_authenticated_at: now)
+    result = { issuer: issuer, total_ial1_active: 2, total_ial2_active: 0 }.to_json
+    result2 = { issuer: issuer2, total_ial1_active: 1, total_ial2_active: 0 }.to_json
+
+    tuples = subject.call(fiscal_start_date)
+    expect(tuples.ntuples).to eq(2)
+    expect(tuples[0].to_json).to eq(result)
+    expect(tuples[1].to_json).to eq(result2)
+  end
+
+  it 'returns total active user counts per sp broken down by ial1 and ial2 for ial2 only sps' do
+    now = Time.zone.now
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+                    last_ial2_authenticated_at: now)
+    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+                    last_ial2_authenticated_at: now)
+    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+                    last_ial2_authenticated_at: now)
+    result = { issuer: issuer, total_ial1_active: 0, total_ial2_active: 2 }.to_json
+    result2 = { issuer: issuer2, total_ial1_active: 0, total_ial2_active: 1 }.to_json
+
+    tuples = subject.call(fiscal_start_date)
+    expect(tuples.ntuples).to eq(2)
+    expect(tuples[0].to_json).to eq(result)
+    expect(tuples[1].to_json).to eq(result2)
+  end
+
+  it 'returns total active user counts per sp broken down by ial1 and ial2 for ial1 ial2 sps' do
+    now = Time.zone.now
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+                    last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
+    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+                    last_ial1_authenticated_at: now)
+    Identity.create(user_id: 3, service_provider: issuer2, uuid: 'foo3',
+                    last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
+    Identity.create(user_id: 4, service_provider: issuer2, uuid: 'foo4',
+                    last_ial2_authenticated_at: now)
+    result = { issuer: issuer, total_ial1_active: 2, total_ial2_active: 1 }.to_json
+    result2 = { issuer: issuer2, total_ial1_active: 1, total_ial2_active: 2 }.to_json
+
+    tuples = subject.call(fiscal_start_date)
+    expect(tuples.ntuples).to eq(2)
+    expect(tuples[0].to_json).to eq(result)
+    expect(tuples[1].to_json).to eq(result2)
   end
 end

--- a/spec/services/db/identity/sp_active_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_active_user_counts_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Db::Identity::SpActiveUserCounts do
+  subject { described_class }
+
+  let(:fiscal_start_date) { 1.year.ago.strftime('%m-%d-%Y') }
+
+  it 'is empty' do
+    expect(subject.call(fiscal_start_date).ntuples).to eq(0)
+  end
+end

--- a/spec/services/reports/sp_active_users_report_spec.rb
+++ b/spec/services/reports/sp_active_users_report_spec.rb
@@ -3,7 +3,27 @@ require 'rails_helper'
 describe Reports::SpActiveUsersReport do
   subject { described_class.new }
 
+  let(:fiscal_start_date) { 1.year.ago.to_s }
+  let(:issuer) { 'foo' }
+  let(:issuer2) { 'foo2' }
+
   it 'is empty' do
     expect(subject.call).to eq('[]')
+  end
+
+  it 'returns total active user counts per sp broken down by ial1 and ial2' do
+    now = Time.zone.now
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'foo1',
+                    last_ial1_authenticated_at: now, last_ial2_authenticated_at: now)
+    Identity.create(user_id: 2, service_provider: issuer, uuid: 'foo2',
+                    last_ial1_authenticated_at: now)
+    Identity.create(user_id: 3, service_provider: issuer, uuid: 'foo3',
+                    last_ial2_authenticated_at: now)
+    Identity.create(user_id: 4, service_provider: issuer, uuid: 'foo4',
+                    last_ial2_authenticated_at: now)
+    result = [{ issuer: issuer, total_ial1_active: 2, total_ial2_active: 3 }].to_json
+
+    expect(subject.call).to eq(result)
   end
 end

--- a/spec/services/reports/sp_active_users_report_spec.rb
+++ b/spec/services/reports/sp_active_users_report_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Reports::SpActiveUsersReport do
+  subject { described_class.new }
+
+  it 'is empty' do
+    expect(subject.call).to eq('[]')
+  end
+end


### PR DESCRIPTION
**Why**: For analytics and billing
**How**: Add two new columns to the identities table: last_ial1_authenticated_at and last_ial2_authenticated_at.  Update them appropriately for each auth.  For reporting do two full scan passes on identities and aggregate the number of ial1 auths and ial2 auths for each SP.  Combine the results to produce IAL1 and IAL2 counts for each SP.