### PR TITLE
LG-2857 Add analytics tracking for no SP IAL2/link flow

### DIFF
--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -10,7 +10,7 @@ module VerifyProfileConcern
   end
 
   def account_or_verify_profile_route
-    return 'idv' if session[:ial2_request_with_no_sp] && current_user.active_profile.blank?
+    return 'idv' if session[:ial2_with_no_sp_campaign] && current_user.active_profile.blank?
     return 'account' unless profile_needs_verification?
     return 'idv_usps' if usps_mail_bounced?
     'verify_account'

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -18,7 +18,7 @@ class IdvController < ApplicationController
 
   def activated
     redirect_to idv_url unless active_profile?
-    redirect_to account_url if session[:ial2_request_with_no_sp]
+    redirect_to account_url if session[:ial2_with_no_sp_campaign]
     idv_session.clear
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ module Users
       )
 
       @ial = sp_session ? sp_session_ial : 1
-      session[:ial2_request_with_no_sp] = campaign if sp_session.blank? && params[:ial] == '2'
+      session[:ial2_with_no_sp_campaign] = campaign if sp_session.blank? && params[:ial] == '2'
       super
     end
 
@@ -61,7 +61,7 @@ module Users
     private
 
     def campaign
-      params[:campaign] || true
+      params[:campaign] || 'none'
     end
 
     def redirect_to_signin

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ module Users
       )
 
       @ial = sp_session ? sp_session_ial : 1
-      session[:ial2_request_with_no_sp] = true if sp_session.blank? && params[:ial] == '2'
+      session[:ial2_request_with_no_sp] = campaign if sp_session.blank? && params[:ial] == '2'
       super
     end
 
@@ -59,6 +59,10 @@ module Users
     end
 
     private
+
+    def campaign
+      params[:campaign] || true
+    end
 
     def redirect_to_signin
       controller_info = 'users/sessions#create'

--- a/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
+++ b/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
@@ -1,7 +1,7 @@
 module Db
   module DocAuthLog
     class DocAuthFunnelSummaryStats
-      SKIP_FIELDS = %w[id user_id created_at updated_at].freeze
+      SKIP_FIELDS = %w[id user_id created_at updated_at no_sp_at no_sp_campaign].freeze
 
       def call
         total_count = ::DocAuthLog.count

--- a/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
+++ b/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
@@ -1,7 +1,8 @@
 module Db
   module DocAuthLog
     class DocAuthFunnelSummaryStats
-      SKIP_FIELDS = %w[id user_id created_at updated_at no_sp_at no_sp_campaign].freeze
+      SKIP_FIELDS =
+        %w[id user_id created_at updated_at no_sp_session_started_at no_sp_campaign].freeze
 
       def call
         total_count = ::DocAuthLog.count

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -33,7 +33,7 @@ module Flow
     private
 
     def register_campaign
-      Funnel::DocAuth::RegisterCampaign.call(user_id, session[:ial2_request_with_no_sp])
+      Funnel::DocAuth::RegisterCampaign.call(user_id, session[:ial2_with_no_sp_campaign])
     end
 
     def user_id

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -17,6 +17,7 @@ module Flow
       step = params[:step]
       analytics.track_event(analytics_visited, step: step) if @analytics_id
       Funnel::DocAuth::RegisterStep.call(user_id, step, :view, true)
+      register_campaign
       render_step(step, flow.flow_session)
     end
 
@@ -30,6 +31,10 @@ module Flow
     end
 
     private
+
+    def register_campaign
+      Funnel::DocAuth::RegisterCampaign.call(user_id, session[:ial2_request_with_no_sp])
+    end
 
     def user_id
       current_user ? current_user.id : user_id_from_token

--- a/app/services/funnel/doc_auth/register_campaign.rb
+++ b/app/services/funnel/doc_auth/register_campaign.rb
@@ -5,7 +5,7 @@ module Funnel
         doc_auth_log = DocAuthLog.find_by(user_id: user_id)
         return if doc_auth_log.nil? || doc_auth_log.no_sp_campaign
         doc_auth_log.no_sp_campaign = campaign.to_s
-        doc_auth_log.no_sp_at = Time.zone.now
+        doc_auth_log.no_sp_session_started_at = Time.zone.now
         doc_auth_log.save
       end
     end

--- a/app/services/funnel/doc_auth/register_campaign.rb
+++ b/app/services/funnel/doc_auth/register_campaign.rb
@@ -3,7 +3,7 @@ module Funnel
     class RegisterCampaign
       def self.call(user_id, campaign)
         doc_auth_log = DocAuthLog.find_by(user_id: user_id)
-        return if doc_auth_log&.no_sp_campaign
+        return if doc_auth_log.nil? || doc_auth_log.no_sp_campaign
         doc_auth_log.no_sp_campaign = campaign.to_s
         doc_auth_log.no_sp_at = Time.zone.now
         doc_auth_log.save

