### PR TITLE
RISC event cleanup

### DIFF
--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -104,9 +104,9 @@ class SecurityEventForm
 
   def validate_aud
     return if jwt_payload.blank?
-    return if jwt_payload['aud'] == api_security_events_url
+    return if jwt_payload['aud'] == api_risc_security_events_url
 
-    errors.add(:aud, t('risc.security_event.errors.aud_invalid', url: api_security_events_url))
+    errors.add(:aud, t('risc.security_event.errors.aud_invalid', url: api_risc_security_events_url))
     @error_code = ErrorCodes::JWT_AUD
   end
 

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -108,7 +108,7 @@ class SecurityEventForm
 
     return if !user || !service_provider
 
-    return if !record_already_exists?
+    return unless record_already_exists?
 
     errors.add(:jti, t('risc.security_event.errors.jti_not_unique'))
     @error_code = ErrorCodes::DUP

--- a/app/presenters/risc_configuration_presenter.rb
+++ b/app/presenters/risc_configuration_presenter.rb
@@ -14,7 +14,7 @@ class RiscConfigurationPresenter
       delivery: [
         {
           delivery_method: DELIVERY_METHOD_PUSH,
-          url: api_risc_security_events,
+          url: api_risc_security_events_url,
         },
       ],
     }

--- a/app/presenters/risc_configuration_presenter.rb
+++ b/app/presenters/risc_configuration_presenter.rb
@@ -14,7 +14,7 @@ class RiscConfigurationPresenter
       delivery: [
         {
           delivery_method: DELIVERY_METHOD_PUSH,
-          url: api_security_events_url,
+          url: api_risc_security_events,
         },
       ],
     }

--- a/config/locales/image_description/es.yml
+++ b/config/locales/image_description/es.yml
@@ -4,7 +4,7 @@ es:
     accordian_minus_buttom: Botón menos
     accordian_plus_buttom: Botón más
     camera_mobile_phone: Cámara parpadeando en un teléfono móvil
+    close: Botón de cierre
     spinner: Indicador de carga
     totp_qrcode: Código QR para la aplicación de autenticación
     us_flag: Bandera de estados unidos
-    close: Botón de cierre

--- a/config/locales/image_description/fr.yml
+++ b/config/locales/image_description/fr.yml
@@ -4,7 +4,7 @@ fr:
     accordian_minus_buttom: Bouton moins
     accordian_plus_buttom: Bouton Plus
     camera_mobile_phone: Appareil photo clignotant sur un téléphone mobile
+    close: Bouton de fermeture
     spinner: Indicateur de chargement
     totp_qrcode: Code QR pour l'application d'authentification
     us_flag: Drapeau américain
-    close: Bouton de fermeture

--- a/config/locales/risc/en.yml
+++ b/config/locales/risc/en.yml
@@ -8,6 +8,8 @@ en:
         event_type_missing: missing event
         event_type_unsupported: unsupported event type %{event_type}
         exp_present: SET events must not have an exp claim
+        jti_required: jti claim is required
+        jti_not_unique: jti was not unique
         jwt_could_not_parse: could not parse JWT
         no_public_key: could not load public key for issuer
         sub_not_found: invalid event.subject.sub claim

--- a/config/locales/risc/en.yml
+++ b/config/locales/risc/en.yml
@@ -8,8 +8,8 @@ en:
         event_type_missing: missing event
         event_type_unsupported: unsupported event type %{event_type}
         exp_present: SET events must not have an exp claim
-        jti_required: jti claim is required
         jti_not_unique: jti was not unique
+        jti_required: jti claim is required
         jwt_could_not_parse: could not parse JWT
         no_public_key: could not load public key for issuer
         sub_not_found: invalid event.subject.sub claim

--- a/config/locales/risc/es.yml
+++ b/config/locales/risc/es.yml
@@ -8,6 +8,8 @@ es:
         event_type_missing: event perdido
         event_type_unsupported: tipo de evento no admitido %{event_type}
         exp_present: Los eventos SET no deben tener un reclamo de exp
+        jti_not_unique: jti ya existe
+        jti_required: se requiere reclamo jti
         jwt_could_not_parse: no se pudo analizar JWT
         no_public_key: no se pudo cargar la clave pública para el emisor
         sub_not_found: reclamo de event.subject.sub no válido

--- a/config/locales/risc/fr.yml
+++ b/config/locales/risc/fr.yml
@@ -8,6 +8,8 @@ fr:
         event_type_missing: event manquant
         event_type_unsupported: type d'événement non pris en charge %{event_type}
         exp_present: Les événements SET ne doivent pas avoir de réclamation exp
