### PR TITLE
LG-2734 aXe Audit

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.assets.digest = ENV.key?('RAILS_DISABLE_ASSET_DIGEST') ? false : true
 
   config.middleware.use RackSessionAccess::Middleware
-  config.lograge.enabled = true
+  config.lograge.enabled = false
 
   config.after_initialize do
     # Having bullet enabled in the test environment causes issues with unit

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
 
   # Disable lograge when computing coverage and not in CircleCI, where lograge is required.
   # This enables scanning for view test coverage with `rake test:scan_log_for_render`
-  config.lograge.enabled = !(ENV['COVERAGE'] && !ENV['CI'])
+  config.lograge.enabled = !ENV['COVERAGE'] || ENV['CI']
 
   config.after_initialize do
     # Having bullet enabled in the test environment causes issues with unit

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,8 @@ Rails.application.configure do
   config.assets.digest = ENV.key?('RAILS_DISABLE_ASSET_DIGEST') ? false : true
 
   config.middleware.use RackSessionAccess::Middleware
+
+  # Lograge must be disabled to scan for view test coverage with `rake test:scan_logs_for_render`
   config.lograge.enabled = false
 
   config.after_initialize do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.middleware.use RackSessionAccess::Middleware
 
   # Lograge must be disabled to scan for view test coverage with `rake test:scan_logs_for_render`
-  config.lograge.enabled = false
+  config.lograge.enabled = !ENV['COVERAGE']
 
   config.after_initialize do
     # Having bullet enabled in the test environment causes issues with unit

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,8 +29,9 @@ Rails.application.configure do
 
   config.middleware.use RackSessionAccess::Middleware
 
-  # Lograge must be disabled to scan for view test coverage with `rake test:scan_logs_for_render`
-  config.lograge.enabled = !ENV['COVERAGE']
+  # Disable lograge when computing coverage and not in CircleCI, where lograge is required.
+  # This enables scanning for view test coverage with `rake test:scan_log_for_render`
+  config.lograge.enabled = !(ENV['COVERAGE'] && !ENV['CI'])
 
   config.after_initialize do
     # Having bullet enabled in the test environment causes issues with unit

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,19 @@
+namespace :test do
+
+  # Note: you probably want to `> log/test.log` to empty the test log file
+  #  and then re-run tests to get a fresh view
+  desc 'Scan test.log for rendered views'
+  task scan_log_for_render: :environment do
+    test_log = File.read("log/test.log")
+    # Rendered + space + word + [/ + non-whitespace](any number of times)
+    regex_finder = /Rendered\s\w*(\/\S*)*/
+    results = []
+    
+    test_log.each_line do |li|
+      results.push(li.match(regex_finder))
+    end
+
+    puts results.map(&:to_s).compact.sort.uniq
+  end
+
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,11 +1,11 @@
 namespace :test do
-  # Note: you probably want to `> log/test.log` to empty the test log file
-  #  and then re-run tests to get a fresh view
+  # Use `> log/test.log` to empty test.log before re-running tests to get an accurate list
+  # Note you must run tests with `COVERAGE=true` to generate scannable logs.
   desc 'Scan test.log for rendered views'
   task scan_log_for_render: :environment do
     # match 'Rendered two_factor_authentication/otp_verification/show.html.erb'
     # Rendered + space + word + [/ + non-whitespace](any number of times)
-    regex_finder = /Rendered\s\w*(\/\S*)*/
+    regex_finder = %r|Rendered\s\w*(/\S*)*|
     results = []
     File.readlines('log/test.log').each do |line|
       results.push(line.match(regex_finder))

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -3,13 +3,12 @@ namespace :test do
   #  and then re-run tests to get a fresh view
   desc 'Scan test.log for rendered views'
   task scan_log_for_render: :environment do
-    test_log = File.read('log/test.log')
+    # match 'Rendered two_factor_authentication/otp_verification/show.html.erb'
     # Rendered + space + word + [/ + non-whitespace](any number of times)
     regex_finder = /Rendered\s\w*(\/\S*)*/
     results = []
-
-    test_log.each_line do |li|
-      results.push(li.match(regex_finder))
+    File.readlines('log/test.log').each do |line|
+      results.push(line.match(regex_finder))
     end
 
     puts results.map(&:to_s).compact.sort.uniq

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -5,7 +5,7 @@ namespace :test do
   task scan_log_for_render: :environment do
     # match 'Rendered two_factor_authentication/otp_verification/show.html.erb'
     # Rendered + space + word + [/ + non-whitespace](any number of times)
-    regex_finder = %r|Rendered\s\w*(/\S*)*|
+    regex_finder = %r{Rendered\s\w*(/\S*)*}
     results = []
     File.readlines('log/test.log').each do |line|
       results.push(line.match(regex_finder))

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,19 +1,17 @@
 namespace :test do
-
   # Note: you probably want to `> log/test.log` to empty the test log file
   #  and then re-run tests to get a fresh view
   desc 'Scan test.log for rendered views'
   task scan_log_for_render: :environment do
-    test_log = File.read("log/test.log")
+    test_log = File.read('log/test.log')
     # Rendered + space + word + [/ + non-whitespace](any number of times)
     regex_finder = /Rendered\s\w*(\/\S*)*/
     results = []
-    
+
     test_log.each_line do |li|
       results.push(li.match(regex_finder))
     end
 
     puts results.map(&:to_s).compact.sort.uniq
   end
-
 end


### PR DESCRIPTION
A rake task to scan `test.log` and output views that have been rendered, in order to help get an idea of view test coverage for accessibility tests.