### PR TITLE
Migrate ESLint linting from CodeClimate to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,6 @@ jobs:
 
             bundle exec rake knapsack:rspec
             yarn test
-            yarn run lint
-            bundle exec slim-lint app/views
       - run:
           name: Code Climate Test Coverage
           command: |
@@ -172,6 +170,17 @@ jobs:
           command: |
             aws s3 sync "s3://login-gov-test-coverage/coverage/$CIRCLE_BUILD_NUM" coverage/
             ./cc-test-reporter sum-coverage --output - --parts $CIRCLE_NODE_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+  lints:
+    working_directory: ~/identity-idp
+    executor: ruby_browsers
+    steps:
+      - checkout
+      - bundle-yarn-install
+      - run:
+          name: Run Lints
+          command: |
+            yarn run lint
+            bundle exec slim-lint app/views
   build-latest-container:
     working_directory: ~/identity-idp
     docker:
@@ -272,6 +281,7 @@ workflows:
   release:
     jobs:
       - build
+      - lints
       - build-latest-dev-container:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
 
             bundle exec rake knapsack:rspec
             yarn test
+            yarn run lint
             bundle exec slim-lint app/views
       - run:
           name: Code Climate Test Coverage

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -56,13 +56,6 @@ plugins:
     - 'app/forms/password_form.rb'
     - 'lib/user_flow_exporter.rb'
     - 'lib/rspec/formatters/user_flow_formatter.rb'
-  eslint:
-    enabled: true
-    channel: eslint-6
-    config:
-      extensions:
-        - .js
-        - .jsx
   fixme:
     enabled: true
     exclude_patterns:


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/3909#issuecomment-658190715, #3914

**Why**: CodeClimate does not appear to respect local ESLint configuration in all cases, causing many false negatives and false positives.

These changes propose to remove ESLint testing from CodeClimate, running them instead as part of the existing CircleCI test step.

_To Do:_

- [ ] Since #3914 downgraded ESLint for the purpose of trying to appease CodeClimate, it may make sense to upgrade it once more to the latest version.