### PR TITLE
LG-3167 Require auth cert for HSPD12 compliant PIV/CAC

### DIFF
--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -79,6 +79,7 @@ module TwoFactorAuthentication
         user: current_user,
         token: params[:token],
         nonce: piv_cac_nonce,
+        piv_cac_required: aal3_policy.piv_cac_required?,
       )
     end
 

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -87,6 +87,7 @@ module Users
         token: params[:token],
         nonce: piv_cac_nonce,
         name: user_session[:piv_cac_nickname],
+        piv_cac_required: aal3_policy.piv_cac_required?,
       )
     end
 

--- a/app/forms/concerns/piv_cac_form_helpers.rb
+++ b/app/forms/concerns/piv_cac_form_helpers.rb
@@ -13,7 +13,7 @@ module PivCacFormHelpers
   end
 
   def not_error_token
-    possible_error = @data['error']
+    possible_error = @data['error'] || hspd12_compliant_cert_required_error
     if possible_error
       self.error_type = possible_error
       self.key_id = @data['key_id']
@@ -23,6 +23,11 @@ module PivCacFormHelpers
       self.x509_dn = @data['subject']
       true
     end
+  end
+
+  def hspd12_compliant_cert_required_error
+    return if !@piv_cac_required || @data['has_eku']
+    'certificate.not_auth_cert'
   end
 
   def token_has_correct_nonce

--- a/app/forms/concerns/piv_cac_form_helpers.rb
+++ b/app/forms/concerns/piv_cac_form_helpers.rb
@@ -26,7 +26,7 @@ module PivCacFormHelpers
   end
 
   def hspd12_compliant_cert_required_error
-    return if !@piv_cac_required || @data['has_eku']
+    return if !@piv_cac_required || @data['is_auth_cert']
     'certificate.not_auth_cert'
   end
 

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -2,7 +2,8 @@ class UserPivCacSetupForm
   include ActiveModel::Model
   include PivCacFormHelpers
 
-  attr_accessor :x509_dn_uuid, :x509_dn, :token, :user, :nonce, :error_type, :name, :key_id
+  attr_accessor :x509_dn_uuid, :x509_dn, :token, :user, :nonce, :error_type, :name, :key_id,
+                :piv_cac_required
   attr_reader :name_taken
 
   validates :token, presence: true

--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -2,7 +2,8 @@ class UserPivCacVerificationForm
   include ActiveModel::Model
   include PivCacFormHelpers
 
-  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user, :key_id
+  attr_accessor :x509_dn_uuid, :x509_dn, :token, :error_type, :nonce, :user, :key_id,
+                :piv_cac_required
 
   validates :token, presence: true
   validates :nonce, presence: true

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -92,6 +92,8 @@ en:
           your administrator to ensure your certificate is up to date.
         none_html: Please contact your administrator to ensure your certificate is
           up to date.
+        not_auth_cert_html: Please choose a different certificate from your PIV/CAC
+          or contact your administrator to ensure your certificate is up to date.
         ocsp_error_html: We’re having technical difficulties.  Please try again later.
         revoked_html: Please choose a different certificate from your PIV/CAC or contact
           your administrator to ensure your certificate is up to date.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -97,6 +97,8 @@ es:
           con su administrador para asegurarse de que su certificado esté actualizado.
         none_html: Por favor, póngase en contacto con su administrador para asegurarse
           de que su certificado esté actualizado.
+        not_auth_cert_html: Por favor, póngase en contacto con su administrador para
+          asegurarse de que su certificado esté actualizado.
         ocsp_error_html: Estamos teniendo dificultades técnicas. Por favor, inténtelo
           de nuevo más tarde.
         revoked_html: Elija un certificado diferente de su PIV/CAC o póngase en contacto

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -98,6 +98,8 @@ fr:
           à jour.
         none_html: Veuillez contacter votre administrateur pour vous assurer que votre
           certificat est à jour.
+        not_auth_cert_html: Veuillez contacter votre administrateur pour vous assurer
+          que votre certificat est à jour.
         ocsp_error_html: Nous avons des difficultés techniques. Veuillez réessayer
           plus tard.
         revoked_html: Veuillez choisir un certificat différent de votre PIV/CAC ou

--- a/config/locales/headings/en.yml
+++ b/config/locales/headings/en.yml
@@ -48,6 +48,7 @@ en:
         expired: The certificate you selected has expired.
         invalid: The certificate you selected is invalid.
         none: We cannot detect a certificate on your PIV/CAC card.
+        not_auth_cert: Please choose a different certificate from your PIV/CAC card.
         ocsp_error: We’re having technical difficulties.  Please try again later.
         revoked: The certificate you selected has been revoked from your card.
         timeout: We’re having technical difficulties.  Please try again later.

