### PR TITLE
Redo proofing cost migrations as strong migrations

### DIFF
--- a/db/migrate/20200731213827_add_acuant_result_to_proofing_costs.rb
+++ b/db/migrate/20200731213827_add_acuant_result_to_proofing_costs.rb
@@ -1,5 +1,0 @@
-class AddAcuantResultToProofingCosts < ActiveRecord::Migration[5.2]
-  def change
-    add_column :proofing_costs, :acuant_result_count, :integer, default: 0
-  end
-end

--- a/db/migrate/20200803211123_add_acuant_result_to_proofing_costs.rb
+++ b/db/migrate/20200803211123_add_acuant_result_to_proofing_costs.rb
@@ -1,0 +1,10 @@
+class AddAcuantResultToProofingCosts < ActiveRecord::Migration[5.2]
+  def up
+    add_column :proofing_costs, :acuant_result_count, :integer
+    change_column_default :proofing_costs, :acuant_result_count, 0
+  end
+
+  def down
+    remove_column :proofing_costs, :acuant_result_count
+  end
+end

--- a/db/migrate/20200803211145_backfill_add_acuant_result_to_proofing_costs.rb
+++ b/db/migrate/20200803211145_backfill_add_acuant_result_to_proofing_costs.rb
@@ -1,0 +1,10 @@
+class BackfillAddAcuantResultToProofingCosts < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    ProofingCost.unscoped.in_batches do |relation|
+      relation.update_all acuant_result_count: 0
+      sleep(0.01)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_213827) do
+ActiveRecord::Schema.define(version: 2020_08_03_211145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The migration I previously added failed when deployed in prod because adding a column with a default value causes a table rewrite. Here's literally what the gem told me to do:

              Adding a column with a non-null default causes the entire table to be rewritten.
              Instead, add the column without a default value, then change the default.
              
              class AddAcuantResultToProofingCosts < ActiveRecord::Migration[5.2]
                def up
                  add_column :proofing_costs, :acuant_result_count, :integer
                  change_column_default :proofing_costs, :acuant_result_count, 0
                end
              
                def down
                  remove_column :proofing_costs, :acuant_result_count
                end
              end
              
              Then backfill the existing rows in the Rails console or a separate migration with disable_ddl_transaction!.
              
              class BackfillAddAcuantResultToProofingCosts < ActiveRecord::Migration[5.2]
                disable_ddl_transaction!
              
                def up
                  ProofingCost.unscoped.in_batches do |relation| 
                    relation.update_all acuant_result_count: 0
                    sleep(0.01)
                  end
                end
              end
              