### PR TITLE
Ensure React useAsync calls createPromise once at mount

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "prefer-arrow-callback": 0,
     "import/prefer-default-export": "off",
     "import/extensions": ["off", "never"],
+    "newline-per-chained-call": "off",
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
     "implicit-arrow-linebreak": "off",

--- a/spec/javascripts/app/document-capture/hooks/use-async-spec.jsx
+++ b/spec/javascripts/app/document-capture/hooks/use-async-spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import sinon from 'sinon';
 import render from '../../../support/render';
 import useAsync from '../../../../../app/javascript/app/document-capture/hooks/use-async';
 import SuspenseErrorBoundary from '../../../../../app/javascript/app/document-capture/components/suspense-error-boundary';
@@ -22,12 +23,18 @@ describe('document-capture/hooks/use-async', () => {
 
   it('returns suspense resource that renders fallback', async () => {
     let resolve;
-    const createPromise = () =>
-      new Promise((_resolve) => {
-        resolve = () => {
-          _resolve();
-        };
-      });
+    const createPromise = sinon
+      .stub()
+      .onCall(0)
+      .returns(
+        new Promise((_resolve) => {
+          resolve = () => {
+            _resolve();
+          };
+        }),
+      )
+      .onCall(1)
+      .throws();
 
     const { container, findByText } = render(<Parent createPromise={createPromise} />);
 
@@ -40,12 +47,18 @@ describe('document-capture/hooks/use-async', () => {
 
   it('returns suspense resource that renders error fallback', async () => {
     let reject;
-    const createPromise = () =>
-      new Promise((_resolve, _reject) => {
-        reject = () => {
-          _reject();
-        };
-      });
+    const createPromise = sinon
+      .stub()
+      .onCall(0)
+      .returns(
+        new Promise((_resolve, _reject) => {
+          reject = () => {
+            _reject();
+          };
+        }),
+      )
+      .onCall(1)
+      .throws();
 
     const { container, findByText } = render(<Parent createPromise={createPromise} />);
 

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import sinon from 'sinon';
 import UploadContext from '../../../app/javascript/app/document-capture/context/upload';
 
 /**
@@ -13,11 +14,14 @@ import UploadContext from '../../../app/javascript/app/document-capture/context/
  * @return {import('@testing-library/react').RenderResult}
  */
 function renderWithDefaultContext(element) {
-  return render(
-    <UploadContext.Provider value={(payload) => Promise.resolve(payload)}>
-      {element}
-    </UploadContext.Provider>,
-  );
+  const upload = sinon
+    .stub()
+    .onCall(0)
+    .callsFake((payload) => Promise.resolve(payload))
+    .onCall(1)
+    .throws();
+
+  return render(<UploadContext.Provider value={upload}>{element}</UploadContext.Provider>);
 }
 
 export default renderWithDefaultContext;


### PR DESCRIPTION
**Why**: The `read` function returned by `useAsync` is expected to be called multiple times, but it is intended to operate on a single promise created once at mount time (or at least once per unique set of arguments). Prior to these changes, this was behaving wrongly by creating a new promise each time `read` was called. While this was not particularly troublesome for the stubbed upload behavior, in real-world testing it showed to trigger repeated API requests.

Included in these changes are improvements to the test suite to try to provide stronger guarantees that both uploading and `useAsync`'s default behavior will not make repeated calls to create a new promise.

**Implementation Notes:**

This is a pretty unfortunate oversight on my part, and shows that there's a fair bit of complexity in this implementation. It raises a question as to whether the form submission should occur via some more direct means: Calling `upload` at the time of [`DocumentCapture`'s `onComplete` handling](https://github.com/18F/identity-idp/blob/397849acfca037ba8060d811f4f25bfb33c242da/app/javascript/app/document-capture/components/document-capture.jsx#L26), rather than managing this as a combination of component state and lifecycle side effects. That being said, there would still be complexity in managing the more "direct" path, since it needs to handle many states (pre-submission, mid-submission, post-submission success, and post-submission failure) that would likely need to be absorbed into `DocumentCapture`. The intent of the `Submission` component and `useAsync` hook was to try to encapsulate this, and to isolate the responsibilities of each more appropriately.