### PR TITLE
LG-954 Retain events for users that delete their account

### DIFF
--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -9,6 +9,7 @@ module Users
 
     def delete
       send_push_notifications
+      Db::DeletedUser::Create.call(current_user.id)
       current_user.destroy!
       sign_out
       flash[:success] = t('devise.registrations.destroyed')

--- a/app/controllers/users/delete_controller.rb
+++ b/app/controllers/users/delete_controller.rb
@@ -9,8 +9,7 @@ module Users
 
     def delete
       send_push_notifications
-      Db::DeletedUser::Create.call(current_user.id)
-      current_user.destroy!
+      delete_user
       sign_out
       flash[:success] = t('devise.registrations.destroyed')
       analytics.track_event(Analytics::ACCOUNT_DELETE_SUBMITTED, success: true)
@@ -18,6 +17,13 @@ module Users
     end
 
     private
+
+    def delete_user
+      ActiveRecord::Base.transaction do
+        Db::DeletedUser::Create.call(current_user.id)
+        current_user.destroy!
+      end
+    end
 
     def confirm_current_password
       return if valid_password?

--- a/app/models/deleted_user.rb
+++ b/app/models/deleted_user.rb
@@ -1,0 +1,2 @@
+class DeletedUser < ApplicationRecord
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,8 @@
 class Device < ApplicationRecord
   belongs_to :user
-  has_many :events, dependent: :destroy
+  # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :events # we are retaining events after delete
+  # rubocop:enable Rails/HasManyOrHasOneDependent
   attr_accessor :nice_name
   validates :user_id, presence: true
   validates :cookie_uuid, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   # rubocop:enable Rails/HasManyOrHasOneDependent
   has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
-  has_many :events, dependent: :destroy
+  has_many :events # we are retaining events after delete
   has_one :account_reset_request, dependent: :destroy
   has_many :phone_configurations, dependent: :destroy, inverse_of: :user
   has_many :email_addresses, dependent: :destroy, inverse_of: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,10 +29,10 @@ class User < ApplicationRecord
   has_many :authorizations, dependent: :destroy
   # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :identities # identities need to be orphaned to prevent UUID reuse
+  has_many :events # we are retaining events after delete
   # rubocop:enable Rails/HasManyOrHasOneDependent
   has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
-  has_many :events # we are retaining events after delete
   has_one :account_reset_request, dependent: :destroy
   has_many :phone_configurations, dependent: :destroy, inverse_of: :user
   has_many :email_addresses, dependent: :destroy, inverse_of: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
   # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :identities # identities need to be orphaned to prevent UUID reuse
   has_many :events # we are retaining events after delete
+  has_many :devices # we are retaining devices after delete
   # rubocop:enable Rails/HasManyOrHasOneDependent
   has_many :agency_identities, dependent: :destroy
   has_many :profiles, dependent: :destroy
@@ -41,7 +42,6 @@ class User < ApplicationRecord
   has_many :auth_app_configurations, dependent: :destroy, inverse_of: :user
   has_one :doc_auth, dependent: :destroy, inverse_of: :user
   has_many :backup_code_configurations, dependent: :destroy
-  has_many :devices, dependent: :destroy
   has_one :doc_capture, dependent: :destroy
   has_one :account_recovery_request, dependent: :destroy
   has_many :throttles, dependent: :destroy

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -39,8 +39,10 @@ module AccountReset
     end
 
     def destroy_user
-      Db::DeletedUser::Create.call(user.id)
-      user.destroy!
+      ActiveRecord::Base.transaction do
+        Db::DeletedUser::Create.call(user.id)
+        user.destroy!
+      end
     end
 
     def send_push_notifications

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -39,6 +39,7 @@ module AccountReset
     end
 
     def destroy_user
+      Db::DeletedUser::Create.call(user.id)
       user.destroy!
     end
 

--- a/app/services/db/deleted_user/create.rb
+++ b/app/services/db/deleted_user/create.rb
@@ -6,7 +6,7 @@ module Db
         return unless user
         ::DeletedUser.create!(user_id: user.id,
                               uuid: user.uuid,
-                              created_at: user.created_at,
+                              user_created_at: user.created_at,
                               deleted_at: Time.zone.now)
       end
     end

--- a/app/services/db/deleted_user/create.rb
+++ b/app/services/db/deleted_user/create.rb
@@ -1,0 +1,14 @@
+module Db
+  module DeletedUser
+    class Create
+      def self.call(user_id)
+        user = User.find_by(id: user_id)
+        return unless user
+        ::DeletedUser.create!(user_id: user.id,
+                              uuid: user.uuid,
+                              created_at: user.created_at,
+                              deleted_at: Time.zone.now)
+      end
+    end
+  end
+end

