### PR TITLE
Smoketest INT against deployed INT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       - run:
           name: "Smoke tests"
           command: |
-            ./bin/smoke_test --remote --no-source-env
+            bin/smoke_test --remote --no-source-env
   smoketest-staging:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: "Smoke tests"
           command: |
-            ./bin/smoke_test --remote --no-source-env
+            bin/smoke_test --remote --no-source-env
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ commands:
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
+            pwd
+
             # Use HTTPS to check out, since we don't need to authenticate
             CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
             echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"
@@ -96,6 +98,7 @@ commands:
             fi
             git reset --hard "$DEPLOYED_SHA"
 
+            pwd
             ls -al
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
           paths:
             - ~/.cache/yarn
 
-  # Custom version of "checkout" that checks out a SHA deployed to DEPLOY_URL env
+  # Custom version of "checkout" that checks out a SHA deployed to sha_url param
   # Adapter from https://gist.github.com/drazisil/e97dc21454120251472154de1c1b1c7b
   checkout-deployed-sha:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,13 +78,13 @@ commands:
 
             git config --global gc.auto 0 || true
 
-            if [ -e /home/circleci/project/.git ]
+            if [ -e "$CIRCLE_WORKING_DIRECTORY/.git" ]
             then
-              cd /home/circleci/project
+              cd "$CIRCLE_WORKING_DIRECTORY"
               git remote set-url origin "$CIRCLE_REPOSITORY_URL_AS_HTTPS" || true
             else
-              mkdir -p /home/circleci/project
-              cd /home/circleci/project
+              mkdir -p "$CIRCLE_WORKING_DIRECTORY"
+              cd "$CIRCLE_WORKING_DIRECTORY"
               git clone "$CIRCLE_REPOSITORY_URL_AS_HTTPS" .
             fi
 
@@ -95,10 +95,6 @@ commands:
               git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
             git reset --hard "$DEPLOYED_SHA"
-
-            echo "checking if this is here"
-            ls -al bin/smoke_test
-            echo "$(ls -al bin/smoke_test)"
 jobs:
   build:
     executor: ruby_browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,6 @@ commands:
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
-            DEPLOYED_SHA="$CIRCLE_SHA1" # temporary test
-
             # Use HTTPS to check out, since we don't need to authenticate
             CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
             echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"
@@ -215,7 +213,6 @@ jobs:
       - run:
           name: "Smoke tests"
           command: |
-            head -n 3 bin/smoke_test
             bin/smoke_test --remote --no-source-env
   smoketest-staging:
     working_directory: ~/identity-idp
@@ -247,11 +244,6 @@ workflows:
           filters:
             tags:
               only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
-
-  # temporary to test the custom checkout code
-  custom_int_build:
-    jobs:
-      - smoketest-int
 
   # INT
   smoketest-int-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ commands:
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
+            DEPLOYED_SHA="$CIRCLE_SHA1" # temporary test
+
             # Use HTTPS to check out, since we don't need to authenticate
             CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
             echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ commands:
           command: |
             DEPLOYED_SHA=$(curl --silent << parameters.sha_url >> | jq -r '.git_sha')
 
