### PR TITLE
Fix bug where signups from IAL2 strict SPs did not require proofing (…

### DIFF
--- a/app/services/ial_context.rb
+++ b/app/services/ial_context.rb
@@ -19,7 +19,7 @@ class IalContext
   end
 
   def ial2_requested?
-    ial == Identity::IAL2 && !service_provider_requires_liveness?
+    ial == Identity::IAL2
   end
 
   def ial2_or_greater?

--- a/spec/services/ial_context_spec.rb
+++ b/spec/services/ial_context_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe IalContext do
     context 'when ial 2 is requested and the sp requires liveness checking' do
       let(:ial) { Identity::IAL2 }
       let(:sp_liveness_checking_required) { true }
-      it { expect(ial_context.ial2_requested?).to eq(false) }
+      it { expect(ial_context.ial2_requested?).to eq(true) }
     end
 
     context 'when ial 2 strict is requested' do


### PR DESCRIPTION
…LG-3217) (#3959)

* Fix bug where signups from IAL2 strict SPs did not require proofing (LG-3217)

* Rubocop: useless assign