### PR TITLE
LG-3053 Exempt NameIDPolicy in SAML AuthnRequest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: eaae3d28294cf79023eee1257ce2c9a0b3e29f62
+  revision: d36270634b8157e6cd73f0c0eefe25a052f24c75
   branch: master
   specs:
     saml_idp (0.9.0.pre.18f)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 8d0bedcd71b025617c0ab094bbc6a7982d9df1cd
+  revision: eaae3d28294cf79023eee1257ce2c9a0b3e29f62
   branch: master
   specs:
     saml_idp (0.9.0.pre.18f)

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -33,8 +33,8 @@ module SamlIdpAuthConcern
   end
 
   def default_name_id_format
-    return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL_CLASSREF if sp_uses_email_nameid_format?
-    Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT_CLASSREF
+    return Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL if sp_uses_email_nameid_format?
+    Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
   end
 
   def sp_uses_email_nameid_format?

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -89,6 +89,7 @@ module SamlIdpAuthConcern
     AttributeAsserter.new(
       user: principal,
       service_provider: current_service_provider,
+      name_id_format: name_id_format,
       authn_request: saml_request,
       decrypted_pii: decrypted_pii,
     )
@@ -107,6 +108,7 @@ module SamlIdpAuthConcern
   def saml_response
     encode_response(
       current_user,
+      name_id_format: name_id_format,
       authn_context_classref: requested_authn_context,
       reference_id: active_identity.session_uuid,
       encryption: current_service_provider.encryption_opts,

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -16,9 +16,10 @@ class AttributeAsserter
     phone
   ].freeze
 
-  def initialize(user:, service_provider:, authn_request:, decrypted_pii:)
+  def initialize(user:, service_provider:, name_id_format:, authn_request:, decrypted_pii:)
     self.user = user
     self.service_provider = service_provider
+    self.name_id_format = name_id_format
     self.authn_request = authn_request
     self.decrypted_pii = decrypted_pii
   end
@@ -35,7 +36,7 @@ class AttributeAsserter
 
   private
 
-  attr_accessor :user, :service_provider, :authn_request, :decrypted_pii
+  attr_accessor :user, :service_provider, :name_id_format, :authn_request, :decrypted_pii
 
   def ial_context
     @ial_context ||= IalContext.new(ial: authn_context, service_provider: service_provider)

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -47,7 +47,10 @@ class SamlRequestValidator
   end
 
   def email_nameid_format?
-    nameid_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'
+    [
+      'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
+    ].include?(nameid_format)
   end
 
   def service_provider_allowed_to_use_email_nameid_format?

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -5,8 +5,6 @@ class SamlRequestValidator
   validate :authorized_authn_context
   validate :authorized_email_nameid_format
 
-  ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').freeze
-
   def call(service_provider:, authn_context:, nameid_format:)
     self.service_provider = service_provider
     self.authn_context = authn_context
@@ -52,6 +50,6 @@ class SamlRequestValidator
   end
 
   def service_provider_allowed_to_use_email_nameid_format?
-    ISSUERS_WITH_EMAIL_NAMEID_FORMAT.include?(service_provider.issuer)
+    Saml::Idp::Constants::ISSUERS_WITH_EMAIL_NAMEID_FORMAT.include?(service_provider.issuer)
   end
 end

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -19,6 +19,7 @@ class SamlRequestValidator
 
   def extra_analytics_attributes
     {
+      nameid_format: nameid_format,
       authn_context: authn_context,
       service_provider: service_provider.issuer,
     }
@@ -46,7 +47,7 @@ class SamlRequestValidator
   end
 
   def email_nameid_format?
-    nameid_format == 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+    nameid_format == 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'
   end
 
   def service_provider_allowed_to_use_email_nameid_format?

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -14,7 +14,7 @@ module Saml
       AAL3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/3'.freeze
 
       ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').
-                                               freeze
+                                         freeze
       NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'.freeze
       NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'.freeze
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -13,6 +13,10 @@ module Saml
       AAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/2'.freeze
       AAL3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/3'.freeze
 