--- a/app/services/funnel/doc_auth/register_campaign.rb
+++ b/app/services/funnel/doc_auth/register_campaign.rb
@@ -1,0 +1,13 @@
+module Funnel
+  module DocAuth
+    class RegisterCampaign
+      def self.call(user_id, campaign)
+        doc_auth_log = DocAuthLog.find_by(user_id: user_id)
+        return if doc_auth_log&.no_sp_campaign
+        doc_auth_log.no_sp_campaign = campaign.to_s
+        doc_auth_log.no_sp_at = Time.zone.now
+        doc_auth_log.save
+      end
+    end
+  end
+end

--- a/db/migrate/20200405233913_add_no_sp_tracking_to_doc_auth_logs.rb
+++ b/db/migrate/20200405233913_add_no_sp_tracking_to_doc_auth_logs.rb
@@ -1,0 +1,8 @@
+class AddNoSpTrackingToDocAuthLogs < ActiveRecord::Migration[5.1]
+  def change
+    safety_assured do
+      add_column :doc_auth_logs, :no_sp_at, :datetime
+      add_column :doc_auth_logs, :no_sp_campaign, :string
+    end
+  end
+end

--- a/db/migrate/20200405233913_add_no_sp_tracking_to_doc_auth_logs.rb
+++ b/db/migrate/20200405233913_add_no_sp_tracking_to_doc_auth_logs.rb
@@ -1,8 +1,6 @@
 class AddNoSpTrackingToDocAuthLogs < ActiveRecord::Migration[5.1]
   def change
-    safety_assured do
-      add_column :doc_auth_logs, :no_sp_at, :datetime
-      add_column :doc_auth_logs, :no_sp_campaign, :string
-    end
+    add_column :doc_auth_logs, :no_sp_session_started_at, :datetime
+    add_column :doc_auth_logs, :no_sp_campaign, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_26_160855) do
+ActiveRecord::Schema.define(version: 2020_04_05_233913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,8 @@ ActiveRecord::Schema.define(version: 2020_03_26_160855) do
     t.integer "capture_complete_view_count", default: 0
     t.integer "capture_mobile_back_image_submit_count", default: 0
     t.integer "capture_mobile_back_image_error_count", default: 0
+    t.datetime "no_sp_at"
+    t.string "no_sp_campaign"
     t.index ["user_id"], name: "index_doc_auth_logs_on_user_id", unique: true
     t.index ["verified_view_at"], name: "index_doc_auth_logs_on_verified_view_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2020_04_05_233913) do
     t.integer "capture_complete_view_count", default: 0
     t.integer "capture_mobile_back_image_submit_count", default: 0
     t.integer "capture_mobile_back_image_error_count", default: 0
-    t.datetime "no_sp_at"
+    t.datetime "no_sp_session_started_at"
     t.string "no_sp_campaign"
     t.index ["user_id"], name: "index_doc_auth_logs_on_user_id", unique: true
     t.index ["verified_view_at"], name: "index_doc_auth_logs_on_verified_view_at"

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -860,7 +860,7 @@ feature 'Sign in' do
       expect(current_path).to eq(account_path)
       doc_auth_log = DocAuthLog.find_by(user_id: user.id)
       expect(doc_auth_log.no_sp_campaign).to eq(campaign)
-      expect(doc_auth_log.no_sp_at).to be_present
+      expect(doc_auth_log.no_sp_session_started_at).to be_present
     end
 
     it 'invokes ial2 flow if the user does not have an ial1 account' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -838,8 +838,10 @@ feature 'Sign in' do
   end
 
   context 'ial2 param on sign up screen' do
+    let(:campaign) { 'campaign1' }
+
     before do
-      visit root_path(ial: 2)
+      visit root_path(ial: 2, campaign: campaign)
     end
 
     it 'invokes ial2 flow if the user already has an ial1 account' do
@@ -856,6 +858,8 @@ feature 'Sign in' do
       click_continue
 
       expect(current_path).to eq(account_path)
+      doc_auth_log = DocAuthLog.find_by(user_id: user.id)
+      expect(doc_auth_log.no_sp_campaign).to eq(campaign)
     end
 
     it 'invokes ial2 flow if the user does not have an ial1 account' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -860,6 +860,7 @@ feature 'Sign in' do
       expect(current_path).to eq(account_path)
       doc_auth_log = DocAuthLog.find_by(user_id: user.id)
       expect(doc_auth_log.no_sp_campaign).to eq(campaign)
+      expect(doc_auth_log.no_sp_at).to be_present
     end
 
     it 'invokes ial2 flow if the user does not have an ial1 account' do


### PR DESCRIPTION
**Why**: To track the success and funnel for a specific campaign tied to a link supplied to users.
**How**: Store the campaign string and time it was initiated in the doc auth funnel.  To run a campaign simply add the following parameter to the link: campaign=my_campaign