### PR TITLE
Log face match results to events.log (LG-2495)

### DIFF
--- a/app/services/acuant/acuant_client.rb
+++ b/app/services/acuant/acuant_client.rb
@@ -52,7 +52,7 @@ module Acuant
         Acuant::Responses::ResponseWithPii.new(
           acuant_response: selfie_response,
           pii: pii,
-          billed: results.result_code&.billed?,
+          result_code: results.result_code,
         )
       else
         results

--- a/app/services/acuant/responses/get_results_response.rb
+++ b/app/services/acuant/responses/get_results_response.rb
@@ -25,6 +25,7 @@ module Acuant
           errors: errors,
           exception: exception,
           result: result_code.name,
+          billed: result_code.billed,
         }
       end
 

--- a/app/services/acuant/responses/response_with_pii.rb
+++ b/app/services/acuant/responses/response_with_pii.rb
@@ -8,7 +8,7 @@ module Acuant
           exception: acuant_response.exception,
           extra: acuant_response.extra.merge(
             result: result_code.name,
-            billed: result_code.billed?
+            billed: result_code.billed?,
           ),
         )
         @pii = pii

--- a/app/services/acuant/responses/response_with_pii.rb
+++ b/app/services/acuant/responses/response_with_pii.rb
@@ -1,12 +1,15 @@
 module Acuant
   module Responses
     class ResponseWithPii < Acuant::Response
-      def initialize(acuant_response:, pii:, billed:)
+      def initialize(acuant_response:, pii:, result_code:)
         super(
           success: acuant_response.success?,
           errors: acuant_response.errors,
           exception: acuant_response.exception,
-          extra: acuant_response.extra.merge(billed: billed),
+          extra: acuant_response.extra.merge(
+            result: result_code.name,
+            billed: result_code.billed?
+          ),
         )
         @pii = pii
       end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -89,7 +89,6 @@ class Analytics
   CAC_PROOFING = 'CAC Proofing'.freeze # visited or submitted is appended
   CAPTURE_DOC = 'Capture Doc'.freeze # visited or submitted is appended
   DOC_AUTH = 'Doc Auth'.freeze # visited or submitted is appended
-  DOC_AUTH_V2 = 'Doc Auth V2'.freeze # visited or submitted is appended
   IN_PERSON_PROOFING = 'In Person Proofing'.freeze # visited or submitted is appended
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_DELETION_REQUEST = 'Email Deletion Requested'.freeze

--- a/app/services/doc_auth_mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth_mock/doc_auth_mock_client.rb
@@ -67,7 +67,7 @@ module DocAuthMock
         Acuant::Responses::ResponseWithPii.new(
           acuant_response: selfie_response,
           pii: pii,
-          billed: true,
+          result_code: Acuant::ResultCodes::PASSED,
         )
       else
         results

--- a/app/services/doc_auth_mock/responses/get_results_response.rb
+++ b/app/services/doc_auth_mock/responses/get_results_response.rb
@@ -8,14 +8,17 @@ module DocAuthMock
         errors: [],
         exception: nil,
         pii_from_doc:,
-        billed: true
+        result_code: Acuant::ResultCodes::PASSED
       )
         @pii_from_doc = pii_from_doc
         super(
           success: success,
           errors: errors,
           exception: exception,
-          extra: { billed: billed },
+          extra: {
+            billed: result_code.billed?,
+            result: result_code.name,
+          },
         )
       end
     end

--- a/app/services/doc_auth_mock/result_response_builder.rb
+++ b/app/services/doc_auth_mock/result_response_builder.rb
@@ -27,7 +27,6 @@ module DocAuthMock
         success: success?,
         errors: errors,
         pii_from_doc: pii_from_doc,
-        billed: true,
       )
     end
 

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -40,9 +40,16 @@ module Flow
     end
 
     def form_response(obj, value)
-      response = value.class == FormResponse ? value : FormResponse.new(success: true, errors: {})
+      response = form_response?(value) ? value : FormResponse.new(success: true, errors: {})
       obj.mark_step_complete if response.success?
       response
+    end
+
+    # Duck type check for FormResponse
+    def form_response?(response)
+      response.kind_of?(FormResponse) ||
+        response.kind_of?(Acuant::Response) ||
+        (response.respond_to?(:success?) && response.respond_to?(:to_h))
     end
 
     delegate :flash, :session, :current_user, :params, :request, to: :@controller

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -47,8 +47,8 @@ module Flow
 
     # Duck type check for FormResponse
     def form_response?(response)
-      response.kind_of?(FormResponse) ||
-        response.kind_of?(Acuant::Response) ||
+      response.is_a?(FormResponse) ||
+        response.is_a?(Acuant::Response) ||
         (response.respond_to?(:success?) && response.respond_to?(:to_h))
     end
 

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -6,6 +6,7 @@ module Idv
         if response.success?
           save_proofing_components
           extract_pii_from_doc(response)
+          response
         else
           handle_document_verification_failure(response)
         end

--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -2,11 +2,12 @@ module Idv
   module Steps
     class SelfieStep < DocAuthBaseStep
       def call
-        add_cost(:acuant_result) if get_results_response.to_h[:billed]
-        if get_results_response.success?
+        add_cost(:acuant_result) if results_response.to_h[:billed]
+        if results_response.success?
           send_selfie_request
+          results_response
         else
-          handle_selfie_step_failure(get_results_response)
+          handle_selfie_step_failure(results_response)
         end
       end
 
