### PR TITLE
LG-3021 Replace the acuant client with an adaptable doc auth client

### DIFF
--- a/app/services/doc_auth_mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth_mock/doc_auth_mock_client.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Lint/UnusedMethodArgument
-module AcuantMock
-  class AcuantMockClient
+module DocAuthMock
+  class DocAuthMockClient
     class << self
       attr_reader :response_mocks
       attr_accessor :last_uploaded_front_image

--- a/app/services/doc_auth_mock/responses/create_document_response.rb
+++ b/app/services/doc_auth_mock/responses/create_document_response.rb
@@ -1,4 +1,4 @@
-module AcuantMock
+module DocAuthMock
   module Responses
     class CreateDocumentResponse < Acuant::Response
       attr_reader :instance_id

--- a/app/services/doc_auth_mock/responses/get_results_response.rb
+++ b/app/services/doc_auth_mock/responses/get_results_response.rb
@@ -1,4 +1,4 @@
-module AcuantMock
+module DocAuthMock
   module Responses
     class GetResultsResponse < Acuant::Response
       attr_reader :pii_from_doc

--- a/app/services/doc_auth_mock/result_response_builder.rb
+++ b/app/services/doc_auth_mock/result_response_builder.rb
@@ -1,4 +1,4 @@
-module AcuantMock
+module DocAuthMock
   class ResultResponseBuilder
     DEFAULT_PII_FROM_DOC = {
       first_name: 'FAKEY',
@@ -23,7 +23,7 @@ module AcuantMock
     end
 
     def call
-      AcuantMock::Responses::GetResultsResponse.new(
+      DocAuthMock::Responses::GetResultsResponse.new(
         success: success?,
         errors: errors,
         pii_from_doc: pii_from_doc,

--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -13,7 +13,7 @@ module Idv
       private
 
       def fetch_doc_auth_results
-        get_results_response = acuant_client.get_results(instance_id: flow_session[:instance_id])
+        get_results_response = doc_auth_client.get_results(instance_id: flow_session[:instance_id])
         if get_results_response.success?
           mark_selfie_step_complete_unless_liveness_checking_is_enabled
           save_proofing_components

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class FrontImageStep < DocAuthBaseStep
       def call
-        create_document_response = acuant_client.create_document
+        create_document_response = doc_auth_client.create_document
 
         if create_document_response.success?
           flow_session[:instance_id] = create_document_response.instance_id

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -15,7 +15,7 @@ module Idv
       private
 
       def fetch_doc_auth_results
-        acuant_client.get_results(
+        doc_auth_client.get_results(
           instance_id: doc_capture_record.acuant_token,
         )
       end

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -13,7 +13,7 @@ module Idv
       private
 
       def fetch_doc_auth_results
-        get_results_response = acuant_client.get_results(instance_id: flow_session[:instance_id])
+        get_results_response = doc_auth_client.get_results(instance_id: flow_session[:instance_id])
         if get_results_response.success?
           mark_selfie_step_complete_unless_liveness_checking_is_enabled
           save_proofing_components

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class MobileFrontImageStep < DocAuthBaseStep
       def call
-        create_document_response = acuant_client.create_document
+        create_document_response = doc_auth_client.create_document
 
         if create_document_response.success?
           flow_session[:instance_id] = create_document_response.instance_id

--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -2,7 +2,7 @@ module Idv
   module Steps
     class SelfieStep < DocAuthBaseStep
       def call
-        selfie_response = acuant_client.post_selfie(instance_id: instance_id, image: image.read)
+        selfie_response = doc_auth_client.post_selfie(instance_id: instance_id, image: image.read)
         if selfie_response.success?
           return unless user_id_from_token
           CaptureDoc::UpdateAcuantToken.call(user_id_from_token, flow_session[:instance_id])

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -134,7 +134,6 @@ development:
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
   acuant_sdk_document_capture_enabled: 'true'
-  acuant_simulator: 'true'
   async_job_refresh_interval_seconds: '5'
   attribute_cost: 4000$8$4$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
@@ -162,6 +161,7 @@ development:
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
   disallow_ial2_recovery: 'false'
+  doc_auth_vendor: 'mock'
   doc_capture_polling_enabled: 'true'
   domain_name: localhost:3000
   email_deletion_enabled: 'true'
@@ -246,7 +246,6 @@ production:
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
   acuant_sdk_document_capture_enabled: 'false'
-  acuant_simulator: 'false'
   async_job_refresh_interval_seconds: '5'
   attribute_cost: 4000$8$4$
   attribute_encryption_key:
@@ -272,6 +271,7 @@ production:
   disable_email_sending: 'false'
   disallow_all_web_crawlers: 'false'
   disallow_ial2_recovery: 'true'
+  doc_auth_vendor: 'acuant'
   doc_capture_polling_enabled: 'true'
   domain_name: login.gov
   email_deletion_enabled: 'false'
@@ -351,7 +351,6 @@ test:
   acuant_max_attempts: '4'
   acuant_passlive_url: https://liveness.example.com
   acuant_sdk_document_capture_enabled: 'false'
-  acuant_simulator: 'true'
   async_job_refresh_interval_seconds: '1'
   attribute_cost: 800$8$1$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
@@ -378,6 +377,7 @@ test:
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
   disallow_ial2_recovery: 'false'
+  doc_auth_vendor: 'mock'
   doc_capture_polling_enabled: 'false'
   domain_name: www.example.com
   email_deletion_enabled: 'true'

--- a/config/initializers/acuant_simulator_config_validation.rb
+++ b/config/initializers/acuant_simulator_config_validation.rb
@@ -27,9 +27,11 @@ if Figaro.env.acuant_simulator == 'true' &&
     'true'. Making this change will change the current behavior.
   HEREDOC
 
+  # rubocop:disable Style/GuardClause
   if FORCE_ACUANT_CONFIG_UPGRADE
     raise error_message
   else
     warn error_message
   end
+  # rubocop:enable Style/GuardClause
 end

--- a/config/initializers/acuant_simulator_config_validation.rb
+++ b/config/initializers/acuant_simulator_config_validation.rb
@@ -1,0 +1,35 @@
+##
+# This initializer is present to force an upgrade from the `acuant_simulator`
+# config to the `doc_auth_vendor` config. It can be removed after a deploy
+# cycle where everyone has had a chance to upgrade to the new config.
+#
+# Flipping the FORCE_ACUANT_CONFIG_UPGRADE below will require prevent the app
+# from starting if the acuant simulator is enabled but the mock doc auth vendor
+# vendor is not turned on.
+#
+FORCE_ACUANT_CONFIG_UPGRADE = false
+
+if Figaro.env.acuant_simulator == 'true' &&
+   Figaro.env.doc_auth_vendor != 'mock'
+
+  error_message = <<~HEREDOC
+    The `acuant_simulator` config has been retired in favor of `doc_auth_vendor`.
+
+    You are seeing this because you have `acuant_simulator` set to 'true' but
+    you have not updated `doc_auth_vendor` to 'mock'.
+
+    If you do not want Acuant enabled, remove the `acuant_simulator` config and
+    set the `doc_auth_vendor` config to 'mock'. Currently `acuant_simulator` is
+    set to 'true'. Making this change will maintain the current behavior.
+
+    If you want Acuant enabled, remove the `acuant_simulator` and config set the
+    `doc_auth_vendor` config to 'acuant'. Currently `acuant_simulator` is set to
+    'true'. Making this change will change the current behavior.
+  HEREDOC
+
+  if FORCE_ACUANT_CONFIG_UPGRADE
+    raise error_message
+  else
+    warn error_message
+  end
+end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -38,7 +38,7 @@ feature 'doc auth back image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_ssn_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_back_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_back_image).to eq(
       doc_auth_image_data_url_data,
     )
   end
@@ -54,7 +54,7 @@ feature 'doc auth back image step' do
   end
 
   it 'does not proceed to the next page if the image upload fails' do
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_back_image,
       response: Acuant::Response.new(
         success: false,
@@ -82,7 +82,7 @@ feature 'doc auth back image step' do
 
   it 'renders a friendly error message if one is present on the response' do
     error_message = I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read')
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :get_results,
       response: Acuant::Response.new(
         success: false,

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -35,7 +35,7 @@ feature 'doc auth front image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_back_image_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_front_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_front_image).to eq(
       doc_auth_image_data_url_data,
     )
   end
@@ -89,7 +89,7 @@ feature 'doc auth front image step' do
   end
 
   it 'catches network connection errors on post_front_image' do
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_front_image,
       response: Acuant::Response.new(
         success: false,

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -26,7 +26,7 @@ feature 'doc auth mobile back image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_ssn_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_back_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_back_image).to eq(
       doc_auth_image_data_url_data,
     )
   end
@@ -42,7 +42,7 @@ feature 'doc auth mobile back image step' do
   end
 
   it 'does not proceed to the next page if the image upload fails' do
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_back_image,
       response: Acuant::Response.new(
         success: false,

--- a/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_front_image_step_spec.rb
@@ -26,7 +26,7 @@ feature 'doc auth mobile front image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_doc_auth_mobile_back_image_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_front_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_front_image).to eq(
       doc_auth_image_data_url_data,
     )
   end

--- a/spec/features/idv/doc_auth/selfie_step_spec.rb
+++ b/spec/features/idv/doc_auth/selfie_step_spec.rb
@@ -22,7 +22,7 @@ feature 'doc auth self image step' do
   end
 
   it 'restarts doc auth upon failure' do
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_selfie,
       response: Acuant::Response.new(
         success: false,

--- a/spec/features/idv/doc_auth/test_credentials_spec.rb
+++ b/spec/features/idv/doc_auth/test_credentials_spec.rb
@@ -26,12 +26,12 @@ feature 'doc auth test credentials' do
   end
 
   it 'does not initalize a acuant mock if the simulator is not enabled' do
-    allow(Figaro.env).to receive(:acuant_simulator).and_return('false')
+    allow(Figaro.env).to receive(:doc_auth_vendor).and_return('acuant')
 
-    simulated_client = AcuantMock::AcuantMockClient.new
+    simulated_client = DocAuthMock::DocAuthMockClient.new
     allow(Acuant::AcuantClient).to receive(:new).and_return(simulated_client)
 
-    expect(AcuantMock::AcuantMockClient).to_not receive(:new)
+    expect(DocAuthMock::DocAuthMockClient).to_not receive(:new)
 
     complete_all_doc_auth_steps
   end
@@ -44,6 +44,31 @@ feature 'doc auth test credentials' do
 
     expect(page).to have_current_path(idv_doc_auth_front_image_step)
     expect(page).to have_content(I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read'))
+  end
+
+  context 'when the app is using the acuant simulator config' do
+    before do
+      allow(Figaro.env).to receive(:doc_auth_vendor).and_return(nil)
+    end
+
+    it 'uses the mock vendor when acuant_simulator is true' do
+      allow(Figaro.env).to receive(:acuant_simulator).and_return('true')
+
+      expect(Acuant::AcuantClient).to_not receive(:new)
+
+      complete_all_doc_auth_steps
+    end
+
+    it 'uses the acuant vendor when acuant_simulator is not true' do
+      allow(Figaro.env).to receive(:acuant_simulator).and_return('false')
+
+      simulated_client = DocAuthMock::DocAuthMockClient.new
+      allow(Acuant::AcuantClient).to receive(:new).and_return(simulated_client)
+
+      expect(DocAuthMock::DocAuthMockClient).to_not receive(:new)
+
+      complete_all_doc_auth_steps
+    end
   end
 
   def upload_test_credentials_and_continue

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -126,7 +126,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS +
-          [AcuantMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
+          [DocAuthMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
       )
 
       sign_in_and_2fa_user
@@ -148,7 +148,7 @@ feature 'doc auth verify step' do
       stub_const(
         'Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS',
         Idv::Steps::VerifyBaseStep::AAMVA_SUPPORTED_JURISDICTIONS -
-          [AcuantMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
+          [DocAuthMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC[:state_id_jurisdiction]],
       )
 
       sign_in_and_2fa_user

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -30,7 +30,7 @@ feature 'doc capture mobile back image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_capture_doc_capture_complete_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_back_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_back_image).to eq(
       doc_auth_image_data_url_data,
     )
   end

--- a/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_front_image_step_spec.rb
@@ -27,7 +27,7 @@ feature 'doc capture mobile front image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_capture_doc_capture_mobile_back_image_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_front_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_front_image).to eq(
       doc_auth_image_data_url_data,
     )
   end

--- a/spec/features/idv/doc_capture/selfie_step_spec.rb
+++ b/spec/features/idv/doc_capture/selfie_step_spec.rb
@@ -27,7 +27,7 @@ feature 'doc auth self image step' do
   end
 
   it 'restarts doc auth upon failure' do
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_selfie,
       response: Acuant::Response.new(
         success: false,

--- a/spec/features/idv/recovery/back_image_step_spec.rb
+++ b/spec/features/idv/recovery/back_image_step_spec.rb
@@ -41,7 +41,7 @@ feature 'recovery back image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_recovery_ssn_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_back_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_back_image).to eq(
       doc_auth_image_data_url_data,
     )
   end

--- a/spec/features/idv/recovery/front_image_step_spec.rb
+++ b/spec/features/idv/recovery/front_image_step_spec.rb
@@ -30,7 +30,7 @@ feature 'recovery front image step' do
     click_idv_continue
 
     expect(page).to have_current_path(idv_recovery_back_image_step)
-    expect(AcuantMock::AcuantMockClient.last_uploaded_front_image).to eq(
+    expect(DocAuthMock::DocAuthMockClient.last_uploaded_front_image).to eq(
       doc_auth_image_data_url_data,
     )
   end

--- a/spec/features/idv/recovery/recover_fail_step_spec.rb
+++ b/spec/features/idv/recovery/recover_fail_step_spec.rb
@@ -8,7 +8,7 @@ feature 'recovery doc fail step' do
   let(:user) { create(:user, :with_phone) }
   let(:good_ssn) { '666-66-1234' }
   let(:profile) { build(:profile, :active, :verified, user: user, pii: { ssn: good_ssn }) }
-  let(:bad_pii) { AcuantMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(ssn: '123') }
+  let(:bad_pii) { DocAuthMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(ssn: '123') }
 
   before do
     sign_in_before_2fa(user)

--- a/spec/features/idv/recovery/verify_step_spec.rb
+++ b/spec/features/idv/recovery/verify_step_spec.rb
@@ -8,7 +8,7 @@ feature 'recovery verify step' do
   let(:user) { create(:user, :signed_up, :with_phone) }
   let(:good_ssn) { '666-66-1234' }
   let(:profile) { create(:profile, :active, :verified, user: user, pii: saved_pii) }
-  let(:saved_pii) { AcuantMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(ssn: good_ssn) }
+  let(:saved_pii) { DocAuthMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(ssn: good_ssn) }
   let(:max_attempts) { idv_max_attempts }
   before do
     profile

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,7 +86,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    AcuantMock::AcuantMockClient.reset!
+    DocAuthMock::DocAuthMockClient.reset!
   end
 
   config.around(:each, type: :feature) do |example|

--- a/spec/services/acuant_mock/acuant_mock_client_spec.rb
+++ b/spec/services/acuant_mock/acuant_mock_client_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe AcuantMock::AcuantMockClient do
+describe DocAuthMock::DocAuthMockClient do
   subject(:client) { described_class.new }
 
   it 'implements the same public methods as the real Acuant client' do

--- a/spec/services/acuant_mock/result_response_builder_spec.rb
+++ b/spec/services/acuant_mock/result_response_builder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe AcuantMock::ResultResponseBuilder do
+describe DocAuthMock::ResultResponseBuilder do
   describe '#call' do
     context 'with an image file' do
       it 'returns a successful response with the default PII' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -170,7 +170,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
   end
 
   def mock_general_doc_auth_client_error(method)
-    AcuantMock::AcuantMockClient.mock_response!(
+    DocAuthMock::DocAuthMockClient.mock_response!(
       method: method,
       response: Acuant::Response.new(
         success: false,

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -6,7 +6,7 @@ shared_examples 'sp requesting attributes' do |sp|
   let(:good_ssn) { '666-66-1234' }
   let(:profile) { create(:profile, :active, :verified, user: user, pii: saved_pii) }
   let(:saved_pii) do
-    AcuantMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
+    DocAuthMock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.merge(
       ssn: good_ssn,
       phone: '+1 (555) 555-1234',
     )


### PR DESCRIPTION
**Why**: So we can start setting up additional clients in addition to Acuant

The default vendor in production is Acuant. This is done to help prevent a slip-up that may disable Acuant in production.

Having Acuant enabled in production by default was the previous default behavior. However, it was done through the `acuant_simulator` config and not the new `doc_auth_vendor` config. 

This commit includes code to deprecate the `acuant_simulator` but continue supporting it. This will allow people with personal envs some time to migrate over. Once we are ready to retire it there is a flag that can be flipped to force the use of the new `doc_auth_vendor` config.

Todo before merging this:
- [x] Create a Jira task to track the retirement of the `acuant_simulator` config.
- [x] Update the dev, int, staging, and prod application.yml files to use the new config instead of `acuant_simulator`.