### PR TITLE
LG-2573 Configurable NIST conformant verification flow for IAL2

### DIFF
--- a/app/controllers/idv/scan_id_base_controller.rb
+++ b/app/controllers/idv/scan_id_base_controller.rb
@@ -36,11 +36,11 @@ module Idv
     end
 
     def liveness_checking_enabled?
-      FeatureManagement.liveness_checking_enabled? && sp_liveness_checking_enabled?
+      FeatureManagement.liveness_checking_enabled? && sp_liveness_checking_required?
     end
 
-    def sp_liveness_checking_enabled?
-      ServiceProvider.from_issuer(sp_session[:issuer].to_s)&.liveness_checking_enabled
+    def sp_liveness_checking_required?
+      ServiceProvider.from_issuer(sp_session[:issuer].to_s)&.liveness_checking_required
     end
   end
 end

--- a/app/controllers/idv/scan_id_base_controller.rb
+++ b/app/controllers/idv/scan_id_base_controller.rb
@@ -30,5 +30,17 @@ module Idv
     def attempter_throttled?
       Throttler::IsThrottled.call(*idv_throttle_params)
     end
+
+    def selfie_live_and_matches_document?
+      scan_id_session[:facematch_pass] && scan_id_session[:liveness_pass]
+    end
+
+    def liveness_checking_enabled?
+      FeatureManagement.liveness_checking_enabled? && sp_liveness_checking_enabled?
+    end
+
+    def sp_liveness_checking_enabled?
+      ServiceProvider.from_issuer(sp_session[:issuer].to_s)&.liveness_checking_enabled
+    end
   end
 end

--- a/app/controllers/idv/scan_id_controller.rb
+++ b/app/controllers/idv/scan_id_controller.rb
@@ -49,8 +49,8 @@ module Idv
     end
 
     def all_checks_passed?
-      scan_id_session && scan_id_session[:instance_id] && scan_id_session[:facematch_pass] &&
-        (scan_id_session[:liveness_pass] || !FeatureManagement.liveness_checking_enabled?)
+      scan_id_session && scan_id_session[:instance_id] &&
+        (selfie_live_and_matches_document? || !liveness_checking_enabled?)
     end
 
     def token
@@ -90,7 +90,7 @@ module Idv
     def save_proofing_components
       save_proofing_component(:document_check, 'acuant')
       save_proofing_component(:document_type, 'state_id')
-      save_proofing_component(:liveness_check, 'acuant') if scan_id_session[:liveness_pass]
+      save_proofing_component(:liveness_check, 'acuant') if selfie_live_and_matches_document?
     end
 
     def save_proofing_component(key, value)

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -38,4 +38,8 @@ class NullServiceProvider
   def redirect_uris
     []
   end
+
+  def liveness_checking_enabled
+    false
+  end
 end

--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -39,7 +39,7 @@ class NullServiceProvider
     []
   end
 
-  def liveness_checking_enabled
+  def liveness_checking_required
     false
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -272,7 +272,7 @@ production:
   hmac_fingerprinter_key:
   hmac_fingerprinter_key_queue:
   issuers_with_email_nameid_format: sp1,sp2
-  liveness_checking_enabled: 'true'
+  liveness_checking_enabled: 'false'
   lockout_period_in_minutes: '10'
   login_with_piv_cac: 'false'
   logins_per_email_and_ip_limit: '5'

--- a/db/migrate/20200409075651_add_liveness_checking_enabled_to_service_providers.rb
+++ b/db/migrate/20200409075651_add_liveness_checking_enabled_to_service_providers.rb
@@ -1,5 +1,0 @@
-class AddLivenessCheckingEnabledToServiceProviders < ActiveRecord::Migration[5.1]
-  def change
-    add_column :service_providers, :liveness_checking_enabled, :boolean
-  end
-end

--- a/db/migrate/20200409075651_add_liveness_checking_enabled_to_service_providers.rb
+++ b/db/migrate/20200409075651_add_liveness_checking_enabled_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddLivenessCheckingEnabledToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :liveness_checking_enabled, :boolean
+  end
+end

