### PR TITLE
LG-1899 Hide impossible to confirm email address on the account page

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -15,6 +15,12 @@ class UserDecorator # rubocop:disable Metrics/ClassLength
     user.email_addresses.take&.email
   end
 
+  def visible_email_addresses
+    user.email_addresses.filter do |email_address|
+      email_address.confirmed? || !email_address.confirmation_period_expired?
+    end
+  end
+
   def lockout_time_remaining_in_words
     current_time = Time.zone.now
 

--- a/app/views/accounts/_emails.html.slim
+++ b/app/views/accounts/_emails.html.slim
@@ -6,7 +6,7 @@
       - if EmailPolicy.new(current_user).can_add_email?
         .btn.btn-account-action.rounded-lg.bg-light-blue
           = link_to t('account.index.email_add'), add_email_path
-  - current_user.email_addresses.each do |email|
+  - @view_model.decorated_user.visible_email_addresses.each do |email|
     .p2.col.col-12.border-top.border-blue-light.account-list-item
       .col.col-8.sm-6
         span.break-word

--- a/spec/features/multiple_emails/email_management_spec.rb
+++ b/spec/features/multiple_emails/email_management_spec.rb
@@ -17,6 +17,24 @@ feature 'managing email address' do
       expect(page).to have_content(email1)
       expect(page).to have_content(email2)
     end
+
+    scenario 'does not show a unconfirmed email with a expired confirmation period' do
+      user = create(:user, :signed_up)
+      confirmed_email = user.reload.email_addresses.first.email
+
+      expired_unconfirmed_email_address = create(
+        :email_address,
+        user: user,
+        confirmed_at: nil,
+        confirmation_sent_at: 36.hours.ago,
+      )
+      expired_unconfirmed_email = expired_unconfirmed_email_address.email
+
+      sign_in_and_2fa_user(user)
+
+      expect(page).to have_content(confirmed_email)
+      expect(page).to_not have_content(expired_unconfirmed_email)
+    end
   end
 
   context 'allows deletion of email address' do


### PR DESCRIPTION
**Why**: So that these unconfirmed email addresses don't stick around on their account page forever

Co-authored by @shellzie during a pairing session