### PR TITLE
Set random value minimum to 22 chars

### DIFF
--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -19,7 +19,7 @@ class OpenidConnectAuthorizeForm
 
   attr_reader(*ATTRS)
 
-  RANDOM_VALUE_MINIMUM_LENGTH = 32
+  RANDOM_VALUE_MINIMUM_LENGTH = 22
 
   validates :acr_values, presence: true
   validates :client_id, presence: true


### PR DESCRIPTION
WHY:
As a login.gov partner using OIDC, I want the state and nonce to be 22 characters not 32 characters, so that I can integrate with Ping identity and other platforms that "Build to the spec" of 128 bits of entropy.