### PR TITLE
Set full-screen close button to natural width

### DIFF
--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -13,6 +13,7 @@
   position: absolute;
   right: 0;
   top: 0;
+  width: auto;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
**Why**: For the button to appear correctly on mobile devices, it must be explicitly assigned `width: auto` to collapse the button width to its natural width (from the default `100%`).

This only affects the new React-based document capture flow, because it assigns `.usa-button` class to the button. It does this to inherit some other default button styles which would otherwise need to be recreated manually (`appearance: none`, for example). The full-screen capture in the production environment (#3942) is not affected because it does not assign `.usa-button`, because it renders a `div` instead of a `button`.

Before|After
---|---
![before button](https://user-images.githubusercontent.com/1779930/89414731-e32f9000-d6f8-11ea-8cff-60241c8494f0.png)|![after](https://user-images.githubusercontent.com/1779930/89414746-e88cda80-d6f8-11ea-8e73-ea5890cd4b57.png)

(Buttons in screenshots are focused to better clarify intended change)

Relevant upstream source (USWDS): https://github.com/uswds/uswds/blob/f761763/src/stylesheets/elements/_buttons.scss#L22-L26