### PR TITLE
Add explicitly empty alt tag

### DIFF
--- a/app/views/shared/_nav_branded.html.slim
+++ b/app/views/shared/_nav_branded.html.slim
@@ -1,5 +1,5 @@
 nav.nav-branded.vertical-align.bg-light-blue.center.relative
-  = image_tag(asset_url('logo.svg'), height: 15, width: 111,
+  = image_tag(asset_url('logo.svg'), height: 15, width: 111, alt: '',
     class: 'inline-block align-middle')
   .px-12p.inline-block
     span.absolute.top-0.bottom-0.border-right.my1.sm-my2


### PR DESCRIPTION
**Why**: To satisfy accessibility tooling. We aren't putting
an alt because the title of the page is already in the header,
so it would be redundant

(we got a request from a partner)