+            echo "SHA: $DEPLOYED_SHA"
+
+            echo "CIRCLE_REPOSITORY_URL: $CIRCLE_REPOSITORY_URL"
+
             # Workaround old docker images with incorrect $HOME
             # check https://github.com/docker/docker/issues/2968 for details
             if [ "${HOME}" = "/" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,11 @@ workflows:
             tags:
               only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
 
+  # temporary to test the custom checkout code
+  custom_int_build:
+    jobs:
+      smoketest-int
+
   # INT
   smoketest-int-workflow:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ commands:
               git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
             git reset --hard "$DEPLOYED_SHA"
+
+            echo "checking if this is here"
+            ls -al bin/smoke_test
+            echo "$(ls -al bin/smoke_test)"
 jobs:
   build:
     executor: ruby_browsers
@@ -199,6 +203,7 @@ jobs:
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push logindotgov/idp:$CIRCLE_TAG
   smoketest-int:
+    working_directory: ~/identity-idp
     executor: ruby_browsers
     environment:
       MONITOR_ENV: INT
@@ -212,6 +217,7 @@ jobs:
           command: |
             ./bin/smoke_test --remote --no-source-env
   smoketest-staging:
+    working_directory: ~/identity-idp
     executor: ruby_browsers
     environment:
       MONITOR_ENV: STAGING

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,15 +78,17 @@ commands:
               export HOME=$(getent passwd $(id -un) | cut -d: -f6)
             fi
 
+            EXPANDED_CIRCLE_WORKING_DIRECTORY="${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}"
+
             git config --global gc.auto 0 || true
 
-            if [ -e "$CIRCLE_WORKING_DIRECTORY/.git" ]
+            if [ -e "$EXPANDED_CIRCLE_WORKING_DIRECTORY/.git" ]
             then
-              cd "$CIRCLE_WORKING_DIRECTORY"
+              cd "$EXPANDED_CIRCLE_WORKING_DIRECTORY"
               git remote set-url origin "$CIRCLE_REPOSITORY_URL_AS_HTTPS" || true
             else
-              mkdir -p "$CIRCLE_WORKING_DIRECTORY"
-              cd "$CIRCLE_WORKING_DIRECTORY"
+              mkdir -p "$EXPANDED_CIRCLE_WORKING_DIRECTORY"
+              cd "$EXPANDED_CIRCLE_WORKING_DIRECTORY"
               git clone "$CIRCLE_REPOSITORY_URL_AS_HTTPS" .
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@
 #
 version: 2.1
 
+orbs:
+  jq: circleci/jq@2.2.0
 executors:
   # Common container definition used by all jobs
   ruby_browsers:
@@ -48,6 +50,45 @@ commands:
           paths:
             - ~/.cache/yarn
 
+  # Custom version of "checkout" that checks out a SHA deployed to DEPLOY_URL env
+  checkout-deployed-sha:
+    parameters:
+      sha_url:
+        type: string
+    steps:
+      - run:
+          name: Custom Checkout of Deployed SHA
+          command: |
+            DEPLOYED_SHA=$(curl --silent << parameters.sha_url >> | jq -r '.git_sha')
+
+            # Workaround old docker images with incorrect $HOME
+            # check https://github.com/docker/docker/issues/2968 for details
+            if [ "${HOME}" = "/" ]
+            then
+              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
+            fi
+
+            # Use HTTPS to check out, since we don't need to authenticate
+            git config --global url."https://github.com".insteadOf "ssh://git@github.com" || true
+            git config --global gc.auto 0 || true
+
+            if [ -e /home/circleci/project/.git ]
+            then
+              cd /home/circleci/project
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+            else
+              mkdir -p /home/circleci/project
+              cd /home/circleci/project
+              git clone "$CIRCLE_REPOSITORY_URL" .
+            fi
+
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git fetch --force origin "refs/tags/${CIRCLE_TAG}"
+            else
+              git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+            fi
+            git reset --hard "$DEPLOYED_SHA"
 jobs:
   build:
     executor: ruby_browsers
@@ -151,6 +192,18 @@ jobs:
           docker build -t logindotgov/idp:$CIRCLE_TAG -f production.Dockerfile .
           echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
           docker push logindotgov/idp:$CIRCLE_TAG
+  smoketest-int:
+    executor: ruby_browsers
+    environment:
+      MONITOR_ENV: INT
+    steps:
+      - jq/install
+      - checkout-deployed-sha:
+          sha_url: https://idp.int.identitysandbox.gov/api/deploy.json
+      - bundle-yarn-install
+      - run:
+          name: "Smoke tests"
+          command: "bin/smoke_test --remote --no-source-env"
   smoketest-staging:
     executor: ruby_browsers
     environment:
@@ -180,14 +233,29 @@ workflows:
             tags:
               only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
 
-  # STAGING
-  smoketest-staging-workflow:
+  # INT
+  smoketest-int-workflow:
     triggers:
       - schedule:
           # This test is run on the 10th minute of the hour, staggered separately from the
           # smoke tests in the identity-monitor repo
           # https://github.com/18F/identity-monitor/blob/master/.circleci/config.yml
           cron: "10 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - smoketest-int
+
+  # STAGING
+  smoketest-staging-workflow:
+    triggers:
+      - schedule:
+          # This test is run on the 20th minute of the hour, staggered separately from the
+          # smoke tests in the identity-monitor repo
+          # https://github.com/18F/identity-monitor/blob/master/.circleci/config.yml
+          cron: "20 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,8 @@ commands:
               git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
             git reset --hard "$DEPLOYED_SHA"
+
+            ls -al
 jobs:
   build:
     executor: ruby_browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ commands:
             - ~/.cache/yarn
 
   # Custom version of "checkout" that checks out a SHA deployed to DEPLOY_URL env
+  # Adapter from https://gist.github.com/drazisil/e97dc21454120251472154de1c1b1c7b
   checkout-deployed-sha:
     parameters:
       sha_url:
@@ -61,9 +62,14 @@ commands:
           command: |
             DEPLOYED_SHA=$(curl --silent << parameters.sha_url >> | jq -r '.git_sha')
 
+            echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
             echo "CIRCLE_REPOSITORY_URL: $CIRCLE_REPOSITORY_URL"
+
+            # Use HTTPS to check out, since we don't need to authenticate
+            CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
+            echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"
 
             # Workaround old docker images with incorrect $HOME
             # check https://github.com/docker/docker/issues/2968 for details
@@ -72,18 +78,16 @@ commands:
               export HOME=$(getent passwd $(id -un) | cut -d: -f6)
             fi
 
-            # Use HTTPS to check out, since we don't need to authenticate
-            git config --global url."https://github.com".insteadOf "ssh://git@github.com" || true
             git config --global gc.auto 0 || true
 
             if [ -e /home/circleci/project/.git ]
             then
               cd /home/circleci/project
-              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL_AS_HTTPS" || true
             else
               mkdir -p /home/circleci/project
               cd /home/circleci/project
-              git clone "$CIRCLE_REPOSITORY_URL" .
+              git clone "$CIRCLE_REPOSITORY_URL_AS_HTTPS" .
             fi
 
             if [ -n "$CIRCLE_TAG" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ workflows:
   # temporary to test the custom checkout code
   custom_int_build:
     jobs:
-      smoketest-int
+      - smoketest-int
 
   # INT
   smoketest-int-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,8 @@ jobs:
       - run:
           name: "Smoke tests"
           command: |
+            ls -al bin
+            ls -al bin/smoke_test
             bin/smoke_test --remote --no-source-env
   smoketest-staging:
     working_directory: ~/identity-idp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,8 @@ jobs:
       - bundle-yarn-install
       - run:
           name: "Smoke tests"
-          command: "./bin/smoke_test --remote --no-source-env"
+          command: |
+            ./bin/smoke_test --remote --no-source-env
   smoketest-staging:
     executor: ruby_browsers
     environment:
@@ -219,7 +220,8 @@ jobs:
       - bundle-yarn-install
       - run:
           name: "Smoke tests"
-          command: "./bin/smoke_test --remote --no-source-env"
+          command: |
+            ./bin/smoke_test --remote --no-source-env
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,6 @@ commands:
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
-            echo "CIRCLE_REPOSITORY_URL: $CIRCLE_REPOSITORY_URL"
-
             # Use HTTPS to check out, since we don't need to authenticate
             CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
             echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"
@@ -211,7 +209,7 @@ jobs:
       - bundle-yarn-install
       - run:
           name: "Smoke tests"
-          command: "bin/smoke_test --remote --no-source-env"
+          command: "./bin/smoke_test --remote --no-source-env"
   smoketest-staging:
     executor: ruby_browsers
     environment:
@@ -221,7 +219,7 @@ jobs:
       - bundle-yarn-install
       - run:
           name: "Smoke tests"
-          command: "bin/smoke_test --remote --no-source-env"
+          command: "./bin/smoke_test --remote --no-source-env"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,8 +215,7 @@ jobs:
       - run:
           name: "Smoke tests"
           command: |
-            ls -al bin
-            ls -al bin/smoke_test
+            head -n 3 bin/smoke_test
             bin/smoke_test --remote --no-source-env
   smoketest-staging:
     working_directory: ~/identity-idp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,6 @@ commands:
             echo "URL: << parameters.sha_url >>"
             echo "SHA: $DEPLOYED_SHA"
 
-            pwd
-
             # Use HTTPS to check out, since we don't need to authenticate
             CIRCLE_REPOSITORY_URL_AS_HTTPS=$(echo $CIRCLE_REPOSITORY_URL | sed 's/git@github.com:/https:\/\/github.com\//g')
             echo "REPO: $CIRCLE_REPOSITORY_URL_AS_HTTPS"
@@ -99,9 +97,6 @@ commands:
               git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
             git reset --hard "$DEPLOYED_SHA"
-
-            pwd
-            ls -al
 jobs:
   build:
     executor: ruby_browsers

--- a/bin/smoke_test
+++ b/bin/smoke_test
@@ -1,4 +1,5 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash
+set -euo pipefail
 
 params=""
 spec_helper="rails_helper"

--- a/bin/smoke_test
+++ b/bin/smoke_test
@@ -1,4 +1,4 @@
-#!/bin/bash -euo pipefail
+#!/bin/bash -eo pipefail
 
 params=""
 spec_helper="rails_helper"


### PR DESCRIPTION
Since we don't have a `stages/int` branch that gets updated on deploys to int, we need to get creative. This curls the `deploy.json` and attempts to check out the code at that revision

That way, we can run int's tests against int
