### PR TITLE
LG-2579 Add Support for Multi-Region KMS Encryption

### DIFF
--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -45,7 +45,7 @@ module Encryption
         Base64.strict_encode64(
           encrypt_raw_kms(chunk, encryption_context),
         )
-      end.join('')
+      end.to_json
     end
 
     def encrypt_raw_kms(plaintext, encryption_context)

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -57,9 +57,8 @@ module Encryption
       clipped_ciphertext = ciphertext.gsub(/\A#{KEY_TYPE[:KMS]}/, '')
       ciphertext_chunks = JSON.parse(clipped_ciphertext)
       ciphertext_chunks.map do |chunk|
-        dec = Base64.strict_decode64(chunk)
         decrypt_raw_kms(
-          dec,
+          Base64.strict_decode64(chunk),
           encryption_context,
         )
       end.join('')

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -72,7 +72,7 @@ module Encryption
       # checking if it looks like the JSON hash we want
       if ciphertext.start_with?('{"regions"')
         parsed_payload = JSON.parse(ciphertext)
-        if parsed_payload.is_a?(Hash)
+        if parsed_payload.is_a?(Hash) # rubocop:disable Style/GuardClause
           regions = parsed_payload['regions']
           resolve_region_decryption(regions)
         else

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -1,0 +1,72 @@
+require 'json'
+module Encryption
+  class MultiRegionKMSClient
+
+    def initialize
+      @aws_clients = Hash.new
+      # Instantiate an array of aws clients based on the provided regions in the environment
+      JSON.parse(Figaro.env.aws_kms_regions).each do | region |
+        @aws_clients[region] = Aws::KMS::Client.new(
+            instance_profile_credentials_timeout: 1, # defaults to 1 second
+            instance_profile_credentials_retries: 5, # defaults to 0 retries
+            region: region # The region in which the client is being instantiated
+        )
+      end
+    end
+
+    # Use each KMS client to encrypt with params and options
+    # Region format example: '{"reg": {"us-east-1": "cipher", "us-west-2": "othercipher"}}'
+    def encrypt(key_id, plaintext, encryption_context)
+      region_ciphers = Hash.new
+      @aws_clients.each.map{|region, kms_client|
+        region_ciphers[region] = kms_client.encrypt(key_id: key_id,
+                                                    plaintext: plaintext,
+                                                    encryption_context: encryption_context).ciphertext_blob}.join('')
+      {:reg => region_ciphers}.to_json
+    end
+
+    def decrypt(ciphertext, encryption_context)
+      # The client that will be used to decode the ciphertext, the ciphertext after being parsed out of whatever
+      # format it's in, the actual region that it's being decoded in
+      region_client = nil
+      resolved_ciphertext = nil
+      region = nil
+      # The ciphertext should either be a json HASH keyed by "reg", or a plain string. Start by checking if it looks
+      # like the JSON hash we want
+      if ciphertext.start_with?('{"reg"')
+        parsed_ciphertext = JSON.parse(ciphertext)
+        if parsed_ciphertext.is_a?(Hash)
+          # It's a hash, make sure that it has the "reg" key. If not, this is a strange malformed key error
+          regions = parsed_ciphertext["reg"]
+          if parsed_ciphertext.length == 1 and regions
+            # For each region that the ciphertext has a cipher for, check to see if that region is represented
+            # in the clients available
+            regions.each do |region, cipher|
+              region_client = @aws_clients[region]
+              resolved_ciphertext = cipher
+              # If a region was represented, stop looking
+              break if region_client
+            end
+          end
+        else
+          raise EncryptionError, "Malformed JSON ciphertext, not a hash"
+        end
+      else
+        # Decode the raw ciphertext
+        region = Figaro.env.aws_region
+        region_client = @aws_clients[region]
+        resolved_ciphertext = ciphertext
+      end
+
+      if region_client
+        # If the ciphertext is valid and there's a relevant client, try to actually decode it
+        region_client.decrypt(
+            ciphertext_blob: resolved_ciphertext,
+            encryption_context: encryption_context).plaintext
+      else
+        raise EncryptionError, "Couldn't decrypt, no client found for region #{region}"
+      end
+    end
+
+  end
+end

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -41,8 +41,7 @@ module Encryption
     def find_available_region(regions)
       regions.each do |region, cipher|
         region_client = @aws_clients[region]
-        resolved_ciphertext = cipher
-        return CipherData.new(region_client, resolved_ciphertext) if region_client
+        return CipherData.new(region_client, cipher) if region_client
       end
       raise EncryptionError, 'No supported region found in ciphertext'
     end
@@ -53,7 +52,7 @@ module Encryption
       curr_region_client = @aws_clients[Figaro.env.aws_region]
       curr_region_cipher = regions[Figaro.env.aws_region]
       if curr_region_cipher && curr_region_client
-        CipherData.new(curr_region_client, curr_region_cipher) if curr_region_client && curr_region_cipher
+        CipherData.new(curr_region_client, curr_region_cipher)
       else
         find_available_region(regions)
       end

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -2,9 +2,9 @@ require 'json'
 module Encryption
   class MultiRegionKMSClient
     def initialize
-      @aws_clients = Hash.new
+      @aws_clients = {}
       # Instantiate an array of aws clients based on the provided regions in the environment
-      JSON.parse(Figaro.env.aws_kms_regions).each do | region |
+      JSON.parse(Figaro.env.aws_kms_regions).each do |region|
         @aws_clients[region] = Aws::KMS::Client.new(
           instance_profile_credentials_timeout: 1, # defaults to 1 second
           instance_profile_credentials_retries: 5, # defaults to 0 retries
@@ -27,45 +27,51 @@ module Encryption
     end
 
     def decrypt(ciphertext, encryption_context)
-      # The client that will be used to decode the ciphertext, the ciphertext after being parsed out of whatever
-      # format it's in
+      # The client that will be used to decode the ciphertext, the ciphertext after being parsed out
+      # of whatever format it's in
       region_client, resolved_ciphertext = resolve_decryption(ciphertext)
-
       # If the ciphertext is valid and there's a relevant client, try to actually decode it
       region_client.decrypt(
         ciphertext_blob: resolved_ciphertext,
-        encryption_context: encryption_context).plaintext
+        encryption_context: encryption_context,
+      ).plaintext
     end
 
     private
 
+    def resolve_region_decryption(regions)
+      # For each region that the ciphertext has a cipher for, check to see if that region is
+      # represented in the clients available
+      regions.each do |region, cipher|
+        region_client = @aws_clients[region]
+        resolved_ciphertext = cipher
+        return region_client, resolved_ciphertext if region_client
+      end
+      raise EncryptionError, 'No supported region found in ciphertext'
+    end
+
+    def resolve_legacy_decryption(ciphertext)
+      # Decode the raw ciphertext
+      curr_region = Figaro.env.aws_region
+      region_client = @aws_clients[curr_region]
+      resolved_ciphertext = ciphertext
+      return region_client, resolved_ciphertext if region_client
+      raise EncryptionError, "No client found for region #{curr_region}"
+    end
+
     def resolve_decryption(ciphertext)
-      # The ciphertext should either be a json HASH keyed by "reg", or a plain string. Start by checking if it looks
-      # like the JSON hash we want
+      # The ciphertext should either be a json HASH keyed by "reg", or a plain string. Start by
+      # checking if it looks like the JSON hash we want
       if ciphertext.start_with?('{"reg"')
         parsed_ciphertext = JSON.parse(ciphertext)
         unless parsed_ciphertext.is_a?(Hash)
           raise EncryptionError, 'Malformed JSON ciphertext, not a hash'
         end
-        # It's a hash, make sure that it has the "reg" key. If not, this is a strange malformed key error
+        # It's a hash, make sure that it has the "reg" key. If not, this is a malformed key error
         regions = parsed_ciphertext['reg']
-        if parsed_ciphertext.length == 1 and regions
-          # For each region that the ciphertext has a cipher for, check to see if that region is represented
-          # in the clients available
-          regions.each do |region, cipher|
-            region_client = @aws_clients[region]
-            resolved_ciphertext = cipher
-            return region_client, resolved_ciphertext if region_client
-          end
-        end
-        raise EncryptionError, 'No supported region found in ciphertext'
+        resolve_region_decryption(regions)
       else
-        # Decode the raw ciphertext
-        curr_region = Figaro.env.aws_region
-        region_client = @aws_clients[curr_region]
-        resolved_ciphertext = ciphertext
-        return region_client, resolved_ciphertext if region_client
-        raise EncryptionError, "No client found for region #{curr_region}"
+        resolve_legacy_decryption(ciphertext)
       end
     end
   end

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -1,15 +1,14 @@
 require 'json'
 module Encryption
   class MultiRegionKMSClient
-
     def initialize
       @aws_clients = Hash.new
       # Instantiate an array of aws clients based on the provided regions in the environment
       JSON.parse(Figaro.env.aws_kms_regions).each do | region |
         @aws_clients[region] = Aws::KMS::Client.new(
-            instance_profile_credentials_timeout: 1, # defaults to 1 second
-            instance_profile_credentials_retries: 5, # defaults to 0 retries
-            region: region # The region in which the client is being instantiated
+          instance_profile_credentials_timeout: 1, # defaults to 1 second
+          instance_profile_credentials_retries: 5, # defaults to 0 retries
+          region: region, # The region in which the client is being instantiated
         )
       end
     end
@@ -17,56 +16,57 @@ module Encryption
     # Use each KMS client to encrypt with params and options
     # Region format example: '{"reg": {"us-east-1": "cipher", "us-west-2": "othercipher"}}'
     def encrypt(key_id, plaintext, encryption_context)
-      region_ciphers = Hash.new
-      @aws_clients.each.map{|region, kms_client|
-        region_ciphers[region] = kms_client.encrypt(key_id: key_id,
-                                                    plaintext: plaintext,
-                                                    encryption_context: encryption_context).ciphertext_blob}.join('')
-      {:reg => region_ciphers}.to_json
+      region_ciphers = {}
+      @aws_clients.each do |region, kms_client|
+        r_cipher = kms_client.encrypt(key_id: key_id,
+                                      plaintext: plaintext,
+                                      encryption_context: encryption_context)
+        region_ciphers[region] = r_cipher.ciphertext_blob
+      end
+      { reg: region_ciphers }.to_json
     end
 
     def decrypt(ciphertext, encryption_context)
       # The client that will be used to decode the ciphertext, the ciphertext after being parsed out of whatever
-      # format it's in, the actual region that it's being decoded in
-      region_client = nil
-      resolved_ciphertext = nil
-      region = nil
+      # format it's in
+      region_client, resolved_ciphertext = resolve_decryption(ciphertext)
+
+      # If the ciphertext is valid and there's a relevant client, try to actually decode it
+      region_client.decrypt(
+        ciphertext_blob: resolved_ciphertext,
+        encryption_context: encryption_context).plaintext
+    end
+
+    private
+
+    def resolve_decryption(ciphertext)
       # The ciphertext should either be a json HASH keyed by "reg", or a plain string. Start by checking if it looks
       # like the JSON hash we want
       if ciphertext.start_with?('{"reg"')
         parsed_ciphertext = JSON.parse(ciphertext)
-        if parsed_ciphertext.is_a?(Hash)
-          # It's a hash, make sure that it has the "reg" key. If not, this is a strange malformed key error
-          regions = parsed_ciphertext["reg"]
-          if parsed_ciphertext.length == 1 and regions
-            # For each region that the ciphertext has a cipher for, check to see if that region is represented
-            # in the clients available
-            regions.each do |region, cipher|
-              region_client = @aws_clients[region]
-              resolved_ciphertext = cipher
-              # If a region was represented, stop looking
-              break if region_client
-            end
-          end
-        else
-          raise EncryptionError, "Malformed JSON ciphertext, not a hash"
+        unless parsed_ciphertext.is_a?(Hash)
+          raise EncryptionError, 'Malformed JSON ciphertext, not a hash'
         end
+        # It's a hash, make sure that it has the "reg" key. If not, this is a strange malformed key error
+        regions = parsed_ciphertext['reg']
+        if parsed_ciphertext.length == 1 and regions
+          # For each region that the ciphertext has a cipher for, check to see if that region is represented
+          # in the clients available
+          regions.each do |region, cipher|
+            region_client = @aws_clients[region]
+            resolved_ciphertext = cipher
+            return region_client, resolved_ciphertext if region_client
+          end
+        end
+        raise EncryptionError, 'No supported region found in ciphertext'
       else
         # Decode the raw ciphertext
-        region = Figaro.env.aws_region
-        region_client = @aws_clients[region]
+        curr_region = Figaro.env.aws_region
+        region_client = @aws_clients[curr_region]
         resolved_ciphertext = ciphertext
-      end
-
-      if region_client
-        # If the ciphertext is valid and there's a relevant client, try to actually decode it
-        region_client.decrypt(
-            ciphertext_blob: resolved_ciphertext,
-            encryption_context: encryption_context).plaintext
-      else
-        raise EncryptionError, "Couldn't decrypt, no client found for region #{region}"
+        return region_client, resolved_ciphertext if region_client
+        raise EncryptionError, "No client found for region #{curr_region}"
       end
     end
-
   end
 end

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -38,7 +38,10 @@ module Encryption
 
     def resolve_region_decryption(regions)
       # For each region that the ciphertext has a cipher for, check to see if that region is
-      # represented in the clients available
+      # represented in the clients available. Check default region before checking others
+      curr_region_client = @aws_clients[Figaro.env.aws_region]
+      curr_region_cipher = regions[Figaro.env.aws_region]
+      return curr_region_client, curr_region_cipher if curr_region_client && curr_region_cipher
       regions.each do |region, cipher|
         region_client = @aws_clients[region]
         resolved_ciphertext = cipher

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,6 +41,7 @@ async_job_refresh_max_wait_seconds: '15'
 available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
+aws_kms_regions: '["us-west-2", "us-east-1"]'
 cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 disallow_ial2_recovery:

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,7 +41,6 @@ async_job_refresh_max_wait_seconds: '15'
 available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
-aws_kms_regions: '["us-west-2", "us-east-1"]'
 cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 disallow_ial2_recovery:
@@ -146,6 +145,7 @@ development:
   aws_kms_key_id: alias/login-dot-gov-development-keymaker
   aws_logo_bucket:
   aws_region: us-east-1
+  aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user
@@ -255,6 +255,7 @@ production:
   attribute_encryption_key_queue:
   aws_kms_key_id:
   aws_region:
+  aws_kms_regions: '["us-west-2"]'
   aws_logo_bucket:
   backup_codes_as_only_2fa:
   basic_auth_password:
@@ -362,6 +363,7 @@ test:
     }]'
   aws_kms_key_id: alias/login-dot-gov-test-keymaker
   aws_region: us-east-1
