### PR TITLE
Scope or add matching scss-lint re-enable

### DIFF
--- a/app/assets/stylesheets/components/_abbr.scss
+++ b/app/assets/stylesheets/components/_abbr.scss
@@ -1,3 +1,4 @@
 // normalize.css adds a text underline by default
 // scss-lint:disable QualifyingElement
 abbr[title] { text-decoration: none; }
+// scss-lint:enable QualifyingElement

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -106,8 +106,8 @@ input::-webkit-inner-spin-button {
   z-index: inherit;
 }
 
-// scss-lint:disable VendorPrefix
 .indicator {
+  // scss-lint:disable VendorPrefix
   background-position: center center;
   background-repeat: no-repeat;
   background-size: .5rem .5rem;

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -46,3 +46,4 @@ h6, .h6 { font-size: $h6; }
   h5, .h5 { font-size: $sm-h5; }
   h6, .h6 { font-size: $sm-h6; }
 }
+// scss-lint:enable SingleLinePerSelector


### PR DESCRIPTION
**Why**: Unless a matching enable tag is included, the lint rule will be disabled for the rest of the file, allowing future developers to unknowingly introduce unintended violations.

See: https://github.com/sds/scss-lint#disabling-linters-via-source

Scoping within a block can be sufficient alternative if rule is intended to be disabled for the block, as is the case in form indicator styles.