### PR TITLE
Add a test controller that let's us see outbound SMS and voice calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ If you would like to see the Spanish translations on a particular page, add
 Currently, you'll need to add `?locale=es` to each URL manually. We are working
 on a more robust and user-friendly way to switch between locales.
 
+To see outbound SMS messages and phone calls, visit `http://localhost:3000/test/telephony`.
+
 ### Running Tests
 
 To run all the tests:

--- a/app/controllers/test/telephony_controller.rb
+++ b/app/controllers/test/telephony_controller.rb
@@ -2,9 +2,18 @@ module Test
   class TelephonyController < ApplicationController
     layout 'card_wide'
 
+    before_action :render_not_found_in_production
+
     def index
       @messages = Telephony::Test::Message.messages.reverse
       @calls = Telephony::Test::Call.calls.reverse
+    end
+
+    private
+
+    def render_not_found_in_production
+      return unless Rails.env.production?
+      render_not_found
     end
   end
 end

--- a/app/controllers/test/telephony_controller.rb
+++ b/app/controllers/test/telephony_controller.rb
@@ -1,0 +1,10 @@
+module Test
+  class TelephonyController < ApplicationController
+    layout 'card_wide'
+
+    def index
+      @messages = Telephony::Test::Message.messages.reverse
+      @calls = Telephony::Test::Call.calls.reverse
+    end
+  end
+end

--- a/app/controllers/test/telephony_controller.rb
+++ b/app/controllers/test/telephony_controller.rb
@@ -9,6 +9,12 @@ module Test
       @calls = Telephony::Test::Call.calls.reverse
     end
 
+    def destroy
+      Telephony::Test::Message.clear_messages
+      Telephony::Test::Call.clear_calls
+      redirect_to test_telephony_url
+    end
+
     private
 
     def render_not_found_in_production

--- a/app/views/test/telephony/index.html.erb
+++ b/app/views/test/telephony/index.html.erb
@@ -1,8 +1,12 @@
-<%= content_for(:meta_refresh) { '5' } %>
+<%= content_for(:meta_refresh) { '15' } %>
 
-<div class='grid-row grid-gap'>
+<h1>Outbound calls and messages</h1>
+
+<%= button_to 'Clear messages and calls', test_telephony_path, method: :delete, class: 'usa-button' %>
+
+<div class='grid-row grid-gap margin-top-2'>
   <div class='desktop:grid-col-6'>
-    <h1>Messages</h1>
+    <h2>Messages</h2>
 
     <% @messages.each do |message| %>
       <div class='lg-card margin-bottom-4'>
@@ -20,7 +24,7 @@
   </div>
 
   <div class='desktop:grid-col-6'>
-    <h1>Calls</h1>
+    <h2>Calls</h2>
 
     <% @calls.each do |call| %>
       <div class='lg-card margin-bottom-4'>

--- a/app/views/test/telephony/index.html.erb
+++ b/app/views/test/telephony/index.html.erb
@@ -1,0 +1,39 @@
+<%= content_for(:meta_refresh) { '5' } %>
+
+<div class='grid-row grid-gap'>
+  <div class='desktop:grid-col-6'>
+    <h1>Messages</h1>
+
+    <% @messages.each do |message| %>
+      <div class='lg-card margin-bottom-4'>
+        <p class='margin-y-05'>
+          <strong>To:</strong> <%= message.to %>
+        </p>
+        <p class='margin-y-05'>
+          <strong>Body:</strong> <%= message.body %>
+        </p>
+        <p class='margin-y-05'>
+          <strong>Sent at:</strong> <%= message.sent_at.strftime(t('time.formats.event_timestamp')) %>
+        </p>
+      </div>
+    <% end %>
+  </div>
+
+  <div class='desktop:grid-col-6'>
+    <h1>Calls</h1>
+
+    <% @calls.each do |call| %>
+      <div class='lg-card margin-bottom-4'>
+        <p class='margin-y-05'>
+          <strong>To:</strong> <%= call.to %>
+        </p>
+        <p class='margin-y-05'>
+          <strong>Body:</strong> <%= call.body %>
+        </p>
+        <p class='margin-y-05'>
+          <strong>Sent at:</strong> <%= call.sent_at.strftime(t('time.formats.event_timestamp')) %>
+        </p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
         get '/oidc' => 'oidc_test#index'
 
         get '/telephony' => 'telephony#index'
+        delete '/telephony' => 'telephony#destroy'
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,8 @@ Rails.application.routes.draw do
         post '/piv_cac_entry' => 'piv_cac_authentication_test_subject#create'
 
         get '/oidc' => 'oidc_test#index'
+
+        get '/telephony' => 'telephony#index'
       end
     end
 

--- a/spec/controllers/test/telephony_controller_spec.rb
+++ b/spec/controllers/test/telephony_controller_spec.rb
@@ -33,4 +33,27 @@ describe Test::TelephonyController do
       expect(response.status).to eq(404)
     end
   end
+
+  describe '#destroy' do
+    it 'clears messages and calls and redirects to index' do
+      Telephony.send_authentication_otp(
+        to: '(555) 555-5000',
+        otp: '123456',
+        expiration: 10,
+        channel: :sms,
+      )
+      Telephony.send_authentication_otp(
+        to: '(555) 555-5000',
+        otp: '654321',
+        expiration: 10,
+        channel: :voice,
+      )
+
+      delete :destroy
+
+      expect(Telephony::Test::Message.messages.length).to eq(0)
+      expect(Telephony::Test::Call.calls.length).to eq(0)
+      expect(response).to redirect_to(test_telephony_url)
+    end
+  end
 end

--- a/spec/controllers/test/telephony_controller_spec.rb
+++ b/spec/controllers/test/telephony_controller_spec.rb
@@ -24,5 +24,13 @@ describe Test::TelephonyController do
       expect(assigns(:calls).length).to eq(1)
       expect(assigns(:calls).first.body).to include('6, 5, 4, 3, 2, 1')
     end
+
+    it '404s in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      get :index
+
+      expect(response.status).to eq(404)
+    end
   end
 end

--- a/spec/controllers/test/telephony_controller_spec.rb
+++ b/spec/controllers/test/telephony_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe Test::TelephonyController do
+  describe '#index' do
+    it 'sets @messages and @calls and renders' do
+      Telephony.send_authentication_otp(
+        to: '(555) 555-5000',
+        otp: '123456',
+        expiration: 10,
+        channel: :sms,
+      )
+      Telephony.send_authentication_otp(
+        to: '(555) 555-5000',
+        otp: '654321',
+        expiration: 10,
+        channel: :voice,
+      )
+
+      get :index
+
+      expect(assigns(:messages).length).to eq(1)
+      expect(assigns(:messages).first.body).to include('123456')
+
+      expect(assigns(:calls).length).to eq(1)
+      expect(assigns(:calls).first.body).to include('6, 5, 4, 3, 2, 1')
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that we can look there to see the content of alerts we send instead of adding logging statements to the code.

Inspired by a question from @amathews-fs

Here is what it looks like:
![image](https://user-images.githubusercontent.com/963654/87178587-5cc79000-c2ab-11ea-9abe-5a1eb0c2c59e.png)