+  aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -37,7 +37,7 @@ describe Encryption::KmsClient do
     )
   end
 
-  kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
+  let(:kms_regions) { %w[us-west-2 us-east-1] }
 
   let(:kms_ciphertext) do
     'KMSc' + %w[kms1 kms2 kms3].map do |c|

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -41,11 +41,11 @@ describe Encryption::KmsClient do
 
   let(:kms_ciphertext) do
     'KMSc' + %w[kms1 kms2 kms3].map { |c|
-      region_hash = Hash.new
+      region_hash = {}
       kms_regions.each do |r|
         region_hash[r] = c
       end
-      Base64.strict_encode64({:reg => region_hash}.to_json)
+      Base64.strict_encode64({ reg: region_hash }.to_json)
     }.to_json
   end
 

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -40,13 +40,13 @@ describe Encryption::KmsClient do
   kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
 
   let(:kms_ciphertext) do
-    'KMSc' + %w[kms1 kms2 kms3].map { |c|
+    'KMSc' + %w[kms1 kms2 kms3].map do |c|
       region_hash = {}
       kms_regions.each do |r|
         region_hash[r] = c
       end
       Base64.strict_encode64({ reg: region_hash }.to_json)
-    }.to_json
+    end.to_json
   end
 
   let(:oth_kms_ciphertext) do

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -37,6 +37,8 @@ describe Encryption::KmsClient do
     )
   end
 
