### PR TITLE
Add Make task to validate asset strings

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,6 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+module.exports = {
+  require: ['@babel/register', 'spec/javascripts/spec_helper.js'],
+  extension: ['js', 'jsx'],
+};

--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,8 @@ normalize_yaml:
 	i18n-tasks normalize
 	find ./config/locales -type f | xargs ./scripts/normalize-yaml
 
+check_asset_strings:
+	find ./app/javascript -name "*.js*" | xargs ./scripts/check-assets
+
 generate_deploy_checklist:
 	ruby lib/release_management/generate_deploy_checklist.rb

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require i18n-strings
+//= require assets
 //= require local-time

--- a/app/assets/javascripts/assets.js.erb
+++ b/app/assets/javascripts/assets.js.erb
@@ -1,0 +1,13 @@
+window.LoginGov = window.LoginGov || {};
+window.LoginGov.assets = {};
+
+<% keys = [
+  'state-id-sample-front.jpg',
+  'plus.svg',
+  'minus.svg',
+  'up-carat-thin.svg'
+] %>
+
+<% keys.each do |key| %>
+  window.LoginGov.assets['<%= ActionController::Base.helpers.j key %>'] = '<%= ActionController::Base.helpers.j ActionController::Base.helpers.asset_path key %>';
+<% end %>

--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -49,7 +49,17 @@ window.LoginGov = window.LoginGov || {};
   'doc_auth.headings.welcome',
   'image_description.accordian_plus_buttom',
   'image_description.accordian_minus_buttom',
