### PR TITLE
LG-3101 Create JSON feed for billing report by IAA

### DIFF
--- a/app/services/db/identity/iaa_active_user_count.rb
+++ b/app/services/db/identity/iaa_active_user_count.rb
@@ -1,0 +1,73 @@
+module Db
+  module Identity
+    class IaaActiveUserCount
+      def initialize(iaa, iaa_start_date, iaa_end_date)
+        @iaa = iaa
+        @iaa_start_date = iaa_start_date
+        @iaa_end_date = iaa_end_date
+      end
+
+      def call(ial, today)
+        issuers = issuers_sql(iaa)
+        return unless issuers
+        and_month_in_iaa_start_month_to_last_month = prior_months_sql(today)
+        sql = format(<<~SQL, sql_params(today))
+          SELECT COUNT(*) FROM identities
+          WHERE service_provider in #{issuers}
+          AND last_ial#{ial}_authenticated_at >= %{beginning_of_month} and
+          user_id NOT IN (
+            SELECT DISTINCT user_id FROM monthly_sp_auth_counts
+            WHERE issuer IN #{issuers} and ial=#{ial}
+            #{and_month_in_iaa_start_month_to_last_month}
+          )
+        SQL
+        ActiveRecord::Base.connection.execute(sql)[0]
+      end
+
+      private
+
+      attr_reader :iaa, :iaa_start_date, :iaa_end_date
+
+      def sql_params(today)
+        {
+          beginning_of_month: ActiveRecord::Base.connection.quote(today.beginning_of_month),
+        }
+      end
+
+      def issuers_sql(iaa)
+        sps = ServiceProvider.where(iaa: iaa)
+        return if sps.blank?
+        "(#{sps.map { |sp| "'#{sp.issuer}'" }.join(',')})"
+      end
+
+      def prior_months_sql(today)
+        last_month = today.month - 1
+        last_month = 12 if last_month < 1
+        iaa_start_month = iaa_start_date.month
+        return '' if last_month == iaa_start_month
+        months_sql(last_month, iaa_start_month, today)
+      end
+
+      def months_sql(last_month, iaa_start_month, today)
+        if iaa_start_month < last_month
+          list_to_sql(year_month_list(iaa_start_month, last_month, today.year))
+        else
+          list = year_month_list(iaa_start_month, 12, today.year - 1) +
+                 year_month_list(1,
+                                 last_month < iaa_end_date.month ? last_month : iaa_end_date.month,
+                                 today.year)
+          list_to_sql(list)
+        end
+      end
+
+      def list_to_sql(list)
+        list = list.map { |val| "'#{val}'" }
+        "and year_month in (#{list.join(',')})"
+      end
+
+      def year_month_list(start_month, finish_month, year)
+        (start_month..finish_month).to_a.map { |val| format('%04d%02d', year, val) }
+      end
+    end
+  end
+end

--- a/app/services/db/monthly_sp_auth_count/sp_month_total_auth_counts.rb
+++ b/app/services/db/monthly_sp_auth_count/sp_month_total_auth_counts.rb
@@ -1,0 +1,15 @@
+module Db
+  module MonthlySpAuthCount
+    class SpMonthTotalAuthCounts
+      def self.call(today, issuer, ial)
+        sql = <<~SQL
+          SELECT SUM(auth_count) AS total
+          FROM monthly_sp_auth_counts
+          WHERE issuer = '#{issuer}' AND ial=#{ial} AND year_month='#{today.strftime('%Y%m')}'
+        SQL
+        results = ActiveRecord::Base.connection.execute(sql)
+        results.count.positive? ? results[0]['total'] || 0 : 0
+      end
+    end
+  end
+end

--- a/app/services/reports/iaa_billing_report.rb
+++ b/app/services/reports/iaa_billing_report.rb
@@ -58,7 +58,7 @@ module Reports
       ServiceProvider.where.not(iaa: nil).each do |sp|
         iaa = sp.iaa
         (sps_for_iaa[iaa] ||= []) << sp
