### PR TITLE
Quit using Typhoeus to connect to Acuant

### DIFF
--- a/app/services/acuant/request.rb
+++ b/app/services/acuant/request.rb
@@ -58,6 +58,7 @@ module Acuant
 
     def faraday_connection
       Faraday.new(request: faraday_request_params, url: url.to_s, headers: headers) do |conn|
+        conn.adapter :net_http
         conn.basic_auth(
           Figaro.env.acuant_assure_id_username,
           Figaro.env.acuant_assure_id_password,

--- a/app/services/acuant/request.rb
+++ b/app/services/acuant/request.rb
@@ -58,7 +58,6 @@ module Acuant
 
     def faraday_connection
       Faraday.new(request: faraday_request_params, url: url.to_s, headers: headers) do |conn|
-        conn.adapter :typhoeus
         conn.basic_auth(
           Figaro.env.acuant_assure_id_username,
           Figaro.env.acuant_assure_id_password,

--- a/spec/services/acuant/request_spec.rb
+++ b/spec/services/acuant/request_spec.rb
@@ -86,7 +86,7 @@ describe Acuant::Request do
 
         expect(response.success?).to eq(false)
         expect(response.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
-        expect(response.exception).to be_a(Faraday::TimeoutError)
+        expect(response.exception).to be_a(Faraday::ConnectionFailed)
       end
     end
   end


### PR DESCRIPTION
**Why**: Since introducing this adapter we have see a few SSL connect errors. We are going to try to disable it to see if that clears them up.