+      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').freeze
+      NAME_ID_FORMAT_PERSISTENT_CLASSREF = 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'.freeze
+      NAME_ID_FORMAT_EMAIL_CLASSREF = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
+
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
       VALID_AUTHN_CONTEXTS = JSON.parse(Figaro.env.valid_authn_contexts).freeze

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -13,9 +13,10 @@ module Saml
       AAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/2'.freeze
       AAL3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/3'.freeze
 
-      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').freeze
-      NAME_ID_FORMAT_PERSISTENT_CLASSREF = 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'.freeze
-      NAME_ID_FORMAT_EMAIL_CLASSREF = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
+      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',')
+                                               .freeze
+      NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'.freeze
+      NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -13,10 +13,10 @@ module Saml
       AAL2_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/2'.freeze
       AAL3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/aal/3'.freeze
 
-      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',')
-                                               .freeze
-      NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'.freeze
-      NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'.freeze
+      ISSUERS_WITH_EMAIL_NAMEID_FORMAT = Figaro.env.issuers_with_email_nameid_format.split(',').
+                                               freeze
+      NAME_ID_FORMAT_PERSISTENT = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'.freeze
+      NAME_ID_FORMAT_EMAIL = 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'.freeze
 
       REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -123,6 +123,7 @@ describe SamlIdpController do
           user: user,
           service_provider: ServiceProvider.from_issuer(ial2_saml_settings.issuer),
           authn_request: this_authn_request,
+          name_id_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           decrypted_pii: pii,
         )
       end
@@ -418,7 +419,7 @@ describe SamlIdpController do
 
           it 'has a format attribute defining the NameID to be email' do
             expect(name_id.attributes['Format'].value).
-              to eq('urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress')
+              to eq('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress')
           end
 
           it 'has NameID value of the email address of the user making the AuthN Request' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -201,6 +201,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { authn_context: [t('errors.messages.unauthorized_authn_context')] },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
           service_provider: 'http://localhost:3000',
         }
@@ -226,6 +227,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: true,
           errors: {},
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           idv: false,
@@ -253,6 +255,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { service_provider: [t('errors.messages.unauthorized_service_provider')] },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'invalid_provider',
         }
@@ -282,6 +285,7 @@ describe SamlIdpController do
             service_provider: [t('errors.messages.unauthorized_service_provider')],
             authn_context: [t('errors.messages.unauthorized_authn_context')],
           },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: 'http://idmanagement.gov/ns/assurance/loa/5',
           service_provider: 'invalid_provider',
         }
@@ -414,7 +418,7 @@ describe SamlIdpController do
 
           it 'has a format attribute defining the NameID to be email' do
             expect(name_id.attributes['Format'].value).
-              to eq('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress')
+              to eq('urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress')
           end
 
           it 'has NameID value of the email address of the user making the AuthN Request' do
@@ -423,6 +427,34 @@ describe SamlIdpController do
         end
       end
     end
+
+    # context 'nameid_format is missing' do
+    #   it 'defaults to persistant' do
+    #     stub_analytics
+    #     allow(@analytics).to receive(:track_event)
+    #
+    #     user = create(:user, :signed_up)
+    #     auth_settings = missing_nameid_format_saml_settings
+    #     IdentityLinker.new(user, auth_settings.issuer).link_identity
+    #     user.identities.last.update!(verified_attributes: ['email'])
+    #     generate_saml_response(user, auth_settings)
+    #
+    #     expect(response.status).to eq(200)
+    #
+    #     analytics_hash = {
+    #       success: true,
+    #       errors: {},
+    #       nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+    #       authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+    #       service_provider: 'http://localhost:3000',
+    #       idv: false,
+    #       finish_profile: false,
+    #     }
+    #
+    #     expect(@analytics).to have_received(:track_event).
+    #       with(Analytics::SAML_AUTH, analytics_hash)
+    #   end
+    # end
 
     context 'service provider uses email NameID format but is not allowed to use email' do
       it 'returns an error' do
@@ -438,6 +470,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: false,
           errors: { nameid_format: [t('errors.messages.unauthorized_nameid_format')] },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL,
           authn_context: 'http://idmanagement.gov/ns/assurance/ial/1',
           service_provider: 'http://localhost:3000',
         }
