### PR TITLE
Look for content on the screen after clicking sign in at an SP

### DIFF
--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -11,6 +11,9 @@ module MonitorSpSteps
       find(:css, '.sign-in-bttn').click
     end
 
+    expect(page).to have_content(
+      'is using login.gov to allow you to sign in to your account safely and securely.',
+    )
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
   end
 
@@ -18,6 +21,9 @@ module MonitorSpSteps
     visit monitor.config.oidc_sp_url + '?ial=2'
     find(:css, '.sign-in-bttn').click
 
+    expect(page).to have_content(
+      'is using login.gov to allow you to sign in to your account safely and securely.',
+    )
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
   end
 
@@ -25,6 +31,9 @@ module MonitorSpSteps
     visit monitor.config.saml_sp_url
     first(:css, '.sign-in-bttn').click
 
+    expect(page).to have_content(
+      'is using login.gov to allow you to sign in to your account safely and securely.',
+    )
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov}) if monitor.remote?
   end
 


### PR DESCRIPTION
**Why**: It looks like the USAJobs -> login.gov redirect can take some time. This may be causing tests that look at the current URL in prod to fail. This test adds a line to look for content on the screen which includes a timeout to wait for the content to load.