### PR TITLE
Mark a fingerprint stale if the fingerprint value is nil

### DIFF
--- a/app/services/pii/fingerprinter.rb
+++ b/app/services/pii/fingerprinter.rb
@@ -27,6 +27,7 @@ module Pii
     end
 
     def self.stale?(text, fingerprint)
+      return true if text.present? && fingerprint.nil?
       !verify_current(text, fingerprint)
     end
   end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -75,6 +75,18 @@ describe Pii::Cacher do
 
       expect { cacher.save(password) }.to_not raise_error
     end
+
+    it 'does not raise an error if pii_fingerprint is nil but attributes are present' do
+      # The name_zip_birth_year_signature column was added after users  had
+      # ecrypted PII. As a result, those users may have a profile with valid PII
+      # and a nil value here. Caching the PII into the session for those users
+      # should update the signature column without raising an error
+      profile.update!(name_zip_birth_year_signature: nil)
+
+      subject.save(password, profile)
+
+      expect(profile.reload.name_zip_birth_year_signature).to_not be_nil
+    end
   end
 
   describe '#fetch' do

--- a/spec/services/pii/fingerprinter_spec.rb
+++ b/spec/services/pii/fingerprinter_spec.rb
@@ -83,5 +83,12 @@ describe Pii::Fingerprinter do
 
       expect(described_class.stale?(text, fingerprint)).to eq false
     end
+
+    it 'returns true if the fingerprint is nil and the text is not' do
+      text = SecureRandom.uuid
+      fingerprint = nil
+
+      expect(described_class.stale?(text, fingerprint)).to eq true
+    end
   end
 end


### PR DESCRIPTION
**Why**: We added the name_zip_birth_year_signature column to the profile. This value is nil for several users. Checking whether the nil fingerprint was stale resulted in several NilClass exceptions in the logic to build the fingerprint.

If the text for a fingerprint is not nil, but the fingerprint itself is nil then the fingerprint is always stale. This commit adds that checks and shortcuts the code that was causing the NilClass exceptions.