### PR TITLE
Configure ESLint to check JSX files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -58,6 +58,10 @@ plugins:
     - 'lib/rspec/formatters/user_flow_formatter.rb'
   eslint:
     enabled: true
+    config:
+      extensions:
+        - .js
+        - .jsx
   fixme:
     enabled: true
     exclude_patterns:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	@echo "--- fasterer ---"
 	bundle exec fasterer
 	@echo "--- eslint ---"
-	node_modules/.bin/eslint app spec
+	yarn run lint
 
 lintfix:
 	@echo "--- rubocop fix ---"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": "6.x.x"
   },
   "scripts": {
+    "lint": "eslint app spec --ext .js,.jsx",
     "test": "NODE_ENV=test `npm bin`/mocha --require @babel/register --extension 'js,jsx' --require spec/javascripts/spec_helper.js 'spec/javascripts/**/**spec.js?(x)'",
     "build": "true"
   },


### PR DESCRIPTION
Related: LG-3023, #3903

By default, both ESLint and CodeClimate will only check files with `.js` file extension. This would prevent legitimate linting errors in `.jsx` files from being flagged. The changes proposed here reconfigure CodeClimate to check `.jsx` files, and introduces a new NPM script for linting, which includes JSX file checking.

**Why**: As a developer, I want linting on my JSX files so that I can be certain of authoring quality code.

Note that with the changes in #3903 to use [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb) instead of [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base), it's expected ESLint should already be configured to handle JSX syntax ([see base config source](https://github.com/airbnb/javascript/blob/c5bee75b1b358a3749f1a6d38ee6fad73de28e29/packages/eslint-config-airbnb/rules/react.js#L11-L15)).

See CodeClimate documentation: https://docs.codeclimate.com/docs/eslint#extensions
See ESLint CLI documentation: https://eslint.org/docs/user-guide/command-line-interface#options