### PR TITLE
LG-3175: Create localization utilities for React components

### DIFF
--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -45,7 +45,8 @@ window.LoginGov = window.LoginGov || {};
   'zxcvbn.feedback.this_is_a_very_common_password',
   'zxcvbn.feedback.this_is_similar_to_a_commonly_used_password',
   'zxcvbn.feedback.for_a_stronger_password_use_a_few_words_separated_by_spaces_but_avoid_common_phrases',
-  'zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns'
+  'zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns',
+  'doc_auth.headings.welcome'
 ] %>
 
 window.LoginGov.I18n = {

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,5 +1,9 @@
+import useI18n from '../hooks/use-i18n';
+
 function DocumentCapture() {
-  return 'Document Capture';
+  const t = useI18n();
+
+  return t('doc_auth.headings.welcome');
 }
 
 export default DocumentCapture;

--- a/app/javascript/app/document-capture/context/i18n.js
+++ b/app/javascript/app/document-capture/context/i18n.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const I18nContext = createContext({});
+
+export default I18nContext;

--- a/app/javascript/app/document-capture/hooks/use-i18n.js
+++ b/app/javascript/app/document-capture/hooks/use-i18n.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import I18nContext from '../context/i18n';
+
+function useI18n() {
+  const strings = useContext(I18nContext);
+  const t = (key) => (
+    Object.prototype.hasOwnProperty.call(strings, key) ? strings[key] : key
+  );
+  return t;
+}
+
+export default useI18n;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { render } from 'react-dom';
 import DocumentCapture from '../app/document-capture/components/document-capture';
+import I18nContext from '../app/document-capture/context/i18n';
+
+const { I18n: i18n } = window.LoginGov;
 
 const appRoot = document.getElementById('document-capture-form');
 appRoot.innerHTML = '';
 render(
-  <DocumentCapture />,
+  <I18nContext.Provider value={i18n.strings[i18n.currentLocale()]}>
+    <DocumentCapture />
+  </I18nContext.Provider>,
   appRoot,
 );

--- a/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
@@ -9,7 +9,7 @@ describe('document-capture/components/document-capture', () => {
   it('renders', () => {
     const { getByText } = render(<DocumentCapture />);
 
-    const button = getByText('Document Capture');
+    const button = getByText('doc_auth.headings.welcome');
 
     expect(button).to.be.ok();
   });

--- a/spec/javascripts/app/document-capture/context/i18n-spec.jsx
+++ b/spec/javascripts/app/document-capture/context/i18n-spec.jsx
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { render } from '@testing-library/react';
+import I18nContext from '../../../../../app/javascript/app/document-capture/context/i18n';
+import { useDOM } from '../../../support/dom';
+
+describe('document-capture/context/i18n', () => {
+  useDOM();
+
+  const ContextValue = () => JSON.stringify(useContext(I18nContext));
+
+  it('defaults to empty object', () => {
+    const { container } = render(<ContextValue />);
+
+    expect(container.textContent).to.equal('{}');
+  });
+});

--- a/spec/javascripts/app/document-capture/hooks/use-i18n-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-i18n-spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import I18nContext from '../../../../../app/javascript/app/document-capture/context/i18n';
+import useI18n from '../../../../../app/javascript/app/document-capture/hooks/use-i18n';
+import { useDOM } from '../../../support/dom';
+
+describe('document-capture/hooks/use-i18n', () => {
+  useDOM();
+
+  const LocalizedString = ({ stringKey }) => useI18n()(stringKey);
+
+  it('returns localized key value', () => {
+    const { container } = render(
+      <I18nContext.Provider value={{ sample: 'translation' }}>
+        <LocalizedString stringKey="sample" />
+      </I18nContext.Provider>,
+    );
+
+    expect(container.textContent).to.equal('translation');
+  });
+
+  it('falls back to key value', () => {
+    const { container } = render(<LocalizedString stringKey="sample" />);
+
+    expect(container.textContent).to.equal('sample');
+  });
+});


### PR DESCRIPTION
**Why**: As a user, I want pages that I'm viewing to be localized to my language, including those page which use React.

This pull request adds simple localization utilities for React components. It is implemented using [React context](https://reactjs.org/docs/context.html) to establish localization data at the root of the application. A custom [React hook](https://reactjs.org/docs/hooks-intro.html) is included for the purpose of simplifying usage, modeled after existing `LoginGov.I18n.t` and server-side `t` [Rails internationalization](https://guides.rubyonrails.org/i18n.html).

Making this data available via context should hopefully facilitate better unit testing, since it doesn't require mocking of `window` globals, but instead allows for any (or no) simple JavaScript object to be provided as localization data. The current implementation of the translation utility will return the given key if there is no localized data. While this is not appropriate for the front-end user experience, it could be a fine compromise for tests to be able to find elements by a given string key.

The alternative would be to find some way to make the localization data available to the tests. This would have the advantage of bringing tests closer to a "real" user experience of testing components by text visible in the page, but would require additional test bootstrapping logic. The logic would likely involve either loading all YAML files from `config/locales` as a plain JavaScript object, or as a prerequisite build artifact generated by Rails (see also: [`i18n-js` export](https://github.com/fnando/i18n-js#export-configuration-for-translations), [`react_on_rails` I18n](https://github.com/shakacode/react_on_rails/blob/master/docs/basics/i18n.md)).