-  'users.personal_key.close'
+  'users.personal_key.close',
+  'doc_auth.tips.title',
+  'doc_auth.tips.title_more',
+  'doc_auth.tips.header_text',
+  'doc_auth.tips.text1',
+  'doc_auth.tips.text2',
+  'doc_auth.tips.text3',
+  'doc_auth.tips.text4',
+  'doc_auth.tips.text5',
+  'doc_auth.tips.text6',
+  'doc_auth.tips.text7'
 ] %>
 
 window.LoginGov.I18n = {

--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -46,7 +46,10 @@ window.LoginGov = window.LoginGov || {};
   'zxcvbn.feedback.this_is_similar_to_a_commonly_used_password',
   'zxcvbn.feedback.for_a_stronger_password_use_a_few_words_separated_by_spaces_but_avoid_common_phrases',
   'zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns',
-  'doc_auth.headings.welcome'
+  'doc_auth.headings.welcome',
+  'image_description.accordian_plus_buttom',
+  'image_description.accordian_minus_buttom',
+  'users.personal_key.close'
 ] %>
 
 window.LoginGov.I18n = {

--- a/app/javascript/app/components/accordion.js
+++ b/app/javascript/app/components/accordion.js
@@ -17,8 +17,10 @@ class Accordion extends Events {
   }
 
   setup() {
-    this.bindEvents();
-    this.onInitialize();
+    if (!this.isInitialized()) {
+      this.bindEvents();
+      this.onInitialize();
+    }
   }
 
   bindEvents() {
@@ -41,6 +43,11 @@ class Accordion extends Events {
   onInitialize() {
     this.setExpanded(false);
     this.collapsedIcon.classList.remove('display-none');
+    this.el.setAttribute('data-initialized', '');
+  }
+
+  isInitialized() {
+    return this.el.hasAttribute('data-initialized');
   }
 
   handleClick() {

--- a/app/javascript/app/document-capture/components/accordion.jsx
+++ b/app/javascript/app/document-capture/components/accordion.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import BaseAccordion from '../../components/accordion';
+import useI18n from '../hooks/use-i18n';
+import Image from './image';
+
+function Accordion({ title, children }) {
+  const elementRef = useRef(null);
+  const instanceId = useMemo(() => {
+    Accordion.instances += 1;
+    return Accordion.instances;
+  }, []);
+  const t = useI18n();
+  useEffect(() => {
+    new BaseAccordion(elementRef.current).setup();
+  }, []);
+
+  const contentId = `accordion-content-${instanceId}`;
+
+  return (
+    <div ref={elementRef} className="accordion mb4 col-12 fs-16p">
+      <div aria-describedby={contentId} className="accordion-header">
+        <div
+          aria-controls={contentId}
+          aria-expanded="false"
+          role="button"
+          tabIndex={0}
+          className="accordion-header-controls py1 px2 mt-tiny mb-tiny"
+        >
+          <span className="mb0 mr2">{title}</span>
+          <Image
+            assetPath="plus.svg"
+            alt={t('image_description.accordian_plus_buttom')}
+            width={16}
+            className="plus-icon display-none"
+          />
+          <Image
+            assetPath="minus.svg"
+            alt={t('image_description.accordian_minus_buttom')}
+            width={16}
+            className="minus-icon display-none"
+          />
+        </div>
+      </div>
+      <div
+        id={contentId}
+        className="accordion-content clearfix pt1"
+        role="region"
+        aria-hidden="true"
+      >
+        <div className="px2">{children}</div>
+        <div
+          className="py1 accordion-footer"
+          aria-controls={contentId}
+          role="button"
+          tabIndex={0}
+        >
+          <div className="pb-tiny pt-tiny">
+            <Image
+              assetPath="up-carat-thin.svg"
+              alt=""
+              width={14}
+              className="mr1"
+            />
+            {t('users.personal_key.close')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Accordion.instances = 0;
+
+Accordion.propTypes = {
+  title: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Accordion;

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,9 +1,26 @@
+import React from 'react';
+import DocumentTips from './document-tips';
+import Image from './image';
 import useI18n from '../hooks/use-i18n';
 
 function DocumentCapture() {
   const t = useI18n();
 
-  return t('doc_auth.headings.welcome');
+  const sample = (
+    <Image
+      assetPath="state-id-sample-front.jpg"
+      alt="Sample front of state issued ID"
+      width={450}
+      height={338}
+    />
+  );
+
+  return (
+    <>
+      <DocumentTips sample={sample} />
+      {t('doc_auth.headings.welcome')}
+    </>
+  );
 }
 
 export default DocumentCapture;

--- a/app/javascript/app/document-capture/components/document-tips.jsx
+++ b/app/javascript/app/document-capture/components/document-tips.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Accordion from './accordion';
+import useI18n from '../hooks/use-i18n';
+
+function DocumentTips({ sample }) {
+  const t = useI18n();
+
+  const title = (
+    <>
+      <strong>{t('doc_auth.tips.title')}</strong>
+      {` ${t('doc_auth.tips.title_more')}`}
+    </>
+  );
+
+  return (
+    <Accordion title={title}>
+      <strong>{t('doc_auth.tips.header_text')}</strong>
+      <ul>
+        <li>{t('doc_auth.tips.text1')}</li>
+        <li>{t('doc_auth.tips.text2')}</li>
+        <li>{t('doc_auth.tips.text3')}</li>
+        <li>{t('doc_auth.tips.text4')}</li>
+        <li>{t('doc_auth.tips.text5')}</li>
+        <li>{t('doc_auth.tips.text6')}</li>
+        <li>{t('doc_auth.tips.text7')}</li>
+      </ul>
+      {!!sample && <div className="center">{sample}</div>}
+    </Accordion>
+  );
+}
+
+DocumentTips.propTypes = {
+  sample: PropTypes.node,
+};
+
+DocumentTips.defaultProps = {
+  sample: null,
+};
+
+export default DocumentTips;

--- a/app/javascript/app/document-capture/components/image.jsx
+++ b/app/javascript/app/document-capture/components/image.jsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import AssetContext from '../context/asset';
+
+function Image({ assetPath, alt, ...imgProps }) {
+  const assets = useContext(AssetContext);
+
+  const src = Object.prototype.hasOwnProperty.call(assets, assetPath)
+    ? assets[assetPath]
+    : assetPath;
+
+  // Disable reason: While props spreading can introduce confusion to what is
+  // being passed down, in this case the component is intended to represent a
+  // pass-through to a base `<img />` element, with handling for asset paths.
+  //
+  // Seee: https://github.com/airbnb/javascript/tree/master/react#props
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <img src={src} alt={alt} {...imgProps} />;
+}
+
+Image.propTypes = {
+  assetPath: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+};
+
+export default Image;

--- a/app/javascript/app/document-capture/context/asset.js
+++ b/app/javascript/app/document-capture/context/asset.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const AssetContext = createContext({});
+
+export default AssetContext;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { render } from 'react-dom';
 import DocumentCapture from '../app/document-capture/components/document-capture';
+import AssetContext from '../app/document-capture/context/asset';
 import I18nContext from '../app/document-capture/context/i18n';
 
-const { I18n: i18n } = window.LoginGov;
+const { I18n: i18n, assets } = window.LoginGov;
 
 const appRoot = document.getElementById('document-capture-form');
 appRoot.innerHTML = '';
 render(
-  <I18nContext.Provider value={i18n.strings[i18n.currentLocale()]}>
-    <DocumentCapture />
-  </I18nContext.Provider>,
+  <AssetContext.Provider value={assets}>
+    <I18nContext.Provider value={i18n.strings[i18n.currentLocale()]}>
+      <DocumentCapture />
+    </I18nContext.Provider>
+  </AssetContext.Provider>,
   appRoot,
 );

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -92,9 +92,9 @@ en:
         information.
       text7: Use a high-resolution camera. A good mobile phone or tablet camera will
         work.
-      title: "Don't take the photo on a white surface!"
-      title_more: "See more tips…"
+      title: Don't take the photo on a white surface!
       title_html: "<b>Don't take the photo on a white surface!</b> &nbsp;&nbsp; See
         more tips..."
+      title_more: See more tips…
     titles:
       doc_auth: Document Authentication

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -92,6 +92,8 @@ en:
         information.
       text7: Use a high-resolution camera. A good mobile phone or tablet camera will
         work.
+      title: "Don't take the photo on a white surface!"
+      title_more: "See more tips…"
       title_html: "<b>Don't take the photo on a white surface!</b> &nbsp;&nbsp; See
         more tips..."
     titles:

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -99,6 +99,8 @@ es:
         la información.
       text7: Utilice una cámara de alta resolución. La cámara de un buen teléfono
         móvil o tableta funcionará.
+      title: "¡No tome la foto en una superficie blanca!"
+      title_more: "Ver más…"
       title_html: "<b>¡No tome la foto en una superficie blanca!</b> Ver más..."
     titles:
       doc_auth: Autenticación de documentos

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -100,7 +100,7 @@ es:
       text7: Utilice una cámara de alta resolución. La cámara de un buen teléfono
         móvil o tableta funcionará.
       title: "¡No tome la foto en una superficie blanca!"
-      title_more: "Ver más…"
       title_html: "<b>¡No tome la foto en una superficie blanca!</b> Ver más..."
+      title_more: Ver más…
     titles:
       doc_auth: Autenticación de documentos

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -107,6 +107,8 @@ fr:
         de lire toutes les informations.
       text7: Utilisez une caméra haute résolution. La caméra d'un bon téléphone mobile
         ou d'une tablette fonctionnera.
+      title: "Ne prenez pas la photo sur une surface blanche!"
+      title_more: "Voir plus…"
       title_html: "<b>Ne prenez pas la photo sur une surface blanche!</b> Voir plus..."
     titles:
       doc_auth: Authentification de document

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -107,8 +107,8 @@ fr:
         de lire toutes les informations.
       text7: Utilisez une caméra haute résolution. La caméra d'un bon téléphone mobile
         ou d'une tablette fonctionnera.
-      title: "Ne prenez pas la photo sur une surface blanche!"
-      title_more: "Voir plus…"
+      title: Ne prenez pas la photo sur une surface blanche!
       title_html: "<b>Ne prenez pas la photo sur une surface blanche!</b> Voir plus..."
+      title_more: Voir plus…
     titles:
       doc_auth: Authentification de document

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,6 +1,6 @@
 # Front-end architecture
 
-### CSS + HTML
+## CSS + HTML
 
 - utilizes single-purposed, reusable utility classes (via `Basscss`) to
   build UI components
@@ -12,7 +12,7 @@
 - uses Sass as the CSS preprocessor and `scss-lint` to keep files tidy
 - uses well structured, accessible, semantic HTML
 
-### JavaScript
+## JavaScript
 
 - site should work if JS is off (and have enhanced features if JS is on)
 - uses AirBnB's ESLint config
@@ -20,7 +20,9 @@
 - JS is transpiled, bundled, and minified via `webpacker` (using
   `rails-webpacker` gem to utilize Rails asset pipeline)
 
-### Testing
+## Testing
+
+### At a Glance
 
 - integration tests and unit tests should always be running and passing
 - tests should be added/updated with new functionality and when features
@@ -28,7 +30,31 @@
 - attempt to unit test data-related JS; functional/integration tests are
   fine for DOM-related code
 
-### Devices
+### Running Tests
+
+#### Mocha
+
+To run all test specs:
+
+```
+yarn test
+```
+
+To run a single test file:
+
+```
+npx mocha spec/javascripts/app/utils/ms-formatter_spec.js
+```
+
+Using `npx`, you can also pass any [Mocha command-line arguments](https://mochajs.org/#command-line-usage).
+
+For example, to watch a file and rerun tests after any change:
+
+```
+npx mocha spec/javascripts/app/utils/ms-formatter_spec.js --watch
+```
+
+## Devices
 
 - strive to support all browsers with > 1% usage
 - site should look good and work well across all device sizes

--- a/lib/asset_checker.rb
+++ b/lib/asset_checker.rb
@@ -1,0 +1,39 @@
+class AssetChecker
+  def self.run(argv)
+    assets_file = 'app/assets/javascripts/assets.js.erb'
+    translations_file = 'app/assets/javascripts/i18n-strings.js.erb'
+    @asset_strings = load_included_strings(assets_file)
+    @translation_strings = load_included_strings(translations_file)
+    argv.map { |f| check_file(f) }
+  end
+
+  def self.check_file(file)
+    data = File.open(file).read
+    missing_translations = find_missing(data,/\Wt\(['"](.*)['"]\)/, @translation_strings)
+    missing_assets = find_missing(data, /\WassetPath=["'](.*)['"]/, @asset_strings)
+    if missing_translations.any? || missing_assets.any?
+      warn file
+      missing_translations.each do |t|
+        warn "Missing translation, #{t}"
+      end
+      missing_assets.each do |a|
+        warn "Missing asset, #{a}"
+      end
+    end
+  end
+
+  def self.find_missing(file_data, pattern, source)
+    missing = []
+    strings = file_data.scan pattern
+    strings.each do |s|
+      missing.push(s) unless source.include? s
+    end
+    missing
+  end
+
+  def self.load_included_strings(file)
+    data = File.open(file).read
+    key_data = data.split('<% keys = [')[1].split('] %>')[0]
+    key_data.scan(/['"](.*)['"]/)
+  end
+end

--- a/lib/asset_checker.rb
+++ b/lib/asset_checker.rb
@@ -9,9 +9,9 @@ class AssetChecker
 
   def self.check_file(file)
     data = File.open(file).read
-    missing_translations = find_missing(data,/\Wt\(['"](.*)['"]\)/, @translation_strings)
+    missing_translations = find_missing(data, /\Wt\(['"](.*)['"]\)/, @translation_strings)
     missing_assets = find_missing(data, /\WassetPath=["'](.*)['"]/, @asset_strings)
-    if missing_translations.any? || missing_assets.any?
+    if missing_translations.any? || missing_assets.any? # rubocop:disable Style/GuardClause
       warn file
       missing_translations.each do |t|
         warn "Missing translation, #{t}"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jquery": "^3.5.0",
     "libphonenumber-js": "^1.7.26",
     "normalize.css": "^4.2.0",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "sinon": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.4.4",
     "atob": "^2.1.2",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^10.1.0",
     "btoa": "^1.2.1",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint app spec --ext .js,.jsx",
-    "test": "NODE_ENV=test `npm bin`/mocha --require @babel/register --extension 'js,jsx' --require spec/javascripts/spec_helper.js 'spec/javascripts/**/**spec.js?(x)'",
+    "test": "mocha 'spec/javascripts/**/**spec.js?(x)'",
     "build": "true"
   },
   "dependencies": {

--- a/scripts/check-assets
+++ b/scripts/check-assets
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path('../lib', File.dirname(__FILE__)))
+require 'asset_checker'
+
+AssetChecker.run(ARGV)
+

--- a/spec/javascripts/app/document-capture/components/accordion-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/accordion-spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Accordion from '../../../../../app/javascript/app/document-capture/components/accordion';
+import { useDOM } from '../../../support/dom';
+
+describe('document-capture/components/accordion', () => {
+  useDOM();
+
+  it('renders with a unique ID', () => {
+    const { container } = render(
+      <>
+        <Accordion title="Title">Content</Accordion>
+        <Accordion title="Title">Content</Accordion>
+      </>,
+    );
+
+    const contents = container.querySelectorAll('[id^="accordion-content-"]');
+
+    expect(contents).to.have.lengthOf(2);
+    expect(contents[0].id).to.be.ok();
+    expect(contents[1].id).to.be.ok();
+    expect(contents[0].id).not.to.equal(contents[1].id);
+  });
+});

--- a/spec/javascripts/app/document-capture/components/image-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/image-spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Image from '../../../../../app/javascript/app/document-capture/components/image';
+import { useDOM } from '../../../support/dom';
+import AssetContext from '../../../../../app/javascript/app/document-capture/context/asset';
+
+describe('document-capture/components/image', () => {
+  useDOM();
+
+  it('renders the given assetPath as src if the asset is not known', () => {
+    const { getByAltText } = render(
+      <Image assetPath="unknown.png" alt="unknown" />,
+    );
+
+    const img = getByAltText('unknown');
+
+    expect(img.src).to.equal('unknown.png');
+  });
+
+  it('renders an img at mapped src if known by context', () => {
+    const { getByAltText } = render(
+      <AssetContext.Provider value={{ 'icon.png': 'icon-12345.png' }}>
+        <Image assetPath="icon.png" alt="icon" />
+      </AssetContext.Provider>,
+    );
+
+    const img = getByAltText('icon');
+
+    expect(img.src).to.equal('icon-12345.png');
+  });
+
+  it('renders with given props', () => {
+    const { getByAltText } = render(
+      <Image assetPath="icon.png" alt="icon" width={50} />,
+    );
+
+    const img = getByAltText('icon');
+
+    expect(img.width).to.equal(50);
+  });
+});

--- a/spec/javascripts/app/document-capture/context/asset-spec.jsx
+++ b/spec/javascripts/app/document-capture/context/asset-spec.jsx
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { render } from '@testing-library/react';
+import AssetContext from '../../../../../app/javascript/app/document-capture/context/asset';
+import { useDOM } from '../../../support/dom';
+
+describe('document-capture/context/asset', () => {
+  useDOM();
+
+  const ContextValue = () => JSON.stringify(useContext(AssetContext));
+
+  it('defaults to empty object', () => {
+    const { container } = render(<ContextValue />);
+
+    expect(container.textContent).to.equal('{}');
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -3,3 +3,12 @@ const dirtyChai = require('dirty-chai');
 
 chai.use(dirtyChai);
 global.expect = chai.expect;
+
+// classList.js will throw an error when loaded into the test environment, since
+// it assumes the presence of a `self` global. This shim is enough only to skip
+// the polyfill. It's expected where a DOM is used that JSDOM will provide the
+// Element#classList implementation.
+//
+// See: https://github.com/eligrey/classList.js/issues/48
+// See: https://github.com/eligrey/classList.js/blob/ecb3305/classList.js#L14
+global.self = global;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.0.tgz#04815556fc90b0c174abd2c0c1bb966faa036a6c"
@@ -38,6 +45,15 @@
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.10.5":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.5.tgz#1b903554bc8c583ee8d25f1e8969732e6b829a69"
+  integrity sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==
+  dependencies:
+    "@babel/types" "^7.10.5"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/generator@^7.9.0":
@@ -138,6 +154,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -146,6 +171,13 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -248,6 +280,13 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-split-export-declaration@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz#2c70576eaa3b5609b24cb99db2888cc3fc4251d1"
+  integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
@@ -284,6 +323,15 @@
     "@babel/traverse" "^7.9.0"
     "@babel/types" "^7.9.0"
 
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.8.3":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
@@ -292,6 +340,11 @@
     "@babel/helper-validator-identifier" "^7.9.0"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.7.0":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.5.tgz#e7c6bf5a7deff957cec9f04b551e2762909d826b"
+  integrity sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
 
 "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
   version "7.9.3"
@@ -876,6 +929,15 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -884,6 +946,21 @@
     "@babel/code-frame" "^7.8.3"
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
+
+"@babel/traverse@^7.7.0":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.5.tgz#77ce464f5b258be265af618d8fddf0536f20b564"
+  integrity sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.10.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/parser" "^7.10.5"
+    "@babel/types" "^7.10.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
 
 "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
@@ -907,6 +984,15 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.5", "@babel/types@^7.7.0":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.5.tgz#d88ae7e2fde86bfbfe851d4d81afa70a997b5d15"
+  integrity sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
@@ -1613,24 +1699,17 @@ axobject-query@^2.1.2:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
   dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
-babel-eslint@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
-  integrity sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-loader@^8.0.6:
   version "8.1.0"
@@ -1642,13 +1721,6 @@ babel-loader@^8.0.6:
     mkdirp "^0.5.3"
     pify "^4.0.1"
     schema-utils "^2.6.5"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
@@ -1665,44 +1737,6 @@ babel-plugin-macros@^2.6.1:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-traverse@^6.23.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.23.0, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.17.0, babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2313,7 +2347,7 @@ chalk@2.4.2, chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1,
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -2692,11 +2726,6 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
-
 core-js@^3.4.0:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
@@ -3016,7 +3045,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3575,7 +3604,7 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -4275,11 +4304,6 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
-
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 globby@^6.1.0:
   version "6.1.0"
@@ -5121,11 +5145,6 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
-
 js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -5451,12 +5470,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.12:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.16:
+lodash@^4.17.16, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -7600,11 +7619,6 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
@@ -8763,11 +8777,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
New JS code added in #3909 and others require strings configured in `assets.js.erb` and `i18n-strings.js.erb`.  

The added make task, `check_asset_strings`, assets that for each such string referenced in a Javascript file, there exists a corresponding entry in one of the erb files