--- a/config/locales/headings/es.yml
+++ b/config/locales/headings/es.yml
@@ -48,6 +48,7 @@ es:
         expired: El certificado que seleccionó ha expirado.
         invalid: El certificado que seleccionaste no es válido.
         none: No podemos detectar un certificado en su tarjeta PIV/CAC.
+        not_auth_cert: Elija un certificado diferente de su tarjeta PIV/CAC.
         ocsp_error: Estamos teniendo dificultades técnicas. Por favor, inténtelo de
           nuevo más tarde.
         revoked: El certificado que seleccionó ha sido revocado de su tarjeta.

--- a/config/locales/headings/fr.yml
+++ b/config/locales/headings/fr.yml
@@ -48,6 +48,7 @@ fr:
         expired: Le certificat que vous avez sélectionné a expiré.
         invalid: Le certificat que vous avez sélectionné n'est pas valide.
         none: Nous ne pouvons pas détecter un certificat sur votre carte PIV/CAC.
+        not_auth_cert: Veuillez choisir un autre certificat de votre carte PIV/CAC.
         ocsp_error: Nous avons des difficultés techniques. Veuillez réessayer plus
           tard.
         revoked: Le certificat que vous avez sélectionné a été retiré de votre carte.

--- a/config/locales/instructions/en.yml
+++ b/config/locales/instructions/en.yml
@@ -61,11 +61,11 @@ en:
         confirm_code_html: Want us to call you again? %{resend_code_link}
         number_message_html: We just called you at %{number}.
       webauthn:
+        confirm_webauthn_html: Present the security key that you associated with your
+          account.
         confirm_webauthn_only_html: This app requires a higher level of security.
           You need to verify your identity using a security key that you previously
           set up to access your information.
-        confirm_webauthn_html: Present the security key that you associated with your
-          account.
       wrong_number_html: Entered the wrong phone number? %{link}
     password:
       forgot: Don’t know your password? Reset it after confirming your email address.

--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -30,6 +30,7 @@ en:
         expired: PIV/CAC certificate error
         invalid: PIV/CAC certificate error
         none: PIV/CAC certificate error
+        not_auth_cert: PIV/CAC authentication certificate is required
         ocsp_error: PIV/CAC OCSP certificate error
         revoked: PIV/CAC certificate error
         timeout: PIV/CAC certificate timeout error

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -31,6 +31,7 @@ es:
         expired: Error de certificado PIV/CAC
         invalid: Error de certificado PIV/CAC
         none: Error de certificado PIV/CAC
+        not_auth_cert: Se requiere certificado de autenticación PIV/CAC
         ocsp_error: Error de certificado PIV/CAC OCSP
         revoked: Error de certificado PIV/CAC
         timeout: Error de tiempo de espera del certificado PIV/CAC

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -30,6 +30,7 @@ fr:
         expired: Erreur de certificat PIV/CAC
         invalid: Erreur de certificat PIV/CAC
         none: Erreur de certificat PIV/CAC
+        not_auth_cert: Un certificat d'authentification PIV/CAC est requis
         ocsp_error: Erreur de certificat OCSP PIV/CAC
         revoked: Erreur de certificat PIV/CAC
         timeout: Erreur d'expiration du certificat PIV/CAC

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -110,17 +110,9 @@ describe UserPivCacSetupForm do
         described_class.new(user: user, token: token, nonce: nonce, name: 'Card 1',
                             piv_cac_required: true)
       end
-      let(:no_eku_token_response) do
-        { 'nonce' => nonce, 'key_id' => 'foo', 'has_eku' => false, 'uuid' => x509_dn_uuid,
-          'subject' => 'x509-subject' }
-      end
-      let(:has_eku_token_response) do
-        { 'nonce' => nonce, 'key_id' => 'foo', 'has_eku' => true, 'uuid' => x509_dn_uuid,
-          'subject' => 'x509-subject' }
-      end
 
       it 'returns FormResponse with success: true when the token has an eku' do
-        allow(PivCacService).to receive(:decode_token).with(token) { has_eku_token_response }
+        allow(PivCacService).to receive(:decode_token).with(token) { eku_token_response(true) }
 
         result = instance_double(FormResponse)
         extra = { multi_factor_auth_method: 'piv_cac' }
@@ -132,7 +124,7 @@ describe UserPivCacSetupForm do
       end
 
       it 'returns FormResponse with success: false when the token does not have an eku' do
-        allow(PivCacService).to receive(:decode_token).with(token) { no_eku_token_response }
+        allow(PivCacService).to receive(:decode_token).with(token) { eku_token_response(false) }
 
         extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
 
@@ -156,5 +148,10 @@ describe UserPivCacSetupForm do
         expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
       end
     end