+  kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
+
   let(:kms_ciphertext) do
     'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
   end
@@ -50,7 +52,6 @@ describe Encryption::KmsClient do
     context 'with KMS enabled' do
       it 'encrypts with KMS' do
         result = subject.encrypt(plaintext, encryption_context)
-
         expect(result).to eq(kms_ciphertext)
       end
     end
@@ -76,7 +77,6 @@ describe Encryption::KmsClient do
     context 'with a ciphertext encrypted with KMS' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(kms_ciphertext, encryption_context)
-
         expect(result).to eq(plaintext)
       end
     end
@@ -120,7 +120,6 @@ describe Encryption::KmsClient do
 
     it 'logs the context' do
       expect(Encryption::KmsLogger).to receive(:log).with(:decrypt, encryption_context)
-
       subject.decrypt(kms_ciphertext, encryption_context)
     end
   end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -40,8 +40,19 @@ describe Encryption::KmsClient do
   kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
 
   let(:kms_ciphertext) do
+    'KMSc' + %w[kms1 kms2 kms3].map { |c|
+      region_hash = Hash.new
+      kms_regions.each do |r|
+        region_hash[r] = c
+      end
+      Base64.strict_encode64({:reg => region_hash}.to_json)
+    }.to_json
+  end
+
+  let(:oth_kms_ciphertext) do
     'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
   end
