### PR TITLE
Add TypeScript tooling for JavaScript type-checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,7 @@ jobs:
           name: Run Lints
           command: |
             yarn run lint
+            yarn run typecheck
             bundle exec slim-lint app/views
   build-latest-container:
     working_directory: ~/identity-idp

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,8 +30,8 @@
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "operator-linebreak": "off",
-    "react/prop-types": ["error", { "skipUndeclared": true }],
-    "react/jsx-one-expression-per-line": "off"
+    "react/jsx-one-expression-per-line": "off",
+    "react/prop-types": "off"
   },
   "parserOptions": {
     "ecmaVersion": 6,
@@ -50,13 +50,5 @@
       "app/phone-internationalization",
       "app/i18n-dropdown"
     ]
-  },
-  "overrides": [
-    {
-      "files": ["spec/javascripts/**/*"],
-      "rules": {
-        "react/prop-types": "off"
-      }
-    }
-  ]
+  }
 }

--- a/app/javascript/app/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/app/document-capture/components/acuant-capture-canvas.jsx
@@ -1,5 +1,21 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
+
+/**
+ * @typedef AcuantCameraUI
+ *
+ * @prop {(AcuantSuccessCallback,AcuantFailureCallback)=>void} start Start capture.
+ * @prop {()=>void}                                            end   End capture.
+ */
+
+/**
+ * @typedef AcuantGlobals
+ *
+ * @prop {AcuantCameraUI} AcuantCameraUI Acuant camera UI API.
+ */
+
+/**
+ * @typedef {typeof window & AcuantGlobals} AcuantGlobal
+ */
 
 /**
  * @typedef AcuantImage
@@ -22,21 +38,35 @@ import PropTypes from 'prop-types';
  */
 
 /**
+ * @typedef {(response:AcuantSuccessResponse)=>void} AcuantSuccessCallback
+ */
+
+/**
+ * @typedef {(error:Error)=>void} AcuantFailureCallback
+ */
+
+/**
  * @typedef AcuantCaptureCanvasProps
  *
- * @prop {(response:AcuantSuccessResponse)=>void} onImageCaptureSuccess Success callback.
- * @prop {(error:Error)=>void}                    onImageCaptureFailure Failure callback.
+ * @prop {AcuantSuccessCallback} onImageCaptureSuccess Success callback.
+ * @prop {AcuantFailureCallback} onImageCaptureFailure Failure callback.
  */
 
 /**
  * @param {AcuantCaptureCanvasProps} props Component props.
  */
-function AcuantCaptureCanvas({ onImageCaptureSuccess, onImageCaptureFailure }) {
+function AcuantCaptureCanvas({
+  onImageCaptureSuccess = () => {},
+  onImageCaptureFailure = () => {},
+}) {
   useEffect(() => {
-    window.AcuantCameraUI.start(onImageCaptureSuccess, onImageCaptureFailure);
+    /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
+      onImageCaptureSuccess,
+      onImageCaptureFailure,
+    );
 
     return () => {
-      window.AcuantCameraUI.end();
+      /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
     };
   }, []);
 
@@ -53,15 +83,5 @@ function AcuantCaptureCanvas({ onImageCaptureSuccess, onImageCaptureFailure }) {
     </>
   );
 }
-
-AcuantCaptureCanvas.propTypes = {
-  onImageCaptureSuccess: PropTypes.func,
-  onImageCaptureFailure: PropTypes.func,
-};
-
-AcuantCaptureCanvas.defaultProps = {
-  onImageCaptureSuccess: () => {},
-  onImageCaptureFailure: () => {},
-};
 
 export default AcuantCaptureCanvas;

