### PR TITLE
Make sure hidden webauthn element is skipped by screen readers (LG-2984)

### DIFF
--- a/app/javascript/packs/webauthn-unhide-signup.js
+++ b/app/javascript/packs/webauthn-unhide-signup.js
@@ -4,6 +4,7 @@ function unhideWebauthn() {
   if (WebAuthn.isWebAuthnEnabled()) {
     const elem = document.querySelector('label[for=two_factor_options_form_selection_webauthn]');
     if (elem) {
+      elem.hidden = false;
       elem.classList.remove('hide');
     }
   }

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -12,7 +12,9 @@
     <fieldset class="m0 p0 border-none">
       <legend class="mb2 serif bold"><%= t('forms.two_factor_choice.legend') %>:</legend>
       <% @presenter.options.each do |option| %>
-        <label class="btn-border col-12 mb2 <%= option.html_class %>" for="two_factor_options_form_selection_<%= option.type %>">
+        <%= label_tag "two_factor_options_form_selection_#{option.type}",
+                      class: "btn-border col-12 mb2 #{option.html_class}",
+                      hidden: option.html_class == 'hide' do %>
           <div class="radio">
             <%= radio_button_tag('two_factor_options_form[selection]', option.type) %>
             <span class="indicator mt-tiny"></span>
@@ -22,7 +24,7 @@
           <% if option.security_level %>
             <span class="usa-tag float-right bg-info-dark"><%= option.security_level %></span>
           <% end %>
-        </label>
+        <% end %>
     <% end %>
     </fieldset>
   </div>

--- a/spec/features/remember_device/user_opted_preference.rb
+++ b/spec/features/remember_device/user_opted_preference.rb
@@ -34,7 +34,7 @@ describe 'Unchecking remember device' do
       before do
         user = sign_in_user
         mock_webauthn_setup_challenge
-        select_2fa_option('webauthn')
+        select_2fa_option('webauthn', visible: :all)
 
         allow(WebauthnSetupForm).to receive(:domain_name).and_return('localhost:3000')
 

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -39,7 +39,8 @@ describe 'Remembering a webauthn device' do
       user = sign_up_and_set_password
       user.password = Features::SessionHelper::VALID_PASSWORD
 
-      select_2fa_option('webauthn')
+      # webauthn option is hidden in browsers that don't support it
+      select_2fa_option('webauthn', visible: :all)
       fill_in_nickname_and_click_continue
       check :remember_device
       mock_press_button_on_hardware_key_on_setup

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -21,6 +21,7 @@ describe 'webauthn hide' do
     def webauthn_option_hidden?
       page.find(
         'label[for=two_factor_options_form_selection_webauthn]',
+        visible: :all
       )[:class].include?('hide')
     end
   end

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -21,7 +21,7 @@ describe 'webauthn hide' do
     def webauthn_option_hidden?
       page.find(
         'label[for=two_factor_options_form_selection_webauthn]',
-        visible: :all
+        visible: :all,
       )[:class].include?('hide')
     end
   end

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -6,7 +6,8 @@ feature 'webauthn sign up' do
   let!(:user) { sign_up_and_set_password }
 
   def visit_webauthn_setup
-    select_2fa_option('webauthn')
+    # webauthn option is hidden in browsers that don't support it
+    select_2fa_option('webauthn', visible: :all)
   end
 
   def expect_webauthn_setup_success

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -23,8 +23,8 @@ module Features
       select_2fa_option(option)
     end
 
-    def select_2fa_option(option)
-      find("label[for='two_factor_options_form_selection_#{option}']").click
+    def select_2fa_option(option, **find_options)
+      find("label[for='two_factor_options_form_selection_#{option}']", **find_options).click
       click_on t('forms.buttons.continue')
       click_button t('forms.backup_code.are_you_sure_continue') if
         page.has_button?(t('forms.backup_code.are_you_sure_continue'))

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -98,7 +98,7 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     mock_webauthn_setup_challenge
     visit_idp_from_sp_with_ial2(sp)
     confirm_email_and_password('test@test.com')
-    select_2fa_option('webauthn',visible: :all)
+    select_2fa_option('webauthn', visible: :all)
     fill_in_nickname_and_click_continue
     mock_press_button_on_hardware_key_on_setup
     expect(page).to have_current_path(idv_doc_auth_step_path(step: :welcome))

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -98,7 +98,7 @@ shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     mock_webauthn_setup_challenge
     visit_idp_from_sp_with_ial2(sp)
     confirm_email_and_password('test@test.com')
-    select_2fa_option('webauthn')
+    select_2fa_option('webauthn',visible: :all)
     fill_in_nickname_and_click_continue
     mock_press_button_on_hardware_key_on_setup
     expect(page).to have_current_path(idv_doc_auth_step_path(step: :welcome))


### PR DESCRIPTION
**Why**: Merely styling it as hidden, or setting aria-hidden does
not hide sufficiently from screen readers, so we use the HTML5
"hidden" attribute to do this.

---

To test this, I went to `webauthn-unhide-signup.js` and commented on the DOM listener at the bottom of the page so I could see what the behavior is like in an unsupported browser