### PR TITLE
Restore email confirmation link_text locale value

### DIFF
--- a/app/views/user_mailer/unconfirmed_email_instructions.html.erb
+++ b/app/views/user_mailer/unconfirmed_email_instructions.html.erb
@@ -30,7 +30,7 @@
 
 <p>
   <%= t('user_mailer.email_confirmation_instructions.use_this_email') %>
-  <%= link_to t('user_mailer.email_confirmation_instructions.link_text'),
+  <%= link_to t('user_mailer.email_confirmation_instructions.create_new_account'),
               sign_up_create_email_confirmation_url(_request_id: @request_id,
                                                     confirmation_token: @token,
                                                     locale: @locale),

--- a/config/locales/user_mailer/en.yml
+++ b/config/locales/user_mailer/en.yml
@@ -63,6 +63,7 @@ en:
         email addresses. We recommend that you also change your password.
       subject: New email address added
     email_confirmation_instructions:
+      create_new_account: create a new account.
       email_not_found: Email not found
       first_sentence:
         confirmed: Trying to change your email address?
@@ -72,7 +73,7 @@ en:
       footer: This link will expire in %{confirmation_period}.
       header: "%{intro} Please click the link below or copy and paste the entire link
         into your browser."
-      link_text: create a new account.
+      link_text: Confirm email address
       request_with_diff_email: You can request your password using a different email
         address that is connected to your %{app_name} account.
       subject: Confirm your email

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -65,6 +65,7 @@ es:
         direcciones de correo electrónico. Le recomendamos que también cambie su contraseña.
       subject: Nueva dirección de correo electrónico añadida
     email_confirmation_instructions:
+      create_new_account: crea una cuenta nueva.
       email_not_found: El correo electrónico no encontrado
       first_sentence:
         confirmed: "¿Desea cambiar su email?"
@@ -74,7 +75,7 @@ es:
       footer: Este enlace expira en %{confirmation_period}.
       header: "%{intro} Haga clic en el enlace de abajo o copie y pegue el enlace
         completo en su navegador."
-      link_text: crea una cuenta nueva.
+      link_text: Confirmar el correo
       request_with_diff_email: Puedes solicitar tu contraseña usando una dirección
         de correo electrónico diferente que está conectada a su cuenta %{app_name}.
       subject: Confirme su email

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -67,6 +67,7 @@ fr:
         votre mot de passe.
       subject: Nouvelle adresse email ajoutée
     email_confirmation_instructions:
+      create_new_account: créer un nouveau compte.
       email_not_found: Email non trouvé
       first_sentence:
         confirmed: Vous tentez de changer votre adresse courriel?
@@ -77,7 +78,7 @@ fr:
       footer: Ce lien expirera dans %{confirmation_period}.
       header: "%{intro} Veuillez cliquer sur le lien ci-dessous ou copier et coller
         le lien complet dans votre navigateur."
-      link_text: créer un nouveau compte.
+      link_text: Confirmez votre adresse email
       request_with_diff_email: Vous pouvez demander votre mot de passe en utilisant
         une adresse e-mail différente qui est connectée à votre compte %{app_name}.
       subject: Confirmez votre adresse courriel

--- a/spec/views/account_reset/user_mailer/unconfirmed_email_instructions.html.erb_spec.rb
+++ b/spec/views/account_reset/user_mailer/unconfirmed_email_instructions.html.erb_spec.rb
@@ -36,13 +36,13 @@ describe 'user_mailer/unconfirmed_email_instructions.html.erb' do
     )
   end
 
-  it 'includes a link to confirmation' do
+  it 'includes a link to create another account with the email address' do
     assign(:resource, build_stubbed(:user, confirmed_at: nil))
     assign(:token, 'foo')
     render
 
     expect(rendered).to have_link(
-      t('user_mailer.email_confirmation_instructions.link_text'),
+      t('user_mailer.email_confirmation_instructions.create_new_account'),
       href: 'http://test.host/sign_up/email/confirm?confirmation_token=foo',
     )
   end
@@ -50,13 +50,13 @@ describe 'user_mailer/unconfirmed_email_instructions.html.erb' do
   context 'in a non-default locale' do
     before { assign(:locale, 'fr') }
 
-    it 'puts the locale in the URL' do
+    it 'puts the locale in the account creation URL' do
       assign(:resource, build_stubbed(:user, confirmed_at: nil))
       assign(:token, 'foo')
       render
 
       expect(rendered).to have_link(
-        t('user_mailer.email_confirmation_instructions.link_text'),
+        t('user_mailer.email_confirmation_instructions.create_new_account'),
         href: 'http://test.host/fr/sign_up/email/confirm?confirmation_token=foo',
       )
     end


### PR DESCRIPTION
**Why**: Value should be "Confirm email address" (pre commit de8d32)
**How**: Fix "link_text"/ add "create_new_account" key / update ERB

This is relation to LG-2940.  The locale key was properly restored but not the key value.  My apologies.