### PR TITLE
LG-3310: Skip "Upload" document capture step if camera supported

### DIFF
--- a/app/javascript/packages/device/index.js
+++ b/app/javascript/packages/device/index.js
@@ -1,0 +1,29 @@
+/**
+ * Returns true if the device is likely a mobile device, or false otherwise. This is a rough
+ * approximation, using device user agent sniffing.
+ *
+ * @return {boolean}
+ */
+export function isLikelyMobile() {
+  return /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);
+}
+
+/**
+ * Returns true if the current device allows access to camera device APIs.
+ *
+ * @return {boolean}
+ */
+export function hasMediaAccess() {
+  return 'mediaDevices' in window.navigator;
+}
+
+/**
+ * Returns true if the current device is assumed to be a mobile device where a camera is available,
+ * or false otherwise. This is a rough approximation, using device user agent sniffing and
+ * availability of camera device APIs.
+ *
+ * @return {boolean}
+ */
+export function isCameraCapableMobile() {
+  return isLikelyMobile() && hasMediaAccess();
+}

--- a/app/javascript/packages/device/package.json
+++ b/app/javascript/packages/device/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@18f/identity-device",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,0 +1,22 @@
+const form = document.querySelector('form[action="/verify/doc_auth/welcome"]');
+
+// TODO:
+//  Change to: import { hasCamera } from '@18f/identity-device';
+//  ...after:  https://github.com/18F/identity-idp/pull/4048
+export async function hasCamera() {
+  if (!('mediaDevices' in navigator)) {
+    return false;
+  }
+
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return devices.some((device) => device.kind === 'videoinput');
+}
+
+(async () => {
+  if (form && (await hasCamera())) {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'skip_upload';
+    form.appendChild(input);
+  }
+})();

--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,22 +1,14 @@
 const form = document.querySelector('form[action="/verify/doc_auth/welcome"]');
 
 // TODO:
-//  Change to: import { hasCamera } from '@18f/identity-device';
+//  Change to: import { isMobile } from '@18f/identity-device';
 //  ...after:  https://github.com/18F/identity-idp/pull/4048
-export async function hasCamera() {
-  if (!('mediaDevices' in navigator)) {
-    return false;
-  }
+const isMobile =
+  'mediaDevices' in window.navigator && /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);
 
-  const devices = await navigator.mediaDevices.enumerateDevices();
-  return devices.some((device) => device.kind === 'videoinput');
+if (form && isMobile) {
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'skip_upload';
+  form.appendChild(input);
 }
-
-(async () => {
-  if (form && (await hasCamera())) {
-    const input = document.createElement('input');
-    input.type = 'hidden';
-    input.name = 'skip_upload';
-    form.appendChild(input);
-  }
-})();

--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,12 +1,8 @@
+import { isCameraCapableMobile } from '@18f/identity-device';
+
 const form = document.querySelector('form[action="/verify/doc_auth/welcome"]');
 
