### PR TITLE
LG-3171: Fix new registration page title grammar

### DIFF
--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -45,7 +45,7 @@ en:
     present_webauthn: Present your hardware security key
     reactivate_account: Reactivate your account
     registrations:
-      new: Sign up for a account
+      new: Sign up for an account
     remembered_browsers: Remembered browsers
     revoke_consent: Revoke Consent
     sign_up:


### PR DESCRIPTION
**Why**: Page titles should be written with correct grammar