@@ -27,7 +28,7 @@ module Idv
         if user_id_from_token.present?
           CaptureDoc::UpdateAcuantToken.call(user_id_from_token, flow_session[:instance_id])
         else
-          extract_pii_from_doc(get_results_response)
+          extract_pii_from_doc(results_response)
         end
       end
 
@@ -43,13 +44,11 @@ module Idv
         failure(failure_response.errors.first, failure_response.to_h)
       end
 
-      # rubocop:disable Naming/AccessorMethodName
-      def get_results_response
-        @get_results_response ||= doc_auth_client.get_results(
+      def results_response
+        @results_response ||= doc_auth_client.get_results(
           instance_id: flow_session[:instance_id],
         )
       end
-      # rubocop:enable Naming/AccessorMethodName
 
       def form_submit
         Idv::ImageUploadForm.new.submit(permit(:image, :image_data_url))

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -54,7 +54,8 @@ feature 'doc auth document capture step' do
       end
 
       it 'proceeds to the next page with valid info and logs analytics info' do
-        allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+        allow_any_instance_of(ApplicationController).
+          to receive(:analytics).and_return(fake_analytics)
 
         attach_images
         click_idv_continue

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -8,6 +8,7 @@ feature 'doc auth document capture step' do
   let(:max_attempts) { Figaro.env.acuant_max_attempts.to_i }
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { 'false' }
+  let(:fake_analytics) { FakeAnalytics.new }
   before do
     allow(Figaro.env).to receive(:document_capture_react_enabled).and_return('false')
     allow(Figaro.env).to receive(:document_capture_step_enabled).
@@ -52,11 +53,19 @@ feature 'doc auth document capture step' do
         expect(page).to have_content(I18n.t('doc_auth.tips.document_capture_selfie_text3'))
       end
 
-      it 'proceeds to the next page with valid info' do
+      it 'proceeds to the next page with valid info and logs analytics info' do
+        allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+
         attach_images
         click_idv_continue
 
         expect(page).to have_current_path(next_step)
+        expect(fake_analytics).to have_logged_event(
+          Analytics::DOC_AUTH + ' submitted',
+          step: 'document_capture',
+          result: 'Passed',
+          billed: true,
+        )
       end
 
       it 'allows the use of a base64 encoded data url representation of the image' do

--- a/spec/services/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/acuant/responses/get_results_response_spec.rb
@@ -19,6 +19,7 @@ describe Acuant::Responses::GetResultsResponse do
         success: true,
         errors: [],
         exception: nil,
+        billed: true,
         result: 'Passed',
       )
       expect(response.result_code).to eq(Acuant::ResultCodes::PASSED)

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -23,16 +23,16 @@ RSpec::Matchers.define :have_logged_event do |event_name, attributes|
   match do |actual|
     expect(actual).to be_kind_of(FakeAnalytics)
 
-    expect(actual.events[event_name]).to be_any { |event| attributes < event }
+    expect(actual.events[event_name]).to(be_any { |event| attributes < event })
   end
 
   failure_message do |actual|
-    <<~EOS
+    <<~MESSAGE
       Expected that FakeAnalytics would have received event #{event_name.inspect}
       with #{attributes.inspect}.
 
       Events received:
       #{actual.events.pretty_inspect}
-    EOS
+    MESSAGE
   end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -1,6 +1,13 @@
 class FakeAnalytics
-  def track_event(_event, _attributes = {})
-    # no-op
+  attr_reader :events
+
+  def initialize
+    @events = Hash.new { |hash, key| hash[key] = [] }
+  end
+
+  def track_event(event, attributes = {})
+    events[event] << attributes
+    nil
   end
 
   def track_mfa_submit_event(_attributes, _ga_client_id)
@@ -9,5 +16,23 @@ class FakeAnalytics
 
   def grab_ga_client_id
     '123.456'
+  end
+end
+
+RSpec::Matchers.define :have_logged_event do |event_name, attributes|
+  match do |actual|
+    expect(actual).to be_kind_of(FakeAnalytics)
+
+    expect(actual.events[event_name]).to be_any { |event| attributes < event }
+  end
+
+  failure_message do |actual|
+    <<~EOS
+      Expected that FakeAnalytics would have received event #{event_name.inspect}
+      with #{attributes.inspect}.
+
+      Events received:
+      #{actual.events.pretty_inspect}
+    EOS
   end
 end

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -23,7 +23,7 @@ RSpec::Matchers.define :have_logged_event do |event_name, attributes|
   match do |actual|
     expect(actual).to be_kind_of(FakeAnalytics)
 
-    expect(actual.events[event_name]).to(be_any { |event| attributes < event })
+    expect(actual.events[event_name]).to(be_any { |event| attributes <= event })
   end
 
   failure_message do |actual|


### PR DESCRIPTION
(Builds on previous work in #4007 and #4001 that update logging to the database)

This PR adds logging to events.log, it's stringing together a few different files so here's what's going on:

- We have Flows and Steps, and FormResponses.
- **Before**
  - If `Step#call` returns a FormResponse, we would log it
  - Our `Acuant::Response` objects duck-type FormResponses, but are not actually form responses so the previous check to log would fail
  - The `Step#call` was not returning the result object in most cases at all anyways
- **After**
   - We now do a duck type check that allows `Acuant::Response` objects to be logged (the response objects are already pretty well-behaved about PII)
   - Updates specific steps to make sure they log results (not all)
- **Open Questions**
  - Should we audit all steps now and make sure they log? For the purposes of this ticket and this PR, I think no, but it would probably match expectations later down the line

I also added a matcher for FakeAnalytics and to make testing this a little cleaner