-// TODO:
-//  Change to: import { isMobile } from '@18f/identity-device';
-//  ...after:  https://github.com/18F/identity-idp/pull/4048
-const isMobile =
-  'mediaDevices' in window.navigator && /ip(hone|ad|od)|android/i.test(window.navigator.userAgent);
-
-if (form && isMobile) {
+if (form && isCameraCapableMobile()) {
   const input = document.createElement('input');
   input.type = 'hidden';
   input.name = 'skip_upload';

--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,6 +1,6 @@
 import { isCameraCapableMobile } from '@18f/identity-device';
 
-const form = document.querySelector('form[action="/verify/doc_auth/welcome"]');
+const form = document.querySelector('.js-consent-form');
 
 if (form && isCameraCapableMobile()) {
   const input = document.createElement('input');

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -8,6 +8,7 @@ import {
   AcuantProvider,
 } from '@18f/identity-document-capture';
 import { loadPolyfills } from '@18f/identity-polyfill';
+import { isCameraCapableMobile } from '@18f/identity-device';
 
 const { I18n: i18n, assets } = window.LoginGov;
 
@@ -17,9 +18,7 @@ function getMetaContent(name) {
 
 /** @type {import('@18f/identity-document-capture/context/device').DeviceContext} */
 const device = {
-  isMobile:
-    'mediaDevices' in window.navigator &&
-    /ip(hone|ad|od)|android/i.test(window.navigator.userAgent),
+  isMobile: isCameraCapableMobile(),
 };
 
 loadPolyfills(['fetch']).then(() => {

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -6,11 +6,25 @@ module Idv
       end
 
       def form_submit
+        skip_to_capture if params[:skip_upload] && FeatureManagement.document_capture_step_enabled?
+
         Idv::ConsentForm.new.submit(consent_form_params)
       end
 
       def consent_form_params
         params.permit(:ial2_consent_given)
+      end
+
+      private
+
+      def skip_to_capture
+        mark_step_complete(:upload)
+        mark_step_complete(:send_link)
+        mark_step_complete(:link_sent)
+        mark_step_complete(:email_sent)
+        mark_step_complete(:mobile_front_image)
+        mark_step_complete(:mobile_back_image)
+        mark_step_complete(:mobile_document_capture)
       end
     end
   end

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -18,12 +18,14 @@ module Idv
       private
 
       def skip_to_capture
+        # Skips to `document_capture` step. Assumes that base step will have already flagged old
+        # flow steps if `FeatureManagement.document_capture_step_enabled?`.
+        #
+        # See: `mark_document_capture_or_image_upload_steps_complete`
         mark_step_complete(:upload)
         mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
         mark_step_complete(:email_sent)
-        mark_step_complete(:mobile_front_image)
-        mark_step_complete(:mobile_back_image)
         mark_step_complete(:mobile_document_capture)
       end
     end

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -95,3 +95,4 @@
 
 <%= javascript_pack_tag('clipboard') %>
 <%= javascript_pack_tag('ial2-consent-button') %>
+<%= javascript_pack_tag('document-capture-welcome') if FeatureManagement.document_capture_step_enabled? %>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -68,7 +68,7 @@
 <%= simple_form_for :doc_auth,
                     url: url_for,
                     method: 'put',
-                    html: { autocomplete: 'off', role: 'form', class: 'mt2' } do |f| %>
+                    html: { autocomplete: 'off', role: 'form', class: 'mt2 js-consent-form' } do |f| %>
   <br/>
   <label class="mtn1 mb3" for="ial2_consent_given">
     <div class="checkbox">

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -115,16 +115,34 @@ describe Idv::DocAuthController do
       )
     end
 
-    it 'progresses from welcome to upload' do
-      put :update, params: { step: 'welcome', ial2_consent_given: true }
+    describe 'when document capture is enabled' do
+      before(:each) do
+        allow(Figaro.env).to receive(:document_capture_step_enabled).and_return('true')
+      end
 
-      expect(response).to redirect_to idv_doc_auth_step_url(step: :upload)
+      it 'progresses from welcome to upload' do
+        put :update, params: { step: 'welcome', ial2_consent_given: true }
+
+        expect(response).to redirect_to idv_doc_auth_step_url(step: :upload)
+      end
+
+      it 'skips from welcome to document capture' do
+        put :update, params: { step: 'welcome', ial2_consent_given: true, skip_upload: true }
+
+        expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
+      end
     end
 
-    it 'skips from welcome to document capture' do
-      put :update, params: { step: 'welcome', ial2_consent_given: true, skip_upload: true }
+    describe 'when document capture is disabled' do
+      before(:each) do
+        allow(Figaro.env).to receive(:document_capture_step_enabled).and_return('false')
+      end
 
-      expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
+      it 'progresses from welcome to upload' do
+        put :update, params: { step: 'welcome', ial2_consent_given: true, skip_upload: true }
+
+        expect(response).to redirect_to idv_doc_auth_step_url(step: :upload)
+      end
     end
   end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -114,6 +114,18 @@ describe Idv::DocAuthController do
         Analytics::DOC_AUTH + ' submitted', result
       )
     end
+
+    it 'progresses from welcome to upload' do
+      put :update, params: { step: 'welcome', ial2_consent_given: true }
+
+      expect(response).to redirect_to idv_doc_auth_step_url(step: :upload)
+    end
+
+    it 'skips from welcome to document capture' do
+      put :update, params: { step: 'welcome', ial2_consent_given: true, skip_upload: true }
+
+      expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
+    end
   end
 
   def mock_next_step(step)

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -1,0 +1,103 @@
+import { isLikelyMobile, hasMediaAccess, isCameraCapableMobile } from '@18f/identity-device';
+
+describe('isLikelyMobile', () => {
+  let originalUserAgent;
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+  });
+
+  it('returns false if not mobile', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+
+    expect(isLikelyMobile()).to.be.false();
+  });
+
+  it('returns true if likely mobile', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+
+    expect(isLikelyMobile()).to.be.true();
+  });
+});
+
+describe('hasMediaAccess', () => {
+  let originalMediaDevices;
+  beforeEach(() => {
+    originalMediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    navigator.mediaDevices = originalMediaDevices;
+  });
+
+  it('returns false if no media device API access', () => {
+    delete navigator.mediaDevices;
+
+    expect(hasMediaAccess()).to.be.false();
+  });
+
+  it('returns true if media device API access', () => {
+    navigator.mediaDevices = {};
+
+    expect(hasMediaAccess()).to.be.true();
+  });
+});
+
+describe('isCameraCapableMobile', () => {
+  let originalUserAgent;
+  let originalMediaDevices;
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+    originalMediaDevices = navigator.mediaDevices;
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    navigator.userAgent = originalUserAgent;
+    navigator.mediaDevices = originalMediaDevices;
+  });
+
+  it('returns false if not mobile', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36';
+    navigator.mediaDevices = {};
+
+    expect(isCameraCapableMobile()).to.be.false();
+  });
+
+  it('returns false if no media device API access', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    delete navigator.mediaDevices;
+
+    expect(isCameraCapableMobile()).to.be.false();
+  });
+
+  it('returns true if likely mobile and media device API access', () => {
+    navigator.userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    navigator.mediaDevices = {};
+
+    expect(isCameraCapableMobile()).to.be.true();
+  });
+});


### PR DESCRIPTION
**Why**: The "Upload" step exists primarily to encourage a user to use their phone to take advantage of the availability of the phone camera to do liveness checking. When the user is on a mobile device, we don't need to recommend that they use their phone, since they're already on a phone. Instead, we can skip straight to document capture.

**Testing Instructions:**

1. Set `document_capture_step_enabled: 'true'` in local `config/application.yml`
2. Visit `/verify` once logged in
3. Give consent, then click "Continue"
4. If in mobile device, you should be brought straight to the document capture React flow
5. Click "Start over"
6. Repeat steps using opposite device ([browser emulation](https://developers.google.com/web/tools/chrome-devtools/device-mode) is fine)

~To do:~

- [x] ~Add tests to verify behavior for skipping upload step.~
- [x] ~Pending #4048, refactor `hasCamera` per inline code "TODO" comment.~