### PR TITLE
Add link back to SP on IDV fail page (LG-3264)

### DIFF
--- a/app/views/idv/fail.html.erb
+++ b/app/views/idv/fail.html.erb
@@ -5,3 +5,10 @@
 <h1 class="h3 mb1 mt3 my0"><%= t('idv.titles.hardfail', app: APP_NAME) %></h1>
 
 <p><%= t('idv.messages.hardfail', hours: Figaro.env.idv_attempt_window_in_hours) %></p>
+
+<% if decorated_session.sp_name %>
+  <div class='mt2'>
+    <%= t('idv.failure.help.get_help_html',
+          sp_name: link_to(decorated_session.sp_name, decorated_session.failure_to_proof_url)) %>
+  </div>
+<% end %>

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -120,7 +120,7 @@ describe IdvController do
     end
 
     context 'user does not have an active profile and has exceeded IdV attempts' do
-      let(:user) { user = create(:user) }
+      let(:user) { create(:user) }
 
       before do
         profile = create(

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -120,8 +120,9 @@ describe IdvController do
     end
 
     context 'user does not have an active profile and has exceeded IdV attempts' do
-      it 'allows direct access' do
-        user = create(:user)
+      let(:user) { user = create(:user) }
+
+      before do
         profile = create(
           :profile,
           user: user,
@@ -134,10 +135,30 @@ describe IdvController do
         )
 
         stub_sign_in(profile.user)
+      end
 
+      it 'allows direct access' do
         get :fail
 
         expect(response).to render_template('idv/fail')
+      end
+
+      context 'when there is an SP in the session' do
+        render_views
+
+        let(:service_provider) do
+          create(:service_provider, failure_to_proof_url: 'https://foo.bar')
+        end
+
+        before do
+          session[:sp] = { issuer: service_provider.issuer }
+        end
+
+        it "includes a link back to the SP's failure to proof URL" do
+          get :fail
+
+          expect(response.body).to include('https://foo.bar')
+        end
       end
     end
   end


### PR DESCRIPTION
Existing (or, without an SP in the session)

<img width="1017" alt="Screen Shot 2020-08-07 at 9 56 18 AM" src="https://user-images.githubusercontent.com/458784/89669798-ecedfa80-d894-11ea-9c14-5ec832504900.png">

After (with an SP in the session)

<img width="988" alt="Screen Shot 2020-08-07 at 9 58 07 AM" src="https://user-images.githubusercontent.com/458784/89669803-eeb7be00-d894-11ea-991e-c17f85751235.png">
