### PR TITLE
Simplify logic for allowing prefilling OTP codes

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -1,12 +1,4 @@
 class FeatureManagement
-  ENVS_DO_NOT_DISPLAY_FAKE_BANNER = %w[
-    idp.staging.login.gov secure.login.gov
-  ].freeze
-
-  ENVS_WHERE_PREFILLING_OTP_ALLOWED = %w[
-    idp.dev.login.gov idp.pt.login.gov idp.dev.identitysandbox.gov idp.pt.identitysandbox.gov
-  ].freeze
-
   ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED = %w[
     idp.dev.login.gov idp.int.login.gov idp.qa.login.gov idp.pt.login.gov
     idp.dev.identitysandbox.gov idp.qa.identitysandbox.gov idp.int.identitysandbox.gov
@@ -38,15 +30,15 @@ class FeatureManagement
     # In development, when SMS is disabled we pre-fill the correct codes so that
     # developers can log in without needing to configure SMS delivery.
     # We also allow this in production on a single server that is used for load testing.
-    development_and_telephony_test_adapter? || prefill_otp_codes_allowed_in_production?
+    development_and_telephony_test_adapter? || prefill_otp_codes_allowed_in_sandbox?
   end
 
   def self.development_and_telephony_test_adapter?
     Rails.env.development? && telephony_test_adapter?
   end
 
-  def self.prefill_otp_codes_allowed_in_production?
-    ENVS_WHERE_PREFILLING_OTP_ALLOWED.include?(Figaro.env.domain_name) && telephony_test_adapter?
+  def self.prefill_otp_codes_allowed_in_sandbox?
+    LoginGov::Hostdata.domain == 'identitysandbox.gov' && telephony_test_adapter?
   end
 
   def self.enable_load_testing_mode?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -22,30 +22,25 @@ describe 'FeatureManagement', type: :feature do
       before do
         allow(FeatureManagement).to receive(:telephony_test_adapter?).and_return(true)
         allow(Rails.env).to receive(:production?).and_return(true)
-        allow(Figaro.env).to receive(:domain_name).and_return(domain_name)
       end
 
-      context 'when the server is idp.pt.login.gov' do
-        let(:domain_name) { 'idp.pt.login.gov' }
-
-        it 'prefills codes' do
-          expect(FeatureManagement.prefill_otp_codes?).to eq(true)
+      context 'when the server is in production' do
+        before do
+          allow(LoginGov::Hostdata).to receive(:domain).and_return('login.gov')
         end
-      end
-
-      context 'when the server is idp.dev.login.gov' do
-        let(:domain_name) { 'idp.dev.login.gov' }
-
-        it 'prefills codes' do
-          expect(FeatureManagement.prefill_otp_codes?).to eq(true)
-        end
-      end
-
-      context 'when the server is idp.staging.login.gov' do
-        let(:domain_name) { 'idp.staging.login.gov' }
 
         it 'does not prefill codes' do
           expect(FeatureManagement.prefill_otp_codes?).to eq(false)
+        end
+      end
+
+      context 'when the server is in sandbox' do
+        before do
+          allow(LoginGov::Hostdata).to receive(:domain).and_return('identitysandbox.gov')
+        end
+
+        it 'prefills codes' do
+          expect(FeatureManagement.prefill_otp_codes?).to eq(true)
         end
       end
     end


### PR DESCRIPTION
**Why**: We have pt2 as well as pt now, and that wasn't
in the fixed list. This just lets any "lower" environment
(aka the sandbox) prefill

--

This means that `staging` will not be able to prefill, but given that staging talks to "real" vendors, I think that's expected