### PR TITLE
Replace static page document capture with mounted React application

### DIFF
--- a/app/assets/javascripts/assets.js.erb
+++ b/app/assets/javascripts/assets.js.erb
@@ -3,7 +3,6 @@ window.LoginGov.assets = {};
 
 <% keys = [
   'clock.svg',
-  'state-id-sample-front.jpg',
   'plus.svg',
   'minus.svg',
   'up-carat-thin.svg',

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import AcuantCapture from './acuant-capture';
-import DocumentTips from './document-tips';
-import Image from './image';
 import FormSteps from './form-steps';
 import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
 import Submission from './submission';
@@ -9,34 +7,24 @@ import Submission from './submission';
 function DocumentCapture() {
   const [formValues, setFormValues] = useState(null);
 
-  const sample = (
-    <Image
-      assetPath="state-id-sample-front.jpg"
-      alt="Sample front of state issued ID"
-      width={450}
-      height={338}
-    />
-  );
-
   return formValues ? (
     <Submission payload={formValues} />
   ) : (
-    <>
-      <AcuantCapture />
-      <DocumentTips sample={sample} />
-      <FormSteps
-        steps={[
-          {
-            name: 'documents',
-            component: DocumentsStep,
-            isValid: isDocumentsStepValid,
-          },
-          { name: 'selfie', component: () => 'Selfie' },
-          { name: 'confirm', component: () => 'Confirm?' },
-        ]}
-        onComplete={setFormValues}
-      />
-    </>
+    <FormSteps
+      steps={[
+        {
+          name: 'documents',
+          component: DocumentsStep,
+          isValid: isDocumentsStepValid,
+        },
+        {
+          name: 'selfie',
+          component: AcuantCapture,
+        },
+        { name: 'confirm', component: () => 'Confirm?' },
+      ]}
+      onComplete={setFormValues}
+    />
   );
 }
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -81,7 +81,7 @@
 
           <%= f.input :selfie_image_data_url, as: :hidden %>
           <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-          <div class='my2' id='selfie_target'>
+          <div class='my2' id='selfie_target'></div>
         </div>
       <% end %>
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -94,8 +94,8 @@
 
     <p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
 
-    <%= render 'idv/doc_auth/start_over_or_cancel' %>
     <%= javascript_pack_tag 'image-preview' %>
   </div>
+  <%= render 'idv/doc_auth/start_over_or_cancel' %>
   <%= javascript_pack_tag 'document-capture' %>
 <% end %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -1,4 +1,5 @@
 <% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
+  <% title t('doc_auth.titles.doc_auth') %>
   <% content_for :meta_tags do %>
     <meta
       name="acuant-sdk-initialization-endpoint"
@@ -9,95 +10,92 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"></div>
+  <div id="document-capture-form">
+    <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
+
+    <h1>
+      <% if liveness_checking_enabled? %>
+        <%= t('doc_auth.headings.document_capture_with_selfie_html') %>
+      <% else %>
+        <%= t('doc_auth.headings.document_capture_html') %>
+      <% end %>
+    </h1>
+
+    <%= render 'idv/doc_auth/document_capture_notices', flow_session: flow_session %>
+
+    <%= simple_form_for(
+      :doc_auth,
+      url: url_for,
+      method: 'PUT',
+      html: { autocomplete: 'off', role: 'form', class: 'mt2' }
+    ) do |f| %>
+      <%# ---- Front Image ----- %>
+
+      <hr class="mt3 mb3"/>
+      <div class="front-image">
+        <h2>
+          <%= t('doc_auth.headings.upload_front_html') %>
+        </h2>
+
+        <%= accordion('totp-info', t('doc_auth.tips.title_html'),
+          wrapper_css: 'my2 col-12 fs-16p') do %>
+          <%= render 'idv/doc_auth/tips_and_sample' %>
+          <div class='center'>
+            <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
+          </div>
+        <% end %>
+
+        <%= f.input :front_image_data_url, as: :hidden %>
+        <%= f.input :front_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+        <div class='my2' id='front_target'></div>
+      </div>
+
+      <%# ---- Back Image ----- %>
+
+      <hr class="mt3 mb3"/>
+      <div class="back-image">
+        <h2>
+          <%= t('doc_auth.headings.upload_back_html') %>
+        </h2>
+
+        <%= accordion('totp-info', t('doc_auth.tips.title_html'),
+          wrapper_css: 'my2 col-12 fs-16p') do %>
+          <%= render 'idv/doc_auth/tips_and_sample' %>
+          <div class='center'>
+            <%= image_tag(asset_url('state-id-sample-back.jpg'), height: 338, width: 450) %>
+          </div>
+        <% end %>
+
+        <%= f.input :back_image_data_url, as: :hidden %>
+        <%= f.input :back_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+        <div class='my2' id='back_target'></div>
+      </div>
+
+      <%# ---- Selfie ----- %>
+      <% if liveness_checking_enabled? %>
+        <hr class="mt3 mb3"/>
+        <div class="selfie">
+          <h2>
+            <%= t('doc_auth.headings.selfie') %>
+          </h2>
+
+          <%= f.input :selfie_image_data_url, as: :hidden %>
+          <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+          <div class='my2' id='selfie_target'>
+        </div>
+      <% end %>
+
+      <%# ---- Submit ----- %>
+
+      <div class='mt3'>
+        <%= render 'idv/doc_auth/submit_with_spinner' %>
+      </div>
+    <% end %>
+
+    <p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
+
+    <%= render 'idv/doc_auth/start_over_or_cancel' %>
+    <%= javascript_pack_tag 'image-preview' %>
+  </div>
   <%= javascript_pack_tag 'document-capture' %>
 <% end %>
-<div>
-<% title t('doc_auth.titles.doc_auth') %>
-
-<%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
-
-<h1>
-  <% if liveness_checking_enabled? %>
-    <%= t('doc_auth.headings.document_capture_with_selfie_html') %>
-  <% else %>
-    <%= t('doc_auth.headings.document_capture_html') %>
-  <% end %>
-</h1>
-
-<%= render 'idv/doc_auth/document_capture_notices', flow_session: flow_session %>
-
-<%= simple_form_for(
-  :doc_auth,
-  url: url_for,
-  method: 'PUT',
-  html: { autocomplete: 'off', role: 'form', class: 'mt2' }
-) do |f| %>
-  <%# ---- Front Image ----- %>
-
-  <hr class="mt3 mb3"/>
-  <div class="front-image">
-    <h2>
-      <%= t('doc_auth.headings.upload_front_html') %>
-    </h2>
-
-    <%= accordion('totp-info', t('doc_auth.tips.title_html'),
-      wrapper_css: 'my2 col-12 fs-16p') do %>
-      <%= render 'idv/doc_auth/tips_and_sample' %>
-      <div class='center'>
-        <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
-      </div>
-    <% end %>
-
-    <%= f.input :front_image_data_url, as: :hidden %>
-    <%= f.input :front_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-    <div class='my2' id='front_target'></div>
-  </div>
-
-  <%# ---- Back Image ----- %>
-
-  <hr class="mt3 mb3"/>
-  <div class="back-image">
-    <h2>
-      <%= t('doc_auth.headings.upload_back_html') %>
-    </h2>
-
-    <%= accordion('totp-info', t('doc_auth.tips.title_html'),
-      wrapper_css: 'my2 col-12 fs-16p') do %>
-      <%= render 'idv/doc_auth/tips_and_sample' %>
-      <div class='center'>
-        <%= image_tag(asset_url('state-id-sample-back.jpg'), height: 338, width: 450) %>
-      </div>
-    <% end %>
-
-    <%= f.input :back_image_data_url, as: :hidden %>
-    <%= f.input :back_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-    <div class='my2' id='back_target'></div>
-  </div>
-
-  <%# ---- Selfie ----- %>
-  <% if liveness_checking_enabled? %>
-    <hr class="mt3 mb3"/>
-    <div class="selfie">
-      <h2>
-        <%= t('doc_auth.headings.selfie') %>
-      </h2>
-
-      <%= f.input :selfie_image_data_url, as: :hidden %>
-      <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-      <div class='my2' id='selfie_target'>
-    </div>
-  <% end %>
-
-  <%# ---- Submit ----- %>
-
-  <div class='mt3'>
-    <%= render 'idv/doc_auth/submit_with_spinner' %>
-  </div>
-<% end %>
-
-<p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
-
-<%= render 'idv/doc_auth/start_over_or_cancel' %>
-<%= javascript_pack_tag 'image-preview' %>
-</div>

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -13,6 +13,7 @@ feature 'document capture step' do
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
+    allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).and_return('true')
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_document_capture_step
   end


### PR DESCRIPTION
**Why**: Static content is intended as a fallback in case e.g. JavaScript is disabled.

Up until now, the document capture screen has largely serves as a testing ground implementing both the new React-based application, alongside the static fallback form. This works well for incremental updates, but it poses some challenge in testing and demonstration of the intended flow. The changes introduced in this pull request seek to update the screen to render only the React application when available. It also removes some demonstration code (accordion) and moves some content into more appropriate steps of the flow (capture on selfie step).

In order to test the fallback flow, it will now be required to disable JavaScript while viewing the page. Alternatively, we could also expose either a configuration flag or query parameter that could be appended to control whether the React application is rendered.

For review, it may help to use "Hide whitespace changes" in the "Files changed" tab settings, since the bulk of the changes to `document_capture.html.erb` are indenting the contents within the `<% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>` condition.

![hide whitespace changes](https://user-images.githubusercontent.com/1779930/88690812-0db29500-d0ca-11ea-9af8-67037d4168fd.png)

**Screen recording:**

![react-only-flow mov](https://user-images.githubusercontent.com/1779930/88690840-14410c80-d0ca-11ea-947a-8746e381b732.gif)