### PR TITLE
Only log alerts from Acuant response on doc auth verification failure

### DIFF
--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -185,8 +185,9 @@ module Idv
       end
 
       def friendly_failure_extra(data)
+        binding.pry
         return data if data.is_a? String
-        data.slice('Alerts')
+        data&.slice('Alerts', :notice)
       end
 
       def friendly_acuant_alert(data)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -170,8 +170,13 @@ module Idv
         NewRelic::Agent.notice_error(exception)
         [
           false,
-          I18n.t('errors.doc_auth.acuant_network_error'),
-          { acuant_network_error: exception.message },
+          {
+            'Alerts' => {
+              'Disposition' => I18n.t('errors.doc_auth.acuant_network_error'),
+              'Timeout' => true,
+              'Exception message' => exception.message,
+            },
+          },
         ]
       end
 
@@ -183,7 +188,7 @@ module Idv
         acuant_alert = friendly_acuant_alert(data)
         message = acuant_alert if acuant_alert.present?
         new_message = friendly_message(message)
-        failure(new_message, alerts: data['Alerts'])
+        failure(new_message, alerts: data&.dig('Alerts'))
       end
 
       def friendly_acuant_alert(data)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -58,16 +58,15 @@ module Idv
       end
 
       def verify_back_image(reset_step:)
-        general_info_message = I18n.t('errors.doc_auth.general_info')
-
+        general_error = I18n.t('errors.doc_auth.general_error')
         back_image_verified, data = assure_id_results
-        data[:notice] = general_info_message if data.class == Hash
-        return friendly_failure(general_info_message, data) unless back_image_verified
+        data[:notice] = I18n.t('errors.doc_auth.general_info')
+        return friendly_failure(general_error, data) unless back_image_verified
 
         return [nil, data] if process_good_result(data)
 
         mark_step_incomplete(reset_step)
-        friendly_failure(I18n.t('errors.doc_auth.general_error'), data)
+        friendly_failure(general_error, data)
       end
 
       def process_good_result(data)
@@ -171,11 +170,9 @@ module Idv
         [
           false,
           {
-            'Alerts' => {
-              'Disposition' => I18n.t('errors.doc_auth.acuant_network_error'),
-              'Timeout' => true,
-              'Exception message' => exception.message,
-            },
+            'Alerts' => [{ 'Disposition' => I18n.t('errors.doc_auth.acuant_network_error') }],
+            'Timeout' => true,
+            'Exception message' => exception.message,
           },
         ]
       end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -60,7 +60,8 @@ module Idv
       def verify_back_image(reset_step:)
         back_image_verified, data, analytics_hash = assure_id_results
         data[:notice] = I18n.t('errors.doc_auth.general_info') if data.class == Hash
-        return friendly_failure(data, analytics_hash) unless back_image_verified
+        # return friendly_failure(data, analytics_hash) unless back_image_verified
+        return friendly_failure(I18n.t('errors.doc_auth.general_info'), data) unless back_image_verified
 
         return [nil, data] if process_good_result(data)
 
@@ -181,7 +182,7 @@ module Idv
         acuant_alert = friendly_acuant_alert(data)
         message = acuant_alert if acuant_alert.present?
         new_message = friendly_message(message)
-        failure(new_message, data)
+        failure(new_message, alerts: data['Alerts'])
       end
 
       def friendly_acuant_alert(data)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -185,7 +185,6 @@ module Idv
       end
 
       def friendly_failure_extra(data)
-        binding.pry
         return data if data.is_a? String
         data&.slice('Alerts', :notice)
       end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -186,7 +186,7 @@ module Idv
 
       def friendly_failure_extra(data)
         return data if data.is_a? String
-        data&.dig('Alerts')
+        data.slice('Alerts')
       end
 
       def friendly_acuant_alert(data)

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -58,10 +58,11 @@ module Idv
       end
 
       def verify_back_image(reset_step:)
-        back_image_verified, data, analytics_hash = assure_id_results
-        data[:notice] = I18n.t('errors.doc_auth.general_info') if data.class == Hash
-        # return friendly_failure(data, analytics_hash) unless back_image_verified
-        return friendly_failure(I18n.t('errors.doc_auth.general_info'), data) unless back_image_verified
+        general_info_message = I18n.t('errors.doc_auth.general_info')
+
+        back_image_verified, data = assure_id_results
+        data[:notice] = general_info_message if data.class == Hash
+        return friendly_failure(general_info_message, data) unless back_image_verified
 
         return [nil, data] if process_good_result(data)
 


### PR DESCRIPTION
**Why**: The entire Acuant response can log info we don't want in our logs