### PR TITLE
Rename analytics event names to match rest of feature

### DIFF
--- a/app/controllers/users/forget_all_browsers_controller.rb
+++ b/app/controllers/users/forget_all_browsers_controller.rb
@@ -3,13 +3,13 @@ module Users
     before_action :confirm_two_factor_authenticated
 
     def show
-      analytics.track_event(Analytics::FORGET_ALL_DEVICES_VISITED)
+      analytics.track_event(Analytics::FORGET_ALL_BROWSERS_VISITED)
     end
 
     def destroy
       DeviceTracking::ForgetAllBrowsers.new(current_user).call
 
-      analytics.track_event(Analytics::FORGET_ALL_DEVICES_SUBMITTED)
+      analytics.track_event(Analytics::FORGET_ALL_BROWSERS_SUBMITTED)
 
       redirect_to account_path
     end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -84,8 +84,8 @@ class Analytics
   EVENT_DISAVOWAL_TOKEN_INVALID = 'Event disavowal token invalid'.freeze
   EVENTS_VISIT = 'Events Page Visited'.freeze
   EXPIRED_LETTERS = 'Expired Letters'.freeze
-  FORGET_ALL_DEVICES_SUBMITTED = 'Forget All Devices Submitted'.freeze
-  FORGET_ALL_DEVICES_VISITED = 'Forget All Devices Visited'.freeze
+  FORGET_ALL_BROWSERS_SUBMITTED = 'Forget All Browsers Submitted'.freeze
+  FORGET_ALL_BROWSERS_VISITED = 'Forget All Browsers Visited'.freeze
   FRONTEND_BROWSER_CAPABILITIES = 'Frontend: Browser capabilities'.freeze
   IAL2_RECOVERY = 'IAL2 Recovery'.freeze # visited or submitted is appended
   IAL2_RECOVERY_REQUEST = 'IAL2 Recovery Request'.freeze

--- a/spec/controllers/users/forget_all_browsers_controller_spec.rb
+++ b/spec/controllers/users/forget_all_browsers_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for visiting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with(Analytics::FORGET_ALL_DEVICES_VISITED)
+      expect(@analytics).to receive(:track_event).with(Analytics::FORGET_ALL_BROWSERS_VISITED)
 
       subject
     end
@@ -53,7 +53,7 @@ RSpec.describe Users::ForgetAllBrowsersController do
 
     it 'logs an analytics event for forgetting' do
       stub_analytics
-      expect(@analytics).to receive(:track_event).with(Analytics::FORGET_ALL_DEVICES_SUBMITTED)
+      expect(@analytics).to receive(:track_event).with(Analytics::FORGET_ALL_BROWSERS_SUBMITTED)
 
       subject
     end


### PR DESCRIPTION
**Why**: I renamed the copy, URL, and classes, but forgot
to rename the analytics event

Quick follow-up to #3625