### PR TITLE
Add error states for React document capture file input

### DIFF
--- a/app/assets/javascripts/i18n-strings.js.erb
+++ b/app/assets/javascripts/i18n-strings.js.erb
@@ -5,6 +5,7 @@ window.LoginGov = window.LoginGov || {};
   'two_factor_authentication.otp_delivery_preference.phone_unsupported',
   'errors.messages.format_mismatch',
   'errors.messages.missing_field',
+  'errors.doc_auth.selfie',
   'forms.buttons.continue',
   'forms.buttons.submit.default',
   'forms.passwords.show',

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -110,10 +110,14 @@ function FileInput({ label, hint, bannerText, accept, value, errors, onChange, c
    */
   function onChangeAsDataURL(event) {
     const file = event.target.files[0];
-    if (isValidForAccepts(file.type, accept)) {
-      toDataURL(file).then(ifStillMounted((data) => onChange(new DataURLFile(data, file.name))));
+    if (file) {
+      if (isValidForAccepts(file.type, accept)) {
+        toDataURL(file).then(ifStillMounted((data) => onChange(new DataURLFile(data, file.name))));
+      } else {
+        setOwnErrors((previousErrors) => [...previousErrors, t('errors.doc_auth.selfie')]);
+      }
     } else {
-      setOwnErrors((previousErrors) => [...previousErrors, t('errors.doc_auth.selfie')]);
+      onChange(file);
     }
   }
 

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -1,10 +1,51 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useI18n from '../hooks/use-i18n';
 import DataURLFile from '../models/data-url-file';
+
+/**
+ * Given a data URL string, returns the MIME type.
+ *
+ * @see https://tools.ietf.org/html/rfc2397#section-3
+ *
+ * @param {string} dataURL Data URL.
+ *
+ * @return {string} MIME type.
+ */
+export function getDataURLMimeType(dataURL) {
+  const [mimeType] = dataURL.replace(/^data:/, '').split(/[;,]/);
+  return mimeType || 'text/plain';
+}
+
+/**
+ * Given a token of an file input accept attribute, returns an equivalent regular expression
+ * pattern, or undefined if a pattern cannot be determined. This is an approximation, and not fully
+ * spec-compliant to allowable characters in what is considered a valid MIME type.
+ *
+ * @see https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+ * @see https://tools.ietf.org/html/rfc7231#section-3.1.1.1
+ * @see https://tools.ietf.org/html/rfc2045#section-5.1
+ *
+ * @param {string} accept Accept token.
+ *
+ * @return {RegExp=} Regular expression, or undefined if cannot be determined.
+ */
+export function getAcceptPattern(accept) {
+  switch (accept) {
+    case 'audio/*':
+    case 'video/*':
+    case 'image/*': {
+      const [type] = accept.split('/');
+      return new RegExp(`^${type}/.+`);
+    }
+
+    default:
+      return /^[\w-]+\/[\w-]+$/.test(accept) ? new RegExp(`^${accept}$`) : undefined;
+  }
+}
 
 /**
  * Returns true if the given data URL represents an image, or false otherwise.
@@ -14,7 +55,22 @@ import DataURLFile from '../models/data-url-file';
  * @return {boolean} Whether given data URL is an image.
  */
 export function isImage(dataURL) {
-  return /^data:image\//.test(dataURL);
+  return getAcceptPattern('image/*').test(getDataURLMimeType(dataURL));
+}
+
+/**
+ * Returns true if the given MIME type is valid for the array of accept tokens or if the accept
+ * parameter is empty. Returns false otherwise.
+ *
+ * @param {string}    mimeType MIME type to test.
+ * @param {?string[]} accept   Accept tokens.
+ *
+ * @return {boolean} Whether data URL is valid.
+ */
+export function isValidForAccepts(mimeType, accept) {
+  return (
+    !accept || accept.map(getAcceptPattern).some((pattern) => pattern && pattern.test(mimeType))
+  );
 }
 
 /**
@@ -33,14 +89,18 @@ export function toDataURL(file) {
   });
 }
 
-function FileInput({ label, hint, bannerText, accept, value, onChange, className }) {
+function FileInput({ label, hint, bannerText, accept, value, errors, onChange, className }) {
   const { t, formatHTML } = useI18n();
   const ifStillMounted = useIfStillMounted();
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const [ownErrors, setOwnErrors] = useState(/** @type {string[]} */ ([]));
+  useMemo(() => setOwnErrors([]), [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
+
+  const allErrors = [...ownErrors, ...errors];
 
   /**
    * In response to a file input change event, converts the assigned file to a data URL before
@@ -50,11 +110,19 @@ function FileInput({ label, hint, bannerText, accept, value, onChange, className
    */
   function onChangeAsDataURL(event) {
     const file = event.target.files[0];
-    toDataURL(file).then(ifStillMounted((data) => onChange(new DataURLFile(data, file.name))));
+    if (isValidForAccepts(file.type, accept)) {
+      toDataURL(file).then(ifStillMounted((data) => onChange(new DataURLFile(data, file.name))));
+    } else {
+      setOwnErrors((previousErrors) => [...previousErrors, t('errors.doc_auth.selfie')]);
+    }
   }
 
   return (
-    <div className={className}>
+    <div
+      className={[className, allErrors.length && 'usa-form-group usa-form-group--error']
+        .filter(Boolean)
+        .join(' ')}
+    >
       {/*
        * Disable reason: The Airbnb configuration of the `jsx-a11y` rule is strict in that it
        * requires _both_ the `for` attribute and nesting, to maximize support for assistive
@@ -66,9 +134,17 @@ function FileInput({ label, hint, bannerText, accept, value, onChange, className
        * See: https://github.com/airbnb/javascript/pull/2136
        */}
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label htmlFor={inputId} className="usa-label">
+      <label
+        htmlFor={inputId}
+        className={['usa-label', allErrors.length && 'usa-label--error'].filter(Boolean).join(' ')}
+      >
         {label}
       </label>
+      {allErrors.map((error) => (
+        <span key={error} className="usa-error-message" role="alert">
+          {error}
+        </span>
+      ))}
       {hint && (
         <span className="usa-hint" id={hintId}>
           {hint}
@@ -126,7 +202,7 @@ function FileInput({ label, hint, bannerText, accept, value, onChange, className
             className="usa-file-input__input"
             type="file"
             onChange={onChangeAsDataURL}
-            accept={accept.join()}
+            accept={accept ? accept.join() : undefined}
             aria-describedby={hint ? hintId : null}
           />
         </div>
@@ -141,6 +217,7 @@ FileInput.propTypes = {
   bannerText: PropTypes.string,
   accept: PropTypes.arrayOf(PropTypes.string),
   value: PropTypes.instanceOf(DataURLFile),
+  errors: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func,
   className: PropTypes.string,
 };
@@ -148,8 +225,9 @@ FileInput.propTypes = {
 FileInput.defaultProps = {
   hint: null,
   bannerText: null,
-  accept: [],
+  accept: null,
   value: undefined,
+  errors: [],
   onChange: () => {},
   className: null,
 };

--- a/spec/javascripts/app/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/documents-step-spec.jsx
@@ -38,11 +38,6 @@ describe('document-capture/components/documents-step', () => {
 
     const input = getByLabelText('doc_auth.headings.document_capture_front');
 
-    // Ideally this wouldn't be so tightly-coupled with the DOM implementation, but instead attempt
-    // to upload a file of an invalid type. `@testing-library/user-event` doesn't currently support
-    // this usage.
-    //
-    // See: https://github.com/testing-library/user-event/issues/421
     expect(input.getAttribute('accept')).to.equal('image/*');
   });
 

--- a/spec/javascripts/app/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/file-input-spec.jsx
@@ -5,13 +5,98 @@ import { fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import render from '../../../support/render';
 import FileInput, {
+  getDataURLMimeType,
+  getAcceptPattern,
   isImage,
+  isValidForAccepts,
   toDataURL,
 } from '../../../../../app/javascript/app/document-capture/components/file-input';
 import DeviceContext from '../../../../../app/javascript/app/document-capture/context/device';
 import DataURLFile from '../../../../../app/javascript/app/document-capture/models/data-url-file';
 
 describe('document-capture/components/file-input', () => {
+  describe('getDataURLMimeType', () => {
+    it('returns text/plain when mediatype is absent', () => {
+      const url = 'data:,Hello%2C%20World!';
+
+      expect(getDataURLMimeType(url)).to.equal('text/plain');
+    });
+
+    it('returns mime type with parameter', () => {
+      const url = 'data:text/plain;charset=US-ASCII,Hello%2C%20World!';
+
+      expect(getDataURLMimeType(url)).to.equal('text/plain');
+    });
+
+    it('returns mime type with base64', () => {
+      const url = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==';
+
+      expect(getDataURLMimeType(url)).to.equal('text/plain');
+    });
+
+    it('returns mime type with data', () => {
+      const url = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+      expect(getDataURLMimeType(url)).to.equal('image/gif');
+    });
+  });
+
+  describe('getAcceptPattern', () => {
+    it('returns a pattern for audio matching', () => {
+      const accept = 'audio/*';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern.test('audio/mp3')).to.be.true();
+      expect(pattern.test('xaudio/mp3')).to.be.false();
+      expect(pattern.test('video/mp4')).to.be.false();
+      expect(pattern.test('image/jpg')).to.be.false();
+    });
+
+    it('returns a pattern for video matching', () => {
+      const accept = 'video/*';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern.test('video/mp4')).to.be.true();
+      expect(pattern.test('xvideo/mp4')).to.be.false();
+      expect(pattern.test('audio/mp3')).to.be.false();
+      expect(pattern.test('image/jpg')).to.be.false();
+    });
+
+    it('returns a pattern for image matching', () => {
+      const accept = 'image/*';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern.test('image/jpg')).to.be.true();
+      expect(pattern.test('ximage/jpg')).to.be.false();
+      expect(pattern.test('audio/mp3')).to.be.false();
+      expect(pattern.test('video/mp4')).to.be.false();
+    });
+
+    it('returns a pattern for mime type matching', () => {
+      const accept = 'image/jpg';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern.test('image/jpg')).to.be.true();
+      expect(pattern.test('ximage/jpg')).to.be.false();
+      expect(pattern.test('audio/mp3')).to.be.false();
+      expect(pattern.test('video/mp4')).to.be.false();
+    });
+
+    it('returns undefined for unknown accept', () => {
+      const accept = 'jpg';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern).to.be.undefined();
+    });
+
+    it('returns undefined for file extension matching', () => {
+      const accept = '.jpg';
+      const pattern = getAcceptPattern(accept);
+
+      expect(pattern).to.be.undefined();
+    });
+  });
+
   describe('isImage', () => {
     it('returns false if given file is not an image', () => {
       expect(isImage('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')).to.be.false();
@@ -21,6 +106,29 @@ describe('document-capture/components/file-input', () => {
       expect(
         isImage('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'),
       ).to.be.true();
+    });
+  });
+
+  describe('isValidForAccepts', () => {
+    it('returns false if invalid', () => {
+      const url = 'text/plain';
+      const accept = ['image/*'];
+
+      expect(isValidForAccepts(url, accept)).to.be.false();
+    });
+
+    it('returns true if valid', () => {
+      const url = 'image/gif';
+      const accept = ['image/*'];
+
+      expect(isValidForAccepts(url, accept)).to.be.true();
+    });
+
+    it('returns true if accept is nullish', () => {
+      const url = 'image/gif';
+      const accept = null;
+
+      expect(isValidForAccepts(url, accept)).to.be.true();
     });
   });
 
@@ -196,5 +304,16 @@ describe('document-capture/components/file-input', () => {
     expect(container.classList.contains('usa-file-input--drag')).to.be.false();
   });
 
-  it.skip('shows an error state', () => {});
+  it('shows an error state', () => {
+    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const onChange = sinon.stub();
+    const { getByLabelText, getByText } = render(
+      <FileInput label="File" accept={['text/*']} onChange={onChange} />,
+    );
+
+    const input = getByLabelText('File');
+    userEvent.upload(input, file);
+
+    expect(getByText('errors.doc_auth.selfie')).to.be.ok();
+  });
 });

--- a/spec/javascripts/app/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/file-input-spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
 import { expect } from 'chai';
 import render from '../../../support/render';
 import FileInput, {
@@ -249,6 +250,20 @@ describe('document-capture/components/file-input', () => {
     onChange.onCall(1).callsFake((nextValue) => {
       expect(nextValue.name).to.equal('upload2.png');
       expect(nextValue.data).to.equal('data:image/png;base64,');
+      done();
+    });
+  });
+
+  it('allows clearing the selected value', (done) => {
+    const file = new window.File([''], 'upload1.png', { type: 'image/png' });
+    const onChange = sinon.stub();
+    const { getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
+
+    const input = getByLabelText('File');
+    userEvent.upload(input, file);
+    onChange.onCall(0).callsFake(async () => {
+      fireEvent.change(input, { target: { files: [] } });
+      await waitFor(() => expect(input.value).to.be.empty());
       done();
     });
   });


### PR DESCRIPTION
**Why**: If a user's selected file is not acceptable for any reason, the user should be informed of the problem. The [USWDS File Input component](https://designsystem.digital.gov/components/form-controls/#file-input) that this component seeks to recreate defines how to display error messages, which these changes implement.

Currently, error management is limited to the file input checking its own file type, based on [discovery](https://github.com/testing-library/user-event/issues/421) that file type restrictions via `accept` attribute are easily bypassed by a user. The implementation is done in a way which anticipates and supports _external_ error messages as well as these internal messages. It's expected this could be used for errors such as those from Acuant's SDK (the design includes an example error message "too much glare").

It also fixes an error which occurs when the user clears a file value already assigned to the input.

**Screen Recording:**

![input errors](https://user-images.githubusercontent.com/1779930/89653735-887f6b00-d895-11ea-8113-69778324ec43.gif)