### PR TITLE
move rubocop to circleci from codeclimate (LG-3299)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
   ruby_browsers:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.6.5-node-browsers
+      - image: circleci/ruby:2.6.6-node-browsers
         environment:
           RAILS_ENV: test
 
@@ -23,7 +23,7 @@ executors:
         environment:
           POSTGRES_USER: circleci
 
-      - image: redis:4.0.1
+      - image: redis:5.0.8
 
 commands:
   bundle-yarn-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,7 @@ jobs:
           command: |
             yarn run lint
             yarn run typecheck
+            bundle exec rubocop
             bundle exec slim-lint app/views
   build-latest-container:
     working_directory: ~/identity-idp

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -72,9 +72,6 @@ plugins:
     enabled: true
   reek:
     enabled: false
-  rubocop:
-    enabled: true
-    channel: rubocop-0-72
   scss-lint:
     enabled: true
     checks:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -348,3 +348,6 @@ Style/RedundantRegexpEscape:
 
 Style/SlicingWithRange:
   Enabled: false
+
+Rails/ApplicationMailer:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Rails:
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
-  Enabled: true
+  Enabled: false
   Max: 15
   Exclude:
   - spec/**/*
@@ -46,7 +46,7 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Description: Avoid classes longer than 100 lines of code.
-  Enabled: true
+  Enabled: false
   CountComments: false
   Max: 100
 
@@ -65,7 +65,7 @@ Layout/LineLength:
 Metrics/MethodLength:
   Description: Avoid methods longer than 15 lines of code.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
-  Enabled: true
+  Enabled: false
   CountComments: false
   Max: 15
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - 'lib/user_flow_exporter.rb'
     - 'node_modules/**/*'
     - 'tmp/**/*'
+    - 'vendor/**/*'
   TargetRubyVersion: 2.6
   TargetRailsVersion: 5.1
   UseCache: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
   TargetRubyVersion: 2.6
-  TargetRailsVersion: 5.1
+  TargetRailsVersion: 5.2
   UseCache: true
 
 Rails:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,7 @@ Metrics/ClassLength:
   CountComments: false
   Max: 100
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: Limit lines to 100 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
   Enabled: true
@@ -113,7 +113,7 @@ Rails/TimeZone:
     - strict
     - flexible
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   # Alignment of parameters in multi-line method calls.
   #
   # The `with_first_parameter` style aligns the following lines along the same
@@ -196,7 +196,7 @@ Style/IfUnlessModifier:
   Enabled: true
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -283,7 +283,7 @@ Style/TrailingCommaInHashLiteral:
     - consistent_comma
     - no_comma
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   MinNameLength: 2
 
 Style/ExpandPathArguments:
@@ -291,7 +291,6 @@ Style/ExpandPathArguments:
 
 Style/FormatStringToken:
   Enabled: false
-
 
 Style/SingleLineBlockParams:
   Enabled: false
@@ -303,4 +302,19 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 
 Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+Lint/SuppressedException:
+  Enabled: false
+
+Lint/SendWithMixinArgument:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -318,3 +318,33 @@ Lint/SuppressedException:
 
 Lint/SendWithMixinArgument:
   Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :development, :test do
   gem 'psych'
   gem 'puma'
   gem 'rspec-rails', '~> 3.9', '>= 3.9.1'
-  gem 'rubocop', '~> 0.72.0', require: false
+  gem 'rubocop', '~> 0.80.0', require: false
   gem 'rubocop-rails', '>= 2.5.2', require: false
   gem 'slim_lint'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :development, :test do
   gem 'puma'
   gem 'rspec-rails', '~> 3.9', '>= 3.9.1'
   gem 'rubocop', '~> 0.72.0', require: false
-  gem 'rubocop-rails', '>= 2.3.2', require: false
+  gem 'rubocop-rails', '>= 2.5.2', require: false
   gem 'slim_lint'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :development, :test do
   gem 'psych'
   gem 'puma'
   gem 'rspec-rails', '~> 3.9', '>= 3.9.1'
-  gem 'rubocop', '~> 0.80.0', require: false
+  gem 'rubocop', '~> 0.85.0', require: false
   gem 'rubocop-rails', '>= 2.5.2', require: false
   gem 'slim_lint'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,11 +529,12 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.72.0)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-rails (2.5.2)
@@ -772,7 +773,7 @@ DEPENDENCIES
   rotp (~> 3.3.1)
   rqrcode
   rspec-rails (~> 3.9, >= 3.9.1)
-  rubocop (~> 0.72.0)
+  rubocop (~> 0.80.0)
   rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     connection_pool (2.2.2)
     cose (0.10.0)
       cbor (~> 0.5.9)
@@ -394,11 +394,11 @@ GEM
     overcommit (0.51.0)
       childprocess (>= 0.6.3, < 4)
       iniparse (~> 1.4)
-    parallel (1.19.1)
+    parallel (1.19.2)
     parallel_tests (2.29.2)
       parallel
-    parser (2.7.1.3)
-      ast (~> 2.4.0)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pg (1.1.4)
     phonelib (0.6.39)
     pkcs11 (0.3.2)
@@ -773,7 +773,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 3.9, >= 3.9.1)
   rubocop (~> 0.72.0)
