### PR TITLE
Add webpack dev server to the Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec rackup config.ru --port ${PORT:-3000}
 mailcatcher: mailcatcher -f
+webpacker: ./bin/webpack-dev-server


### PR DESCRIPTION
**Why**: So the webpack dev server runs alongs the IdP. This makes the assets compile quicker and gives us faster reloading.