### PR TITLE
Always end Acuant camera capture on React component unmount

### DIFF
--- a/app/javascript/app/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture-canvas.jsx
@@ -1,35 +1,12 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 function AcuantCaptureCanvas({ onImageCaptureSuccess, onImageCaptureFailure }) {
-  const isCapturing = useRef(false);
-
   useEffect(() => {
-    /**
-     * Creates a new callback function which also sets the internal component
-     * state to mark capture as completed.
-     *
-     * @param {Function} callback Original callback.
-     *
-     * @return {Function} Enhanced callback.
-     */
-    const createOnComplete = (callback) => (result) => {
-      isCapturing.current = false;
-      callback(result);
-    };
-
-    isCapturing.current = true;
-
-    window.AcuantCameraUI.start(
-      createOnComplete(onImageCaptureSuccess),
-      createOnComplete(onImageCaptureFailure),
-    );
+    window.AcuantCameraUI.start(onImageCaptureSuccess, onImageCaptureFailure);
 
     return () => {
-      // If capturing while component unmounts, end the capture.
-      if (isCapturing.current) {
-        window.AcuantCameraUI.end();
-      }
+      window.AcuantCameraUI.end();
     };
   }, []);
 

--- a/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
@@ -113,7 +113,7 @@ describe('document-capture/components/acuant-capture', () => {
     );
     expect(image.width).to.equal(10);
     expect(image.height).to.equal(20);
-    expect(window.AcuantCameraUI.end.called).to.be.false();
+    expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
   });
 
   it('renders the button when the capture failed', () => {
@@ -139,7 +139,7 @@ describe('document-capture/components/acuant-capture', () => {
     button = getByText('doc_auth.buttons.take_picture');
 
     expect(button).to.be.ok();
-    expect(window.AcuantCameraUI.end.called).to.be.false();
+    expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
   });
 
   it('ends the capture when the component unmounts', () => {


### PR DESCRIPTION
Related: #3958 (LG-3216)
Previously: #3922 (LG-3023)

**Why**: The Acuant SDK does not automatically end capture upon completion (success or failure) and must be called directly. Newer versions of the SDK will end the camera automatically, but even in those cases, calling end when the camera is inactive still behaves as a noop. Avoiding to manage current capturing state is a simplification to our integration.