### PR TITLE
Create stub React submission upload component flow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,5 +46,13 @@
       "app/phone-internationalization",
       "app/i18n-dropdown"
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["spec/javascripts/**/*"],
+      "rules": {
+        "react/prop-types": "off"
+      }
+    }
+  ]
 }

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AcuantCapture from './acuant-capture';
 import DocumentTips from './document-tips';
 import Image from './image';
 import useI18n from '../hooks/use-i18n';
+import Submission from './submission';
 
 function DocumentCapture() {
   const t = useI18n();
+  const [formValues] = useState({ example: true });
 
   const sample = (
     <Image
@@ -21,6 +23,7 @@ function DocumentCapture() {
       <h2>{t('doc_auth.headings.welcome')}</h2>
       <DocumentTips sample={sample} />
       <AcuantCapture />
+      {formValues && <Submission payload={formValues} />}
     </>
   );
 }

--- a/app/javascript/app/document-capture/components/submission-complete.jsx
+++ b/app/javascript/app/document-capture/components/submission-complete.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+
+function SubmissionComplete({ resource }) {
+  const response = resource.read();
+
+  return `Finished sending: ${JSON.stringify(response)}`;
+}
+
+SubmissionComplete.propTypes = {
+  resource: PropTypes.shape({ read: PropTypes.func }),
+};
+
+export default SubmissionComplete;

--- a/app/javascript/app/document-capture/components/submission.jsx
+++ b/app/javascript/app/document-capture/components/submission.jsx
@@ -1,0 +1,31 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import useAsync from '../hooks/use-async';
+import UploadContext from '../context/upload';
+import SuspenseErrorBoundary from './suspense-error-boundary';
+import SubmissionComplete from './submission-complete';
+
+function Submission({ payload }) {
+  const upload = useContext(UploadContext);
+  const resource = useAsync(upload, payload);
+
+  return (
+    <SuspenseErrorBoundary fallback="Loading..." errorFallback="Error">
+      <SubmissionComplete resource={resource} />
+    </SuspenseErrorBoundary>
+  );
+}
+
+Submission.propTypes = {
+  // Disable reason: While normally its advisable for a components prop shape to
+  // be well-defined, in this case we expect to be able to send arbitrary data
+  // to an endpoint.
+  // eslint-disable-next-line react/forbid-prop-types
+  payload: PropTypes.any,
+};
+
+Submission.defaultProps = {
+  payload: undefined,
+};
+
+export default Submission;

--- a/app/javascript/app/document-capture/components/suspense-error-boundary.jsx
+++ b/app/javascript/app/document-capture/components/suspense-error-boundary.jsx
@@ -1,0 +1,31 @@
+import React, { Component, Suspense } from 'react';
+import PropTypes from 'prop-types';
+
+class SuspenseErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return {
+      hasError: true,
+    };
+  }
+
+  render() {
+    const { fallback, errorFallback, children } = this.props;
+    const { hasError } = this.state;
+
+    return hasError ? errorFallback : <Suspense fallback={fallback}>{children}</Suspense>;
+  }
+}
+
+SuspenseErrorBoundary.propTypes = {
+  fallback: PropTypes.node.isRequired,
+  errorFallback: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default SuspenseErrorBoundary;

--- a/app/javascript/app/document-capture/context/upload.js
+++ b/app/javascript/app/document-capture/context/upload.js
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import upload from '../services/upload';
+
+const UploadContext = createContext(upload);
+
+export default UploadContext;

--- a/app/javascript/app/document-capture/hooks/use-async.js
+++ b/app/javascript/app/document-capture/hooks/use-async.js
@@ -1,0 +1,69 @@
+import { useState, useCallback } from 'react';
+import useIfStillMounted from './use-if-still-mounted';
+
+/**
+ * @typedef SuspenseResource
+ *
+ * @prop {()=>any} read Resource reader, called from a descendent of a Suspense
+ *                      element. The reader will either throw an error, throw
+ *                      the pending promise, or return the value of the resolved
+ *                      promise upon completion.
+ */
+
+/**
+ * Given a function which returns a promise, returns a Suspense resource object.
+ * The resource object can be read from a descendent of a Suspense element,
+ * allowing for fallback states for loading or error handling. Any additional
+ * arguments are passed through to the promise creator, and are treated as
+ * dependencies to trigger a new promise to be issued.
+ *
+ * @see https://reactjs.org/docs/concurrent-mode-suspense.html
+ *
+ * @param {(...args:any)=>Promise} createPromise Promise creator.
+ * @param {...any}                 args          Additional arguments to pass to
+ *                                               promise creator.
+ *
+ * @return {SuspenseResource} Suspense resource object.
+ */
+function useAsync(createPromise, ...args) {
+  const ifStillMounted = useIfStillMounted();
+  const [data, setData] = useState();
+  const [hasData, setHasData] = useState(false);
+  const [error, setError] = useState();
+  const [hasError, setHasError] = useState(false);
+  const read = useCallback(
+    () =>
+      createPromise(...args)
+        .then(
+          ifStillMounted((nextData) => {
+            setData(nextData);
+            setHasData(true);
+          }),
+        )
+        .catch(
+          ifStillMounted((nextError) => {
+            setError(nextError);
+            setHasError(true);
+          }),
+        ),
+    args,
+  );
+
+  return {
+    read() {
+      const promise = read();
+
+      if (hasData) {
+        return data;
+      }
+
+      if (hasError) {
+        throw error;
+      }
+
+      throw promise;
+    },
+  };
+}
+
+export default useAsync;

--- a/app/javascript/app/document-capture/hooks/use-if-still-mounted.js
+++ b/app/javascript/app/document-capture/hooks/use-if-still-mounted.js
@@ -1,0 +1,29 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Hook which returns a higher-order function to compose another function to be
+ * executed only if the component is mounted.
+ *
+ * Note that this can be useful in creating safe callbacks for promise results,
+ * but since dangling references to components can cause memory leaks, it's
+ * preferred to cancel a subscription immediately on unmount whenever possible.
+ *
+ * @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+ */
+function useIfStillMounted() {
+  const isMounted = useRef(false);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  });
+
+  const ifStillMounted = (fn) => (...args) => {
+    if (isMounted.current) fn(...args);
+  };
+
+  return ifStillMounted;
+}
+
+export default useIfStillMounted;

