### PR TITLE
Update newrelic_rpm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (5.2.0)
-    newrelic_rpm (6.7.0.359)
+    newrelic_rpm (6.12.0.367)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)


### PR DESCRIPTION
**Why**:
Update potentially fixes intermittent
"can't add a new key into hash during iteration" crash