### PR TITLE
Update OIDC developer docs link

### DIFF
--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -19,7 +19,7 @@ class OpenidConnectConfigurationPresenter
       authorization_endpoint: openid_connect_authorize_url,
       issuer: root_url,
       jwks_uri: api_openid_connect_certs_url,
-      service_documentation: 'https://pages.18f.gov/identity-dev-docs/',
+      service_documentation: 'https://developers.login.gov/',
       token_endpoint: api_openid_connect_token_url,
       userinfo_endpoint: api_openid_connect_userinfo_url,
       end_session_endpoint: openid_connect_logout_url,

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OpenidConnectConfigurationPresenter do
         expect(configuration[:userinfo_endpoint]).to eq(api_openid_connect_userinfo_url)
         expect(configuration[:end_session_endpoint]).to eq(openid_connect_logout_url)
         expect(configuration[:jwks_uri]).to eq(api_openid_connect_certs_url)
-        expect(configuration[:service_documentation]).to eq('https://pages.18f.gov/identity-dev-docs/')
+        expect(configuration[:service_documentation]).to eq('https://developers.login.gov/')
         expect(configuration[:response_types_supported]).to eq(%w[code])
         expect(configuration[:grant_types_supported]).to eq(%w[authorization_code])
         expect(configuration[:acr_values_supported]).


### PR DESCRIPTION
I just found that this was out of date. The old URL has a redirect, which is good, but I figured I may as well update it while I noticed.