### PR TITLE
OIDC: return the most recent nonce given (LG-3059)

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -20,7 +20,7 @@ module OpenidConnect
       return redirect_to_account_or_verify_profile_url if profile_or_identity_needs_verification?
       return redirect_to(sign_up_completed_url) if needs_sp_attribute_verification?
       link_identity_to_service_provider
-      return redirect_to(user_authorization_confirmation_url) if auth_count > 1
+      return redirect_to(user_authorization_confirmation_url) if auth_count == 1
       handle_successful_handoff
     end
 

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,8 +7,6 @@ class ServiceProviderRequestHandler
   end
 
   def call
-    return if current_sp == sp_stored_in_session
-
     delete_sp_request_if_session_has_matching_request_id
     ServiceProviderRequestProxy.create!(attributes)
 
@@ -23,10 +21,6 @@ class ServiceProviderRequestHandler
 
   def ial
     Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include?(protocol.ial) ? 2 : 1
-  end
-
-  def current_sp
-    protocol.issuer
   end
 
   def sp_stored_in_session

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,7 +7,7 @@ class ServiceProviderRequestHandler
   end
 
   def call
-    pull_request_id_from_session_if
+    pull_request_id_from_current_sp_session_id
 
     delete_sp_request_if_session_has_matching_request_id
     ServiceProviderRequestProxy.create!(attributes)
@@ -34,7 +34,7 @@ class ServiceProviderRequestHandler
     ServiceProviderRequestProxy.from_uuid(sp_session[:request_id]).issuer
   end
 
-  def pull_request_id_from_session_if
+  def pull_request_id_from_current_sp_session_id
     @request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
   end
 

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,7 +7,7 @@ class ServiceProviderRequestHandler
   end
 
   def call
-    request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
+    self.request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
 
     delete_sp_request_if_session_has_matching_request_id
     ServiceProviderRequestProxy.create!(attributes)
@@ -48,6 +48,10 @@ class ServiceProviderRequestHandler
       uuid: request_id,
       url: url,
     }
+  end
+
+  def request_id=(request_id)
+    @request_id = request_id
   end
 
   def request_id

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,6 +7,8 @@ class ServiceProviderRequestHandler
   end
 
   def call
+    request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
+
     delete_sp_request_if_session_has_matching_request_id
     ServiceProviderRequestProxy.create!(attributes)
 
@@ -21,6 +23,10 @@ class ServiceProviderRequestHandler
 
   def ial
     Saml::Idp::Constants::IAL2_AUTHN_CONTEXTS.include?(protocol.ial) ? 2 : 1
+  end
+
+  def current_sp
+    protocol.issuer
   end
 
   def sp_stored_in_session

--- a/app/services/service_provider_request_handler.rb
+++ b/app/services/service_provider_request_handler.rb
@@ -7,7 +7,7 @@ class ServiceProviderRequestHandler
   end
 
   def call
-    self.request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
+    pull_request_id_from_session_if
 
     delete_sp_request_if_session_has_matching_request_id
     ServiceProviderRequestProxy.create!(attributes)
@@ -34,6 +34,10 @@ class ServiceProviderRequestHandler
     ServiceProviderRequestProxy.from_uuid(sp_session[:request_id]).issuer
   end
 
+  def pull_request_id_from_session_if
+    @request_id = sp_session[:request_id] if current_sp == sp_stored_in_session
+  end
+
   def delete_sp_request_if_session_has_matching_request_id
     return if sp_request_id.blank?
     ServiceProviderRequestProxy.delete(sp_session[:request_id])
@@ -48,10 +52,6 @@ class ServiceProviderRequestHandler
       uuid: request_id,
       url: url,
     }
-  end
-
-  def request_id=(request_id)
-    @request_id = request_id
   end
 
   def request_id

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -362,14 +362,14 @@ describe 'OpenID Connect' do
 
     it 'returns the most recent nonce when there are multiple authorize calls' do
       client_id = 'urn:gov:gsa:openidconnect:test'
