### PR TITLE
Update Acuant client to send correct JSON headers

### DIFF
--- a/app/services/idv/acuant/assure_id.rb
+++ b/app/services/idv/acuant/assure_id.rb
@@ -20,11 +20,11 @@ module Idv
         url = '/AssureIDService/Document/Instance'
 
         options = default_options.merge(
-          headers: content_type_json,
+          headers: content_type_json.merge(accept_json),
           body: image_params,
         )
 
-        status, @instance_id = post(url, options) { |body| body.delete('"') }
+        status, @instance_id = post(url, options) { |body| JSON.parse(body) }
         [status, @instance_id]
       end
 

--- a/spec/services/idv/acuant/assure_id_spec.rb
+++ b/spec/services/idv/acuant/assure_id_spec.rb
@@ -16,9 +16,9 @@ describe Idv::Acuant::AssureId do
     let(:path) { '/AssureIDService/Document/Instance' }
 
     it 'returns a good status with an instance id' do
-      stub_request(:post, acuant_base_url + path)
-        .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
-        .to_return(status: 200, body: instance_id.to_json)
+      stub_request(:post, acuant_base_url + path).
+        with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }).
+        to_return(status: 200, body: instance_id.to_json)
 
       result = subject.create_document
 

--- a/spec/services/idv/acuant/assure_id_spec.rb
+++ b/spec/services/idv/acuant/assure_id_spec.rb
@@ -16,7 +16,9 @@ describe Idv::Acuant::AssureId do
     let(:path) { '/AssureIDService/Document/Instance' }
 
     it 'returns a good status with an instance id' do
-      stub_request(:post, acuant_base_url + path).to_return(status: 200, body: instance_id)
+      stub_request(:post, acuant_base_url + path)
+        .with(headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .to_return(status: 200, body: instance_id.to_json)
 
       result = subject.create_document
 


### PR DESCRIPTION
**Why**: without the Accept header, the API returns an XML body