### PR TITLE
LG-3191: one mobile page to submit them all

### DIFF
--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -55,11 +55,11 @@ window.LoginGov = window.LoginGov || {};
   'doc_auth.headings.document_capture',
   'doc_auth.headings.upload_front',
   'doc_auth.headings.upload_back',
-  'doc_auth.instructions.document_capture_header_text',
-  'doc_auth.instructions.document_capture_id_text1',
-  'doc_auth.instructions.document_capture_id_text2',
-  'doc_auth.instructions.document_capture_id_text3',
-  'doc_auth.instructions.document_capture_id_text4',
+  'doc_auth.tips.document_capture_header_text',
+  'doc_auth.tips.document_capture_id_text1',
+  'doc_auth.tips.document_capture_id_text2',
+  'doc_auth.tips.document_capture_id_text3',
+  'doc_auth.tips.document_capture_id_text4',
   'users.personal_key.close'
 ] %>
 

--- a/app/javascript/app/document-capture/components/documents-step.jsx
+++ b/app/javascript/app/document-capture/components/documents-step.jsx
@@ -20,13 +20,13 @@ function DocumentsStep({ value, onChange }) {
     <>
       <PageHeading>{t('doc_auth.headings.document_capture')}</PageHeading>
       <p className="margin-top-2 margin-bottom-0">
-        {t('doc_auth.instructions.document_capture_header_text')}
+        {t('doc_auth.tips.document_capture_header_text')}
       </p>
       <ul>
-        <li>{t('doc_auth.instructions.document_capture_id_text1')}</li>
-        <li>{t('doc_auth.instructions.document_capture_id_text2')}</li>
-        <li>{t('doc_auth.instructions.document_capture_id_text3')}</li>
-        {!isMobile && <li>{t('doc_auth.instructions.document_capture_id_text4')}</li>}
+        <li>{t('doc_auth.tips.document_capture_id_text1')}</li>
+        <li>{t('doc_auth.tips.document_capture_id_text2')}</li>
+        <li>{t('doc_auth.tips.document_capture_id_text3')}</li>
+        {!isMobile && <li>{t('doc_auth.tips.document_capture_id_text4')}</li>}
       </ul>
       {DOCUMENT_SIDES.map((side) => {
         const label = t(`doc_auth.headings.upload_${side}`);

--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -29,16 +29,16 @@ function imagePreview() {
 document.addEventListener('DOMContentLoaded', imagePreview);
 
 function imagePreviewFunction(imageType) {
-  const imageId = 'doc_auth_' + imageType + '_image';
-  const imageIdSelector = '#' + imageId;
-  const takeImageSelector = '#take_' + imageType + '_picture';
-  const targetIdSelector = '#' + imageType + '_target';
+  const imageId = `doc_auth_${imageType}_image`;
+  const imageIdSelector = `#${imageId}`;
+  const takeImageSelector = `#take_${imageType}_picture`;
+  const targetIdSelector = `#${imageType}_target`;
 
-  return function() {
-    $(takeImageSelector).on('click', function() {
+  return function () {
+    $(takeImageSelector).on('click', function () {
       document.getElementById(imageId).click();
     });
-    $(imageIdSelector).on('change', function(event) {
+    $(imageIdSelector).on('change', function (event) {
       $('.simple_form .alert-error').hide();
       $('.simple_form .alert-notice').hide();
       const { files } = event.target;

--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -29,10 +29,10 @@ function imagePreview() {
 document.addEventListener('DOMContentLoaded', imagePreview);
 
 function imagePreviewFunction(imageType) {
-  imageId = 'doc_auth_' + imageType + '_image';
-  imageIdSelector = '#' + imageId;
-  takeImageSelector = '#take_' + imageType + '_picture';
-  targetIdSelector = '#' + imageType + '_target';
+  const imageId = 'doc_auth_' + imageType + '_image';
+  const imageIdSelector = '#' + imageId;
+  const takeImageSelector = '#take_' + imageType + '_picture';
+  const targetIdSelector = '#' + imageType + '_target';
 
   return function() {
     $(takeImageSelector).on('click', function() {

--- a/app/javascript/packs/image-preview.js
+++ b/app/javascript/packs/image-preview.js
@@ -28,9 +28,17 @@ function imagePreview() {
 
 document.addEventListener('DOMContentLoaded', imagePreview);
 
-function imagePreviewFunction(imageId, imageTarget) {
-  return function () {
-    $(imageId).on('change', function (event) {
+function imagePreviewFunction(imageType) {
+  imageId = 'doc_auth_' + imageType + '_image';
+  imageIdSelector = '#' + imageId;
+  takeImageSelector = '#take_' + imageType + '_picture';
+  targetIdSelector = '#' + imageType + '_target';
+
+  return function() {
+    $(takeImageSelector).on('click', function() {
+      document.getElementById(imageId).click();
+    });
+    $(imageIdSelector).on('change', function(event) {
       $('.simple_form .alert-error').hide();
       $('.simple_form .alert-notice').hide();
       const { files } = event.target;
@@ -43,19 +51,19 @@ function imagePreviewFunction(imageId, imageTarget) {
           const ratio = this.height / this.width;
           img.width = displayWidth;
           img.height = displayWidth * ratio;
-          $(imageTarget).html(img);
+          $(targetIdSelector).html(img);
         };
         img.src = file.target.result;
-        $(imageTarget).html(img);
+        $(targetIdSelector).html(img);
       };
       reader.readAsDataURL(image);
     });
   };
 }
 
-const frontImagePreview = imagePreviewFunction('#doc_auth_front_image', '#front_target');
-const backImagePreview = imagePreviewFunction('#doc_auth_back_image', '#back_target');
-const selfieImagePreview = imagePreviewFunction('#doc_auth_selfie_image', '#selfie_target');
+const frontImagePreview = imagePreviewFunction('front');
+const backImagePreview = imagePreviewFunction('back');
+const selfieImagePreview = imagePreviewFunction('selfie');
 
 document.addEventListener('DOMContentLoaded', frontImagePreview);
 document.addEventListener('DOMContentLoaded', backImagePreview);

--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -8,6 +8,7 @@ module Idv
         link_sent: Idv::Steps::LinkSentStep,
         email_sent: Idv::Steps::EmailSentStep,
         document_capture: Idv::Steps::DocumentCaptureStep,
+        mobile_document_capture: Idv::Steps::MobileDocumentCaptureStep,
         front_image: Idv::Steps::FrontImageStep,
         back_image: Idv::Steps::BackImageStep,
         mobile_front_image: Idv::Steps::MobileFrontImageStep,

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -194,6 +194,7 @@ module Idv
           mark_step_complete(:mobile_back_image)
         else
           mark_step_complete(:document_capture)
+          mark_step_complete(:mobile_document_capture)
         end
       end
 

--- a/app/services/idv/steps/mobile_document_capture_step.rb
+++ b/app/services/idv/steps/mobile_document_capture_step.rb
@@ -1,0 +1,36 @@
+module Idv
+  module Steps
+    class MobileDocumentCaptureStep < DocAuthBaseStep
+      def call
+        response = post_images
+        if response.success?
+          save_proofing_components
+          extract_pii_from_doc(response)
+        else
+          handle_document_verification_failure(response)
+        end
+      end
+
+      private
+
+      def handle_document_verification_failure(response)
+        mark_step_incomplete(:mobile_document_capture)
+        notice = if liveness_checking_enabled?
+                   { notice: I18n.t('errors.doc_auth.document_capture_info_with_selfie_html') }
+                 else
+                   { notice: I18n.t('errors.doc_auth.document_capture_info_html') }
+                 end
+        extra = response.to_h.merge(notice)
+        failure(response.errors.first, extra)
+      end
+
+      def form_submit
+        Idv::DocumentCaptureForm.
+          new(liveness_checking_enabled: liveness_checking_enabled?).
+          submit(permit(:front_image,  :front_image_data_url,
+                        :back_image,   :back_image_data_url,
+                        :selfie_image, :selfie_image_data_url))
+      end
+    end
+  end
+end

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -36,6 +36,7 @@ module Idv
         mark_step_complete(:email_sent)
         mark_step_complete(:mobile_front_image)
         mark_step_complete(:mobile_back_image)
+        mark_step_complete(:mobile_document_capture)
       end
 
       def mobile
@@ -44,6 +45,7 @@ module Idv
         mark_step_complete(:email_sent)
         mark_step_complete(:front_image)
         mark_step_complete(:back_image)
+        mark_step_complete(:document_capture)
       end
     end
   end

--- a/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
+++ b/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
@@ -3,6 +3,6 @@
   idv_doc_auth_step_path(step: :reset),
   method: :put,
   class: 'btn btn-link',
-  form_class: 'inline-block. mt3'
+  form_class: 'inline-block mt3'
 ) %>
 <%= render 'shared/cancel', link: idv_cancel_path %>

--- a/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
+++ b/app/views/idv/doc_auth/_start_over_or_cancel.html.erb
@@ -1,9 +1,8 @@
-<br/>
 <%= button_to(
   t('doc_auth.buttons.start_over'),
   idv_doc_auth_step_path(step: :reset),
   method: :put,
   class: 'btn btn-link',
-  form_class: 'inline-block'
+  form_class: 'inline-block. mt3'
 ) %>
 <%= render 'shared/cancel', link: idv_cancel_path %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -29,14 +29,20 @@
     ) do |f| %>
       <%# ---- Front Image ----- %>
 
-      <%= t('doc_auth.instructions.document_capture_id_best_results_html') %>
+      <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+      <ul>
+        <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
+      </ul>
 
       <div class="front-image mt2">
         <p>
           <span class='bold'>
             <%= t('doc_auth.headings.document_capture_front') %><br/>
           </span>
-          <%= t('doc_auth.instructions.document_capture_hint') %>
+          <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
         <%= f.input :front_image_data_url, as: :hidden %>
@@ -51,7 +57,7 @@
           <span class='bold'>
             <%= t('doc_auth.headings.document_capture_back') %><br/>
           </span>
-          <%= t('doc_auth.instructions.document_capture_hint') %>
+          <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
         <%= f.input :back_image_data_url, as: :hidden %>
@@ -64,13 +70,19 @@
         <hr class="mt3 mb3"/>
         <div class="selfie">
           <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
-          <%= t('doc_auth.instructions.document_capture_selfie_best_results_html') %>
+
+          <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+          <ul>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text3') %></li>
+          </ul>
 
           <p class='mt3'>
             <span class='bold'>
               <%= t('doc_auth.headings.document_capture_selfie') %><br/>
             </span>
-            <%= t('doc_auth.instructions.document_capture_hint') %>
+            <%= t('doc_auth.tips.document_capture_hint') %>
           </p>
 
           <%= f.input :selfie_image_data_url, as: :hidden %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -13,7 +13,7 @@
   <div id="document-capture-form">
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-    <h1>
+    <h1 class="h3 my0">
       <% if liveness_checking_enabled? %>
         <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
       <% else %>
@@ -39,9 +39,9 @@
 
       <div class="front-image mt2">
         <p>
-          <span class='bold'>
+          <strong>
             <%= t('doc_auth.headings.document_capture_front') %><br/>
-          </span>
+          </strong>
           <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
@@ -54,9 +54,9 @@
 
       <div class="back-image mt3">
         <p>
-          <span class='bold'>
+          <strong>
             <%= t('doc_auth.headings.document_capture_back') %><br/>
-          </span>
+          </strong>
           <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
@@ -79,9 +79,9 @@
           </ul>
 
           <p class='mt3'>
-            <span class='bold'>
+            <strong>
               <%= t('doc_auth.headings.document_capture_selfie') %><br/>
-            </span>
+            </strong>
             <%= t('doc_auth.tips.document_capture_hint') %>
           </p>
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -15,13 +15,11 @@
 
     <h1>
       <% if liveness_checking_enabled? %>
-        <%= t('doc_auth.headings.document_capture_with_selfie_html') %>
+        <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
       <% else %>
-        <%= t('doc_auth.headings.document_capture_html') %>
+        <%= t('doc_auth.headings.document_capture_heading_html') %>
       <% end %>
     </h1>
-
-    <%= render 'idv/doc_auth/document_capture_notices', flow_session: flow_session %>
 
     <%= simple_form_for(
       :doc_auth,
@@ -31,41 +29,33 @@
     ) do |f| %>
       <%# ---- Front Image ----- %>
 
-      <hr class="mt3 mb3"/>
-      <div class="front-image">
-        <h2>
-          <%= t('doc_auth.headings.upload_front_html') %>
-        </h2>
+      <%= t('doc_auth.instructions.document_capture_id_best_results_html') %>
 
-        <%= accordion('totp-info-front', t('doc_auth.tips.title_html')) do %>
-          <%= render 'idv/doc_auth/tips_and_sample' %>
-          <div class='center'>
-            <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
-          </div>
-        <% end %>
+      <div class="front-image mt2">
+        <p>
+          <span class='bold'>
+            <%= t('doc_auth.headings.document_capture_front') %><br/>
+          </span>
+          <%= t('doc_auth.instructions.document_capture_hint') %>
+        </p>
 
         <%= f.input :front_image_data_url, as: :hidden %>
-        <%= f.input :front_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+        <%= f.input :front_image, label: false, as: :file, required: true %>
         <div class='my2' id='front_target'></div>
       </div>
 
       <%# ---- Back Image ----- %>
 
-      <hr class="mt3 mb3"/>
-      <div class="back-image">
-        <h2>
-          <%= t('doc_auth.headings.upload_back_html') %>
-        </h2>
-
-        <%= accordion('totp-info-back', t('doc_auth.tips.title_html')) do %>
-          <%= render 'idv/doc_auth/tips_and_sample' %>
-          <div class='center'>
-            <%= image_tag(asset_url('state-id-sample-back.jpg'), height: 338, width: 450) %>
-          </div>
-        <% end %>
+      <div class="back-image mt3">
+        <p>
+          <span class='bold'>
+            <%= t('doc_auth.headings.document_capture_back') %><br/>
+          </span>
+          <%= t('doc_auth.instructions.document_capture_hint') %>
+        </p>
 
         <%= f.input :back_image_data_url, as: :hidden %>
-        <%= f.input :back_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+        <%= f.input :back_image, label: false, as: :file, required: true %>
         <div class='my2' id='back_target'></div>
       </div>
 
@@ -73,9 +63,15 @@
       <% if liveness_checking_enabled? %>
         <hr class="mt3 mb3"/>
         <div class="selfie">
-          <h2>
-            <%= t('doc_auth.headings.selfie') %>
-          </h2>
+          <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
+          <%= t('doc_auth.instructions.document_capture_selfie_best_results_html') %>
+
+          <p class='mt3'>
+            <span class='bold'>
+              <%= t('doc_auth.headings.document_capture_selfie') %><br/>
+            </span>
+            <%= t('doc_auth.instructions.document_capture_hint') %>
+          </p>
 
           <%= f.input :selfie_image_data_url, as: :hidden %>
           <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
@@ -85,15 +81,17 @@
 
       <%# ---- Submit ----- %>
 
-      <div class='mt3'>
+      <div class='mt4 mb4'>
         <%= render 'idv/doc_auth/submit_with_spinner' %>
       </div>
-    <% end %>
+    <% end %> <%# end simple_form_for %>
 
-    <p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
+    <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
 
     <%= javascript_pack_tag 'image-preview' %>
   </div>
   <%= render 'idv/doc_auth/start_over_or_cancel' %>
-  <%= javascript_pack_tag 'document-capture' %>
+  <% unless Figaro.env.document_capture_react_enabled == 'false' %>
+    <%= javascript_pack_tag 'document-capture' %>
+  <% end %>
 <% end %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -86,7 +86,7 @@
           </p>
 
           <%= f.input :selfie_image_data_url, as: :hidden %>
-          <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+          <%= f.input :selfie_image, label: false, as: :file, required: true %>
           <div class='my2' id='selfie_target'></div>
         </div>
       <% end %>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -29,7 +29,7 @@
     ) do |f| %>
       <%# ---- Front Image ----- %>
 
-      <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+      <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
       <ul>
         <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
         <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
@@ -71,7 +71,7 @@
         <div class="selfie">
           <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
 
-          <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+          <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
           <ul>
             <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
             <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -13,7 +13,7 @@
   <div id="document-capture-form">
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-    <h1>
+    <h1 class="h3 my0">
       <% if liveness_checking_enabled? %>
         <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
       <% else %>
@@ -39,9 +39,9 @@
 
       <div class="front-image mt2">
         <p>
-          <span class='bold'>
+          <strong>
             <%= t('doc_auth.headings.document_capture_front') %><br/>
-          </span>
+          </strong>
           <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
@@ -54,9 +54,9 @@
 
       <div class="back-image mt3">
         <p>
-          <span class='bold'>
+          <strong>
             <%= t('doc_auth.headings.document_capture_back') %><br/>
-          </span>
+          </strong>
           <%= t('doc_auth.tips.document_capture_hint') %>
         </p>
 
@@ -79,9 +79,9 @@
           </ul>
 
           <p class='mt3'>
-            <span class='bold'>
+            <strong>
               <%= t('doc_auth.headings.document_capture_selfie') %><br/>
-            </span>
+            </strong>
             <%= t('doc_auth.tips.document_capture_hint') %>
           </p>
 

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -1,0 +1,109 @@
+<% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
+  <% content_for :meta_tags do %>
+    <meta
+      name="acuant-sdk-initialization-endpoint"
+      content="<%= Figaro.env.acuant_sdk_initialization_endpoint %>"
+    >
+    <meta
+      name="acuant-sdk-initialization-creds"
+      content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
+    >
+  <% end %>
+  <div id="document-capture-form"></div>
+  <%= javascript_pack_tag 'document-capture' %>
+<% end %>
+
+<div>
+  <% title t('doc_auth.titles.doc_auth') %>
+
+  <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
+
+  <h1>
+    <% if liveness_checking_enabled? %>
+      <%= t('doc_auth.headings.document_capture_with_selfie_html') %>
+    <% else %>
+      <%= t('doc_auth.headings.document_capture_html') %>
+    <% end %>
+  </h1>
+
+  <%= render 'idv/doc_auth/document_capture_notices', flow_session: flow_session %>
+
+  <%= simple_form_for(
+    :doc_auth,
+    url: url_for,
+    method: 'PUT',
+    html: { autocomplete: 'off', role: 'form', class: 'mt2' }
+  ) do |f| %>
+
+    <%# ---- Front Image ----- %>
+
+    <hr class="mt3 mb3"/>
+
+    <div class="front-image">
+      <h2 class='h3 mb0'>
+        <%= t('doc_auth.headings.take_pic_front') %>
+      </h2>
+
+      <%= accordion('totp-info', t('doc_auth.tips.title_html'),
+        wrapper_css: 'my2 col-12 fs-16p') do %>
+        <%= render 'idv/doc_auth/tips_and_sample' %>
+        <div class='center'>
+          <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
+        </div>
+      <% end %>
+
+      <%= f.input :front_image_data_url, as: :hidden %>
+      <%= f.input :front_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+      <div class='my2' id='front_target'></div>
+    </div>
+
+    <%# ---- Back Image ----- %>
+
+    <hr class="mt3 mb3"/>
+
+    <div class="back-image">
+      <h2 class='h3 mb0'>
+        <%= t('doc_auth.headings.take_pic_back') %>
+      </h2>
+
+      <%= accordion('totp-info', t('doc_auth.tips.title_html'),
+        wrapper_css: 'my2 col-12 fs-16p') do %>
+        <%= render 'idv/doc_auth/tips_and_sample' %>
+        <div class='center'>
+          <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
+        </div>
+      <% end %>
+
+      <%= f.input :back_image_data_url, as: :hidden %>
+      <%= f.input :back_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+      <div class='my2' id='back_target'></div>
+    </div>
+
+    <%# ---- Selfie ----- %>
+
+    <% if liveness_checking_enabled? %>
+      <hr class="mt3 mb3"/>
+
+      <div class="selfie">
+        <h2>
+          <%= t('doc_auth.headings.selfie') %>
+        </h2>
+
+        <%= f.input :selfie_image_data_url, as: :hidden %>
+        <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+        <div class='my2' id='selfie_target'></div>
+      </div>
+    <% end %>
+
+    <%# ---- Submit ----- %>
+
+    <div class='mt3'>
+      <%= render 'idv/doc_auth/submit_with_spinner' %>
+    </div>
+  <% end %> <%# end simple_form_for %>
+
+  <p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
+
+  <%= render 'idv/doc_auth/start_over_or_cancel' %>
+  <%= javascript_pack_tag 'image-preview' %>
+</div>

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -1,4 +1,5 @@
 <% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
+  <% title t('doc_auth.titles.doc_auth') %>
   <% content_for :meta_tags do %>
     <meta
       name="acuant-sdk-initialization-endpoint"
@@ -9,101 +10,100 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"></div>
-  <%= javascript_pack_tag 'document-capture' %>
-<% end %>
+  <div id="document-capture-form">
+    <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
-<div>
-  <% title t('doc_auth.titles.doc_auth') %>
-
-  <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
-
-  <h1>
-    <% if liveness_checking_enabled? %>
-      <%= t('doc_auth.headings.document_capture_with_selfie_html') %>
-    <% else %>
-      <%= t('doc_auth.headings.document_capture_html') %>
-    <% end %>
-  </h1>
-
-  <%= render 'idv/doc_auth/document_capture_notices', flow_session: flow_session %>
-
-  <%= simple_form_for(
-    :doc_auth,
-    url: url_for,
-    method: 'PUT',
-    html: { autocomplete: 'off', role: 'form', class: 'mt2' }
-  ) do |f| %>
-
-    <%# ---- Front Image ----- %>
-
-    <hr class="mt3 mb3"/>
-
-    <div class="front-image">
-      <h2 class='h3 mb0'>
-        <%= t('doc_auth.headings.take_pic_front') %>
-      </h2>
-
-      <%= accordion('totp-info', t('doc_auth.tips.title_html'),
-        wrapper_css: 'my2 col-12 fs-16p') do %>
-        <%= render 'idv/doc_auth/tips_and_sample' %>
-        <div class='center'>
-          <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
-        </div>
+    <h1>
+      <% if liveness_checking_enabled? %>
+        <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
+      <% else %>
+        <%= t('doc_auth.headings.document_capture_heading_html') %>
       <% end %>
+    </h1>
 
-      <%= f.input :front_image_data_url, as: :hidden %>
-      <%= f.input :front_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-      <div class='my2' id='front_target'></div>
-    </div>
+    <%= simple_form_for(
+      :doc_auth,
+      url: url_for,
+      method: 'PUT',
+      html: { autocomplete: 'off', role: 'form', class: 'mt2' }
+    ) do |f| %>
+      <%# ---- Front Image ----- %>
 
-    <%# ---- Back Image ----- %>
+      <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+      <ul>
+        <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
+        <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
+      </ul>
 
-    <hr class="mt3 mb3"/>
+      <div class="front-image mt2">
+        <p>
+          <span class='bold'>
+            <%= t('doc_auth.headings.document_capture_front') %><br/>
+          </span>
+          <%= t('doc_auth.tips.document_capture_hint') %>
+        </p>
 
-    <div class="back-image">
-      <h2 class='h3 mb0'>
-        <%= t('doc_auth.headings.take_pic_back') %>
-      </h2>
-
-      <%= accordion('totp-info', t('doc_auth.tips.title_html'),
-        wrapper_css: 'my2 col-12 fs-16p') do %>
-        <%= render 'idv/doc_auth/tips_and_sample' %>
-        <div class='center'>
-          <%= image_tag(asset_url('state-id-sample-front.jpg'), height: 338, width: 450) %>
-        </div>
-      <% end %>
-
-      <%= f.input :back_image_data_url, as: :hidden %>
-      <%= f.input :back_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-      <div class='my2' id='back_target'></div>
-    </div>
-
-    <%# ---- Selfie ----- %>
-
-    <% if liveness_checking_enabled? %>
-      <hr class="mt3 mb3"/>
-
-      <div class="selfie">
-        <h2>
-          <%= t('doc_auth.headings.selfie') %>
-        </h2>
-
-        <%= f.input :selfie_image_data_url, as: :hidden %>
-        <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
-        <div class='my2' id='selfie_target'></div>
+        <%= f.input :front_image_data_url, as: :hidden %>
+        <%= f.input :front_image, label: false, as: :file, required: true %>
+        <div class='my2' id='front_target'></div>
       </div>
-    <% end %>
 
-    <%# ---- Submit ----- %>
+      <%# ---- Back Image ----- %>
 
-    <div class='mt3'>
-      <%= render 'idv/doc_auth/submit_with_spinner' %>
-    </div>
-  <% end %> <%# end simple_form_for %>
+      <div class="back-image mt3">
+        <p>
+          <span class='bold'>
+            <%= t('doc_auth.headings.document_capture_back') %><br/>
+          </span>
+          <%= t('doc_auth.tips.document_capture_hint') %>
+        </p>
 
-  <p class='mt3 mb0'><%= t('doc_auth.info.upload_image') %></p>
+        <%= f.input :back_image_data_url, as: :hidden %>
+        <%= f.input :back_image, label: false, as: :file, required: true %>
+        <div class='my2' id='back_target'></div>
+      </div>
 
+      <%# ---- Selfie ----- %>
+      <% if liveness_checking_enabled? %>
+        <hr class="mt3 mb3"/>
+        <div class="selfie">
+          <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
+
+          <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+          <ul>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>
+            <li><%= t('doc_auth.tips.document_capture_selfie_text3') %></li>
+          </ul>
+
+          <p class='mt3'>
+            <span class='bold'>
+              <%= t('doc_auth.headings.document_capture_selfie') %><br/>
+            </span>
+            <%= t('doc_auth.tips.document_capture_hint') %>
+          </p>
+
+          <%= f.input :selfie_image_data_url, as: :hidden %>
+          <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+          <div class='my2' id='selfie_target'></div>
+        </div>
+      <% end %>
+
+      <%# ---- Submit ----- %>
+
+      <div class='mt4 mb4'>
+        <%= render 'idv/doc_auth/submit_with_spinner' %>
+      </div>
+    <% end %> <%# end simple_form_for %>
+
+    <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
+
+    <%= javascript_pack_tag 'image-preview' %>
+  </div>
   <%= render 'idv/doc_auth/start_over_or_cancel' %>
-  <%= javascript_pack_tag 'image-preview' %>
-</div>
+  <% unless Figaro.env.document_capture_react_enabled == 'false' %>
+    <%= javascript_pack_tag 'document-capture' %>
+  <% end %>
+<% end %>

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -86,7 +86,7 @@
           </p>
 
           <%= f.input :selfie_image_data_url, as: :hidden %>
-          <%= f.input :selfie_image, label: false, as: :file, required: true, wrapper_class: 'mt3 sm-col-8' %>
+          <%= f.input :selfie_image, label: false, as: :file, required: true %>
           <div class='my2' id='selfie_target'></div>
         </div>
       <% end %>

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -29,7 +29,7 @@
     ) do |f| %>
       <%# ---- Front Image ----- %>
 
-      <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+      <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
       <ul>
         <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
         <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
@@ -71,7 +71,7 @@
         <div class="selfie">
           <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
 
-          <div><%= t('doc_auth.tips.document_capture_header_text') %></div>
+          <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
           <ul>
             <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
             <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -48,6 +48,7 @@ disallow_ial2_recovery:
 doc_capture_request_valid_for_minutes: '15'
 doc_auth_extend_timeout_by_minutes: '40'
 document_capture_step_enabled: 'false'
+document_capture_react_enabled: 'true'
 email_from: no-reply@login.gov
 enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -34,6 +34,10 @@ en:
         selfie
       document_capture_front: Front of your ID
       document_capture_back: Back of your ID
+      document_capture_front: Front of your ID
+      document_capture_heading_html: Add your state&#8209;issued&nbsp;ID
+      document_capture_heading_with_selfie_html: Add your state&#8209;issued&nbsp;ID
+        and selfie
       document_capture_selfie: Your photo
       selfie: Take a selfie.
       ssn: Please enter your social security number.
@@ -43,20 +47,18 @@ en:
       text_message: We sent a message to your phone
       upload: How would you like to upload your state issued ID?
       upload_back: Upload an image of the back of your state issued ID
-      upload_back_html: Upload an image of the back of your state&#8209;issued&nbsp;ID
       upload_from_phone: Take a photo with a mobile phone to upload your ID
       upload_front: Upload an image of the front of your state issued ID
-      upload_front_html: Upload an image of the front of your state&#8209;issued&nbsp;ID
       verify: Please verify your information
       welcome: We need to verify your identity
     info:
       camera_required: Your mobile phone must have a camera and a web browser
+      document_capture_upload_image: We only use your ID to verify your identity,
+        and we will not save any images.
       link_sent:
       - Please check your phone and follow instructions to take a photo of your state
         issued ID.
       - When you are done click continue here to finish verifying your identity.
-      document_capture_upload_image: We only use your ID to verify your identity, and we will not save
-        any images.
       tag: Recommended
       take_picture: Use the camera on your mobile phone and upload images of your
         ID.  We only use the images to verify your identity.
@@ -95,7 +97,8 @@ en:
         <li>Do not use the flash on your camera</li>
         <li>File size should be at least 2 MB</li>
         </ul>
-      document_capture_selfie_instructions: Now take a picture of yourself. We'll compare it to the image on the front of your ID.
+      document_capture_selfie_instructions: Now take a picture of yourself. We'll
+        compare it to the image on the front of your ID.
       email_sent: Link sent to %{email}. Please check your desktop email and follow
         instructions to verify your identity.
       learn_more: Learn more.
@@ -113,13 +116,14 @@ en:
       text4: make sure you always have access
       welcome: 'What you''ll need to do:'
     tips:
-      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
       document_capture_header_text: 'For best results:'
+      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
       document_capture_id_text1: Use a dark background
       document_capture_id_text2: Take the photo on a flat surface
       document_capture_id_text3: Do not use the flash on your camera
       document_capture_id_text4: File size should be at least 2 MB
-      document_capture_selfie_text1: Face the camera and ensure your entire head is in the photo
+      document_capture_selfie_text1: Face the camera and ensure your entire head is
+        in the photo
       document_capture_selfie_text2: Take a photo against a plain background
       document_capture_selfie_text3: Do not wear a hat or sunglasses
       header_text: Guidelines for taking a photo of your ID

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -29,6 +29,12 @@ en:
       document_capture_html: Upload your state&#8209;issued&nbsp;ID
       document_capture_with_selfie_html: Upload your state&#8209;issued&nbsp;ID and
         a photo of you
+      document_capture_heading_html: Add your state&#8209;issued&nbsp;ID
+      document_capture_heading_with_selfie_html: Add your state&#8209;issued&nbsp;ID and
+        selfie
+      document_capture_front: Front of your ID
+      document_capture_back: Back of your ID
+      document_capture_selfie: Your photo
       selfie: Take a selfie.
       ssn: Please enter your social security number.
       take_pic_back: Take a photo of the back of your ID
@@ -49,6 +55,8 @@ en:
       - Please check your phone and follow instructions to take a photo of your state
         issued ID.
       - When you are done click continue here to finish verifying your identity.
+      document_capture_upload_image: We only use your ID to verify your identity, and we will not save
+        any images.
       tag: Recommended
       take_picture: Use the camera on your mobile phone and upload images of your
         ID.  We only use the images to verify your identity.
@@ -78,6 +86,23 @@ en:
       document_capture_id_text2: Take the photo on a flat surface
       document_capture_id_text3: Do not use the flash on your camera
       document_capture_id_text4: File size should be at least 2 MB
+      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
+      document_capture_id_best_results_html: |-
+        <div>For best results:</div>
+        <ul>
+        <li>Use a dark background</li>
+        <li>Take the photo on a flat surface</li>
+        <li>Do not use the flash on your camera</li>
+        <li>File size should be at least 2 MB</li>
+        </ul>
+      document_capture_selfie_instructions: Now take a picture of yourself. We'll compare it to the image on the front of your ID.
+      document_capture_selfie_best_results_html: |-
+        <div>For best results:</div>
+        <ul>
+        <li>Face the camera and ensure your entire head is in the photo</li>
+        <li>Take a photo against a plain background</li>
+        <li>Do not wear a hat or sunglasses</li>
+        </ul>
       email_sent: Link sent to %{email}. Please check your desktop email and follow
         instructions to verify your identity.
       learn_more: Learn more.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -26,13 +26,6 @@ en:
       address: Mailing Address
       capture_complete: We have verified your state issued ID
       document_capture: Add your state-issued ID
-      document_capture_html: Upload your state&#8209;issued&nbsp;ID
-      document_capture_with_selfie_html: Upload your state&#8209;issued&nbsp;ID and
-        a photo of you
-      document_capture_heading_html: Add your state&#8209;issued&nbsp;ID
-      document_capture_heading_with_selfie_html: Add your state&#8209;issued&nbsp;ID and
-        selfie
-      document_capture_front: Front of your ID
       document_capture_back: Back of your ID
       document_capture_front: Front of your ID
       document_capture_heading_html: Add your state&#8209;issued&nbsp;ID
@@ -83,20 +76,6 @@ en:
         and share your personal information. We will only use it to verify your identity.
       document_capture_fallback_html: Having trouble? %{link}
       document_capture_fallback_link: Click here to upload an image
-      document_capture_header_text: 'For best results:'
-      document_capture_id_text1: Use a dark background
-      document_capture_id_text2: Take the photo on a flat surface
-      document_capture_id_text3: Do not use the flash on your camera
-      document_capture_id_text4: File size should be at least 2 MB
-      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
-      document_capture_id_best_results_html: |-
-        <div>For best results:</div>
-        <ul>
-        <li>Use a dark background</li>
-        <li>Take the photo on a flat surface</li>
-        <li>Do not use the flash on your camera</li>
-        <li>File size should be at least 2 MB</li>
-        </ul>
       document_capture_selfie_instructions: Now take a picture of yourself. We'll
         compare it to the image on the front of your ID.
       email_sent: Link sent to %{email}. Please check your desktop email and follow

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -96,13 +96,6 @@ en:
         <li>File size should be at least 2 MB</li>
         </ul>
       document_capture_selfie_instructions: Now take a picture of yourself. We'll compare it to the image on the front of your ID.
-      document_capture_selfie_best_results_html: |-
-        <div>For best results:</div>
-        <ul>
-        <li>Face the camera and ensure your entire head is in the photo</li>
-        <li>Take a photo against a plain background</li>
-        <li>Do not wear a hat or sunglasses</li>
-        </ul>
       email_sent: Link sent to %{email}. Please check your desktop email and follow
         instructions to verify your identity.
       learn_more: Learn more.
@@ -120,6 +113,15 @@ en:
       text4: make sure you always have access
       welcome: 'What you''ll need to do:'
     tips:
+      document_capture_hint: Must be a JPG, BMP, PNG, or TIFF
+      document_capture_header_text: 'For best results:'
+      document_capture_id_text1: Use a dark background
+      document_capture_id_text2: Take the photo on a flat surface
+      document_capture_id_text3: Do not use the flash on your camera
+      document_capture_id_text4: File size should be at least 2 MB
+      document_capture_selfie_text1: Face the camera and ensure your entire head is in the photo
+      document_capture_selfie_text2: Take a photo against a plain background
+      document_capture_selfie_text3: Do not wear a hat or sunglasses
       header_text: Guidelines for taking a photo of your ID
       text1: Take it in a room with lots of light. Indirect sunlight is best.
       text2: Make sure your ID doesn't have dirt or damaged barcodes.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -30,6 +30,12 @@ es:
       document_capture_html: Cargue su identificación emitida por el estado
       document_capture_with_selfie_html: Cargue su identificación emitida por el estado
         y una foto suya
+      document_capture_back: Detrás de su identificación
+      document_capture_front: Frente de su identificación
+      document_capture_heading_html: Cargue su identificación emitida por el estado
+      document_capture_heading_with_selfie_html: Cargue su identificación emitida
+        por el estado y una foto suya
+      document_capture_selfie: Tu foto
       selfie: Toma una selfie.
       ssn: Por favor ingrese su número de seguro social.
       take_pic_back: Toma una foto de la parte posterior de tu identificación
@@ -38,17 +44,15 @@ es:
       text_message: Enviamos un mensaje a su teléfono
       upload: "¿Cómo te gustaría subir tu identificación emitida por el estado?"
       upload_back: Cargue una foto del dorso de su identificación emitida por el estado.
-      upload_back_html: Cargue una foto del dorso de su identificación emitida por
-        el estado.
       upload_from_phone: Tome una foto con un teléfono móvil para cargar su identificación
       upload_front: Cargue una foto del frente de su identificación emitida por el
         estado.
-      upload_front_html: Cargue una foto del frente de su identificación emitida por
-        el
       verify: Por favor verifica tu información
       welcome: Nosotros necesitamos verificar tu identidad
     info:
       camera_required: Su teléfono móvil debe tener una cámara y un navegador web
+      document_capture_upload_image: Solo utilizamos su ID para verificar su identidad
+        y no guardaremos ninguna imagen.
       link_sent:
       - Verifique su teléfono y siga las instrucciones para tomar una fotografía de
         la identificación emitida por su estado.
@@ -84,6 +88,8 @@ es:
       document_capture_id_text2: Toma la foto sobre una superficie plana
       document_capture_id_text3: No uses el flash en tu cámara
       document_capture_id_text4: El tamaño del archivo debe ser de al menos 2 MB
+      document_capture_selfie_instructions: Ahora toma una foto de ti mismo. Lo compararemos
+        con la imagen en el frente de su identificación.
       email_sent: Enlace enviado a %{email}. Compruebe el correo electrónico de su
         escritorio y siga las instrucciones para verificar su identidad.
       learn_more: Aprende más.
@@ -102,6 +108,16 @@ es:
       text4: asegúrate de tener siempre acceso
       welcome: 'Lo que necesitarás hacer:'
     tips:
+      document_capture_header_text: 'Para mejores resultados:'
+      document_capture_hint: Aceptamos los formatos BMP, PNG, TIFF y JPG.
+      document_capture_id_text1: Usa un fondo oscuro
+      document_capture_id_text2: Toma la foto sobre una superficie plana
+      document_capture_id_text3: No uses el flash en tu cámara
+      document_capture_id_text4: El tamaño del archivo debe ser de al menos 2 MB
+      document_capture_selfie_text1: Mira a la cámara y asegúrate de que toda tu cabeza
+        esté en la foto
+      document_capture_selfie_text2: Toma una foto sobre un fondo liso
+      document_capture_selfie_text3: No use sombrero o lentes de sol
       header_text: Pautas para tomar una foto de su identificación
       text1: Tómalo en una habitación con mucha luz. La luz solar indirecta es la
         mejor.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -27,9 +27,6 @@ es:
       address: Dirección de envio
       capture_complete: Hemos verificado la identificación emitida por su estado
       document_capture: Agregue su identificación emitida por el estado
-      document_capture_html: Cargue su identificación emitida por el estado
-      document_capture_with_selfie_html: Cargue su identificación emitida por el estado
-        y una foto suya
       document_capture_back: Detrás de su identificación
       document_capture_front: Frente de su identificación
       document_capture_heading_html: Cargue su identificación emitida por el estado
@@ -83,11 +80,6 @@ es:
         su identidad.
       document_capture_fallback_html: "¿Teniendo problemas? %{link}"
       document_capture_fallback_link: Haga clic aquí para cargar una imagen.
-      document_capture_header_text: 'Para mejores resultados:'
-      document_capture_id_text1: Usa un fondo oscuro
-      document_capture_id_text2: Toma la foto sobre una superficie plana
-      document_capture_id_text3: No uses el flash en tu cámara
-      document_capture_id_text4: El tamaño del archivo debe ser de al menos 2 MB
       document_capture_selfie_instructions: Ahora toma una foto de ti mismo. Lo compararemos
         con la imagen en el frente de su identificación.
       email_sent: Enlace enviado a %{email}. Compruebe el correo electrónico de su

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -30,6 +30,13 @@ fr:
       document_capture_html: Téléchargez votre pièce d'identité délivrée par l'État
       document_capture_with_selfie_html: Téléchargez votre pièce d'identité officielle
         et une photo de vous
+      document_capture_back: Dos de votre pièce d'identité
+      document_capture_front: Recto de votre pièce d'identité
+      document_capture_heading_html: Téléchargez votre pièce d'identité délivrée par
+        l'État
+      document_capture_heading_with_selfie_html: Téléchargez votre pièce d'identité
+        officielle et une photo de vous
+      document_capture_selfie: Ta photo
       selfie: Prendre un selfie.
       ssn: S'il vous plaît entrez votre numéro de sécurité sociale.
       take_pic_back: Prenez une photo au verso de votre identifiant
@@ -39,19 +46,17 @@ fr:
       upload: Comment voudriez-vous télécharger votre ID émis par l'état?
       upload_back: S'il vous plaît télécharger une photo du dos de votre ID émis par
         l'état.
-      upload_back_html: S'il vous plaît télécharger une photo du dos de votre ID émis
-        par l'état.
       upload_from_phone: Prenez une photo avec un téléphone portable pour télécharger
         votre pièce d'identité
       upload_front: Veuillez télécharger une photo du recto de votre identifiant émis
         par l'État.
-      upload_front_html: Veuillez télécharger une photo du recto de votre identifiant
-        émis par l'État.
       verify: S'il vous plaît vérifier vos informations
       welcome: Nous devons vérifier votre identité
     info:
       camera_required: Votre téléphone portable doit avoir une caméra et un navigateur
         Web
+      document_capture_upload_image: Nous n'utilisons votre identifiant que pour vérifier
+        votre identité, et nous n'enregistrerons aucune image.
       link_sent:
       - Veuillez vérifier votre téléphone et suivre les instructions pour prendre
         une photo de votre identité émise par l'État.
@@ -90,6 +95,8 @@ fr:
       document_capture_id_text2: Prenez la photo sur une surface plane
       document_capture_id_text3: Ne pas utiliser le flash sur votre appareil photo
       document_capture_id_text4: La taille du fichier doit être d'au moins 2 Mo
+      document_capture_selfie_instructions: Maintenant, prenez une photo de vous.
+        Nous le comparerons à l'image au recto de votre pièce d'identité.
       email_sent: Lien envoyé à %{email}. Veuillez vérifier votre email de bureau
         et suivez les instructions pour vérifier votre identité.
       learn_more: Apprendre encore plus.
@@ -109,6 +116,16 @@ fr:
       text4: assurez-vous d'avoir toujours accès
       welcome: 'Ce que vous devez faire:'
     tips:
+      document_capture_header_text: 'Pour les meilleurs résultats:'
+      document_capture_hint: Nous acceptons les formats BMP, PNG, TIFF et JPG.
+      document_capture_id_text1: Utilisez un fond sombre
+      document_capture_id_text2: Prenez la photo sur une surface plane
+      document_capture_id_text3: Ne pas utiliser le flash sur votre appareil photo
+      document_capture_id_text4: La taille du fichier doit être d'au moins 2 Mo
+      document_capture_selfie_text1: Faites face à la caméra et assurez-vous que toute
+        votre tête est sur la photo
+      document_capture_selfie_text2: Prenez une photo sur un fond uni
+      document_capture_selfie_text3: Ne portez pas de chapeau ni de lunettes de soleil
       header_text: Directives pour prendre une photo de votre identité
       text1: Prenez-le dans une pièce très éclairée. La lumière solaire indirecte
         est la meilleure.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -27,9 +27,6 @@ fr:
       address: Adresse mail
       capture_complete: Nous avons vérifié votre ID émis par l'état
       document_capture: Ajoutez votre pièce d'identité émise par l'État
-      document_capture_html: Téléchargez votre pièce d'identité délivrée par l'État
-      document_capture_with_selfie_html: Téléchargez votre pièce d'identité officielle
-        et une photo de vous
       document_capture_back: Dos de votre pièce d'identité
       document_capture_front: Recto de votre pièce d'identité
       document_capture_heading_html: Téléchargez votre pièce d'identité délivrée par
@@ -90,11 +87,6 @@ fr:
         que pour vérifier votre identité.
       document_capture_fallback_html: Avoir des problèmes? %{link}
       document_capture_fallback_link: Cliquez ici pour télécharger une image
-      document_capture_header_text: 'Pour les meilleurs résultats:'
-      document_capture_id_text1: Utilisez un fond sombre
-      document_capture_id_text2: Prenez la photo sur une surface plane
-      document_capture_id_text3: Ne pas utiliser le flash sur votre appareil photo
-      document_capture_id_text4: La taille du fichier doit être d'au moins 2 Mo
       document_capture_selfie_instructions: Maintenant, prenez une photo de vous.
         Nous le comparerons à l'image au recto de votre pièce d'identité.
       email_sent: Lien envoyé à %{email}. Veuillez vérifier votre email de bureau

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -61,11 +61,11 @@ en:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         number_message_html: We just called you at %{number}.
       webauthn:
+        confirm_webauthn_html: Present the security key that you associated with your
+          account.
         confirm_webauthn_only_html: This app requires a higher level of security.
           You need to verify your identity using a security key that you previously
           set up to access your information.
-        confirm_webauthn_html: Present the security key that you associated with your
-          account.
       wrong_number_html: Entered the wrong phone number? %{link}
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -9,6 +9,7 @@ feature 'doc auth document capture step' do
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { 'false' }
   before do
+    allow(Figaro.env).to receive(:document_capture_react_enabled).and_return('false')
     allow(Figaro.env).to receive(:document_capture_step_enabled).
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
@@ -34,14 +35,21 @@ feature 'doc auth document capture step' do
 
       it 'is on the correct_page' do
         expect(current_path).to eq(idv_doc_auth_document_capture_step)
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_front_html')))
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_back_html')))
-        expect(page).to have_content(t('doc_auth.headings.selfie'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_selfie'))
       end
 
-      it 'displays tips and sample images' do
-        expect(page).to have_content(I18n.t('doc_auth.tips.text1'))
-        expect(page).to have_css('img[src*=state-id-sample-front]')
+      it 'displays tips' do
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
 
       it 'proceeds to the next page with valid info' do
@@ -139,9 +147,21 @@ feature 'doc auth document capture step' do
 
       it 'is on the correct_page, but does not show the selfie upload option' do
         expect(current_path).to eq(idv_doc_auth_document_capture_step)
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_front_html')))
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_back_html')))
-        expect(page).not_to have_content(t('doc_auth.headings.selfie'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+      end
+
+      it 'displays tips' do
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
 
       it 'proceeds to the next page with valid info' do
@@ -212,10 +232,5 @@ feature 'doc auth document capture step' do
 
   def next_step
     idv_doc_auth_ssn_step
-  end
-
-  def render_html_string(html_string)
-    rendered = Nokogiri::HTML.parse(html_string).text
-    strip_nbsp(rendered)
   end
 end

--- a/spec/features/idv/doc_auth/mobile_document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_document_capture_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'doc auth document capture step' do
+feature 'doc auth mobile document capture step' do
   include IdvStepHelper
   include DocAuthHelper
   include InPersonHelper
@@ -13,16 +13,15 @@ feature 'doc auth document capture step' do
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
-    allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).and_return('true')
     sign_in_and_2fa_user(user)
-    complete_doc_auth_steps_before_document_capture_step
+    complete_doc_auth_steps_before_mobile_document_capture_step
   end
 
   context 'when the step is disabled' do
     let(:document_capture_step_enabled) { 'false' }
 
-    it 'takes the user to the front image step' do
-      expect(current_path).to eq(idv_doc_auth_front_image_step)
+    it 'takes the user to the mobile front image step' do
+      expect(current_path).to eq(idv_doc_auth_mobile_front_image_step)
     end
   end
 
@@ -33,9 +32,9 @@ feature 'doc auth document capture step' do
       let(:liveness_enabled) { 'true' }
 
       it 'is on the correct_page' do
-        expect(current_path).to eq(idv_doc_auth_document_capture_step)
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_front_html')))
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_back_html')))
+        expect(current_path).to eq(idv_doc_auth_mobile_document_capture_step)
+        expect(page).to have_content(render_html_string(t('doc_auth.headings.take_pic_front')))
+        expect(page).to have_content(render_html_string(t('doc_auth.headings.take_pic_back')))
         expect(page).to have_content(t('doc_auth.headings.selfie'))
       end
 
@@ -74,7 +73,7 @@ feature 'doc auth document capture step' do
         attach_images
         click_idv_continue
 
-        expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+        expect(page).to have_current_path(idv_doc_auth_mobile_document_capture_step)
       end
 
       it 'offers in person option on failure' do
@@ -129,7 +128,7 @@ feature 'doc auth document capture step' do
         attach_images
         click_idv_continue
 
-        expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+        expect(page).to have_current_path(idv_doc_auth_mobile_document_capture_step)
         expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
       end
     end
@@ -138,7 +137,7 @@ feature 'doc auth document capture step' do
       let(:liveness_enabled) { 'false' }
 
       it 'is on the correct_page, but does not show the selfie upload option' do
-        expect(current_path).to eq(idv_doc_auth_document_capture_step)
+        expect(current_path).to eq(idv_doc_auth_mobile_document_capture_step)
         expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_front_html')))
         expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_back_html')))
         expect(page).not_to have_content(t('doc_auth.headings.selfie'))
@@ -204,7 +203,7 @@ feature 'doc auth document capture step' do
         attach_images(liveness_enabled: false)
         click_idv_continue
 
-        expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+        expect(page).to have_current_path(idv_doc_auth_mobile_document_capture_step)
         expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
       end
     end

--- a/spec/features/idv/doc_auth/mobile_document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/mobile_document_capture_step_spec.rb
@@ -9,10 +9,12 @@ feature 'doc auth mobile document capture step' do
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { 'false' }
   before do
+    allow(Figaro.env).to receive(:document_capture_react_enabled).and_return('false')
     allow(Figaro.env).to receive(:document_capture_step_enabled).
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
+    allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).and_return('true')
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_mobile_document_capture_step
   end
@@ -33,14 +35,21 @@ feature 'doc auth mobile document capture step' do
 
       it 'is on the correct_page' do
         expect(current_path).to eq(idv_doc_auth_mobile_document_capture_step)
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.take_pic_front')))
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.take_pic_back')))
-        expect(page).to have_content(t('doc_auth.headings.selfie'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_selfie'))
       end
 
-      it 'displays tips and sample images' do
-        expect(page).to have_content(I18n.t('doc_auth.tips.text1'))
-        expect(page).to have_css('img[src*=state-id-sample-front]')
+      it 'displays tips' do
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
 
       it 'proceeds to the next page with valid info' do
@@ -98,7 +107,7 @@ feature 'doc auth mobile document capture step' do
 
           expect(page).to have_current_path(next_step)
           click_on t('doc_auth.buttons.start_over')
-          complete_doc_auth_steps_before_document_capture_step
+          complete_doc_auth_steps_before_mobile_document_capture_step
         end
 
         attach_images
@@ -108,7 +117,7 @@ feature 'doc auth mobile document capture step' do
 
         Timecop.travel(Figaro.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
           sign_in_and_2fa_user(user)
-          complete_doc_auth_steps_before_document_capture_step
+          complete_doc_auth_steps_before_mobile_document_capture_step
           attach_images
           click_idv_continue
 
@@ -138,9 +147,21 @@ feature 'doc auth mobile document capture step' do
 
       it 'is on the correct_page, but does not show the selfie upload option' do
         expect(current_path).to eq(idv_doc_auth_mobile_document_capture_step)
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_front_html')))
-        expect(page).to have_content(render_html_string(t('doc_auth.headings.upload_back_html')))
-        expect(page).not_to have_content(t('doc_auth.headings.selfie'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_front'))
+        expect(page).to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
+      end
+
+      it 'displays tips' do
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_header_text'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text1'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text2'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text3'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_id_text4'))
+        expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_hint'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text1'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text2'))
+        expect(page).not_to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
 
       it 'proceeds to the next page with valid info' do
@@ -173,7 +194,7 @@ feature 'doc auth mobile document capture step' do
 
           expect(page).to have_current_path(next_step)
           click_on t('doc_auth.buttons.start_over')
-          complete_doc_auth_steps_before_document_capture_step
+          complete_doc_auth_steps_before_mobile_document_capture_step
         end
 
         attach_images(liveness_enabled: false)
@@ -183,7 +204,7 @@ feature 'doc auth mobile document capture step' do
 
         Timecop.travel(Figaro.env.acuant_attempt_window_in_minutes.to_i.minutes.from_now) do
           sign_in_and_2fa_user(user)
-          complete_doc_auth_steps_before_document_capture_step
+          complete_doc_auth_steps_before_mobile_document_capture_step
           attach_images(liveness_enabled: false)
           click_idv_continue
 
@@ -211,10 +232,5 @@ feature 'doc auth mobile document capture step' do
 
   def next_step
     idv_doc_auth_ssn_step
-  end
-
-  def render_html_string(html_string)
-    rendered = Nokogiri::HTML.parse(html_string).text
-    strip_nbsp(rendered)
   end
 end

--- a/spec/javascripts/app/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/documents-step-spec.jsx
@@ -48,10 +48,10 @@ describe('document-capture/components/documents-step', () => {
       </DeviceContext.Provider>,
     );
 
-    expect(() => getByText('doc_auth.instructions.document_capture_id_text4')).to.throw();
+    expect(() => getByText('doc_auth.tips.document_capture_id_text4')).to.throw();
 
     getByText = render(<DocumentsStep />).getByText;
 
-    expect(() => getByText('doc_auth.instructions.document_capture_id_text4')).not.to.throw();
+    expect(() => getByText('doc_auth.tips.document_capture_id_text4')).not.to.throw();
   });
 });

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -42,6 +42,10 @@ module DocAuthHelper
     idv_doc_auth_step_path(step: :document_capture)
   end
 
+  def idv_doc_auth_mobile_document_capture_step
+    idv_doc_auth_step_path(step: :mobile_document_capture)
+  end
+
   def idv_doc_auth_front_image_step
     idv_doc_auth_step_path(step: :front_image)
   end
@@ -95,6 +99,12 @@ module DocAuthHelper
   def complete_doc_auth_steps_before_document_capture_step
     complete_doc_auth_steps_before_upload_step
     click_on t('doc_auth.info.upload_computer_link')
+  end
+
+  def complete_doc_auth_steps_before_mobile_document_capture_step
+    allow(DeviceDetector).to receive(:new).and_return(mobile_device)
+    complete_doc_auth_steps_before_upload_step
+    click_on t('doc_auth.buttons.use_phone')
   end
 
   def complete_doc_auth_steps_before_front_image_step


### PR DESCRIPTION
We've redesigned the doc_auth backstop to a much simpler form, and now it is the same for the desktop and mobile flows.

I've added an undocumented flag, `document_capture_react_enabled`, that if set to 'false' will skip over the React code import thus disabling the react version of the form. This was done to make it easy for development and test, but should never be set in a deployed environment (except perhaps personal).

Here's a screenshot of the final result. I tried to get the margins to match the design, but it seems the design system classes don't have quite the granularity required, e.g., `mt2` is a 1 rem margin-top, while `mt3` is 2 rem. If we want 1.5 rem, we would have to include custom css.

The error message at the top is only included upon a failure to proof, while the "For best results" sections are always present.

![Screen Shot 2020-07-29 at 8 56 06 PM](https://user-images.githubusercontent.com/2583060/88873656-249cd880-d1eb-11ea-88f3-599e9f820f8c.png)
