### PR TITLE
Remove user_id index on email_addresses (LG-3219)

### DIFF
--- a/db/migrate/20200721220357_remove_user_id_index_from_email_address.rb
+++ b/db/migrate/20200721220357_remove_user_id_index_from_email_address.rb
@@ -1,0 +1,7 @@
+class RemoveUserIdIndexFromEmailAddress < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :email_addresses, name: "index_email_addresses_on_user_id", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_132954) do
+ActiveRecord::Schema.define(version: 2020_07_21_220357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -220,7 +220,6 @@ ActiveRecord::Schema.define(version: 2020_06_29_132954) do
     t.index ["email_fingerprint"], name: "index_email_addresses_on_all_email_fingerprints"
     t.index ["email_fingerprint"], name: "index_email_addresses_on_email_fingerprint", unique: true, where: "(confirmed_at IS NOT NULL)"
     t.index ["user_id", "last_sign_in_at"], name: "index_email_addresses_on_user_id_and_last_sign_in_at", order: { last_sign_in_at: :desc }
-    t.index ["user_id"], name: "index_email_addresses_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|


### PR DESCRIPTION
**Why**:
The email_addresses table has an index on [:user_id, :last_sign_in_at],
so an index on [:user_id] is redundant. Removing the index may reduce
space usage and improve performance.

There are a handful more that fit that pattern, but @zachmargolis mentioned it would be easier to revert 1 rather than 6 if an issue comes up. If things go well on this one, will take a go at the remaining ones. I've noted the other potential ones on a branch [here](https://github.com/18F/identity-idp/compare/mitchell-henke/remove-redundant-user-id-index-from-email-address...mitchell-henke/remove-more-redundant-indices?expand=1)