### PR TITLE
Add the Acuant SDK to capture-doc routes with a hyphen

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,7 @@ Rails.application.routes.draw do
     AcuantSdkController::ACUANT_SDK_STATIC_FILES.each do |acuant_sdk_file|
       get "/verify/doc_auth/#{acuant_sdk_file}" => 'acuant_sdk#show'
       get "/verify/capture_doc/#{acuant_sdk_file}" => 'acuant_sdk#show'
+      get "/verify/capture-doc/#{acuant_sdk_file}" => 'acuant_sdk#show'
     end
 
     scope '/verify', as: 'idv' do


### PR DESCRIPTION
**Why**: This is the url that actually gets sent to a phone during the hybrid flow. The Acuant SDK needs to be available there.