### PR TITLE
LG-3237: React internationalization string element interpolation

### DIFF
--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -51,7 +51,7 @@ window.LoginGov = window.LoginGov || {};
   'doc_auth.buttons.take_picture',
   'doc_auth.forms.selected_file',
   'doc_auth.forms.change_file',
-  'doc_auth.forms.choose_file',
+  'doc_auth.forms.choose_file_html',
   'doc_auth.headings.document_capture',
   'doc_auth.headings.upload_front',
   'doc_auth.headings.upload_back',

--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -8,7 +8,7 @@ function AcuantCapture() {
   const { isReady, isError } = useContext(AcuantContext);
   const [isCapturing, setIsCapturing] = useState(false);
   const [capture, setCapture] = useState(null);
-  const t = useI18n();
+  const { t } = useI18n();
 
   if (isError) {
     return 'Error!';

--- a/app/javascript/app/document-capture/components/documents-step.jsx
+++ b/app/javascript/app/document-capture/components/documents-step.jsx
@@ -13,7 +13,7 @@ import DeviceContext from '../context/device';
 const DOCUMENT_SIDES = ['front', 'back'];
 
 function DocumentsStep({ value, onChange }) {
-  const t = useI18n();
+  const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
   return (

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -60,7 +60,9 @@ function FileInput({ label, hint, accept, value, onChange }) {
               <span className="usa-file-input__drag-text">
                 {formatHTML(t('doc_auth.forms.choose_file_html'), {
                   // eslint-disable-next-line react/prop-types
-                  u: ({ children }) => <span className="usa-file-input__choose">{children}</span>,
+                  'lg-underline': ({ children }) => (
+                    <span className="usa-file-input__choose">{children}</span>
+                  ),
                 })}
               </span>
             </div>

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -16,7 +16,7 @@ export function isImageFile(file) {
 }
 
 function FileInput({ label, hint, accept, value, onChange }) {
-  const { t } = useI18n();
+  const { t, formatHTML } = useI18n();
   const instanceId = useInstanceId();
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
@@ -57,7 +57,12 @@ function FileInput({ label, hint, accept, value, onChange }) {
           )}
           {!value && (
             <div className="usa-file-input__instructions" aria-hidden="true">
-              <span className="usa-file-input__drag-text">{t('doc_auth.forms.choose_file')}</span>
+              <span className="usa-file-input__drag-text">
+                {formatHTML(t('doc_auth.forms.choose_file_html'), {
+                  // eslint-disable-next-line react/prop-types
+                  u: ({ children }) => <span className="usa-file-input__choose">{children}</span>,
+                })}
+              </span>
             </div>
           )}
           <div className="usa-file-input__box" />

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -16,7 +16,7 @@ export function isImageFile(file) {
 }
 
 function FileInput({ label, hint, accept, value, onChange }) {
-  const t = useI18n();
+  const { t } = useI18n();
   const instanceId = useInstanceId();
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;

--- a/app/javascript/app/document-capture/components/form-steps.jsx
+++ b/app/javascript/app/document-capture/components/form-steps.jsx
@@ -56,7 +56,7 @@ export function getLastValidStepIndex(steps, values) {
 function FormSteps({ steps, onComplete }) {
   const [values, setValues] = useState({});
   const [stepName, setStepName] = useHistoryParam('step');
-  const t = useI18n();
+  const { t } = useI18n();
 
   // An "effective" step is computed in consideration of the facts that (1) there may be no history
   // parameter present, in which case the first step should be used, and (2) the values may not be

--- a/app/javascript/app/document-capture/components/full-screen.jsx
+++ b/app/javascript/app/document-capture/components/full-screen.jsx
@@ -5,7 +5,7 @@ import Image from './image';
 import useI18n from '../hooks/use-i18n';
 
 function FullScreen({ onRequestClose, children }) {
-  const t = useI18n();
+  const { t } = useI18n();
   const modalRef = useRef(/** @type {?HTMLDivElement} */ (null));
   const trapRef = useRef(/** @type {?import('focus-trap').FocusTrap} */ (null));
   const onRequestCloseRef = useRef(onRequestClose);

--- a/app/javascript/app/document-capture/hooks/use-i18n.js
+++ b/app/javascript/app/document-capture/hooks/use-i18n.js
@@ -4,13 +4,15 @@ import I18nContext from '../context/i18n';
 /** @typedef {import('react').FC|import('react').ComponentClass} Component */
 
 /**
- * Given an HTML string and an object of tag names to React component, returns a new of React node
+ * Given an HTML string and an object of tag names to React component, returns a new React node
  * where the mapped tag names are replaced by the resulting element of the rendered component.
  *
  * Note that this is a very simplistic interpolation of HTML. It only supports well-balanced, non-
- * nested tag names, where there are no attributes or excess whitespace within the tag names. While
- * the subject markup itself cannot contain attributes, the return value of the component can be any
- * valid React element, with or without additional attributes.
+ * nested tag names, where there are no attributes or excess whitespace within the tag names. The
+ * tag name cannot contain regular expression special characters.
+ *
+ * While the subject markup itself cannot contain attributes, the return value of the component can
+ * be any valid React element, with or without additional attributes.
  *
  * @example
  * ```

--- a/app/javascript/app/document-capture/hooks/use-i18n.js
+++ b/app/javascript/app/document-capture/hooks/use-i18n.js
@@ -1,10 +1,65 @@
-import { useContext } from 'react';
+import { createElement, cloneElement, useContext } from 'react';
 import I18nContext from '../context/i18n';
+
+/** @typedef {import('react').FC|import('react').ComponentClass} Component */
+
+/**
+ * Given an HTML string and an object of tag names to React component, returns a new of React node
+ * where the mapped tag names are replaced by the resulting element of the rendered component.
+ *
+ * Note that this is a very simplistic interpolation of HTML. It only supports well-balanced, non-
+ * nested tag names, where there are no attributes or excess whitespace within the tag names. While
+ * the subject markup itself cannot contain attributes, the return value of the component can be any
+ * valid React element, with or without additional attributes.
+ *
+ * @example
+ * ```
+ * formatHTML('Hello <lg-sparkles>world</lg-sparkles>!', {
+ *   'lg-sparkles': ({children}) => <span className="lg-sparkles">{children}</span>
+ * });
+ * ```
+ *
+ * @param {string}                   html     HTML to format.
+ * @param {Record<string,Component>} handlers Mapping of tag names to components.
+ *
+ * @return {import('react').ReactNode}
+ */
+export function formatHTML(html, handlers) {
+  const pattern = new RegExp(`</?(?:${Object.keys(handlers).join('|')})>`, 'g');
+  const matches = html.match(pattern);
+  if (!matches) {
+    return html;
+  }
+
+  /** @type {Array<import('react').ReactNode>} */
+  const parts = html.split(pattern);
+
+  for (let i = 0; i < matches.length; i += 2) {
+    const tag = matches[i].slice(1, -1);
+    const part = /** @type {string} */ (parts[i + 1]);
+    const replacement = createElement(handlers[tag], null, part);
+    parts[i + 1] = cloneElement(replacement, { key: part });
+  }
+
+  return parts.filter(Boolean);
+}
 
 function useI18n() {
   const strings = useContext(I18nContext);
+
+  /**
+   * Returns the translated string by the given key.
+   *
+   * @param {string} key Key to retrieve.
+   *
+   * @return {string} Translated string.
+   */
   const t = (key) => (Object.prototype.hasOwnProperty.call(strings, key) ? strings[key] : key);
-  return t;
+
+  return {
+    t,
+    formatHTML,
+  };
 }
 
 export default useI18n;

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -12,7 +12,7 @@ en:
     forms:
       address1: Address
       change_file: Change file
-      choose_file_html: Drag file here or <u>choose from folder</u>
+      choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
       city: City
       dob: Date of Birth
       doc_success: We've verified your social security number and state-issued ID.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -12,7 +12,7 @@ en:
     forms:
       address1: Address
       change_file: Change file
-      choose_file: Drag file here or choose from folder
+      choose_file_html: Drag file here or <u>choose from folder</u>
       city: City
       dob: Date of Birth
       doc_success: We've verified your social security number and state-issued ID.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -12,7 +12,7 @@ es:
     forms:
       address1: Dirección
       change_file: Cambiar archivo
-      choose_file_html: Arrastre el archivo aquí o <u>elija de la carpeta</u>
+      choose_file_html: Arrastre el archivo aquí o <lg-underline>elija de la carpeta</lg-underline>
       city: Ciudad
       dob: Fecha de nacimiento
       doc_success: Verificamos su número de seguro social y su identificación emitida

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -12,7 +12,7 @@ es:
     forms:
       address1: Dirección
       change_file: Cambiar archivo
-      choose_file: Arrastre el archivo aquí o elija de la carpeta
+      choose_file_html: Arrastre el archivo aquí o <u>elija de la carpeta</u>
       city: Ciudad
       dob: Fecha de nacimiento
       doc_success: Verificamos su número de seguro social y su identificación emitida

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -12,7 +12,7 @@ fr:
     forms:
       address1: Adresse
       change_file: Changer de fichier
-      choose_file: Faites glisser le fichier ici ou choisissez dans un dossier
+      choose_file_html: Faites glisser le fichier ici ou <u>choisissez dans un dossier</u>
       city: Ville
       dob: Date de naissance
       doc_success: Nous avons vérifié votre numéro de sécurité sociale et votre identifiant

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -12,7 +12,8 @@ fr:
     forms:
       address1: Adresse
       change_file: Changer de fichier
-      choose_file_html: Faites glisser le fichier ici ou <u>choisissez dans un dossier</u>
+      choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez
+        dans un dossier</lg-underline>
       city: Ville
       dob: Date de naissance
       doc_success: Nous avons vérifié votre numéro de sécurité sociale et votre identifiant

--- a/spec/lib/asset_checker_spec.rb
+++ b/spec/lib/asset_checker_spec.rb
@@ -9,7 +9,7 @@ def get_js_with_strings(asset, translation)
   import useI18n from '../hooks/use-i18n';
 
   function DocumentCapture() {
-    const t = useI18n();
+    const { t } = useI18n();
 
     const sample = (
       <Image


### PR DESCRIPTION
**Why**: Localized strings may contain HTML markup, which React will escape by default. This provides a mechanism to be able to safely replace intended HTML markup with equivalent React elements substitutes.

See inline code documentation for `formatHTML` for more details, limitations, etc.

Before|After
---|---
![Before screenshot](https://user-images.githubusercontent.com/1779930/88970130-e30a3d00-d27f-11ea-925e-ad627c6ecf48.png)|![After screenshot](https://user-images.githubusercontent.com/1779930/88970105-d554b780-d27f-11ea-82d4-d4d2ac999a25.png)