### PR TITLE
Fix bug where signups from IAL2 strict SPs did not require proofing (LG-3217)

### DIFF
--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -19,7 +19,7 @@ class IalContext
   end
 
   def ial2_requested?
-    ial == Identity::IAL2 && !service_provider_requires_liveness?
+    ial == Identity::IAL2
   end
 
   def ial2_or_greater?

--- a/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
+++ b/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
@@ -16,7 +16,7 @@ describe 'Strong IAL2' do
       allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
 
       visit_idp_from_sp_with_ial2(:saml)
-      user = sign_up_and_2fa_ial1_user
+      sign_up_and_2fa_ial1_user
 
       click_agree_and_continue_optional
 

--- a/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
+++ b/spec/features/idv/liveness/upgrade_to_strong_ial2_spec.rb
@@ -3,7 +3,26 @@ require 'rails_helper'
 describe 'Strong IAL2' do
   include IdvHelper
   include OidcAuthHelper
+  include SamlAuthHelper
   include DocAuthHelper
+
+  context 'with an sp that requires livess and a new account' do
+    before do
+      ServiceProvider.from_issuer('https://rp1.serviceprovider.com/auth/saml/metadata').
+        update!(liveness_checking_required: true)
+    end
+
+    it 'starts the proofing process if liveness is enabled' do
+      allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
+
+      visit_idp_from_sp_with_ial2(:saml)
+      user = sign_up_and_2fa_ial1_user
+
+      click_agree_and_continue_optional
+
+      expect(page.current_path).to eq(idv_doc_auth_welcome_step)
+    end
+  end
 
   context 'with an sp that requires liveness and a current verified profile with no liveness' do
     before do

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe IalContext do
     context 'when ial 2 is requested and the sp requires liveness checking' do
       let(:ial) { Identity::IAL2 }
       let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial2_requested?).to eq(false) }
+      it { expect(ial_context.ial2_requested?).to eq(true) }
     end
 
     context 'when ial 2 strict is requested' do


### PR DESCRIPTION
The ial2 logic had some ial2 strict exclusions when it was translated 

https://github.com/18F/identity-idp/pull/3855 -- basically the `store_sp_metadata_in_session` had a slightly different implementation of `ial2_requested`