### PR TITLE
LG-2959 Add a missing `return` statement when a Acuant SDK file is not permitted

### DIFF
--- a/app/controllers/acuant_sdk_controller.rb
+++ b/app/controllers/acuant_sdk_controller.rb
@@ -10,7 +10,7 @@ class AcuantSdkController < ApplicationController
 
   def show
     # Only render files on an allowlist to prevent path traversal issues
-    render plain: 'Not found', status: :not_found unless requested_asset_permitted?
+    return render(plain: 'Not found', status: :not_found) unless requested_asset_permitted?
 
     SecureHeaders.append_content_security_policy_directives(
       request,

--- a/spec/requests/acuant_sdk_spec.rb
+++ b/spec/requests/acuant_sdk_spec.rb
@@ -31,5 +31,11 @@ describe 'requesting acuant SDK assets' do
 
       expect(response.status).to eq(404)
     end
+
+    it 'renders a 404 for map files' do
+      get '/verify/doc_auth/AcuantImageProcessingService.wasm.map'
+
+      expect(response.status).to eq(404)
+    end
   end
 end


### PR DESCRIPTION
**Why**: So the execution does not continue leading to a 500 error