-  rubocop-rails (>= 2.3.2)
+  rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml
   safe_target_blank (>= 1.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,6 @@ GEM
     ice_nine (0.11.2)
     iniparse (1.4.4)
     irb (1.0.0)
-    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     json (2.3.0)
     json-jwt (1.12.0)
@@ -529,14 +528,17 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.85.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
       rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-rails (2.5.2)
       activesupport
       rack (>= 1.1)
@@ -636,7 +638,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     unicode_plot (0.0.4)
       enumerable-statistics (>= 2.0.1)
     uniform_notifier (1.13.0)
@@ -773,7 +775,7 @@ DEPENDENCIES
   rotp (~> 3.3.1)
   rqrcode
   rspec-rails (~> 3.9, >= 3.9.1)
-  rubocop (~> 0.80.0)
+  rubocop (~> 0.85.0)
   rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 require 'core_extensions/string/permit'
 
-class ApplicationController < ActionController::Base # rubocop:disable Metrics/ClassLength
+class ApplicationController < ActionController::Base
   String.include CoreExtensions::String::Permit
   include UserSessionContext
   include VerifyProfileConcern

--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -26,9 +26,9 @@ module SamlIdpLogoutConcern
       current_user,
       signature: saml_response_signature_options,
     )
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     Rails.logger.info "#{'~' * 10} Response #{'~' * 10}\n#{response}\n#{'~' * 10} Done with response #{'~' * 10}"
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
     response
   end
 

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -1,5 +1,5 @@
 module Idv
-  class UspsController < ApplicationController # rubocop:disable Metrics/ClassLength
+  class UspsController < ApplicationController
     include IdvSession
 
     before_action :confirm_two_factor_authenticated

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -6,7 +6,6 @@ class IdvController < ApplicationController
   before_action :confirm_idv_needed, only: [:fail]
   before_action :profile_needs_reactivation?, only: [:index]
 
-  # rubocop:disable Metrics/AbcSize
   def index
     if decorated_session.requested_more_recent_verification?
       verify_identity
@@ -21,7 +20,6 @@ class IdvController < ApplicationController
       verify_identity
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def activated
     redirect_to idv_url unless active_profile?

--- a/app/controllers/idv_controller.rb
+++ b/app/controllers/idv_controller.rb
@@ -6,6 +6,7 @@ class IdvController < ApplicationController
   before_action :confirm_idv_needed, only: [:fail]
   before_action :profile_needs_reactivation?, only: [:index]
 
+  # rubocop:disable Metrics/AbcSize
   def index
     if decorated_session.requested_more_recent_verification?
       verify_identity
@@ -20,6 +21,7 @@ class IdvController < ApplicationController
       verify_identity
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def activated
     redirect_to idv_url unless active_profile?

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module OpenidConnect
   class AuthorizationController < ApplicationController
     include FullyAuthenticatable
@@ -139,4 +138,3 @@ module OpenidConnect
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -15,7 +15,6 @@ class SamlIdpController < ApplicationController
   before_action :confirm_user_is_authenticated_with_fresh_mfa, only: :auth
   before_action :bump_auth_count, only: [:auth]
 
-  # rubocop:disable Metrics/AbcSize
   def auth
     link_identity_from_session_data
     capture_analytics
@@ -24,7 +23,6 @@ class SamlIdpController < ApplicationController
     return redirect_to(user_authorization_confirmation_url) if auth_count == 1
     handle_successful_handoff
   end
-  # rubocop:enable Metrics/AbcSize
 
   def metadata
     render inline: saml_metadata.signed, content_type: 'text/xml'

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module SignUp
   class CompletionsController < ApplicationController
     include SecureHeadersConcern
@@ -149,4 +148,3 @@ module SignUp
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -85,7 +85,6 @@ module TwoFactorAuthentication
       @personal_key_form.personal_key
     end
 
-    # rubocop:disable Metrics/AbcSize
     def handle_valid_otp
       handle_valid_otp_for_authentication_context
       if decorated_user.identity_verified? || decorated_user.password_reset_profile.present?
@@ -99,6 +98,5 @@ module TwoFactorAuthentication
       # This next line can be removed after RC 116
       user_session.delete(:mfa_device_remembered)
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module Users
   class PivCacAuthenticationSetupController < ApplicationController
     include UserAuthenticator
@@ -137,4 +136,3 @@ module Users
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -1,5 +1,5 @@
 module Users
-  class ResetPasswordsController < Devise::PasswordsController # rubocop:disable Metrics/ClassLength
+  class ResetPasswordsController < Devise::PasswordsController
     include RecaptchaConcern
 
     def new

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 module Users
-  class SessionsController < Devise::SessionsController # rubocop:disable Metrics/ClassLength
+  class SessionsController < Devise::SessionsController
     include ::ActionView::Helpers::DateHelper
     include SecureHeadersConcern
     include RememberDeviceConcern

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -1,5 +1,4 @@
 module Users
-  # rubocop:disable Metrics/ClassLength
   class TotpSetupController < ApplicationController
     include RememberDeviceConcern
     include MfaSetupConcern
@@ -132,5 +131,4 @@ module Users
       current_user.auth_app_configurations.count
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -1,5 +1,4 @@
 module Users
-  # rubocop:disable Metrics/ClassLength
   class TwoFactorAuthenticationController < ApplicationController
     include TwoFactorAuthenticatable
 
@@ -232,5 +231,4 @@ module Users
       end
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -1,5 +1,4 @@
 module Users
-  # rubocop:disable Metrics/ClassLength
   class WebauthnSetupController < ApplicationController
     include MfaSetupConcern
     include RememberDeviceConcern
