### PR TITLE
Request password reset form prefers confirmed email addresses (LG-3017)

### DIFF
--- a/app/models/concerns/user_encrypted_attribute_overrides.rb
+++ b/app/models/concerns/user_encrypted_attribute_overrides.rb
@@ -11,13 +11,13 @@ module UserEncryptedAttributeOverrides
     end
 
     def find_with_email(email)
-      email_address = EmailAddress.where.not(confirmed_at: nil).find_with_email(email) ||
-                      EmailAddress.where(confirmed_at: nil).find_with_email(email)
+      email_address = EmailAddress.confirmed.find_with_email(email) ||
+                      EmailAddress.unconfirmed.find_with_email(email)
       email_address&.user
     end
 
     def find_with_confirmed_email(email)
-      email_address = EmailAddress.where.not(confirmed_at: nil).find_with_email(email)
+      email_address = EmailAddress.confirmed.find_with_email(email)
       email_address&.user
     end
   end

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -7,6 +7,9 @@ class EmailAddress < ApplicationRecord
   validates :encrypted_email, presence: true
   validates :email_fingerprint, presence: true
 
+  scope :confirmed, -> { where('confirmed_at IS NOT NULL') }
+  scope :unconfirmed, -> { where(confirmed_at: nil) }
+
   def email=(email)
     set_encrypted_attribute(name: :email, value: email)
     self.email_fingerprint = email.present? ? encrypted_attributes[:email].fingerprint : ''

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -48,6 +48,9 @@ RequestPasswordReset = Struct.new(:email, :request_id) do
   end
 
   def email_address_record
-    @email_address_record ||= EmailAddress.find_with_email(email)
+    @email_address_record ||= begin
+      EmailAddress.confirmed.find_with_email(email) ||
+        EmailAddress.unconfirmed.find_with_email(email)
+    end
   end
 end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -95,7 +95,7 @@ describe RequestPasswordReset do
         @user_confirmed = create(:user, email: email, confirmed_at: Time.zone.now)
 
         # make the test more deterministic
-        EmailAddress.default_scopes = [ -> { order('id ASC') } ]
+        EmailAddress.default_scopes = [-> { order('id ASC') }]
       end
 
       it 'always finds the user with the confirmed email address' do

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -91,9 +91,11 @@ describe RequestPasswordReset do
       let(:email) { 'aaa@test.com' }
 
       before do
-        # order matters here
         @user_unconfirmed = create(:user, email: email, confirmed_at: nil)
         @user_confirmed = create(:user, email: email, confirmed_at: Time.zone.now)
+
+        # make the test more deterministic
+        EmailAddress.default_scopes = [ -> { order('id ASC') } ]
       end
 
       it 'always finds the user with the confirmed email address' do
@@ -101,6 +103,10 @@ describe RequestPasswordReset do
         form.perform
 
         expect(form.send(:user)).to eq(@user_confirmed)
+      end
+
+      after do
+        EmailAddress.default_scopes = []
       end
     end
   end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -93,9 +93,13 @@ describe RequestPasswordReset do
       before do
         @user_unconfirmed = create(:user, email: email, confirmed_at: nil)
         @user_confirmed = create(:user, email: email, confirmed_at: Time.zone.now)
+      end
 
+      around do |example|
         # make the test more deterministic
         EmailAddress.default_scopes = [-> { order('id ASC') }]
+        example.run
+        EmailAddress.default_scopes = []
       end
 
       it 'always finds the user with the confirmed email address' do
@@ -103,10 +107,6 @@ describe RequestPasswordReset do
         form.perform
 
         expect(form.send(:user)).to eq(@user_confirmed)
-      end
-
-      after do
-        EmailAddress.default_scopes = []
       end
     end
   end

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -86,5 +86,22 @@ describe RequestPasswordReset do
         RequestPasswordReset.new(unconfirmed_email_address.email).perform
       end
     end
+
+    context 'when two users have the same email address' do
+      let(:email) { 'aaa@test.com' }
+
+      before do
+        # order matters here
+        @user_unconfirmed = create(:user, email: email, confirmed_at: nil)
+        @user_confirmed = create(:user, email: email, confirmed_at: Time.zone.now)
+      end
+
+      it 'always finds the user with the confirmed email address' do
+        form = RequestPasswordReset.new(email)
+        form.perform
+
+        expect(form.send(:user)).to eq(@user_confirmed)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**: Otherwise we may send an reset password email
for the wrong (unconfirmed) account