### PR TITLE
Remove accordion for QR code to fix TOTP page accessibility (LG-3116)

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -103,7 +103,7 @@ class UserDecorator # rubocop:disable Metrics/ClassLength
     }
     url = user.provisioning_uri(nil, options)
     qrcode = RQRCode::QRCode.new(url)
-    qrcode.as_png(size: 280).to_data_url
+    qrcode.as_png(size: 240).to_data_url
   end
 
   def locked_out?

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -28,20 +28,19 @@
         <div class="inline-block bold"><%= t('forms.totp_setup.totp_step_3') %></div>
       </div>
       <div class="sm-col-9 sm-ml-28p">
-        <div class="px2 py1 border border-dashed border-navy">
+        <div class="center">
+          <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
+        </div>
+        <div class="center">
+          <%= t('instructions.mfa.authenticator.manual_entry') %>
+        </div>
+        <div class="px2 py1 mt1 border border-dashed border-navy">
           <div class="inline fs-20p caps monospace" id="qr-code"><%= @code %></div>
           <button class="clipboard ml2 right mt-tiny btn btn-primary p0 w-60p bg-light-blue blue h6 regular border-box center"
                   data-clipboard-text="<%= @code.upcase %>">
             <%= t('links.copy') %>
           </button>
         </div>
-        <div class="py2 center bold"><%= t('instructions.mfa.authenticator.or') %></div>
-        <%= accordion('totp-info', t('instructions.mfa.authenticator.accordion_header'),
-                      wrapper_css: 'mb2 col-12 fs-16p') do %>
-          <div class="center">
-            <%= image_tag @qrcode, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
-          </div>
-        <% end %>
       </div>
     </li>
     <li class="py2 border-top">

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -126,7 +126,7 @@ en:
       totp_step_1: Give it a nickname
       totp_step_1a: If you add more than one app, you'll know which ones which.
       totp_step_2: Open your authentication app
-      totp_step_3: With your app, enter this key manually or scan the barcode
+      totp_step_3: Scan this QR barcode with your app
       totp_step_4: Enter the temporary code from your app
     two_factor:
       backup_code: Security code

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -134,8 +134,7 @@ es:
       totp_step_1: Darle un apodo
       totp_step_1a: Si agrega más de una aplicación, sabrá cuáles.
       totp_step_2: Abra su app de autenticación.
-      totp_step_3: Con su aplicación, ingrese esta clave manualmente o escanee el
-        código de barras
+      totp_step_3: Escanee este código de barras QR con su aplicación
       totp_step_4: Ingrese el código temporal de su aplicación
     two_factor:
       backup_code: Código de seguridad

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -139,8 +139,7 @@ fr:
       totp_step_1: Donnez-lui un surnom
       totp_step_1a: Si vous ajoutez plusieurs applications, vous saurez lesquelles.
       totp_step_2: Démarrez votre application d'authentification
-      totp_step_3: Avec votre application, entrez cette clé manuellement ou scannez
-        le code-barres
+      totp_step_3: Scannez ce code-barres QR avec votre application
       totp_step_4: Entrez le code temporaire de votre application
     two_factor:
       backup_code: Code de sécurité

--- a/config/locales/image_description/en.yml
+++ b/config/locales/image_description/en.yml
@@ -5,5 +5,5 @@ en:
     accordian_plus_buttom: Plus button
     camera_mobile_phone: Camera flashing on a mobile phone
     spinner: Loading spinner
-    totp_qrcode: QR Code for authenticator app
+    totp_qrcode: QR code for authenticator app
     us_flag: US flag

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -19,11 +19,10 @@ en:
       and sign in.
     mfa:
       authenticator:
-        accordion_header: Scan code with your mobile device
         confirm_code_html: Enter the code from your authenticator app. If you have
           several accounts set up in your app, enter the code corresponding to %{email}
           at %{app}.%{tooltip}
-        or: or
+        manual_entry: Or enter this code manually into your authentication app
       piv_cac:
         account_not_found:
           paragraph_1_html: "<strong>%{sign_in}</strong> with your email address and

--- a/config/locales/instructions/es.yml
+++ b/config/locales/instructions/es.yml
@@ -20,11 +20,10 @@ es:
       app e inicie una sesión.
     mfa:
       authenticator:
-        accordion_header: Escanear código con su dispositivo móvil
         confirm_code_html: Ingrese el código de su app de autenticación. Si tiene
           varias cuentas configuradas en su app, ingrese el código correspondiente
           a %{email} en %{app}.%{tooltip}
-        or: o
+        manual_entry: O ingrese este código manualmente en su aplicación de autenticación
       piv_cac:
         account_not_found:
           paragraph_1_html: "<strong>%{sign_in}</strong> con su dirección de correo

--- a/config/locales/instructions/fr.yml
+++ b/config/locales/instructions/fr.yml
@@ -22,11 +22,10 @@ fr:
       et vous connecter.
     mfa:
       authenticator:
-        accordion_header: Balayez le code avec votre appareil mobile
         confirm_code_html: Entrez le code à partir de votre application d'authentification.
           Si vous avez plusieurs comptes configurés dans votre application, entrez
           le code correspondant à %{email} à %{app}.%{tooltip}
-        or: or
+        manual_entry: Ou entrez ce code manuellement dans votre application d'authentification
       piv_cac:
         account_not_found:
           paragraph_1_html: "<strong>%{sign_in}</strong> votre adresse email et votre


### PR DESCRIPTION
Reorders the QR code screen and always shows the code to improve accessibiltiy

### Before

<img width="684" alt="Screen Shot 2020-06-16 at 11 47 16 AM" src="https://user-images.githubusercontent.com/458784/84815119-6a00a000-afc7-11ea-95ed-cccbc524bf4c.png">

### After

<img width="670" alt="Screen Shot 2020-06-16 at 11 46 58 AM" src="https://user-images.githubusercontent.com/458784/84815133-7127ae00-afc7-11ea-9bd3-ff94400db4d7.png">