--- a/app/javascript/app/document-capture/components/button.jsx
+++ b/app/javascript/app/document-capture/components/button.jsx
@@ -1,8 +1,28 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
+/** @typedef {import('react').MouseEvent} ReactMouseEvent */
+/** @typedef {import('react').ReactNode} ReactNode */
+/** @typedef {"button"|"reset"|"submit"} ButtonType */
+
+/**
+ * @typedef ButtonProps
+ *
+ * @prop {ButtonType=}              type        Button type, defaulting to "button".
+ * @prop {(ReactMouseEvent)=>void=} onClick     Click handler.
+ * @prop {ReactNode=}               children    Element children.
+ * @prop {boolean=}                 isPrimary   Whether button should be styled as primary button.
+ * @prop {boolean=}                 isSecondary Whether button should be styled as secondary button.
+ * @prop {boolean=}                 isDisabled  Whether button is disabled.
+ * @prop {boolean=}                 isUnstyled  Whether button should be unstyled, visually as a
+ *                                              link.
+ * @prop {string=}                  className   Optional additional class names.
+ */
+
+/**
+ * @param {ButtonProps} props Props object.
+ */
 function Button({
-  type,
+  type = 'button',
   onClick,
   children,
   isPrimary,
@@ -29,27 +49,5 @@ function Button({
     </button>
   );
 }
-
-Button.propTypes = {
-  type: PropTypes.string,
-  onClick: PropTypes.func,
-  children: PropTypes.node,
-  isPrimary: PropTypes.bool,
-  isSecondary: PropTypes.bool,
-  isDisabled: PropTypes.bool,
-  isUnstyled: PropTypes.bool,
-  className: PropTypes.string,
-};
-
-Button.defaultProps = {
-  type: 'button',
-  onClick: undefined,
-  children: null,
-  isPrimary: false,
-  isSecondary: false,
-  isDisabled: false,
-  isUnstyled: false,
-  className: undefined,
-};
 
 export default Button;

--- a/app/javascript/app/document-capture/components/document-capture.jsx
+++ b/app/javascript/app/document-capture/components/document-capture.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext } from 'react';
-import PropTypes from 'prop-types';
 import FormSteps from './form-steps';
 import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
 import SelfieStep, { isValid as isSelfieStepValid } from './selfie-step';
@@ -7,7 +6,17 @@ import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
 
-function DocumentCapture({ isLivenessEnabled }) {
+/**
+ * @typedef DocumentCaptureProps
+ *
+ * @prop {boolean=} isLivenessEnabled Whether liveness capture should be expected from the user.
+ *                                    Defaults to false.
+ */
+
+/**
+ * @param {DocumentCaptureProps} props Props object.
+ */
+function DocumentCapture({ isLivenessEnabled = true }) {
   const [formValues, setFormValues] = useState(null);
   const { isMobile } = useContext(DeviceContext);
 
@@ -34,13 +43,5 @@ function DocumentCapture({ isLivenessEnabled }) {
     <FormSteps steps={steps} onComplete={setFormValues} />
   );
 }
-
-DocumentCapture.propTypes = {
-  isLivenessEnabled: PropTypes.bool,
-};
-
-DocumentCapture.defaultProps = {
-  isLivenessEnabled: true,
-};
 
 export default DocumentCapture;

--- a/app/javascript/app/document-capture/components/documents-step.jsx
+++ b/app/javascript/app/document-capture/components/documents-step.jsx
@@ -1,10 +1,24 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
 import AcuantCapture from './acuant-capture';
 import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
-import DataURLFile from '../models/data-url-file';
+
+/** @typedef {import('../models/data-url-file')} DataURLFile */
+
+/**
+ * @typedef DocumentsStepValue
+ *
+ * @prop {DataURLFile=} front_image Front image value.
+ * @prop {DataURLFile=} back_image  Back image value.
+ */
+
+/**
+ * @typedef DocumentsStepProps
+ *
+ * @prop {DocumentsStepValue=}                            value Current value.
+ * @prop {(nextValue:Partial<DocumentsStepValue>)=>void=} onChange Value change handler.
+ */
 
 /**
  * Sides of document to present as file input.
@@ -13,7 +27,10 @@ import DataURLFile from '../models/data-url-file';
  */
 const DOCUMENT_SIDES = ['front', 'back'];
 
-function DocumentsStep({ value, onChange }) {
+/**
+ * @param {DocumentsStepProps} props Props object.
+ */
+function DocumentsStep({ value = {}, onChange = () => {} }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -50,19 +67,6 @@ function DocumentsStep({ value, onChange }) {
     </>
   );
 }
-
-DocumentsStep.propTypes = {
-  value: PropTypes.shape({
-    front_image: PropTypes.instanceOf(DataURLFile),
-    back_image: PropTypes.instanceOf(DataURLFile),
-  }),
-  onChange: PropTypes.func,
-};
-
-DocumentsStep.defaultProps = {
-  value: {},
-  onChange: () => {},
-};
 
 /**
  * Returns true if the step is valid for the given values, or false otherwise.

--- a/app/javascript/app/document-capture/components/file-input.jsx
+++ b/app/javascript/app/document-capture/components/file-input.jsx
@@ -1,10 +1,26 @@
 import React, { useContext, useState, useMemo, forwardRef } from 'react';
-import PropTypes from 'prop-types';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useI18n from '../hooks/use-i18n';
 import DataURLFile from '../models/data-url-file';
+
+/** @typedef {import('react').MouseEvent} ReactMouseEvent */
+/** @typedef {import('react').ChangeEvent} ReactChangeEvent */
+/** @typedef {import('react').RefAttributes} ReactRefAttributes */
+
+/**
+ * @typedef FileInputProps
+ *
+ * @prop {string}                    label      Input label.
+ * @prop {string=}                   hint       Optional hint text.
+ * @prop {string=}                   bannerText Optional banner overlay text.
+ * @prop {string[]=}                 accept     Optional array of file input accept patterns.
+ * @prop {DataURLFile=}              value      Current value.
+ * @prop {string[]=}                 errors     Errors to show.
+ * @prop {(ReactMouseEvent)=>void=}  onClick    Input click handler.
+ * @prop {(ReactChangeEvent)=>void=} onChange   Input change handler.
+ */
 
 /**
  * Given a data URL string, returns the MIME type.
@@ -89,8 +105,20 @@ export function toDataURL(file) {
   });
 }
 
+/**
+ * @type {import('react').ForwardRefExoticComponent<FileInputProps & ReactRefAttributes>}
+ */
 const FileInput = forwardRef((props, ref) => {
-  const { label, hint, bannerText, accept, value, errors, onClick, onChange } = props;
+  const {
+    label,
+    hint,
+    bannerText,
+    accept,
+    value,
+    errors = [],
+    onClick = () => {},
+    onChange = () => {},
+  } = props;
   const { t, formatHTML } = useI18n();
   const ifStillMounted = useIfStillMounted();
   const instanceId = useInstanceId();
@@ -216,26 +244,5 @@ const FileInput = forwardRef((props, ref) => {
     </div>
   );
 });
-
-FileInput.propTypes = {
-  label: PropTypes.string.isRequired,
-  hint: PropTypes.string,
-  bannerText: PropTypes.string,
-  accept: PropTypes.arrayOf(PropTypes.string),
-  value: PropTypes.instanceOf(DataURLFile),
-  errors: PropTypes.arrayOf(PropTypes.string),
-  onClick: PropTypes.func,
-  onChange: PropTypes.func,
-};
-
-FileInput.defaultProps = {
-  hint: null,
-  bannerText: null,
-  accept: null,
-  value: undefined,
-  errors: [],
-  onClick: () => {},
-  onChange: () => {},
-};
 
 export default FileInput;

--- a/app/javascript/app/document-capture/components/form-steps.jsx
+++ b/app/javascript/app/document-capture/components/form-steps.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import tabbable from 'tabbable';
 import Button from './button';
 import useI18n from '../hooks/use-i18n';
@@ -8,10 +7,18 @@ import useHistoryParam from '../hooks/use-history-param';
 /**
  * @typedef FormStep
  *
- * @prop {string}                    name      Step name, used in history parameter.
- * @prop {import('react').Component} component Step component implementation.
- * @prop {(values:object)=>boolean}  isValid   Step validity function. Given set of form values,
- *                                             returns true if values satisfy requirements.
+ * @prop {string}                            name      Step name, used in history parameter.
+ * @prop {import('react').FunctionComponent} component Step component implementation.
+ * @prop {(values:object)=>boolean=}         isValid   Step validity function. Given set of form
+ *                                                     values, returns true if values satisfy
+ *                                                     requirements.
+ */
+
+/**
+ * @typedef FormStepsProps
+ *
+ * @prop {FormStep[]=}                        steps      Form steps.
+ * @prop {(values:Record<string,any>)=>void=} onComplete Form completion callback.
  */
 
 /**
@@ -54,7 +61,10 @@ export function getLastValidStepIndex(steps, values) {
   return index === -1 ? steps.length - 1 : index - 1;
 }
 
-function FormSteps({ steps, onComplete }) {
+/**
+ * @param {FormStepsProps} props Props object.
+ */
+function FormSteps({ steps = [], onComplete = () => {} }) {
   const [values, setValues] = useState({});
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
   const isProgressingToNextStep = useRef(false);
@@ -151,21 +161,5 @@ function FormSteps({ steps, onComplete }) {
     </form>
   );
 }
-
-FormSteps.propTypes = {
-  steps: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      component: PropTypes.elementType.isRequired,
-      isValid: PropTypes.func,
-    }),
-  ),
-  onComplete: PropTypes.func,
-};
-
-FormSteps.defaultProps = {
-  steps: [],
-  onComplete: () => {},
-};
 
 export default FormSteps;

--- a/app/javascript/app/document-capture/components/full-screen.jsx
+++ b/app/javascript/app/document-capture/components/full-screen.jsx
@@ -1,10 +1,21 @@
 import React, { useRef, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import createFocusTrap from 'focus-trap';
 import Image from './image';
 import useI18n from '../hooks/use-i18n';
 
-function FullScreen({ onRequestClose, children }) {
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef FullScreenProps
+ *
+ * @prop {()=>void=} onRequestClose Callback invoked when user initiates close intent.
+ * @prop {ReactNode} children       Child elements.
+ */
+
+/**
+ * @param {FullScreenProps} props Props object.
+ */
+function FullScreen({ onRequestClose = () => {}, children }) {
   const { t } = useI18n();
   const modalRef = useRef(/** @type {?HTMLDivElement} */ (null));
   const trapRef = useRef(/** @type {?import('focus-trap').FocusTrap} */ (null));
@@ -37,14 +48,5 @@ function FullScreen({ onRequestClose, children }) {
     </div>
   );
 }
-
-FullScreen.propTypes = {
-  onRequestClose: PropTypes.func,
-  children: PropTypes.node.isRequired,
-};
-
-FullScreen.defaultProps = {
-  onRequestClose: () => {},
-};
 
 export default FullScreen;

--- a/app/javascript/app/document-capture/components/image.jsx
+++ b/app/javascript/app/document-capture/components/image.jsx
@@ -1,7 +1,16 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
 import AssetContext from '../context/asset';
 
+/**
+ * @typedef ImageProps
+ *
+ * @prop {string} assetPath Asset path to resolve.
+ * @prop {string} alt       Image alt attribute.
+ */
+
+/**
+ * @param {ImageProps & Record<string,any>} props Props object.
+ */
 function Image({ assetPath, alt, ...imgProps }) {
   const assets = useContext(AssetContext);
 
@@ -18,10 +27,5 @@ function Image({ assetPath, alt, ...imgProps }) {
   // eslint-disable-next-line react/jsx-props-no-spreading
   return <img src={src} alt={alt} {...imgProps} />;
 }
-
-Image.propTypes = {
-  assetPath: PropTypes.string.isRequired,
-  alt: PropTypes.string.isRequired,
-};
 
 export default Image;

--- a/app/javascript/app/document-capture/components/page-heading.jsx
+++ b/app/javascript/app/document-capture/components/page-heading.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
+/**
+ * @typedef PageHeadingProps
+ *
+ * @prop {import('react').ReactNode} children Child elements.
+ */
+
+/**
+ * @param {PageHeadingProps} props Props object.
+ */
 function PageHeading({ children }) {
   return <h1 className="h3 my0">{children}</h1>;
 }
-
-PageHeading.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default PageHeading;

--- a/app/javascript/app/document-capture/components/selfie-step.jsx
+++ b/app/javascript/app/document-capture/components/selfie-step.jsx
@@ -1,11 +1,27 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 import AcuantCapture from './acuant-capture';
-import DataURLFile from '../models/data-url-file';
 
-function SelfieStep({ value, onChange }) {
+/** @typedef {import('../models/data-url-file').default} DataURLFile */
+
+/**
+ * @typedef SelfieStepValue
+ *
+ * @prop {DataURLFile=} selfie Selfie value.
+ */
+
+/**
+ * @typedef SelfieStepProps
+ *
+ * @prop {SelfieStepValue=}                            value    Current value.
+ * @prop {(nextValue:Partial<SelfieStepValue>)=>void=} onChange Change handler.
+ */
+
+/**
+ * @param {SelfieStepProps} props Props object.
+ */
+function SelfieStep({ value = {}, onChange = () => {} }) {
   const { t } = useI18n();
 
   return (
@@ -29,18 +45,6 @@ function SelfieStep({ value, onChange }) {
     </>
   );
 }
-
-SelfieStep.propTypes = {
-  value: PropTypes.shape({
-    selfie: PropTypes.instanceOf(DataURLFile),
-  }),
-  onChange: PropTypes.func,
-};
-
-SelfieStep.defaultProps = {
-  value: {},
-  onChange: () => {},
-};
 
 /**
  * Returns true if the step is valid for the given values, or false otherwise.

--- a/app/javascript/app/document-capture/components/submission-complete.jsx
+++ b/app/javascript/app/document-capture/components/submission-complete.jsx
@@ -1,13 +1,26 @@
-import PropTypes from 'prop-types';
+import React from 'react';
 
+/**
+ * @typedef Resource
+ *
+ * @prop {()=>T} read Resource reader.
+ *
+ * @template T
+ */
+
+/**
+ * @typedef SubmissionCompleteProps
+ *
+ * @prop {Resource<any>} resource Resource object.
+ */
+
+/**
+ * @param {SubmissionCompleteProps} props Props object.
+ */
 function SubmissionComplete({ resource }) {
   const response = resource.read();
 
-  return `Finished sending: ${JSON.stringify(response)}`;
+  return <>Finished sending: {JSON.stringify(response)}</>;
 }
-
-SubmissionComplete.propTypes = {
-  resource: PropTypes.shape({ read: PropTypes.func }),
-};
 
 export default SubmissionComplete;

--- a/app/javascript/app/document-capture/components/submission.jsx
+++ b/app/javascript/app/document-capture/components/submission.jsx
@@ -1,11 +1,19 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
 import useAsync from '../hooks/use-async';
 import UploadContext from '../context/upload';
 import SuspenseErrorBoundary from './suspense-error-boundary';
 import SubmissionComplete from './submission-complete';
 import SubmissionPending from './submission-pending';
 
+/**
+ * @typedef SubmissionProps
+ *
+ * @prop {Record<string,string>} payload Payload object.
+ */
+
+/**
+ * @param {SubmissionProps} props Props object.
+ */
 function Submission({ payload }) {
   const upload = useContext(UploadContext);
   const resource = useAsync(upload, payload);
@@ -16,17 +24,5 @@ function Submission({ payload }) {
     </SuspenseErrorBoundary>
   );
 }
-
-Submission.propTypes = {
-  // Disable reason: While normally its advisable for a components prop shape to
-  // be well-defined, in this case we expect to be able to send arbitrary data
-  // to an endpoint.
-  // eslint-disable-next-line react/forbid-prop-types
-  payload: PropTypes.any,
-};
-
-Submission.defaultProps = {
-  payload: undefined,
-};
 
 export default Submission;

--- a/app/javascript/app/document-capture/components/suspense-error-boundary.jsx
+++ b/app/javascript/app/document-capture/components/suspense-error-boundary.jsx
@@ -1,6 +1,18 @@
 import React, { Component, Suspense } from 'react';
-import PropTypes from 'prop-types';
 
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef SuspenseErrorBoundaryProps
+ *
+ * @prop {ReactNode} fallback      Fallback to show while suspense pending.
+ * @prop {ReactNode} errorFallback Fallback to show if suspense resolves as error.
+ * @prop {ReactNode} children      Suspense child.
+ */
+
+/**
+ * @extends {Component<SuspenseErrorBoundaryProps>}
+ */
 class SuspenseErrorBoundary extends Component {
   constructor(props) {
     super(props);
@@ -21,11 +33,5 @@ class SuspenseErrorBoundary extends Component {
     return hasError ? errorFallback : <Suspense fallback={fallback}>{children}</Suspense>;
   }
 }
-
-SuspenseErrorBoundary.propTypes = {
-  fallback: PropTypes.node.isRequired,
-  errorFallback: PropTypes.node.isRequired,
-  children: PropTypes.node.isRequired,
-};
 
 export default SuspenseErrorBoundary;

--- a/app/javascript/app/document-capture/context/acuant.jsx
+++ b/app/javascript/app/document-capture/context/acuant.jsx
@@ -1,5 +1,50 @@
 import React, { createContext, useMemo, useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef AcuantCamera
+ *
+ * @prop {boolean} isCameraSupported Whether camera is supported.
+ */
+
+/**
+ * @typedef AcuantCallbackOptions
+ *
+ * @prop {()=>void} onSuccess Success callback.
+ * @prop {()=>void} onFail    Failure callback.
+ */
+
+/**
+ * @typedef {(credentials:string,endpoint:string,AcuantCallbackOptions)=>void} AcuantInitialize
+ */
+
+/**
+ * @typedef AcuantJavaScriptWebSDK
+ *
+ * @prop {AcuantInitialize} initialize Acuant SDK initializer.
+ */
+
+/**
+ * @typedef AcuantGlobals
+ *
+ * @prop {()=>void}               onAcuantSdkLoaded      Acuant initialization callback.
+ * @prop {AcuantCamera}           AcuantCamera           Acuant camera API.
+ * @prop {AcuantJavaScriptWebSDK} AcuantJavascriptWebSdk Acuant web SDK.
+ */
+
+/**
+ * @typedef {typeof window & AcuantGlobals} AcuantGlobal
+ */
+
+/**
+ * @typedef AcuantContextProviderProps
+ *
+ * @prop {string=}   sdkSrc      SDK source URL.
+ * @prop {string=}   credentials SDK credentials.
+ * @prop {string=}   endpoint    Endpoint to submit payload.
+ * @prop {ReactNode} children    Child element.
+ */
 
 const AcuantContext = createContext({
   isReady: false,
@@ -9,7 +54,15 @@ const AcuantContext = createContext({
   endpoint: null,
 });
 
-function AcuantContextProvider({ sdkSrc, credentials, endpoint, children }) {
+/**
+ * @param {AcuantContextProviderProps} props Props object.
+ */
+function AcuantContextProvider({
+  sdkSrc = '/AcuantJavascriptWebSdk.min.js',
+  credentials = null,
+  endpoint = null,
+  children,
+}) {
   const [isReady, setIsReady] = useState(false);
   const [isError, setIsError] = useState(false);
   const [isCameraSupported, setIsCameraSupported] = useState(/** @type {?boolean} */ (null));
@@ -24,15 +77,21 @@ function AcuantContextProvider({ sdkSrc, credentials, endpoint, children }) {
   useEffect(() => {
     // Acuant SDK expects this global to be assigned at the time the script is
     // loaded, which is why the script element is manually appended to the DOM.
-    const originalOnAcuantSdkLoaded = window.onAcuantSdkLoaded;
-    window.onAcuantSdkLoaded = () => {
-      window.AcuantJavascriptWebSdk.initialize(credentials, endpoint, {
-        onSuccess: () => {
-          setIsReady(true);
-          setIsCameraSupported(window.AcuantCamera.isCameraSupported);
+    const originalOnAcuantSdkLoaded = /** @type {AcuantGlobal} */ (window).onAcuantSdkLoaded;
+    /** @type {AcuantGlobal} */ (window).onAcuantSdkLoaded = () => {
+      /** @type {AcuantGlobal} */ (window).AcuantJavascriptWebSdk.initialize(
+        credentials,
+        endpoint,
+        {
+          onSuccess: () => {
+            setIsReady(true);
+            setIsCameraSupported(
+              /** @type {AcuantGlobal} */ (window).AcuantCamera.isCameraSupported,
+            );
+          },
+          onFail: () => setIsError(true),
         },
-        onFail: () => setIsError(true),
-      });
+      );
     };
 
     const script = document.createElement('script');
@@ -42,27 +101,13 @@ function AcuantContextProvider({ sdkSrc, credentials, endpoint, children }) {
     document.body.appendChild(script);
 
     return () => {
-      window.onAcuantSdkLoaded = originalOnAcuantSdkLoaded;
+      /** @type {AcuantGlobal} */ (window).onAcuantSdkLoaded = originalOnAcuantSdkLoaded;
       document.body.removeChild(script);
     };
   }, []);
 
   return <AcuantContext.Provider value={value}>{children}</AcuantContext.Provider>;
 }
-
-AcuantContextProvider.propTypes = {
-  sdkSrc: PropTypes.string,
-  credentials: PropTypes.string,
-  endpoint: PropTypes.string,
-  children: PropTypes.node,
-};
-
-AcuantContextProvider.defaultProps = {
-  sdkSrc: '/AcuantJavascriptWebSdk.min.js',
-  credentials: null,
-  endpoint: null,
-  children: null,
-};
 
 export const Provider = AcuantContextProvider;
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "npm": "6.x.x"
   },
   "scripts": {
+    "typecheck": "tsc",
     "lint": "eslint app spec --ext .js,.jsx",
     "test": "mocha 'spec/javascripts/**/**spec.js?(x)'",
     "build": "true"
@@ -37,6 +38,7 @@
     "@testing-library/dom": "^7.21.8",
     "@testing-library/react": "^10.4.8",
     "@testing-library/user-event": "^12.0.11",
+    "@types/react": "^16.9.46",
     "babel-eslint": "^10.1.0",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
@@ -52,6 +54,7 @@
     "prettier": "^2.0.5",
     "proxyquire": "^1.8.0",
     "sinon": "^9.0.2",
+    "typescript": "^3.9.7",
     "webpack-dev-server": "^3.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "jquery": "^3.5.0",
     "libphonenumber-js": "^1.7.26",
     "normalize.css": "^4.2.0",
-    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "tabbable": "^4.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "moduleResolution": "node"
+  },
+  "include": ["app/javascript/app/document-capture"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,10 +1239,23 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/react@^16.9.46":
+  version "16.9.46"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
+  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3144,6 +3157,11 @@ cssstyle@^2.2.0:
   integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -9191,6 +9209,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
**Why**: To improve confidence in our code. The error fixed in #4040 would have never happened if these changes had been in place.

Applies only to new code in `app/javascripts/app/document-capture` (the React-based document capture flow).

See also: #4040

This removes `prop-types` and disables the associated ESLint configuration.

From #4040:

>**Benefits:**
>
>1. Can be used to provide type checking to surface these sorts of errors
>  - ![Screen Shot 2020-08-11 at 9 42 27 AM](https://user-images.githubusercontent.com/1779930/89904959-8d0a9300-dbb7-11ea-8642-088efc3143b4.png)
>2. Can be used to provide type checking and props detailed information from rendering parent components
>  - ![Screen Shot 2020-08-11 at 9 41 11 AM](https://user-images.githubusercontent.com/1779930/89905038-a4e21700-dbb7-11ea-9ad4-26870cc6d57b.png)
>3. Takes advantage of existing mechanisms for documenting functions using JSDoc
>4. Affords opportunity to describe the purpose of the prop type in the detail of the custom `@typedef`
>5. Provides ~an excuse~ timely and relevant space to describe the purpose of the component 
>6. Allows prop validation errors to be checked at _build time_, rather than at _run time_ (if enabled in build step, see "Downsides")
>7. Ships less code, since `propTypes` are only relevant for development, but are still shipped to production ([unless steps are taken to strip them from production builds](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types))
>8. Removes a dependency (`prop-types`)
>9. Allows prop defaults to be assigned using [language-native defaulting syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Default_values_2)