### PR TITLE
LG-2299 change copy on the re-enter your password to encrypt screen

### DIFF
--- a/app/views/idv/in_person/encrypt.html.slim
+++ b/app/views/idv/in_person/encrypt.html.slim
@@ -4,6 +4,7 @@ h5.my1.caps.bold.accent-blue = t('in_person_proofing.step', step: 2)
 br
 h1.h3 = 'Re-enter your login.gov password to protect your information'
 
+p = t('in_person_proofing.instructions.encrypt')
 a(target="_blank" href= "https://login.gov/security/") = t('in_person_proofing.instructions.read_more_encrypt')
 
 = simple_form_for(:in_person_proofing, url: url_for, method: 'PUT',

--- a/app/views/idv/in_person/encrypt.html.slim
+++ b/app/views/idv/in_person/encrypt.html.slim
@@ -4,7 +4,7 @@ h5.my1.caps.bold.accent-blue = t('in_person_proofing.step', step: 2)
 br
 h1.h3 = 'Re-enter your login.gov password to protect your information'
 
-p = t('in_person_proofing.instructions.encrypt')
+a(target="_blank" href= "https://login.gov/security/") = t('in_person_proofing.instructions.read_more_encrypt')
 
 = simple_form_for(:in_person_proofing, url: url_for, method: 'PUT',
         html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/app/views/idv/in_person/encrypt.html.slim
+++ b/app/views/idv/in_person/encrypt.html.slim
@@ -5,7 +5,8 @@ br
 h1.h3 = 'Re-enter your login.gov password to protect your information'
 
 p = t('in_person_proofing.instructions.encrypt')
-a(target="_blank" href= "https://login.gov/security/") = t('in_person_proofing.instructions.read_more_encrypt')
+a(target="_blank" href= "https://login.gov/security/")
+  = t('in_person_proofing.instructions.read_more_encrypt')
 
 = simple_form_for(:in_person_proofing, url: url_for, method: 'PUT',
         html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/app/views/idv/review/new.html.slim
+++ b/app/views/idv/review/new.html.slim
@@ -3,6 +3,8 @@
 h1.h3 = t('idv.titles.session.review')
 
 p = t('idv.messages.sessions.review_message')
+a(target="_blank" href= "https://login.gov/security/") = t('idv.messages.sessions.read_more_encrypt')
+
 
 = simple_form_for(current_user, url: idv_review_path,
   html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|

--- a/app/views/idv/review/new.html.slim
+++ b/app/views/idv/review/new.html.slim
@@ -3,7 +3,8 @@
 h1.h3 = t('idv.titles.session.review')
 
 p = t('idv.messages.sessions.review_message')
-a(target="_blank" href= "https://login.gov/security/") = t('idv.messages.sessions.read_more_encrypt')
+a(target="_blank" href= "https://login.gov/security/")
+  = t('idv.messages.sessions.read_more_encrypt')
 
 
 = simple_form_for(current_user, url: idv_review_path,

--- a/app/views/idv/review/new.html.slim
+++ b/app/views/idv/review/new.html.slim
@@ -6,7 +6,6 @@ p = t('idv.messages.sessions.review_message')
 a(target="_blank" href= "https://login.gov/security/")
   = t('idv.messages.sessions.read_more_encrypt')
 
-
 = simple_form_for(current_user, url: idv_review_path,
   html: { autocomplete: 'off', method: :put, role: 'form' }) do |f|
   = f.input :password, label: t('idv.form.password'), required: true

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -167,6 +167,6 @@ en:
       select_verification: Choose how to confirm your address
       session:
         phone: Enter a phone number with your name on the plan
-        review: Re-enter your login.gov password to encrypt your data
+        review: Re-enter your login.gov password to protect your data
       sessions: Information about you
       unsupported_jurisdiction: We're sorry, login.gov doesn't support %{state} yet.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -132,8 +132,8 @@ en:
       sessions:
         no_pii: TEST SITE - Do not use real personal information (demo purposes only)
           - TEST SITE
-        review_message: When you re-enter your password, login.gov will encrypt your
-          data to make sure no one else can access it.
+        review_message: When you re-enter your password, login.gov will protect the information you've given us, so that only you can access it
+        read_more_encrypt: Read more about how login.gov protects your personal information
       usps:
         address_on_file: We will mail a letter with a confirmation code to your verified
           address on file.

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -132,8 +132,9 @@ en:
       sessions:
         no_pii: TEST SITE - Do not use real personal information (demo purposes only)
           - TEST SITE
-        review_message: When you re-enter your password, login.gov will protect the information you've given us, so that only you can access it
         read_more_encrypt: Read more about how login.gov protects your personal information
+        review_message: When you re-enter your password, login.gov will protect the
+          information you've given us, so that only you can access it
       usps:
         address_on_file: We will mail a letter with a confirmation code to your verified
           address on file.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -136,9 +136,9 @@ es:
       sessions:
         no_pii: SITIO DE PRUEBA - No utilice información personal real (sólo para
           propósitos de demostración) - SITIO DE PRUEBA
+        read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
         review_message: Cuando vuelva a ingresar su contraseña, login.gov cifrará
           sus datos para asegurarse de que nadie más pueda acceder a ellos.
-        read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
       usps:
         address_on_file: Le enviaremos una carta con un código de confirmación a su
           dirección verificada en el archivo.

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -138,6 +138,7 @@ es:
           propósitos de demostración) - SITIO DE PRUEBA
         review_message: Cuando vuelva a ingresar su contraseña, login.gov cifrará
           sus datos para asegurarse de que nadie más pueda acceder a ellos.
+        read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
       usps:
         address_on_file: Le enviaremos una carta con un código de confirmación a su
           dirección verificada en el archivo.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -150,6 +150,7 @@ fr:
           s'agit d'une démonstration seulement) - SITE DE TEST
         review_message: Lorsque vous entrez à nouveau votre mot de passe, login.gov
           crypte vos données pour vous assurer que personne ne peut y accéder.
+        read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations personnelles
       usps:
         address_on_file: Nous posterons une lettre à l'adresse vérifiée dans nos dossiers.
           Celle-ci contient un code de confirmation.

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -148,9 +148,10 @@ fr:
       sessions:
         no_pii: SITE DE TEST - N'utilisez pas de véritables données personnelles (il
           s'agit d'une démonstration seulement) - SITE DE TEST
+        read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos
+          informations personnelles
         review_message: Lorsque vous entrez à nouveau votre mot de passe, login.gov
           crypte vos données pour vous assurer que personne ne peut y accéder.
-        read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations personnelles
       usps:
         address_on_file: Nous posterons une lettre à l'adresse vérifiée dans nos dossiers.
           Celle-ci contient un code de confirmation.

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -32,8 +32,8 @@ en:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: When you re-enter your password, login.gov will encrypt your information
-        to make sure no one else can access it.
+      encrypt: When you re-enter your password, login.gov will protect the information you've given us, so that only you can access it
+      read_more_encrypt: Read more about how login.gov protects your personal information
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
       text1: by entering your ZIP code

--- a/config/locales/in_person_proofing/en.yml
+++ b/config/locales/in_person_proofing/en.yml
@@ -32,10 +32,11 @@ en:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: When you re-enter your password, login.gov will protect the information you've given us, so that only you can access it
-      read_more_encrypt: Read more about how login.gov protects your personal information
+      encrypt: When you re-enter your password, login.gov will protect the information
+        you've given us, so that only you can access it
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
+      read_more_encrypt: Read more about how login.gov protects your personal information
       text1: by entering your ZIP code
       text2: name, date of birth, address, and social security number
       text3: a bar code that you need to take to the post office with you

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -32,10 +32,11 @@ es:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: Cuando vuelva a ingresar su contraseña, login.gov protegerá la información que nos ha proporcionado, de modo que solo usted pueda acceder a ella.
-      read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
+      encrypt: Cuando vuelva a ingresar su contraseña, login.gov protegerá la información
+        que nos ha proporcionado, de modo que solo usted pueda acceder a ella.
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
+      read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
       text1: by entering your ZIP code
       text2: name, date of birth, address, and social security number
       text3: a bar code that you need to take to the post office with you

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -34,6 +34,7 @@ es:
       bullet5: Come back to login.gov
       encrypt: When you re-enter your password, login.gov will encrypt your information
         to make sure no one else can access it.
+      read_more_encrypt: Read more about how login.gov protects your personal information
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
       text1: by entering your ZIP code

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -32,9 +32,8 @@ es:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: When you re-enter your password, login.gov will encrypt your information
-        to make sure no one else can access it.
-      read_more_encrypt: Read more about how login.gov protects your personal information
+      encrypt: Cuando vuelva a ingresar su contraseña, login.gov protegerá la información que nos ha proporcionado, de modo que solo usted pueda acceder a ella.
+      read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
       text1: by entering your ZIP code

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -32,10 +32,12 @@ fr:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: Lorsque vous ressaisissez votre mot de passe, login.gov protégera les informations que vous nous avez fournies, afin que vous seul puissiez y accéder.
-      read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations personnelles
+      encrypt: Lorsque vous ressaisissez votre mot de passe, login.gov protégera les
+        informations que vous nous avez fournies, afin que vous seul puissiez y accéder.
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
+      read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations
+        personnelles
       text1: by entering your ZIP code
       text2: name, date of birth, address, and social security number
       text3: a bar code that you need to take to the post office with you

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -32,8 +32,8 @@ fr:
       bullet3: Print or save your enrollment form
       bullet4: Visit the post office to get verified
       bullet5: Come back to login.gov
-      encrypt: When you re-enter your password, login.gov will encrypt your information
-        to make sure no one else can access it.
+      encrypt: Lorsque vous ressaisissez votre mot de passe, login.gov protégera les informations que vous nous avez fournies, afin que vous seul puissiez y accéder.
+      read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations personnelles
       enrollment_form: 'Bring this code to the following post office along with a
         government-issued ID:'
       text1: by entering your ZIP code


### PR DESCRIPTION
The current message on the screens that ask you to re-enter your password to encrypt has the potential to confuse users who don't know what encryption is.

 This change makes the brief description easier to understand for these users, as well as linking (in a new tab), to login.gov/security in case users want to read more about the process 

 