### PR TITLE
Add drag-and-drop styling effects to FileInput

### DIFF
--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
@@ -38,6 +38,7 @@ function FileInput({ label, hint, bannerText, accept, value, onChange, className
   const ifStillMounted = useIfStillMounted();
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
 
@@ -76,10 +77,14 @@ function FileInput({ label, hint, bannerText, accept, value, onChange, className
       <div
         className={[
           'usa-file-input usa-file-input--single-value',
+          isDraggingOver && 'usa-file-input--drag',
           value && 'usa-file-input--has-value',
         ]
           .filter(Boolean)
           .join(' ')}
+        onDragOver={() => setIsDraggingOver(true)}
+        onDragLeave={() => setIsDraggingOver(false)}
+        onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
           {value && !isMobile && (

--- a/spec/javascripts/app/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/file-input-spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import render from '../../../support/render';
 import FileInput, {
@@ -176,7 +177,24 @@ describe('document-capture/components/file-input', () => {
     expect(container.querySelector('.usa-file-input__preview-heading')).to.not.be.ok();
   });
 
-  it.skip('supports change by drag and drop', () => {});
+  it('adds drag effects', () => {
+    const { getByLabelText } = render(<FileInput label="File" />);
+
+    const input = getByLabelText('File');
+    const container = input.closest('.usa-file-input');
+
+    fireEvent.dragOver(input);
+    expect(container.classList.contains('usa-file-input--drag')).to.be.true();
+
+    fireEvent.dragLeave(input);
+    expect(container.classList.contains('usa-file-input--drag')).to.be.false();
+
+    fireEvent.dragOver(input);
+    expect(container.classList.contains('usa-file-input--drag')).to.be.true();
+
+    fireEvent.drop(input);
+    expect(container.classList.contains('usa-file-input--drag')).to.be.false();
+  });
 
   it.skip('shows an error state', () => {});
 });


### PR DESCRIPTION
This pull request adds drag-and-drop styling effects when the user drags a file over `FileInput`.

**Why**: Since this component is intended to faithfully recreate the [USWDS File Input component](https://designsystem.digital.gov/components/form-controls/#file-input), a drag effect should be added when the user drags a file over the droppable area.

**Screen Recording:**

![drag-effects mov](https://user-images.githubusercontent.com/1779930/89546858-09c1f980-d7d3-11ea-97dd-37eb74f961c0.gif)

**Implementation Notes:**

Because the USWDS File Input is implemented as a visible pass-through to a `<input type="file" />` as an underlay, it's not necessary to implement behaviors for handling the interpretation of the dropped file, since it can take advantage of existing handling for the input's `onChange` behavior. The only missing functionality was the visual appearance of the drag styling.

Reference implementation: https://github.com/uswds/uswds/blob/f761763c66399fe63800f22cc17c228b2c46b097/src/js/components/file-input.js#L256-L267