### PR TITLE
Hide document capture hint on capture devices

### DIFF
--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -39,7 +39,7 @@ function AcuantCapture({ label, hint, bannerText, value, onChange, className }) 
       )}
       <FileInput
         label={label}
-        hint={hint}
+        hint={hasCapture ? undefined : t('doc_auth.tips.document_capture_hint')}
         bannerText={bannerText}
         accept={['image/*']}
         value={value}

--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -9,7 +9,7 @@ import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import DataURLFile from '../models/data-url-file';
 
-function AcuantCapture({ label, hint, bannerText, value, onChange, className }) {
+function AcuantCapture({ label, bannerText, value, onChange, className }) {
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const [isCapturing, setIsCapturing] = useState(false);
   const { isMobile } = useContext(DeviceContext);
@@ -62,7 +62,6 @@ function AcuantCapture({ label, hint, bannerText, value, onChange, className }) 
 
 AcuantCapture.propTypes = {
   label: PropTypes.string.isRequired,
-  hint: PropTypes.string,
   bannerText: PropTypes.string,
   value: PropTypes.instanceOf(DataURLFile),
   onChange: PropTypes.func,
@@ -70,7 +69,6 @@ AcuantCapture.propTypes = {
 };
 
 AcuantCapture.defaultProps = {
-  hint: null,
   value: null,
   bannerText: null,
   onChange: () => {},

--- a/app/javascript/app/document-capture/components/documents-step.jsx
+++ b/app/javascript/app/document-capture/components/documents-step.jsx
@@ -38,7 +38,6 @@ function DocumentsStep({ value, onChange }) {
             /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
             /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
             label={t(`doc_auth.headings.document_capture_${side}`)}
-            hint={t('doc_auth.tips.document_capture_hint')}
             /* i18n-tasks-use t('doc_auth.headings.back') */
             /* i18n-tasks-use t('doc_auth.headings.front') */
             bannerText={t(`doc_auth.headings.${side}`)}

--- a/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
@@ -221,4 +221,37 @@ describe('document-capture/components/acuant-capture', () => {
 
     expect(container.firstChild.classList.contains('my-custom-class')).to.be.true();
   });
+
+  it('does not show hint if capture is supported', () => {
+    const { getByText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture label="Image" />
+      </AcuantContextProvider>,
+    );
+
+    window.AcuantJavascriptWebSdk = {
+      initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
+    };
+    window.AcuantCamera = { isCameraSupported: true };
+    window.onAcuantSdkLoaded();
+
+    expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
+  });
+
+  it('shows hint if capture is not supported', () => {
+    const { getByText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture label="Image" />
+      </AcuantContextProvider>,
+    );
+
+    window.AcuantJavascriptWebSdk = {
+      initialize: (_credentials, _endpoint, { onFail }) => onFail(),
+    };
+    window.onAcuantSdkLoaded();
+
+    const hint = getByText('doc_auth.tips.document_capture_hint');
+
+    expect(hint).to.be.ok();
+  });
 });


### PR DESCRIPTION
**Why**: It's assumed that if the user is going to perform direct capture of documents, it's not necessary for them to be informed of file upload restrictions.

**Screenshots:**

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/89800125-558ae080-dafc-11ea-933c-e9003a6f987e.png)|![after](https://user-images.githubusercontent.com/1779930/89800124-558ae080-dafc-11ea-9850-910425dda6c5.png)
