### PR TITLE
Validate document capture step completion after page reload

### DIFF
--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -3,7 +3,7 @@ import AcuantCapture from './acuant-capture';
 import DocumentTips from './document-tips';
 import Image from './image';
 import FormSteps from './form-steps';
-import DocumentsStep from './documents-step';
+import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
 import Submission from './submission';
 
 function DocumentCapture() {
@@ -29,6 +29,7 @@ function DocumentCapture() {
           {
             name: 'documents',
             component: DocumentsStep,
+            isValid: isDocumentsStepValid,
           },
           { name: 'selfie', component: () => 'Selfie' },
           { name: 'confirm', component: () => 'Confirm?' },

--- a/app/javascript/app/document-capture/components/documents-step.jsx
+++ b/app/javascript/app/document-capture/components/documents-step.jsx
@@ -53,6 +53,6 @@ DocumentsStep.defaultProps = {
  *
  * @return {boolean} Whether step is valid.
  */
-DocumentsStep.isValid = (value) => Boolean(value.front_image && value.back_image);
+export const isValid = (value) => Boolean(value.front_image && value.back_image);
 
 export default DocumentsStep;

--- a/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/form-steps-spec.jsx
@@ -4,6 +4,8 @@ import sinon from 'sinon';
 import render from '../../../support/render';
 import FormSteps, {
   isStepValid,
+  getStepIndexByName,
+  getLastValidStepIndex,
 } from '../../../../../app/javascript/app/document-capture/components/form-steps';
 
 describe('document-capture/components/form-steps', () => {
@@ -50,6 +52,41 @@ describe('document-capture/components/form-steps', () => {
       const result = isStepValid(step, { ok: false });
 
       expect(result).to.be.false();
+    });
+  });
+
+  describe('getStepIndexByName', () => {
+    it('returns -1 if no step by name', () => {
+      const result = getStepIndexByName(STEPS, 'third');
+
+      expect(result).to.be.equal(-1);
+    });
+
+    it('returns index of step by name', () => {
+      const result = getStepIndexByName(STEPS, 'second');
+
+      expect(result).to.be.equal(1);
+    });
+  });
+
+  describe('getLastValidStepIndex', () => {
+    it('returns -1 if array is empty', () => {
+      const result = getLastValidStepIndex([], {});
+
+      expect(result).to.be.equal(-1);
+    });
+
+    it('returns -1 if all steps are invalid', () => {
+      const steps = [...STEPS].map((step) => ({ ...step, isValid: () => false }));
+      const result = getLastValidStepIndex(steps, {});
+
+      expect(result).to.be.equal(-1);
+    });
+
+    it('returns index of the last valid step', () => {
+      const result = getLastValidStepIndex(STEPS, { second: 'valid' });
+
+      expect(result).to.be.equal(2);
     });
   });
 
@@ -113,6 +150,8 @@ describe('document-capture/components/form-steps', () => {
 
   it('pushes step to URL', () => {
     const { getByText } = render(<FormSteps steps={STEPS} />);
+
+    expect(window.location.hash).to.equal('');
 
     userEvent.click(getByText('forms.buttons.continue'));
 


### PR DESCRIPTION
**Why**: The `useHistoryParam` React hook introduced in #3952 works a little too well in that it will blindly accept a hash parameter `#step=selfie` to skip to the corresponding step. This is not desirable in the case that the user reloads the page after completing one of the steps, since the state (form values) will not persist after the page reload. Instead, the step's validity logic (introduced in #3978) should be used to verify step completion of all form steps up until the one associated with value assigned to the URL hash. The user should be returned to the last step which qualifies as valid. In our case, this will be the first step (`#step=documents`).

**Screen recording:**

![return-to-first-step mov](https://user-images.githubusercontent.com/1779930/88684559-0340cd00-d0c3-11ea-9365-01a752d6811a.gif)
