### PR TITLE
Add unsafe-eval to the CSP for the Acuant SDK JS and WASM

### DIFF
--- a/app/controllers/acuant_sdk_controller.rb
+++ b/app/controllers/acuant_sdk_controller.rb
@@ -11,6 +11,11 @@ class AcuantSdkController < ApplicationController
   def show
     # Only render files on an allowlist to prevent path traversal issues
     render plain: 'Not found', status: :not_found unless requested_asset_permitted?
+
+    SecureHeaders.append_content_security_policy_directives(
+      request,
+      script_src: ['\'unsafe-eval\''],
+    )
     send_file(
       Rails.root.join('public', requested_asset_name),
       type: response_content_type,

--- a/spec/requests/acuant_sdk_spec.rb
+++ b/spec/requests/acuant_sdk_spec.rb
@@ -17,6 +17,12 @@ describe 'requesting acuant SDK assets' do
       expect(response.headers['Content-Type']).to eq('application/wasm')
       expect(response.body.length).to eq(File.size('public/AcuantImageProcessingService.wasm'))
     end
+
+    it 'adds unsafe-eval to the CSP' do
+      get '/verify/doc_auth/AcuantJavascriptWebSdk.min.js'
+
+      expect(response.headers['Content-Security-Policy']).to match(/script-src[^;]*'unsafe-eval'/)
+    end
   end
 
   context 'with something that is not a valid Acuant SDK asset' do


### PR DESCRIPTION
**Why**: Because apparently that is where Safari and a few other mobile browsers look for it