### PR TITLE
Add a feature flag that hides phone (SMS/voice) options for MFA creation

### DIFF
--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -48,6 +48,8 @@ class TwoFactorOptionsPresenter
   end
 
   def phone_options
+    return [] if FeatureManagement.hide_phone_mfa_signup?
+
     if TwoFactorAuthentication::PhonePolicy.new(current_user).second_phone?
       [
         TwoFactorAuthentication::SecondPhoneSelectionPresenter.new(

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -127,4 +127,8 @@ class FeatureManagement
   def self.doc_capture_polling_enabled?
     Figaro.env.doc_capture_polling_enabled == 'true'
   end
+
+  def self.hide_phone_mfa_signup?
+    Figaro.env.hide_phone_mfa_signup == 'true'
+  end
 end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -33,6 +33,21 @@ describe TwoFactorOptionsPresenter do
       ]
     end
 
+    context 'when hide_phone_mfa_signup is enabled' do
+      before do
+        allow(FeatureManagement).to receive(:hide_phone_mfa_signup?).and_return(true)
+      end
+
+      it 'supplies all the options except phone' do
+        expect(presenter.options.map(&:class)).to eq [
+          TwoFactorAuthentication::AuthAppSelectionPresenter,
+          TwoFactorAuthentication::WebauthnSelectionPresenter,
+          TwoFactorAuthentication::PivCacSelectionPresenter,
+          TwoFactorAuthentication::BackupCodeSelectionPresenter,
+        ]
+      end
+    end
+
     context 'with a user with a phone configured' do
       let(:user) { build(:user, :with_phone) }
 


### PR DESCRIPTION
- To help reduce our SMS capacity

After

![localhost_3000_two_factor_options](https://user-images.githubusercontent.com/458784/77594408-ae423f80-6eb3-11ea-8e95-f3b8099f62ba.png)


Before
![idp int identitysandbox gov_two_factor_options](https://user-images.githubusercontent.com/458784/77594396-a8e4f500-6eb3-11ea-955c-e022b5901e00.png)