+  end
+
+  def eku_token_response(eku)
+    { 'nonce' => nonce, 'key_id' => 'foo', 'has_eku' => eku, 'uuid' => x509_dn_uuid,
+      'subject' => 'x509-subject' }
   end
 end

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -136,8 +136,7 @@ describe UserPivCacSetupForm do
   end
 
   def expect_results_with_eku(has_eku, errors = {})
-    response = { 'nonce' => nonce, 'has_eku' => has_eku, 'uuid' => x509_dn_uuid,
-      'subject' => 'x509-subject' }
+    response = { 'nonce' => nonce, 'has_eku' => has_eku, 'uuid' => 'bar', 'subject' => 'foo' }
     allow(PivCacService).to receive(:decode_token).with(token) { response }
 
     result = form.submit

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -106,12 +106,12 @@ describe UserPivCacSetupForm do
     context 'when piv cac is required' do
       let(:token) { 'good-token' }
 
-      it 'returns FormResponse with success: true when the token has an eku' do
-        expect_results_with_eku(true)
+      it 'returns FormResponse with success: true when the token indicates auth cert' do
+        expect_results_with_auth_cert(true)
       end
 
-      it 'returns FormResponse with success: false when the token does not have an eku' do
-        expect_results_with_eku(false, type: 'certificate.not_auth_cert')
+      it 'returns FormResponse with success: false when the token indicates not an auth cert' do
+        expect_results_with_auth_cert(false, type: 'certificate.not_auth_cert')
       end
     end
 
@@ -130,13 +130,13 @@ describe UserPivCacSetupForm do
     end
   end
 
-  def expect_results_with_eku(has_eku, errors = {})
-    response = { 'nonce' => nonce, 'has_eku' => has_eku, 'uuid' => 'bar', 'subject' => 'foo' }
-    allow(PivCacService).to receive(:decode_token).with(token) { response }
+  def expect_results_with_auth_cert(is_auth_cert, errors = {})
+    resp = { 'nonce' => nonce, 'is_auth_cert' => is_auth_cert, 'uuid' => 'a', 'subject' => 'b' }
+    allow(PivCacService).to receive(:decode_token).with(token) { resp }
 
     result = described_class.new(user: user, token: token, nonce: nonce, name: 'Card 1',
                                  piv_cac_required: true).submit
-    expect(result.success?).to eq(has_eku)
+    expect(result.success?).to eq(is_auth_cert)
     expect(result.errors).to eq(errors)
   end
 end

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -134,14 +134,12 @@ describe UserPivCacSetupForm do
       it 'returns FormResponse with success: false when the token does not have an eku' do
         allow(PivCacService).to receive(:decode_token).with(token) { no_eku_token_response }
 
-        result = instance_double(FormResponse)
         extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
 
-        expect(FormResponse).to receive(:new).
-          with(success: false, errors: { type: 'certificate.not_auth_cert' }, extra: extra).
-          and_return(result)
-        expect(form.submit).to eq result
-        expect(form.error_type).to eq 'certificate.not_auth_cert'
+        result = form.submit
+        expect(result.success?).to eq(false)
+        expect(result.errors).to eq(type: 'certificate.not_auth_cert')
+        expect(result.extra).to eq(extra)
       end
     end
 

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -105,7 +105,6 @@ describe UserPivCacSetupForm do
 
     context 'when piv cac is required' do
       let(:token) { 'good-token' }
-      let(:x509_dn_uuid) { 'random-uuid-for-x509-subject' }
       let(:form) do
         described_class.new(user: user, token: token, nonce: nonce, name: 'Card 1',
                             piv_cac_required: true)

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -105,10 +105,6 @@ describe UserPivCacSetupForm do
 
     context 'when piv cac is required' do
       let(:token) { 'good-token' }
-      let(:form) do
-        described_class.new(user: user, token: token, nonce: nonce, name: 'Card 1',
-                            piv_cac_required: true)
-      end
 
       it 'returns FormResponse with success: true when the token has an eku' do
         expect_results_with_eku(true)
@@ -138,7 +134,8 @@ describe UserPivCacSetupForm do
     response = { 'nonce' => nonce, 'has_eku' => has_eku, 'uuid' => 'bar', 'subject' => 'foo' }
     allow(PivCacService).to receive(:decode_token).with(token) { response }
 
-    result = form.submit
+    result = described_class.new(user: user, token: token, nonce: nonce, name: 'Card 1',
+                                 piv_cac_required: true).submit
     expect(result.success?).to eq(has_eku)
     expect(result.errors).to eq(errors)
   end


### PR DESCRIPTION
**How**: Have PIV/CAC server send back a boolean in the token (is_auth_cert).  HSPD12 rejects anything but an auth cert to authenticate.