### PR TITLE
Check axe best practices and section 508 (LG-3221)

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -10,7 +10,7 @@ feature 'Accessibility on IDV pages', :js do
 
       visit idv_path
 
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'cancel idv' do
@@ -19,7 +19,7 @@ feature 'Accessibility on IDV pages', :js do
       visit idv_cancel_path
 
       expect(current_path).to eq idv_cancel_path
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'phone info' do
@@ -28,7 +28,7 @@ feature 'Accessibility on IDV pages', :js do
       complete_all_doc_auth_steps
 
       expect(current_path).to eq idv_phone_path
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'review page' do
@@ -38,7 +38,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_review_path
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'personal key / confirmation page' do
@@ -51,7 +51,7 @@ feature 'Accessibility on IDV pages', :js do
       click_continue
 
       expect(current_path).to eq idv_confirmations_path
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
   end
 end

--- a/spec/features/accessibility/static_pages_spec.rb
+++ b/spec/features/accessibility/static_pages_spec.rb
@@ -5,30 +5,30 @@ feature 'Accessibility on static pages', :js do
   scenario 'not found page' do
     visit '/non_existent_page'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario '401 page' do
     visit '/401'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario '422 page' do
     visit '/422'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario '429 page' do
     visit '/429'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario '500 page' do
     visit '/500'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -7,7 +7,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_up_with(email)
 
     expect(current_path).to eq(sign_up_verify_email_path)
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   describe 'user confirmation page' do
@@ -16,14 +16,14 @@ feature 'Accessibility on pages that require authentication', :js do
       confirm_last_user
 
       expect(current_path).to eq(sign_up_enter_password_path)
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'invalid confirmation token' do
       visit sign_up_create_email_confirmation_path(confirmation_token: '123456')
 
       expect(current_path).to eq(sign_up_email_resend_path)
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
   end
 
@@ -32,7 +32,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_up_and_set_password
 
       expect(current_path).to eq(two_factor_options_path)
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'phone setup page' do
@@ -41,7 +41,7 @@ feature 'Accessibility on pages that require authentication', :js do
       click_button t('forms.buttons.continue')
 
       expect(current_path).to eq(phone_setup_path)
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     scenario 'two factor auth page' do
@@ -49,7 +49,7 @@ feature 'Accessibility on pages that require authentication', :js do
       sign_in_before_2fa(user)
 
       expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))
-      expect(page).to be_accessible
+      expect(page).to be_accessible.according_to :section508, :"best-practice"
     end
 
     describe 'SMS' do
@@ -59,7 +59,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'sms')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
-        expect(page).to be_accessible
+        expect(page).to be_accessible.according_to :section508, :"best-practice"
       end
     end
 
@@ -70,7 +70,7 @@ feature 'Accessibility on pages that require authentication', :js do
         visit login_two_factor_path(otp_delivery_preference: 'voice')
 
         expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
-        expect(page).to be_accessible
+        expect(page).to be_accessible.according_to :section508, :"best-practice"
       end
     end
   end
@@ -79,7 +79,7 @@ feature 'Accessibility on pages that require authentication', :js do
     sign_in_and_2fa_user
     visit manage_personal_key_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'profile page' do
@@ -87,7 +87,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit account_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'edit email page' do
@@ -96,7 +96,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit delete_email_path(id: user.email_addresses.take.id)
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'edit password page' do
@@ -104,7 +104,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_password_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'add phone page' do
@@ -112,7 +112,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit add_phone_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'edit phone page' do
@@ -120,7 +120,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_phone_path(id: user.phone_configurations.first.id)
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'generate new personal key page' do
@@ -128,7 +128,7 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit manage_personal_key_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'set up authenticator app page' do
@@ -136,6 +136,6 @@ feature 'Accessibility on pages that require authentication', :js do
 
     visit '/authenticator_setup'
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 end

--- a/spec/features/accessibility/visitor_pages_spec.rb
+++ b/spec/features/accessibility/visitor_pages_spec.rb
@@ -5,24 +5,24 @@ feature 'Accessibility on pages that do not require authentication', :js do
   scenario 'login / root path' do
     visit root_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'forgot password page' do
     visit new_user_password_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'new user start registration page' do
     visit new_user_session_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 
   scenario 'new user registration page' do
     visit sign_up_email_path
 
-    expect(page).to be_accessible
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
   end
 end


### PR DESCRIPTION
**Why**:
By default, axe only checks "best practices", which may not
overlap with Section 508 checks.