### PR TITLE
LG-3216 Bug fix to prevent the camera from staying on after…

### DIFF
--- a/app/javascript/app/acuant/document_capture_dom.js
+++ b/app/javascript/app/acuant/document_capture_dom.js
@@ -93,6 +93,7 @@ export const acuantImageCaptureSuccess = (response) => {
   acuantSdkPreviewImage().src = response.image.data;
   imageDataUrlInput().value = response.image.data;
   imageFileInput().required = false;
+  window.AcuantCameraUI.end();
   showAcuantSdkContainer('continue-form');
 };
 

--- a/spec/javascripts/app/acuant/document_capture_spec.js
+++ b/spec/javascripts/app/acuant/document_capture_spec.js
@@ -120,7 +120,10 @@ describe('acuant/document_capture', () => {
     const event = { preventDefault: () => {} };
 
     beforeEach(() => {
-      window.AcuantCameraUI = { start: sinon.spy() };
+      window.AcuantCameraUI = {
+        start: sinon.spy(),
+        end: sinon.spy(),
+      };
 
       fallbackImageForm().classList.add('hidden');
       acuantSdkUploadForm().classList.remove('hidden');
@@ -149,8 +152,12 @@ describe('acuant/document_capture', () => {
 
       imageCaptureButtonClicked(event);
 
+      expect(window.AcuantCameraUI.end.calledOnce).to.eq(false);
+
       const successCallback = window.AcuantCameraUI.start.lastCall.args[0];
       successCallback(response);
+
+      expect(window.AcuantCameraUI.end.calledOnce).to.eq(true);
 
       expect(fallbackImageForm().classList.contains('hidden')).to.eq(true);
       expect(acuantSdkUploadForm().classList.contains('hidden')).to.eq(true);
@@ -169,8 +176,12 @@ describe('acuant/document_capture', () => {
       imageCaptureButtonClicked(event);
       documentCaptureFallbackLinkClicked(event);
 
+      expect(window.AcuantCameraUI.end.calledOnce).to.eq(false);
+
       const successCallback = window.AcuantCameraUI.start.lastCall.args[0];
       successCallback(response);
+
+      expect(window.AcuantCameraUI.end.calledOnce).to.eq(true);
 
       expect(fallbackImageForm().classList.contains('hidden')).to.eq(false);
       expect(acuantSdkUploadForm().classList.contains('hidden')).to.eq(true);


### PR DESCRIPTION
…a successful document capture with the Acuent SDK and modified a couple of tests to  show that the correct method was called on success.