### PR TITLE
Make the Acuant SDK files available relative to URLs where we will use the SDK

### DIFF
--- a/app/controllers/acuant_sdk_controller.rb
+++ b/app/controllers/acuant_sdk_controller.rb
@@ -11,16 +11,34 @@ class AcuantSdkController < ApplicationController
   def show
     # Only render files on an allowlist to prevent path traversal issues
     render plain: 'Not found', status: :not_found unless requested_asset_permitted?
-    render file: "public/#{requested_asset}"
+    send_data(
+      requested_asset_data,
+      type: response_content_type,
+      disposition: :inline,
+    )
   end
 
   private
 
   def requested_asset_permitted?
-    ACUANT_SDK_STATIC_FILES.include?(requested_asset)
+    ACUANT_SDK_STATIC_FILES.include?(requested_asset_name)
   end
 
-  def requested_asset
-    @requested_asset ||= URI.parse(request.original_url).path.split('/').last
+  def requested_asset_name
+    @requested_asset_name ||= URI.parse(request.original_url).path.split('/').last
+  end
+
+  def requested_asset_data
+    File.read(
+      Rails.root.join('public', requested_asset_name),
+    )
+  end
+
+  def response_content_type
+    if requested_asset_name.match(/\.wasm/)
+      'application/wasm'
+    else
+      'text/javascript'
+    end
   end
 end

--- a/app/controllers/acuant_sdk_controller.rb
+++ b/app/controllers/acuant_sdk_controller.rb
@@ -1,0 +1,26 @@
+class AcuantSdkController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  ACUANT_SDK_STATIC_FILES = %w[
+    AcuantImageProcessingService.wasm
+    AcuantImageProcessingWorker.min.js
+    AcuantImageProcessingWorker.wasm
+    AcuantJavascriptWebSdk.min.js
+  ].freeze
+
+  def show
+    # Only render files on an allowlist to prevent path traversal issues
+    render plain: 'Not found', status: :not_found unless requested_asset_permitted?
+    render file: "public/#{requested_asset}"
+  end
+
+  private
+
+  def requested_asset_permitted?
+    ACUANT_SDK_STATIC_FILES.include?(requested_asset)
+  end
+
+  def requested_asset
+    @requested_asset ||= URI.parse(request.original_url).path.split('/').last
+  end
+end

--- a/app/controllers/acuant_sdk_controller.rb
+++ b/app/controllers/acuant_sdk_controller.rb
@@ -11,8 +11,8 @@ class AcuantSdkController < ApplicationController
   def show
     # Only render files on an allowlist to prevent path traversal issues
     render plain: 'Not found', status: :not_found unless requested_asset_permitted?
-    send_data(
-      requested_asset_data,
+    send_file(
+      Rails.root.join('public', requested_asset_name),
       type: response_content_type,
       disposition: :inline,
     )
@@ -28,17 +28,13 @@ class AcuantSdkController < ApplicationController
     @requested_asset_name ||= URI.parse(request.original_url).path.split('/').last
   end
 
-  def requested_asset_data
-    File.read(
-      Rails.root.join('public', requested_asset_name),
-    )
-  end
-
   def response_content_type
-    if requested_asset_name.match(/\.wasm/)
+    extension = File.extname(requested_asset_name)
+    case extension
+    when '.js'
+      'application/javascript'
+    when '.wasm'
       'application/wasm'
-    else
-      'text/javascript'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,6 +324,10 @@ Rails.application.routes.draw do
       end
     end
 
+    AcuantSdkController::ACUANT_SDK_STATIC_FILES.each do |acuant_sdk_file|
+      get "/verify/doc_auth/#{acuant_sdk_file}" => 'acuant_sdk#show'
+    end
+
     root to: 'users/sessions#new'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,10 @@ Rails.application.routes.draw do
 
     delete '/users' => 'users#destroy', as: :destroy_user
 
+    AcuantSdkController::ACUANT_SDK_STATIC_FILES.each do |acuant_sdk_file|
+      get "/verify/doc_auth/#{acuant_sdk_file}" => 'acuant_sdk#show'
+    end
+
     scope '/verify', as: 'idv' do
       get '/' => 'idv#index'
       get '/activated' => 'idv#activated'
@@ -322,10 +326,6 @@ Rails.application.routes.draw do
         put '/usps' => 'usps#create'
         post '/usps' => 'usps#update'
       end
-    end
-
-    AcuantSdkController::ACUANT_SDK_STATIC_FILES.each do |acuant_sdk_file|
-      get "/verify/doc_auth/#{acuant_sdk_file}" => 'acuant_sdk#show'
     end
 
     root to: 'users/sessions#new'

--- a/spec/requests/acuant_sdk_spec.rb
+++ b/spec/requests/acuant_sdk_spec.rb
@@ -6,7 +6,7 @@ describe 'requesting acuant SDK assets' do
       get '/verify/doc_auth/AcuantJavascriptWebSdk.min.js'
 
       expect(response.status).to eq(200)
-      expect(response.headers['Content-Type']).to eq('text/javascript')
+      expect(response.headers['Content-Type']).to eq('application/javascript')
       expect(response.body).to eq(File.read('public/AcuantJavascriptWebSdk.min.js'))
     end
 
@@ -15,7 +15,7 @@ describe 'requesting acuant SDK assets' do
 
       expect(response.status).to eq(200)
       expect(response.headers['Content-Type']).to eq('application/wasm')
-      expect(response.body).to eq(File.read('public/AcuantImageProcessingService.wasm'))
+      expect(response.body.length).to eq(File.size('public/AcuantImageProcessingService.wasm'))
     end
   end
 

--- a/spec/requests/acuant_sdk_spec.rb
+++ b/spec/requests/acuant_sdk_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'requesting acuant SDK assets' do
+  context 'with a valid Acuant SDK asset' do
+    it 'renders the asset' do
+      get '/verify/doc_auth/AcuantJavascriptWebSdk.min.js'
+
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq('text/javascript')
+      expect(response.body).to eq(File.read('public/AcuantJavascriptWebSdk.min.js'))
+    end
+  end
+
+  context 'with something that is not a valid Acuant SDK asset' do
+    it 'renders a 404' do
+      get '/verify/doc_auth/uselss-noise.min.js'
+
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/requests/acuant_sdk_spec.rb
+++ b/spec/requests/acuant_sdk_spec.rb
@@ -2,12 +2,20 @@ require 'rails_helper'
 
 describe 'requesting acuant SDK assets' do
   context 'with a valid Acuant SDK asset' do
-    it 'renders the asset' do
+    it 'renders a JS asset' do
       get '/verify/doc_auth/AcuantJavascriptWebSdk.min.js'
 
       expect(response.status).to eq(200)
-      expect(response.content_type).to eq('text/javascript')
+      expect(response.headers['Content-Type']).to eq('text/javascript')
       expect(response.body).to eq(File.read('public/AcuantJavascriptWebSdk.min.js'))
+    end
+
+    it 'renders a WASM asset' do
+      get '/verify/doc_auth/AcuantImageProcessingService.wasm'
+
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to eq('application/wasm')
+      expect(response.body).to eq(File.read('public/AcuantImageProcessingService.wasm'))
     end
   end
 


### PR DESCRIPTION
**Why**: The SDK has several assets it uses that it depends on being available relative to the current URL.