-        next if sp.ial == 1 || iaa_done[iaa]
+        next if iaa_done[iaa]
         sps << sp
         iaa_done[iaa] = true
       end

--- a/app/services/reports/iaa_billing_report.rb
+++ b/app/services/reports/iaa_billing_report.rb
@@ -4,22 +4,48 @@ module Reports
   class IaaBillingReport < BaseReport
     REPORT_NAME = 'iaa-billing-report'.freeze
 
+    def initialize
+      @sps_for_iaa = {}
+      @today = Time.zone.today
+    end
+
     def call
       results = []
       transaction_with_timeout do
-        unique_iaa_sps.each { |sp| results << iaa_results(sp) }
+        unique_iaa_sps.each do |sp|
+          iaa_results = active_ial2_counts_for_iaa(sp)
+          auth_counts = auth_counts_for_iaa(sp.iaa)
+          iaa_results['auth_counts'] = auth_counts
+          results << iaa_results
+        end
       end
       save_report(REPORT_NAME, results.to_json)
     end
 
     private
 
-    def iaa_results(sp)
+    attr_accessor :today, :sps_for_iaa
+
+    def auth_counts_for_iaa(iaa)
+      results = []
+      sps_for_iaa[iaa].each do |sp|
+        results << sp_month_auth_counts(sp, 1)
+        results << sp_month_auth_counts(sp, 2)
+      end
+      results
+    end
+
+    def sp_month_auth_counts(sp, ial)
+      count = Db::MonthlySpAuthCount::SpMonthTotalAuthCounts.call(today, sp.issuer, ial)
+      { issuer: sp.issuer, ial: ial, count: count }.stringify_keys
+    end
+
+    def active_ial2_counts_for_iaa(sp)
       count = Db::Identity::IaaActiveUserCount.new(
         sp.iaa,
         sp.iaa_start_date,
         sp.iaa_end_date,
-      ).call(2, Time.zone.today)
+      ).call(2, today)
       { iaa: sp.iaa,
         iaa_start_date: sp.iaa_start_date.strftime('%Y-%m-%d'),
         iaa_end_date: sp.iaa_end_date.strftime('%Y-%m-%d'),
@@ -29,9 +55,9 @@ module Reports
     def unique_iaa_sps
       iaa_done = {}
       sps = []
-      ServiceProvider.where.not(iaa: nil).select('iaa', 'iaa_start_date', 'iaa_end_date', 'ial').
-        each do |sp|
+      ServiceProvider.where.not(iaa: nil).each do |sp|
         iaa = sp.iaa
+        (sps_for_iaa[iaa] ||= []) << sp
         next if sp.ial == 1 || iaa_done[iaa]
         sps << sp
         iaa_done[iaa] = true

--- a/app/services/reports/iaa_billing_report.rb
+++ b/app/services/reports/iaa_billing_report.rb
@@ -1,0 +1,37 @@
+require 'login_gov/hostdata'
+
+module Reports
+  class IaaBillingReport < BaseReport
+    REPORT_NAME = 'iaa-billing-report'.freeze
+
+    def call
+      ret = []
+      results = transaction_with_timeout do
+        unique_iaa_sps.each do |sp|
+          count = Db::Identity::IaaActiveUserCount.new(
+            sp.iaa,
+            sp.iaa_start_date,
+            sp.iaa_end_date,
+          ).call(2, Time.zone.today)
+          ret << { service_provider: sp.to_json, ial2_count: count }
+        end
+      end
+      save_report(REPORT_NAME, results.to_json)
+    end
+
+    private
+
+    def unique_iaa_sps
+      iaa_done = {}
+      sps = []
+      ServiceProvider.where.not(iaa: nil).select('iaa', 'iaa_start_date', 'iaa_end_date', 'ial').
+        each do |sp|
+        iaa = sp.iaa
+        next if sp.ial == 1 || iaa_done[iaa]
+        sps << sp
+        iaa_done[iaa] = true
+      end
+      sps
+    end
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -145,3 +145,11 @@ JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
   timeout: 300,
   callback: -> { Reports::DocAuthDropOffRatesReport.new.call },
 )
