### PR TITLE
Add missing closing tag for send link view h1 tag

### DIFF
--- a/app/views/idv/doc_auth/send_link.html.erb
+++ b/app/views/idv/doc_auth/send_link.html.erb
@@ -8,6 +8,7 @@
 
 <h1 class='h3'>
   <%= t('doc_auth.headings.take_picture') %>
+</h1>
 
 <p class='mt-tiny mb3'><%= t('doc_auth.info.take_picture') %></p>
 


### PR DESCRIPTION
Adds missing closing tag for `h1` tag.

**Why**? So the entire screen contents are not presented as a heading.

