### PR TITLE
Onions have layers - IdPs also can have layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@ node_modules
 db/*.sqlite3
 *.md
 .git*
+vendor/bundle
 postgres-data

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,37 @@
+# Base for all IdP images
+FROM ruby:2.5-slim
+
+# Enable package fetch over https and add a few core tools
+RUN apt-get update \
+    && apt-get install -y \
+       apt-transport-https \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Postgres client
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       postgresql-client \
+       libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node 12.x
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../node/bin/node /usr/local/bin/ \
+    && ln -s ../node/bin/npm /usr/local/bin/
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add application user 
+RUN groupadd -r appuser \
+    && useradd --system --create-home --gid appuser appuser
+
+CMD ["sh"]

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -24,8 +24,11 @@ Dir.chdir APP_ROOT do
            |___/          |___/
   ]
 
-  # Build and tag the base production image
-  puts "== Building the base/production Docker image =="
-  run "docker build . -f production.Dockerfile -t identity-idp-production"
+  # Rebuild the base, build, and production images
+  # TODO - rails_base and rails_build should be moved out of this repo
+  {:base=>"rails_base", :build=>"rails_build", :production=>"idp_app"}.each do |d, n|
+    puts "== Building the #{d} Docker image =="
+    run "docker build . -f #{d}.Dockerfile -t identity-#{n} --no-cache"
+  end
 
 end

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path("../../",  __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 def run(command)
   puts("* Running command: #{command}")
@@ -25,10 +25,11 @@ Dir.chdir APP_ROOT do
   ]
 
   # Rebuild the base, build, and production images
-  # TODO - rails_base and rails_build should be moved out of this repo
-  {:base=>"rails_base", :build=>"rails_build", :production=>"idp_app"}.each do |d, n|
-    puts "== Building the #{d} Docker image =="
-    run "docker build . -f #{d}.Dockerfile -t identity-#{n} --no-cache"
+  # ** Eventually we will keep the `base` and `build` images in a separate repo,
+  #   build them in a separate pipeline, and just pull them down for development
+  #   Note: building the production image here is not necessary for development work
+  { base: 'rails_base', build: 'rails_build', production: 'idp_app' }.each do |name, description|
+    puts "== Building the #{name} Docker image =="
+    run "docker build . --file #{name}.Dockerfile --tag identity-#{description} --no-cache"
   end
-
 end

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -56,15 +56,15 @@ Dir.chdir APP_ROOT do
   run "cp config/service_providers.localdev.yml config/service_providers.yml"
 
   puts "== Creating and migrating dev database =="
-  run "docker-compose run --rm web bundle exec rake db:create"
+  run "docker-compose run --rm development bundle exec rake db:create"
   # The following pattern prevents a database reset from happening in prod.
-  run "docker-compose run --rm web bundle exec rake db:environment:set"
-  run "docker-compose run --rm web bundle exec rake db:reset"
-  run "docker-compose run --rm web bundle exec rake db:environment:set"
+  run "docker-compose run --rm development bundle exec rake db:environment:set"
+  run "docker-compose run --rm development bundle exec rake db:reset"
+  run "docker-compose run --rm development bundle exec rake db:environment:set"
   # This populates the dev database with sample data
-  run "docker-compose run --rm web bundle exec rake dev:prime"
+  run "docker-compose run --rm development bundle exec rake dev:prime"
   # Create all parallell test databases
-  run "docker-compose run --rm web bundle exec rake parallel:setup"
+  run "docker-compose run --rm development bundle exec rake parallel:setup"
 
   puts "== Shut down cluster =="
   run "docker-compose down"

--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -56,15 +56,15 @@ Dir.chdir APP_ROOT do
   run "cp config/service_providers.localdev.yml config/service_providers.yml"
 
   puts "== Creating and migrating dev database =="
-  run "docker-compose run --rm development bundle exec rake db:create"
+  run "docker-compose run --rm app bundle exec rake db:create"
   # The following pattern prevents a database reset from happening in prod.
-  run "docker-compose run --rm development bundle exec rake db:environment:set"
-  run "docker-compose run --rm development bundle exec rake db:reset"
-  run "docker-compose run --rm development bundle exec rake db:environment:set"
+  run "docker-compose run --rm app bundle exec rake db:environment:set"
+  run "docker-compose run --rm app bundle exec rake db:reset"
+  run "docker-compose run --rm app bundle exec rake db:environment:set"
   # This populates the dev database with sample data
-  run "docker-compose run --rm development bundle exec rake dev:prime"
+  run "docker-compose run --rm app bundle exec rake dev:prime"
   # Create all parallell test databases
-  run "docker-compose run --rm development bundle exec rake parallel:setup"
+  run "docker-compose run --rm app bundle exec rake parallel:setup"
 
   puts "== Shut down cluster =="
   run "docker-compose down"

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,5 @@
-# Build base image - Use to build only, not as a final base!
+# Build base image - Use to build only, not as a final base.
+# Docker multi-stage builds are used to copy output from this heavy image into others
 FROM identity-rails_base
 
 # Everything happens here from now on   

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,0 +1,17 @@
+# Build base image - Use to build only, not as a final base!
+FROM identity-rails_base
+
+# Everything happens here from now on   
+WORKDIR /upaya
+
+# Prepare for Gem builds
+RUN apt-get update \
+    && apt-get install -y \
+       build-essential \
+       git \
+       liblzma-dev \
+       patch \
+       ruby-dev \
+    && gem install bundler --conservative
+
+CMD ["sh"]

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,35 +1,42 @@
-# This is the image we run in our local development docker-compose cluster
-#   it is built on top of the local production.Dockerfile
-FROM identity-idp-production
-
-# Use root for more configuration
-USER root
-
-# Re-install dev dependencies
-RUN apt-get update \
-    && apt-get install -y \
-       build-essential \
-       git \
-       liblzma-dev \
-       patch \
-       ruby-dev \
-       wget 
-
-# Install Chrome for integration tests
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - 
-RUN sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update
-RUN apt-get install -y google-chrome-stable
+# Use build image to 
+FROM identity-rails_build as build
 
 # Everything happens here from now on   
 WORKDIR /upaya
 
-# Remove vendored gems from base image
-RUN rm -rf vendor/bundle
-# Install dev and test gems on the system
+# Install dev and test gems
+COPY Gemfile Gemfile.lock ./
 RUN bundle install --system --with development test
 
-# Change back to appuser to run the app
+# Install NPM packages
+COPY package.json yarn.lock ./
+RUN NODE_ENV=development yarn install --force \
+    && yarn cache clean
+
+# Switch to production image and add in Gems
+FROM identity-rails_base
+WORKDIR /upaya
+
+# Copy system Gems into base container
+COPY --from=build /usr/local/bundle /usr/local/bundle
+
+# Set alternate node module path and copy NPMs in - Avoids conflict
+# with local node_modules for dev
+ENV NODE_PATH=/usr/local/node_modules
+COPY --from=build /upaya/node_modules /usr/local/node_modules
+
+# Install Chrome for integration tests
+RUN curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy in whole source (minus items matched in .dockerignore)
+COPY --chown=appuser:appuser . .
+
+# Up to this point we've been root, change to a lower priv. user
 USER appuser
 
-# CMD and EXPOSE are inherited from the base image
+EXPOSE 3000
+CMD ["bundle", "exec", "rackup", "config.ru", "--host", "0.0.0.0", "--port", "3000"]

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,4 +1,4 @@
-# Use build image to 
+# Use build image first for heavy lifting
 FROM identity-rails_build as build
 
 # Everything happens here from now on   
@@ -13,7 +13,7 @@ COPY package.json yarn.lock ./
 RUN NODE_ENV=development yarn install --force \
     && yarn cache clean
 
-# Switch to production image and add in Gems
+# Switch to base image and add in Gems
 FROM identity-rails_base
 WORKDIR /upaya
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,4 +1,6 @@
-# Local run of production-like stack
+# Use this compose file to run a local production-like stack
+#  `docker-compose --file docker-compose-production.yml` to use it up
+# Not great for development work
 version: '3'
 services:
   app:
@@ -42,7 +44,7 @@ services:
     image: postgres:9.6-alpine
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
-    # Trust Docker network - Not suitable for production
+    # Trust Docker network - Not suitable for real production
     environment:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
   redis:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,17 +1,20 @@
-# Docker Compose def for local development
+# Local run of production-like stack
 version: '3'
 services:
-  development:
+  app:
     build: 
       context: .
-      dockerfile: development.Dockerfile
+      dockerfile: production.Dockerfile
     volumes:
-      # Mounts entire tree into container - Only suitable for development
-      # image with Gems installed into system path and node modules in
-      # alternate location
-       - .:/upaya
-    ports:
-      - "3000:3000"
+       - ./app:/upaya/app
+       - ./certs:/upaya/certs
+       - ./config:/upaya/config
+       - ./db:/upaya/db
+       - ./keys:/upaya/keys
+       - ./lib:/upaya/lib
+       - ./log:/upaya/log
+       - ./pwned_passwords:/upaya/pwned_passwords
+       - ./vendor:/upaya/vendor
     environment:
       redis_url: "redis://redis:6379"
       redis_throttle_url: "redis://redis:6379"
@@ -29,7 +32,12 @@ services:
     depends_on:
       - db
       - redis
+  #    - web
       - mailcatcher
+  web:
+    image: nginx:alpine
+    ports:
+      - "3000:3000"
   db:
     image: postgres:9.6-alpine
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-# Docker Compose def for local development
+# Compose file for local development
 version: '3'
 services:
-  development:
+  app:
     build: 
       context: .
       dockerfile: development.Dockerfile

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,5 +1,12 @@
 # Docker
 
+We use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds) to build different kinds of containers.
+
+1. `base.Dockerfile` installs some core tools necessary for all images. All other images inherit from this base image.
+2. `build.Dockerfile` installs some heavier-weight tools used to compile code.
+3. `development.Dockerfile` installs development and test tools useful for local development.
+4. `production.Dockerfile` stays lightweight by `COPY`ing over built packages and other assets from the `build` image.
+
 ## Run the app locally with Docker
 
 1. Download, install, and launch [Docker](https://www.docker.com/products/docker-desktop). You may need to increase memory resources in Docker above the defaults to avoid timeouts.
@@ -14,22 +21,22 @@
 
 Please note that the `docker_setup` script will destroy and re-create configuration files that were previously symlinked.  See the script source for more info.
 
-If `Gemfile` or `package.json` change, you'll need to `docker-compose build` again to install those new dependencies. 
+If `Gemfile` or `package.json` change, you'll need to `docker-compose build` again to install those new dependencies.
 
 ## More useful Docker commands:
 
-* Run migrations: `docker-compose run --rm web bundle exec rails db:migrate`
+* Run migrations: `docker-compose run --rm app bundle exec rails db:migrate`
 * Force the images to re-build: `docker-compose build --no-cache`. You might have to do this if a "regular build" doesn't seem to correctly install new dependencies.
 * Stop the containers: `docker-compose stop`
 * Stop and remove the containers (`-v` removes Volumes, which includes Postgres data): `docker-compose down`
-* Open a shell in a one-off web container: `docker-compose run --rm web bash`
-* Open a shell in the running web container: `docker-compose exec web bash`
-* Open a shell in the running web container as root: `docker-compose exec --user=root web bash`
+* Open a shell in a one-off app container: `docker-compose run --rm app bash`
+* Open a shell in the running app container: `docker-compose exec app bash`
+* Open a shell in the running app container as root: `docker-compose exec --user=root app bash`
 * Open a psql shell in the running db container: `docker-compose exec db psql -U postgres`
 * `docker system prune` to remove dangling images and free up disk space
 
 ## Running Tests in Docker
 
-* After Docker is set up you can run the entire suite with `docker-compose run web bundle exec rspec`. This takes a while.
-* You can run a one-off test with `docker-compose run web bundle exec rspec spec/file.rb`
-* If the cluster is already running you can run the test on those containers using `exec` instead of `run`: `docker-compose exec web bundle exec rspec spec/file.rb`
+* After Docker is set up you can run the entire suite with `docker-compose run app bundle exec rspec`. This takes a while.
+* You can run a one-off test with `docker-compose run app bundle exec rspec spec/file.rb`
+* If the cluster is already running you can run the test on those containers using `exec` instead of `run`: `docker-compose exec app bundle exec rspec spec/file.rb`

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -4,9 +4,9 @@
 
 1. Download, install, and launch [Docker](https://www.docker.com/products/docker-desktop). You may need to increase memory resources in Docker above the defaults to avoid timeouts.
 
-1. Build the production IDP image, which serves as a base for the development container: `bin/docker_build`
+1. Build the __Rails base__, __Rails development__, and __production IDP__ images: `bin/docker_build`
 
-1. Build the development Docker containers: `docker-compose build`
+1. Build the development Docker containers using __Rails base__ and __Rails development__ images: `docker-compose build`
 
 1. Run `make docker_setup` to copy configuration files and bootstrap the database.
 

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -13,7 +13,7 @@ COPY package.json yarn.lock ./
 RUN NODE_ENV=development yarn install --force \
     && yarn cache clean
 
-# Use our base
+# Switch to base image
 FROM identity-rails_base
 WORKDIR /upaya
 

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,73 +1,27 @@
-# Use the official Ruby image because the Rails images have been deprecated
-FROM ruby:2.5-slim
-
-# Set necessary ENV
-ENV LC_ALL=C.UTF-8
-
-# Enable package fetch over https and add a few core tools
-RUN apt-get update \
-    && apt-get install -y \
-       apt-transport-https \
-       curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Postgres client
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       postgresql-client \
-       libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node 12.x
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get update \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s ../node/bin/node /usr/local/bin/ \
-    && ln -s ../node/bin/npm /usr/local/bin/
-
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update \
-    && apt-get install yarn \
-    && rm -rf /var/lib/apt/lists/*
+# Use build to install our required Gems
+FROM identity-rails_build as build
 
 # Everything happens here from now on   
 WORKDIR /upaya
 
-# Simple Gem cache.  Success here creates a new layer in the image.
-# Note - Installs build related debs then removes after use
+# Prod Gems
 COPY Gemfile Gemfile.lock ./
-RUN apt-get update \
-    && apt-get install -y \
-       build-essential \
-       git \
-       liblzma-dev \
-       patch \
-       ruby-dev \
-    && gem install bundler --conservative \
-    && bundle install --deployment --without development test \
-    && apt-get remove -y \
-       build-essential \
-       git \
-       liblzma-dev \
-       patch \
-       ruby-dev \
-    && apt autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN bundle install --deployment --clean --without development test
 
-# Simple npm cache. Success here creates a new layer in the image.
+# Prod NPM packages
 COPY package.json yarn.lock ./
-RUN NODE_ENV=development yarn install --force
+RUN NODE_ENV=development yarn install --force \
+    && yarn cache clean
+
+# Use our base
+FROM identity-rails_base
+WORKDIR /upaya
+
+# Copy Gems, NPMs, and other relevant items from build layer
+COPY --chown=appuser:appuser --from=build /upaya .
 
 # Copy in whole source (minus items matched in .dockerignore)
-COPY . .
-
-# Add application user and fix perms
-RUN groupadd -r appuser \
-    && useradd --system --create-home --gid appuser appuser \
-    && chown -R appuser.appuser /upaya
+COPY --chown=appuser:appuser . .
 
 # Up to this point we've been root, change to a lower priv. user
 USER appuser


### PR DESCRIPTION
Experimental Branch

This uses layering for significantly smaller images:

~~~
REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
identity-idp_development   latest              4370aebbce80        28 hours ago        1.31GB
identity-idp_app           latest              742885e5bd2e        29 hours ago        712MB
identity-rails_build       latest              e49f93d4f3c9        29 hours ago        575MB
identity-rails_base        latest              690a2e509ccc        29 hours ago        299MB
~~~

Layers are:

* identity-rails_base (base.Dockerfile) - Ruby 2.5-slim with just the bare minimum needed for all our images
* identity-rails_build (build.Dockerfile)  - Full set of build tools (gcc, etc) for use as temporary build image
* identity-idp_app (production.Dockerfile) - Production image that builds using identity-rails_build then starts fresh with identity-rails_base and copies in what is needed
* identity-idp_development (development.Dockerfile) - Same as above but with Gems installed to system paths, Chromium, and (WIP!) alternate node_modules to allow mounting all of source tree into /upaya for dev

The alternate node_modules portion is not done yet!  `docker-compose` up should still work if you have a local node_modules dir.