### PR TITLE
Underscore step names when determining if unsafe-eval is set in capture doc controller

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -22,8 +22,7 @@ module Idv
     end
 
     def add_unsafe_eval_to_capture_steps
-      step = params[:step]&.underscore
-      return unless %w[mobile_front_image capture_mobile_back_image].include?(step)
+      return unless %w[mobile_front_image capture_mobile_back_image].include?(current_step)
 
       # required to run wasm until wasm-eval is available
       SecureHeaders.append_content_security_policy_directives(

--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -22,7 +22,8 @@ module Idv
     end
 
     def add_unsafe_eval_to_capture_steps
-      return unless %w[mobile_front_image capture_mobile_back_image].include?(params[:step])
+      step = params[:step]&.underscore
+      return unless %w[mobile_front_image capture_mobile_back_image].include?(step)
 
       # required to run wasm until wasm-eval is available
       SecureHeaders.append_content_security_policy_directives(

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -33,7 +33,7 @@ module Flow
     private
 
     def current_step
-      params[:step].underscore
+      params[:step]&.underscore
     end
 
     def register_campaign

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -115,14 +115,14 @@ describe Idv::CaptureDocController do
       it 'add unsafe-eval to the CSP for capture steps' do
         mock_next_step(:mobile_front_image)
 
-        get :show, params: { step: 'mobile_front_image' }
+        get :show, params: { step: 'mobile-front-image' }
 
         script_src = response.request.headers.env['secure_headers_request_config'].csp.script_src
         expect(script_src).to include("'unsafe-eval'")
 
         mock_next_step(:capture_mobile_back_image)
 
-        get :show, params: { step: 'capture_mobile_back_image' }
+        get :show, params: { step: 'capture-mobile-back-image' }
 
         script_src = response.request.headers.env['secure_headers_request_config'].csp.script_src
         expect(script_src).to include("'unsafe-eval'")


### PR DESCRIPTION
**Why**: Because the steps have hyphens instead of underscores.