### PR TITLE
Update redis, silence deprecation warning with note

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ GEM
       redis (>= 3.0, < 5.0)
     recaptcha (5.2.1)
       json
-    redis (4.1.4)
+    redis (4.2.1)
     redis-session-store (0.11.1)
       actionpack (>= 3)
       redis (>= 3, < 5)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,10 @@
+# redis-session-store uses #exists which is changing behavior in redis,
+# this silences the corresponding deprecation warning.
+# If this PR is merged and accepted, we can remove this option when we upgrade
+# the redis-sessions-store gem:
+# https://github.com/roidrage/redis-session-store/pull/119
+Redis.exists_returns_integer = true
+
 require 'session_encryptor'
 
 options = {


### PR DESCRIPTION
Updating this will let some of the security patches apply more cleanly