### PR TITLE
LG-2579 Multi Region KMS fix/reintroduction

### DIFF
--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -50,11 +50,7 @@ module Encryption
 
     def encrypt_raw_kms(plaintext, encryption_context)
       raise ArgumentError, 'kms plaintext exceeds 4096 bytes' if plaintext.bytesize > 4096
-      aws_client.encrypt(
-        key_id: Figaro.env.aws_kms_key_id,
-        plaintext: plaintext,
-        encryption_context: encryption_context,
-      ).ciphertext_blob
+      multi_aws_client.encrypt(Figaro.env.aws_kms_key_id, plaintext, encryption_context)
     end
 
     def decrypt_kms(ciphertext, encryption_context)
@@ -71,10 +67,7 @@ module Encryption
     end
 
     def decrypt_raw_kms(ciphertext, encryption_context)
-      aws_client.decrypt(
-        ciphertext_blob: ciphertext,
-        encryption_context: encryption_context,
-      ).plaintext
+      multi_aws_client.decrypt(ciphertext, encryption_context)
     rescue Aws::KMS::Errors::InvalidCiphertextException
       raise EncryptionError, 'Aws::KMS::Errors::InvalidCiphertextException'
     end
@@ -121,15 +114,12 @@ module Encryption
       plaintext.scan(/.{1,#{chunk_size}}/m)
     end
 
-    def aws_client
-      @aws_client ||= Aws::KMS::Client.new(
-        instance_profile_credentials_timeout: 1, # defaults to 1 second
-        instance_profile_credentials_retries: 5, # defaults to 0 retries
-      )
-    end
-
     def encryptor
       @encryptor ||= Encryptors::AesEncryptor.new
+    end
+
+    def multi_aws_client
+      @multi_aws_client ||= MultiRegionKMSClient.new
     end
   end
 end

--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -1,0 +1,85 @@
+require 'json'
+module Encryption
+  class MultiRegionKMSClient
+    def initialize
+      @aws_clients = {}
+      # Instantiate an array of aws clients based on the provided regions in the environment
+      JSON.parse(Figaro.env.aws_kms_regions).each do |region|
+        @aws_clients[region] = Aws::KMS::Client.new(
+          instance_profile_credentials_timeout: 1, # defaults to 1 second
+          instance_profile_credentials_retries: 5, # defaults to 0 retries
+          region: region, # The region in which the client is being instantiated
+        )
+      end
+    end
+
+    # Use each KMS client to encrypt with params and options
+    # Region format example: '{"regions": {"us-east-1": "cipher", "us-west-2": "othercipher"}}'
+    def encrypt(key_id, plaintext, encryption_context)
+      region_ciphers = {}
+      @aws_clients.each do |region, kms_client|
+        r_cipher = kms_client.encrypt(key_id: key_id,
+                                      plaintext: plaintext,
+                                      encryption_context: encryption_context)
+        region_ciphers[region] = r_cipher.ciphertext_blob
+      end
+      { regions: region_ciphers }.to_json
+    end
+
+    def decrypt(ciphertext, encryption_context)
+      cipher_data = resolve_decryption(ciphertext)
+      cipher_data.region_client.decrypt(
+        ciphertext_blob: cipher_data.resolved_ciphertext,
+        encryption_context: encryption_context,
+      ).plaintext
+    end
+
+    private
+
+    CipherData = Struct.new(:region_client, :resolved_ciphertext)
+
+    def find_available_region(regions)
+      regions.each do |region, cipher|
+        region_client = @aws_clients[region]
+        return CipherData.new(region_client, cipher) if region_client
+      end
+      raise EncryptionError, 'No supported region found in ciphertext'
+    end
+
+    def resolve_region_decryption(regions)
+      # For each region that the ciphertext has a cipher for, check to see if that region is
+      # represented in the clients available. Check default region before checking others
+      curr_region_client = @aws_clients[Figaro.env.aws_region]
+      curr_region_cipher = regions[Figaro.env.aws_region]
+      if curr_region_cipher && curr_region_client
+        CipherData.new(curr_region_client, curr_region_cipher)
+      else
+        find_available_region(regions)
+      end
+    end
+
+    def resolve_legacy_decryption(ciphertext)
+      # Decode the raw ciphertext
+      curr_region = Figaro.env.aws_region
+      region_client = @aws_clients[curr_region]
+      resolved_ciphertext = ciphertext
+      return CipherData.new(region_client, resolved_ciphertext) if region_client
+      raise EncryptionError, "No client found for region #{curr_region}"
+    end
+
+    def resolve_decryption(ciphertext)
+      # The ciphertext should either be a json HASH keyed by "regions", or a plain string. Start by
+      # checking if it looks like the JSON hash we want
+      if ciphertext.start_with?('{"regions"')
+        parsed_payload = JSON.parse(ciphertext)
+        if parsed_payload.is_a?(Hash) # rubocop:disable Style/GuardClause
+          regions = parsed_payload['regions']
+          resolve_region_decryption(regions)
+        else
+          raise EncryptionError, 'Malformed JSON ciphertext, not a hash'
+        end
+      else resolve_legacy_decryption(ciphertext)
+      end
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -145,6 +145,7 @@ development:
   aws_kms_key_id: alias/login-dot-gov-development-keymaker
   aws_logo_bucket:
   aws_region: us-east-1
+  aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user
@@ -254,6 +255,7 @@ production:
   attribute_encryption_key_queue:
   aws_kms_key_id:
   aws_region:
+  aws_kms_regions: '["us-west-2"]'
   aws_logo_bucket:
   backup_codes_as_only_2fa:
   basic_auth_password:
@@ -361,6 +363,7 @@ test:
     }]'
   aws_kms_key_id: alias/login-dot-gov-test-keymaker
   aws_region: us-east-1
