### PR TITLE
Pass in root directory instead of specifying file paths in activate

### DIFF
--- a/spec/lib/deploy/activate_spec.rb
+++ b/spec/lib/deploy/activate_spec.rb
@@ -3,7 +3,7 @@ require 'login_gov/hostdata/fake_s3_client'
 require Rails.root.join('lib', 'deploy', 'activate.rb')
 
 describe Deploy::Activate do
-  let(:config_dir) { Rails.root.join('tmp') }
+  let(:config_dir) { Rails.root.join('tmp', 'config') }
 
   around(:each) do |ex|
     LoginGov::Hostdata.reset!
@@ -19,11 +19,10 @@ describe Deploy::Activate do
   let(:s3_client) { LoginGov::Hostdata::FakeS3Client.new }
   let(:set_up_files!) {}
 
-  let(:result_yaml_path) { config_dir.join('s3.yml') }
-  let(:env_yaml_path) { config_dir.join('env.yml') }
+  let(:result_yaml_path) { config_dir.join('application.yml') }
+  let(:env_yaml_path) { config_dir.join('application_s3_env.yml') }
   let(:subject) do
-    Deploy::Activate.new(logger: logger, s3_client: s3_client, result_yaml_path: result_yaml_path,
-                         env_yaml_path: env_yaml_path)
+    Deploy::Activate.new(logger: logger, s3_client: s3_client, root_path: 'tmp')
   end
 
   context 'in a deployed production environment' do


### PR DESCRIPTION
This spec currently modifies files in the config folder, and those files are used in development and other specs. This fixes that by allowing the root path to be specified.

The one exception is `example_application_yaml_path` which has to be from the actual project root, but it only ever is expected to be read, so that should be ok?