### PR TITLE
Enable voice calls for Jordan

### DIFF
--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -433,7 +433,7 @@ JE:
 JO:
   name: Jordan
   country_code: '962'
-  sms_only: true
+  sms_only: false
 KZ:
   name: Kazakhstan
   country_code: '7'


### PR DESCRIPTION
**Why**: So that users with Jordan phone numbers can use voice to receive OTPs while we work on getting a Jordan sender ID.