### PR TITLE
Update dev:random_users task to mark emails as confirmed

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -107,6 +107,7 @@ namespace :dev do
     warn "Emails: #{emails.join(', ')}\nPassword: salty pickles"
   end
 
+  # rubocop:disable all
   def setup_user(user, args)
     user.encrypted_email = args[:ee].encrypted
     user.reset_password(args[:pw], args[:pw])
@@ -114,6 +115,7 @@ namespace :dev do
     Event.create(user_id: user.id, event_type: :account_created)
     user.email_addresses.update_all(confirmed_at: Time.zone.now)
   end
+  # rubocop:enable all
 
   def setup_totp_user(user, args)
     user.encrypted_email = args[:ee].encrypted

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -112,6 +112,7 @@ namespace :dev do
     user.reset_password(args[:pw], args[:pw])
     MfaContext.new(user).phone_configurations.create(phone_configuration_data(user, args))
     Event.create(user_id: user.id, event_type: :account_created)
+    user.email_addresses.update_all(confirmed_at: Time.zone.now)
   end
 
   def setup_totp_user(user, args)


### PR DESCRIPTION
Looks like it's not trivial to run these rake tasks inside our specs, so this will remain un-tested for now

Future work: pull all the logic into a simple class and call into that from both Rake and the specs so we can test these