### PR TITLE
Add Acuant glare error message

### DIFF
--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -24,6 +24,7 @@
 - doc_auth.tips.document_capture_selfie_text1
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
+- errors.doc_auth.photo_glare
 - errors.doc_auth.selfie
 - errors.messages.format_mismatch
 - errors.messages.missing_field

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -61,6 +61,7 @@ en:
         </ul>
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
+      photo_glare: Photo has too much glare. Please try again.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.
       selfie: Sorry, your photo was not accepted. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -61,6 +61,7 @@ es:
         </ul>
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
+      photo_glare: La foto tiene demasiado brillo. Inténtalo de nuevo.
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite
         de verificación de identidad. Póngase en contacto con su proveedor de servicios
         para obtener más información.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -61,6 +61,7 @@ fr:
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.
+      photo_glare: La photo est trop éblouissante. Veuillez réessayer.
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d'identité. Veuillez contacter votre fournisseur de services
         pour plus d'informations.

--- a/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
@@ -149,6 +149,7 @@ describe('document-capture/components/acuant-capture', () => {
       window.AcuantCameraUI = {
         start(onImageCaptureSuccess) {
           const capture = {
+            glare: 70,
             image: {
               data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
             },
@@ -248,6 +249,41 @@ describe('document-capture/components/acuant-capture', () => {
       expect(button).to.be.ok();
 
       userEvent.click(button);
+    });
+
+    it('renders error message if capture succeeds but photo glare exceeds threshold', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      window.AcuantJavascriptWebSdk = {
+        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
+      };
+      window.AcuantCamera = { isCameraSupported: true };
+      window.onAcuantSdkLoaded();
+      window.AcuantCameraUI = {
+        start(onImageCaptureSuccess) {
+          const capture = {
+            glare: 38,
+            image: {
+              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+            },
+          };
+          onImageCaptureSuccess(capture);
+        },
+        end: sinon.spy(),
+      };
+
+      const button = getByText('doc_auth.buttons.take_picture');
+      fireEvent.click(button);
+
+      const error = getByText('errors.doc_auth.photo_glare');
+
+      expect(error).to.be.ok();
     });
   });
 


### PR DESCRIPTION
**Why**: To improve the likelihood for successful proofing, the user should be informed as early as possible of potential issues with their selected image. Acuant recommends a glare score of 50 or greater to be considered an image with an acceptable level of glare.

**Screenshot:**

![Screen Shot 2020-08-10 at 1 48 46 PM](https://user-images.githubusercontent.com/1779930/89814426-1c10a000-db11-11ea-8585-c0da208f6b7f.png)
