### PR TITLE
Add a mobile headless chrome driver

### DIFF
--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -4,6 +4,8 @@ feature 'View personal key' do
   include XPathHelper
   include PersonalKeyHelper
   include SamlAuthHelper
+  include JavascriptDriverHelper
+
   let(:user) { create(:user, :signed_up, :with_personal_key) }
 
   context 'after sign up' do
@@ -71,7 +73,6 @@ feature 'View personal key' do
     let(:invisible_selector) { generate_class_selector('invisible') }
 
     it 'prompts the user to enter their personal key to confirm they have it' do
-      Capybara.current_session.current_window.resize_to(2560, 1600)
       sign_in_and_2fa_user(user)
       click_button t('account.links.regenerate_personal_key')
 
@@ -97,8 +98,7 @@ feature 'View personal key' do
       expect(current_path).to eq account_path
     end
 
-    it 'confirms personal key on mobile' do
-      Capybara.current_session.current_window.resize_to(414, 736)
+    it 'confirms personal key on mobile', driver: :headless_chrome_mobile do
       sign_in_and_2fa_user(user)
       click_button t('account.links.regenerate_personal_key')
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -4,7 +4,6 @@ feature 'View personal key' do
   include XPathHelper
   include PersonalKeyHelper
   include SamlAuthHelper
-  include JavascriptDriverHelper
 
   let(:user) { create(:user, :signed_up, :with_personal_key) }
 

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -51,7 +51,6 @@ feature 'Internationalization' do
     end
 
     it 'allows user to manually toggle language from dropdown menu', js: true do
-      Capybara.current_session.current_window.resize_to(2560, 1600)
       visit root_path
       using_wait_time(5) do
         within(:css, '.i18n-desktop-toggle') do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -18,6 +18,19 @@ end
 Capybara.javascript_driver = :headless_chrome
 Webdrivers.cache_time = 86_400
 
+Capybara.register_driver(:headless_chrome_mobile) do |app|
+  browser_options = Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--disable-dev-shm-usage'
+  browser_options.args << '--window-size=414,736'
+
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 options: browser_options
+end
+
 Capybara.server = :puma, { Silent: true }
 
 Capybara.default_max_wait_time = 0.5


### PR DESCRIPTION
**Why**: Prior to this commit some of the tests would resize the browser. Specifically the regenerate personal key spec would shrink the window to the mobile breakpoint. This breaks later tests which expect to interact with pages that are not shrunk past the mobile breakpoint.