### PR TITLE
Use `auth_method` to track whether remember device was used

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,7 +264,12 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   end
 
   def aal3_policy
-    @aal3 ||= AAL3Policy.new(session: session, user: current_user)
+    @aal3 ||= AAL3Policy.new(
+      user: current_user,
+      service_provider: sp_from_sp_session,
+      auth_method: user_session[:auth_method],
+      aal_level_requested: sp_session[:aal_level_requested],
+    )
   end
 
   def sp_session

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -51,6 +51,8 @@ module RememberDeviceConcern
   private
 
   def expired_for_interval?(user, interval)
+    # After RC 115 this should become:
+    # `return false unless user_session[:auth_method] == 'remember_device'`
     return false unless user_session[:mfa_device_remembered]
     remember_cookie = remember_device_cookie
     return true if remember_cookie.nil?
@@ -62,7 +64,9 @@ module RememberDeviceConcern
   end
 
   def handle_valid_remember_device_cookie
+    # After RC 116 this next line can be removed
     user_session[:mfa_device_remembered] = true
+    user_session[:auth_method] = 'remember_device'
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -76,6 +76,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def handle_valid_otp(next_url = nil)
     handle_valid_otp_for_context
     handle_remember_device
+    # After RC 116 this line can be removed
     user_session.delete(:mfa_device_remembered)
     next_url ||= after_otp_verification_confirmation_url
     reset_otp_session_data

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -138,7 +138,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def handle_valid_otp_for_authentication_context
-    session[:auth_method] = two_factor_authentication_method.to_s
+    user_session[:auth_method] = two_factor_authentication_method.to_s
     mark_user_session_authenticated(:valid_2fa)
     bypass_sign_in current_user
     create_user_event(:sign_in_after_2fa)

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -70,6 +70,7 @@ module TwoFactorAuthentication
     def handle_valid_backup_code
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
+      # This next line can be removed after RC 116
       user_session.delete(:mfa_device_remembered)
     end
   end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -45,7 +45,7 @@ module TwoFactorAuthentication
 
     def two_factor_options_presenter
       TwoFactorLoginOptionsPresenter.new(
-        current_user, view_context, current_sp, aal3_policy.aal3_required?,
+        current_user, view_context, current_sp, aal3_policy.aal3_required?
       )
     end
 

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -44,7 +44,9 @@ module TwoFactorAuthentication
     private
 
     def two_factor_options_presenter
-      TwoFactorLoginOptionsPresenter.new(current_user, view_context, current_sp, session)
+      TwoFactorLoginOptionsPresenter.new(
+        current_user, view_context, current_sp, aal3_policy.aal3_required?,
+      )
     end
 
     def process_valid_form

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -96,6 +96,7 @@ module TwoFactorAuthentication
         redirect_to two_factor_options_url
       end
       reset_otp_session_data
+      # This next line can be removed after RC 116
       user_session.delete(:mfa_device_remembered)
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -48,6 +48,7 @@ module TwoFactorAuthentication
       handle_valid_otp_for_authentication_context
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
+      # This next line can be removed after RC 116
       user_session.delete(:mfa_device_remembered)
     end
 

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -34,6 +34,7 @@ module TwoFactorAuthentication
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
+      # This next line can be removed after RC 116
       user_session.delete(:mfa_device_remembered)
     end
 

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -36,7 +36,7 @@ module Users
     def two_factor_options_presenter
       TwoFactorOptionsPresenter.new(user_agent: request.user_agent,
                                     user: current_user,
-                                    session: session)
+                                    aal3_required: aal3_policy.aal3_required?)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -3,11 +3,11 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   attr_reader :current_user
 
-  def initialize(current_user, view, service_provider, session)
+  def initialize(current_user, view, service_provider, aal3_required)
     @current_user = current_user
     @view = view
     @service_provider = service_provider
-    @session = session
+    @aal3_required = aal3_required
   end
 
   def title
@@ -28,7 +28,7 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def options
     mfa = MfaContext.new(current_user)
-    if aal3_policy.aal3_required?
+    if @aal3_required
       configurations = mfa.aal3_configurations
     else
       configurations = mfa.two_factor_configurations
@@ -87,9 +87,5 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
 
   def account_reset_token_valid?
     current_user&.account_reset_request&.granted_token_valid?
-  end
-
-  def aal3_policy
-    @aal3 ||= AAL3Policy.new(session: @session, user: @current_user)
   end
 end

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -1,10 +1,10 @@
 class TwoFactorOptionsPresenter
   include ActionView::Helpers::TranslationHelper
 
-  def initialize(user_agent:, user: nil, session: nil)
+  def initialize(user_agent:, user: nil, aal3_required: false)
     @user_agent = user_agent
     @user = user
-    @session = session
+    @aal3_required = aal3_required
   end
 
   def options
@@ -66,11 +66,7 @@ class TwoFactorOptionsPresenter
   end
 
   def aal3_only?
-    aal3_policy.aal3_required? && !mfa_policy.aal3_mfa_enabled?
-  end
-
-  def aal3_policy
-    @aal3_policy ||= AAL3Policy.new(session: @session, user: @user)
+    @aal3_required && !mfa_policy.aal3_mfa_enabled?
   end
 
   def mfa_policy

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               credential_id: credential_id,
               credential_public_key: credential_public_key,
             )
