### PR TITLE
Migrate the rest of monitor specs

### DIFF
--- a/app/controllers/test/oidc_test_controller.rb
+++ b/app/controllers/test/oidc_test_controller.rb
@@ -1,0 +1,30 @@
+module Test
+  class OidcTestController < ApplicationController
+    def index
+      @oidc_authorize_url = oidc_authorize_url
+    end
+
+    private
+
+    def oidc_authorize_url
+      openid_connect_authorize_path(
+        client_id: 'urn:gov:gsa:openidconnect:sp:server',
+        response_type: 'code',
+        acr_values: acr_values,
+        scope: 'openid email',
+        redirect_uri: test_oidc_url,
+        state: SecureRandom.hex,
+        prompt: 'select_account',
+        nonce: SecureRandom.hex,
+      )
+    end
+
+    def acr_values
+      if params[:ial].to_i == 2
+        Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+      else
+        Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      end
+    end
+  end
+end

--- a/app/controllers/test/oidc_test_controller.rb
+++ b/app/controllers/test/oidc_test_controller.rb
@@ -11,7 +11,7 @@ module Test
         client_id: 'urn:gov:gsa:openidconnect:sp:server',
         response_type: 'code',
         acr_values: acr_values,
-        scope: 'openid email',
+        scope: scope,
         redirect_uri: test_oidc_url,
         state: SecureRandom.hex,
         prompt: 'select_account',
@@ -24,6 +24,14 @@ module Test
         Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
       else
         Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      end
+    end
+
+    def scope
+      if params[:ial].to_i == 2
+        'openid email profile'
+      else
+        'openid email'
       end
     end
   end

--- a/app/controllers/test/saml_test_controller.rb
+++ b/app/controllers/test/saml_test_controller.rb
@@ -8,6 +8,10 @@ module Test
 
     skip_before_action :verify_authenticity_token, only: %i[decode_response decode_slo_request]
 
+    def index
+      @start_url = test_saml_url
+    end
+
     def start
       request = OneLogin::RubySaml::Authrequest.new
       redirect_to(request.create(test_saml_settings, {}))

--- a/app/views/test/oidc_test/index.html.erb
+++ b/app/views/test/oidc_test/index.html.erb
@@ -1,0 +1,3 @@
+<h1>OpenID Connect Test Controller</h1>
+
+<%= link_to 'Sign in', @oidc_authorize_url, class: 'sign-in-bttn' %>

--- a/app/views/test/saml_test/index.html.erb
+++ b/app/views/test/saml_test/index.html.erb
@@ -1,0 +1,3 @@
+<h1>SAML Test Controller</h1>
+
+<%= link_to 'Sign in', @start_url, class: 'sign-in-bttn' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,12 +133,15 @@ Rails.application.routes.draw do
     if Figaro.env.enable_test_routes == 'true'
       namespace :test do
         # Assertion granting test start + return.
+        get '/saml/login' => 'saml_test#index'
         get '/saml' => 'saml_test#start'
         get '/saml/decode_assertion' => 'saml_test#start'
         post '/saml/decode_assertion' => 'saml_test#decode_response'
         post '/saml/decode_slo_request' => 'saml_test#decode_slo_request'
         get '/piv_cac_entry' => 'piv_cac_authentication_test_subject#new'
         post '/piv_cac_entry' => 'piv_cac_authentication_test_subject#create'
+
+        get '/oidc' => 'oidc_test#index'
       end
     end
 

--- a/config/service_providers.localdev.yml
+++ b/config/service_providers.localdev.yml
@@ -168,6 +168,7 @@ test:
     redirect_uris:
       - 'http://localhost:7654/auth/result'
       - 'https://example.com'
+      - 'http://www.example.com/test/oidc'
     cert: 'saml_test_sp'
     friendly_name: 'Test SP'
     assertion_consumer_logout_service_url: ''

