### PR TITLE
Add attributes to NewRelic traces in track_event

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -23,7 +23,7 @@ class Analytics
         user_id: analytics_hash[:user_id],
         user_ip: request.remote_ip,
         service_provider: sp,
-        event: event
+        event_name: event
     )
   end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -20,10 +20,10 @@ class Analytics
     # Tag NewRelic APM trace with a handful of useful metadata
     # https://www.rubydoc.info/github/newrelic/rpm/NewRelic/Agent#add_custom_attributes-instance_method
     ::NewRelic::Agent.add_custom_attributes(
-        user_id: analytics_hash[:user_id],
-        user_ip: request.remote_ip,
-        service_provider: sp,
-        event_name: event
+      user_id: analytics_hash[:user_id],
+      user_ip: request.remote_ip,
+      service_provider: sp,
+      event_name: event,
     )
   end
 


### PR DESCRIPTION
Without added dimensions it can be hard to see if a given exception or slowness triggered APM trace is tied to a specific SP or user.  This usually leads to having to switch to CloudWatch logs or Kibana to research and understand the scope of the problem.

This change adds the following attributes (dimensions) to traces:

* user_id - Logged in user UUID
* user_ip - A.K.A. remote_ip (source IP of user as seen from ALB)
* service_provider - Service provider issuer
* event_name - Friendly name of event

Values align with those logged to `events.log` for easier correlation.

Custom attributes from a sample trace: (Note - Older test - `event` will actually show as `event_name`)

![Screen Shot 2020-07-05 at 11 59 08](https://user-images.githubusercontent.com/59626817/86537788-3d99be80-beb7-11ea-87f8-b53dc5d0be49.png)
