### PR TITLE
Switch reports to use TimeWithZone objects

### DIFF
--- a/app/services/db/sp_cost/sp_cost_summary.rb
+++ b/app/services/db/sp_cost/sp_cost_summary.rb
@@ -2,10 +2,15 @@ module Db
   module SpCost
     class SpCostSummary
       def self.call(start, finish)
-        sql = <<~SQL
+        params = {
+          start: ActiveRecord::Base.connection.quote(start),
+          finish: ActiveRecord::Base.connection.quote(finish),
+        }
+
+        sql = format(<<~SQL, params)
           SELECT issuer,ial,cost_type,COUNT(*)
           FROM sp_costs
-          WHERE '#{start}' <= created_at and created_at <= '#{finish}'
+          WHERE %{start} <= created_at and created_at <= %{finish}
           GROUP BY issuer,ial,cost_type ORDER BY issuer,ial,cost_type
         SQL
         ActiveRecord::Base.connection.execute(sql)

--- a/app/services/db/sp_cost/sp_cost_summary.rb
+++ b/app/services/db/sp_cost/sp_cost_summary.rb
@@ -1,6 +1,7 @@
 module Db
   module SpCost
     class SpCostSummary
+      # rubocop:disable Metrics/MethodLength
       def self.call(start, finish)
         params = {
           start: ActiveRecord::Base.connection.quote(start),
@@ -15,6 +16,7 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/db/sp_cost/total_sp_cost_summary.rb
+++ b/app/services/db/sp_cost/total_sp_cost_summary.rb
@@ -1,6 +1,7 @@
 module Db
   module SpCost
     class TotalSpCostSummary
+      # rubocop:disable Metrics/MethodLength
       def self.call(start, finish)
         params = {
           start: ActiveRecord::Base.connection.quote(start),
@@ -15,6 +16,7 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/db/sp_cost/total_sp_cost_summary.rb
+++ b/app/services/db/sp_cost/total_sp_cost_summary.rb
@@ -2,10 +2,15 @@ module Db
   module SpCost
     class TotalSpCostSummary
       def self.call(start, finish)
-        sql = <<~SQL
+        params = {
+          start: ActiveRecord::Base.connection.quote(start),
+          finish: ActiveRecord::Base.connection.quote(finish),
+        }
+
+        sql = format(<<~SQL, params)
           SELECT cost_type,COUNT(*)
           FROM sp_costs
-          WHERE '#{start}' <= created_at and created_at <= '#{finish}'
+          WHERE %{start} <= created_at and created_at <= %{finish}
           GROUP BY cost_type ORDER BY cost_type
         SQL
         ActiveRecord::Base.connection.execute(sql)

--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -10,11 +10,11 @@ module Reports
     end
 
     def first_of_this_month
-      Time.zone.today.beginning_of_month.strftime('%m-%d-%Y')
+      Time.zone.now.beginning_of_month
     end
 
     def end_of_today
-      Time.zone.today.strftime('%m-%d-%Y 23:59:59')
+      Time.zone.now.end_of_day
     end
 
     def ec2_data


### PR DESCRIPTION
Specs are failing on master, this fixes that: https://circleci.com/gh/18F/identity-idp/11456

**Why**: It's March 31 locally, but April 1 UTC, so objects
created "now" were falling into the bucket for the next month.
This makes the tests more stable across timezones, because the
objects are created in UTC time and are now queried against in
UTC time