### PR TITLE
LG-2736: Leading zeroes in OTP fields

### DIFF
--- a/app/views/idv/otp_verification/show.html.slim
+++ b/app/views/idv/otp_verification/show.html.slim
@@ -12,7 +12,7 @@ p == @presenter.phone_number_message
     = text_field_tag(:code, '', value: @code, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-      type: 'number')
+      type: 'tel')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12'
   br
   br

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -8,7 +8,7 @@ h1.h3.my0 = @presenter.header
     class: 'block bold'
   .col-12.sm-col-5.mb1.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', value: @code, required: true, autofocus: true,
-      pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'number',
+      pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
       'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
   .border.border-light-blue.rounded-lg.py1.mt2.mb4.sm-my2.col-12.sm-col-7
     = hidden_field_tag 'remember_device', false, id: 'remember_device_preference'

--- a/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/totp_verification/show.html.slim_spec.rb
@@ -22,6 +22,13 @@ describe 'two_factor_authentication/totp_verification/show.html.slim' do
 
   it_behaves_like 'an otp form'
 
+  it 'uses type=tel (to allow leading zeroes)' do
+    render
+
+    code_input = Nokogiri::HTML(rendered).at_css('input#code')
+    expect(code_input[:type]).to eq('tel')
+  end
+
   it 'shows the correct header' do
     expect(rendered).to have_content t('two_factor_authentication.totp_header_text')
   end


### PR DESCRIPTION
Switch fields to use type="tel"
- type="number" has issues with leading zeroes