### PR TITLE
Update error styling for file input per design

### DIFF
--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -51,6 +51,14 @@
   }
 }
 
+.usa-form-group--error .usa-file-input .usa-file-input__target {
+  border-color: color('error-dark');
+
+  &:hover {
+    border-color: color('error-darker');
+  }
+}
+
 .usa-file-input__banner-text {
   @include u-font('sans', 'xl');
   @include u-margin-bottom(1);

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -180,3 +180,17 @@ input::-webkit-inner-spin-button {
 .text-hint {
   color: #707070;
 }
+
+//================================================
+// Pending upstream Login Design System revisions:
+//================================================
+
+.usa-form-group--error {
+  border-left-style: none;
+  margin-top: 0;
+  padding-left: 0;
+
+  @include at-media('desktop') {
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
**Why**: Styling should be consistent with USWDS default styling, with customizations intended by design specifications.

This is a quick follow-on to #4021 to resolve a few styling mistakes.

- File input target should show with error color border when in error state
- Per design customizations, the left border default of error group should be hidden
   - As implemented, it's assumed this is a _global_ customization for all form groups

Before|After
---|---
![before screenshot](https://user-images.githubusercontent.com/1779930/89670140-b0c79380-d8ae-11ea-9720-a27e00a205fa.png)|![after screenshot](https://user-images.githubusercontent.com/1779930/89670143-b1f8c080-d8ae-11ea-806c-c7c07ed8619c.png)

**Needs Design Feedback:** As [raised in Slack](https://gsa-tts.slack.com/archives/CEUQ9FXNJ/p1596819343237800), there's a discrepancy between Login Design System and USWDS in the color token used for error text and borders. USWDS [uses `error-dark`](https://github.com/uswds/uswds/blob/f761763c66399fe63800f22cc17c228b2c46b097/src/stylesheets/elements/form-controls/_global.scss#L56), while Login [uses `error`](https://github.com/18F/identity-style-guide/blob/65c305f/src/scss/components/_inputs.scss#L193-L194) (side-note: `.usa-input--error-message` is both invalid BEM syntax in how it's used, and appears redundant with `usa-error-message`). In this implementation, since I'm already using USWDS `usa-error-message`, I deferred toward `error-dark`.