### PR TITLE
LG-3210 Check the results in the selfie step if it is enabled

### DIFF
--- a/app/services/idv/steps/capture_mobile_back_image_step.rb
+++ b/app/services/idv/steps/capture_mobile_back_image_step.rb
@@ -4,7 +4,7 @@ module Idv
       def call
         back_image_response = post_back_image
         if back_image_response.success?
-          handle_back_image_success
+          fetch_doc_auth_results_or_redirect_to_selfie
         else
           failure(back_image_response.errors.first, back_image_response.to_h)
         end
@@ -12,11 +12,27 @@ module Idv
 
       private
 
-      def handle_back_image_success
+      def fetch_doc_auth_results_or_redirect_to_selfie
+        # If liveness checking is enabled, we will wait until the selfie check
+        # to get the results. If there will not be a selfie check we need to
+        # validate them here before continuing.
         return if liveness_checking_enabled?
 
-        mark_step_complete(:selfie)
-        CaptureDoc::UpdateAcuantToken.call(user_id_from_token, flow_session[:instance_id])
+        get_results_response = doc_auth_client.get_results(instance_id: flow_session[:instance_id])
+        if get_results_response.success?
+          mark_step_complete(:selfie)
+          CaptureDoc::UpdateAcuantToken.call(user_id_from_token, flow_session[:instance_id])
+        else
+          handle_document_verification_failure(get_results_response)
+        end
+      end
+
+      def handle_document_verification_failure(get_results_response)
+        mark_step_incomplete(:mobile_front_image)
+        extra = get_results_response.to_h.merge(
+          notice: I18n.t('errors.doc_auth.general_info'),
+        )
+        failure(get_results_response.errors.first, extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -4,6 +4,8 @@ module Idv
       def call
         return render_step_incomplete_error unless take_photo_with_phone_successful?
 
+        # The doc capture flow will have fetched the results already. We need
+        # to fetch them again here to add the PII to this session
         get_results_response = fetch_doc_auth_results
         if get_results_response.success?
           handle_document_verification_success(get_results_response)

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -80,6 +80,20 @@ feature 'doc auth back image step' do
     expect(page).to have_content(strip_tags(I18n.t('errors.doc_auth.general_info'))[0..32])
   end
 
+  it 'does not attempt to verify the document if selfie checking is enabled' do
+    allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
+
+    mock_client = DocAuthMock::DocAuthMockClient.new
+    allow(DocAuthMock::DocAuthMockClient).to receive(:new).and_return(mock_client)
+
+    expect(mock_client).to_not receive(:get_results)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_selfie_step)
+  end
+
   it 'renders a friendly error message if one is present on the response' do
     error_message = I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read')
     DocAuthMock::DocAuthMockClient.mock_response!(

--- a/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_back_image_step_spec.rb
@@ -67,4 +67,18 @@ feature 'doc auth mobile back image step' do
     expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
     expect(page).to have_content(strip_tags(I18n.t('errors.doc_auth.general_info'))[0..32])
   end
+
+  it 'does not attempt to verify the document if selfie checking is enabled' do
+    allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
+
+    mock_client = DocAuthMock::DocAuthMockClient.new
+    allow(DocAuthMock::DocAuthMockClient).to receive(:new).and_return(mock_client)
+
+    expect(mock_client).to_not receive(:get_results)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_selfie_step)
+  end
 end

--- a/spec/features/idv/doc_auth/selfie_step_spec.rb
+++ b/spec/features/idv/doc_auth/selfie_step_spec.rb
@@ -21,7 +21,17 @@ feature 'doc auth self image step' do
     expect(page).to have_current_path(idv_doc_auth_ssn_step)
   end
 
-  it 'restarts doc auth upon failure' do
+  it 'restarts doc auth if the document cannot be authenticated' do
+    mock_general_doc_auth_client_error(:get_results)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_front_image_step)
+    expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
+  end
+
+  it 'restarts doc auth if the selfie cannot be matched' do
     DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_selfie,
       response: Acuant::Response.new(

--- a/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
+++ b/spec/features/idv/doc_capture/mobile_back_image_step_spec.rb
@@ -43,4 +43,18 @@ feature 'doc capture mobile back image step' do
 
     expect(page).to have_current_path(idv_capture_doc_capture_mobile_back_image_step)
   end
+
+  it 'does not attempt to verify the document if selfie checking is enabled' do
+    allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
+
+    mock_client = DocAuthMock::DocAuthMockClient.new
+    allow(DocAuthMock::DocAuthMockClient).to receive(:new).and_return(mock_client)
+
+    expect(mock_client).to_not receive(:get_results)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_capture_doc_capture_selfie_step)
+  end
 end

--- a/spec/features/idv/doc_capture/selfie_step_spec.rb
+++ b/spec/features/idv/doc_capture/selfie_step_spec.rb
@@ -26,7 +26,17 @@ feature 'doc auth self image step' do
     expect(page).to have_current_path(idv_capture_doc_capture_complete_step)
   end
 
-  it 'restarts doc auth upon failure' do
+  it 'restarts doc auth if the document cannot be authenticated' do
+    mock_general_doc_auth_client_error(:get_results)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_capture_doc_mobile_front_image_step(nil))
+    expect(page).to have_content(I18n.t('errors.doc_auth.general_error'))
+  end
+
+  it 'restarts doc auth if the selfie cannot be matched' do
     DocAuthMock::DocAuthMockClient.mock_response!(
       method: :post_selfie,
       response: Acuant::Response.new(


### PR DESCRIPTION
**Why**: To work around the 60 second timeout we don't get the results until right before we upload the selfie.

This required changes to several of the doc auth steps:

Back image:
- If the selfie step is not enabled, we check the results and proceed as normal.
- If the selfie step is enabled we don't check results. The flow moves on to the selfie step.

Capture mobile back image
- This step looks more like the back image now
- If selfie checking is disabled, we verify the results but do not save the PII in the session.
- If selfie checking is enabled we do not verify the results. The flow moves on to the selfie step.

Selfie step:
- Before uploading the selfie we check the results.
- If the results are no good we go back to the front image step.
- If the results are good we upload the selfie.
- If the selfie is no good we go back to the front image step.
- If the selfie matches and we are in the hybrid flow we set the instance ID and go to the complete step.
- If the selfie matches and we are in the normal flow we get the results and save them in the session.

Link sent step
- The selfie and document were already verified. This happened in either in the capture mobile back image step or selfie step.
- We get the results again and use them to store the PII in the session.