### PR TITLE
LG-3265: Change "Take a selfie" to "Take a photo of yourself"

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -38,7 +38,7 @@ en:
       document_capture_selfie: Your photo
       front: Front
       photo: Photo
-      selfie: Take a selfie
+      selfie: Take a photo of yourself
       ssn: Please enter your social security number.
       take_pic_back: Take a photo of the back of your ID
       take_pic_front: Take a photo of the front of your ID

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -39,7 +39,7 @@ es:
       document_capture_selfie: Tu foto
       front: Frente
       photo: Foto
-      selfie: Toma una selfie
+      selfie: Toma una foto de ti mismo
       ssn: Por favor ingrese su número de seguro social.
       take_pic_back: Toma una foto de la parte posterior de tu identificación
       take_pic_front: Toma una foto del frente de tu identificación

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -41,7 +41,7 @@ fr:
       document_capture_selfie: Ta photo
       front: De face
       photo: Photo
-      selfie: Prendre un selfie
+      selfie: Prenez une photo de vous
       ssn: S'il vous plaît entrez votre numéro de sécurité sociale.
       take_pic_back: Prenez une photo au verso de votre identifiant
       take_pic_front: Prenez une photo du recto de votre identifiant


### PR DESCRIPTION
**Why** As a user, I want to see instructions and headings for the "take a photo of yourself" step written in plain language, so that I understand what I need to do to verify my identity. Because "selfie" is colloquial language, change "take a selfie" h1 to "take a photo of yourself".

cc @anniehirshman-gsa 