### PR TITLE
Update email confirmation template selection

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -13,7 +13,7 @@ module SignUp
     end
 
     def create
-      @register_user_email_form = RegisterUserEmailForm.new(validate_recaptcha)
+      @register_user_email_form = RegisterUserEmailForm.new(recaptcha_results: validate_recaptcha)
 
       result = @register_user_email_form.submit(permitted_params)
 

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -7,16 +7,16 @@ class RegisterUserEmailForm
   validate :service_provider_request_exists
 
   attr_reader :email_address
-  attr_accessor :for_password_reset
+  attr_accessor :password_reset_requested
 
   def self.model_name
     ActiveModel::Name.new(self, nil, 'User')
   end
 
-  def initialize(recaptcha_results = [true, {}])
+  def initialize(recaptcha_results: [true, {}], password_reset_requested: false)
     @allow, @recaptcha_h = recaptcha_results
     @throttled = false
-    @for_password_reset = false
+    @password_reset_requested = password_reset_requested
   end
 
   def user
@@ -48,8 +48,8 @@ class RegisterUserEmailForm
     @email_taken = lookup_email_taken
   end
 
-  def for_password_reset?
-    @for_password_reset
+  def password_reset_requested?
+    @password_reset_requested
   end
 
   private
@@ -89,7 +89,7 @@ class RegisterUserEmailForm
     Funnel::Registration::Create.call(user.id)
     SendSignUpEmailConfirmation.new(user).call(request_id: request_id,
                                                instructions: instructions,
-                                               for_password_reset: for_password_reset?)
+                                               password_reset_requested: password_reset_requested?)
   end
 
   def extra_analytics_attributes

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,7 +23,7 @@ class UserMailer < ActionMailer::Base
     @request_id = request_id
     @locale = locale_url_param
     @token = token
-    mail(to: email, subject: t('user_mailer.email_confirmation_instructions.subject'))
+    mail(to: email, subject: t('user_mailer.email_confirmation_instructions.email_not_found'))
   end
 
   def signup_with_your_email(email)

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -2,6 +2,7 @@ RequestPasswordReset = Struct.new(:email, :request_id) do
   def perform
     if user_should_receive_registration_email?
       form = RegisterUserEmailForm.new
+      form.for_password_reset = true
       result = form.submit({ email: email }, instructions)
       [form.user, result]
     else

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -1,8 +1,7 @@
 RequestPasswordReset = Struct.new(:email, :request_id) do
   def perform
     if user_should_receive_registration_email?
-      form = RegisterUserEmailForm.new
-      form.for_password_reset = true
+      form = RegisterUserEmailForm.new(password_reset_requested: true)
       result = form.submit({ email: email }, instructions)
       [form.user, result]
     else

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -5,12 +5,12 @@ class SendSignUpEmailConfirmation
     @user = user
   end
 
-  def call(request_id: nil, instructions: nil, for_password_reset: false)
+  def call(request_id: nil, instructions: nil, password_reset_requested: false)
     remove_legacy_confirmation_info_on_user
     update_email_address_record
 
-    if !user.confirmed? && for_password_reset
-      send_unconfirmed_email(request_id, instructions)
+    if password_reset_requested && !user.confirmed?
+      send_pw_reset_request_unconfirmed_user_email(request_id, instructions)
     else
       send_confirmation_email(request_id, instructions)
     end
@@ -67,7 +67,7 @@ class SendSignUpEmailConfirmation
     ).deliver_later
   end
 