+  aws_kms_regions: '["us-west-2", "us-east-1"]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -41,6 +41,7 @@ async_job_refresh_max_wait_seconds: '15'
 available_locales: en es fr
 aws_http_timeout: '5'
 aws_logo_bucket:
+aws_kms_multi_region_enabled: 'false'
 cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 disallow_ial2_recovery:

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -49,6 +49,10 @@ class FeatureManagement
     Figaro.env.use_kms == 'true'
   end
 
+  def self.kms_multi_region_enabled?
+    Figaro.env.aws_kms_multi_region_enabled == 'true'
+  end
+
   def self.use_dashboard_service_providers?
     Figaro.env.use_dashboard_service_providers == 'true'
   end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -22,7 +22,7 @@ describe Encryption::KmsClient do
         and_return(plaintext)
     end
     allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
-
+    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Metrics/LineLength
     allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
   end
 
@@ -38,15 +38,20 @@ describe Encryption::KmsClient do
   end
 
   let(:kms_regions) { %w[us-west-2 us-east-1] }
+  let(:kms_multi_region_enabled) { true }
 
-  let(:kms_ciphertext) do
+  let(:kms_regionalized_ciphertext) do
     'KMSc' + %w[kms1 kms2 kms3].map do |c|
       region_hash = {}
       kms_regions.each do |r|
-        region_hash[r] = c
+        region_hash[r] = Base64.strict_encode64(c)
       end
       Base64.strict_encode64({ regions: region_hash }.to_json)
     end.to_json
+  end
+
+  let(:kms_legacy_ciphertext) do
+    'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
   end
 
   let(:local_ciphertext) do
@@ -57,9 +62,18 @@ describe Encryption::KmsClient do
 
   describe '#encrypt' do
     context 'with KMS enabled' do
-      it 'encrypts with KMS' do
-        result = subject.encrypt(plaintext, encryption_context)
-        expect(result).to eq(kms_ciphertext)
+      context 'with multi region enabled' do
+        it 'encrypts with KMS multi region' do
+          result = subject.encrypt(plaintext, encryption_context)
+          expect(result).to eq(kms_regionalized_ciphertext)
+        end
+      end
+      context 'with multi region disabled' do
+        let(:kms_multi_region_enabled) { false }
+        it 'encrypts with KMS legacy single region' do
+          result = subject.encrypt(plaintext, encryption_context)
+          expect(result).to eq(kms_legacy_ciphertext)
+        end
       end
     end
 
@@ -81,9 +95,10 @@ describe Encryption::KmsClient do
   end
 
   describe '#decrypt' do
-    context 'with a ciphertext encrypted with KMS' do
+    context 'with a ciphertext encrypted with KMS multi region' do
+      let(:kms_multi_region_enabled) { true }
       it 'decrypts the ciphertext with KMS' do
-        result = subject.decrypt(kms_ciphertext, encryption_context)
+        result = subject.decrypt(kms_regionalized_ciphertext, encryption_context)
         expect(result).to eq(plaintext)
       end
     end
@@ -127,7 +142,7 @@ describe Encryption::KmsClient do
 
     it 'logs the context' do
       expect(Encryption::KmsLogger).to receive(:log).with(:decrypt, encryption_context)
-      subject.decrypt(kms_ciphertext, encryption_context)
+      subject.decrypt(kms_regionalized_ciphertext, encryption_context)
     end
   end
 end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -37,9 +37,18 @@ describe Encryption::KmsClient do
     )
   end
 
+  let(:kms_regions) { %w[us-west-2 us-east-1] }
+
   let(:kms_ciphertext) do
-    'KMSc' + %w[kms1 kms2 kms3].map { |c| Base64.strict_encode64(c) }.to_json
+    'KMSc' + %w[kms1 kms2 kms3].map do |c|
+      region_hash = {}
+      kms_regions.each do |r|
+        region_hash[r] = c
+      end
+      Base64.strict_encode64({ regions: region_hash }.to_json)
+    end.to_json
   end