+        jti_not_unique: jti n'était pas unique
+        jti_required: La revendication jti est requise
         jwt_could_not_parse: impossible d'analyser JWT
         no_public_key: impossible de charger la clé publique de l'émetteur
         sub_not_found: revendication event.subject.sub non valide

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   post '/api/openid_connect/token' => 'openid_connect/token#create'
   match '/api/openid_connect/token' => 'openid_connect/token#options', via: :options
   get '/api/openid_connect/userinfo' => 'openid_connect/user_info#show'
-  post '/api/security_events' => 'risc/security_events#create'
+  post '/api/risc/security_events' => 'risc/security_events#create'
   post '/analytics' => 'analytics#create'
 
   # SAML secret rotation paths

--- a/db/migrate/20200723214611_add_unique_indexes_to_security_events.rb
+++ b/db/migrate/20200723214611_add_unique_indexes_to_security_events.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexesToSecurityEvents < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :security_events, ["jti", "user_id", "issuer"], name: "index_security_events_on_jti_and_user_id_and_issuer", unique: true, algorithm: :concurrently
+
+    # created in past PR, now redundant
+    remove_index :security_events, name: "index_security_events_on_jti", column: ["jti"]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_214611) do
     t.string "issuer"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jti", "user_id", "issuer"], name: "index_security_events_on_user_id_jti_and_issuer", unique: true
+    t.index ["jti", "user_id", "issuer"], name: "index_security_events_on_jti_and_user_id_and_issuer", unique: true
     t.index ["user_id"], name: "index_security_events_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_220357) do
+ActiveRecord::Schema.define(version: 2020_07_23_214611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_220357) do
     t.string "issuer"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jti"], name: "index_security_events_on_jti"
+    t.index ["jti", "user_id", "issuer"], name: "index_security_events_on_user_id_jti_and_issuer", unique: true
     t.index ["user_id"], name: "index_security_events_on_user_id"
   end
 

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Risc::SecurityEventsController do
         iss: identity.service_provider,
         jti: jti,
         iat: Time.zone.now.to_i,
-        aud: api_security_events_url,
+        aud: api_risc_security_events_url,
         events: {
           SecurityEvent::CREDENTIAL_CHANGE_REQUIRED => {
             subject: {
@@ -70,7 +70,7 @@ RSpec.describe Risc::SecurityEventsController do
         json = JSON.parse(response.body).with_indifferent_access
 
         expect(json[:err]).to eq(SecurityEventForm::ErrorCodes::JWT_AUD)
-        expect(json[:description]).to include("expected #{api_security_events_url}")
+        expect(json[:description]).to include("expected #{api_risc_security_events_url}")
       end
 
       it 'tracks an error event in analytics' do

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SecurityEventForm do
       iss: identity.service_provider,
       jti: SecureRandom.urlsafe_base64,
       iat: Time.zone.now.to_i,
-      aud: api_security_events_url,
+      aud: api_risc_security_events_url,
       events: {
         SecurityEvent::CREDENTIAL_CHANGE_REQUIRED => {
           subject: {
@@ -142,7 +142,7 @@ RSpec.describe SecurityEventForm do
           expect(valid?).to eq(false)
           expect(form.error_code).to eq('jwtAud')
           expect(form.errors[:aud]).
-            to include("invalid aud claim, expected #{api_security_events_url}")
+            to include("invalid aud claim, expected #{api_risc_security_events_url}")
         end
       end
     end

--- a/spec/presenters/risc_configuration_presenter_spec.rb
+++ b/spec/presenters/risc_configuration_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RiscConfigurationPresenter do
 
         expect(configuration[:delivery].first).to eq(
           delivery_method: RiscConfigurationPresenter::DELIVERY_METHOD_PUSH,
-          url: api_security_events_url,
+          url: api_risc_security_events_url,
         )
       end
     end


### PR DESCRIPTION
As I was drafting up docs for our RISC implementation (https://github.com/18F/identity-dev-docs/pull/138
), I found a few ways I wanted to clean up the RISC events implementation:

- Namespace the API URL (like we namespace `openid_connect`)
- Make sure JTI is present, and validate JTI uniqueness
   - I scope the JTI uniqueness by user, SP because I don't think it's reasonable to expect SP to coordinate with each other. I also figured that allowing different users to have the same unique ID might be OK, the index mostly exists to prevent against double submissions of the same event