--- a/db/migrate/20200409075651_add_liveness_checking_required_to_service_providers.rb
+++ b/db/migrate/20200409075651_add_liveness_checking_required_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddLivenessCheckingRequiredToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :liveness_checking_required, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -423,7 +423,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_075651) do
     t.boolean "allow_prompt_login", default: false
     t.boolean "signed_response_message_requested", default: false
     t.integer "ial2_quota"
-    t.boolean "liveness_checking_enabled"
+    t.boolean "liveness_checking_required"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_08_213043) do
+ActiveRecord::Schema.define(version: 2020_04_09_075651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -423,6 +423,7 @@ ActiveRecord::Schema.define(version: 2020_04_08_213043) do
     t.boolean "allow_prompt_login", default: false
     t.boolean "signed_response_message_requested", default: false
     t.integer "ial2_quota"
+    t.boolean "liveness_checking_enabled"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 

--- a/spec/controllers/idv/scan_id_controller_spec.rb
+++ b/spec/controllers/idv/scan_id_controller_spec.rb
@@ -56,7 +56,8 @@ describe Idv::ScanIdController do
     it 'redirects to ssn page when liveness fails but liveness is disabled for all sps' do
       allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('false')
       controller.user_session['idv/doc_auth_v2'] = {}
-      session[:scan_id] = { instance_id: 'foo', liveness_pass: false, facematch_pass: false, pii: {} }
+      session[:scan_id] = { instance_id: 'foo', liveness_pass: false, facematch_pass: false,
+                            pii: {} }
       get :scan_complete
       expect(response).to redirect_to(idv_doc_auth_v2_step_url(step: :ssn))
     end

--- a/spec/controllers/idv/scan_id_controller_spec.rb
+++ b/spec/controllers/idv/scan_id_controller_spec.rb
@@ -64,7 +64,7 @@ describe Idv::ScanIdController do
 
     it 'redirects to ssn page when liveness fails but liveness is disabled for the sp' do
       controller.user_session['idv/doc_auth_v2'] = {}
-      session[:sp] = { issuer:'foo' }
+      session[:sp] = { issuer: 'foo' }
       session[:scan_id] = { instance_id: 'foo', liveness_pass: false, facematch_pass: false,
                             pii: {} }
       get :scan_complete

--- a/spec/controllers/idv/scan_id_controller_spec.rb
+++ b/spec/controllers/idv/scan_id_controller_spec.rb
@@ -62,6 +62,15 @@ describe Idv::ScanIdController do
       expect(response).to redirect_to(idv_doc_auth_v2_step_url(step: :ssn))
     end
 
+    it 'redirects to ssn page when liveness fails but liveness is disabled for the sp' do
+      controller.user_session['idv/doc_auth_v2'] = {}
+      session[:sp] = { issuer:'foo' }
+      session[:scan_id] = { instance_id: 'foo', liveness_pass: false, facematch_pass: false,
+                            pii: {} }
+      get :scan_complete
+      expect(response).to redirect_to(idv_doc_auth_v2_step_url(step: :ssn))
+    end
+
     it 'renders scan id complete page when all the checks pass in hybrid flow', :skip_sign_in do
       token = CaptureDoc::CreateRequest.call(create(:user).id).request_token
       get :new, params: { token: token }

--- a/spec/controllers/idv/scan_id_controller_spec.rb
+++ b/spec/controllers/idv/scan_id_controller_spec.rb
@@ -53,6 +53,14 @@ describe Idv::ScanIdController do
       expect(response).to redirect_to(idv_doc_auth_v2_step_url(step: :ssn))
     end
 
+    it 'redirects to ssn page when liveness fails but liveness is disabled for all sps' do
+      allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('false')
+      controller.user_session['idv/doc_auth_v2'] = {}
+      session[:scan_id] = { instance_id: 'foo', liveness_pass: false, facematch_pass: false, pii: {} }
+      get :scan_complete
+      expect(response).to redirect_to(idv_doc_auth_v2_step_url(step: :ssn))
+    end
+
     it 'renders scan id complete page when all the checks pass in hybrid flow', :skip_sign_in do
       token = CaptureDoc::CreateRequest.call(create(:user).id).request_token
       get :new, params: { token: token }


### PR DESCRIPTION
**Why**: So SP's can enable/disable liveness checking individually.