### PR TITLE
Use the progress formatter when parallel tests is running

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.order = :random
   config.color = true
-  config.formatter = :documentation
+  config.formatter = ENV['PARALLEL_PID_FILE'].nil? ? :documentation : :progress
 
   # allows you to run only the failures from the previous run:
   # rspec --only-failures


### PR DESCRIPTION
**Why**: Because 4 processes writing to STDOUT with the documentation formatter makes a huge mess