### PR TITLE
Add FullScreen React component

### DIFF
--- a/app/assets/javascripts/assets.js.erb
+++ b/app/assets/javascripts/assets.js.erb
@@ -5,7 +5,8 @@ window.LoginGov.assets = {};
   'state-id-sample-front.jpg',
   'plus.svg',
   'minus.svg',
-  'up-carat-thin.svg'
+  'up-carat-thin.svg',
+  'close-white-alt.svg'
 ] %>
 
 <% keys.each do |key| %>

--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import AcuantContext from '../context/acuant';
 import AcuantCaptureCanvas from './acuant-capture-canvas';
+import FullScreen from './full-screen';
 import useI18n from '../hooks/use-i18n';
 
 function AcuantCapture() {
@@ -24,18 +25,23 @@ function AcuantCapture() {
     );
   }
 
-  return isCapturing ? (
-    <AcuantCaptureCanvas
-      onImageCaptureSuccess={(nextCapture) => {
-        setCapture(nextCapture);
-        setIsCapturing(false);
-      }}
-      onImageCaptureFailure={() => setIsCapturing(false)}
-    />
-  ) : (
-    <button type="button" onClick={() => setIsCapturing(true)}>
-      {t('doc_auth.buttons.take_picture')}
-    </button>
+  return (
+    <>
+      {isCapturing && (
+        <FullScreen onRequestClose={() => setIsCapturing(false)}>
+          <AcuantCaptureCanvas
+            onImageCaptureSuccess={(nextCapture) => {
+              setCapture(nextCapture);
+              setIsCapturing(false);
+            }}
+            onImageCaptureFailure={() => setIsCapturing(false)}
+          />
+        </FullScreen>
+      )}
+      <button type="button" onClick={() => setIsCapturing(true)}>
+        {t('doc_auth.buttons.take_picture')}
+      </button>
+    </>
   );
 }
 

--- a/app/javascript/app/document-capture/components/full-screen.jsx
+++ b/app/javascript/app/document-capture/components/full-screen.jsx
@@ -1,0 +1,54 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import createFocusTrap from 'focus-trap';
+import Image from './image';
+import useI18n from '../hooks/use-i18n';
+
+function FullScreen({ onRequestClose, children }) {
+  const t = useI18n();
+  const modalRef = useRef(/** @type {?HTMLDivElement} */ (null));
+  const trapRef = useRef(/** @type {?import('focus-trap').FocusTrap} */ (null));
+  const onRequestCloseRef = useRef(onRequestClose);
+  useEffect(() => {
+    // Since the focus trap is only initialized once, but the callback could
+    // be changed, ensure that the current reference is kept as a mutable value
+    // to reference in the deactivation.
+    onRequestCloseRef.current = onRequestClose;
+  }, [onRequestClose]);
+  useEffect(() => {
+    trapRef.current = createFocusTrap(modalRef.current, {
+      onDeactivate: () => onRequestCloseRef.current(),
+    });
+    trapRef.current.activate();
+    return trapRef.current.deactivate;
+  }, []);
+
+  return (
+    <div ref={modalRef} aria-modal="true" className="full-screen bg-white">
+      <button
+        type="button"
+        aria-label={t('users.personal_key.close')}
+        onClick={() => trapRef.current.deactivate()}
+        className="full-screen-close-button usa-button padding-2 margin-2"
+      >
+        <Image
+          alt=""
+          assetPath="close-white-alt.svg"
+          className="full-screen-close-icon"
+        />
+      </button>
+      {children}
+    </div>
+  );
+}
+
+FullScreen.propTypes = {
+  onRequestClose: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+FullScreen.defaultProps = {
+  onRequestClose: () => {},
+};
+
+export default FullScreen;

--- a/spec/javascripts/app/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/full-screen-spec.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
+import FullScreen from '../../../../../app/javascript/app/document-capture/components/full-screen';
+
+describe('document-capture/components/full-screen', () => {
+  it('renders with a close button', () => {
+    const { getByLabelText } = render(<FullScreen>Content</FullScreen>);
+
+    const button = getByLabelText('users.personal_key.close');
+
+    expect(button.nodeName).to.equal('BUTTON');
+  });
+
+  it('is rendered as an accessible modal', () => {
+    const { container } = render(<FullScreen>Content</FullScreen>);
+
+    expect(container.firstChild.hasAttribute('aria-modal')).to.be.true();
+  });
+
+  it('calls close callback when close button is clicked', () => {
+    const onRequestClose = sinon.spy();
+    const { getByLabelText } = render(
+      <FullScreen onRequestClose={onRequestClose}>Content</FullScreen>,
+    );
+
+    const button = getByLabelText('users.personal_key.close');
+    fireEvent.click(button);
+
+    expect(onRequestClose.calledOnce).to.be.true();
+  });
+
+  it('transitions focus into the modal', (done) => {
+    const { container } = render(<FullScreen>Content</FullScreen>);
+
+    // The `focus-trap` library only assigns initial focus after a timeout.
+    // Schedule to assert immediately following.
+    setTimeout(() => {
+      expect(container.contains(document.activeElement)).to.be.true();
+
+      done();
+    }, 0);
+  });
+
+  it('traps focus', (done) => {
+    const { container, getByLabelText } = render(
+      <FullScreen>Content</FullScreen>,
+    );
+
+    const button = getByLabelText('users.personal_key.close');
+
+    const event = new window.KeyboardEvent('keydown', {
+      key: 'Tab',
+      code: 'Tab',
+      which: 9,
+    });
+
+    // The `focus-trap` library only assigns initial focus after a timeout.
+    // Schedule to assert immediately following.
+    setTimeout(() => {
+      fireEvent(button, event);
+
+      expect(container.contains(document.activeElement)).to.be.true();
+
+      done();
+    }, 0);
+  });
+
+  it('closes on escape press', () => {
+    const onRequestClose = sinon.spy();
+    const { getByLabelText, rerender } = render(
+      <FullScreen>Content</FullScreen>,
+    );
+    rerender(<FullScreen onRequestClose={onRequestClose}>Content</FullScreen>);
+
+    const button = getByLabelText('users.personal_key.close');
+
+    const event = new window.KeyboardEvent('keydown', {
+      key: 'Escape',
+      code: 'Escape',
+      which: 27,
+    });
+
+    fireEvent(button, event);
+
+    expect(onRequestClose.calledOnce).to.be.true();
+  });
+});


### PR DESCRIPTION
Relates to: LG-3094, LG-3023
Currently configured to merge to (blocked by) #3931 in order to leverage assets behavior

**Why**: As a user trying to proof, I want the capture mode to be more intuitive in landscape and portrait orientation, so that I can easily capture images of my IDs and selfie.

The changes in this pull request introduce a new React component `<FullScreen />`, implementing the behavior of a dismissible full-screen modal dialog. This is currently integrated in the work-in-progress single-page document authorization upload flow, shown in response to clicking the "Take photo" button in the verification step.

Screenshot:

Before Activating|After Activating
---|---
![before activating](https://user-images.githubusercontent.com/1779930/87806156-6f4e4600-c824-11ea-822f-d2240e08696d.png)|![after activating](https://user-images.githubusercontent.com/1779930/87806167-72e1cd00-c824-11ea-9cb5-3f0156a8dd4a.png)

Notes:

- The desktop experience doesn't currently support camera capture, so the content is expected to be empty. A prompt will appear to upload a photo.
- Changes were needed to the testing setup, since I encountered that the existing `focus-trap` dependency has side effects in its imports which depend on DOM globals. These changes are included here, though could make sense to break off into a separate pull request. Overall it should simplify authoring tests in many cases.