### PR TITLE
Add Mocha configuration file

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,6 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+module.exports = {
+  require: ['@babel/register', 'spec/javascripts/spec_helper.js'],
+  extension: ['js', 'jsx'],
+};

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,6 +1,6 @@
 # Front-end architecture
 
-### CSS + HTML
+## CSS + HTML
 
 - utilizes single-purposed, reusable utility classes (via `Basscss`) to
   build UI components
@@ -12,7 +12,7 @@
 - uses Sass as the CSS preprocessor and `scss-lint` to keep files tidy
 - uses well structured, accessible, semantic HTML
 
-### JavaScript
+## JavaScript
 
 - site should work if JS is off (and have enhanced features if JS is on)
 - uses AirBnB's ESLint config
@@ -20,7 +20,9 @@
 - JS is transpiled, bundled, and minified via `webpacker` (using
   `rails-webpacker` gem to utilize Rails asset pipeline)
 
-### Testing
+## Testing
+
+### At a Glance
 
 - integration tests and unit tests should always be running and passing
 - tests should be added/updated with new functionality and when features
@@ -28,7 +30,31 @@
 - attempt to unit test data-related JS; functional/integration tests are
   fine for DOM-related code
 
-### Devices
+### Running Tests
+
+#### Mocha
+
+To run all test specs:
+
+```
+yarn test
+```
+
+To run a single test file:
+
+```
+npx mocha spec/javascripts/app/utils/ms-formatter_spec.js
+```
+
+Using `npx`, you can also pass any [Mocha command-line arguments](https://mochajs.org/#command-line-usage).
+
+For example, to watch a file and rerun tests after any change:
+
+```
+npx mocha spec/javascripts/app/utils/ms-formatter_spec.js --watch
+```
+
+## Devices
 
 - strive to support all browsers with > 1% usage
 - site should look good and work well across all device sizes

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint app spec --ext .js,.jsx",
-    "test": "NODE_ENV=test `npm bin`/mocha --require @babel/register --extension 'js,jsx' --require spec/javascripts/spec_helper.js 'spec/javascripts/**/**spec.js?(x)'",
+    "test": "mocha 'spec/javascripts/**/**spec.js?(x)'",
     "build": "true"
   },
   "dependencies": {


### PR DESCRIPTION
**Why**: By delegating this to a configuration file, it is easier to run Mocha directly with shared setup configuration, notably in combination with Mocha CLI arguments.

See also updated documentation changes for usage examples.

>### Running Tests
>
>#### Mocha
>
>To run all test specs:
>
>```
>yarn test
>```
>
>To run a single test file:
>
>```
>npx mocha spec/javascripts/app/utils/ms-formatter_spec.js
>```
>
>Using `npx`, you can also pass any [Mocha command-line arguments](https://mochajs.org/#command-line-usage).
>
>For example, to watch a file and rerun tests after any change:
>
>```
>npx mocha spec/javascripts/app/utils/ms-formatter_spec.js --watch
>```

I'd alternatively tried (without success) to use some combination of either [shell parameter expansion for defaulting](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion) or `xargs` to try to keep the existing command as supporting _either_ an input argument _or_ the default path. As currently proposed, it's slightly more intuitive to pass Mocha CLI arguments, since it's being used directly and not through the npm script proxy.