+
   let(:local_ciphertext) do
     'LOCc' + %w[local1 local2 local3].map { |c| Base64.strict_encode64(c) }.to_json
   end
@@ -50,7 +59,6 @@ describe Encryption::KmsClient do
     context 'with KMS enabled' do
       it 'encrypts with KMS' do
         result = subject.encrypt(plaintext, encryption_context)
-
         expect(result).to eq(kms_ciphertext)
       end
     end
@@ -76,7 +84,6 @@ describe Encryption::KmsClient do
     context 'with a ciphertext encrypted with KMS' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(kms_ciphertext, encryption_context)
-
         expect(result).to eq(plaintext)
       end
     end
@@ -120,7 +127,6 @@ describe Encryption::KmsClient do
 
     it 'logs the context' do
       expect(Encryption::KmsLogger).to receive(:log).with(:decrypt, encryption_context)
-
       subject.decrypt(kms_ciphertext, encryption_context)
     end
   end

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe Encryption::MultiRegionKMSClient do
+  before do
+    stub_mapped_aws_kms_client(
+      'a' * 3000 => 'kms1',
+      'b' * 3000 => 'kms2',
+    )
+
+    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+  end
+
+  let(:first_plaintext) { 'a' * 3000 }
+  let(:second_plaintext) { 'b' * 3000 }
+  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
+
+  let(:kms_regions) { %w[us-west-2 us-east-1] }
+  let(:current_aws_region) { 'us-east-1' }
+
+  let(:regionalized_kms_ciphertext) do
+    region_hash = {}
+    kms_regions.each do |r|
+      region_hash[r] = 'kms1'
+    end
+    { regions: region_hash }.to_json
+  end
+
+  let(:legacy_kms_ciphertext) do
+    'kms1'
+  end
+
+  let(:kms_enabled) { true }
+
+  let(:aws_key_id) { Figaro.env.aws_kms_key_id }
+
+  describe '#encrypt' do
+    context 'with multi region enabled' do
+      it 'encrypts with KMS' do
+        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
+        expect(result).to eq(regionalized_kms_ciphertext)
+      end
+    end
+  end
+
+  describe '#decrypt' do
+    context 'with a multi region ciphertext' do
+      it 'decrypts the ciphertext with KMS' do
+        result = subject.decrypt(regionalized_kms_ciphertext, encryption_context)
+        expect(result).to eq(first_plaintext)
+      end
+    end
+
+    context 'with a legacy ciphertext' do
+      it 'decrypts the ciphertext with KMS' do
+        result = subject.decrypt(legacy_kms_ciphertext, encryption_context)
+        expect(result).to eq(first_plaintext)
+      end
+    end
+
+    it 'decrypts successfully if the default region is not present' do
+      non_default_ciphertext = {
+        regions: { 'us-east-1' => 'kms1' },
+      }.to_json
+      result = subject.decrypt(non_default_ciphertext, encryption_context)
+      expect(result).to eq(first_plaintext)
+    end
+
+    it 'errors if none of the encryption regions are present' do
+      bad_region_ciphertext = {
+        regions: {
+          foo: 'kms1',
+          bar: 'kms2',
+        },
+      }.to_json
+      expect do
+        subject.decrypt(bad_region_ciphertext, encryption_context)
+      end.to raise_error(Encryption::EncryptionError)
+    end
+
+    it 'decrypts successfully if only one of the encryption regions is valid' do
+      partially_valid_ciphertext = {
+        regions: {
+          foo: 'kms1',
+          'us-west-2': 'kms2',
+        },
+      }.to_json
+      result = subject.decrypt(partially_valid_ciphertext, encryption_context)
+      expect(result).to eq(second_plaintext)
+    end
+
+    it 'decrypts in default region where multiple regions present' do
+      multi_region_ciphertext = {
+        regions: {
+          'us-east-1': 'kms1',
+          'us-west-2': 'kms2',
+        },
+      }.to_json
+      result = subject.decrypt(multi_region_ciphertext, encryption_context)
+      expect(result).to eq(first_plaintext)
+    end
+  end
+end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -36,6 +36,6 @@ module AwsKmsClientHelper
   end
 
   def random_str
-    SecureRandom.random_bytes(32)
+    SecureRandom.alphanumeric(32)
   end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -36,6 +36,6 @@ module AwsKmsClientHelper
   end
 
   def random_str
-    SecureRandom.alphanumeric(32)
+    SecureRandom.random_bytes(32)
   end
 end


### PR DESCRIPTION
Add a feature flag and a feature management method for KMS multi region so that it can be introduced without breaking existing processes.

Additionally, encode multi region ciphertexts in Base64 so that they don't error when encoding into JSON