### PR TITLE
Deploy RC 111.1 to staging

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -6,13 +6,13 @@ module Users
     before_action :retain_confirmed_emails, only: %i[delete]
 
     def show
-      @register_user_email_form = AddUserEmailForm.new
+      @add_user_email_form = AddUserEmailForm.new
     end
 
     def add
-      @register_user_email_form = AddUserEmailForm.new
+      @add_user_email_form = AddUserEmailForm.new
 
-      result = @register_user_email_form.submit(current_user, permitted_params)
+      result = @add_user_email_form.submit(current_user, permitted_params)
 
       if result.success?
         process_successful_creation
@@ -75,7 +75,7 @@ module Users
 
     def process_successful_creation
       resend_confirmation = params[:user][:resend]
-      session[:email] = @register_user_email_form.email
+      session[:email] = @add_user_email_form.email
 
       redirect_to add_email_verify_email_url(resend: resend_confirmation,
                                              request_id: permitted_params[:request_id])

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -18,8 +18,8 @@ class AddUserEmailForm
 
   def submit(user, params)
     @user = user
-    @email_address = new_email_address(params)
     @email = params[:email]
+    @email_address = email_address_record(@email)
 
     if valid_form?
       process_successful_submission
@@ -30,11 +30,14 @@ class AddUserEmailForm
     FormResponse.new(success: success, errors: errors.messages, extra: extra_analytics_attributes)
   end
 
-  def new_email_address(params)
-    EmailAddress.new(user_id: user.id,
-                     email: params[:email],
-                     confirmation_token: SecureRandom.uuid,
-                     confirmation_sent_at: Time.zone.now)
+  def email_address_record(email)
+    record = EmailAddress.where(user_id: user.id).find_with_email(email) ||
+             EmailAddress.new(user_id: user.id, email: email)
+
+    record.confirmation_token = SecureRandom.uuid
+    record.confirmation_sent_at = Time.zone.now
+
+    record
   end
 
   private

--- a/app/validators/form_add_email_validator.rb
+++ b/app/validators/form_add_email_validator.rb
@@ -22,7 +22,7 @@ module FormAddEmailValidator
   end
 
   def email_is_available_to_user
-    email_address = EmailAddress.find_with_email(email)
+    email_address = EmailAddress.confirmed.find_with_email(email)
     return unless email_address&.user_id == @user.id
     errors.add(:email, I18n.t('email_addresses.add.duplicate'))
   end

--- a/app/views/users/emails/show.html.slim
+++ b/app/views/users/emails/show.html.slim
@@ -5,7 +5,7 @@
 h1.h3.my0 = t('headings.add_email')
 
 .mb4
-  = simple_form_for(@register_user_email_form,
+  = simple_form_for(@add_user_email_form,
           html: { autocomplete: 'off', role: 'form' },
           url: add_email_path) do |f|
     = f.input :email, label: t('forms.registration.labels.email'), required: true

--- a/spec/features/multiple_emails/add_email_spec.rb
+++ b/spec/features/multiple_emails/add_email_spec.rb
@@ -192,6 +192,8 @@ feature 'adding email address' do
 
     fake_email = instance_double(EmailAddress)
     expect(fake_email).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique)
+    expect(fake_email).to receive(:confirmation_token=)
+    expect(fake_email).to receive(:confirmation_sent_at=)
     expect(EmailAddress).to receive(:new).and_return(fake_email)
 
     fill_in 'Email', with: email

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe AddUserEmailForm do
+  subject(:form) { AddUserEmailForm.new }
+
+  let(:original_email) { 'original@example.com' }
+  let(:user) { User.create(email: original_email) }
+
+  describe '#submit' do
+    let(:new_email) { 'new@example.com' }
+
+    subject(:submit) { form.submit(user, email: new_email) }
+
+    it 'creates a new EmailAddress record for a new email address' do
+      expect(EmailAddress.find_with_email(new_email)).to be_nil
+
+      response = submit
+      expect(response.success?).to eq(true)
+
+      email_address_record = EmailAddress.find_with_email(new_email)
+      expect(email_address_record).to be_present
+      expect(email_address_record.confirmed_at).to be_nil
+    end
+
+    context 'when the new email address has an expired previous attempt for the same account' do
+      before do
+        create(:email_address,
+               email: new_email,
+               user: user,
+               confirmed_at: nil,
+               confirmation_sent_at: 1.month.ago)
+      end
+
+      it 'sends a confirmation email, as if it was not previously linked' do
+        expect(SendAddEmailConfirmation).to receive(:new).and_call_original
+
+        response = submit
+        expect(response.success?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Patch release of #3821

**Why**: If a user has attempted to add an email address and
the link expires, we previously would not let them resend the confirmation
link and we'd show an error that "you have already added this email"

(cherry picked from commit 9ab99fb476b3bef93d7413707b17e71f07329974)