### PR TITLE
Bring back i18n keys removed in #3767

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -8,6 +8,8 @@ en:
       start_over: Start over
       take_picture: Take photo
       take_picture_retry: Retake photo
+      upload_picture: Upload photo
+      upload_picture_retry: Re-upload photo
       use_phone: Use your phone
     forms:
       address1: Address

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -8,6 +8,8 @@ es:
       start_over: Comenzar de nuevo
       take_picture: Tomar la foto
       take_picture_retry: Retomar foto
+      upload_picture: Subir foto
+      upload_picture_retry: Volver a subir la foto
       use_phone: Usa tu telefono
     forms:
       address1: Dirección

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -8,6 +8,8 @@ fr:
       start_over: Recommencer
       take_picture: Prendre une photo
       take_picture_retry: Reprendre la photo
+      upload_picture: Envoyer la photo
+      upload_picture_retry: Re-télécharger la photo
       use_phone: Utilisez votre téléphone
     forms:
       address1: Adresse


### PR DESCRIPTION
**Why**: They're still used

This is failing on master branch right now:

```
identity-idp:master> bundle exec i18n-tasks missing --format keys
en.doc_auth.buttons.upload_picture
en.doc_auth.buttons.upload_picture_retry
es.doc_auth.buttons.upload_picture
es.doc_auth.buttons.upload_picture_retry
fr.doc_auth.buttons.upload_picture
fr.doc_auth.buttons.upload_picture_retry
```