### PR TITLE
Conditionally omit liveness step in document capture flow when disabled

### DIFF
--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import PropTypes from 'prop-types';
 import FormSteps from './form-steps';
 import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
 import SelfieStep, { isValid as isSelfieStepValid } from './selfie-step';
@@ -6,7 +7,7 @@ import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
 
-function DocumentCapture() {
+function DocumentCapture({ isLivenessEnabled }) {
   const [formValues, setFormValues] = useState(null);
   const { isMobile } = useContext(DeviceContext);
 
@@ -20,7 +21,7 @@ function DocumentCapture() {
       component: DocumentsStep,
       isValid: isDocumentsStepValid,
     },
-    {
+    isLivenessEnabled && {
       name: 'selfie',
       component: SelfieStep,
       isValid: isSelfieStepValid,
@@ -33,5 +34,13 @@ function DocumentCapture() {
     <FormSteps steps={steps} onComplete={setFormValues} />
   );
 }
+
+DocumentCapture.propTypes = {
+  isLivenessEnabled: PropTypes.bool,
+};
+
+DocumentCapture.defaultProps = {
+  isLivenessEnabled: true,
+};
 
 export default DocumentCapture;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -20,6 +20,7 @@ const device = {
 };
 
 const appRoot = document.getElementById('document-capture-form');
+const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
 render(
   <AcuantProvider
     credentials={getMetaContent('acuant-sdk-initialization-creds')}
@@ -28,7 +29,7 @@ render(
     <I18nContext.Provider value={i18n.strings[i18n.currentLocale()]}>
       <AssetContext.Provider value={assets}>
         <DeviceContext.Provider value={device}>
-          <DocumentCapture />
+          <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
         </DeviceContext.Provider>
       </AssetContext.Provider>
     </I18nContext.Provider>

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -10,7 +10,7 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"></div>
+  <div id="document-capture-form"<%= ' data-liveness' if liveness_checking_enabled? %>></div>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -10,7 +10,7 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"<%= ' data-liveness' if liveness_checking_enabled? %>></div>
+  <%= tag.div id: 'document-capture-form', data: { liveness: liveness_checking_enabled?.presence } %>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -10,7 +10,7 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"></div>
+  <div id="document-capture-form"<%= ' data-liveness' if liveness_checking_enabled? %>></div>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -10,7 +10,7 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form"<%= ' data-liveness' if liveness_checking_enabled? %>></div>
+  <%= tag.div id: 'document-capture-form', data: { liveness: liveness_checking_enabled?.presence } %>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/mobile_document_capture.html.erb
+++ b/app/views/idv/doc_auth/mobile_document_capture.html.erb
@@ -10,7 +10,8 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <div id="document-capture-form">
+  <div id="document-capture-form"></div>
+  <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 
     <h1 class="h3 my0">
@@ -101,7 +102,7 @@
     <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
 
     <%= javascript_pack_tag 'image-preview' %>
-  </div>
+  </noscript>
   <%= render 'idv/doc_auth/start_over_or_cancel' %>
   <% unless Figaro.env.document_capture_react_enabled == 'false' %>
     <%= javascript_pack_tag 'document-capture' %>


### PR DESCRIPTION
**Why**: Since liveness checking may be disabled (either by environment or service provider configuration), the step should only be present in the document capture flow if it's enabled.