### PR TITLE
Change the content the sign in specs look for on the consent screen

### DIFF
--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
       visit_idp_from_saml_sp
       sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
 
-      if on_consent_screen?
-        click_on 'Agree and continue'
-      end
+      click_on 'Agree and continue' if on_consent_screen?
 
       if monitor.remote?
         expect(page).to have_content('SAML Sinatra Example')

--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
       visit_idp_from_oidc_sp
       sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
 
-      if page.has_content?('You are now signing in for the first time')
+      if on_consent_screen?
         click_on 'Agree and continue'
       end
 
@@ -38,7 +38,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
       visit_idp_from_saml_sp
       sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
 
-      if page.has_content?('You are now signing in for the first time')
+      if on_consent_screen?
         click_on 'Agree and continue'
       end
 
@@ -53,5 +53,10 @@ RSpec.describe 'smoke test: SP initiated sign in' do
 
       log_out_from_saml_sp
     end
+  end
+
+  def on_consent_screen?
+    page.has_content?("It's been a year since you gave us consent") ||
+      page.has_content?('You are now signing in for the first time')
   end
 end

--- a/spec/features/monitor/sp_signin_spec.rb
+++ b/spec/features/monitor/sp_signin_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe 'smoke test: SP initiated sign in' do
       visit_idp_from_oidc_sp
       sign_in_and_2fa(monitor.config.login_gov_sign_in_email)
 
-      if on_consent_screen?
-        click_on 'Agree and continue'
-      end
+      click_on 'Agree and continue' if on_consent_screen?
 
       if oidc_sp_is_usajobs?
         expect(page).to have_content('Welcome ')


### PR DESCRIPTION
**Why**: The consent screen can show up on the first time the tests are run or if consent has expired. Previously we were just checking after the first sign in.