+
   let(:local_ciphertext) do
     'LOCc' + %w[local1 local2 local3].map { |c| Base64.strict_encode64(c) }.to_json
   end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -45,12 +45,8 @@ describe Encryption::KmsClient do
       kms_regions.each do |r|
         region_hash[r] = c
       end
-      Base64.strict_encode64({ reg: region_hash }.to_json)
+      Base64.strict_encode64({ regions: region_hash }.to_json)
     end.to_json
-  end
-
-  let(:oth_kms_ciphertext) do
-    'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
   end
 
   let(:local_ciphertext) do

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -14,7 +14,9 @@ describe Encryption::MultiRegionKMSClient do
   let(:second_plaintext) { 'b' * 3000 }
   let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
 
-  kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
+  let(:kms_regions) { %w[us-west-2 us-east-1] }
+  let(:current_aws_region) { 'us-east-1' }
+
 
   let(:regionalized_kms_ciphertext) do
     region_hash = {}
@@ -66,7 +68,7 @@ describe Encryption::MultiRegionKMSClient do
       expect(result).to eq(first_plaintext)
     end
 
-    it 'decrypts unsuccessfully if none of the encryption regions are present' do
+    it 'errors if none of the encryption regions are present' do
       bad_region_ciphertext = {
         regions: {
           foo: 'kms1',
@@ -90,8 +92,6 @@ describe Encryption::MultiRegionKMSClient do
     end
 
     it 'decrypts in default region where multiple regions present' do
-      # At the moment, 'us-east-1' is the default AWS region for testing in application.yml.
-      # This test will fail if that changes, make sure to update accordingly
       multi_region_ciphertext = {
         regions: {
           'us-east-1': 'kms1',

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -38,6 +38,25 @@ describe Encryption::MultiRegionKMSClient do
       end
     end
 
+    it 'decrypts successfully if the default region is not present' do
+      ciphertext = {
+        regions: { 'us-east-1' => 'kms1' },
+      }.to_json
+      result = subject.decrypt(ciphertext, encryption_context)
+      expect(result).to eq(plaintext)
+    end
+
+    it 'decrypts unsuccessfully if none of the encryption regions are present' do
+      ciphertext = {
+        regions: {
+          foo: 'kms1',
+          bar: 'kms2',
+        },
+      }.to_json
+      expect {
+        subject.decrypt(ciphertext, encryption_context)
+      }.to raise_error(Encryption::EncryptionError)
+    end
   end
 
   describe '#decrypt' do
@@ -54,6 +73,5 @@ describe Encryption::MultiRegionKMSClient do
         expect(result).to eq(plaintext)
       end
     end
-
   end
 end

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -17,7 +17,6 @@ describe Encryption::MultiRegionKMSClient do
   let(:kms_regions) { %w[us-west-2 us-east-1] }
   let(:current_aws_region) { 'us-east-1' }
 
-
   let(:regionalized_kms_ciphertext) do
     region_hash = {}
     kms_regions.each do |r|
@@ -32,7 +31,7 @@ describe Encryption::MultiRegionKMSClient do
 
   let(:kms_enabled) { true }
 
-  aws_key_id = Figaro.env.aws_kms_key_id
+  let(:aws_key_id) { Figaro.env.aws_kms_key_id }
 
   describe '#encrypt' do
     context 'with multi region enabled' do
@@ -41,8 +40,6 @@ describe Encryption::MultiRegionKMSClient do
         expect(result).to eq(regionalized_kms_ciphertext)
       end
     end
-
-
   end
 
   describe '#decrypt' do

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe Encryption::MultiRegionKMSClient do
+  before do
+    stub_mapped_aws_kms_client(
+      'a' * 3000 => 'kms1',
+    )
+
+    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+  end
+
+  let(:plaintext) { 'a' * 3000 }
+  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
+
+  kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
+
+  let(:regionalized_kms_ciphertext) do
+    region_hash = {}
+    kms_regions.each do |r|
+      region_hash[r] = 'kms1'
+    end
+    { regions: region_hash }.to_json
+  end
+
+  let(:legacy_kms_ciphertext) do
+    'kms1'
+  end
+
+  let(:kms_enabled) { true }
+
+  aws_key_id = Figaro.env.aws_kms_key_id
+
+  describe '#encrypt' do
+    context 'with multi region enabled' do
+      it 'encrypts with KMS' do
+        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
+        expect(result).to eq(regionalized_kms_ciphertext)
+      end
+    end
+
+  end
+
+  describe '#decrypt' do
+    context 'with a multi region ciphertext' do
+      it 'decrypts the ciphertext with KMS' do
+        result = subject.decrypt(regionalized_kms_ciphertext, encryption_context)
+        expect(result).to eq(plaintext)
+      end
+    end
+
+    context 'with a legacy ciphertext' do
+      it 'decrypts the ciphertext with KMS' do
+        result = subject.decrypt(legacy_kms_ciphertext, encryption_context)
+        expect(result).to eq(plaintext)
+      end
+    end
+
+  end
+end

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -4,12 +4,14 @@ describe Encryption::MultiRegionKMSClient do
   before do
     stub_mapped_aws_kms_client(
       'a' * 3000 => 'kms1',
+      'b' * 3000 => 'kms2',
     )
 
     allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
   end
 
-  let(:plaintext) { 'a' * 3000 }
+  let(:first_plaintext) { 'a' * 3000 }
+  let(:second_plaintext) { 'b' * 3000 }
   let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
 
   kms_regions = JSON.parse(Figaro.env.aws_kms_regions)
@@ -33,45 +35,71 @@ describe Encryption::MultiRegionKMSClient do
   describe '#encrypt' do
     context 'with multi region enabled' do
       it 'encrypts with KMS' do
-        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
+        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
         expect(result).to eq(regionalized_kms_ciphertext)
       end
     end
 
-    it 'decrypts successfully if the default region is not present' do
-      ciphertext = {
-        regions: { 'us-east-1' => 'kms1' },
-      }.to_json
-      result = subject.decrypt(ciphertext, encryption_context)
-      expect(result).to eq(plaintext)
-    end
 
-    it 'decrypts unsuccessfully if none of the encryption regions are present' do
-      ciphertext = {
-        regions: {
-          foo: 'kms1',
-          bar: 'kms2',
-        },
-      }.to_json
-      expect {
-        subject.decrypt(ciphertext, encryption_context)
-      }.to raise_error(Encryption::EncryptionError)
-    end
   end
 
   describe '#decrypt' do
     context 'with a multi region ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(regionalized_kms_ciphertext, encryption_context)
-        expect(result).to eq(plaintext)
+        expect(result).to eq(first_plaintext)
       end
     end
 
     context 'with a legacy ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(legacy_kms_ciphertext, encryption_context)
-        expect(result).to eq(plaintext)
+        expect(result).to eq(first_plaintext)
       end
+    end
+
+    it 'decrypts successfully if the default region is not present' do
+      non_default_ciphertext = {
+        regions: { 'us-east-1' => 'kms1' },
+      }.to_json
+      result = subject.decrypt(non_default_ciphertext, encryption_context)
+      expect(result).to eq(first_plaintext)
+    end
+
+    it 'decrypts unsuccessfully if none of the encryption regions are present' do
+      bad_region_ciphertext = {
+        regions: {
+          foo: 'kms1',
+          bar: 'kms2',
+        },
+      }.to_json
+      expect do
+        subject.decrypt(bad_region_ciphertext, encryption_context)
+      end.to raise_error(Encryption::EncryptionError)
+    end
+
+    it 'decrypts successfully if only one of the encryption regions is valid' do
+      partially_valid_ciphertext = {
+        regions: {
+          foo: 'kms1',
+          'us-west-2': 'kms2',
+        },
+      }.to_json
+      result = subject.decrypt(partially_valid_ciphertext, encryption_context)
+      expect(result).to eq(second_plaintext)
+    end
+
+    it 'decrypts in default region where multiple regions present' do
+      # At the moment, 'us-east-1' is the default AWS region for testing in application.yml.
+      # This test will fail if that changes, make sure to update accordingly
+      multi_region_ciphertext = {
+        regions: {
+          'us-east-1': 'kms1',
+          'us-west-2': 'kms2',
+        },
+      }.to_json
+      result = subject.decrypt(multi_region_ciphertext, encryption_context)
+      expect(result).to eq(first_plaintext)
     end
   end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -36,6 +36,6 @@ module AwsKmsClientHelper
   end
 
   def random_str
-    SecureRandom.random_bytes(32)
+    SecureRandom.alphanumeric(32)
   end
 end


### PR DESCRIPTION
Any data encrypted through the KMS module is now encrypted in each region listed in the environment variable `aws_kms_regions`. 

Decryption is done in the first available region a ciphertext was encrypted in. Ciphertexts without regions attached will be decrypted in the region that the application is running in