### PR TITLE
LG-3228: inelegant patch to fix PIVCAC redirect loop

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -96,7 +96,13 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def two_factor_authentication_method
-    params[:otp_delivery_preference] || request.path.split('/').last
+    auth_method = params[:otp_delivery_preference] || request.path.split('/').last
+    # the above check gets a wrong value for piv_cac when there is no OTP screen
+    # so we patch it to fix LG-3228
+    if auth_method == 'present_piv_cac'
+      auth_method = 'piv_cac'
+    end
+    auth_method
   end
 
   # Method will be renamed in the next refactor.

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -99,9 +99,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
     auth_method = params[:otp_delivery_preference] || request.path.split('/').last
     # the above check gets a wrong value for piv_cac when there is no OTP screen
     # so we patch it to fix LG-3228
-    if auth_method == 'present_piv_cac'
-      auth_method = 'piv_cac'
-    end
+    auth_method = 'piv_cac' if auth_method == 'present_piv_cac'
     auth_method
   end
 


### PR DESCRIPTION
### Bug
- Sign in from an SP marked as AAL3
- Get stuck in a redirect loop on the PIV/CAC page (instead of continuing on)

### Root cause

Our good friend `TwoFactorAuthenticatable`

1. To check that people logged in with a PIV/CAC, we look at `#two_factor_authentication_method` and see that people have logged in with a PIV/CAC
2. The implementation of `#two_factor_authentication_method`  was returning `"present_piv_cac"` and not `"piv_cac"`
3. The reason for that: `#two_factor_authentication_method` infers  authentication delivery method from the last segment of the URL (which is usually `/authenticator`, `/personal_key`, `/webauthn`, `/backup_code`, `/phone` or `sms` and stores that in the session. The URL to redirect to the PIVCAC server is `/piv_cac/present_piv_cac`, hence `"present_piv_cac"`

### Solution
(and I am *not* happy with this but it's *something*)
- Patch `#two_factor_authentication_method` to return a correct value

### Alternative Solutions

#### Hack no. 2
Another option would be to hack the URL in `routes.rb` but I think that would be harder to follow and debug in the future when it breaks
```patch
diff --git a/config/routes.rb b/config/routes.rb
index 49fdd3193..662f29ffc 100644
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,7 @@ Rails.application.routes.draw do
       get '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#show'
       post '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#create'
       get '/login/two_factor/piv_cac' => 'two_factor_authentication/piv_cac_verification#show'
-      get '/login/two_factor/piv_cac/present_piv_cac' => 'two_factor_authentication/piv_cac_verification#redirect_to_piv_cac_service'
+      get '/login/two_factor/piv_cac/present/piv_cac' => 'two_factor_authentication/piv_cac_verification#redirect_to_piv_cac_service'
```

#### A "real fix"
- We could explicitly store the authentication method in the session rather than infer it from the URL. I'm not sure how big that is, so I'll need to do a lot more digging. This PR is up so we can discuss our options