### PR TITLE
LG-2375 Don't truncate the return to SP link

### DIFF
--- a/app/views/devise/sessions/_return_to_service_provider.html.erb
+++ b/app/views/devise/sessions/_return_to_service_provider.html.erb
@@ -1,0 +1,8 @@
+<div class='sm-col py1 sm-p0'>
+  <%= link_to(
+    "‹ #{t('links.back_to_sp',
+    sp: decorated_session.sp_name)}",
+    decorated_session.sp_return_url,
+    class: 'inline-block align-bottom',
+  ) %>
+</div>

--- a/app/views/devise/sessions/_return_to_service_provider.html.slim
+++ b/app/views/devise/sessions/_return_to_service_provider.html.slim
@@ -1,4 +1,0 @@
-.sm-col.py1.sm-p0
-  = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
-    decorated_session.sp_return_url,
-    class: 'inline-block align-bottom'

--- a/app/views/devise/sessions/_return_to_service_provider.html.slim
+++ b/app/views/devise/sessions/_return_to_service_provider.html.slim
@@ -1,4 +1,4 @@
 .sm-col.py1.sm-p0
   = link_to "‹ #{t('links.back_to_sp', sp: decorated_session.sp_name)}",
     decorated_session.sp_return_url,
-    class: 'inline-block truncate align-bottom sm-maxw-250p'
+    class: 'inline-block align-bottom'


### PR DESCRIPTION
**Why**: SPs have names of varying length. Before this commit you can't read the name of SPs with long names.