### PR TITLE
Click on the sign in link with the correct href on USA Jobs

### DIFF
--- a/spec/support/monitor/monitor_sp_steps.rb
+++ b/spec/support/monitor/monitor_sp_steps.rb
@@ -6,7 +6,7 @@ module MonitorSpSteps
   def visit_idp_from_oidc_sp
     visit monitor.config.oidc_sp_url
     if oidc_sp_is_usajobs?
-      click_on 'Sign In'
+      click_link 'Sign In', href: '/Applicant/Profile/Dashboard'
     else
       find(:css, '.sign-in-bttn').click
     end


### PR DESCRIPTION
**Why**: The smoke tests might be clicking on a link that is wired up with some JS before that JS actually executes. This might be preventing a redirect to login.gov and causing the tests to fail.