### PR TITLE
Localize document capture interstitial texts

### DIFF
--- a/app/javascript/packages/document-capture/components/submission-pending.jsx
+++ b/app/javascript/packages/document-capture/components/submission-pending.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import Image from './image';
+import useI18n from '../hooks/use-i18n';
 
 function SubmissionPending() {
+  const { t } = useI18n();
+
   return (
     <div>
       <Image assetPath="id-card.svg" alt="" width="216" height="116" />
-      <h2>We are processing your images…</h2>
-      <p>This might take up to a minute. We’ll load the next step automatically when it’s done.</p>
-      <p>Thanks for your patience!</p>
+      <h2>{t('doc_auth.headings.interstitial')}</h2>
+      <p>{t('doc_auth.info.interstitial_eta')}</p>
+      <p>{t('doc_auth.info.interstitial_thanks')}</p>
     </div>
   );
 }

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -11,9 +11,12 @@
 - doc_auth.headings.document_capture_front
 - doc_auth.headings.document_capture_selfie
 - doc_auth.headings.front
+- doc_auth.headings.interstitial
 - doc_auth.headings.photo
 - doc_auth.headings.selfie
 - doc_auth.info.document_capture_intro_acknowledgment
+- doc_auth.info.interstitial_eta
+- doc_auth.info.interstitial_thanks
 - doc_auth.instructions.document_capture_selfie_instructions
 - doc_auth.tips.document_capture_header_text
 - doc_auth.tips.document_capture_hint

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -37,6 +37,7 @@ en:
         and selfie
       document_capture_selfie: Your photo
       front: Front
+      interstitial: We are processing your images…
       photo: Photo
       selfie: Take a photo of yourself
       ssn: Please enter your social security number.
@@ -57,6 +58,9 @@ en:
         your identity.
       document_capture_upload_image: We only use your ID to verify your identity,
         and we will not save any images.
+      interstitial_eta: This might take up to a minute. We’ll load the next step automatically
+        when it’s done.
+      interstitial_thanks: Thanks for your patience!
       link_sent:
       - Please check your phone and follow instructions to take a photo of your state
         issued ID.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -38,6 +38,7 @@ es:
         por el estado y una foto suya
       document_capture_selfie: Tu foto
       front: Frente
+      interstitial: Estamos procesando tus imágenes…
       photo: Foto
       selfie: Toma una foto de ti mismo
       ssn: Por favor ingrese su número de seguro social.
@@ -59,6 +60,9 @@ es:
         que subes. Solo verificamos su identidad.
       document_capture_upload_image: Solo utilizamos su ID para verificar su identidad
         y no guardaremos ninguna imagen.
+      interstitial_eta: Esto puede tardar hasta un minuto. Cargaremos el siguiente
+        paso automáticamente cuando esté listo.
+      interstitial_thanks: "¡Gracias por su paciencia!"
       link_sent:
       - Verifique su teléfono y siga las instrucciones para tomar una fotografía de
         la identificación emitida por su estado.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -40,6 +40,7 @@ fr:
         officielle et une photo de vous
       document_capture_selfie: Ta photo
       front: De face
+      interstitial: Nous traitons vos images…
       photo: Photo
       selfie: Prenez une photo de vous
       ssn: S'il vous plaît entrez votre numéro de sécurité sociale.
@@ -64,6 +65,9 @@ fr:
         images que vous téléchargez. Nous vérifions uniquement votre identité.
       document_capture_upload_image: Nous n'utilisons votre identifiant que pour vérifier
         votre identité, et nous n'enregistrerons aucune image.
+      interstitial_eta: Cela peut prendre jusqu'à une minute. Nous chargerons automatiquement
+        l’étape suivante une fois celle-ci terminée.
+      interstitial_thanks: Merci pour votre patience!
       link_sent:
       - Veuillez vérifier votre téléphone et suivre les instructions pour prendre
         une photo de votre identité émise par l'État.

--- a/spec/javascripts/packages/document-capture/components/submission-pending-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-pending-spec.jsx
@@ -6,7 +6,7 @@ describe('document-capture/components/submission-pending', () => {
   it('renders interstitial content', () => {
     const { getByText } = render(<SubmissionPending />);
 
-    const heading = getByText('We are processing your images…');
+    const heading = getByText('doc_auth.headings.interstitial');
 
     expect(heading).to.be.ok();
   });


### PR DESCRIPTION
**Why**: All user-facing texts should be localized