### PR TITLE
Fix ESLint errors in image preview pack file

### DIFF
--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -30,7 +30,7 @@ function frontImagePreview() {
   $('#doc_auth_front_image').on('change', function(event) {
     $('.simple_form .alert-error').hide();
     $('.simple_form .alert-notice').hide();
-    const files = event.target.files;
+    const { files } = event.target;
     const image = files[0];
     const reader = new FileReader();
     reader.onload = function(file) {
@@ -53,7 +53,7 @@ function backImagePreview() {
   $('#doc_auth_back_image').on('change', function(event) {
     $('.simple_form .alert-error').hide();
     $('.simple_form .alert-notice').hide();
-    const files = event.target.files;
+    const { files } = event.target;
     const image = files[0];
     const reader = new FileReader();
     reader.onload = function(file) {


### PR DESCRIPTION
**Why**: As a developer, when I run `yarn run lint` I expect no errors, so that I can have confidence in the quality of the code.

The changes proposed in this pull request resolve a lint error in the image previews pack.

This occurred as an unfortunate timing overlap between the merges of #3901 and #3914 , where the changes introduced in the latter surfaced new errors in the former.

The changes also bring the added code in line with the previous implementation of `imagePreview`:

https://github.com/18F/identity-idp/blob/748af83f6847d80a3416a0f51caec9307a107974/app/javascript/packs/image-preview.js#L10