### PR TITLE
Stop writing to mfa_device_remembered in the session

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -62,8 +62,6 @@ module RememberDeviceConcern
   end
 
   def handle_valid_remember_device_cookie
-    # After RC 116 this next line can be removed
-    user_session[:mfa_device_remembered] = true
     user_session[:auth_method] = 'remember_device'
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -76,8 +76,6 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def handle_valid_otp(next_url = nil)
     handle_valid_otp_for_context
     handle_remember_device
-    # After RC 116 this line can be removed
-    user_session.delete(:mfa_device_remembered)
     next_url ||= after_otp_verification_confirmation_url
     reset_otp_session_data
     redirect_to next_url

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -71,8 +71,6 @@ module TwoFactorAuthentication
     def handle_valid_backup_code
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
-      # This next line can be removed after RC 116
-      user_session.delete(:mfa_device_remembered)
     end
   end
 end

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -95,8 +95,6 @@ module TwoFactorAuthentication
         redirect_to two_factor_options_url
       end
       reset_otp_session_data
-      # This next line can be removed after RC 116
-      user_session.delete(:mfa_device_remembered)
     end
   end
 end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -48,8 +48,6 @@ module TwoFactorAuthentication
       handle_valid_otp_for_authentication_context
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
-      # This next line can be removed after RC 116
-      user_session.delete(:mfa_device_remembered)
     end
 
     def handle_invalid_piv_cac

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -35,8 +35,6 @@ module TwoFactorAuthentication
       handle_remember_device
       redirect_to after_otp_verification_confirmation_url
       reset_otp_session_data
-      # This next line can be removed after RC 116
-      user_session.delete(:mfa_device_remembered)
     end
 
     def handle_remember_device


### PR DESCRIPTION
**Why**: Because we no longer use this value after the preceding commits get merged.