@@ -892,6 +925,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: true,
           errors: {},
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           idv: true,
@@ -926,6 +960,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: true,
           errors: {},
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           idv: false,
@@ -950,6 +985,7 @@ describe SamlIdpController do
         analytics_hash = {
           success: true,
           errors: {},
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           authn_context: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
           service_provider: 'http://localhost:3000',
           idv: false,

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -12,6 +12,7 @@ describe AttributeAsserter do
       session_uuid: SecureRandom.uuid,
     )
   end
+  let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT }
   let(:service_provider_ial) { 2 }
   let(:service_provider) do
     instance_double(
@@ -37,6 +38,7 @@ describe AttributeAsserter do
       let(:subject) do
         described_class.new(
           user: user,
+          name_id_format: name_id_format,
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
@@ -141,6 +143,7 @@ describe AttributeAsserter do
       let(:subject) do
         described_class.new(
           user: user,
+          name_id_format: name_id_format,
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,
@@ -279,6 +282,7 @@ describe AttributeAsserter do
       let(:subject) do
         described_class.new(
           user: ial1_user,
+          name_id_format: name_id_format,
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
@@ -292,6 +296,7 @@ describe AttributeAsserter do
       let(:subject) do
         described_class.new(
           user: ial1_user,
+          name_id_format: name_id_format,
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -1,21 +1,24 @@
 require 'rails_helper'
 
 describe SamlRequestValidator do
+
   describe '#call' do
-    context 'valid authentication context and service provider' do
+    context 'valid authn context and sp and authorized nameID format' do
       it 'returns FormResponse with success: true' do
         sp = ServiceProvider.from_issuer('http://localhost:3000')
         authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
 
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -23,14 +26,16 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'valid authentication context and invalid service provider' do
+    context 'valid authn context and invalid sp and authorized nameID format' do
       it 'returns FormResponse with success: false' do
         sp = ServiceProvider.from_issuer('foo')
         authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
         errors = {
           service_provider: [t('errors.messages.unauthorized_service_provider')],
@@ -39,7 +44,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -47,14 +52,16 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'valid authentication context and unauthorized nameid format' do
+    context 'valid authn context and unauthorized nameid format' do
       it 'returns FormResponse with success: false' do
         sp = ServiceProvider.from_issuer('http://localhost:3000')
         authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
         errors = {
           nameid_format: [t('errors.messages.unauthorized_nameid_format')],
@@ -63,7 +70,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -71,20 +78,22 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'valid authentication context and authorized nameid format for SP' do
+    context 'valid authn context and authorized email nameid format for SP' do
       it 'returns FormResponse with success: true' do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')
         authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
 
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -95,16 +104,18 @@ describe SamlRequestValidator do
         sp = ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata')
         sp.ial = 2
         authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
 
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -112,14 +123,16 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'invalid authentication context and valid service provider' do
+    context 'invalid authn context and valid sp and authorized nameID format' do
       it 'returns FormResponse with success: false for unknown authn context' do
         sp = ServiceProvider.from_issuer('http://localhost:3000')
         authn_context = 'IAL1'
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -128,7 +141,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -139,10 +152,12 @@ describe SamlRequestValidator do
         sp = ServiceProvider.from_issuer('http://localhost:3000')
         sp.ial = 1
         authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -151,7 +166,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).
@@ -159,14 +174,16 @@ describe SamlRequestValidator do
       end
     end
 
-    context 'invalid authentication context and invalid service provider' do
+    context 'invalid authn context and invalid sp and authorized nameID format' do
       it 'returns FormResponse with success: false' do
         sp = ServiceProvider.from_issuer('foo')
         authn_context = 'IAL1'
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
         allow(FormResponse).to receive(:new)
         extra = {
           authn_context: authn_context,
           service_provider: sp.issuer,
+          nameid_format: name_id_format,
         }
         errors = {
           authn_context: [t('errors.messages.unauthorized_authn_context')],
@@ -176,7 +193,33 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          nameid_format: name_id_format,
+        )
+
+        expect(FormResponse).to have_received(:new).
+          with(success: false, errors: errors, extra: extra)
+      end
+    end
+
+    context 'valid authn context and sp and unauthorized nameID format' do
+      it 'returns FormResponse with success: true' do
+        sp = ServiceProvider.from_issuer('http://localhost:3000')
+        authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+        name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
+        allow(FormResponse).to receive(:new)
+        extra = {
+          authn_context: authn_context,
+          service_provider: sp.issuer,
+          nameid_format: name_id_format,
+        }
+        errors = {
+          nameid_format: [t('errors.messages.unauthorized_nameid_format')],
+        }
+
+        SamlRequestValidator.new.call(
+          service_provider: sp,
+          authn_context: authn_context,
+          nameid_format: name_id_format,
         )
 
         expect(FormResponse).to have_received(:new).

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe SamlRequestValidator do
-
   describe '#call' do
     context 'valid authn context and sp and authorized nameID format' do
       it 'returns FormResponse with success: true' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -201,7 +201,7 @@ describe SamlRequestValidator do
     end
 
     context 'valid authn context and sp and unauthorized nameID format' do
-      it 'returns FormResponse with success: true' do
+      it 'returns FormResponse with success: false with unauthorized nameid format' do
         sp = ServiceProvider.from_issuer('http://localhost:3000')
         authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
         name_id_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -63,7 +63,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -84,7 +84,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
         )
 
         expect(FormResponse).to have_received(:new).
@@ -104,7 +104,7 @@ describe SamlRequestValidator do
         SamlRequestValidator.new.call(
           service_provider: sp,
           authn_context: authn_context,
-          nameid_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
         )
 
         expect(FormResponse).to have_received(:new).

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -11,6 +11,7 @@ module SamlAuthHelper
     settings.certificate = saml_test_sp_cert
     settings.private_key = saml_test_sp_key
     settings.authn_context = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT
 
     # SP + IdP Settings
     settings.issuer = 'http://localhost:3000'
@@ -19,7 +20,6 @@ module SamlAuthHelper
     settings.security[:embed_sign] = true
     settings.security[:digest_method] = 'http://www.w3.org/2001/04/xmlenc#sha256'
     settings.security[:signature_method] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-    settings.name_identifier_format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
     settings.double_quote_xml_attribute_values = true
     # IdP setting
     settings.idp_sso_target_url = "http://#{Figaro.env.domain_name}/api/saml/auth2019"
@@ -121,7 +121,7 @@ module SamlAuthHelper
 
   def email_nameid_saml_settings_for_allowed_issuer
     settings = saml_settings.dup
-    settings.name_identifier_format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
     settings
   end
@@ -141,12 +141,13 @@ module SamlAuthHelper
 
   def email_nameid_saml_settings_for_disallowed_issuer
     settings = saml_settings.dup
-    settings.name_identifier_format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     settings
   end
 
   def ial2_saml_settings
     settings = sp1_saml_settings.dup
+    settings.name_identifier_format = Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL
     settings.authn_context = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     settings
   end

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -126,6 +126,19 @@ module SamlAuthHelper
     settings
   end
 
+  def missing_nameid_format_saml_settings_for_allowed_email_issuer
+    settings = saml_settings.dup
+    settings.name_identifier_format = nil
+    settings.issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
+    settings
+  end
+
+  def missing_nameid_format_saml_settings
+    settings = saml_settings.dup
+    settings.name_identifier_format = nil
+    settings
+  end
+
   def email_nameid_saml_settings_for_disallowed_issuer
     settings = saml_settings.dup
     settings.name_identifier_format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'


### PR DESCRIPTION
WHY
As a partner trying to integrate with Login.gov using SAML, I do not want NameIDPolicy to be required in the AuthnRequest, so that I can use the default XML that Salseforce and other CRMs spit out without customization. 

1. NameIDPolicy is no longer required in the AuthnRequest
2. When NameIDPolicy is not specified, then default to urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
3. When NameIDPolicy is not specified and sp is added to issuers_with_email_nameid_format,  then default to urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress

This relates to:
https://github.com/18F/saml_idp/pull/31