### PR TITLE
Update GSA logo alt text for screen readers (LG-2988)

### DIFF
--- a/app/views/shared/_footer_lite.html.slim
+++ b/app/views/shared/_footer_lite.html.slim
@@ -52,8 +52,8 @@ footer.footer.bg-light-blue.sm-bg-navy
           class: 'flex flex-center text-decoration-none white h6',
           target: '_blank') do
           = image_tag asset_url('sp-logos/square-gsa.svg'),
-            width: 20, class: 'mr1 sm-show', alt: 'GSA homepage'
+            width: 20, class: 'mr1 sm-show', alt: ''
           = image_tag asset_url('sp-logos/square-gsa-dark.svg'),
-            width: 20, class: 'mr1 sm-hide', alt: 'GSA homepage'
+            width: 20, class: 'mr1 sm-hide', alt: ''
           span.sm-show
            = t('shared.footer_lite.gsa')

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -13,4 +13,4 @@ en:
         and transmitted securely.
       secure_heading: The site is secure.
     footer_lite:
-      gsa: U.S. General Services Administration
+      gsa: US General Services Administration


### PR DESCRIPTION
**Why**: The alt text and link text both described GSA
so now it's just the link text

(Also JAWS on windows read "U.S." as "U dot S" so I dropped the period