### PR TITLE
LG-2730 fix sign-in piv setup bug 

### DIFF
--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -98,6 +98,7 @@ module Users
       )
       create_user_event(:piv_cac_enabled)
       Funnel::Registration::AddMfa.call(current_user.id, 'piv_cac')
+      session[:needs_to_setup_piv_cac_after_sign_in] = false
       redirect_to after_sign_in_path_for(current_user)
     end
 

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.slim
@@ -15,7 +15,7 @@ p.mt2.mb2 == t('instructions.mfa.piv_cac.add_from_sign_in')
       .mt2
         = submit_tag t('forms.piv_cac_setup.submit'), class: 'btn btn-primary mr1'
         .inline-block
-          = button_to t('forms.piv_cac_setup.no_thanks'), login_add_piv_cac_prompt_url,
+          = link_to t('forms.piv_cac_setup.no_thanks'), new_user_session_url,
             class: 'btn btn-secondary'
 
 = render 'shared/cancel', link: new_user_session_url

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -108,6 +108,12 @@ describe Users::PivCacAuthenticationSetupController do
 
             expect(subject.user_session[:decrypted_x509]).to eq json
           end
+
+          it 'sets the session to not require piv setup upon sign-in' do
+            get :new, params: { token: good_token }
+
+            expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
+          end
         end
 
         context 'when redirected with an error token' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -59,7 +59,7 @@ feature 'Sign in' do
   scenario 'user opts to not add piv/cac card' do
     perform_steps_to_get_to_add_piv_cac_during_sign_up
     click_on t('forms.piv_cac_setup.no_thanks')
-    expect(current_path).to eq sign_up_completed_path
+    expect(current_path).to eq new_user_session_path
   end
 
   scenario 'user opts to add piv/cac card' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -59,7 +59,7 @@ feature 'Sign in' do
   scenario 'user opts to not add piv/cac card' do
     perform_steps_to_get_to_add_piv_cac_during_sign_up
     click_on t('forms.piv_cac_setup.no_thanks')
-    expect(current_path).to eq new_user_session_path
+    expect(current_path).to eq account_path
   end
 
   scenario 'user opts to add piv/cac card' do


### PR DESCRIPTION
**Why** Because we want to be able submit the form in the PIV setup that occurs when a user attempts to sign in without a PIV.

https://cm-jira.usa.gov/browse/LG-2730