@@ -123,5 +122,4 @@ module Users
       TwoFactorAuthentication::PersonalKeyPolicy.new(current_user).configured?
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -63,7 +63,6 @@ class MfaContext
       piv_cac_configurations + auth_app_configurations
   end
 
-  # rubocop:disable Metrics/AbcSize
   def enabled_mfa_methods_count
     phone_configurations.to_a.select(&:mfa_enabled?).count +
       webauthn_configurations.to_a.select(&:mfa_enabled?).count +
@@ -72,7 +71,6 @@ class MfaContext
       auth_app_configurations.to_a.select(&:mfa_enabled?).count +
       personal_key_method_count
   end
-  # rubocop:enable Metrics/AbcSize
 
   # returns a hash showing the count for each enabled 2FA configuration,
   # such as: { phone: 2, webauthn: 1 }. This is useful for analytics purposes.

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -1,4 +1,4 @@
-class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
+class ServiceProviderSessionDecorator
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers
 
@@ -126,7 +126,6 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
     sp.failure_to_proof_url || sp_return_url
   end
 
-  # rubocop:disable Metrics/AbcSize
   def sp_alert?(path)
     sign_in_path =
       I18n.locale == :en ? new_user_session_path : new_user_session_path(locale: I18n.locale)
@@ -139,7 +138,6 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
                             forgot_password_path => 'forgot_password' }
     custom_alert?(path_to_section_map[path])
   end
-  # rubocop:enable Metrics/AbcSize
 
   def mfa_expiration_interval
     aal_1_expiration = Figaro.env.remember_device_expiration_hours_aal_1.to_i.hours

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,4 +1,4 @@
-class UserDecorator # rubocop:disable Metrics/ClassLength
+class UserDecorator
   include ActionView::Helpers::DateHelper
 
   attr_reader :user

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class OpenidConnectAuthorizeForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
@@ -217,4 +216,3 @@ class OpenidConnectAuthorizeForm
     errors.add(:acr_values, t('openid_connect.authorization.errors.liveness_checking_disabled'))
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -1,4 +1,4 @@
-class OpenidConnectTokenForm # rubocop:disable Metrics/ClassLength
+class OpenidConnectTokenForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
   include Rails.application.routes.url_helpers

--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class RegisterUserEmailForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
@@ -133,4 +132,3 @@ class RegisterUserEmailForm
     @_user ||= User.find_with_email(email) || AnonymousUser.new
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -1,5 +1,4 @@
 # Handles SET events (Security Event Tokens)
-# rubocop:disable Metrics/ClassLength
 class SecurityEventForm
   include ActionView::Helpers::TranslationHelper
   include ActiveModel::Model
@@ -247,4 +246,3 @@ class SecurityEventForm
     }
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,5 +1,4 @@
 module FormHelper
-  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Style/WordArray
   # This method is single statement spread across many lines for readability
   def us_states_territories
@@ -66,7 +65,6 @@ module FormHelper
       ['Wyoming', 'WY'],
     ]
   end
-  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Style/WordArray
 
   def international_phone_codes

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,5 +1,5 @@
 module FormHelper
-  # rubocop:disable MethodLength
+  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Style/WordArray
   # This method is single statement spread across many lines for readability
   def us_states_territories
@@ -66,7 +66,7 @@ module FormHelper
       ['Wyoming', 'WY'],
     ]
   end
-  # rubocop:enable MethodLength
+  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Style/WordArray
 
   def international_phone_codes

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 # rubocop:disable Metrics/ClassLength
-class UserMailer < ActionMailer::Base
+class UserMailer < ApplicationMailer
   include Mailable
   include LocaleHelper
   before_action :attach_images

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 # rubocop:disable Metrics/ClassLength
-class UserMailer < ApplicationMailer
+class UserMailer < ActionMailer::Base
   include Mailable
   include LocaleHelper
   before_action :attach_images

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class UserMailer < ActionMailer::Base
   include Mailable
   include LocaleHelper
@@ -171,4 +170,3 @@ class UserMailer < ActionMailer::Base
     !banlist.include?(modified_email)
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Rails/UniqueValidationWithoutIndex
 class Authorization < ApplicationRecord
   belongs_to :user
   validates :user_id, :uid, :provider, presence: true
@@ -6,3 +7,4 @@ class Authorization < ApplicationRecord
   AAL2 = 2
   AAL3 = 3
 end
+# rubocop:enable Rails/UniqueValidationWithoutIndex

--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -4,7 +4,7 @@ class ConfirmationEmailPresenter
     @view = view
   end
 
-  def first_sentence # rubocop:disable MethodLength
+  def first_sentence
     if user.confirmed_at.present?
       I18n.t(
         'user_mailer.email_confirmation_instructions.first_sentence.confirmed',

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -31,7 +31,6 @@ class OpenidConnectUserInfoPresenter
     EmailContext.new(identity.user).last_sign_in_email_address.email
   end
 
-  # rubocop:disable Metrics/AbcSize
   def ial2_attributes
     phone = stringify_attr(ial2_data.phone)
 
@@ -45,7 +44,6 @@ class OpenidConnectUserInfoPresenter
       phone_verified: phone.present? ? true : nil,
     }
   end
