### PR TITLE
LG-3282 Fix IAL2 counts for SAML for all reports that include counts

### DIFF
--- a/app/services/db/doc_auth_log/blanket_drop_off_rates_per_sp_all_time.rb
+++ b/app/services/db/doc_auth_log/blanket_drop_off_rates_per_sp_all_time.rb
@@ -12,7 +12,8 @@ module Db
       def verified_user_counts_query
         <<~SQL
           select count(*) from identities
-          where ial>=2 and service_provider = '#{@issuer}'
+          where ial>=2 and service_provider = '#{@issuer}' and
+          user_id in (select user_id from profiles)
         SQL
       end
 

--- a/app/services/db/doc_auth_log/blanket_drop_off_rates_per_sp_in_range.rb
+++ b/app/services/db/doc_auth_log/blanket_drop_off_rates_per_sp_in_range.rb
@@ -13,6 +13,7 @@ module Db
         <<~SQL
           select count(*) from identities
           where ial>=2 and service_provider = '#{@issuer}' and #{start} <= created_at and created_at < #{finish}
+          and user_id in (select user_id from profiles)
         SQL
       end
 

--- a/app/services/db/doc_auth_log/drop_off_rates_helper.rb
+++ b/app/services/db/doc_auth_log/drop_off_rates_helper.rb
@@ -80,7 +80,8 @@ module Db
 
       def verified_profiles_count_for_issuer
         query = <<~SQL
-          select count(*) from identities where service_provider = '#{issuer}'
+          select count(*) from identities where service_provider = '#{issuer}' and
+          user_id in (select user_id from profiles)
         SQL
         ActiveRecord::Base.connection.execute(query)
       end

--- a/app/services/db/doc_auth_log/overall_drop_off_rates_per_sp_all_time.rb
+++ b/app/services/db/doc_auth_log/overall_drop_off_rates_per_sp_all_time.rb
@@ -14,6 +14,7 @@ module Db
           select count(*) from identities
           where service_provider='#{issuer}' and ial>=2
           and user_id in (select user_id from doc_auth_logs where #{at_least_one_image_submitted})
+          and user_id in (select user_id from profiles)
         SQL
       end
 

--- a/app/services/db/doc_auth_log/overall_drop_off_rates_per_sp_in_range.rb
+++ b/app/services/db/doc_auth_log/overall_drop_off_rates_per_sp_in_range.rb
@@ -14,6 +14,7 @@ module Db
           select count(*) from identities
           where service_provider='#{issuer}' and ial>=2
           and user_id in (select user_id from doc_auth_logs where #{start} <= welcome_view_at and welcome_view_at < #{finish} and #{at_least_one_image_submitted})
+          and user_id in (select user_id from profiles)
         SQL
       end
 


### PR DESCRIPTION
**Why**: SAML is prepopulating identity records.
**How**: In addition to counting identity records make sure those user ids are in profiles.