+      user = user_with_2fa
+      link_identity(user, client_id)
+      user.identities.last.update!(verified_attributes: ['email'])
+
       state1 = SecureRandom.hex
       nonce1 = SecureRandom.hex
       code_verifier1 = SecureRandom.hex
       code_challenge1 = Digest::SHA256.base64digest(code_verifier1)
-      user = user_with_2fa
-
-      link_identity(user, client_id)
-      user.identities.last.update!(verified_attributes: ['email'])
 
       visit openid_connect_authorize_path(
         client_id: client_id,
@@ -383,34 +383,6 @@ describe 'OpenID Connect' do
         code_challenge: code_challenge1,
         code_challenge_method: 'S256',
       )
-
-      sign_in_live_with_2fa(user)
-
-      redirect_uri1 = URI(current_url)
-      redirect_params1 = Rack::Utils.parse_query(redirect_uri1.query).with_indifferent_access
-
-      expect(redirect_uri1.to_s).to start_with('gov.gsa.openidconnect.test://result')
-      expect(redirect_params1[:state]).to eq(state1)
-
-      code1 = redirect_params1[:code]
-      expect(code1).to be_present
-
-      page.driver.post api_openid_connect_token_path,
-                       grant_type: 'authorization_code',
-                       code: code1,
-                       code_verifier: code_verifier1
-
-
-      expect(page.status_code).to eq(200)
-      token_response1 = JSON.parse(page.body).with_indifferent_access
-
-      id_token1 = token_response1[:id_token]
-      expect(id_token1).to be_present
-      decoded_id_token1, _headers = JWT.decode(
-        id_token1, sp_public_key, true, algorithm: 'RS256'
-      ).map(&:with_indifferent_access)
-
-      expect(decoded_id_token1['nonce']).to eq(nonce1)
 
       state2 = SecureRandom.hex
       nonce2 = SecureRandom.hex
@@ -430,13 +402,17 @@ describe 'OpenID Connect' do
         code_challenge_method: 'S256',
       )
 
+      sign_in_live_with_2fa(user)
       continue_as(user.email)
 
       redirect_uri2 = URI(current_url)
-      redirect_params2 = Rack::Utils.parse_query(redirect_uri2.query).with_indifferent_access
-
       expect(redirect_uri2.to_s).to start_with('gov.gsa.openidconnect.test://result')
-      expect(redirect_params2[:state]).to eq(state2)
+
+      redirect_params2 = Rack::Utils.parse_query(redirect_uri2.query).with_indifferent_access
+      aggregate_failures do
+        expect(redirect_params2[:state]).to eq(state2)
+        expect(redirect_params2[:state]).to_not eq(state1)
+      end
 
       code2 = redirect_params2[:code]
       expect(code2).to be_present
@@ -455,7 +431,10 @@ describe 'OpenID Connect' do
         id_token2, sp_public_key, true, algorithm: 'RS256'
       ).map(&:with_indifferent_access)
 
-      expect(decoded_id_token2['nonce']).to eq(nonce2)
+      aggregate_failures do
+        expect(decoded_id_token2['nonce']).to eq(nonce2)
+        expect(decoded_id_token2['nonce']).to_not eq(nonce1)
+      end
     end
 
     it 'continues to the branded authorization page on first-time signup', email: true do

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -109,7 +109,7 @@ module Features
     end
 
     def continue_as(email = nil, password = VALID_PASSWORD)
-      return unless %r{#{user_authorization_confirmation_path}}.match?(current_url)
+      return unless current_url.include?(user_authorization_confirmation_path)
 
       if email.nil? || page.has_content?(email)
         click_button t('user_authorization_confirmation.continue')


### PR DESCRIPTION
~I figured this would fail if we were mixing up nonces across requests....but it passes....~

~I also tried it without requesting the first `id_token` and it still passes~

This PR reproduces and fixes an issue clients were seeing where they'd get back an older nonce value instead of the most recent one.