--- a/app/javascript/app/document-capture/services/upload.js
+++ b/app/javascript/app/document-capture/services/upload.js
@@ -1,0 +1,8 @@
+function upload(payload) {
+  return new Promise((resolve, reject) => {
+    const isFailure = window.location.search === '?fail';
+    setTimeout(isFailure ? reject : () => resolve({ ...payload, saved: true }), 2000);
+  });
+}
+
+export default upload;

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -101,4 +101,3 @@
 <%= render 'idv/doc_auth/start_over_or_cancel' %>
 <%= javascript_pack_tag 'image-preview' %>
 </div>
-<%= javascript_pack_tag 'document-capture' %>

--- a/spec/javascripts/app/document-capture/components/accordion-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/accordion-spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import Accordion from '../../../../../app/javascript/app/document-capture/components/accordion';
 
 describe('document-capture/components/accordion', () => {

--- a/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { fireEvent, cleanup } from '@testing-library/react';
 import sinon from 'sinon';
+import render from '../../../support/render';
 import AcuantCapture from '../../../../../app/javascript/app/document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '../../../../../app/javascript/app/document-capture/context/acuant';
 

--- a/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/document-capture-spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import DocumentCapture from '../../../../../app/javascript/app/document-capture/components/document-capture';
 
 describe('document-capture/components/document-capture', () => {

--- a/spec/javascripts/app/document-capture/components/image-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/image-spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import Image from '../../../../../app/javascript/app/document-capture/components/image';
 import AssetContext from '../../../../../app/javascript/app/document-capture/context/asset';
 

--- a/spec/javascripts/app/document-capture/components/suspense-error-boundary-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/suspense-error-boundary-spec.jsx
@@ -1,0 +1,48 @@
+import React, { lazy } from 'react';
+import sinon from 'sinon';
+import render from '../../../support/render';
+import SuspenseErrorBoundary from '../../../../../app/javascript/app/document-capture/components/suspense-error-boundary';
+
+describe('document-capture/components/suspense-error-boundary', () => {
+  it('renders its children', async () => {
+    const { container } = render(
+      <SuspenseErrorBoundary fallback="Loading" errorFallback="Error">
+        No error
+      </SuspenseErrorBoundary>,
+    );
+
+    expect(container.textContent).to.equal('No error');
+  });
+
+  it('renders fallback prop if suspense pending', async () => {
+    const Child = lazy(() => Promise.resolve({ default: () => 'Done' }));
+
+    const { container, findByText } = render(
+      <SuspenseErrorBoundary fallback="Loading" errorFallback="Error">
+        <Child />
+      </SuspenseErrorBoundary>,
+    );
+
+    expect(container.textContent).to.equal('Loading');
+    expect(await findByText('Done')).to.be.ok();
+  });
+
+  it('returns errorFallback prop if an error is caught', async () => {
+    const Child = () => {
+      throw new Error();
+    };
+
+    sinon.stub(console, 'error', () => {});
+
+    const { findByText } = render(
+      <SuspenseErrorBoundary fallback="Loading" errorFallback="Error">
+        <Child />
+      </SuspenseErrorBoundary>,
+    );
+
+    expect(await findByText('Error')).to.be.ok();
+
+    // eslint-disable-next-line no-console
+    console.error.restore();
+  });
+});

--- a/spec/javascripts/app/document-capture/context/acuant.jsx
+++ b/spec/javascripts/app/document-capture/context/acuant.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import AcuantContext, {
   Provider as AcuantContextProvider,
 } from '../../../../../app/javascript/app/document-capture/context/acuant';

--- a/spec/javascripts/app/document-capture/context/asset-spec.jsx
+++ b/spec/javascripts/app/document-capture/context/asset-spec.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import AssetContext from '../../../../../app/javascript/app/document-capture/context/asset';
 
 describe('document-capture/context/asset', () => {

--- a/spec/javascripts/app/document-capture/context/i18n-spec.jsx
+++ b/spec/javascripts/app/document-capture/context/i18n-spec.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import I18nContext from '../../../../../app/javascript/app/document-capture/context/i18n';
 
 describe('document-capture/context/i18n', () => {

--- a/spec/javascripts/app/document-capture/hooks/use-async-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-async-spec.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import sinon from 'sinon';
+import render from '../../../support/render';
+import useAsync from '../../../../../app/javascript/app/document-capture/hooks/use-async';
+import SuspenseErrorBoundary from '../../../../../app/javascript/app/document-capture/components/suspense-error-boundary';
+
+describe('document-capture/hooks/use-async', () => {
+  function Child({ resource }) {
+    resource.read();
+
+    return 'Finished';
+  }
+
+  function Parent({ createPromise }) {
+    const resource = useAsync(createPromise);
+
+    return (
+      <SuspenseErrorBoundary fallback="Loading" errorFallback="Error">
+        <Child resource={resource} />
+      </SuspenseErrorBoundary>
+    );
+  }
+
+  it('returns suspense resource that renders fallback', async () => {
+    let resolve;
+    const createPromise = () =>
+      new Promise((_resolve) => {
+        resolve = () => {
+          _resolve();
+        };
+      });
+
+    const { container, findByText } = render(<Parent createPromise={createPromise} />);
+
+    expect(container.textContent).to.equal('Loading');
+
+    resolve();
+
+    expect(await findByText('Finished')).to.be.ok();
+  });
+
+  it('returns suspense resource that renders error fallback', async () => {
+    let reject;
+    const createPromise = () =>
+      new Promise((_resolve, _reject) => {
+        reject = () => {
+          _reject();
+        };
+      });
+
+    const { container, findByText } = render(<Parent createPromise={createPromise} />);
+
+    expect(container.textContent).to.equal('Loading');
+
+    sinon.stub(console, 'error', () => {});
+    reject();
+
+    expect(await findByText('Error')).to.be.ok();
+    // eslint-disable-next-line no-console
+    console.error.restore();
+  });
+});

--- a/spec/javascripts/app/document-capture/hooks/use-i18n-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-i18n-spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import render from '../../../support/render';
 import I18nContext from '../../../../../app/javascript/app/document-capture/context/i18n';
 import useI18n from '../../../../../app/javascript/app/document-capture/hooks/use-i18n';
 

--- a/spec/javascripts/app/document-capture/hooks/use-if-still-mounted-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-if-still-mounted-spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
+import render from '../../../support/render';
+import useIfStillMounted from '../../../../../app/javascript/app/document-capture/hooks/use-if-still-mounted';
+
+describe('document-capture/hooks/use-if-still-mounted', () => {
+  function TestComponent({ callback }) {
+    const ifStillMounted = useIfStillMounted();
+    const fn = ifStillMounted(callback);
+
+    return (
+      <button type="button" onClick={() => setTimeout(fn, 0)}>
+        trigger
+      </button>
+    );
+  }
+
+  it('returns function which executes callback if component is still mounted', (done) => {
+    const spy = sinon.spy();
+
+    const { getByText } = render(<TestComponent callback={spy} />);
+    fireEvent.click(getByText('trigger'));
+
+    setTimeout(() => {
+      expect(spy.calledOnce).to.be.true();
+      done();
+    }, 0);
+  });
+
+  it('returns function which does not execute callback if component is unmounted', (done) => {
+    const spy = sinon.spy();
+
+    const { getByText, unmount } = render(<TestComponent callback={spy} />);
+    fireEvent.click(getByText('trigger'));
+    unmount();
+
+    setTimeout(() => {
+      expect(spy.called).to.be.false();
+      done();
+    }, 0);
+  });
+});

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import UploadContext from '../../../app/javascript/app/document-capture/context/upload';
+
+/**
+ * Pass-through to React Testing Library, which applies default context values
+ * to stub behavior for testing environment.
+ *
+ * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
+ *
+ * @param {import('react').ReactElement} element Element to render.
+ *
+ * @return {import('@testing-library/react').RenderResult}
+ */
+function renderWithDefaultContext(element) {
+  return render(
+    <UploadContext.Provider value={() => Promise.resolve()}>{element}</UploadContext.Provider>,
+  );
+}
+
+export default renderWithDefaultContext;


### PR DESCRIPTION
Relates to: LG-3023

**Why**: While the API endpoint for submitting the document upload form values does not yet exist, it can be abstracted as a function which receives a payload object and returns a Promise resolving or rejecting by the result of an attempt to upload.

This implements [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html)-based asynchronous component handling, and introduces an optional upload context used in tests to replace the submission handler with a mock value.

Screen recording:

![upload-suspense mov](https://user-images.githubusercontent.com/1779930/88106841-1fe57e00-cb74-11ea-922d-d8ce62c4dde0.gif)

Resources:

- React Suspense: https://reactjs.org/docs/concurrent-mode-suspense.html
- React Error Boundaries: https://reactjs.org/docs/error-boundaries.html
- Test render helper: https://testing-library.com/docs/react-testing-library/setup#custom-render