-            controller.session[:auth_method] = 'webauthn'
+            controller.user_session[:auth_method] = 'webauthn'
           end
 
           it 'redirects to the SP with params' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -935,6 +935,7 @@ describe SamlIdpController do
       allow(controller).to receive(:user_fully_authenticated?).and_return(true)
       allow(controller).to receive(:link_identity_from_session_data).and_return(true)
       allow(controller).to receive(:current_user).and_return(build(:user))
+      allow(controller).to receive(:user_session).and_return({})
     end
 
     context 'user requires ID verification' do

--- a/spec/policies/aal3_policy_spec.rb
+++ b/spec/policies/aal3_policy_spec.rb
@@ -1,35 +1,53 @@
 require 'rails_helper'
 
 describe AAL3Policy do
-  let(:service_provider) { create(:service_provider, aal: 1) }
-  let(:sp_session) { { issuer: service_provider.issuer, aal_level_requested: 1 } }
-  let(:session) { { auth_method: 'phone', sp: sp_session } }
   let(:user) { create(:user) }
+  let(:service_provider) { create(:service_provider, aal: 1) }
+  let(:auth_method) { 'phone' }
+  let(:aal_level_requested) { 1 }
 
   describe '#aal3_required?' do
     it 'is false if the SP did not request and does not require AAL3' do
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_required?).to eq(false)
     end
 
     it 'is true if the SP requested AAL3' do
-      sp_session[:aal_level_requested] = 3
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_required?).to eq(true)
     end
 
     it 'is true if the SP is configured for AAL3 only' do
       service_provider.update!(aal: 3)
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_required?).to eq(true)
     end
 
     it 'is false if there is no SP' do
-      session[:sp] = nil
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: nil,
+        auth_method: auth_method,
+        aal_level_requested: nil,
+      )
 
       expect(aal3_policy.aal3_required?).to eq(false)
     end
@@ -37,22 +55,34 @@ describe AAL3Policy do
 
   describe '#aal3_used?' do
     it 'returns true if the user used PIV/CAC for MFA' do
-      session[:auth_method] = 'piv_cac'
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: 'piv_cac',
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_used?).to eq(true)
     end
 
     it 'returns true if the user used webauthn for MFA' do
-      session[:auth_method] = 'webauthn'
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: 'webauthn',
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_used?).to eq(true)
     end
 
     it 'returns false if the user has not used an AAL3 method for MFA' do
-      session[:auth_method] = 'phone'
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: 'phone',
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_used?).to eq(false)
     end
@@ -60,22 +90,34 @@ describe AAL3Policy do
 
   describe '#aal3_required_but_not_used?' do
     it 'returns false if AAL3 is not required' do
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_required_but_not_used?).to eq(false)
     end
 
     it 'returns true if AAL3 is required and was not used to sign in' do
-      sp_session[:aal_level_requested] = 3
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_required_but_not_used?).to eq(true)
     end
 
     it 'returns false if AAL3 is required and was used to sign in' do
-      sp_session[:aal_level_requested] = 3
-      session[:auth_method] = 'webauthn'
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: 'webauthn',
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_required_but_not_used?).to eq(false)
     end
@@ -84,31 +126,47 @@ describe AAL3Policy do
   describe '#aal3_configured_but_not_used?' do
     it 'returns false if AAL3 is configured and not required and not used' do
       configure_aal3_for_user(user)
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: aal_level_requested,
+      )
 
       expect(aal3_policy.aal3_configured_but_not_used?).to eq(false)
     end
 
     it 'returns false if AAL3 is not configured' do
-      sp_session[:aal_level_requested] = 3
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_configured_but_not_used?).to eq(false)
     end
 
     it 'returns true if AAL3 is configured and was not used to sign in' do
-      sp_session[:aal_level_requested] = 3
       configure_aal3_for_user(user)
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: auth_method,
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_configured_but_not_used?).to eq(true)
     end
 
     it 'returns false if AAL3 is configured and was used to sign in' do
-      sp_session[:aal_level_requested] = 3
       configure_aal3_for_user(user)
-      session[:auth_method] = 'webauthn'
-      aal3_policy = AAL3Policy.new(session: session, user: user)
+      aal3_policy = AAL3Policy.new(
+        user: user,
+        service_provider: service_provider,
+        auth_method: 'webauthn',
+        aal_level_requested: 3,
+      )
 
       expect(aal3_policy.aal3_configured_but_not_used?).to eq(false)
     end

--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -25,12 +25,8 @@ describe TwoFactorOptionsPresenter do
     end
 
     context 'when an AAL3 only SP is being used' do
-      let(:service_provider) { create(:service_provider, aal: 3) }
-      let(:sp_session) { { issuer: service_provider.issuer, aal_level_requested: 3 } }
-      let(:session) { { auth_method: 'phone', sp: sp_session } }
-
       let(:presenter) do
-        described_class.new(user_agent: user_agent, user: user_with_2fa, session: session)
+        described_class.new(user_agent: user_agent, user: user_with_2fa, aal3_required: true)
       end
 
       it 'only displays AAL3 MFA methods' do


### PR DESCRIPTION
**Why**: To treat remember device like auth auth methods in MFA policies and AAL3 policies

There is another commit in here to make this one possible:

Modify the AAL3Policy so it does not require the session

**Why**: So we do not have to pass the session through callers to initialize it. This allows us to move the `auth_method` out of the `session` and into the `user_session` without needing to re-implement `user_session` inside the policy.
