### PR TITLE
Allow wasm on mobile capture

### DIFF
--- a/app/controllers/mobile_capture_controller.rb
+++ b/app/controllers/mobile_capture_controller.rb
@@ -1,7 +1,7 @@
 class MobileCaptureController < ApplicationController
   def new
-    SecureHeaders.append_content_security_policy_directives(request,
-                                                            script_src: ['\'unsafe-eval\''])
+    # required to run wasm until wasm-eval is available
+    SecureHeaders.append_content_security_policy_directives(request, script_src: %w['unsafe-eval'])
     render layout: false
   end
 end

--- a/app/controllers/mobile_capture_controller.rb
+++ b/app/controllers/mobile_capture_controller.rb
@@ -1,7 +1,8 @@
 class MobileCaptureController < ApplicationController
   def new
     # required to run wasm until wasm-eval is available
-    SecureHeaders.append_content_security_policy_directives(request, script_src: %w['unsafe-eval'])
+    SecureHeaders.append_content_security_policy_directives(request,
+                                                            script_src: ['\'unsafe-eval\''])
     render layout: false
   end
 end

--- a/app/controllers/mobile_capture_controller.rb
+++ b/app/controllers/mobile_capture_controller.rb
@@ -1,5 +1,6 @@
 class MobileCaptureController < ApplicationController
   def new
+    SecureHeaders.append_content_security_policy_directives(request, script_src: ['\'unsafe-eval\''])
     render layout: false
   end
 end

--- a/app/controllers/mobile_capture_controller.rb
+++ b/app/controllers/mobile_capture_controller.rb
@@ -1,6 +1,7 @@
 class MobileCaptureController < ApplicationController
   def new
-    SecureHeaders.append_content_security_policy_directives(request, script_src: ['\'unsafe-eval\''])
+    SecureHeaders.append_content_security_policy_directives(request,
+                                                            script_src: ['\'unsafe-eval\''])
     render layout: false
   end
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,7 +6,8 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
 
-  connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com']
+  connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
+                 'sentry.io']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   default_csp_config = {
     default_src: ["'self'"],


### PR DESCRIPTION
**Why**: Required to run wasm until wasm-eval is available