### PR TITLE
Shift focus to document capture step title after step transition

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -5,6 +5,7 @@ import SelfieStep, { isValid as isSelfieStepValid } from './selfie-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
+import useI18n from '../hooks/use-i18n';
 
 /**
  * @typedef DocumentCaptureProps
@@ -18,20 +19,24 @@ import Submission from './submission';
  */
 function DocumentCapture({ isLivenessEnabled = true }) {
   const [formValues, setFormValues] = useState(null);
+  const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
   const steps = [
     isMobile && {
       name: 'intro',
+      title: t('doc_auth.headings.document_capture'),
       component: MobileIntroStep,
     },
     {
       name: 'documents',
+      title: t('doc_auth.headings.document_capture'),
       component: DocumentsStep,
       isValid: isDocumentsStepValid,
     },
     isLivenessEnabled && {
       name: 'selfie',
+      title: t('doc_auth.headings.selfie'),
       component: SelfieStep,
       isValid: isSelfieStepValid,
     },

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import AcuantCapture from './acuant-capture';
-import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 
@@ -36,7 +35,6 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
 
   return (
     <>
-      <PageHeading>{t('doc_auth.headings.document_capture')}</PageHeading>
       <p className="margin-top-2 margin-bottom-0">
         {t('doc_auth.tips.document_capture_header_text')}
       </p>

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import tabbable from 'tabbable';
 import Button from './button';
+import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 import useHistoryParam from '../hooks/use-history-param';
 
@@ -8,6 +8,7 @@ import useHistoryParam from '../hooks/use-history-param';
  * @typedef FormStep
  *
  * @prop {string}                            name      Step name, used in history parameter.
+ * @prop {string}                            title     Step title, shown as heading.
  * @prop {import('react').FunctionComponent} component Step component implementation.
  * @prop {(values:object)=>boolean=}         isValid   Step validity function. Given set of form
  *                                                     values, returns true if values satisfy
@@ -67,7 +68,7 @@ export function getLastValidStepIndex(steps, values) {
 function FormSteps({ steps = [], onComplete = () => {} }) {
   const [values, setValues] = useState({});
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
-  const isProgressingToNextStep = useRef(false);
+  const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
   const [stepName, setStepName] = useHistoryParam('step');
   const { t } = useI18n();
 
@@ -86,15 +87,6 @@ function FormSteps({ steps = [], onComplete = () => {} }) {
       setStepName(effectiveStep.name);
     }
   }, []);
-
-  useEffect(() => {
-    // After a step progression, shift focus to the first tabbable element within the new form
-    // contents. The form itself serves as a fallback in case there are no tabbable elements.
-    if (isProgressingToNextStep.current && formRef.current) {
-      (tabbable(formRef.current)[0] ?? formRef.current).focus();
-      isProgressingToNextStep.current = false;
-    }
-  }, [stepName]);
 
   // An empty steps array is allowed, in which case there is nothing to render.
   if (!effectiveStep) {
@@ -135,14 +127,17 @@ function FormSteps({ steps = [], onComplete = () => {} }) {
       setStepName(nextStepName);
     }
 
-    isProgressingToNextStep.current = true;
+    headingRef.current.focus();
   }
 
-  const { component: Component, name } = effectiveStep;
+  const { component: Component, name, title } = effectiveStep;
   const isLastStep = effectiveStepIndex + 1 === steps.length;
 
   return (
-    <form ref={formRef} onSubmit={toNextStep} tabIndex={-1}>
+    <form ref={formRef} onSubmit={toNextStep}>
+      <PageHeading key="title" ref={headingRef} tabIndex={-1}>
+        {title}
+      </PageHeading>
       <Component
         key={name}
         value={values}

--- a/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
+++ b/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 
 function MobileIntroStep() {
@@ -7,7 +6,6 @@ function MobileIntroStep() {
 
   return (
     <>
-      <PageHeading>{t('doc_auth.headings.document_capture')}</PageHeading>
       <p className="margin-top-2">{t('doc_auth.info.document_capture_intro_acknowledgment')}</p>
       <p>
         <a href="/verify/jurisdiction/errors/no_id">{t('idv.messages.jurisdiction.no_id')}</a>

--- a/app/javascript/packages/document-capture/components/page-heading.jsx
+++ b/app/javascript/packages/document-capture/components/page-heading.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 /**
  * @typedef PageHeadingProps
@@ -7,10 +7,18 @@ import React from 'react';
  */
 
 /**
- * @param {PageHeadingProps} props Props object.
+ * @param {PageHeadingProps & Record<string,any>} props Props object.
  */
-function PageHeading({ children }) {
-  return <h1 className="h3 my0">{children}</h1>;
+function PageHeading({ children, className, ...props }, ref) {
+  const classes = ['h3', 'my0', className].filter(Boolean).join(' ');
+
+  return (
+    // Disable reason: Intended as pass-through to heading HTML element.
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <h1 ref={ref} {...props} className={classes}>
+      {children}
+    </h1>
+  );
 }
 
-export default PageHeading;
+export default forwardRef(PageHeading);

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PageHeading from './page-heading';
 import useI18n from '../hooks/use-i18n';
 import AcuantCapture from './acuant-capture';
 
@@ -26,7 +25,6 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
 
   return (
     <>
-      <PageHeading>{t('doc_auth.headings.selfie')}</PageHeading>
       <p className="margin-top-2">
         {t('doc_auth.instructions.document_capture_selfie_instructions')}
       </p>

--- a/app/javascript/packages/document-capture/components/submission-pending.jsx
+++ b/app/javascript/packages/document-capture/components/submission-pending.jsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import Image from './image';
 import useI18n from '../hooks/use-i18n';
 
 function SubmissionPending() {
   const { t } = useI18n();
+  const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
+  useEffect(() => {
+    headingRef.current.focus();
+  }, []);
 
   return (
     <div>
       <Image assetPath="id-card.svg" alt="" width="216" height="116" />
-      <h2>{t('doc_auth.headings.interstitial')}</h2>
+      <h2 ref={headingRef} tabIndex={-1}>
+        {t('doc_auth.headings.interstitial')}
+      </h2>
       <p>{t('doc_auth.info.interstitial_eta')}</p>
       <p>{t('doc_auth.info.interstitial_thanks')}</p>
     </div>

--- a/app/javascript/packages/document-capture/package.json
+++ b/app/javascript/packages/document-capture/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "focus-trap": "^2.3.0",
-    "react": "^16.13.1",
-    "tabbable": "^4.0.0"
+    "react": "^16.13.1"
   }
 }

--- a/spec/javascripts/app/document-capture/components/page-heading-spec.jsx
+++ b/spec/javascripts/app/document-capture/components/page-heading-spec.jsx
@@ -1,0 +1,36 @@
+import React, { createRef } from 'react';
+import PageHeading from '@18f/identity-document-capture/components/page-heading';
+import render from '../../../support/render';
+
+describe('document-capture/components/page-heading', () => {
+  it('renders as h1', () => {
+    const { getByText } = render(<PageHeading>Title</PageHeading>);
+
+    const heading = getByText('Title');
+
+    expect(heading.nodeName).to.equal('H1');
+  });
+
+  it('accepts custom class name', () => {
+    const { getByText } = render(<PageHeading className="example">Title</PageHeading>);
+
+    const heading = getByText('Title');
+
+    expect(heading.classList.contains('example')).to.be.true();
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef();
+    render(<PageHeading ref={ref} />);
+
+    expect(ref.current.nodeName).to.equal('H1');
+  });
+
+  it('forwards additional props', () => {
+    const { getByText } = render(<PageHeading tabIndex="-1">Title</PageHeading>);
+
+    const heading = getByText('Title');
+
+    expect(heading.getAttribute('tabindex')).to.equal('-1');
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -10,9 +10,10 @@ import render from '../../../support/render';
 
 describe('document-capture/components/form-steps', () => {
   const STEPS = [
-    { name: 'first', component: () => <span>First</span> },
+    { name: 'first', title: 'First Title', component: () => <span>First</span> },
     {
       name: 'second',
+      title: 'Second Title',
       component: ({ value = {}, onChange }) => (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
         <label>
@@ -28,7 +29,7 @@ describe('document-capture/components/form-steps', () => {
       ),
       isValid: (value) => Boolean(value.second),
     },
-    { name: 'last', component: () => <span>Last</span> },
+    { name: 'last', title: 'Last Title', component: () => <span>Last</span> },
   ];
 
   let originalHash;
@@ -195,24 +196,12 @@ describe('document-capture/components/form-steps', () => {
     userEvent.click(getByText('forms.buttons.submit.default'));
   });
 
-  it('shifts focus to first tabbable after step change', async () => {
-    const { getByText, getByLabelText } = render(<FormSteps steps={STEPS} />);
+  it('shifts focus to next heading on step change', async () => {
+    const { getByText } = render(<FormSteps steps={STEPS} />);
 
     userEvent.click(getByText('forms.buttons.continue'));
 
-    expect(document.activeElement).to.equal(getByLabelText('Second'));
-  });
-
-  it('shifts focus to form after step change if next step has no tabbables', async () => {
-    const steps = [...STEPS];
-    steps[2] = { ...steps[2], isValid: () => false };
-    const { getByText, getByRole } = render(<FormSteps steps={steps} />);
-
-    userEvent.click(getByText('forms.buttons.continue'));
-    userEvent.type(getByRole('textbox'), 'val');
-    userEvent.click(getByText('forms.buttons.continue'));
-
-    expect(document.activeElement.nodeName).to.equal('FORM');
+    expect(document.activeElement).to.equal(getByText('Second Title'));
   });
 
   it("doesn't assign focus on mount", async () => {

--- a/spec/javascripts/packages/document-capture/components/submission-pending-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-pending-spec.jsx
@@ -8,6 +8,7 @@ describe('document-capture/components/submission-pending', () => {
 
     const heading = getByText('doc_auth.headings.interstitial');
 
+    expect(document.activeElement).to.equal(heading);
     expect(heading).to.be.ok();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8940,11 +8940,6 @@ tabbable@^1.0.3:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-1.1.3.tgz#0e4ee376f3631e42d7977a074dbd2b3827843081"
   integrity sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg==
 
-tabbable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
-  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
-
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"


### PR DESCRIPTION
Previously: #4015

**Why**: As a keyboard user or user of assistive technology, I expect that each step transition in the document capture flow leaves focus in a reasonable place for me to continue from where I had left off.

This revisits the work in #4015.

Namely:

- As evidenced by comments in #4015 of "so that they can proceed to read through the initial instructions of the next step" and "required to step backward in focus order in order to complete the next step", the first focusable form input may not be an ideal place to put the user after a focus transition, since they will have to reverse focus to earlier content to gain context about what's expected from the next step. Just the same as a user who interprets the content visually will want to be brought to the beginning of instruction text to begin reading, the same is true of all users.
- We must still manage focus after the steps have completed and submission begins. The title "We are processing your images…" serves as useful announcement for current progress.

The implemented behavior will ensure that in each "page transition" within the document capture form flow, the heading of the next "screen" is focused.

Reference material:

- https://daverupert.com/2019/01/accessible-page-navigations-in-single-page-apps/
- https://www.youtube.com/watch?v=srLRSQg6Jgg
  - >[01:43] The second the new content loads, we're moving focus into the page. And then [...] we can very quickly get down to the next interactive element
- https://www.deque.com/blog/accessibility-tips-in-single-page-applications/
- https://reach.tech/router/accessibility
  - >When the location changes, the top-most part of your application that changed is identified and focus is moved to it.

