### PR TITLE
Show fallback document capture flow in noscript

### DIFF
--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -20,7 +20,6 @@ const device = {
 };
 
 const appRoot = document.getElementById('document-capture-form');
-appRoot.innerHTML = '';
 render(
   <AcuantProvider
     credentials={getMetaContent('acuant-sdk-initialization-creds')}

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -10,18 +10,7 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form">
-    <h1 class="h3 my0">
-      <%= t('doc_auth.headings.document_capture_heading_html') %>
-    </h1>
-    <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
-    <ul>
-      <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
-      <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
-      <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
-      <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
-    </ul>
-  </div>
+  <div id="document-capture-form"></div>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -11,6 +11,18 @@
     >
   <% end %>
   <div id="document-capture-form">
+    <h1 class="h3 my0">
+      <%= t('doc_auth.headings.document_capture_heading_html') %>
+    </h1>
+    <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
+    <ul>
+      <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
+    </ul>
+  </div>
+  <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
     <h1 class="h3 my0">
@@ -101,7 +113,7 @@
     <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
 
     <%= javascript_pack_tag 'image-preview' %>
-  </div>
+  </noscript>
   <%= render 'idv/doc_auth/start_over_or_cancel' %>
   <% unless Figaro.env.document_capture_react_enabled == 'false' %>
     <%= javascript_pack_tag 'document-capture' %>


### PR DESCRIPTION
**Why**: To avoid the user briefly seeing the static fallback form before the JavaScript has finished initialization, since otherwise it may be jarring to the user that the page is updating frenetically. 

**Alternatives Considered:**

- Some use of the combination of [`no-js` and `js-fallback` class name utilties](https://github.com/18F/identity-idp/blob/5a66e1c9f4461a0ae7b0e91fad6097b06b24647a/app/assets/stylesheets/components/_util.scss#L28-L36)
- Creating separate containers for the `div`, then moving the `script` tag earlier than the static fallback, to take advantage of the fact that script loading is synchronous and blocking. This would prevent the static fallback from being shown until at least after the JavaScript has been loaded.

**Room for improvement:**

I'd considered if there could be some middle-ground to take advantage of the commonalities between the static fallback and React capture flow, where parts of the static fallback could be allowed to be shown under the assumption that they would appear the same in the React application (notably, title, description, hints). This is made challenging by the fact that the title is shown differently in the static fallback ("Add your state-issued ID and selfie" vs. "Add your state-issued ID").