### PR TITLE
Fix positioning of remember-this-browser checkbox

### DIFF
--- a/app/assets/stylesheets/components/_util.scss
+++ b/app/assets/stylesheets/components/_util.scss
@@ -89,3 +89,7 @@
 .flex-center {
   justify-content: center;
 }
+
+.flex-no-shrink {
+  flex-shrink: 0;
+}

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -11,47 +11,43 @@
 <%= form_tag(:login_otp, method: :post, role: 'form', class: 'mt3') do %>
   <%= render @presenter.reauthn_hidden_field_partial %>
   <%= label_tag 'code',
-    t('simple_form.required.html') + t('forms.two_factor.code'),
-    class: 'block bold'
-  %>
+                t('simple_form.required.html') + t('forms.two_factor.code'),
+                class: 'block bold' %>
   <div class="col-12 sm-col-5 mb2 sm-mb0 sm-mr-20p inline-block">
     <%= text_field_tag(:code, '',
-      value: @presenter.code_value,
-      required: true,
-      autofocus: true,
-      pattern: '[0-9]*',
-      class: 'col-12 field monospace mfa',
-      'aria-describedby': 'code-instructs',
-      maxlength: Devise.direct_otp_length,
-      type: 'tel')
-    %>
+                       value: @presenter.code_value,
+                       required: true,
+                       autofocus: true,
+                       pattern: '[0-9]*',
+                       class: 'col-12 field monospace mfa',
+                       'aria-describedby': 'code-instructs',
+                       maxlength: Devise.direct_otp_length,
+                       type: 'tel') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number',
-    @presenter.otp_make_default_number %>
+                       @presenter.otp_make_default_number %>
   <%= submit_tag t('forms.buttons.submit.default'),
-    class: 'btn btn-primary align-top sm-col-6 col-12' %>
+                 class: 'btn btn-primary align-top sm-col-6 col-12' %>
 
   <br/><br/>
   <div class="flex flex-row flex-align-center flex-wrap">
-    <%= link_to(
-      t('links.two_factor_authentication.get_another_code'),
-      otp_send_path(otp_delivery_selection_form: {
-        otp_delivery_preference: @presenter.otp_delivery_preference,
-        resend: true
-      }),
-      class: 'btn btn-link btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
-      form_class: 'inline-block'
-    ) %>
+    <%= link_to(t('links.two_factor_authentication.get_another_code'),
+                otp_send_path(otp_delivery_selection_form: {
+                  otp_delivery_preference: @presenter.otp_delivery_preference,
+                  resend: true
+                }),
+                class: 'btn btn-link btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
+                form_class: 'inline-block') %>
 
     <span class="text-no-wrap flex-no-shrink flex flex-row flex-align-center">
       <%= hidden_field_tag 'remember_device', false,
-        id: 'remember_device_preference' %>
+                           id: 'remember_device_preference' %>
       <%= check_box_tag 'remember_device', true,
-        @presenter.remember_device_box_checked?,
-        class: 'my2 ml2 mr1 margin-left-0' %>
+                        @presenter.remember_device_box_checked?,
+                        class: 'my2 ml2 mr1 margin-left-0' %>
       <%= label_tag 'remember_device',
-        t('forms.messages.remember_device'),
-        class: 'blue margin-bottom-0' %>
+                    t('forms.messages.remember_device'),
+                    class: 'blue margin-bottom-0' %>
     </span>
   </div>
 <% end %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -21,19 +21,21 @@
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>
 
   <br/><br/>
-  <%= link_to(t('links.two_factor_authentication.get_another_code'),
-              otp_send_path(otp_delivery_selection_form:
-                { otp_delivery_preference: @presenter.otp_delivery_preference, resend: true }),
-              class: 'btn btn-link btn-border ico ico-refresh text-decoration-none',
-              form_class: 'inline-block') %>
+  <div class="flex flex-row flex-align-center flex-wrap">
+    <%= link_to(t('links.two_factor_authentication.get_another_code'),
+    otp_send_path(otp_delivery_selection_form:
+      { otp_delivery_preference: @presenter.otp_delivery_preference, resend: true }),
+    class: 'btn btn-link btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
+    form_class: 'inline-block') %>
 
