### PR TITLE
LG-3185 & LG-3209: AAL3 Bugfixes

### DIFF
--- a/app/controllers/concerns/aal3_concern.rb
+++ b/app/controllers/concerns/aal3_concern.rb
@@ -6,4 +6,14 @@ module Aal3Concern
     return if mfa_policy.aal3_mfa_enabled?
     redirect_to two_factor_options_url
   end
+
+  def aal3_redirect_url(user)
+    if TwoFactorAuthentication::PivCacPolicy.new(user).enabled? && !mobile?
+      login_two_factor_piv_cac_url
+    elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
+      login_two_factor_webauthn_url
+    else
+      aal3_required_url
+    end
+  end
 end

--- a/app/controllers/concerns/aal3_concern.rb
+++ b/app/controllers/concerns/aal3_concern.rb
@@ -12,8 +12,6 @@ module Aal3Concern
       login_two_factor_piv_cac_url
     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
       login_two_factor_webauthn_url
-    else
-      aal3_required_url
     end
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -7,6 +7,7 @@ module TwoFactorAuthenticatable
     before_action :authenticate_user
     before_action :require_current_password, if: :current_password_required?
     before_action :check_already_authenticated
+    before_action :check_aal3_bypass
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
     before_action :apply_secure_headers_override, only: %i[show create]
     # rubocop:enable Rails/LexicallyScopedActionFilter

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -48,6 +48,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     return unless initial_authentication_context?
     return unless user_fully_authenticated?
     return if remember_device_expired_for_sp?
+    return if aal3_policy.aal3_configured_but_not_used?
 
     redirect_to after_otp_verification_confirmation_url
   end
@@ -55,7 +56,9 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def check_aal3_bypass
     return unless aal3_policy.aal3_required?
     method = two_factor_authentication_method
-    redirect_to aal3_redirect_url(current_user) unless AAL3Policy::AAL3_METHODS.include? method
+    return if AAL3Policy::AAL3_METHODS.include? method
+    aal3_redirect = aal3_redirect_url(current_user)
+    redirect_to aal3_redirect || aal3_required_url
   end
 
   def reset_attempt_count_if_user_no_longer_locked_out

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -2,6 +2,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   include RememberDeviceConcern
   include SecureHeadersConcern
