### PR TITLE
LG-2886: Remove underscores from URLs sent in SMS

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -14,7 +14,7 @@ module Flow
     end
 
     def show
-      step = params[:step]
+      step = current_step
       analytics.track_event(analytics_visited, step: step) if @analytics_id
       Funnel::DocAuth::RegisterStep.call(user_id, step, :view, true)
       register_campaign
@@ -22,7 +22,7 @@ module Flow
     end
 
     def update
-      step = params[:step]
+      step = current_step
       result = flow.handle(step)
       analytics.track_event(analytics_submitted, result.to_h.merge(step: step)) if @analytics_id
       register_update_step(step, result)
@@ -31,6 +31,10 @@ module Flow
     end
 
     private
+
+    def current_step
+      params[:step].underscore
+    end
 
     def register_campaign
       Funnel::DocAuth::RegisterCampaign.call(user_id, session[:ial2_with_no_sp_campaign])
@@ -81,7 +85,7 @@ module Flow
     end
 
     def ensure_correct_step
-      redirect_to_step(next_step) if next_step.to_s != params[:step]
+      redirect_to_step(next_step) if next_step.to_s != current_step
     end
 
     def flow_finish

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -28,9 +28,9 @@ module Idv
 
       def link(token)
         if request.path.include?('doc_auth_v2')
-          idv_doc_auth_v2_step_url(step: :scan_id, token: token)
+          idv_doc_auth_v2_step_dashes_url(step: :scan_idto_s.dasherize, token: token)
         else
-          idv_capture_doc_step_url(step: :mobile_front_image, token: token)
+          idv_capture_doc_step_dashes_url(step: :mobile_front_image.to_s.dasherize, token: token)
         end
       end
 

--- a/app/services/idv/steps/send_link_step.rb
+++ b/app/services/idv/steps/send_link_step.rb
@@ -28,7 +28,7 @@ module Idv
 
       def link(token)
         if request.path.include?('doc_auth_v2')
-          idv_doc_auth_v2_step_dashes_url(step: :scan_idto_s.dasherize, token: token)
+          idv_doc_auth_v2_step_dashes_url(step: :scan_id.to_s.dasherize, token: token)
         else
           idv_capture_doc_step_dashes_url(step: :mobile_front_image.to_s.dasherize, token: token)
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,8 +295,8 @@ Rails.application.routes.draw do
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
       get '/capture-doc/:step' => 'capture_doc#show',
-        # sometimes underscores get messed up when linked to via SMS
-        as: :capture_doc_step_dashes
+          # sometimes underscores get messed up when linked to via SMS
+          as: :capture_doc_step_dashes
       unless FeatureManagement.disallow_ial2_recovery?
         get '/recovery' => 'recovery#index'
         get '/recovery/:step' => 'recovery#show', as: :recovery_step
@@ -317,8 +317,8 @@ Rails.application.routes.draw do
       put '/verify/doc_auth_v2/:step' => 'idv/doc_auth_v2#update'
       get '/verify/doc_auth_v2/link_sent/poll' => 'idv/doc_auth_v2#doc_capture_poll'
       get '/verify/doc-auth-v2/:step' => 'idv/doc_auth_v2#show',
-        # sometimes underscores get messed up when linked to via SMS
-        as: :idv_doc_auth_v2_step_dashes
+          # sometimes underscores get messed up when linked to via SMS
+          as: :idv_doc_auth_v2_step_dashes
 
       get '/scan_id' => 'idv/scan_id#new'
       get '/scan_complete' => 'idv/scan_id#scan_complete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,9 @@ Rails.application.routes.draw do
       get '/capture_doc' => 'capture_doc#index'
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
+      get '/capture-doc/:step' => 'capture_doc#show',
+        # sometimes underscores get messed up when linked to via SMS
+        as: :capture_doc_step_dashes
       unless FeatureManagement.disallow_ial2_recovery?
         get '/recovery' => 'recovery#index'
         get '/recovery/:step' => 'recovery#show', as: :recovery_step
@@ -313,6 +316,9 @@ Rails.application.routes.draw do
       get '/verify/doc_auth_v2/:step' => 'idv/doc_auth_v2#show', as: :idv_doc_auth_v2_step
       put '/verify/doc_auth_v2/:step' => 'idv/doc_auth_v2#update'
       get '/verify/doc_auth_v2/link_sent/poll' => 'idv/doc_auth_v2#doc_capture_poll'
+      get '/verify/doc-auth-v2/:step' => 'idv/doc_auth_v2#show',
+        # sometimes underscores get messed up when linked to via SMS
+        as: :idv_doc_auth_v2_step_dashes
 
       get '/scan_id' => 'idv/scan_id#new'
       get '/scan_complete' => 'idv/scan_id#scan_complete'

--- a/spec/features/idv/doc_auth/send_link_step_spec.rb
+++ b/spec/features/idv/doc_auth/send_link_step_spec.rb
@@ -30,6 +30,20 @@ feature 'doc auth send link step' do
     expect(page).to have_current_path(idv_doc_auth_link_sent_step)
   end
 
+  it 'sends a link that does not contain any underscores' do
+    # because URLs with underscores sometimes get messed up by carriers
+    expect(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
+      expect(config[:link]).to_not include('_')
+
+      impl.call(config)
+    end
+
+    fill_in :doc_auth_phone, with: '415-555-0199'
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_link_sent_step)
+  end
+
   it 'does not proceed to the next page with invalid info' do
     fill_in :doc_auth_phone, with: ''
     click_idv_continue


### PR DESCRIPTION
**Why**: Some carriers mess up and try to escape underscores so
the links end up 404-ing

I didn't wholesale replace URLs with underscores because
1. we don't have an official policy on underscores vs dashes
2. we'd need a transition plan (because there could be old links out there we wouldn't want to break, ex somebody IDV-ing while we deploy)