### PR TITLE
Fix error in mobile React Acuant document capture

### DIFF
--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -54,7 +54,7 @@ function AcuantCapture({ label, bannerText, value, onChange, className }) {
         <FullScreen onRequestClose={() => setIsCapturing(false)}>
           <AcuantCaptureCanvas
             onImageCaptureSuccess={(nextCapture) => {
-              onChange(nextCapture.image.data);
+              onChange(new DataURLFile(nextCapture.image.data));
               setIsCapturing(false);
             }}
             onImageCaptureFailure={() => setIsCapturing(false)}

--- a/app/javascript/app/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture.jsx
@@ -1,5 +1,4 @@
 import React, { useContext, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import AcuantContext from '../context/acuant';
 import AcuantCaptureCanvas from './acuant-capture-canvas';
 import FileInput from './file-input';
@@ -9,7 +8,23 @@ import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import DataURLFile from '../models/data-url-file';
 
-function AcuantCapture({ label, bannerText, value, onChange, className }) {
+/**
+ * @typedef AcuantCaptureProps
+ *
+ * @prop {string}                        label      Label associated with file input.
+ * @prop {string=}                       bannerText Optional banner text to show in file input.
+ * @prop {DataURLFile=}                  value      Current value.
+ * @prop {(nextValue:DataURLFile)=>void} onChange   Callback receiving next value on change.
+ * @prop {string=}                       className  Optional additional class names.
+ */
+
+/**
+ * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK
+ * in supported devices.
+ *
+ * @param {AcuantCaptureProps} props Props object.
+ */
+function AcuantCapture({ label, bannerText, value, onChange = () => {}, className }) {
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const inputRef = useRef(/** @type {?HTMLElement} */ (null));
   const isForceUploading = useRef(false);
@@ -100,20 +115,5 @@ function AcuantCapture({ label, bannerText, value, onChange, className }) {
     </div>
   );
 }
-
-AcuantCapture.propTypes = {
-  label: PropTypes.string.isRequired,
-  bannerText: PropTypes.string,
-  value: PropTypes.instanceOf(DataURLFile),
-  onChange: PropTypes.func,
-  className: PropTypes.string,
-};
-
-AcuantCapture.defaultProps = {
-  value: null,
-  bannerText: null,
-  onChange: () => {},
-  className: null,
-};
 
 export default AcuantCapture;

--- a/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/acuant-capture-spec.jsx
@@ -161,9 +161,11 @@ describe('document-capture/components/acuant-capture', () => {
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
-      expect(onChange.getCall(0).args).to.deep.equal([
+      expect(onChange.getCall(0).args).to.have.lengthOf(1);
+      expect(onChange.getCall(0).args[0]).to.be.instanceOf(DataURLFile);
+      expect(onChange.getCall(0).args[0].data).to.equal(
         'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-      ]);
+      );
       expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
     });
 


### PR DESCRIPTION
**Why**: The expected shape of value is instance of DataURLFile. This was never updated for the occurrence of AcuantCaptureCanvas, which receives a data URL as next capture image data.

(Note: This only affects the non-public development version of the React-based Acuant document capture flow)

Included in these changes, I'd like to propose to move away from [Airbnb's recommendation to use `propTypes`](https://github.com/airbnb/javascript/tree/master/react#ordering) for prop validation, in favor of [TypeScript-based JSDoc function annotations](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).

**Benefits:**

1. Can be used to provide type checking to surface these sorts of errors
  - ![Screen Shot 2020-08-11 at 9 42 27 AM](https://user-images.githubusercontent.com/1779930/89904959-8d0a9300-dbb7-11ea-8642-088efc3143b4.png)
2. Can be used to provide type checking and props detailed information from rendering parent components
  - ![Screen Shot 2020-08-11 at 9 41 11 AM](https://user-images.githubusercontent.com/1779930/89905038-a4e21700-dbb7-11ea-9ad4-26870cc6d57b.png)
3. Takes advantage of existing mechanisms for documenting functions using JSDoc
4. Affords opportunity to describe the purpose of the prop type in the detail of the custom `@typedef`
5. Provides ~an excuse~ timely and relevant space to describe the purpose of the component 
6. Allows prop validation errors to be checked at _build time_, rather than at _run time_ (if enabled in build step, see "Downsides")
7. Ships less code, since `propTypes` are only relevant for development, but are still shipped to production ([unless steps are taken to strip them from production builds](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types))
8. Removes a dependency (`prop-types`)
9. Allows prop defaults to be assigned using [language-native defaulting syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Default_values_2)

**Downsides:**

1. Until the point at which type-checking is enabled at the project level, the validation is not enforced, so validation errors are only surfaced in the environment of a developer who has explicitly opted in to type-checking (for example, adding `// @ts-check` to the top of a file).