### PR TITLE
Enable proofing w/ a CAC by default

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,7 +41,7 @@ async_job_refresh_max_wait_seconds: '15'
 available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
-cac_proofing_enabled:
+cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 disallow_ial2_recovery:
 doc_capture_request_valid_for_minutes: '15'

--- a/spec/features/idv/cac/choose_method_step_spec.rb
+++ b/spec/features/idv/cac/choose_method_step_spec.rb
@@ -6,7 +6,6 @@ feature 'cac proofing choose method step' do
 
   let(:user) { user_with_2fa }
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user(user)
     complete_cac_proofing_steps_before_choose_method_step
   end

--- a/spec/features/idv/cac/enter_info_step_spec.rb
+++ b/spec/features/idv/cac/enter_info_step_spec.rb
@@ -4,7 +4,6 @@ feature 'cac proofing enter info step' do
   include CacProofingHelper
 
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user
     complete_cac_proofing_steps_before_enter_info_step
   end

--- a/spec/features/idv/cac/present_cac_step_spec.rb
+++ b/spec/features/idv/cac/present_cac_step_spec.rb
@@ -11,7 +11,6 @@ feature 'cac proofing present cac step' do
   end
 
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user
     complete_cac_proofing_steps_before_present_cac_step
   end

--- a/spec/features/idv/cac/success_step_spec.rb
+++ b/spec/features/idv/cac/success_step_spec.rb
@@ -4,7 +4,6 @@ feature 'cac proofing success step' do
   include CacProofingHelper
 
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user
     complete_cac_proofing_steps_before_success_step
   end

--- a/spec/features/idv/cac/use_cac_step_spec.rb
+++ b/spec/features/idv/cac/use_cac_step_spec.rb
@@ -9,7 +9,6 @@ feature 'use cac step' do
   end
 
   it 'shows cac proofing option if cac proofing is enabled' do
-    enable_cac_proofing
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_upload_step
 
@@ -27,7 +26,6 @@ feature 'use cac step' do
   end
 
   it 'does not show cac proofing option on mobile' do
-    enable_cac_proofing
     allow(DeviceDetector).to receive(:new).and_return(mobile_device)
 
     sign_in_and_2fa_user

--- a/spec/features/idv/cac/use_cac_step_spec.rb
+++ b/spec/features/idv/cac/use_cac_step_spec.rb
@@ -19,6 +19,8 @@ feature 'use cac step' do
   end
 
   it 'does not show cac proofing option if cac proofing is disabled' do
+    allow(Figaro.env).to receive(:cac_proofing_enabled).and_return('false')
+
     sign_in_and_2fa_user
     complete_doc_auth_steps_before_upload_step
 

--- a/spec/features/idv/cac/verify_step_spec.rb
+++ b/spec/features/idv/cac/verify_step_spec.rb
@@ -4,7 +4,6 @@ feature 'cac proofing verify info step' do
   include CacProofingHelper
 
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user
     complete_cac_proofing_steps_before_verify_step
   end

--- a/spec/features/idv/cac/welcome_step_spec.rb
+++ b/spec/features/idv/cac/welcome_step_spec.rb
@@ -6,7 +6,6 @@ feature 'cac proofing welcome step' do
 
   let(:user) { user_with_2fa }
   before do
-    enable_cac_proofing
     sign_in_and_2fa_user(user)
     complete_cac_proofing_steps_before_welcome_step
   end

--- a/spec/support/features/cac_proofing_helper.rb
+++ b/spec/support/features/cac_proofing_helper.rb
@@ -23,10 +23,6 @@ module CacProofingHelper
     idv_cac_step_path(step: :success)
   end
 
-  def enable_cac_proofing
-    allow(Figaro.env).to receive(:cac_proofing_enabled).and_return('true')
-  end
-
   def complete_cac_proofing_steps_before_choose_method_step
     visit idv_cac_proofing_choose_method_step
   end


### PR DESCRIPTION
**Why**: It is enabled in production now, so it doesn't make sense to keep it disabled in other envs.