### PR TITLE
Store last service provider request uuid in runtime

### DIFF
--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -6,6 +6,8 @@ class ServiceProviderRequestProxy
   REDIS_KEY_PREFIX = 'spr:'.freeze
   DEFAULT_TTL_HOURS = 24
 
+  # This is used to support the .last method. That method is only used in the
+  # test environment
   cattr_accessor :redis_last_uuid
 
   def self.from_uuid(uuid)


### PR DESCRIPTION
**Why**: Storing the value in redis leads to a race condition when running in parallel since all of the processes share the same redis instance.