-  # rubocop:enable Metrics/AbcSize
 
   def x509_attributes
     {

--- a/app/services/acuant/acuant_client.rb
+++ b/app/services/acuant/acuant_client.rb
@@ -33,7 +33,6 @@ module Acuant
       merge_facial_match_and_liveness_response(facial_match_response, liveness_response)
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def post_images(front_image:, back_image:, selfie_image:,
                     liveness_checking_enabled: nil, instance_id: nil)
       document = create_document
@@ -58,7 +57,6 @@ module Acuant
         results
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def get_results(instance_id:)
       Requests::GetResultsRequest.new(instance_id: instance_id).fetch

--- a/app/services/acuant/request.rb
+++ b/app/services/acuant/request.rb
@@ -56,7 +56,6 @@ module Acuant
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def faraday_connection
       retry_options = {
         max: 2,
@@ -78,7 +77,6 @@ module Acuant
         conn.request :retry, retry_options
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def faraday_request_params
       timeout = Figaro.env.acuant_timeout&.to_i || 45

--- a/app/services/acuant/requests/create_document_request.rb
+++ b/app/services/acuant/requests/create_document_request.rb
@@ -9,7 +9,6 @@ module Acuant
         super().merge 'Content-Type' => 'application/json'
       end
 
-      # rubocop:disable Metrics/MethodLength
       def body
         {
           AuthenticationSensitivity: 0,
@@ -31,7 +30,6 @@ module Acuant
           SubscriptionId: Figaro.env.acuant_assure_id_subscription_id,
         }.to_json
       end
-      # rubocop:enable Metrics/MethodLength
 
       def handle_http_response(response)
         Responses::CreateDocumentResponse.new(response)

--- a/app/services/acuant/result_codes.rb
+++ b/app/services/acuant/result_codes.rb
@@ -26,7 +26,7 @@ module Acuant
       ATTENTION,
     ].freeze
 
-    BY_CODE = ALL.map { |r| [r.code, r] }.to_h.freeze
+    BY_CODE = ALL.index_by(&:code).freeze
 
     # @return [ResultCode]
     def self.from_int(code)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -74,7 +74,7 @@ class Analytics
     }
   end
 
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   ACCOUNT_RESET = 'Account Reset'.freeze
   ACCOUNT_DELETE_SUBMITTED = 'Account Delete submitted'.freeze
   ACCOUNT_DELETE_VISITED = 'Account Delete visited'.freeze
@@ -217,5 +217,5 @@ class Analytics
   WEBAUTHN_SETUP_VISIT = 'WebAuthn Setup Visited'.freeze
 end
 # rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength
 # rubocop:enable Metrics/ClassLength

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class Analytics
   def initialize(user:, request:, sp:, ahoy: nil)
     @user = user
@@ -60,7 +59,6 @@ class Analytics
     @browser ||= DeviceDetector.new(request.user_agent)
   end
 