+  include Aal3Concern
 
   DELIVERY_METHOD_MAP = {
     authenticator: 'authenticator',
@@ -47,9 +48,14 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     return unless initial_authentication_context?
     return unless user_fully_authenticated?
     return if remember_device_expired_for_sp?
-    return if aal3_policy.aal3_configured_but_not_used?
 
     redirect_to after_otp_verification_confirmation_url
+  end
+
+  def check_aal3_bypass
+    return unless aal3_policy.aal3_required?
+    method = two_factor_authentication_method
+    redirect_to aal3_redirect_url(current_user) unless AAL3Policy::AAL3_METHODS.include? method
   end
 
   def reset_attempt_count_if_user_no_longer_locked_out

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -54,7 +54,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def check_aal3_bypass
-    return unless aal3_policy.aal3_required?
+    return unless aal3_policy.aal3_configured_and_required?
     method = two_factor_authentication_method
     return if AAL3Policy::AAL3_METHODS.include? method
     aal3_redirect = aal3_redirect_url(current_user)

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -41,7 +41,6 @@ module TwoFactorAuthentication
       end
     end
 
-
     private
 
     def two_factor_options_presenter

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -41,10 +41,11 @@ module TwoFactorAuthentication
       end
     end
 
+
     private
 
     def two_factor_options_presenter
-      TwoFactorLoginOptionsPresenter.new(current_user, view_context, current_sp)
+      TwoFactorLoginOptionsPresenter.new(current_user, view_context, current_sp, session)
     end
 
     def process_valid_form

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -2,6 +2,7 @@ module Users
   # rubocop:disable Metrics/ClassLength
   class TwoFactorAuthenticationController < ApplicationController
     include TwoFactorAuthenticatable
+    include Aal3Concern
 
     before_action :check_remember_device_preference
 
@@ -24,7 +25,7 @@ module Users
     private
 
     def aal3_requirement_redirect
-      aal3_url = aal3_redirect_url
+      aal3_url = aal3_redirect_url(current_user)
       if aal3_url
         redirect_to aal3_url
       elsif aal3_policy.aal3_required? && user_fully_authenticated?
@@ -50,14 +51,6 @@ module Users
 
     def redirect_on_nothing_enabled
       redirect_to two_factor_options_url
-    end
-
-    def aal3_redirect_url
-      if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled? && !mobile?
-        login_two_factor_piv_cac_url
-      elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
-        login_two_factor_webauthn_url
-      end
     end
 
     def phone_enabled?

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -54,6 +54,10 @@ class MfaContext
     PersonalKeyConfiguration.new(user)
   end
 
+  def aal3_configurations
+    webauthn_configurations + piv_cac_configurations
+  end
+
   def two_factor_configurations
     phone_configurations + webauthn_configurations + backup_code_configurations +
       piv_cac_configurations + auth_app_configurations

--- a/app/policies/aal3_policy.rb
+++ b/app/policies/aal3_policy.rb
@@ -21,9 +21,12 @@ class AAL3Policy
   end
 
   def aal3_configured_but_not_used?
-    aal3_required? &&
-      @mfa_policy&.aal3_mfa_enabled? &&
+    aal3_configured_and_required? &&
       !aal3_used?
+  end
+
+  def aal3_configured_and_required?
+    aal3_required? && @mfa_policy&.aal3_mfa_enabled?
   end
 
   private

--- a/app/policies/aal3_policy.rb
+++ b/app/policies/aal3_policy.rb
@@ -1,4 +1,6 @@
 class AAL3Policy
+  AAL3_METHODS = %w[webauthn piv_cac].freeze
+
   def initialize(session:, user: nil)
     @session = session
     @mfa_policy = MfaPolicy.new(user) if user
@@ -11,7 +13,7 @@ class AAL3Policy
   def aal3_used?
     return false unless @session
 
-    %w[webauthn piv_cac].include?(@session[:auth_method])
+    AAL3_METHODS.include?(@session[:auth_method])
   end
 
   def aal3_required_but_not_used?

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -90,6 +90,6 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
   end
 
   def aal3_policy
-    @aal3_policy ||= AAL3Policy.new(session: @session, user: @current_user)
+    @aal3 ||= AAL3Policy.new(session: @session, user: @current_user)
   end
 end

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -3,10 +3,11 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   attr_reader :current_user
 
-  def initialize(current_user, view, service_provider)
+  def initialize(current_user, view, service_provider, session)
     @current_user = current_user
     @view = view
     @service_provider = service_provider
+    @session = session
   end
 
   def title
@@ -27,13 +28,17 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def options
     mfa = MfaContext.new(current_user)
-    # for now, we include the personal key since that's our current behavior,
-    # but there are designs to remove personal key from the option list and
-    # make it a link with some additional text to call it out as a special
-    # case.
-    configurations = mfa.two_factor_configurations
-    if TwoFactorAuthentication::PersonalKeyPolicy.new(current_user).enabled?
-      configurations << mfa.personal_key_configuration
+    if aal3_policy.aal3_required?
+      configurations = mfa.aal3_configurations
+    else
+      configurations = mfa.two_factor_configurations
+      # for now, we include the personal key since that's our current behavior,
+      # but there are designs to remove personal key from the option list and
+      # make it a link with some additional text to call it out as a special
+      # case.
+      if TwoFactorAuthentication::PersonalKeyPolicy.new(current_user).enabled?
+        configurations << mfa.personal_key_configuration
+      end
     end
     # A user can have multiples of certain types of MFA methods, such as
     # webauthn keys and phones. However, we only want to show one of each option
@@ -82,5 +87,9 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def account_reset_token_valid?
     current_user&.account_reset_request&.granted_token_valid?
+  end
+
+  def aal3_policy
+    @aal3_policy ||= AAL3Policy.new(session: @session, user: @current_user)
   end
 end

--- a/spec/features/openid_connect/aal3_required_spec.rb
+++ b/spec/features/openid_connect/aal3_required_spec.rb
@@ -19,11 +19,10 @@ describe 'AAL3 authentication required in an OIDC context' do
 
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
-        user = user_with_aal3_2fa
+        sign_in_before_2fa(user_with_aal3_2fa)
 
-        visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-        visit login_two_factor_path
-
+        visit_idp_from_ial1_oidc_sp_requiring_aal3(prompt: 'select_account')
+        visit login_two_factor_path(otp_delivery_preference: 'sms')
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
     end
@@ -45,8 +44,9 @@ describe 'AAL3 authentication required in an OIDC context' do
 
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
+        sign_in_before_2fa(user_with_aal3_2fa)
         visit_idp_from_ial1_oidc_sp_requiring_aal3(prompt: 'select_account')
-        visit login_two_factor_path
+        visit login_two_factor_path(otp_delivery_preference: 'sms')
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end

--- a/spec/features/openid_connect/aal3_required_spec.rb
+++ b/spec/features/openid_connect/aal3_required_spec.rb
@@ -22,7 +22,7 @@ describe 'AAL3 authentication required in an OIDC context' do
         user = user_with_aal3_2fa
 
         visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-        sign_in_live_with_aal2_2fa_only(user)
+        visit login_two_factor_path
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
@@ -45,10 +45,8 @@ describe 'AAL3 authentication required in an OIDC context' do
 
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
-        user = user_with_aal3_2fa
-
         visit_idp_from_ial1_oidc_sp_requiring_aal3(prompt: 'select_account')
-        sign_in_live_with_aal2_2fa_only(user)
+        visit login_two_factor_path
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end

--- a/spec/features/saml/aal3_required_spec.rb
+++ b/spec/features/saml/aal3_required_spec.rb
@@ -18,10 +18,8 @@ describe 'AAL3 authentication required in an SAML context' do
   describe 'SAML ServiceProvider configured to require AAL3 authentication' do
     context 'user does not have aal3 auth configured' do
       it 'sends user to set up AAL3 auth' do
-        user = user_with_2fa
-
+        sign_in_and_2fa_user(user_with_2fa)
         visit aal3_sp1_authnrequest
-        sign_in_live_with_2fa(user)
 
         expect(current_url).to eq(two_factor_options_url)
         expect(page).to have_content(t('two_factor_authentication.two_factor_aal3_choice'))
@@ -33,7 +31,7 @@ describe 'AAL3 authentication required in an SAML context' do
       it 'sends user to authenticate with AAL3 auth' do
         sign_in_before_2fa(user_with_aal3_2fa)
         visit aal3_sp1_authnrequest
-        visit login_two_factor_path, constraints: sms
+        visit login_two_factor_path(otp_delivery_preference: 'sms')
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
     end

--- a/spec/features/saml/aal3_required_spec.rb
+++ b/spec/features/saml/aal3_required_spec.rb
@@ -34,7 +34,7 @@ describe 'AAL3 authentication required in an SAML context' do
         user = user_with_aal3_2fa
 
         visit aal3_sp1_authnrequest
-        sign_in_live_with_aal2_2fa_only(user)
+        visit login_two_factor_path
 
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end

--- a/spec/features/saml/aal3_required_spec.rb
+++ b/spec/features/saml/aal3_required_spec.rb
@@ -31,11 +31,9 @@ describe 'AAL3 authentication required in an SAML context' do
 
     context 'user has aal3 auth configured' do
       it 'sends user to authenticate with AAL3 auth' do
-        user = user_with_aal3_2fa
-
+        sign_in_before_2fa(user_with_aal3_2fa)
         visit aal3_sp1_authnrequest
-        visit login_two_factor_path
-
+        visit login_two_factor_path, constraints: sms
         expect(current_url).to eq(login_two_factor_webauthn_url)
       end
     end

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -6,7 +6,7 @@ describe TwoFactorLoginOptionsPresenter do
   let(:user) { User.new }
   let(:view) { ActionController::Base.new.view_context }
   let(:presenter) do
-    TwoFactorLoginOptionsPresenter.new(user, view, nil)
+    TwoFactorLoginOptionsPresenter.new(user, view, nil, nil)
   end
 
   it 'supplies a title' do

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -2,14 +2,17 @@ require 'rails_helper'
 
 describe TwoFactorOptionsPresenter do
   include Rails.application.routes.url_helpers
+  include RequestHelper
 
   let(:user_agent) do
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 \
 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36'
   end
+
   let(:presenter) do
     described_class.new(user_agent: user_agent)
   end
+
 
   describe '#options' do
     it 'supplies all the options for a user' do
@@ -20,6 +23,23 @@ describe TwoFactorOptionsPresenter do
         TwoFactorAuthentication::PivCacSelectionPresenter,
         TwoFactorAuthentication::BackupCodeSelectionPresenter,
       ]
+    end
+
+    context 'when an AAL3 only SP is being used' do
+      let(:service_provider) { create(:service_provider, aal: 3) }
+      let(:sp_session) { { issuer: service_provider.issuer, aal_level_requested: 3 } }
+      let(:session) { { auth_method: 'phone', sp: sp_session } }
+
+      let(:presenter) do
+        described_class.new(user_agent: user_agent, user: user_with_2fa, session: session)
+      end
+
+      it 'only displays AAL3 MFA methods' do
+        expect(presenter.options.map(&:class)).to eq [
+          TwoFactorAuthentication::WebauthnSelectionPresenter,
+          TwoFactorAuthentication::PivCacSelectionPresenter,
+        ]
+      end
     end
 
     context 'when hide_phone_mfa_signup is enabled' do

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -13,7 +13,6 @@ describe TwoFactorOptionsPresenter do
     described_class.new(user_agent: user_agent)
   end
 
-
   describe '#options' do
     it 'supplies all the options for a user' do
       expect(presenter.options.map(&:class)).to eq [

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -244,17 +244,6 @@ module Features
       user
     end
 
-    def sign_in_live_with_aal2_2fa_only(user = user_with_aal3_2fa)
-      sign_in_user(user)
-      click_link('Choose another authentication method')
-      choose('two_factor_options_form_selection_sms')
-      click_button('Continue')
-      uncheck(t('forms.messages.remember_device'))
-      fill_in_code_with_last_phone_otp
-      click_submit_default
-      user
-    end
-
     def sign_in_live_with_piv_cac(user = user_with_piv_cac)
       sign_in_user(user)
       allow(FeatureManagement).to receive(:development_and_identity_pki_disabled?).and_return(true)

--- a/spec/views/two_factor_authentication/options/index.html.slim_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.slim_spec.rb
@@ -5,7 +5,7 @@ describe 'two_factor_authentication/options/index.html.slim' do
   before do
     allow(view).to receive(:user_session).and_return({})
     allow(view).to receive(:current_user).and_return(User.new)
-    @presenter = TwoFactorLoginOptionsPresenter.new(user, view, nil)
+    @presenter = TwoFactorLoginOptionsPresenter.new(user, view, nil, nil)
     @two_factor_options_form = TwoFactorLoginOptionsForm.new(user)
   end
 


### PR DESCRIPTION
Do not allow a user to view non AAL3 MFA options when they're signing into an AAL3 SP. 

Additionally, if a user manually navigates to a non AAL3 MFA option, while trying to sign into an AAL3 SP, redirect them back to the AAL3 option that they have configured.