### PR TITLE
Bump geocoder to 1.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
       thor (~> 0.14)
     formatador (0.2.5)
     foundation_emails (2.2.1.0)
-    geocoder (1.5.2)
+    geocoder (1.6.2)
     get_process_mem (0.2.5)
       ffi (~> 1.0)
     gibberish (2.1.1)


### PR DESCRIPTION
**Why**: To pick up fix an issue with the geofencing queries supported by the gem.