--- a/db/migrate/20200601215509_create_deleted_users.rb
+++ b/db/migrate/20200601215509_create_deleted_users.rb
@@ -8,5 +8,7 @@ class CreateDeletedUsers < ActiveRecord::Migration[5.1]
     end
     add_index :deleted_users, %i[user_id], unique: true
     add_index :deleted_users, %i[uuid], unique: true
+
+    remove_foreign_key :events, :users
   end
 end

--- a/db/migrate/20200601215509_create_deleted_users.rb
+++ b/db/migrate/20200601215509_create_deleted_users.rb
@@ -1,0 +1,12 @@
+class CreateDeletedUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :deleted_users do |t|
+      t.integer :user_id, null: false
+      t.string :uuid, null: false
+      t.datetime :created_at, null: false
+      t.datetime :deleted_at, null: false
+    end
+    add_index :deleted_users, %i[user_id], unique: true
+    add_index :deleted_users, %i[uuid], unique: true
+  end
+end

--- a/db/migrate/20200601215509_create_deleted_users.rb
+++ b/db/migrate/20200601215509_create_deleted_users.rb
@@ -3,7 +3,7 @@ class CreateDeletedUsers < ActiveRecord::Migration[5.1]
     create_table :deleted_users do |t|
       t.integer :user_id, null: false
       t.string :uuid, null: false
-      t.datetime :created_at, null: false
+      t.datetime :user_created_at, null: false
       t.datetime :deleted_at, null: false
     end
     add_index :deleted_users, %i[user_id], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_215509) do
+ActiveRecord::Schema.define(version: 2020_06_01_235647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -565,5 +565,4 @@ ActiveRecord::Schema.define(version: 2020_06_01_215509) do
     t.index ["user_id"], name: "index_webauthn_configurations_on_user_id"
   end
 
-  add_foreign_key "events", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_30_185607) do
+ActiveRecord::Schema.define(version: 2020_06_01_215509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,15 @@ ActiveRecord::Schema.define(version: 2020_05_30_185607) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "code_fingerprint"], name: "index_bcc_on_user_id_code_fingerprint", unique: true
     t.index ["user_id", "created_at"], name: "index_backup_code_configurations_on_user_id_and_created_at"
+  end
+
+  create_table "deleted_users", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "uuid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "deleted_at", null: false
+    t.index ["user_id"], name: "index_deleted_users_on_user_id", unique: true
+    t.index ["uuid"], name: "index_deleted_users_on_uuid", unique: true
   end
 
   create_table "devices", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_235647) do
   create_table "deleted_users", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "uuid", null: false
-    t.datetime "created_at", null: false
+    t.datetime "user_created_at", null: false
     t.datetime "deleted_at", null: false
     t.index ["user_id"], name: "index_deleted_users_on_user_id", unique: true
     t.index ["uuid"], name: "index_deleted_users_on_uuid", unique: true

--- a/spec/features/account_reset/delete_account_spec.rb
+++ b/spec/features/account_reset/delete_account_spec.rb
@@ -50,6 +50,9 @@ describe 'Account Reset Request: Delete Account', email: true do
         )
         expect(page).to have_current_path(account_reset_confirm_delete_account_path)
         expect(User.where(id: user.id)).to be_empty
+        deleted_user = DeletedUser.find_by(user_id: user.id)
+        expect(deleted_user.user_id).to eq(user.id)
+        expect(deleted_user.uuid).to eq(user.uuid)
         expect(last_email.subject).to eq t('user_mailer.account_reset_complete.subject')
 
         click_link t('account_reset.confirm_delete_account.link_text')

--- a/spec/services/db/deleted_user/create_spec.rb
+++ b/spec/services/db/deleted_user/create_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Db::DeletedUser::Create do
+  subject { described_class }
+
+  it 'does nothing if the user does not exist' do
+    subject.call(1)
+    expect(DeletedUser.count).to eq(0)
+  end
+
+  it 'creates a deleted_user and retains some fields' do
+    user = create(:user)
+    subject.call(user.id)
+
+    expect(DeletedUser.count).to eq(1)
+    deleted_user = DeletedUser.first
+    expect(deleted_user.user_id).to eq(user.id)
+  end
+end


### PR DESCRIPTION
**How**: Before deleting a user save their user_id, creation timestamp, UUID, and add a deletion timestamp. Save this info in a new deleted_users table. Remove the cascading delete on events.