-  # rubocop:disable Metrics/AbcSize
   def browser_attributes
     {
       user_agent: request.user_agent,
@@ -216,6 +214,4 @@ class Analytics
   WEBAUTHN_DELETED = 'WebAuthn Deleted'.freeze
   WEBAUTHN_SETUP_VISIT = 'WebAuthn Setup Visited'.freeze
 end
-# rubocop:enable Metrics/AbcSize
 # rubocop:enable Layout/LineLength
-# rubocop:enable Metrics/ClassLength

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -1,7 +1,6 @@
 require 'stringex/unidecoder'
 require 'stringex/core_ext'
 
-# rubocop:disable Metrics/ClassLength
 class AttributeAsserter
   VALID_ATTRIBUTES = %i[
     first_name
@@ -25,7 +24,7 @@ class AttributeAsserter
     self.decrypted_pii = decrypted_pii
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def build
     attrs = default_attrs
     add_email(attrs) if bundle.include? :email
@@ -34,7 +33,7 @@ class AttributeAsserter
     add_aal(attrs) if authn_request.requested_aal_authn_context || !service_provider.aal.nil?
     user.asserted_attributes = attrs
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   private
 
@@ -127,4 +126,3 @@ class AttributeAsserter
     bundle.include?(:ascii)
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/binary_search_sorted_hash_file.rb
+++ b/app/services/binary_search_sorted_hash_file.rb
@@ -5,8 +5,6 @@ class BinarySearchSortedHashFile
     @file_name = file_name
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def call(password)
     key = Digest::SHA1.hexdigest(password).upcase
     min = 0
@@ -29,6 +27,4 @@ class BinarySearchSortedHashFile
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/services/db/identity/sp_active_user_counts.rb
+++ b/app/services/db/identity/sp_active_user_counts.rb
@@ -1,7 +1,6 @@
 module Db
   module Identity
     class SpActiveUserCounts
-      # rubocop:disable Metrics/MethodLength
       def self.call(start)
         params = {
           start: ActiveRecord::Base.connection.quote(start),
@@ -34,7 +33,6 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/db/identity/sp_user_quotas.rb
+++ b/app/services/db/identity/sp_user_quotas.rb
@@ -1,7 +1,6 @@
 module Db
   module Identity
     class SpUserQuotas
-      # rubocop:disable Metrics/MethodLength
       def self.call(start_date)
         sql = <<~SQL
           SELECT
@@ -27,7 +26,6 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/db/sp_cost/total_sp_cost_summary.rb
+++ b/app/services/db/sp_cost/total_sp_cost_summary.rb
@@ -1,7 +1,6 @@
 module Db
   module SpCost
     class TotalSpCostSummary
-      # rubocop:disable Metrics/MethodLength
       def self.call(start, finish)
         params = {
           start: ActiveRecord::Base.connection.quote(start),
@@ -16,7 +15,6 @@ module Db
         SQL
         ActiveRecord::Base.connection.execute(sql)
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/services/doc_auth_mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth_mock/doc_auth_mock_client.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Lint/UnusedMethodArgument, Metrics/ClassLength
+# rubocop:disable Lint/UnusedMethodArgument
 module DocAuthMock
   class DocAuthMockClient
     class << self
@@ -48,7 +48,6 @@ module DocAuthMock
       Acuant::Response.new(success: true)
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def post_images(front_image:, back_image:, selfie_image:,
                     liveness_checking_enabled: nil, instance_id: nil)
       return mocked_response_for_method(__method__) if method_mocked?(__method__)
@@ -73,7 +72,6 @@ module DocAuthMock
         results
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def get_results(instance_id:)
       return mocked_response_for_method(__method__) if method_mocked?(__method__)
@@ -133,4 +131,4 @@ module DocAuthMock
     end
   end
 end
-# rubocop:enable Lint/UnusedMethodArgument, Metrics/ClassLength
+# rubocop:enable Lint/UnusedMethodArgument

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -1,7 +1,7 @@
 require 'base64'
 
 module Encryption
-  class KmsClient # rubocop:disable Metrics/ClassLength
+  class KmsClient
     include Encodable
 
     KEY_TYPE = {

--- a/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
+++ b/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
@@ -1,6 +1,5 @@
 module EventDisavowal
   class BuildDisavowedEventAnalyticsAttributes
-    # rubocop:disable MethodLength,
     def self.call(event)
       return {} if event.blank?
 
@@ -15,6 +14,5 @@ module EventDisavowal
         disavowed_device_last_used_at: device&.last_used_at,
       }
     end
-    # rubocop:enable MethodLength
   end
 end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -25,7 +25,6 @@ class HolidayService
     observed_holidays.any? { |oh| oh == date }
   end
 
-  # rubocop:disable Metrics/MethodLength
   def holidays
     [
       new_years,
@@ -40,7 +39,6 @@ class HolidayService
       christmas,
     ]
   end
-  # rubocop:enable Metrics/MethodLength
 
   def observed_holidays
     holidays.

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -64,7 +64,6 @@ class IdentityLinker
     }
   end
 
-  # rubocop:disable Metrics/MethodLength
   def optional_attributes(
     code_challenge: nil,
     ial: nil,
@@ -87,7 +86,6 @@ class IdentityLinker
       hash[:deleted_at] = nil if clear_deleted_at
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def merge_attributes(verified_attributes)
     verified_attributes = verified_attributes.to_a.map(&:to_s)

--- a/app/services/idv/proofer.rb
+++ b/app/services/idv/proofer.rb
@@ -68,7 +68,7 @@ module Idv
 
       def require_mock_vendors_if_enabled
         return unless mock_fallback_enabled?
-        Dir[Rails.root.join('lib', 'proofer_mocks', '*')].each { |file| require file }
+        Dir[Rails.root.join('lib', 'proofer_mocks', '*')].sort.each { |file| require file }
       end
 
       def mock_fallback_enabled?

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -1,5 +1,5 @@
 module Idv
-  class Session # rubocop:disable Metrics/ClassLength
+  class Session
     VALID_SESSION_ATTRIBUTES = %i[
       async_result_id
       async_result_started_at

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module Idv
   module Steps
     class DocAuthBaseStep < Flow::BaseStep
@@ -188,5 +187,3 @@ module Idv
     end
   end
 end
-
-# rubocop:enable Metrics/ClassLength

--- a/app/services/pii/fingerprinter.rb
+++ b/app/services/pii/fingerprinter.rb
@@ -5,7 +5,7 @@ module Pii
     end
 
     def self.fingerprint(text, key = current_key)
-      digest = OpenSSL::Digest::SHA256.new
+      digest = OpenSSL::Digest.new('SHA256')
       OpenSSL::HMAC.hexdigest(digest, key, text)
     end
 

--- a/app/services/push_notification/account_delete.rb
+++ b/app/services/push_notification/account_delete.rb
@@ -48,7 +48,6 @@ module PushNotification
 
     # Payload format per
     # https://openid.net/specs/openid-risc-event-types-1_0-ID1.html#account-purged
-    # rubocop:disable Metrics/MethodLength
     def build_payload(issuer, push_notification_url, uuid)
       iat = Time.zone.now.to_i
       {
@@ -68,7 +67,6 @@ module PushNotification
         },
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     def post_to_push_notification_url(push_to_url, payload)
       adapter = faraday_adapter(push_to_url)

--- a/app/services/reports/doc_auth_drop_off_rates_report.rb
+++ b/app/services/reports/doc_auth_drop_off_rates_report.rb
@@ -1,6 +1,5 @@
 require 'login_gov/hostdata'
 
-# rubocop:disable Metrics/ClassLength
 module Reports
   class DocAuthDropOffRatesReport < BaseReport
     REPORT_NAME = 'doc-auth-drop-off-rates-report'.freeze
@@ -122,4 +121,3 @@ module Reports
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -5,7 +5,6 @@ class ServiceProviderSeeder
     @deploy_env = deploy_env
   end
 
-  # rubocop:disable Metrics/MethodLength
   def run
     service_providers.each do |issuer, config|
       next unless write_service_provider?(config)
@@ -20,7 +19,6 @@ class ServiceProviderSeeder
                                 'native'))
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -24,7 +24,6 @@ class ServiceProviderSeeder
 
   attr_reader :rails_env, :deploy_env
 
-  # rubocop:disable Metrics/AbcSize
   def service_providers
     file = remote_setting || Rails.root.join('config', 'service_providers.yml').read
     content = ERB.new(file).result
@@ -36,7 +35,6 @@ class ServiceProviderSeeder
     Rails.logger.error { "Missing env in service_providers.yml?: #{key_error.message}" }
     raise key_error
   end
-  # rubocop:enable Metrics/AbcSize
 
   def remote_setting
     RemoteSetting.find_by(name: 'service_providers.yml')&.contents

--- a/app/services/store_sp_metadata_in_session.rb
+++ b/app/services/store_sp_metadata_in_session.rb
@@ -32,7 +32,6 @@ class StoreSpMetadataInSession
     @sp_request ||= ServiceProviderRequestProxy.from_uuid(request_id)
   end
 
-  # rubocop:disable Metrics/AbcSize
   def update_session
     session[:sp] = {
       issuer: sp_request.issuer,
@@ -46,7 +45,6 @@ class StoreSpMetadataInSession
       requested_attributes: sp_request.requested_attributes,
     }
   end
-  # rubocop:enable Metrics/AbcSize
 
   def aal_requested
     Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[sp_request.aal]

--- a/app/services/usps_confirmation_exporter.rb
+++ b/app/services/usps_confirmation_exporter.rb
@@ -28,7 +28,7 @@ class UspsConfirmationExporter
     [HEADER_ROW_ID, num_entries]
   end
 
-  # rubocop:disable MethodLength, AbcSize
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def make_entry_row(entry)
     now = current_date
     due = now + OTP_MAX_VALID_DAYS.days
@@ -49,7 +49,7 @@ class UspsConfirmationExporter
       "https://#{Figaro.env.domain_name}",
     ]
   end
-  # rubocop:enable MethodLength, AbcSize
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def format_date(date)
     "#{date.strftime('%-B %-e')}, #{date.year}"

--- a/app/services/usps_confirmation_exporter.rb
+++ b/app/services/usps_confirmation_exporter.rb
@@ -28,7 +28,6 @@ class UspsConfirmationExporter
     [HEADER_ROW_ID, num_entries]
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def make_entry_row(entry)
     now = current_date
     due = now + OTP_MAX_VALID_DAYS.days
@@ -49,7 +48,6 @@ class UspsConfirmationExporter
       "https://#{Figaro.env.domain_name}",
     ]
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def format_date(date)
     "#{date.strftime('%-B %-e')}, #{date.year}"

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -22,7 +22,6 @@ class UspsConfirmationMaker
 
   attr_reader :pii, :issuer, :profile
 
-  # rubocop:disable Metrics/AbcSize
   # This method is single statement spread across many lines for readability
   def attributes
     {
@@ -37,7 +36,6 @@ class UspsConfirmationMaker
       issuer: issuer,
     }
   end
-  # rubocop:enable Metrics/AbcSize
 
   def generate_otp
     # Crockford encoding is 5 bits per character

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -22,7 +22,7 @@ class UspsConfirmationMaker
 
   attr_reader :pii, :issuer, :profile
 
-  # rubocop:disable AbcSize, MethodLength
+  # rubocop:disable AbcSize
   # This method is single statement spread across many lines for readability
   def attributes
     {
@@ -37,7 +37,7 @@ class UspsConfirmationMaker
       issuer: issuer,
     }
   end
-  # rubocop:enable AbcSize, MethodLength
+  # rubocop:enable AbcSize
 
   def generate_otp
     # Crockford encoding is 5 bits per character

--- a/app/services/usps_confirmation_maker.rb
+++ b/app/services/usps_confirmation_maker.rb
@@ -22,7 +22,7 @@ class UspsConfirmationMaker
 
   attr_reader :pii, :issuer, :profile
 
-  # rubocop:disable AbcSize
+  # rubocop:disable Metrics/AbcSize
   # This method is single statement spread across many lines for readability
   def attributes
     {
@@ -37,7 +37,7 @@ class UspsConfirmationMaker
       issuer: issuer,
     }
   end
-  # rubocop:enable AbcSize
+  # rubocop:enable Metrics/AbcSize
 
   def generate_otp
     # Crockford encoding is 5 bits per character

--- a/app/view_models/account_show.rb
+++ b/app/view_models/account_show.rb
@@ -1,4 +1,4 @@
-class AccountShow # rubocop:disable Metrics/ClassLength
+class AccountShow
   attr_reader :decorated_user, :decrypted_pii, :personal_key, :locked_for_session, :pii
 
   def initialize(decrypted_pii:, personal_key:, decorated_user:, locked_for_session:)

--- a/app/view_models/sign_up_completions_show.rb
+++ b/app/view_models/sign_up_completions_show.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class SignUpCompletionsShow
   include ActionView::Helpers::TagHelper
 
@@ -140,4 +139,3 @@ class SignUpCompletionsShow
     user_verified? ? 'ial2' : 'ial1'
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,10 +4,8 @@ ENV['RAILS_ENV'] ||= 'production'.freeze if File.exist?('/etc/login.gov/info/dom
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-# rubocop:disable Lint/HandleExceptions
 begin
   require 'bootsnap/setup' if ENV['RAILS_ENV'] != 'production' && ENV['ENABLE_BOOTSNAP'] != 'false'
 rescue LoadError
   # bootsnap is only for dev/test
 end
-# rubocop:enable Lint/HandleExceptions

--- a/config/initializers/idv_proofer.rb
+++ b/config/initializers/idv_proofer.rb
@@ -1,2 +1,2 @@
-Dir[Rails.root.join('lib', 'proofer_mocks', '*')].each { |file| require file }
+Dir[Rails.root.join('lib', 'proofer_mocks', '*')].sort.each { |file| require file }
 Idv::Proofer.validate_vendors!

--- a/lib/deploy/activate.rb
+++ b/lib/deploy/activate.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/AbcSize, Metrics/ClassLength, Metrics/MethodLength
-
 require 'active_support/core_ext/hash/deep_merge'
 require 'logger'
 require 'login_gov/hostdata'
@@ -166,4 +164,3 @@ module Deploy
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/ClassLength, Metrics/MethodLength

--- a/lib/tasks/remote_settings.rake
+++ b/lib/tasks/remote_settings.rake
@@ -22,9 +22,9 @@ namespace :remote_settings do
   end
 end
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 # example invocations:
 # rake "remote_settings:update[agencies.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/agencies.yml]"
 # rake "remote_settings:update[agencies.yml,https://login.gov/assets/idp/config/agencies.yml"
 # rake "remote_settings:update[service_providers.yml,https://raw.githubusercontent.com/18F/identity-idp/master/config/service_providers.yml]"
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,8 +1,8 @@
-namespace :test do
+namespace test: :environment do
   # Use `> log/test.log` to empty test.log before re-running tests to get an accurate list
   # Note you must run tests with `COVERAGE=true` to generate scannable logs.
   desc 'Scan test.log for rendered views and show gaps in test coverage'
-  task :scan_log_for_view_coverage do
+  task scan_log_for_view_coverage: :environment do
     # match lines like 'Rendered two_factor_authentication/otp_verification/show.html.erb'
     # Rendered + space + word + [/ + non-whitespace](any number of times).html(.erb|.slim|'')
     regex_finder = %r{Rendered\s\w*(/\S*)*\.html(\.slim|\.erb|)}

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,4 +1,4 @@
-namespace test: :environment do
+namespace :test do
   # Use `> log/test.log` to empty test.log before re-running tests to get an accurate list
   # Note you must run tests with `COVERAGE=true` to generate scannable logs.
   desc 'Scan test.log for rendered views and show gaps in test coverage'

--- a/lib/tasks/user_flows.rake
+++ b/lib/tasks/user_flows.rake
@@ -1,5 +1,5 @@
 unless Rails.env.production?
-  namespace :spec do
+  namespace spec: :environment do
     desc 'Executes user flow specs'
     RSpec::Core::RakeTask.new('user_flows') do |t|
       t.rspec_opts = %w[--tag user_flow
@@ -9,7 +9,7 @@ unless Rails.env.production?
     end
 
     desc 'Exports user flows for the web'
-    task 'user_flows:web' do
+    task 'user_flows:web' => :environment do
       ENV['RAILS_DISABLE_ASSET_DIGEST'] = 'true'
       require './lib/user_flow_exporter'
       Rake::Task['spec:user_flows'].invoke

--- a/lib/tasks/user_flows.rake
+++ b/lib/tasks/user_flows.rake
@@ -1,5 +1,5 @@
 unless Rails.env.production?
-  namespace spec: :environment do
+  namespace :spec do
     desc 'Executes user flow specs'
     RSpec::Core::RakeTask.new('user_flows') do |t|
       t.rspec_opts = %w[--tag user_flow

--- a/scripts/check-assets
+++ b/scripts/check-assets
@@ -3,4 +3,3 @@ $LOAD_PATH.unshift(File.expand_path('../lib', File.dirname(__FILE__)))
 require 'asset_checker'
 
 exit(AssetChecker.check_files(ARGV) ? 1 : 0)
-

--- a/spec/controllers/health/job_controller_spec.rb
+++ b/spec/controllers/health/job_controller_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
 
-# rubocop:disable Style/BracesAroundHashParameters
-
 RSpec.describe Health::JobsController do
   describe '#index' do
     subject(:action) { get :index }
@@ -45,5 +43,3 @@ RSpec.describe Health::JobsController do
     end
   end
 end
-
-# rubocop:enable Style/BracesAroundHashParameters

--- a/spec/controllers/saml_signed_message_spec.rb
+++ b/spec/controllers/saml_signed_message_spec.rb
@@ -32,7 +32,7 @@ describe SamlIdpController do
           expect(signature_count).to eq 2
         end
 
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         it 'finds a Signature referencing the Response' do
           response_id = REXML::XPath.match(saml_response, '//samlp:Response').first.attributes['ID']
           signature_ref = REXML::XPath.match(saml_response, '//ds:Reference').first.attributes['URI'][1..-1]
@@ -58,7 +58,7 @@ describe SamlIdpController do
 
           expect(signature_ref).to eq assertion_id
         end
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
     end
   end

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe Voice::OtpController do
       end
 
       it 'includes the otp expiration in the message' do
-        locale = :en # rubocop:disable Lint/UselessAssignment
         allow(Devise).to receive(:direct_otp_valid_for).and_return(4.minutes)
 
         action

--- a/spec/features/remember_device/user_opted_preference.rb
+++ b/spec/features/remember_device/user_opted_preference.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 
 describe 'Unchecking remember device' do
   describe '2fa setup' do
@@ -155,4 +155,4 @@ describe 'Unchecking remember device' do
     end
   end
 end
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,7 @@ ActiveRecord::Migration.maintain_test_schema!
 # run twice. It is recommended that you do not name files matching this glob to
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false

--- a/spec/services/acuant/request_spec.rb
+++ b/spec/services/acuant/request_spec.rb
@@ -76,7 +76,6 @@ describe Acuant::Request do
       end
     end
 
-    # rubocop:disable Style/BracesAroundHashParameters
     context 'when the request resolves with retriable error then succeeds it only retries once' do
       it 'calls New Relic notice_error each retry' do
         allow(subject).to receive(:handle_http_response) do |http_response|
@@ -164,7 +163,6 @@ describe Acuant::Request do
         expect(response.success?).to eq(false)
       end
     end
-    # rubocop:enable Style/BracesAroundHashParameters
 
     context 'when the request times out' do
       it 'returns a response with a timeout message and exception and notifies NewRelic' do

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -22,7 +22,7 @@ describe Encryption::KmsClient do
         and_return(plaintext)
     end
     allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
-    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Metrics/LineLength
+    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Layout/LineLength
     allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
   end
 

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -8,7 +8,7 @@ describe Encryption::MultiRegionKMSClient do
     )
 
     allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
-    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Metrics/LineLength
+    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Layout/LineLength
   end
 
   let(:first_plaintext) { 'a' * 3000 }

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -24,7 +24,7 @@ describe SendSignUpEmailConfirmation do
       email_address.update!(confirmed_at: Time.zone.now)
       mail = double
       expect(mail).to receive(:deliver_later)
-      expect(UserMailer). to receive(:email_confirmation_instructions).with(
+      expect(UserMailer).to receive(:email_confirmation_instructions).with(
         user,
         email_address.email,
         confirmation_token,
@@ -39,7 +39,7 @@ describe SendSignUpEmailConfirmation do
       it 'sends an email with a link to try another email if the current email is unconfirmed' do
         mail = double
         expect(mail).to receive(:deliver_later)
-        expect(UserMailer). to receive(:unconfirmed_email_instructions).with(
+        expect(UserMailer).to receive(:unconfirmed_email_instructions).with(
           user,
           email_address.email,
           confirmation_token,
@@ -80,7 +80,7 @@ describe SendSignUpEmailConfirmation do
 
         mail = double
         expect(mail).to receive(:deliver_later)
-        expect(UserMailer). to receive(:email_confirmation_instructions).with(
+        expect(UserMailer).to receive(:email_confirmation_instructions).with(
           user, email_address.email, confirmation_token, instance_of(Hash)
         ).and_return(mail)
 

--- a/spec/services/service_provider_seeder_spec.rb
+++ b/spec/services/service_provider_seeder_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe ServiceProviderSeeder do
       end
     end
 
-    # rubocop:disable Lint/HandleExceptions
     context 'when there is a syntax error in the service_provider.yml config file' do
       let(:seeder) do
         ServiceProviderSeeder.new
@@ -186,6 +185,5 @@ RSpec.describe ServiceProviderSeeder do
         expect { seeder.send(:service_providers) }.to raise_error(KeyError)
       end
     end
-    # rubocop:enable Lint/HandleExceptions
   end
 end

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -51,9 +51,9 @@ module IdvStepHelper
   end
 
   alias complete_idv_steps_before_review_step complete_idv_steps_with_phone_before_review_step
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   alias complete_idv_steps_before_confirmation_step complete_idv_steps_with_phone_before_confirmation_step
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   def complete_idv_steps_with_usps_before_review_step(user = user_with_2fa)
     complete_idv_steps_before_usps_step(user)

--- a/spec/support/saml_response_doc.rb
+++ b/spec/support/saml_response_doc.rb
@@ -1,6 +1,6 @@
 require_relative 'saml_auth_helper'
 
-class SamlResponseDoc # rubocop:disable Metrics/ClassLength
+class SamlResponseDoc
   include SamlAuthHelper
 
   attr_reader :original_encrypted


### PR DESCRIPTION
- Makes rubocop consistent locally and in CI
- Updates rubocop and rubocop-rails
  - Where new rules were added, I weighed how many changes I'd have to make when enabling/disabling
- Disabled MethodLength, ClassLength, and AbcSize based on how often they get disabled manually:

```
# how many times each has a rubocop: disable
  26 Metrics/ClassLength
  15 Metrics/AbcSize
  11 Metrics/MethodLength
   8 Layout/LineLength
   7 Rails/SkipsModelValidations
   4 Metrics/BlockLength
   2 Style/GuardClause
   2 Rails/TimeZone
   2 Rails/OutputSafety
   2 Rails/Output
   2 Rails/LexicallyScopedActionFilter
   2 Rails/HasManyOrHasOneDependent
   2 Metrics/ModuleLength
   1 all
   1 Style/WordArray
   1 Style/TrailingCommaInHashLiteral
   1 Style/GlobalVars
   1 Rails/UniqueValidationWithoutIndex
   1 Rails/HelperInstanceVariable
   1 Rails/Date
   1 Rails/Blank
   1 Rails/ApplicationJob
   1 Naming/AccessorMethodName
   1 Metrics/PerceivedComplexity
   1 Metrics/CyclomaticComplexity
   1 Lint/UnusedMethodArgument
```