### PR TITLE
LG-3075: store the aal level requested, if any, in the session

### DIFF
--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -34,7 +34,7 @@ class StoreSpMetadataInSession
       ial2: ial2_requested?,
       ial2_strict: ial2_strict_requested?,
       ialmax: ialmax_requested?,
-      aal3: aal3_requested?,
+      aal_level_requested: aal_requested,
       request_url: sp_request.url,
       request_id: sp_request.uuid,
       requested_attributes: sp_request.requested_attributes,
@@ -54,8 +54,8 @@ class StoreSpMetadataInSession
       !!(ial2_requested? && service_provider&.liveness_checking_required)
   end
 
-  def aal3_requested?
-    Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF == sp_request.aal
+  def aal_requested
+    Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[sp_request.aal]
   end
 
   def service_provider

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -27,10 +27,10 @@ module Saml
         IALMAX_AUTHN_CONTEXT_CLASSREF => Identity::IAL_MAX,
       }.freeze
 
-      AUTHN_CONTEXT_CLASSREF_TO_AAL = Hash.new(Authorization::AAL2).merge(
+      AUTHN_CONTEXT_CLASSREF_TO_AAL = {
         AAL2_AUTHN_CONTEXT_CLASSREF => Authorization::AAL2,
         AAL3_AUTHN_CONTEXT_CLASSREF => Authorization::AAL3,
-      ).freeze
+      }.freeze
     end
   end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         sp_request_id = ServiceProviderRequestProxy.last.uuid
 
         expect(session[:sp]).to eq(
-          aal3: false,
+          aal_level_requested: nil,
           ial2: false,
           ial2_strict: false,
           ialmax: false,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -305,7 +305,7 @@ describe SamlIdpController do
         sp_request_id = ServiceProviderRequestProxy.last.uuid
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
-          aal3: false,
+          aal_level_requested: nil,
           ial2: false,
           ial2_strict: false,
           ialmax: false,
@@ -327,7 +327,7 @@ describe SamlIdpController do
 
         expect(session[:sp]).to eq(
           issuer: saml_settings.issuer,
-          aal3: false,
+          aal_level_requested: nil,
           ial2: false,
           ial2_strict: false,
           ialmax: false,

--- a/spec/services/store_sp_metadata_in_session_spec.rb
+++ b/spec/services/store_sp_metadata_in_session_spec.rb
@@ -40,7 +40,7 @@ describe StoreSpMetadataInSession do
 
         app_session_hash = {
           issuer: 'issuer',
-          aal3: false,
+          aal_level_requested: nil,
           ial2: false,
           ial2_strict: false,
           ialmax: false,
@@ -78,7 +78,7 @@ describe StoreSpMetadataInSession do
 
         app_session_hash = {
           issuer: 'issuer',
-          aal3: true,
+          aal_level_requested: 3,
           ial2: true,
           ial2_strict: false,
           ialmax: false,


### PR DESCRIPTION
Stores the requested AAL level in the session, not just whether AAL3 was requested.