-  def send_unconfirmed_email(request_id, instructions)
+  def send_pw_reset_request_unconfirmed_user_email(request_id, instructions)
     UserMailer.unconfirmed_email_instructions(
       user,
       email_address.email,

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -5,14 +5,14 @@ class SendSignUpEmailConfirmation
     @user = user
   end
 
-  def call(request_id: nil, instructions: nil)
+  def call(request_id: nil, instructions: nil, for_password_reset: false)
     remove_legacy_confirmation_info_on_user
     update_email_address_record
 
-    if user.confirmed?
-      send_confirmation_email(request_id, instructions)
-    else
+    if !user.confirmed? && for_password_reset
       send_unconfirmed_email(request_id, instructions)
+    else
+      send_confirmation_email(request_id, instructions)
     end
   end
 

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -63,6 +63,7 @@ en:
         email addresses. We recommend that you also change your password.
       subject: New email address added
     email_confirmation_instructions:
+      email_not_found: Email not found
       first_sentence:
         confirmed: Trying to change your email address?
         forgot_password: You tried to reset your login.gov password but we don't have
@@ -74,7 +75,7 @@ en:
       link_text: create a new account.
       request_with_diff_email: You can request your password using a different email
         address that is connected to your %{app_name} account.
-      subject: Email not found
+      subject: Confirm your email
       try_diff_email: Try a different email address
       use_this_email: Or use this email address and
     email_deleted:

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -65,6 +65,7 @@ es:
         direcciones de correo electrónico. Le recomendamos que también cambie su contraseña.
       subject: Nueva dirección de correo electrónico añadida
     email_confirmation_instructions:
+      email_not_found: El correo electrónico no encontrado
       first_sentence:
         confirmed: "¿Desea cambiar su email?"
         forgot_password: Intentó restablecer su contraseña de login.gov pero no tenemos
@@ -76,7 +77,7 @@ es:
       link_text: crea una cuenta nueva.
       request_with_diff_email: Puedes solicitar tu contraseña usando una dirección
         de correo electrónico diferente que está conectada a su cuenta %{app_name}.
-      subject: El correo electrónico no encontrado
+      subject: Confirme su email
       try_diff_email: Pruebe con una dirección de correo electrónico diferente
       use_this_email: O use este correo electrónico y
     email_deleted:

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -67,6 +67,7 @@ fr:
         votre mot de passe.
       subject: Nouvelle adresse email ajoutée
     email_confirmation_instructions:
+      email_not_found: Email non trouvé
       first_sentence:
         confirmed: Vous tentez de changer votre adresse courriel?
         forgot_password: Vous avez essayé de réinitialiser le mot de passe de votre
@@ -79,7 +80,7 @@ fr:
       link_text: créer un nouveau compte.
       request_with_diff_email: Vous pouvez demander votre mot de passe en utilisant
         une adresse e-mail différente qui est connectée à votre compte %{app_name}.
-      subject: Email non trouvé
+      subject: Confirmez votre adresse courriel
       try_diff_email: Essayez une autre adresse e-mail
       use_this_email: Ou utilisez cet e-mail et
     email_deleted:

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -99,7 +99,7 @@ describe RegisterUserEmailForm do
         result = instance_double(FormResponse)
         allow(FormResponse).to receive(:new).and_return(result)
         captcha_results = mock_captcha(enabled: true, present: true, valid: true)
-        form = RegisterUserEmailForm.new(captcha_results)
+        form = RegisterUserEmailForm.new(recaptcha_results: captcha_results)
         submit_form = form.submit(email: 'not_taken@gmail.com')
         extra = {
           email_already_exists: false,
@@ -120,7 +120,7 @@ describe RegisterUserEmailForm do
         result = instance_double(FormResponse)
         allow(FormResponse).to receive(:new).and_return(result)
         captcha_results = mock_captcha(enabled: true, present: true, valid: false)
-        form = RegisterUserEmailForm.new(captcha_results)
+        form = RegisterUserEmailForm.new(recaptcha_results: captcha_results)
         submit_form = form.submit(email: 'not_taken@gmail.com')
         extra = {
           email_already_exists: false,

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -35,18 +35,20 @@ describe SendSignUpEmailConfirmation do
       subject.call(request_id: request_id, instructions: instructions)
     end
 
-    it 'sends an email with a link to try another email if the current email is unconfirmed' do
-      mail = double
-      expect(mail).to receive(:deliver_later)
-      expect(UserMailer). to receive(:unconfirmed_email_instructions).with(
-        user,
-        email_address.email,
-        confirmation_token,
-        request_id: request_id,
-        instructions: instructions,
-      ).and_return(mail)
+    context 'when resetting a password' do
+      it 'sends an email with a link to try another email if the current email is unconfirmed' do
+        mail = double
+        expect(mail).to receive(:deliver_later)
+        expect(UserMailer). to receive(:unconfirmed_email_instructions).with(
+          user,
+          email_address.email,
+          confirmation_token,
+          request_id: request_id,
+          instructions: instructions,
+        ).and_return(mail)
 
-      subject.call(request_id: request_id, instructions: instructions)
+        subject.call(request_id: request_id, instructions: instructions, for_password_reset: true)
+      end
     end
 
     it 'updates the confirmation values on the email address for the user' do

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -47,7 +47,11 @@ describe SendSignUpEmailConfirmation do
           instructions: instructions,
         ).and_return(mail)
 
-        subject.call(request_id: request_id, instructions: instructions, password_reset_requested: true)
+        subject.call(
+          request_id: request_id,
+          instructions: instructions,
+          password_reset_requested: true,
+        )
       end
     end
 

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -47,7 +47,7 @@ describe SendSignUpEmailConfirmation do
           instructions: instructions,
         ).and_return(mail)
 
-        subject.call(request_id: request_id, instructions: instructions, for_password_reset: true)
+        subject.call(request_id: request_id, instructions: instructions, password_reset_requested: true)
       end
     end
 


### PR DESCRIPTION
**Why**: User creation yields email with subject "Email not found"

**How**:
- Fixed locales to keep subject as "Confirm your email"
- Updated RegisterUserEmailForm with password reset attribute
- Updated SendSignUpEmailConfirmation to consider reset attribute