### PR TITLE
LG-3258 Acuant failure retries

### DIFF
--- a/app/services/acuant/request.rb
+++ b/app/services/acuant/request.rb
@@ -56,15 +56,29 @@ module Acuant
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def faraday_connection
+      retry_options = {
+        max: 2,
+        interval: 0.05,
+        interval_randomness: 0.5,
+        backoff_factor: 2,
+        retry_statuses: [404, 438, 439],
+        retry_block: lambda do |_env, _options, retries, exc|
+          NewRelic::Agent.notice_error(exc, { custom_params: { retry: retries } })
+        end,
+      }
+
       Faraday.new(request: faraday_request_params, url: url.to_s, headers: headers) do |conn|
         conn.adapter :net_http
         conn.basic_auth(
           Figaro.env.acuant_assure_id_username,
           Figaro.env.acuant_assure_id_password,
         )
+        conn.request :retry, retry_options
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def faraday_request_params
       timeout = Figaro.env.acuant_timeout&.to_i || 45

--- a/app/services/acuant/request.rb
+++ b/app/services/acuant/request.rb
@@ -65,7 +65,7 @@ module Acuant
         backoff_factor: 2,
         retry_statuses: [404, 438, 439],
         retry_block: lambda do |_env, _options, retries, exc|
-          NewRelic::Agent.notice_error(exc, { custom_params: { retry: retries } })
+          NewRelic::Agent.notice_error(exc, custom_params: { retry: retries })
         end,
       }
 

--- a/spec/services/acuant/request_spec.rb
+++ b/spec/services/acuant/request_spec.rb
@@ -76,6 +76,7 @@ describe Acuant::Request do
       end
     end
 
+    # rubocop:disable Style/BracesAroundHashParameters
     context 'when the request resolves with retriable error then succeeds it only retries once' do
       it 'calls New Relic notice_error each retry' do
         allow(subject).to receive(:handle_http_response) do |http_response|
@@ -98,7 +99,6 @@ describe Acuant::Request do
       end
     end
 
-    # rubocop:disable Style/BracesAroundHashParameters
     context 'when the request resolves with a 404 status it retries' do
       it 'calls New Relic notice_error each retry' do
         allow(subject).to receive(:handle_http_response) do |http_response|

--- a/spec/services/acuant/request_spec.rb
+++ b/spec/services/acuant/request_spec.rb
@@ -86,11 +86,11 @@ describe Acuant::Request do
           with(headers: request_headers).
           to_return(
             { body: 'test response body', status: 404 },
-            body: 'test response body', status: 200,
+            { body: 'test response body', status: 200 },
           )
 
         expect(NewRelic::Agent).to receive(:notice_error).
-            with(anything, hash_including(:custom_params)).once
+          with(anything, hash_including(:custom_params)).once
 
         response = subject.fetch
 
@@ -113,7 +113,7 @@ describe Acuant::Request do
           )
 
         expect(NewRelic::Agent).to receive(:notice_error).
-            with(anything, hash_including(:custom_params)).twice
+          with(anything, hash_including(:custom_params)).twice
 
         response = subject.fetch
 
@@ -157,7 +157,7 @@ describe Acuant::Request do
           )
 
         expect(NewRelic::Agent).to receive(:notice_error).
-            with(anything, hash_including(:custom_params)).twice
+          with(anything, hash_including(:custom_params)).twice
 
         response = subject.fetch
 

--- a/spec/services/acuant/request_spec.rb
+++ b/spec/services/acuant/request_spec.rb
@@ -83,11 +83,11 @@ describe Acuant::Request do
         end
 
         stub_request(:get, full_url).
-            with(headers: request_headers).
-            to_return(
-              { body: 'test response body', status: 404 },
-              { body: 'test response body', status: 200 },
-            )
+          with(headers: request_headers).
+          to_return(
+            { body: 'test response body', status: 404 },
+            body: 'test response body', status: 200,
+          )
 
         expect(NewRelic::Agent).to receive(:notice_error).
             with(anything, hash_including(:custom_params)).once
@@ -98,6 +98,7 @@ describe Acuant::Request do
       end
     end
 
+    # rubocop:disable Style/BracesAroundHashParameters
     context 'when the request resolves with a 404 status it retries' do
       it 'calls New Relic notice_error each retry' do
         allow(subject).to receive(:handle_http_response) do |http_response|
@@ -105,11 +106,11 @@ describe Acuant::Request do
         end
 
         stub_request(:get, full_url).
-            with(headers: request_headers).
-            to_return(
-              { body: 'test response body', status: 404 },
-              { body: 'test response body', status: 404 },
-            )
+          with(headers: request_headers).
+          to_return(
+            { body: 'test response body', status: 404 },
+            { body: 'test response body', status: 404 },
+          )
 
         expect(NewRelic::Agent).to receive(:notice_error).
             with(anything, hash_including(:custom_params)).twice
@@ -127,11 +128,11 @@ describe Acuant::Request do
         end
 
         stub_request(:get, full_url).
-            with(headers: request_headers).
-            to_return(
-              { body: 'test response body', status: 438 },
-              { body: 'test response body', status: 438 },
-            )
+          with(headers: request_headers).
+          to_return(
+            { body: 'test response body', status: 438 },
+            { body: 'test response body', status: 438 },
+          )
 
         expect(NewRelic::Agent).to receive(:notice_error).
           with(anything, hash_including(:custom_params)).twice
@@ -149,11 +150,11 @@ describe Acuant::Request do
         end
 
         stub_request(:get, full_url).
-            with(headers: request_headers).
-            to_return(
-              { body: 'test response body', status: 439 },
-              { body: 'test response body', status: 439 },
-            )
+          with(headers: request_headers).
+          to_return(
+            { body: 'test response body', status: 439 },
+            { body: 'test response body', status: 439 },
+          )
 
         expect(NewRelic::Agent).to receive(:notice_error).
             with(anything, hash_including(:custom_params)).twice
@@ -163,6 +164,7 @@ describe Acuant::Request do
         expect(response.success?).to eq(false)
       end
     end
+    # rubocop:enable Style/BracesAroundHashParameters
 
     context 'when the request times out' do
       it 'returns a response with a timeout message and exception and notifies NewRelic' do


### PR DESCRIPTION
Added retry in the case of Acuant API failures 404, 438, and 439 with some tests 