### PR TITLE
migrated to docker hub.

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -3,31 +3,19 @@ FROM ruby:2.6-slim
 
 # Enable package fetch over https and add a few core tools
 RUN apt-get update \
-    && apt-get install -y \
-       apt-transport-https \
-       curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Postgres client
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       postgresql-client \
-       libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node 12.x
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get update \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s ../node/bin/node /usr/local/bin/ \
-    && ln -s ../node/bin/npm /usr/local/bin/
-
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && apt-get install -y curl \
+    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install yarn \
+    && apt-get install -y --no-install-recommends \
+       apt-transport-https \
+       curl \
+       git \
+       postgresql-client \
+       libpq-dev \
+       nodejs \
+       yarn \
     && rm -rf /var/lib/apt/lists/*
 
 # Add application user 

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 require "pathname"
 
+# todo (mxplusb): this should be a shell script so it can be used a bit easier for downstream CI tooling.
+
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
+
+# todo (mxplusb): there should be logic here for seeing if the rev is a tag, if it is, then use the tag instead.
+head = `git rev-parse --short HEAD`
 
 def run(command)
   puts("* Running command: #{command}")
@@ -28,8 +33,11 @@ Dir.chdir APP_ROOT do
   # ** Eventually we will keep the `base` and `build` images in a separate repo,
   #   build them in a separate pipeline, and just pull them down for development
   #   Note: building the production image here is not necessary for development work
-  { base: 'rails_base', build: 'rails_build', production: 'idp_app' }.each do |name, description|
+  { base: 'base', build: 'build', development: 'dev', production: 'idp' }.each do |name, description|
     puts "== Building the #{name} Docker image =="
-    run "docker build . --file #{name}.Dockerfile --tag identity-#{description} --no-cache"
+    run "docker build . --file #{name}.Dockerfile --tag logindotgov/#{description}:#{head}"
+
+    puts "== Pushing the #{name} image to Docker Hub =="
+    run "docker push logindotgov/#{description}:#{head}"
   end
 end

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,6 +1,6 @@
 # Build base image - Use to build only, not as a final base.
 # Docker multi-stage builds are used to copy output from this heavy image into others
-FROM identity-rails_base
+FROM logindotgov/base
 
 # Everything happens here from now on   
 WORKDIR /upaya
@@ -9,7 +9,6 @@ WORKDIR /upaya
 RUN apt-get update \
     && apt-get install -y \
        build-essential \
-       git \
        liblzma-dev \
        patch \
        ruby-dev \

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,5 +1,5 @@
 # Use build image first for heavy lifting
-FROM identity-rails_build as build
+FROM logindotgov/build as build
 
 # Everything happens here from now on   
 WORKDIR /upaya
@@ -14,7 +14,7 @@ RUN NODE_ENV=development yarn install --force \
     && yarn cache clean
 
 # Switch to base image and add in Gems
-FROM identity-rails_base
+FROM logindotgov/build
 WORKDIR /upaya
 
 # Copy system Gems into base container

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,5 +1,5 @@
 # Use build to install our required Gems
-FROM identity-rails_build as build
+FROM logindotgov/build as build
 
 # Everything happens here from now on   
 WORKDIR /upaya
@@ -10,11 +10,11 @@ RUN bundle install --deployment --clean --without development test
 
 # Prod NPM packages
 COPY package.json yarn.lock ./
-RUN NODE_ENV=development yarn install --force \
+RUN NODE_ENV=production yarn install --force \
     && yarn cache clean
 
 # Switch to base image
-FROM identity-rails_base
+FROM logindotgov/base
 WORKDIR /upaya
 
 # Copy Gems, NPMs, and other relevant items from build layer


### PR DESCRIPTION
* set prod image to use "production" node env.
* replaced local image references with docker hub references.
* the image tag is now the current git commit sha (temporary).
* added push logic to the `bin/docker_build` script.
* renamed the images to be logindotgov/{purpose}.
* added todos.

Example: https://hub.docker.com/orgs/logindotgov/repositories

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>