### PR TITLE
Explicitly remove Rack::Attack when we want to disable rate limiting

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,13 @@ module Upaya
       end
     end
 
-    config.middleware.use Rack::Attack if Figaro.env.enable_rate_limiting == 'true'
+    if Figaro.env.enable_rate_limiting == 'true'
+      config.middleware.use Rack::Attack
+    else
+      # Rack::Attack auto-includes itself as a Railtie, so we need to
+      # explicitly remove it when we want to disable it
+      config.middleware.delete Rack::Attack
+    end
 
     config.middleware.use(
       Rack::TwilioWebhookAuthentication,


### PR DESCRIPTION
Test plan:

```
$ enable_rate_limiting=false bundle exec rails c
Upaya::Application.config.middleware
```
check that it doesn't include `Rack::Attack` before and after this change