--- a/spec/features/monitor/create_account_spec.rb
+++ b/spec/features/monitor/create_account_spec.rb
@@ -1,0 +1,110 @@
+RSpec.describe 'smoke test: create account' do
+  include MonitorIdpSteps
+  include MonitorSpSteps
+
+  let(:monitor) { MonitorHelper.new(self) }
+
+  before { monitor.setup }
+
+  context 'OIDC' do
+    context 'not staging' do
+      before { monitor.filter_unless('STAGING') }
+
+      it 'creates new account with SMS option for 2FA' do
+        visit_idp_from_oidc_sp
+
+        click_on 'Create an account'
+        email_address = create_new_account_with_sms
+
+        expect_user_is_redirected_to_oidc_sp
+
+        log_out_from_oidc_sp
+      end
+
+      it 'creates new account with TOTP for 2FA' do
+        visit_idp_from_oidc_sp
+        click_on 'Create an account'
+        email_address = create_new_account_with_totp
+
+        expect_user_is_redirected_to_oidc_sp
+
+        log_out_from_oidc_sp
+      end
+    end
+
+    context 'on int' do
+      before { monitor.filter_if('INT') }
+
+      it 'creates new IAL2 account with SMS option for 2FA' do
+        visit_idp_from_oidc_sp_with_ial2
+        verify_identity_with_doc_auth
+        expect_user_is_redirected_to_oidc_sp
+
+        log_out_from_oidc_sp
+      end
+    end
+  end
+
+  context 'SAML' do
+    before { monitor.filter_if('INT') }
+
+    it 'creates new account with SMS option for 2FA' do
+      visit_idp_from_saml_sp
+      click_on 'Create an account'
+      email_address = create_new_account_with_sms
+
+      expect_user_is_redirected_to_saml_sp(email_address)
+
+      log_out_from_saml_sp
+    end
+
+    it 'creates new account with TOTP for 2FA' do
+      visit_idp_from_saml_sp
+      click_on 'Create an account'
+      email_address = create_new_account_with_totp
+
+      expect_user_is_redirected_to_saml_sp(email_address)
+
+      log_out_from_saml_sp
+    end
+
+    xit 'creates new IAL2 account with SMS option for 2FA' do
+      visit_idp_from_saml_sp_with_ial2
+      verify_identity_with_doc_auth
+      expect_user_is_redirected_to_saml_sp(email_address)
+
+      log_out_from_saml_sp
+    end
+  end
+
+  def expect_user_is_redirected_to_oidc_sp
+    expect(page).to have_current_path('/sign_up/completed')
+
+    click_on 'Agree and continue'
+
+    if oidc_sp_is_usajobs?
+      expect(page).to have_content('Welcome ')
+      expect(current_url).to match(%r{https://.*usajobs\.gov})
+    elsif monitor.remote?
+      expect(page).to have_content('OpenID Connect Sinatra Example')
+      expect(current_url).to match(%r{https:\/\/(sp|\w+-identity)\-oidc\-sinatra})
+    else
+      expect(page).to have_content('OpenID Connect Test Controller')
+    end
+  end
+
+  def expect_user_is_redirected_to_saml_sp(email_address)
+    expect(page).to have_current_path('/sign_up/completed')
+
+    click_on 'Agree and continue'
+
+    if monitor.remote?
+      expect(page).to have_content('SAML Sinatra Example')
+      expect(page).to have_content(email_address)
+      expect(current_url).to include(monitor.config.saml_sp_url)
+    else
+      click_on 'Submit'
+      expect(page).to have_content('Decoded SAML Response')
+    end
+  end
+end

--- a/spec/features/monitor/create_account_spec.rb
+++ b/spec/features/monitor/create_account_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe 'smoke test: create account' do
   include MonitorIdpSteps
   include MonitorSpSteps
+  include MonitorIdvSteps
 
   let(:monitor) { MonitorHelper.new(self) }
 

--- a/spec/features/monitor/create_account_spec.rb
+++ b/spec/features/monitor/create_account_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'smoke test: create account' do
         visit_idp_from_oidc_sp
 
         click_on 'Create an account'
-        email_address = create_new_account_with_sms
+        create_new_account_with_sms
 
         expect_user_is_redirected_to_oidc_sp
 
@@ -25,7 +25,7 @@ RSpec.describe 'smoke test: create account' do
       it 'creates new account with TOTP for 2FA' do
         visit_idp_from_oidc_sp
         click_on 'Create an account'
-        email_address = create_new_account_with_totp
+        create_new_account_with_totp
 
         expect_user_is_redirected_to_oidc_sp
 

--- a/spec/features/monitor/reset_password_spec.rb
+++ b/spec/features/monitor/reset_password_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'smoke test: password reset' do
 
   it 'resets password at LOA1' do
     visit monitor.idp_reset_password_url
-    fill_in 'password_reset_email_form_email', with: monitor.config.sms_sign_in_email
+    fill_in 'password_reset_email_form_email', with: monitor.config.login_gov_sign_in_email
     click_on 'Continue'
 
     expect(page).to have_content('Check your email')
@@ -15,7 +15,7 @@ RSpec.describe 'smoke test: password reset' do
     reset_link = monitor.check_for_password_reset_link
     expect(reset_link).to be_present
     visit reset_link
-    fill_in 'reset_password_form_password', with: monitor.config.password
+    fill_in 'reset_password_form_password', with: monitor.config.login_gov_sign_in_password
     click_on 'Change password'
 
     expect(page).to have_content('Your password has been changed')

--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe 'smoke test: SP initiated sign in' do
+  include MonitorIdpSteps
+  include MonitorSpSteps
+
+  let(:monitor) { MonitorHelper.new(self) }
+
+  before { monitor.setup }
+
+  context 'OIDC' do
+    before { monitor.filter_unless('STAGING') }
+
+    it 'redirects back to SP' do
+      visit_idp_from_oidc_sp
+      sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
+
+      if page.has_content?('You are now signing in for the first time')
+        click_on 'Agree and continue'
+      end
+
+      if oidc_sp_is_usajobs?
+        expect(page).to have_content('Welcome ')
+        expect(current_url).to match(%r{https://.*usajobs\.gov})
+      elsif monitor.remote?
+        expect(page).to have_content('OpenID Connect Sinatra Example')
+        expect(current_url).to match(%r{https:\/\/(sp|\w+-identity)\-oidc\-sinatra})
+      else
+        expect(page).to have_content('OpenID Connect Test Controller')
+      end
+
+      log_out_from_oidc_sp
+    end
+  end
+
+  context 'SAML' do
+    before { monitor.filter_if('INT') }
+
+    it 'redirects back to SP' do
+      visit_idp_from_saml_sp
+      sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
+
+      if page.has_content?('You are now signing in for the first time')
+        click_on 'Agree and continue'
+      end
+
+      if monitor.remote?
+        expect(page).to have_content('SAML Sinatra Example')
+        expect(page).to have_content(monitor.config.login_gov_sign_in_email)
+        expect(current_url).to include(monitor.config.saml_sp_url)
+      else
+        click_on 'Submit'
+        expect(page).to have_content('Decoded SAML Response')
+      end
+
+      log_out_from_saml_sp
+    end
+  end
+end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -95,10 +95,11 @@ feature 'Sign in' do
 
     perform_steps_to_get_to_add_piv_cac_during_sign_up
 
-    # rubocop:disable Metrics/LineLength
-    expected_form_action =
-      "form-action https://*.pivcac.test.example.com 'self' http://localhost:7654/auth/result https://example.com;"
-    # rubocop:enable Metrics/LineLength
+    expected_form_action = %w[
+      form-action https://*.pivcac.test.example.com 'self'
+      http://localhost:7654/auth/result https://example.com
+      http://www.example.com/test/oidc;
+    ].join(' ')
 
     expect(page.response_headers['Content-Security-Policy']).
       to(include(expected_form_action))

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -95,11 +95,11 @@ feature 'Sign in' do
 
     perform_steps_to_get_to_add_piv_cac_during_sign_up
 
-    expected_form_action = %w[
+    expected_form_action = <<-STR.squish
       form-action https://*.pivcac.test.example.com 'self'
       http://localhost:7654/auth/result https://example.com
       http://www.example.com/test/oidc;
-    ].join(' ')
+    STR
 
     expect(page.response_headers['Content-Security-Policy']).
       to(include(expected_form_action))

--- a/spec/monitor_spec_helper.rb
+++ b/spec/monitor_spec_helper.rb
@@ -4,6 +4,8 @@ require 'capybara/rspec'
 require 'webdrivers/chromedriver'
 require 'active_support/all'
 
+Time.zone ||= ActiveSupport::TimeZone['UTC']
+
 Capybara.register_driver :chrome do |app|
   browser_options = Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--no-sandbox'

--- a/spec/support/monitor/monitor_config.rb
+++ b/spec/support/monitor/monitor_config.rb
@@ -1,5 +1,13 @@
 # Manages all the environment variables used in smoke tests
 class MonitorConfig
+  def initialize(local: local)
+    @local = local
+  end
+
+  def local?
+    @local
+  end
+
   def check_env_variables!
     expected_env_vars = %w[
       MONITOR_EMAIL
@@ -43,12 +51,12 @@ class MonitorConfig
 
   # Looks up the OIDC service provider for that environment, example key: MONITOR_INT_OIDC_SP_URL
   def oidc_sp_url
-    ENV["MONITOR_#{monitor_env}_OIDC_SP_URL"] || '/test/oidc'
+    ENV["MONITOR_#{monitor_env}_OIDC_SP_URL"] || (local? && '/test/oidc')
   end
 
   # Looks up the SML service provider for that environment, example key: MONITOR_INT_SAML_SP_URL
   def saml_sp_url
-    ENV["MONITOR_#{monitor_env}_SAML_SP_URL"] || '/test/saml/login'
+    ENV["MONITOR_#{monitor_env}_SAML_SP_URL"] || (local? && '/test/saml/login')
   end
 
   # Looks up the IDP for that environment, example key: MONITOR_IDP_URL

--- a/spec/support/monitor/monitor_config.rb
+++ b/spec/support/monitor/monitor_config.rb
@@ -1,6 +1,6 @@
 # Manages all the environment variables used in smoke tests
 class MonitorConfig
-  def initialize(local: local)
+  def initialize(local:)
     @local = local
   end
 

--- a/spec/support/monitor/monitor_config.rb
+++ b/spec/support/monitor/monitor_config.rb
@@ -27,8 +27,14 @@ class MonitorConfig
     raise message unless missing_env_vars.empty?
   end
 
+  # Gmail account name
   def email_address
     ENV['MONITOR_EMAIL'] || 'test@example.com'
+  end
+
+  # Password for email_address Gmail account
+  def email_password
+    ENV['MONITOR_EMAIL_PASSWORD'] || 'salty pickles'
   end
 
   # A phone number that has been configured to forward SMS messages to MONITOR_EMAIL
@@ -36,13 +42,17 @@ class MonitorConfig
     ENV['MONITOR_GOOGLE_VOICE_PHONE'] || '18888675309'
   end
 
-  # An email that already has an account created, used for testing the password reset flow
-  def sms_sign_in_email
+  # An email address that should:
+  # - Have an associated login.gov account created in the environment this is run against
+  # - Have its 2FA set to be SMS messages to the google_voice_phone
+  # This is used for testing the password reset flow and SP sign-ins
+  def login_gov_sign_in_email
     ENV['MONITOR_SMS_SIGN_IN_EMAIL'] || 'test+sms@example.com'
   end
 
-  def password
-    ENV['MONITOR_EMAIL_PASSWORD'] || 'salty pickles'
+  # Password for the login.gov account for login_gov_sign_in_email
+  def login_gov_sign_in_password
+    ENV['MONITOR_SMS_SIGN_IN_PASSWORD'] || 'salty pickles'
   end
 
   def monitor_env

--- a/spec/support/monitor/monitor_config.rb
+++ b/spec/support/monitor/monitor_config.rb
@@ -43,12 +43,12 @@ class MonitorConfig
 
   # Looks up the OIDC service provider for that environment, example key: MONITOR_INT_OIDC_SP_URL
   def oidc_sp_url
-    ENV["MONITOR_#{monitor_env}_OIDC_SP_URL"]
+    ENV["MONITOR_#{monitor_env}_OIDC_SP_URL"] || '/test/oidc'
   end
 
   # Looks up the SML service provider for that environment, example key: MONITOR_INT_SAML_SP_URL
   def saml_sp_url
-    ENV["MONITOR_#{monitor_env}_SAML_SP_URL"]
+    ENV["MONITOR_#{monitor_env}_SAML_SP_URL"] || '/test/saml/login'
   end
 
   # Looks up the IDP for that environment, example key: MONITOR_IDP_URL

--- a/spec/support/monitor/monitor_email_helper.rb
+++ b/spec/support/monitor/monitor_email_helper.rb
@@ -41,6 +41,7 @@ class MonitorEmailHelper
             return match_data[1]
           end
         end
+        nil
       end
     end
 

--- a/spec/support/monitor/monitor_helper.rb
+++ b/spec/support/monitor/monitor_helper.rb
@@ -27,10 +27,9 @@ class MonitorHelper
   def setup
     if local?
       context.create(:user,
-        :with_phone,
-        email: config.login_gov_sign_in_email,
-        password: config.login_gov_sign_in_password,
-      )
+                     :with_phone,
+                     email: config.login_gov_sign_in_email,
+                     password: config.login_gov_sign_in_password)
     else
       config.check_env_variables!
       reset_sessions
@@ -49,17 +48,15 @@ class MonitorHelper
   def filter_if(env_name)
     return if local? # always run all tests on local
 
-    if env_name != config.monitor_env
-      context.skip "skipping test only meant for #{env_name}"
-    end
+    return if env_name == config.monitor_env
+    context.skip "skipping test only meant for #{env_name}"
   end
 
   def filter_unless(env_name)
     return if local? # always run all tests on local
 
-    if env_name == config.monitor_env
-      context.skip "skipping test not meant for #{env_name}"
-    end
+    return if env_name != config.monitor_env
+    context.skip "skipping test not meant for #{env_name}"
   end
 
   # Capybara.reset_session! deletes the cookies for the current site. As such

--- a/spec/support/monitor/monitor_helper.rb
+++ b/spec/support/monitor/monitor_helper.rb
@@ -19,14 +19,18 @@ class MonitorHelper
   def email
     @email ||= MonitorEmailHelper.new(
       email: config.email_address,
-      password: config.password,
+      password: config.email_password,
       local: local?,
     )
   end
 
   def setup
     if local?
-      context.create(:user, email: config.sms_sign_in_email, password: config.password)
+      context.create(:user,
+        :with_phone,
+        email: config.login_gov_sign_in_email,
+        password: config.login_gov_sign_in_password,
+      )
     else
       config.check_env_variables!
       reset_sessions

--- a/spec/support/monitor/monitor_helper.rb
+++ b/spec/support/monitor/monitor_helper.rb
@@ -13,7 +13,7 @@ class MonitorHelper
   end
 
   def config
-    @config ||= MonitorConfig.new
+    @config ||= MonitorConfig.new(local: local?)
   end
 
   def email

--- a/spec/support/monitor/monitor_helper.rb
+++ b/spec/support/monitor/monitor_helper.rb
@@ -38,6 +38,26 @@ class MonitorHelper
     defined?(Rails) && Rails.env.test?
   end
 
+  def remote?
+    !local?
+  end
+
+  def filter_if(env_name)
+    return if local? # always run all tests on local
+
+    if env_name != config.monitor_env
+      context.skip "skipping test only meant for #{env_name}"
+    end
+  end
+
+  def filter_unless(env_name)
+    return if local? # always run all tests on local
+
+    if env_name == config.monitor_env
+      context.skip "skipping test not meant for #{env_name}"
+    end
+  end
+
   # Capybara.reset_session! deletes the cookies for the current site. As such
   # we need to visit each site individually and reset there.
   def reset_sessions

--- a/spec/support/monitor/monitor_idp_steps.rb
+++ b/spec/support/monitor/monitor_idp_steps.rb
@@ -27,7 +27,7 @@ module MonitorIdpSteps
     click_on 'Submit'
     confirmation_link = monitor.check_for_confirmation_link
     visit confirmation_link
-    fill_in 'password_form_password', with: monitor.config.password
+    fill_in 'password_form_password', with: monitor.config.login_gov_sign_in_password
     submit_password
 
     email_address
@@ -54,7 +54,7 @@ module MonitorIdpSteps
 
   def sign_in_and_2fa(email)
     fill_in 'user_email', with: email
-    fill_in 'user_password', with: monitor.config.password
+    fill_in 'user_password', with: monitor.config.login_gov_sign_in_password
     click_on 'Sign in'
     fill_in 'code', with: monitor.check_for_otp
     uncheck 'Remember this browser'

--- a/spec/support/monitor/monitor_idp_steps.rb
+++ b/spec/support/monitor/monitor_idp_steps.rb
@@ -79,6 +79,6 @@ module MonitorIdpSteps
   end
 
   def generate_totp_code(secret)
-    ROTP::TOTP.new(secret).at(Time.now, true)
+    ROTP::TOTP.new(secret).at(Time.zone.now, true)
   end
 end

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -7,7 +7,6 @@ module MonitorIdvSteps
     create_new_account_with_sms
     expect(page).to have_current_path('/verify/doc_auth/welcome')
 
-    # page.execute_script("document.getElementById('ial2_consent_given').click()")
     check 'ial2_consent_given', visible: :all, allow_label_click: true
     expect(page).to have_button('Continue', disabled: :all)
 

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -29,7 +29,7 @@ module MonitorIdvSteps
     click_on 'Continue'
     expect(page).to have_current_path('/verify/doc_auth/ssn')
 
-    fill_in 'doc_auth_ssn', with: format("%09d", SecureRandom.random_number(1e9))
+    fill_in 'doc_auth_ssn', with: format('%09d', SecureRandom.random_number(1e9))
     click_on 'Continue'
     expect(page).to have_current_path('/verify/doc_auth/verify')
 
@@ -53,21 +53,23 @@ module MonitorIdvSteps
     end
     click_on 'Continue', class: 'personal-key-continue'
 
-    # TODO: figure out what feature flag enables this for local development
-    if monitor.remote?
-      fill_in 'personal_key', with: (code_words.join('-').downcase + extra_characters_get_ignored), disabled: :all
-      click_on 'Continue', class: 'personal-key-confirm'
+    # TODO: figure out what feature flag enables the rest of the branch for local development
+    return unless monitor.remote?
 
-      # HTML fallback for failed personal key
-      fill_in 'personal_key', with: (code_words.join('-').downcase), disabled: :all
-      click_on 'Continue', class: 'personal-key-confirm'
-    end
+    personal_key = code_words.join('-').downcase
+
+    fill_in 'personal_key', with: (personal_key + extra_characters_get_ignored), disabled: :all
+    click_on 'Continue', class: 'personal-key-confirm'
+
+    # HTML fallback for failed personal key
+    fill_in 'personal_key', with: personal_key, disabled: :all
+    click_on 'Continue', class: 'personal-key-confirm'
   end
 
   def click_doc_auth_fallback_link
-    if !page.has_css?('#doc_auth_image', visible: true)
-      fallback_link = page.find('#acuant-fallback-link', wait: 7)
-      fallback_link.click if fallback_link
-    end
+    return if page.has_css?('#doc_auth_image', visible: true)
+
+    fallback_link = page.find('#acuant-fallback-link', wait: 7)
+    fallback_link&.click
   end
 end

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -52,7 +52,7 @@ module MonitorIdvSteps
     end
     click_on 'Continue', class: 'personal-key-continue'
 
-    # TODO: figure out what feature flag enables the rest of the branch for local development
+    # Need to figure out what feature flag enables the personal key code locally
     return unless monitor.remote?
 
     personal_key = code_words.join('-').downcase

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -42,7 +42,7 @@ module MonitorIdvSteps
     click_on 'Continue'
     expect(page).to have_current_path('/verify/review')
 
-    fill_in 'Password', with: monitor.config.password
+    fill_in 'Password', with: monitor.config.login_gov_sign_in_password
     click_on 'Continue'
     expect(page).to have_current_path('/verify/confirmations')
 

--- a/spec/support/monitor/monitor_idv_steps.rb
+++ b/spec/support/monitor/monitor_idv_steps.rb
@@ -1,0 +1,73 @@
+module MonitorIdvSteps
+  def verify_identity_with_doc_auth
+    allow(Figaro.env).to receive(:doc_auth_vendor).and_return('mock') if monitor.local?
+
+    expect(page).to have_content 'You will also need'
+    click_on 'Create an account'
+    create_new_account_with_sms
+    expect(page).to have_current_path('/verify/doc_auth/welcome')
+
+    # page.execute_script("document.getElementById('ial2_consent_given').click()")
+    check 'ial2_consent_given', visible: :all, allow_label_click: true
+    expect(page).to have_button('Continue', disabled: :all)
+
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/doc_auth/upload')
+
+    click_on 'Upload from your computer'
+    expect(page).to have_current_path('/verify/doc_auth/front_image')
+
+    click_doc_auth_fallback_link
+
+    attach_file 'doc_auth_image', File.expand_path('spec/fixtures/ial2_test_credential.yml')
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/doc_auth/back_image')
+
+    click_doc_auth_fallback_link
+
+    attach_file 'doc_auth_image', File.expand_path('spec/fixtures/ial2_test_credential.yml')
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/doc_auth/ssn')
+
+    fill_in 'doc_auth_ssn', with: format("%09d", SecureRandom.random_number(1e9))
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/doc_auth/verify')
+
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/doc_auth/doc_success')
+
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/phone')
+
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/review')
+
+    fill_in 'Password', with: monitor.config.password
+    click_on 'Continue'
+    expect(page).to have_current_path('/verify/confirmations')
+
+    extra_characters_get_ignored = 'abc123qwerty'
+    code_words = []
+    page.all(:css, '[data-personal-key]').map do |node|
+      code_words << node.text
+    end
+    click_on 'Continue', class: 'personal-key-continue'
+
+    # TODO: figure out what feature flag enables this for local development
+    if monitor.remote?
+      fill_in 'personal_key', with: (code_words.join('-').downcase + extra_characters_get_ignored), disabled: :all
+      click_on 'Continue', class: 'personal-key-confirm'
+
+      # HTML fallback for failed personal key
+      fill_in 'personal_key', with: (code_words.join('-').downcase), disabled: :all
+      click_on 'Continue', class: 'personal-key-confirm'
+    end
+  end
+
+  def click_doc_auth_fallback_link
+    if !page.has_css?('#doc_auth_image', visible: true)
+      fallback_link = page.find('#acuant-fallback-link', wait: 7)
+      fallback_link.click if fallback_link
+    end
+  end
+end

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -15,15 +15,14 @@ module MonitorSpSteps
   end
 
   def visit_idp_from_oidc_sp_with_ial2
-    visit monitor.oidc_sp_url + '?ial=2'
+    visit monitor.config.oidc_sp_url + '?ial=2'
     find(:css, '.sign-in-bttn').click
 
-    expect(current_url).to match(%r{https://(idp|secure)\..*\.gov})
+    expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
   end
 
   def visit_idp_from_saml_sp
     visit monitor.config.saml_sp_url
-    File.open('lol.html', 'w') { |f| f.puts page.html }
     first(:css, '.sign-in-bttn').click
 
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -1,0 +1,47 @@
+module MonitorSpSteps
+  def oidc_sp_is_usajobs?
+    monitor.config.oidc_sp_url.to_s.match(/usajobs\.gov/)
+  end
+
+  def visit_idp_from_oidc_sp
+    visit monitor.config.oidc_sp_url
+    if oidc_sp_is_usajobs?
+      click_on 'Sign In'
+    else
+      find(:css, '.sign-in-bttn').click
+    end
+
+    expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
+  end
+
+  def visit_idp_from_oidc_sp_with_ial2
+    visit monitor.oidc_sp_url + '?ial=2'
+    find(:css, '.sign-in-bttn').click
+
+    expect(current_url).to match(%r{https://(idp|secure)\..*\.gov})
+  end
+
+  def visit_idp_from_saml_sp
+    visit monitor.config.saml_sp_url
+    File.open('lol.html', 'w') { |f| f.puts page.html }
+    first(:css, '.sign-in-bttn').click
+
+    expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
+  end
+
+  def log_out_from_oidc_sp
+    if oidc_sp_is_usajobs?
+      within('.usajobs-home__title') do
+        click_link 'Sign Out'
+      end
+      expect(current_url).to match(%r{https://login.(uat.)?usajobs.gov/externalloggedout}) if monitor.remote?
+    end
+  end
+
+  def log_out_from_saml_sp
+    if monitor.remote?
+      click_on 'Log out'
+      expect(current_url).to match monitor.config.saml_sp_url
+    end
+  end
+end

--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -29,18 +29,20 @@ module MonitorSpSteps
   end
 
   def log_out_from_oidc_sp
-    if oidc_sp_is_usajobs?
-      within('.usajobs-home__title') do
-        click_link 'Sign Out'
-      end
-      expect(current_url).to match(%r{https://login.(uat.)?usajobs.gov/externalloggedout}) if monitor.remote?
+    return unless oidc_sp_is_usajobs?
+
+    within('.usajobs-home__title') do
+      click_link 'Sign Out'
     end
+
+    return unless monitor.remote?
+    expect(current_url).to match(%r{https://login.(uat.)?usajobs.gov/externalloggedout})
   end
 
   def log_out_from_saml_sp
-    if monitor.remote?
-      click_on 'Log out'
-      expect(current_url).to match monitor.config.saml_sp_url
-    end
+    return unless monitor.remote?
+
+    click_on 'Log out'
+    expect(current_url).to match monitor.config.saml_sp_url
   end
 end


### PR DESCRIPTION
Migrate over create_accout_spec to the IDP repo

Changes:
- Adds a local oidc_test controller, this is a replacement for referencig the OIDC sample app or USA Jobs in a deployed environment
- Adds signing in via TOTP
- Adds IAL2 proofing methods