### PR TITLE
Handle bad input in Users::EmailsController better (LG-3287)

### DIFF
--- a/app/services/service_provider_request_proxy.rb
+++ b/app/services/service_provider_request_proxy.rb
@@ -11,7 +11,7 @@ class ServiceProviderRequestProxy
   cattr_accessor :redis_last_uuid
 
   def self.from_uuid(uuid)
-    find_by(uuid: uuid) || NullServiceProviderRequest.new
+    find_by(uuid: uuid.to_s) || NullServiceProviderRequest.new
   rescue ArgumentError # a null byte in the uuid will raise this
     NullServiceProviderRequest.new
   end

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Users::EmailsController do
+  describe '#verify' do
+    context 'with malformed payload' do
+      it 'does not blow up' do
+        expect { get :verify, params: { request_id: { foo: 'bar' } } }.
+          to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/services/service_provider_request_proxy_spec.rb
+++ b/spec/services/service_provider_request_proxy_spec.rb
@@ -41,14 +41,31 @@ describe ServiceProviderRequestProxy do
       end
     end
 
-    context 'when the record does not exists' do
+    context 'when the record does not exist' do
       it 'returns an instance of NullServiceProviderRequest' do
         expect(ServiceProviderRequestProxy.from_uuid('123')).
           to be_an_instance_of NullServiceProviderRequest
       end
+    end
 
-      it 'returns an instance of NullServiceProviderRequest when the uuid contains a null byte' do
+    context 'bad input' do
+      it 'handles a null byte in the uuid' do
         expect(ServiceProviderRequestProxy.from_uuid("\0")).
+          to be_an_instance_of NullServiceProviderRequest
+      end
+
+      it 'handles nil' do
+        expect(ServiceProviderRequestProxy.from_uuid(nil)).
+          to be_an_instance_of NullServiceProviderRequest
+      end
+
+      it 'handles hashes' do
+        expect(ServiceProviderRequestProxy.from_uuid({})).
+          to be_an_instance_of NullServiceProviderRequest
+      end
+
+      it 'handles arrays' do
+        expect(ServiceProviderRequestProxy.from_uuid([])).
           to be_an_instance_of NullServiceProviderRequest
       end
     end


### PR DESCRIPTION
**Why**: A parameter that gets parsed as a hash (instead of string)
would cause type conversion errors

(fyi @pauldoomgov this will fix the cause of the 500s over the weekend 🙈 )