### PR TITLE
Upgrade CodeClimate ESLint engine and resolve errors

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -58,7 +58,7 @@ plugins:
     - 'lib/rspec/formatters/user_flow_formatter.rb'
   eslint:
     enabled: true
-    channel: "eslint-6"
+    channel: eslint-6
     config:
       extensions:
         - .js

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -58,6 +58,7 @@ plugins:
     - 'lib/rspec/formatters/user_flow_formatter.rb'
   eslint:
     enabled: true
+    channel: "eslint-6"
     config:
       extensions:
         - .js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,46 +1,46 @@
 {
-  'extends': 'airbnb',
-  'parser': 'babel-eslint',
-  'env': {
-    'browser': true,
-    'commonjs': true,
-    'es6': true,
-    'mocha': true
+  "extends": "airbnb",
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "mocha": true
   },
-  'globals': {
-    '$': true,
-    '__DEV__': true,
-    'assert': true,
-    'chai': true,
-    'sinon': true,
-    'expect': true,
-    'fixture': true
+  "globals": {
+    "$": true,
+    "__DEV__": true,
+    "assert": true,
+    "chai": true,
+    "sinon": true,
+    "expect": true,
+    "fixture": true
   },
-  'rules': {
-    'jsx-a11y/img-has-alt': 'off',
-    'func-names': 0,
-    'space-before-function-paren': 0,
-    'prefer-arrow-callback': 0,
-    'import/prefer-default-export': 'off',
-    'import/extensions': ['off', 'never'],
-    'no-param-reassign': ['off', 'never'],
+  "rules": {
+    "jsx-a11y/img-has-alt": "off",
+    "func-names": 0,
+    "space-before-function-paren": 0,
+    "prefer-arrow-callback": 0,
+    "import/prefer-default-export": "off",
+    "import/extensions": ["off", "never"],
+    "no-param-reassign": ["off", "never"]
   },
-  'parserOptions': {
-    'ecmaVersion': 6,
-    'sourceType': 'module'
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
-  'settings': {
-    'import/core-modules': [
-      'app/components/index',
-      'app/utils/index',
-      'app/pw-toggle',
-      'app/form-validation',
-      'app/form-field-format',
-      'app/radio-btn',
-      'app/print-personal-key',
-      'app/utils/ms-formatter',
-      'app/phone-internationalization',
-      'app/i18n-dropdown',
-    ],
+  "settings": {
+    "import/core-modules": [
+      "app/components/index",
+      "app/utils/index",
+      "app/pw-toggle",
+      "app/form-validation",
+      "app/form-field-format",
+      "app/radio-btn",
+      "app/print-personal-key",
+      "app/utils/ms-formatter",
+      "app/phone-internationalization",
+      "app/i18n-dropdown"
+    ]
   }
 }

--- a/app/javascript/app/acuant/document_capture_dom.js
+++ b/app/javascript/app/acuant/document_capture_dom.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { documentCaptureFallbackModeEnabled } from './document_capture_fallback';
 
 // Fallback form elements
@@ -16,11 +17,9 @@ export const acuantSdkPreviewImage = () => document.querySelector('#acuant-sdk-p
 export const acuantSdkFallbackText = () => document.querySelector('#acuant-fallback-text');
 export const acuantSdkFallbackLink = () => document.querySelector('#acuant-fallback-link');
 
-export const fetchSdkInitializationCredentials = () =>
-  document.querySelector('meta[name="acuant-sdk-initialization-creds"]').content;
+export const fetchSdkInitializationCredentials = () => document.querySelector('meta[name="acuant-sdk-initialization-creds"]').content;
 
-export const fetchSdkInitializationEndpoint = () =>
-  document.querySelector('meta[name="acuant-sdk-initialization-endpoint"]').content;
+export const fetchSdkInitializationEndpoint = () => document.querySelector('meta[name="acuant-sdk-initialization-endpoint"]').content;
 
 const hideAcuantSdkContainers = () => {
   acuantSdkUploadForm().classList.add('hidden');

--- a/app/javascript/app/acuant/document_capture_fallback.js
+++ b/app/javascript/app/acuant/document_capture_fallback.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import {
   showAcuantSdkFallbackText,
   addClickEventListenerToAcuantFallbackLink,
@@ -9,9 +10,9 @@ export const enableDocumentCaptureFallbackMode = () => {
   acauntDocumentCaptureFallbackEnabled();
 };
 
-export const documentCaptureFallbackModeEnabled = () =>
-  window.isDocumentCaptureFallbackModeEnabled === true;
-
+export const documentCaptureFallbackModeEnabled = () => (
+  window.isDocumentCaptureFallbackModeEnabled === true
+);
 
 export const documentCaptureFallbackLinkClicked = (event) => {
   event.preventDefault();

--- a/app/javascript/app/acuant/selfie_capture.js
+++ b/app/javascript/app/acuant/selfie_capture.js
@@ -1,4 +1,6 @@
-import { acuantSdkPreviewImage, imageDataUrlInput, imageFileInput, showAcuantSdkContainer }
+import {
+  acuantSdkPreviewImage, imageDataUrlInput, imageFileInput, showAcuantSdkContainer,
+}
   from './document_capture_dom';
 
 const {

--- a/app/javascript/app/checkbox.js
+++ b/app/javascript/app/checkbox.js
@@ -22,5 +22,4 @@ function checkbox() {
   }
 }
 
-
 document.addEventListener('DOMContentLoaded', checkbox);

--- a/app/javascript/app/components/focus-trap-proxy.js
+++ b/app/javascript/app/components/focus-trap-proxy.js
@@ -13,7 +13,7 @@ function FocusTrapProxy() {
 
     return {
       activate() {
-        focusables.forEach(trap => trap.deactivate());
+        focusables.forEach((trap) => trap.deactivate());
 
         activated.push(ownTrap);
 
@@ -32,7 +32,7 @@ function FocusTrapProxy() {
           return false;
         }
 
-        activated = activated.filter(activatedTrap => activatedTrap !== ownTrap);
+        activated = activated.filter((activatedTrap) => activatedTrap !== ownTrap);
 
         if (activated.length) {
           activated[activated.length - 1].activate();

--- a/app/javascript/app/components/index.js
+++ b/app/javascript/app/components/index.js
@@ -3,7 +3,7 @@ import modal from './modal';
 import Accordion from './accordion';
 
 window.LoginGov = (window.LoginGov || {});
-const LoginGov = window.LoginGov;
+const { LoginGov } = window;
 const trapModal = modal(focusTrapProxy);
 
 LoginGov.Modal = trapModal;

--- a/app/javascript/app/components/modal.js
+++ b/app/javascript/app/components/modal.js
@@ -45,5 +45,4 @@ function modal(focusTrap) {
   };
 }
 
-
 export default modal;

--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -1,12 +1,12 @@
 import 'classlist.js';
 
-const I18n = window.LoginGov.I18n;
+const { I18n } = window.LoginGov;
 
 document.addEventListener('DOMContentLoaded', () => {
   const forms = document.querySelectorAll('form');
 
   function addListenerMulti(el, events, fn) {
-    events.split(' ').forEach(e => el.addEventListener(e, fn, false));
+    events.split(' ').forEach((e) => el.addEventListener(e, fn, false));
   }
 
   if (forms.length !== 0) {

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const desktopDropdown = document.querySelector('.i18n-desktop-dropdown');
 
   function addListenerMulti(el, s, fn) {
-    s.split(' ').forEach(e => el.addEventListener(e, fn, false));
+    s.split(' ').forEach((e) => el.addEventListener(e, fn, false));
   }
 
   function toggleAriaExpanded(element) {

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -1,6 +1,6 @@
 const INTERNATIONAL_CODE_REGEX = /^\+(\d+) |^1 /;
 
-const I18n = window.LoginGov.I18n;
+const { I18n } = window.LoginGov;
 
 const selectedInternationCodeOption = () => {
   const dropdown = document.querySelector('[data-international-phone-form] .international-code');

--- a/app/javascript/app/pw-toggle.js
+++ b/app/javascript/app/pw-toggle.js
@@ -1,4 +1,4 @@
-const I18n = window.LoginGov.I18n;
+const { I18n } = window.LoginGov;
 
 function togglePw() {
   const inputs = document.querySelectorAll('input[type="password"]');
@@ -26,6 +26,5 @@ function togglePw() {
     });
   }
 }
-
 
 document.addEventListener('DOMContentLoaded', togglePw);

--- a/app/javascript/app/radio-btn.js
+++ b/app/javascript/app/radio-btn.js
@@ -36,5 +36,4 @@ function highlightRadioBtn() {
   }
 }
 
-
 document.addEventListener('DOMContentLoaded', highlightRadioBtn);

--- a/app/javascript/app/utils/events.js
+++ b/app/javascript/app/utils/events.js
@@ -10,7 +10,7 @@ class Events {
 
     const handlersForEvent = this.handlers[eventName] || [];
 
-    if (!handlersForEvent.filter(obj => obj.handler === handler).length) {
+    if (!handlersForEvent.filter((obj) => obj.handler === handler).length) {
       handlersForEvent.push({ handler, context });
     }
 
@@ -26,7 +26,7 @@ class Events {
       this.handlers[eventName].length = 0;
     } else {
       const handlers = this.handlers[eventName] || [];
-      this.handlers[eventName] = handlers.filter(obj => obj.handler !== handler);
+      this.handlers[eventName] = handlers.filter((obj) => obj.handler !== handler);
     }
   }
 

--- a/app/javascript/app/utils/index.js
+++ b/app/javascript/app/utils/index.js
@@ -4,8 +4,8 @@ import msFormatter from './ms-formatter';
 import enableBannerToggling from './toggle-banner';
 
 window.LoginGov = (window.LoginGov || {});
-const LoginGov = window.LoginGov;
-const documentElement = window.document.documentElement;
+const { LoginGov } = window;
+const { documentElement } = window.document;
 
 documentElement.className = documentElement.className.replace(/no-js/, '');
 

--- a/app/javascript/app/webauthn.js
+++ b/app/javascript/app/webauthn.js
@@ -1,15 +1,15 @@
 const base64ToArrayBuffer = (base64) => {
-  const bytes = Uint8Array.from(window.atob(base64).split('').map(char => char.charCodeAt(0)));
+  const bytes = Uint8Array.from(window.atob(base64).split('').map((char) => char.charCodeAt(0)));
   return bytes.buffer;
 };
 
 const arrayBufferToBase64 = (arrayBuffer) => {
   const buffer = new Uint8Array(arrayBuffer);
-  const binaryString = Array.from(buffer).map(byte => String.fromCharCode(byte)).join('');
+  const binaryString = Array.from(buffer).map((byte) => String.fromCharCode(byte)).join('');
   return window.btoa(binaryString);
 };
 
-const longToByteArray = long => new Uint8Array(8).map(() => {
+const longToByteArray = (long) => new Uint8Array(8).map(() => {
   const byte = long & 0xff; // eslint-disable-line no-bitwise
   long = (long - byte) / 256;
   return byte;
@@ -19,7 +19,7 @@ const extractCredentials = (credentials) => {
   if (!credentials) { // empty string check
     return [];
   }
-  return credentials.split(',').map(credential => ({
+  return credentials.split(',').map((credential) => ({
     type: 'public-key',
     id: base64ToArrayBuffer(credential),
   }));
@@ -32,7 +32,9 @@ const isWebAuthnEnabled = () => {
   return false;
 };
 
-const enrollWebauthnDevice = ({ userId, userEmail, userChallenge, excludeCredentials }) => {
+const enrollWebauthnDevice = ({
+  userId, userEmail, userChallenge, excludeCredentials,
+}) => {
   const createOptions = {
     publicKey: {
       challenge: new Uint8Array(JSON.parse(userChallenge)),
@@ -85,7 +87,7 @@ const enrollWebauthnDevice = ({ userId, userEmail, userChallenge, excludeCredent
     },
   };
 
-  return navigator.credentials.create(createOptions).then(newCred => ({
+  return navigator.credentials.create(createOptions).then((newCred) => ({
     webauthnId: arrayBufferToBase64(newCred.rawId),
     webauthnPublicKey: newCred.id,
     attestationObject: arrayBufferToBase64(newCred.response.attestationObject),
@@ -103,7 +105,7 @@ const verifyWebauthnDevice = ({ userChallenge, credentialIds }) => {
     },
   };
 
-  return navigator.credentials.get(getOptions).then(newCred => ({
+  return navigator.credentials.get(getOptions).then((newCred) => ({
     credentialId: arrayBufferToBase64(newCred.rawId),
     authenticatorData: arrayBufferToBase64(newCred.response.authenticatorData),
     clientDataJSON: arrayBufferToBase64(newCred.response.clientDataJSON),

--- a/app/javascript/packs/doc-auth.js
+++ b/app/javascript/packs/doc-auth.js
@@ -20,7 +20,7 @@ function docAuth() {
     player.style.display = 'none';
     canvas.style.display = 'inline-block';
     captureButton.innerHTML = 'X';
-    player.srcObject.getVideoTracks().forEach(track => track.stop());
+    player.srcObject.getVideoTracks().forEach((track) => track.stop());
     player.srcObject = null;
   }
 

--- a/app/javascript/packs/doc_capture_polling.js
+++ b/app/javascript/packs/doc_capture_polling.js
@@ -2,11 +2,9 @@ const DOC_CAPTURE_TIMEOUT = 1000 * 60 * 25; // 25 minutes
 const DOC_CAPTURE_POLL_INTERVAL = 5000;
 const MAX_DOC_CAPTURE_POLL_ATTEMPTS = Math.floor(DOC_CAPTURE_TIMEOUT / DOC_CAPTURE_POLL_INTERVAL);
 
-const docCaptureContinueButtonForm = () =>
-  document.querySelector('.doc_capture_continue_button_form');
+const docCaptureContinueButtonForm = () => document.querySelector('.doc_capture_continue_button_form');
 
-const docCaptureContinueInstructions = () =>
-  document.querySelector('#doc_capture_continue_instructions');
+const docCaptureContinueInstructions = () => document.querySelector('#doc_capture_continue_instructions');
 
 const handleMaxPollAttempts = () => {
   // Unhide the continue buttons so the user can continue manually

--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -7,7 +7,7 @@ function imagePreview() {
   $('#doc_auth_image').on('change', function(event) {
     $('.simple_form .alert-error').hide();
     $('.simple_form .alert-notice').hide();
-    const files = event.target.files;
+    const { files } = event.target;
     const image = files[0];
     const reader = new FileReader();
     reader.onload = function(file) {

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -1,6 +1,6 @@
 import zxcvbn from 'zxcvbn';
 
-const I18n = window.LoginGov.I18n;
+const { I18n } = window.LoginGov;
 
 // zxcvbn returns a strength score from 0 to 4
 // we map those scores to:
@@ -46,7 +46,7 @@ function getFeedback(z) {
   if (!warning && !suggestions.length) return '&nbsp;';
   if (warning) return lookup(warning);
 
-  return `${suggestions.map(s => lookup(s)).join('')}`;
+  return `${suggestions.map((s) => lookup(s)).join('')}`;
 }
 
 function disableSubmit(submitEl, length = 0, score = 0) {
@@ -60,7 +60,7 @@ function disableSubmit(submitEl, length = 0, score = 0) {
 }
 
 function analyzePw() {
-  const userAgent = window.navigator.userAgent;
+  const { userAgent } = window.navigator;
   const input = document.querySelector(
     '#password_form_password, #reset_password_form_password, #update_user_password_form_password',
   );
@@ -69,7 +69,7 @@ function analyzePw() {
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const submit = document.querySelector('input[type="submit"]');
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden-passwords]');
-  const forbiddenPasswords = forbiddenPasswordsElement.dataset.forbiddenPasswords;
+  const { forbiddenPasswords } = forbiddenPasswordsElement.dataset;
 
   disableSubmit(submit);
 

--- a/app/javascript/packs/verify-modal.js
+++ b/app/javascript/packs/verify-modal.js
@@ -16,5 +16,4 @@ function verifyModal() {
   }
 }
 
-
 document.addEventListener('DOMContentLoaded', verifyModal);

--- a/app/javascript/packs/webauthn-setup.js
+++ b/app/javascript/packs/webauthn-setup.js
@@ -1,7 +1,7 @@
 const WebAuthn = require('../app/webauthn');
 
 function webauthn() {
-  if (location.href.indexOf('?error=') === -1 && !WebAuthn.isWebAuthnEnabled()) {
+  if (window.location.href.indexOf('?error=') === -1 && !WebAuthn.isWebAuthnEnabled()) {
     window.location.href = '/webauthn_setup?error=NotSupportedError';
   }
   const continueButton = document.getElementById('continue-button');

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,9 +7,9 @@ module.exports = function(api) {
 
   if (!validEnv.includes(currentEnv)) {
     throw new Error(
-      `${'Please specify a valid `NODE_ENV` or ' +
-        '`BABEL_ENV` environment variables. Valid values are "development", ' +
-        '"test", and "production". Instead, received: '}${
+      `${'Please specify a valid `NODE_ENV` or '
+        + '`BABEL_ENV` environment variables. Valid values are "development", '
+        + '"test", and "production". Instead, received: '}${
         JSON.stringify(currentEnv)
       }.`,
     );

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "btoa": "^1.2.1",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^7.4.0",
+    "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "btoa": "^1.2.1",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^6.8.0",
+    "eslint": "^6.1.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/spec/javascripts/app/acuant/document_capture_fallback_spec.js
+++ b/spec/javascripts/app/acuant/document_capture_fallback_spec.js
@@ -68,7 +68,7 @@ describe('acuant/document_capture_fallback', () => {
 
       expect(window.setTimeout.calledOnce).to.eq(true);
 
-      const args = window.setTimeout.lastCall.args;
+      const { args } = window.setTimeout.lastCall;
       const callback = args[0];
       const timeout = args[1];
 

--- a/spec/javascripts/app/components/focus-trap-proxy_spec.js
+++ b/spec/javascripts/app/components/focus-trap-proxy_spec.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
-const stub = sinon.stub;
+const { stub } = sinon;
 
 describe('focusTrap', () => {
   let proxy;

--- a/spec/javascripts/app/webauthn_spec.js
+++ b/spec/javascripts/app/webauthn_spec.js
@@ -178,7 +178,6 @@ describe('WebAuthn', () => {
         return Promise.resolve(getReturnValue);
       };
 
-
       WebAuthn.verifyWebauthnDevice({
         userChallenge, credentialIds,
       }).then((result) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,11 +1280,6 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
-acorn@^7.2.0:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
-  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
-
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -1343,10 +1338,12 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+ansi-escapes@^4.2.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
+  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  dependencies:
+    type-fest "^0.11.0"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -2307,7 +2304,7 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@2.4.2, chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2335,13 +2332,18 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
@@ -2406,6 +2408,18 @@ cleave.js@^1.5.3:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.5.8.tgz#32a18340e50c53ef050a84e623cd9e13b642e048"
   integrity sha512-UarIXHQ1PpynVk27npmggwM/895aIVjJhtjd2f8jDzlHi9XhsjzoMBt4wobbcARah/UZLsOB6ZGHiui2YerTEg==
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 clipboard@^1.6.1:
   version "1.7.1"
@@ -2745,7 +2759,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@6.0.5, cross-spawn@^6.0.0:
+cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -2763,15 +2777,6 @@ cross-spawn@^3.0.0:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
-
-cross-spawn@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -3066,7 +3071,7 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-is@^0.1.3, deep-is@~0.1.3:
+deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -3321,6 +3326,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emoji-regex@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.0.0.tgz#48a2309cc8a1d2e9d23bc6a67c39b63032e76ea4"
@@ -3365,13 +3375,6 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
-
-enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
 
 entities@^2.0.0:
   version "2.0.0"
@@ -3557,7 +3560,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.0:
+eslint-scope@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
   integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
@@ -3565,35 +3568,34 @@ eslint-scope@^5.1.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0:
+eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.4.0.tgz#4e35a2697e6c1972f9d6ef2b690ad319f80f206f"
-  integrity sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==
+eslint@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
-    eslint-utils "^2.0.0"
-    eslint-visitor-keys "^1.2.0"
-    espree "^7.1.0"
-    esquery "^1.2.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
@@ -3602,38 +3604,40 @@ eslint@^7.4.0:
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
+    levn "^0.3.0"
     lodash "^4.17.14"
     minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.9.1"
+    optionator "^0.8.3"
     progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.1.0.tgz#a9c7f18a752056735bf1ba14cb1b70adc3a5ce1c"
-  integrity sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
   dependencies:
-    acorn "^7.2.0"
+    acorn "^7.1.1"
     acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.2.0"
+    eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
+esquery@^1.0.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
@@ -3781,6 +3785,15 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -3815,7 +3828,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3838,6 +3851,13 @@ figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^5.0.1:
   version "5.0.1"
@@ -4545,7 +4565,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4678,6 +4698,25 @@ ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inquirer@^7.0.0:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.2.tgz#25245d2e32dc9f33dbe26eeaada231daa66e9c7c"
+  integrity sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.16"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -4891,6 +4930,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-function@^1.0.7:
   version "1.0.7"
@@ -5274,15 +5318,7 @@ levenary@^1.1.1:
   dependencies:
     leven "^3.1.0"
 
-levn@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
-  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
-  dependencies:
-    prelude-ls "^1.2.1"
-    type-check "~0.4.0"
-
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
@@ -5419,6 +5455,11 @@ lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.1
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.16:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@2.2.0:
   version "2.2.0"
@@ -5635,7 +5676,7 @@ mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -5821,6 +5862,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
@@ -6171,6 +6217,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -6194,7 +6247,7 @@ optimize-css-assets-webpack-plugin@^5.0.3:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -6205,18 +6258,6 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.3"
 
 original@^1.0.0:
   version "1.0.2"
@@ -6251,7 +6292,7 @@ os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -6467,11 +6508,6 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
-
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -7242,11 +7278,6 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.1
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prelude-ls@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
-  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -7603,10 +7634,10 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-regexpp@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^4.7.0:
   version "4.7.0"
@@ -7765,6 +7796,14 @@ resolve@~1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -7807,12 +7846,24 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rxjs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -7939,12 +7990,12 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -8053,22 +8104,10 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 side-channel@^1.0.2:
   version "1.0.2"
@@ -8082,6 +8121,11 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+signal-exit@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -8397,6 +8441,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
@@ -8512,10 +8565,10 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+strip-json-comments@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 style-loader@^1.0.0:
   version "1.1.3"
@@ -8672,6 +8725,11 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
 thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
@@ -8693,6 +8751,13 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -8812,13 +8877,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-check@^0.4.0, type-check@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
-  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  dependencies:
-    prelude-ls "^1.2.1"
-
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -8835,6 +8893,11 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
   integrity sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
+
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
 type-fest@^0.8.1:
   version "0.8.1"
@@ -9282,13 +9345,6 @@ which@1, which@1.3.1, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
 wide-align@1.1.3, wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -9296,7 +9352,7 @@ wide-align@1.1.3, wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
+word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,7 +3580,7 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@^6.8.0:
+eslint@^6.1.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==


### PR DESCRIPTION
See https://github.com/18F/identity-idp/pull/3909#issuecomment-658190715 for additional context.

By default, CodeClimate uses an older version of ESLint than is installed in the project. It was not adhering to the expected configuration, causing both false positives and false negatives. The changes in this pull request update CodeClimate to use a version of ESLint closer to that which is installed in the application. It includes fixes to all preexisting issues.

Issues were fixed by a combination of:

- Running ESLint's automated fixer
   - `npx eslint app spec --fix`
- Manual review:
   - Line length exceeded -> Break to new line
   - Reference to `location` global -> Reference from window global `window.location`
   - Circular dependency -> Disable the rule
      - This is something which should be fixed, will probably be redundant with future effort toward the doc auth flow, but which would require possible significant refactoring to address now. If it's working well enough as-is, it shouldn't be a problem to keep it.

For all specific changes, note that these rules are inherited largely from [Airbnb's coding standard](https://github.com/airbnb/javascript) that we follow, and are therefore largely expected.