### PR TITLE
LG-3054 Allow doc auth success rate to be calculated by SP

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -41,6 +41,7 @@ module SignUp
 
     def process_successful_creation
       user = @register_user_email_form.user
+      update_sp_return_logs_with_user(user.id)
       create_user_event(:account_created, user) unless @register_user_email_form.email_taken?
 
       resend_confirmation = params[:user][:resend]
@@ -49,6 +50,10 @@ module SignUp
       redirect_to sign_up_verify_email_url(
         resend: resend_confirmation, request_id: permitted_params[:request_id],
       )
+    end
+
+    def update_sp_return_logs_with_user(user_id)
+      Db::SpReturnLog::UpdateUser.call(sp_request_id, user_id)
     end
 
     def sp_request_id

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -108,7 +108,8 @@ module Users
     end
 
     def update_sp_return_logs_with_user(user_id)
-      Db::SpReturnLog::UpdateUser.call(session[:sp][:request_id], user_id)
+      sp_session = session[:sp]
+      Db::SpReturnLog::UpdateUser.call(sp_session[:request_id], user_id) if sp_session
     end
 
     def expires_at

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -98,12 +98,17 @@ module Users
       cache_active_profile(auth_params[:password])
       add_sp_cost(:digest)
       create_user_event(:sign_in_before_2fa)
+      update_sp_return_logs_with_user(current_user.id)
       update_last_sign_in_at_on_email
       redirect_to user_two_factor_authentication_url
     end
 
     def now
       @_now ||= Time.zone.now
+    end
+
+    def update_sp_return_logs_with_user(user_id)
+      Db::SpReturnLog::UpdateUser.call(request_id, user_id)
     end
 
     def expires_at

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -108,7 +108,7 @@ module Users
     end
 
     def update_sp_return_logs_with_user(user_id)
-      Db::SpReturnLog::UpdateUser.call(request_id, user_id)
+      Db::SpReturnLog::UpdateUser.call(session[:sp][:request_id], user_id)
     end
 
     def expires_at

--- a/app/services/db/sp_return_log/update_user.rb
+++ b/app/services/db/sp_return_log/update_user.rb
@@ -1,0 +1,12 @@
+module Db
+  module SpReturnLog
+    class UpdateUser
+      def self.call(request_id, user_id)
+        sp_return_log = ::SpReturnLog.find_by(request_id: request_id)
+        return unless sp_return_log
+        sp_return_log.user_id = user_id
+        sp_return_log.save
+      end
+    end
+  end
+end

--- a/spec/features/account_creation/sp_return_log_spec.rb
+++ b/spec/features/account_creation/sp_return_log_spec.rb
@@ -5,7 +5,7 @@ feature 'SP return logs' do
 
   let(:email) { 'test@test.com' }
 
-  it 'updates user id after user registers an email so we can track any user back to issuer' do
+  it 'updates user id after registration to allow tracking user back to issuer', :email do
     visit_idp_from_sp_with_ial1(:oidc)
     expect(SpReturnLog.count).to eq(1)
     expect(SpReturnLog.first.user_id).to be_nil

--- a/spec/features/account_creation/sp_return_log_spec.rb
+++ b/spec/features/account_creation/sp_return_log_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+feature 'SP return logs' do
+  include SamlAuthHelper
+
+  let(:email) { 'test@test.com' }
+
+  it 'updates user id after user registers an email so we can track any user back to issuer' do
+    visit_idp_from_sp_with_ial1(:oidc)
+    expect(SpReturnLog.count).to eq(1)
+    expect(SpReturnLog.first.user_id).to be_nil
+
+    user = register_user(email)
+
+    expect(SpReturnLog.count).to eq(1)
+    expect(SpReturnLog.first.user_id).to eq(user.id)
+  end
+end

--- a/spec/features/sign_in/sp_return_log_spec.rb
+++ b/spec/features/sign_in/sp_return_log_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'SP return logs' do
   include SamlAuthHelper
 
-  it 'updates user id after user signs in so we can track any user back to issuer' do
+  it 'updates user id after user signs in so we can track any user back to issuer', :email do
     user = create(:user, :signed_up)
     visit_idp_from_sp_with_ial1(:oidc)
     fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/features/sign_in/sp_return_log_spec.rb
+++ b/spec/features/sign_in/sp_return_log_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'SP return logs' do
+  include SamlAuthHelper
+
+  it 'updates user id after user signs in so we can track any user back to issuer' do
+    user = create(:user, :signed_up)
+    visit_idp_from_sp_with_ial1(:oidc)
+    fill_in_credentials_and_submit(user.email, user.password)
+
+    expect(SpReturnLog.count).to eq(1)
+    expect(SpReturnLog.first.user_id).to eq(user.id)
+  end
+end


### PR DESCRIPTION
**How**: sp_return_logs have request id, issuer, and user id but currently the user id is set right before the user is returned to the SP.  If we set the user id when the user registers their email we can always track requests and user ids back to their issuer and thus create any report by SP including the doc auth funnel.