-  <inline-block class="span" style="white-space:nowrap">
+    <span class="text-no-wrap flex-no-shrink flex flex-row flex-align-center">
     <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
-    <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'my2 ml2 mr1' %>
+    <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'my2 ml2 mr1 margin-left-0' %>
     <%= label_tag 'remember_device',
-                t('forms.messages.remember_device'),
-                class: 'blue' %>
-  </inline-block>
+          t('forms.messages.remember_device'),
+          class: 'blue margin-bottom-0' %>
+    </span>
+  </div>
 <% end %>
 
 <% if @presenter.update_phone_link.present? %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -10,30 +10,48 @@
 
 <%= form_tag(:login_otp, method: :post, role: 'form', class: 'mt3') do %>
   <%= render @presenter.reauthn_hidden_field_partial %>
-  <%= label_tag 'code', t('simple_form.required.html') + t('forms.two_factor.code'), class: 'block bold' %>
+  <%= label_tag 'code',
+    t('simple_form.required.html') + t('forms.two_factor.code'),
+    class: 'block bold'
+  %>
   <div class="col-12 sm-col-5 mb2 sm-mb0 sm-mr-20p inline-block">
-    <%= text_field_tag(:code, '', value: @presenter.code_value, required: true, autofocus: true,
-                       pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-                       type: 'tel') %>
+    <%= text_field_tag(:code, '',
+      value: @presenter.code_value,
+      required: true,
+      autofocus: true,
+      pattern: '[0-9]*',
+      class: 'col-12 field monospace mfa',
+      'aria-describedby': 'code-instructs',
+      maxlength: Devise.direct_otp_length,
+      type: 'tel')
+    %>
   </div>
-  <%= hidden_field_tag 'otp_make_default_number', @presenter.otp_make_default_number %>
-  <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>
+  <%= hidden_field_tag 'otp_make_default_number',
+    @presenter.otp_make_default_number %>
+  <%= submit_tag t('forms.buttons.submit.default'),
+    class: 'btn btn-primary align-top sm-col-6 col-12' %>
 
   <br/><br/>
   <div class="flex flex-row flex-align-center flex-wrap">
-    <%= link_to(t('links.two_factor_authentication.get_another_code'),
-    otp_send_path(otp_delivery_selection_form:
-      { otp_delivery_preference: @presenter.otp_delivery_preference, resend: true }),
-    class: 'btn btn-link btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
-    form_class: 'inline-block') %>
+    <%= link_to(
+      t('links.two_factor_authentication.get_another_code'),
+      otp_send_path(otp_delivery_selection_form: {
+        otp_delivery_preference: @presenter.otp_delivery_preference,
+        resend: true
+      }),
+      class: 'btn btn-link btn-border ico ico-refresh text-decoration-none flex-no-shrink margin-right-205',
+      form_class: 'inline-block'
+    ) %>
 
     <span class="text-no-wrap flex-no-shrink flex flex-row flex-align-center">
-    <%= hidden_field_tag 'remember_device', false, id: 'remember_device_preference' %>
-    <%= check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?, class: 'my2 ml2 mr1 margin-left-0' %>
-    <%= label_tag 'remember_device',
-          t('forms.messages.remember_device'),
-          class: 'blue margin-bottom-0' %>
+      <%= hidden_field_tag 'remember_device', false,
+        id: 'remember_device_preference' %>
+      <%= check_box_tag 'remember_device', true,
+        @presenter.remember_device_box_checked?,
+        class: 'my2 ml2 mr1 margin-left-0' %>
+      <%= label_tag 'remember_device',
+        t('forms.messages.remember_device'),
+        class: 'blue margin-bottom-0' %>
     </span>
   </div>
 <% end %>


### PR DESCRIPTION
**Why**: LG-1047 - chk + label are on diff. lines on some mobile devices
**How**: Added flex container and leveraged several USWDS classes