### PR TITLE
Use lazy capture pattern in asset checker

### DIFF
--- a/lib/asset_checker.rb
+++ b/lib/asset_checker.rb
@@ -9,8 +9,8 @@ class AssetChecker
 
   def self.file_has_missing?(file)
     data = File.open(file).read
-    missing_translations = find_missing(data, /\Wt\s?\(['"]([^'^"]*)['"]\)/, @translation_strings)
-    missing_assets = find_missing(data, /\WassetPath=["'](.*)['"]/, @asset_strings)
+    missing_translations = find_missing(data, /\Wt\s?\(['"]([^'"]*?)['"]\)/, @translation_strings)
+    missing_assets = find_missing(data, /\WassetPath=["'](.*?)['"]/, @asset_strings)
     has_missing = (missing_translations.any? || missing_assets.any?)
     if has_missing
       warn file

--- a/spec/lib/asset_checker_spec.rb
+++ b/spec/lib/asset_checker_spec.rb
@@ -25,6 +25,7 @@ def get_js_with_strings(asset, translation)
         <h2>{t('#{translation}')}</h2>
         <DocumentTips sample={sample} />
         <AcuantCapture />
+        <Image assetPath=\"#{asset}\" alt=\"\" />
       </>
     );
   }
@@ -73,7 +74,7 @@ RSpec.describe AssetChecker do
                                                                           translation_strings)
         expect(AssetChecker).to receive(:warn).with(tempfile.path)
         expect(AssetChecker).to receive(:warn).with('Missing translation, not-found')
-        expect(AssetChecker).to receive(:warn).with('Missing asset, wont_find.svg')
+        expect(AssetChecker).to receive(:warn).twice.with('Missing asset, wont_find.svg')
         expect(AssetChecker.check_files([tempfile.path])).to eq(true)
       end
     end


### PR DESCRIPTION
**Why**: To fix an issue where if there's another occurrence of a quote within the same line as a matched asset path, the path would wrongly include the text up to the last occurrence of a quote in the line.

You can see this on master:

```
$ make check_asset_strings 
find ./app/javascript -name "*.js*" | xargs ./scripts/check-assets
./app/javascript/app/document-capture/components/full-screen.jsx
Missing asset, close-white-alt.svg" className="full-screen-close-icon
make: *** [check_asset_strings] Error 1
```

With these changes, the misidentified error above should no longer be reported.

Reference:

- https://www.rexegg.com/regex-quantifiers.html#lazy_solution