### PR TITLE
LG-2389 Link to the recovery path from the recovery error screen

### DIFF
--- a/app/views/idv/session_errors/recovery_warning.html.erb
+++ b/app/views/idv/session_errors/recovery_warning.html.erb
@@ -13,7 +13,7 @@
 <%= render 'idv/shared/reset_your_account' %>
 
 <div class='mt3'>
-  <%= link_to t("idv.failure.button.warning"), idv_doc_auth_path %>
+  <%= link_to t("idv.failure.button.warning"), idv_recovery_path %>
 </div>
 
 <%= render 'idv/doc_auth/in_person_proofing_option' %>


### PR DESCRIPTION
**Why**: Linking to doc auth triggers a call to `confirm_two_factor_authenticated`. This results in the user being sent back to the MFA step and having to start recovery all over again. This commit links the user to the recovery link which texts them to the correct recovery step.