### PR TITLE
Log time as an iso8601 string, instead of as a float

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module Upaya
     routes.default_url_options[:host] = Figaro.env.domain_name
 
     config.lograge.custom_options = lambda do |event|
-      event.payload[:timestamp] = event.time
+      event.payload[:timestamp] = Time.zone.now.iso8601
       event.payload[:uuid] = SecureRandom.uuid
       event.payload[:pid] = Process.pid
       event.payload.except(:params, :headers)


### PR DESCRIPTION
**Why**: Somehow the event.time property was coming in as
a floating point (and not from any known epoch). As far
as I can tell, that came from the event (which is an
ActiveSupport::Notifications::Event) that was initialized
with a float.

The lograge README has an  example using "Time.now" instead
of referencing "event": https://github.com/roidrage/lograge


Before:
```
timestamp":694526.471961
```
```
{"method":"POST","path":"/analytics","format":"*/*","controller":"AnalyticsController","action":"create","status":200,"duration":10.21,"user_id":"1abfbb7f-d721-42ee-9cd7-bc9857c31d9b","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36","ip":"::1","host":"localhost","timestamp":694526.471961,"uuid":"6bd71020-c2fe-4d4d-966c-f3bb3a1f43cb","pid":69498}
```

After:
```
"timestamp":"2020-04-24T21:02:15Z"
```
```
{"method":"GET","path":"/","format":"html","controller":"Users::SessionsController","action":"new","status":200,"duration":926.51,"user_id":"anonymous-uuid","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36","ip":"::1","host":"localhost","timestamp":"2020-04-24T21:02:15Z","uuid":"ab1a6677-6471-4c15-a7b1-b8cf15804a8a","pid":75142}
```