### PR TITLE
Smoke Tests: Custom Slack Notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       # Temporary failure to test slack notification
-      - run: exit 0
+      - run: exit 1
       - notify-slack-smoke-test-status
       - bundle-yarn-install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 
 orbs:
   jq: circleci/jq@2.2.0
+  slack: circleci/slack@3.4.2
 executors:
   # Common container definition used by all jobs
   ruby_browsers:
@@ -97,6 +98,13 @@ commands:
               git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
             git reset --hard "$DEPLOYED_SHA"
+
+  notify-slack-smoke-test-status:
+    steps:
+      - slack/status:
+          fail_only: true
+          failure_message: ":smokeybear::red_circle: Smoke tests failed in environment: $MONITOR_ENV"
+
 jobs:
   build:
     executor: ruby_browsers
@@ -214,6 +222,7 @@ jobs:
           name: "Smoke tests"
           command: |
             bin/smoke_test --remote --no-source-env
+      - notify-slack-smoke-test-status
   smoketest-int:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -228,6 +237,7 @@ jobs:
           name: "Smoke tests"
           command: |
             bin/smoke_test --remote --no-source-env
+      - notify-slack-smoke-test-status
   smoketest-staging:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -240,6 +250,7 @@ jobs:
           name: "Smoke tests"
           command: |
             bin/smoke_test --remote --no-source-env
+      - notify-slack-smoke-test-status
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,9 @@ jobs:
 
     steps:
       - checkout
+      # Temporary failure to test slack notification
+      - run: exit 0
+      - notify-slack-smoke-test-status
       - bundle-yarn-install
       - run:
           name: Install AWS CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,8 +112,9 @@ jobs:
     environment:
       CC_TEST_REPORTER_ID: faecd27e9aed532634b3f4d3e251542d7de9457cfca96a94208a63270ef9b42e
       COVERAGE: true
+      MONITOR_ENV: FAKE_ENV_TO_TEST_ALERT
 
-    parallelism: 4
+    parallelism: 1
 
     working_directory: ~/identity-idp
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ commands:
       - slack/status:
           fail_only: true
           failure_message: ":smokeybear::red_circle: Smoke tests failed in environment: $MONITOR_ENV"
+          include_project_field: false
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,17 +112,13 @@ jobs:
     environment:
       CC_TEST_REPORTER_ID: faecd27e9aed532634b3f4d3e251542d7de9457cfca96a94208a63270ef9b42e
       COVERAGE: true
-      MONITOR_ENV: FAKE_ENV_TO_TEST_ALERT
 
-    parallelism: 1
+    parallelism: 4
 
     working_directory: ~/identity-idp
 
     steps:
       - checkout
-      # Temporary failure to test slack notification
-      - run: exit 1
-      - notify-slack-smoke-test-status
       - bundle-yarn-install
       - run:
           name: Install AWS CLI


### PR DESCRIPTION
The default Slack notification config for CircleCI is for all branches/all builds, but I think we only really want smoke test failures

Also adds a temporary failure on the branch builds to test it out