### PR TITLE
Move assets from the precompilation array to manifest.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,12 @@
 //= link_tree ../images
 //= link application.js
 //= link application.css
+
+//= link i18n-strings.js
+//= link email.css
+//= link es5-shim.min.js
+//= link html5shiv.js
+//= link respond.min.js
+//= link intl-tel-input/build/css/intlTelInput.css
+//= link intl-tel-input/build/img/flags.png
+//= link intl-tel-input/build/img/flags@2x.png

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,13 +5,3 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w[
-  i18n-strings.js email.css es5-shim.min.js html5shiv.js respond.min.js
-  intl-tel-input/build/css/intlTelInput.css intl-tel-input/build/img/flags.png
-  intl-tel-input/build/img/flags@2x.png
-]
-
-Rails.application.config.assets.precompile += %w[spec_helper.js] if Rails.env.test?


### PR DESCRIPTION
**Why**: Sprockets started using the manifest instead of the precompilation array in v4

Ref: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs