### PR TITLE
Add FormSteps React component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
     "no-confusing-arrow": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
-    "operator-linebreak": "off"
+    "operator-linebreak": "off",
+    "react/jsx-one-expression-per-line": "off"
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -48,7 +48,6 @@ window.LoginGov = window.LoginGov || {};
   'zxcvbn.feedback.for_a_stronger_password_use_a_few_words_separated_by_spaces_but_avoid_common_phrases',
   'zxcvbn.feedback.use_a_longer_keyboard_pattern_with_more_turns',
   'doc_auth.buttons.take_picture',
-  'doc_auth.headings.welcome',
   'image_description.accordian_plus_buttom',
   'image_description.accordian_minus_buttom',
   'users.personal_key.close',

--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -5,6 +5,7 @@ window.LoginGov = window.LoginGov || {};
   'two_factor_authentication.otp_delivery_preference.phone_unsupported',
   'errors.messages.format_mismatch',
   'errors.messages.missing_field',
+  'forms.buttons.continue',
   'forms.buttons.submit.default',
   'forms.passwords.show',
   'idv.errors.pattern_mismatch.dob',

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import AcuantCapture from './acuant-capture';
 import DocumentTips from './document-tips';
 import Image from './image';
-import useI18n from '../hooks/use-i18n';
+import FormSteps from './form-steps';
 import Submission from './submission';
 
 function DocumentCapture() {
-  const t = useI18n();
-  const [formValues] = useState({ example: true });
+  const [formValues, setFormValues] = useState(null);
 
   const sample = (
     <Image
@@ -18,12 +17,36 @@ function DocumentCapture() {
     />
   );
 
-  return (
+  return formValues ? (
+    <Submission payload={formValues} />
+  ) : (
     <>
-      <h2>{t('doc_auth.headings.welcome')}</h2>
-      <DocumentTips sample={sample} />
       <AcuantCapture />
-      {formValues && <Submission payload={formValues} />}
+      <DocumentTips sample={sample} />
+      <FormSteps
+        steps={[
+          {
+            name: 'front',
+            // Disable reason: This is intended as throwaway code.
+            // eslint-disable-next-line react/prop-types
+            component: ({ value, onChange }) => (
+              // eslint-disable-next-line jsx-a11y/label-has-associated-control
+              <label>
+                Front
+                <input
+                  type="text"
+                  value={value ?? ''}
+                  onChange={(event) => onChange(event.target.value)}
+                />
+              </label>
+            ),
+          },
+          { name: 'back', component: () => 'Back' },
+          { name: 'selfie', component: () => 'Selfie' },
+          { name: 'confirm', component: () => 'Confirm?' },
+        ]}
+        onComplete={setFormValues}
+      />
     </>
   );
 }

--- a/app/javascript/app/document-capture/components/form-steps.jsx
+++ b/app/javascript/app/document-capture/components/form-steps.jsx
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+function FormSteps({ steps, onComplete }) {
+  const [values, setValues] = useState({});
+  const [stepIndex, setStepIndex] = useState(0);
+
+  function setStepValue(name, nextStepValue) {
+    setValues({ ...values, [name]: nextStepValue });
+  }
+
+  /**
+   * Increments state to the next step, or calls onComplete callback if the current step is the last
+   * step.
+   */
+  function toNextStep() {
+    const nextStepIndex = stepIndex + 1;
+    const isComplete = nextStepIndex === steps.length;
+    if (isComplete) {
+      // Clear step parameter from URL.
+      window.history.pushState(null, null, window.location.pathname);
+
+      onComplete(values);
+    } else {
+      const { name: nextStepName } = steps[nextStepIndex];
+
+      // Push the next step to history, both to update the URL, and to allow the user to return to
+      // an earlier step (see `popstate` sync behavior).
+      window.history.pushState({ stepIndex: nextStepIndex }, nextStepName, `?step=${nextStepName}`);
+
+      setStepIndex(nextStepIndex);
+    }
+  }
+
+  useEffect(() => {
+    function setStepIndexFromHistoryState(event) {
+      // Since there is no history state at the initial step, use 0 as default.
+      const { stepIndex: historyStepIndex = 0 } = event.state ?? {};
+      setStepIndex(historyStepIndex);
+    }
+
+    // If URL contains a step parameter on initial mount, it won't be possible to salvage the state,
+    // and the URL should be synced to the initial step state of the component (the first step).
+    if (window.location.search) {
+      window.history.replaceState(null, null, window.location.pathname);
+    }
+
+    window.addEventListener('popstate', setStepIndexFromHistoryState);
+    return () => window.removeEventListener('popstate', setStepIndexFromHistoryState);
+  }, []);
+
+  const step = steps[stepIndex];
+
+  // An empty steps array is allowed, in which case there is nothing to render.
+  if (!step) {
+    return null;
+  }
+
+  const { component: Component, name } = step;
+  const isLastStep = stepIndex + 1 === steps.length;
+
+  return (
+    <>
+      <Component
+        key={name}
+        value={values[name]}
+        onChange={(nextStepValue) => setStepValue(name, nextStepValue)}
+      />
+      <button type="button" onClick={toNextStep}>
+        {isLastStep ? 'Submit' : 'Continue'}
+      </button>
+    </>
+  );
+}
+
+FormSteps.propTypes = {
+  steps: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      component: PropTypes.elementType,
+    }),
+  ),
+  onComplete: PropTypes.func,
+};
+
+FormSteps.defaultProps = {
+  steps: [],
+  onComplete: () => {},
+};
+
+export default FormSteps;

--- a/app/javascript/app/document-capture/components/form-steps.jsx
+++ b/app/javascript/app/document-capture/components/form-steps.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import useI18n from '../hooks/use-i18n';
 
 function FormSteps({ steps, onComplete }) {
   const [values, setValues] = useState({});
   const [stepIndex, setStepIndex] = useState(0);
+  const t = useI18n();
 
   function setStepValue(name, nextStepValue) {
     setValues({ ...values, [name]: nextStepValue });
@@ -67,7 +69,7 @@ function FormSteps({ steps, onComplete }) {
         onChange={(nextStepValue) => setStepValue(name, nextStepValue)}
       />
       <button type="button" onClick={toNextStep}>
-        {isLastStep ? 'Submit' : 'Continue'}
+        {t(isLastStep ? 'forms.buttons.submit.default' : 'forms.buttons.continue')}
       </button>
     </>
   );

--- a/app/javascript/app/document-capture/hooks/use-history-param.js
+++ b/app/javascript/app/document-capture/hooks/use-history-param.js
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Given a query string and parameter name, returns the decoded value associated with that parameter
+ * in the query string, or null if the value cannot be found. The query string should be provided
+ * without a leading "?".
+ *
+ * This is intended to polyfill a behavior equivalent to:
+ *
+ * ```
+ * new URLSearchParams(queryString).get(name)
+ * ```
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get
+ *
+ * @param {string} queryString Query string to search within.
+ * @param {string} name        Parameter name to search for.
+ *
+ * @return {?string} Decoded parameter value if found, or null otherwise.
+ */
+export function getQueryParam(queryString, name) {
+  const pairs = queryString.split('&');
+  for (let i = 0; i < pairs.length; i += 1) {
+    const [key, value = ''] = pairs[i].split('=').map(decodeURIComponent);
+    if (key === name) return value;
+  }
+
+  return null;
+}
+
+/**
+ * Returns a hook which syncs a querystring parameter by the given name using History pushState.
+ * Returns a `useState`-like tuple of the current value and a setter to assign the next parameter
+ * value.
+ *
+ * The current implementation is limited to managing at most one query parameter at a time for the
+ * entire application.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
+ *
+ * @param {string} name Parameter name to sync.
+ *
+ * @return {[any,(nextParamValue:any)=>void]} Tuple of current state, state setter.
+ */
+function useHistoryParam(name) {
+  const getCurrentQueryParam = () =>
+    getQueryParam(window.location.hash.slice(1), name) ?? undefined;
+
+  const [value, setValue] = useState(getCurrentQueryParam);
+
+  function setParamValue(nextValue) {
+    const nextURL = nextValue
+      ? `#${[name, nextValue].map(encodeURIComponent).join('=')}`
+      : window.location.pathname + window.location.search;
+
+    // Push the next value to history, both to update the URL, and to allow the user to return to
+    // an earlier value (see `popstate` sync behavior).
+    window.history.pushState(null, null, nextURL);
+
+    setValue(nextValue);
+  }
+
+  useEffect(() => {
+    function syncValue() {
+      setValue(getCurrentQueryParam());
+    }
+
+    window.addEventListener('popstate', syncValue);
+    return () => window.removeEventListener('popstate', syncValue);
+  }, []);
+
+  return [value, setParamValue];
+}
+
+export default useHistoryParam;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.4.4",
+    "@testing-library/user-event": "^12.0.11",
     "atob": "^2.1.2",
     "babel-eslint": "^10.1.0",
     "btoa": "^1.2.1",

--- a/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
@@ -1,13 +1,28 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import render from '../../../support/render';
 import DocumentCapture from '../../../../../app/javascript/app/document-capture/components/document-capture';
 
 describe('document-capture/components/document-capture', () => {
-  it('renders a heading', () => {
+  it('renders the form steps', () => {
     const { getByText } = render(<DocumentCapture />);
 
-    const heading = getByText('doc_auth.headings.welcome');
+    const step = getByText('Front');
 
-    expect(heading).to.be.ok();
+    expect(step).to.be.ok();
+  });
+
+  it('progresses through steps to completion', async () => {
+    const { getByText, findByText, getByRole } = render(<DocumentCapture />);
+
+    userEvent.type(getByRole('textbox'), 'abc');
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Submit'));
+
+    const confirmation = await findByText('Finished sending: {"front":"abc"}');
+
+    expect(confirmation).to.be.ok();
   });
 });

--- a/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
@@ -16,10 +16,10 @@ describe('document-capture/components/document-capture', () => {
     const { getByText, findByText, getByRole } = render(<DocumentCapture />);
 
     userEvent.type(getByRole('textbox'), 'abc');
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Submit'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.submit.default'));
 
     const confirmation = await findByText('Finished sending: {"front":"abc"}');
 

--- a/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
@@ -19,6 +19,16 @@ describe('document-capture/components/form-steps', () => {
     { name: 'last', component: () => <span>Last</span> },
   ];
 
+  let originalHash;
+
+  beforeEach(() => {
+    originalHash = window.location.hash;
+  });
+
+  afterEach(() => {
+    window.location.hash = originalHash;
+  });
+
   it('renders nothing if given empty steps array', () => {
     const { container } = render(<FormSteps steps={[]} />);
 
@@ -81,7 +91,7 @@ describe('document-capture/components/form-steps', () => {
 
     userEvent.click(getByText('forms.buttons.continue'));
 
-    expect(window.location.search).to.equal('?step=second');
+    expect(window.location.hash).to.equal('#step=second');
   });
 
   it('syncs step by history events', async () => {
@@ -93,18 +103,18 @@ describe('document-capture/components/form-steps', () => {
     window.history.back();
 
     expect(await findByText('First')).to.be.ok();
-    expect(window.location.search).to.equal('');
+    expect(window.location.hash).to.equal('');
 
     window.history.forward();
 
     expect(await findByText('Second')).to.be.ok();
     expect(getByRole('textbox').value).to.equal('val');
-    expect(window.location.search).to.equal('?step=second');
+    expect(window.location.hash).to.equal('#step=second');
   });
 
   it('clear URL parameter after submission', (done) => {
     const onComplete = sinon.spy(() => {
-      expect(window.location.search).to.equal('');
+      expect(window.location.hash).to.equal('');
 
       done();
     });

--- a/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import sinon from 'sinon';
+import render from '../../../support/render';
+import FormSteps from '../../../../../app/javascript/app/document-capture/components/form-steps';
+
+describe('document-capture/components/form-steps', () => {
+  const STEPS = [
+    { name: 'first', component: () => <span>First</span> },
+    {
+      name: 'second',
+      component: ({ value = '', onChange }) => (
+        <>
+          <span>Second</span>
+          <input value={value} onChange={(event) => onChange(event.target.value)} />
+        </>
+      ),
+    },
+    { name: 'last', component: () => <span>Last</span> },
+  ];
+
+  it('renders nothing if given empty steps array', () => {
+    const { container } = render(<FormSteps steps={[]} />);
+
+    expect(container.childNodes).to.have.lengthOf(0);
+  });
+
+  it('renders the first step initially', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    expect(getByText('First')).to.be.ok();
+  });
+
+  it('renders continue button at first step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    expect(getByText('Continue')).to.be.ok();
+  });
+
+  it('renders the active step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+
+    expect(getByText('Second')).to.be.ok();
+  });
+
+  it('renders continue button until at last step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+
+    expect(getByText('Continue')).to.be.ok();
+  });
+
+  it('renders submit button at last step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Continue'));
+
+    expect(getByText('Submit')).to.be.ok();
+  });
+
+  it('submits with form values', () => {
+    const onComplete = sinon.spy();
+    const { getByText, getByRole } = render(<FormSteps steps={STEPS} onComplete={onComplete} />);
+
+    userEvent.click(getByText('Continue'));
+    userEvent.type(getByRole('textbox'), 'val');
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Submit'));
+
+    expect(onComplete.getCall(0).args[0]).to.eql({
+      second: 'val',
+    });
+  });
+
+  it('pushes step to URL', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+
+    expect(window.location.search).to.equal('?step=second');
+  });
+
+  it('syncs step by history events', async () => {
+    const { getByText, findByText, getByRole } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+    userEvent.type(getByRole('textbox'), 'val');
+
+    window.history.back();
+
+    expect(await findByText('First')).to.be.ok();
+    expect(window.location.search).to.equal('');
+
+    window.history.forward();
+
+    expect(await findByText('Second')).to.be.ok();
+    expect(getByRole('textbox').value).to.equal('val');
+    expect(window.location.search).to.equal('?step=second');
+  });
+
+  it('clear URL parameter after submission', (done) => {
+    const onComplete = sinon.spy(() => {
+      expect(window.location.search).to.equal('');
+
+      done();
+    });
+    const { getByText } = render(<FormSteps steps={STEPS} onComplete={onComplete} />);
+
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('Submit'));
+  });
+
+  it('maintains focus after step change', async () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('Continue'));
+
+    expect(document.activeElement).to.equal(getByText('Continue'));
+  });
+});

--- a/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
@@ -34,13 +34,13 @@ describe('document-capture/components/form-steps', () => {
   it('renders continue button at first step', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    expect(getByText('Continue')).to.be.ok();
+    expect(getByText('forms.buttons.continue')).to.be.ok();
   });
 
   it('renders the active step', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
 
     expect(getByText('Second')).to.be.ok();
   });
@@ -48,28 +48,28 @@ describe('document-capture/components/form-steps', () => {
   it('renders continue button until at last step', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
 
-    expect(getByText('Continue')).to.be.ok();
+    expect(getByText('forms.buttons.continue')).to.be.ok();
   });
 
   it('renders submit button at last step', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
 
-    expect(getByText('Submit')).to.be.ok();
+    expect(getByText('forms.buttons.submit.default')).to.be.ok();
   });
 
   it('submits with form values', () => {
     const onComplete = sinon.spy();
     const { getByText, getByRole } = render(<FormSteps steps={STEPS} onComplete={onComplete} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
     userEvent.type(getByRole('textbox'), 'val');
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Submit'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.submit.default'));
 
     expect(onComplete.getCall(0).args[0]).to.eql({
       second: 'val',
@@ -79,7 +79,7 @@ describe('document-capture/components/form-steps', () => {
   it('pushes step to URL', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
 
     expect(window.location.search).to.equal('?step=second');
   });
@@ -87,7 +87,7 @@ describe('document-capture/components/form-steps', () => {
   it('syncs step by history events', async () => {
     const { getByText, findByText, getByRole } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
     userEvent.type(getByRole('textbox'), 'val');
 
     window.history.back();
@@ -110,16 +110,16 @@ describe('document-capture/components/form-steps', () => {
     });
     const { getByText } = render(<FormSteps steps={STEPS} onComplete={onComplete} />);
 
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Continue'));
-    userEvent.click(getByText('Submit'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
+    userEvent.click(getByText('forms.buttons.submit.default'));
   });
 
   it('maintains focus after step change', async () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
 
-    userEvent.click(getByText('Continue'));
+    userEvent.click(getByText('forms.buttons.continue'));
 
-    expect(document.activeElement).to.equal(getByText('Continue'));
+    expect(document.activeElement).to.equal(getByText('forms.buttons.continue'));
   });
 });

--- a/spec/javascripts/app/document-capture/components/image-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/image-spec.jsx
@@ -9,7 +9,7 @@ describe('document-capture/components/image', () => {
 
     const img = getByAltText('unknown');
 
-    expect(img.src).to.equal('unknown.png');
+    expect(img.getAttribute('src')).to.equal('unknown.png');
   });
 
   it('renders an img at mapped src if known by context', () => {
@@ -21,7 +21,7 @@ describe('document-capture/components/image', () => {
 
     const img = getByAltText('icon');
 
-    expect(img.src).to.equal('icon-12345.png');
+    expect(img.getAttribute('src')).to.equal('icon-12345.png');
   });
 
   it('renders with given props', () => {

--- a/spec/javascripts/app/document-capture/hooks/use-history-param-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-history-param-spec.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import render from '../../../support/render';
+import useHistoryParam, {
+  getQueryParam,
+} from '../../../../../app/javascript/app/document-capture/hooks/use-history-param';
+
+describe('getQueryParam', () => {
+  const queryString = 'a&b=Hello%20world&c';
+
+  it('returns null does not exist', () => {
+    const value = getQueryParam(queryString, 'd');
+
+    expect(value).to.be.null();
+  });
+
+  it('returns decoded value of parameter', () => {
+    const value = getQueryParam(queryString, 'b');
+
+    expect(value).to.equal('Hello world');
+  });
+
+  it('defaults to empty string for empty value', () => {
+    const value = getQueryParam(queryString, 'c');
+
+    expect(value).to.equal('');
+  });
+});
+
+describe('useHistoryParam', () => {
+  function TestComponent() {
+    const [count = 0, setCount] = useHistoryParam('the count');
+
+    return (
+      <>
+        {/* Disable reason: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/566 */}
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label>
+          Count: <input value={count} onChange={(event) => setCount(event.target.value)} />
+        </label>
+        <button type="button" onClick={() => setCount(count + 1)}>
+          Increment
+        </button>
+      </>
+    );
+  }
+
+  let originalHash;
+
+  beforeEach(() => {
+    originalHash = window.location.hash;
+  });
+
+  afterEach(() => {
+    window.location.hash = originalHash;
+  });
+
+  it('returns undefined value if absent from initial URL', () => {
+    const { getByDisplayValue } = render(<TestComponent />);
+
+    expect(getByDisplayValue('0')).to.be.ok();
+  });
+
+  it('returns initial value if present in initial URL', () => {
+    window.location.hash = '#the%20count=5';
+    const { getByDisplayValue } = render(<TestComponent />);
+
+    expect(getByDisplayValue('5')).to.be.ok();
+  });
+
+  it('syncs by setter', () => {
+    const { getByText, getByDisplayValue } = render(<TestComponent />);
+
+    userEvent.click(getByText('Increment'));
+
+    expect(getByDisplayValue('1')).to.be.ok();
+    expect(window.location.hash).to.equal('#the%20count=1');
+
+    userEvent.click(getByText('Increment'));
+
+    expect(getByDisplayValue('2')).to.be.ok();
+    expect(window.location.hash).to.equal('#the%20count=2');
+  });
+
+  it('syncs by history events', async () => {
+    const { getByText, getByDisplayValue, findByDisplayValue } = render(<TestComponent />);
+
+    userEvent.click(getByText('Increment'));
+
+    expect(getByDisplayValue('1')).to.be.ok();
+    expect(window.location.hash).to.equal('#the%20count=1');
+
+    userEvent.click(getByText('Increment'));
+
+    expect(getByDisplayValue('2')).to.be.ok();
+    expect(window.location.hash).to.equal('#the%20count=2');
+
+    window.history.back();
+
+    expect(await findByDisplayValue('1')).to.be.ok();
+    expect(window.location.hash).to.equal('#the%20count=1');
+
+    window.history.back();
+
+    expect(await findByDisplayValue('0')).to.be.ok();
+    expect(window.location.hash).to.equal('');
+  });
+
+  // Skip reason: JSDOM doesn't currently support full history navigation.
+  // Unskip prerequisite: https://github.com/jsdom/jsdom/issues/2112
+  it.skip('preserves existing query parameters', () => {
+    window.location.search = '?ok';
+    const { getByText } = render(<TestComponent />);
+
+    userEvent.click(getByText('Increment'));
+
+    expect(window.location.search).to.equal('?ok');
+  });
+
+  it('encodes parameter names and values', () => {
+    const { getByDisplayValue } = render(<TestComponent />);
+
+    const input = getByDisplayValue('0');
+    userEvent.clear(input);
+    userEvent.type(input, 'one hundred');
+
+    expect(window.location.hash).to.equal('#the%20count=one%20hundred');
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -6,8 +6,9 @@ chai.use(dirtyChai);
 global.expect = chai.expect;
 
 // Emulate a DOM, since many modules will assume the presence of these globals
-// exist as a side effect of their import (focus-trap, classList.js, etc).
-const dom = new JSDOM();
+// exist as a side effect of their import (focus-trap, classList.js, etc). A URL
+// is provided as a prerequisite to managing history API (pushState, etc).
+const dom = new JSDOM('', { url: 'http://example.test' });
 global.window = dom.window;
 global.navigator = window.navigator;
 global.document = window.document;

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -5,9 +5,9 @@ const { JSDOM } = require('jsdom');
 chai.use(dirtyChai);
 global.expect = chai.expect;
 
-// Emulate a DOM, since many modules will assume the presence of these globals
-// exist as a side effect of their import (focus-trap, classList.js, etc). A URL
-// is provided as a prerequisite to managing history API (pushState, etc).
+// Emulate a DOM, since many modules will assume the presence of these globals exist as a side
+// effect of their import (focus-trap, classList.js, etc). A URL is provided as a prerequisite to
+// managing history API (pushState, etc).
 const dom = new JSDOM('', { url: 'http://example.test' });
 global.window = dom.window;
 global.navigator = window.navigator;

--- a/spec/javascripts/support/acuant/document_capture_dom.js
+++ b/spec/javascripts/support/acuant/document_capture_dom.js
@@ -39,13 +39,10 @@ const INITIAL_HTML = `
 </p>
 `;
 
-let originalWindow;
-let originalDocument;
+const originalWindow = global.window;
+const originalDocument = global.document;
 
 export const setupDocumentCaptureTestDOM = () => {
-  originalWindow = global.window;
-  originalDocument = global.document;
-
   // While there's already DOM globals, the current implementation assumes a
   // cleanly initialized DOM in every test case. Ideally all event handlers
   // attached to the DOM in the course of a test case would be cleaned up, and

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -14,7 +14,9 @@ import UploadContext from '../../../app/javascript/app/document-capture/context/
  */
 function renderWithDefaultContext(element) {
   return render(
-    <UploadContext.Provider value={() => Promise.resolve()}>{element}</UploadContext.Provider>,
+    <UploadContext.Provider value={(payload) => Promise.resolve(payload)}>
+      {element}
+    </UploadContext.Provider>,
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,13 @@
     "@testing-library/dom" "^7.17.1"
     semver "^7.3.2"
 
+"@testing-library/user-event@^12.0.11":
+  version "12.0.11"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.0.11.tgz#157594e6c6d73a1503003933177843648b8c7da4"
+  integrity sha512-r7QNfktLE2n8IODEl32orup/HNOMueJpoXRDeTMlvWR4nZIHJwx59+8SkLf6nqV4Ot5Xo6qNeaWrvC1KO4eOng==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/aria-query@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"


### PR DESCRIPTION
**Why**: To manage common behaviors of form values aggregation and history of a linear, step-based form.

**Screen Recording**:

![form-steps mov](https://user-images.githubusercontent.com/1779930/87969759-bc365480-ca90-11ea-8aed-2863c4b3dd52.gif)

The included example is provided for demonstration only, and is not intended to be styled or representative of a final flow. The intent of these changes is to prepare an apparatus for step-based forms flow which accumulates a single payload object, and which can be revised by the user using their browser history.