### PR TITLE
Increase the monitor wait time to 10 seconds

### DIFF
--- a/spec/monitor_spec_helper.rb
+++ b/spec/monitor_spec_helper.rb
@@ -19,7 +19,7 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.javascript_driver = :chrome
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = 10
 
 Dir['spec/support/monitor/**/*.rb'].sort.each { |file| require File.expand_path(file) }
 


### PR DESCRIPTION
**Why**: The tests still don't seem to be waiting for the login.gov page to load after clicking sign in from USAJobs