+
+# IAA Billing Report
+JobRunner::Runner.add_config JobRunner::JobConfiguration.new(
+  name: 'IAA billing report',
+  interval: 24 * 60 * 60, # 24 hours
+  timeout: 300,
+  callback: -> { Reports::IaaBillingReport.new.call },
+)

--- a/spec/config/initializers/job_configurations.rb
+++ b/spec/config/initializers/job_configurations.rb
@@ -219,5 +219,17 @@ describe JobRunner::Runner do
 
       expect(job.callback.call).to eq 'the report test worked'
     end
+
+    it 'runs the iaa billing report job' do
+      job = JobRunner::Runner.configurations.find { |c| c.name == 'IAA Billing report' }
+      expect(job).to be_instance_of(JobRunner::JobConfiguration)
+      expect(job.interval).to eq 24 * 60 * 60
+
+      service = instance_double(Reports::IaaBillingReport)
+      expect(Reports::IaaBillingReport).to receive(:new).and_return(service)
+      expect(service).to receive(:call).and_return('the report test worked')
+
+      expect(job.callback.call).to eq 'the report test worked'
+    end
   end
 end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -3,30 +3,65 @@ require 'rails_helper'
 describe Reports::IaaBillingReport do
   subject { described_class.new }
 
-  let(:results) do
+  let(:issuer) { 'foo' }
+  let(:issuer2) { 'foo2' }
+  let(:issuer3) { 'foo3' }
+  let(:iaa) { 'iaa' }
+  let(:results_for_1_iaa) do
     [
       {
-        'iaa': 'ABC123-2020',
-        'iaa_start_date': '2020-01-01',
-        'iaa_end_date': '2020-12-31',
+        'iaa': 'iaa',
+        'iaa_start_date': '2019-12-15',
+        'iaa_end_date': '2020-07-15',
         'ial2_active_count': 0,
-        'auth_counts': [
-          {
-            'issuer': 'http://test.host',
-            'ial': 1,
-            'count': 0,
-          },
-          {
-            'issuer': 'http://test.host',
-            'ial': 2,
-            'count': 0,
-          },
-        ],
+        'auth_counts':
+          [
+            {
+              'issuer': 'foo',
+              'ial': 1,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo',
+              'ial': 2,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo2',
+              'ial': 1,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo2',
+              'ial': 2,
+              'count': 0,
+            },
+          ],
       },
     ]
   end
+  let(:now) { Time.zone.parse('2020-06-15') }
 
-  it 'works' do
-    expect(subject.call).to eq(results.to_json)
+  before do
+    ServiceProvider.delete_all
+  end
+
+  it 'works with no SPs' do
+    expect(subject.call).to eq([].to_json)
+  end
+
+  it 'ignores sps without an IAA' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer, ial: 1)
+
+    expect(subject.call).to eq([].to_json)
+  end
+
+  it 'rolls up 2 issuers in a single IAA' do
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer, ial: 1, iaa: iaa,
+                           iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial: 2, iaa: iaa,
+                           iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
+
+    expect(subject.call).to eq(results_for_1_iaa.to_json)
   end
 end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -7,6 +7,7 @@ describe Reports::IaaBillingReport do
   let(:issuer2) { 'foo2' }
   let(:issuer3) { 'foo3' }
   let(:iaa) { 'iaa' }
+  let(:iaa2) { 'iaa2' }
   let(:results_for_1_iaa) do
     [
       {
@@ -40,6 +41,58 @@ describe Reports::IaaBillingReport do
       },
     ]
   end
+  let(:results_for_2_iaas) do
+    [
+      {
+        'iaa': 'iaa',
+        'iaa_start_date': '2019-12-15',
+        'iaa_end_date': '2020-07-15',
+        'ial2_active_count': 0,
+        'auth_counts':
+          [
+            {
+              'issuer': 'foo',
+              'ial': 1,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo',
+              'ial': 2,
+              'count': 0,
+            },
+          ],
+      },
+      {
+        'iaa': 'iaa2',
+        'iaa_start_date': '2019-12-15',
+        'iaa_end_date': '2020-07-15',
+        'ial2_active_count': 0,
+        'auth_counts':
+          [
+            {
+              'issuer': 'foo2',
+              'ial': 1,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo2',
+              'ial': 2,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo3',
+              'ial': 1,
+              'count': 0,
+            },
+            {
+              'issuer': 'foo3',
+              'ial': 2,
+              'count': 0,
+            },
+          ],
+      },
+    ]
+  end
   let(:now) { Time.zone.parse('2020-06-15') }
 
   before do
