### PR TITLE
LG-2801 Allow USPS proofing to be disabled without errors

### DIFF
--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -16,10 +16,12 @@
 
 <hr>
 
-<p>
-  <%= t('idv.form.no_alternate_phone_html',
-    link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
-</p>
+<% if FeatureManagement.enable_usps_verification? %>
+  <p>
+    <%= t('idv.form.no_alternate_phone_html',
+      link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
+  </p>
+<% end %>
 
 <p>
   <%= t('idv.failure.errors.text_html',

--- a/app/views/idv/phone_errors/jobfail.html.erb
+++ b/app/views/idv/phone_errors/jobfail.html.erb
@@ -8,10 +8,12 @@
 
 <hr>
 
-<p>
-  <%= t('idv.form.no_alternate_phone_html',
-    link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
-</p>
+<% if FeatureManagement.enable_usps_verification? %>
+  <p>
+    <%= t('idv.form.no_alternate_phone_html',
+      link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
+  </p>
+<% end %>
 
 <p><%= t('idv.failure.attempts_html', count: @remaining_step_attempts) %></p>
 

--- a/app/views/idv/phone_errors/timeout.html.erb
+++ b/app/views/idv/phone_errors/timeout.html.erb
@@ -8,10 +8,12 @@
 
 <hr>
 
-<p>
-  <%= t('idv.form.no_alternate_phone_html',
-    link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
-</p>
+<% if FeatureManagement.enable_usps_verification? %>
+  <p>
+    <%= t('idv.form.no_alternate_phone_html',
+      link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
+  </p>
+<% end %>
 
 <p><%= t('idv.failure.attempts_html', count: @remaining_step_attempts) %></p>
 

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -8,10 +8,12 @@
 
 <hr>
 
-<p>
-  <%= t('idv.form.no_alternate_phone_html',
-    link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
-</p>
+<% if FeatureManagement.enable_usps_verification? %>
+  <p>
+    <%= t('idv.form.no_alternate_phone_html',
+      link: link_to(t('idv.form.activate_by_mail'), idv_usps_path)) %>
+  </p>
+<% end %>
 
 <p><%= t('idv.failure.attempts_html', count: @remaining_step_attempts) %></p>
 

--- a/app/views/users/verify_account/index.html.slim
+++ b/app/views/users/verify_account/index.html.slim
@@ -9,7 +9,7 @@ p.mt-tiny.mb0 = t('forms.verify_profile.instructions')
     wrapper_html: { class: 'mb3' }, wrapper: :inline_form do
     = f.input_field :otp, as: :inline, autofocus: true, type: 'text', maxlength: '10', value: @code
     = f.button :submit, t('forms.verify_profile.submit')
-- unless @mail_spammed
+- if FeatureManagement.enable_usps_verification? && !@mail_spammed
   = link_to t('idv.messages.usps.resend'), idv_usps_path,
     class: 'block mb2'
 = button_to t('idv.messages.clear_and_start_over'), idv_session_path, method: :delete,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,9 +312,9 @@ Rails.application.routes.draw do
       put '/cac/:step' => 'cac#update'
     end
 
+    get '/account/verify' => 'users/verify_account#index', as: :verify_account
+    post '/account/verify' => 'users/verify_account#create'
     if FeatureManagement.enable_usps_verification?
-      get '/account/verify' => 'users/verify_account#index', as: :verify_account
-      post '/account/verify' => 'users/verify_account#create'
       scope '/verify', module: 'idv', as: 'idv' do
         get '/usps' => 'usps#index'
         put '/usps' => 'usps#create'

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -149,7 +149,7 @@ feature 'idv phone step' do
         expect(page).to have_content(t('idv.failure.phone.warning'))
         expect(page).to_not have_content(t('idv.form.activate_by_mail'))
 
-        click_on t("idv.failure.button.warning")
+        click_on t('idv.failure.button.warning')
       end
 
       fill_out_phone_form_fail

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -135,6 +135,29 @@ feature 'idv phone step' do
 
   context "when the user's information cannot be verified" do
     it_behaves_like 'fail to verify idv info', :phone
+
+    it 'does not render the link to proof by mail if proofing by mail is disabled' do
+      allow(FeatureManagement).to receive(:enable_usps_verification?).and_return(false)
+
+      start_idv_from_sp
+      complete_idv_steps_before_phone_step
+
+      2.times do
+        fill_out_phone_form_fail
+        click_idv_continue
+
+        expect(page).to have_content(t('idv.failure.phone.warning'))
+        expect(page).to_not have_content(t('idv.form.activate_by_mail'))
+
+        click_on t("idv.failure.button.warning")
+      end
+
+      fill_out_phone_form_fail
+      click_idv_continue
+
+      expect(page).to have_content(t('headings.lock_failure'))
+      expect(page).to_not have_content(t('idv.form.activate_by_mail'))
+    end
   end
 
   context 'when the IdV background job fails' do

--- a/spec/features/idv/steps/usps_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/usps_otp_verification_step_spec.rb
@@ -6,4 +6,10 @@ feature 'idv usps otp verification step' do
   it_behaves_like 'usps otp verfication step'
   it_behaves_like 'usps otp verfication step', :oidc
   it_behaves_like 'usps otp verfication step', :saml
+
+  context 'with USPS proofing disabled it still lets users with a letter verify' do
+    it_behaves_like 'usps otp verfication step'
+    it_behaves_like 'usps otp verfication step', :oidc
+    it_behaves_like 'usps otp verfication step', :saml
+  end
 end


### PR DESCRIPTION
**Why**: It looks like we may need to temporarily disable USPS proofing while our mailing vendor is temporarily suspending operations.

This commit has 2 changes to enable that:

- Fix a link that was causing an error because of a missing route on the phone steps
- Allow a user who has already received a letter to enter their OTP and verify while not allowing new letters to be sent