### PR TITLE
LG-3177 Update gems to the new typhoeus-less versions and minor updates.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'hiredis'
 gem 'http_accept_language'
 gem 'httparty'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.1'
-gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.4'
+gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.5'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'master'
 gem 'json-jwt', '>= 1.11.0'
 gem 'local_time'
@@ -60,7 +60,6 @@ gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'twilio-ruby'
 gem 'two_factor_authentication', '>= 2.1.1'
-gem 'typhoeus'
 gem 'uglifier', '~> 3.2'
 gem 'user_agent_parser'
 gem 'valid_email', '>= 0.1.3'
@@ -120,6 +119,6 @@ group :test do
 end
 
 group :production do
-  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.0'
-  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v1.2.0'
+  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
+  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,13 @@
 GIT
   remote: https://github.com/18F/identity-aamva-api-client-gem.git
-  revision: f88d3cda9646aaae7f21f5bd37621618743dd88e
-  tag: v3.4.0
+  revision: 149b5b480f0319ec39410e497bb4bbffd1652014
+  tag: v3.4.1
   specs:
-    aamva (3.4.0)
+    aamva (3.4.1)
       dotenv
       faraday
       hashie
       retries
-      typhoeus
       xmldsig
 
 GIT
@@ -21,12 +20,12 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git
-  revision: 29f554ed2ea237c59a20fdbe4a675508b9c8539d
-  tag: v1.2.0
+  revision: 42074c77e3570197791075afb7b0a0f60de84e89
+  tag: v2.1.0
   specs:
-    lexisnexis (1.2.0)
+    lexisnexis (2.1.0)
       dotenv
-      typhoeus
+      faraday
 
 GIT
   remote: https://github.com/18F/identity-proofer-gem.git
@@ -57,15 +56,14 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: d752e9e8ff08ee1412c1c58227f91b3a25474138
-  tag: v0.1.4
+  revision: 656d5cd779217b8be02bdb82ef747cd0fe0680e1
+  tag: v0.1.5
   specs:
-    identity-telephony (0.1.4)
+    identity-telephony (0.1.5)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n
       twilio-ruby
-      typhoeus
 
 GEM
   remote: https://rubygems.org/
@@ -239,7 +237,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
-    dotenv (2.7.5)
+    dotenv (2.7.6)
     dotiw (4.0.1)
       actionpack (>= 4)
       i18n
@@ -253,8 +251,6 @@ GEM
     equalizer (0.0.11)
     errbase (0.2.0)
     erubi (1.9.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
     exception_notification (4.4.0)
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
@@ -632,8 +628,6 @@ GEM
       rails (>= 3.1.1)
       randexp
       rotp (>= 3.2.0)
-    typhoeus (1.3.1)
-      ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -794,7 +788,6 @@ DEPENDENCIES
   timecop
   twilio-ruby
   two_factor_authentication (>= 2.1.1)
-  typhoeus
   uglifier (~> 3.2)
   user_agent_parser
   valid_email (>= 0.1.3)

--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -6,7 +6,7 @@ class GoogleAnalyticsMeasurement
 
   cattr_accessor :adapter do
     Faraday.new(url: GA_URL, request: { open_timeout: TIMEOUT, timeout: TIMEOUT }) do |faraday|
-      faraday.adapter :typhoeus
+      faraday.adapter :net_http
     end
   end
 

--- a/app/services/google_analytics_measurement.rb
+++ b/app/services/google_analytics_measurement.rb
@@ -19,6 +19,7 @@ class GoogleAnalyticsMeasurement
 
   def send_event
     adapter.post do |request|
+      request.headers['Content-Type'] = 'application/json'
       request.body = request_body
     end
   rescue Faraday::TimeoutError, Faraday::ConnectionFailed => err
@@ -29,13 +30,13 @@ class GoogleAnalyticsMeasurement
 
   def request_body
     {
-      v: 1,
+      v: '1',
       tid: Figaro.env.google_analytics_key,
       t: :event,
       ec: category,
       ea: event_action,
       el: method,
       cid: client_id,
-    }
+    }.to_json
   end
 end

--- a/app/services/push_notification/account_delete.rb
+++ b/app/services/push_notification/account_delete.rb
@@ -99,7 +99,7 @@ module PushNotification
 
     def faraday_adapter(url)
       Faraday.new(url: url) do |faraday|
-        faraday.adapter :typhoeus
+        faraday.adapter :net_http
       end
     end
   end


### PR DESCRIPTION
Typhoeus has been removed from all dependencies and the idp itself. We'll see what unexpected things broke with those changes.