@@ -63,5 +116,32 @@ describe Reports::IaaBillingReport do
                            iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
 
     expect(subject.call).to eq(results_for_1_iaa.to_json)
+  end
+
+  it 'works with multiple IAAs and issuers' do
+    last_month = now.last_month
+    today_year_month = now.strftime('%Y%m')
+
+    ServiceProvider.create(issuer: issuer, friendly_name: issuer, ial: 1, iaa: iaa,
+                           iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
+    ServiceProvider.create(issuer: issuer2, friendly_name: issuer2, ial: 2, iaa: iaa2,
+                           iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
+    ServiceProvider.create(issuer: issuer3, friendly_name: issuer3, ial: 2, iaa: iaa2,
+                           iaa_start_date: now - 6.months, iaa_end_date: now + 1.month)
+    Identity.create(user_id: 1, service_provider: issuer, uuid: 'a',
+                    last_ial2_authenticated_at: now - 1.hour)
+    Identity.create(user_id: 2, service_provider: issuer2, uuid: 'b',
+                    last_ial2_authenticated_at: last_month)
+    Identity.create(user_id: 3, service_provider: issuer3, uuid: 'c',
+                    last_ial2_authenticated_at: now - 1.hour)
+    create(:profile, :active, :verified, user_id: 1)
+    create(:profile, :active, :verified, user_id: 2)
+    create(:profile, :active, :verified, user_id: 3)
+    MonthlySpAuthCount.create(issuer: issuer, ial: 1, year_month: today_year_month, user_id: 2,
+                              auth_count: 7)
+    MonthlySpAuthCount.create(issuer: issuer2, ial: 2, year_month: today_year_month, user_id: 3,
+                              auth_count: 3)
+
+    expect(subject.call).to eq(results_for_2_iaas.to_json)
   end
 end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -14,7 +14,7 @@ describe Reports::IaaBillingReport do
     ]
   end
 
-  it 'is empty' do
+  it 'works' do
     expect(subject.call).to eq(results.to_json)
   end
 end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -3,7 +3,18 @@ require 'rails_helper'
 describe Reports::IaaBillingReport do
   subject { described_class.new }
 
+  let(:results) do
+    [
+      {
+        'iaa': 'ABC123-2020',
+        'iaa_start_date': '2020-01-01',
+        'iaa_end_date': '2020-12-31',
+        'ial2_active_count': 0,
+      },
+    ]
+  end
+
   it 'is empty' do
-    expect(subject.call).to be_present
+    expect(subject.call).to eq(results.to_json)
   end
 end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Reports::IaaBillingReport do
+  subject { described_class.new }
+
+  it 'is empty' do
+    expect(subject.call).to be_present
+  end
+end

--- a/spec/services/reports/iaa_billing_report_spec.rb
+++ b/spec/services/reports/iaa_billing_report_spec.rb
@@ -10,6 +10,18 @@ describe Reports::IaaBillingReport do
         'iaa_start_date': '2020-01-01',
         'iaa_end_date': '2020-12-31',
         'ial2_active_count': 0,
+        'auth_counts': [
+          {
+            'issuer': 'http://test.host',
+            'ial': 1,
+            'count': 0,
+          },
+          {
+            'issuer': 'http://test.host',
+            'ial': 2,
+            'count': 0,
+          },
+        ],
       },
     ]
   end


### PR DESCRIPTION
**How**: Generate incremental IAL2 active user counts by IAA (rolling up applications). Incremental means a user can only be active for one month in the entire span of the IAA. Get active users in the current month in identities and subtract out those active in prior months from monthly_sp_auth_counts.