### PR TITLE
Handle NullServiceProvider on accounts page

### DIFF
--- a/app/models/null_service_provider.rb
+++ b/app/models/null_service_provider.rb
@@ -7,6 +7,10 @@ class NullServiceProvider
     @friendly_name = friendly_name
   end
 
+  def id
+    nil
+  end
+
   def active?
     false
   end

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -11,9 +11,11 @@
       <%= t('account.connected_apps.associated',
             timestamp: local_time(identity.created_at, t('time.formats.event_timestamp'))).html_safe %>
     </div>
-    <div class="sm-col sm-col-6 px1 sm-right-align line-height-4">
-      <%= link_to(t('account.revoke_consent.link_title'),
-                  service_provider_revoke_url(identity.service_provider_id)) %>
-    </div>
+    <% if identity.service_provider_id %>
+      <div class="sm-col sm-col-6 px1 sm-right-align line-height-4">
+        <%= link_to(t('account.revoke_consent.link_title'),
+                    service_provider_revoke_url(identity.service_provider_id)) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -130,10 +130,22 @@ describe 'accounts/show.html.erb' do
     expect(rendered).to have_content t('headings.account.account_history')
   end
 
-  it 'contains connected applications' do
-    render
+  context 'connected apps' do
+    it 'contains connected applications' do
+      render
 
-    expect(rendered).to have_content t('headings.account.connected_apps')
+      expect(rendered).to have_content t('headings.account.connected_apps')
+    end
+
+    context 'with a connected app that is a NullServiceProvider' do
+      before do
+        user.identities << create(:identity, :active, service_provider: 'aaaaa')
+      end
+
+      it 'renders' do
+        expect { render }.to_not raise_error
+      end
+    end
   end
 
   it 'shows the auth nav bar' do


### PR DESCRIPTION
**Why**: NullServiceProvider happens if there is no link from
identities <-> service_providers (broken key), so this makes
the "id" property nil-safe and also removes the revoke link
since that uses the id

---

The error manifests as:
```
ActionView::Template::Error: undefined method `id' for #<NullServiceProvider:0x0000560c54e38df0>
```