### PR TITLE
LG-2389 Link to the recovery path from the recovery error screen

### DIFF
--- a/app/views/idv/session_errors/recovery_warning.html.erb
+++ b/app/views/idv/session_errors/recovery_warning.html.erb
@@ -13,7 +13,7 @@
 <%= render 'idv/shared/reset_your_account' %>
 
 <div class='mt3'>
-  <%= link_to t("idv.failure.button.warning"), idv_doc_auth_path %>
+  <%= link_to t("idv.failure.button.warning"), idv_recovery_path %>
 </div>
 
 <%= render 'idv/doc_auth/in_person_proofing_option' %>

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -48,6 +48,10 @@ feature 'doc auth verify step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_session_errors_warning_path)
+
+    click_on t('idv.failure.button.warning')
+
+    expect(page).to have_current_path(idv_doc_auth_verify_step)
   end
 
   it 'does not proceed to the next page if ssn is a duplicate' do

--- a/spec/features/idv/recovery/verify_step_spec.rb
+++ b/spec/features/idv/recovery/verify_step_spec.rb
@@ -38,6 +38,10 @@ feature 'recovery verify step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_session_errors_recovery_warning_path)
+
+    click_on t('idv.failure.button.warning')
+
+    expect(page).to have_current_path(idv_recovery_verify_step)
   end
 
   it 'does not proceed to the next page if ssn is a duplicate' do


### PR DESCRIPTION
**Why**: Linking to doc auth triggers a call to `confirm_two_factor_authenticated`. This results in the user being sent back to the MFA step and having to start recovery all over again.

This commit changes the link to point to the recovery path so the user is linked to the correct recovery step.