### PR TITLE
RISC events: support agency uuid as well as SP uuid

### DIFF
--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -213,10 +213,17 @@ class SecurityEventForm
     return if event.blank? || !service_provider
     return @identity if defined?(@identity)
 
-    @identity = Identity.find_by(
-      uuid: event.dig('subject', 'sub'),
-      service_provider: service_provider.issuer,
-    )
+    @identity = if service_provider.agency_id
+                  AgencyIdentity.find_by(
+                    uuid: event.dig('subject', 'sub'),
+                    agency_id: service_provider.agency_id,
+                  )
+                else
+                  Identity.find_by(
+                    uuid: event.dig('subject', 'sub'),
+                    service_provider: service_provider.issuer,
+                  )
+                end
   end
 
   def user

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -214,16 +214,24 @@ class SecurityEventForm
     return @identity if defined?(@identity)
 
     @identity = if service_provider.agency_id
-                  AgencyIdentity.find_by(
-                    uuid: event.dig('subject', 'sub'),
-                    agency_id: service_provider.agency_id,
-                  )
+                  identity_from_agency_identity
                 else
-                  Identity.find_by(
-                    uuid: event.dig('subject', 'sub'),
-                    service_provider: service_provider.issuer,
-                  )
+                  identity_from_identity
                 end
+  end
+
+  def identity_from_agency_identity
+    AgencyIdentity.find_by(
+      uuid: event.dig('subject', 'sub'),
+      agency_id: service_provider.agency_id,
+    )
+  end
+
+  def identity_from_identity
+    Identity.find_by(
+      uuid: event.dig('subject', 'sub'),
+      service_provider: service_provider.issuer,
+    )
   end
 
   def user

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Risc::SecurityEventsController do
             subject: {
               subject_type: 'iss_sub',
               iss: root_url,
-              sub: identity.uuid,
+              sub: AgencyIdentityLinker.new(identity).link_identity.uuid,
             },
           },
         },

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SecurityEventForm do
   subject(:form) { SecurityEventForm.new(body: jwt) }
 
   let(:user) { create(:user) }
-  let(:service_provider) { create(:service_provider) }
+  let(:service_provider) { create(:service_provider, agency_id: Agency.last.id) }
   let(:rp_private_key) do
     OpenSSL::PKey::RSA.new(
       File.read(Rails.root.join('keys', 'saml_test_sp.key')),
@@ -270,6 +270,15 @@ RSpec.describe SecurityEventForm do
           expect(valid?).to eq(false)
           expect(form.error_code).to eq('setData')
           expect(form.errors[:sub]).to include('invalid event.subject.sub claim')
+        end
+      end
+
+      context 'when the service provider has no agency' do
+        let(:service_provider) { create(:service_provider, agency: nil, agency_id: nil) }
+
+        it 'is still valid' do
+          expect(valid?).to eq(true)
+          expect(form.error_code).to eq(nil)
         end
       end
     end

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SecurityEventForm do
     }
   end
 
-  let(:subject_sub) { identity.uuid }
+  let(:subject_sub) { AgencyIdentityLinker.new(identity).link_identity.uuid }
   let(:jwt_headers) { { typ: 'secevent+jwt' } }
   let(:jwt) { JWT.encode(jwt_payload, rp_private_key, 'RS256', jwt_headers) }
 

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe SecurityEventForm do
   subject(:form) { SecurityEventForm.new(body: jwt) }
 
   let(:user) { create(:user) }
-  let(:service_provider) { create(:service_provider, agency_id: Agency.last.id) }
+  let(:agency) { Agency.last || Agency.create(name: 'Test Agency') }
+  let(:service_provider) { create(:service_provider, agency_id: agency.id) }
   let(:rp_private_key) do
     OpenSSL::PKey::RSA.new(
       File.read(Rails.root.join('keys', 'saml_test_sp.key')),


### PR DESCRIPTION
**Why**: The id_token.sub we expose to apps is shared across agencies

Discovered this when testing locally