### PR TITLE
Remove the Acuant SDK from the desktop flow

### DIFF
--- a/app/views/idv/doc_auth/back_image.html.erb
+++ b/app/views/idv/doc_auth/back_image.html.erb
@@ -18,21 +18,11 @@
 
 <%= simple_form_for(:doc_auth, url: url_for, method: 'PUT',
     html: { autocomplete: 'off', role: 'form', class: 'mt2' }) do |f| %>
-  <%= f.input :image_data_url, as: :hidden %>
   <%= render 'idv/doc_auth/notices', flow_session: flow_session %>
-  <div id='acuant-fallback-image-form'>
-    <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-    <div class='my2' id='target'></div>
-    <div class='mt3'>
-      <%= render 'idv/doc_auth/submit_with_spinner' %>
-    </div>
-  </div>
-  <div class='my3'>
-    <%= render(
-      'idv/acuant_sdk_document_capture_form',
-      capture_button_label: t('doc_auth.buttons.upload_picture'),
-      retry_capture_button_label: t('doc_auth.buttons.upload_picture_retry'),
-    ) %>
+  <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+  <div class='my2' id='target'></div>
+  <div class='mt3'>
+    <%= render 'idv/doc_auth/submit_with_spinner' %>
   </div>
 <% end %>
 

--- a/app/views/idv/doc_auth/back_image.html.erb
+++ b/app/views/idv/doc_auth/back_image.html.erb
@@ -18,6 +18,7 @@
 
 <%= simple_form_for(:doc_auth, url: url_for, method: 'PUT',
     html: { autocomplete: 'off', role: 'form', class: 'mt2' }) do |f| %>
+  <%= f.input :image_data_url, as: :hidden %>
   <%= render 'idv/doc_auth/notices', flow_session: flow_session %>
   <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
   <div class='my2' id='target'></div>

--- a/app/views/idv/doc_auth/front_image.html.erb
+++ b/app/views/idv/doc_auth/front_image.html.erb
@@ -22,6 +22,7 @@
   method: 'PUT',
   html: { autocomplete: 'off', role: 'form', class: 'mt2' }
 ) do |f| %>
+  <%= f.input :image_data_url, as: :hidden %>
   <%= render 'idv/doc_auth/notices', flow_session: flow_session %>
   <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
   <div class='my2' id='target'></div>

--- a/app/views/idv/doc_auth/front_image.html.erb
+++ b/app/views/idv/doc_auth/front_image.html.erb
@@ -22,21 +22,11 @@
   method: 'PUT',
   html: { autocomplete: 'off', role: 'form', class: 'mt2' }
 ) do |f| %>
-  <%= f.input :image_data_url, as: :hidden %>
   <%= render 'idv/doc_auth/notices', flow_session: flow_session %>
-  <div id='acuant-fallback-image-form'>
-    <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-    <div class='my2' id='target'></div>
-    <div class='mt3'>
-      <%= render 'idv/doc_auth/submit_with_spinner' %>
-    </div>
-  </div>
-  <div class='my3'>
-    <%= render(
-      'idv/acuant_sdk_document_capture_form',
-      capture_button_label: t('doc_auth.buttons.upload_picture'),
-      retry_capture_button_label: t('doc_auth.buttons.upload_picture_retry'),
-    ) %>
+  <%= f.input :image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+  <div class='my2' id='target'></div>
+  <div class='mt3'>
+    <%= render 'idv/doc_auth/submit_with_spinner' %>
   </div>
 <% end %>
 

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -8,8 +8,6 @@ en:
       start_over: Start over
       take_picture: Take photo
       take_picture_retry: Retake photo
-      upload_picture: Upload photo
-      upload_picture_retry: Re-upload photo
       use_phone: Use your phone
     forms:
       address1: Address

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -8,8 +8,6 @@ es:
       start_over: Comenzar de nuevo
       take_picture: Tomar la foto
       take_picture_retry: Retomar foto
-      upload_picture: Subir foto
-      upload_picture_retry: Volver a subir la foto
       use_phone: Usa tu telefono
     forms:
       address1: Dirección

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -8,8 +8,6 @@ fr:
       start_over: Recommencer
       take_picture: Prendre une photo
       take_picture_retry: Reprendre la photo
-      upload_picture: Envoyer la photo
-      upload_picture_retry: Re-télécharger la photo
       use_phone: Utilisez votre téléphone
     forms:
       address1: Adresse


### PR DESCRIPTION
**Why**: People using the desktop flow have to use a file picker already. Having the SDK there only means they have to wait for it to load.