### PR TITLE
Handle EOFErrors in the UTF-8 sanitizer

### DIFF
--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -7,6 +7,8 @@ class Utf8Sanitizer
   end
 
   def call(env)
+    parser = RackRequestParser.new(Rack::Request.new(env))
+
     if invalid_strings(parser.values_to_check)
       return bad_request_and_log(invalid_utf8_event(env, parser.request))
     end
@@ -19,10 +21,6 @@ class Utf8Sanitizer
   end
 
   private
-
-  def parser
-    @parser ||= RackRequestParser.new(Rack::Request.new(env))
-  end
 
   def invalid_strings(values)
     string_values(values).any? { |string| invalid_string?(string) }

--- a/lib/utf8_sanitizer.rb
+++ b/lib/utf8_sanitizer.rb
@@ -20,6 +20,9 @@ class Utf8Sanitizer
   rescue Rack::QueryParser::InvalidParameterError => err
     Rails.logger.info(invalid_parameter_event(err))
     [400, {}, ['Bad request']]
+  rescue EOFError => err
+    Rails.logger.info(eof_error_event(err))
+    [400, {}, ['Bad request']]
   end
 
   private
@@ -70,6 +73,13 @@ class Utf8Sanitizer
   def invalid_parameter_event(error)
     {
       event: 'Invalid parameter error',
+      message: error.message,
+    }
+  end
+
+  def eof_error_event(error)
+    {
+      event: 'EOF error',
       message: error.message,
     }
   end


### PR DESCRIPTION
- I think these happen if sockets/connections get
  cut when HTTP clients make a request, they're no-ops

I saw a handful of these in NewRelic, seems like an easy thing to just swallow