### PR TITLE
Show app name instead of agency name on SP handoff page (LG-3172)

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -102,10 +102,6 @@ class ServiceProviderSessionDecorator # rubocop:disable Metrics/ClassLength
     sp.friendly_name || sp.agency
   end
 
-  def sp_agency
-    sp.agency || sp.friendly_name
-  end
-
   def sp_return_url
     if sp.redirect_uris.present? && valid_oidc_request?
       URIService.add_params(

--- a/app/decorators/session_decorator.rb
+++ b/app/decorators/session_decorator.rb
@@ -45,8 +45,6 @@ class SessionDecorator
 
   def sp_name; end
 
-  def sp_agency; end
-
   def sp_logo; end
 
   def sp_logo_url; end

--- a/app/views/sign_up/completions/_show_sp.html.erb
+++ b/app/views/sign_up/completions/_show_sp.html.erb
@@ -1,7 +1,7 @@
 <p class="sm-mr1 sm-ml1 mt3 mb3">
   <%= t('help_text.requested_attributes.intro_html',
       app_name: APP_NAME,
-      sp: content_tag(:strong, decorated_session.sp_agency)) %>
+      sp: content_tag(:strong, decorated_session.sp_name)) %>
 </p>
 <div class='sm-ml1 sm-mr1' >
   <%= render @view_model.requested_attributes_partial, view_model: @view_model %>
@@ -9,7 +9,7 @@
 <p class="sm-mr1 sm-ml1 mt3 mb3">
   <%= t('help_text.requested_attributes.outro_html',
         app_name: APP_NAME,
-        sp: content_tag(:strong, decorated_session.sp_agency)) %>
+        sp: content_tag(:strong, decorated_session.sp_name)) %>
 </p>
 <p>
   <div class="center">

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -92,25 +92,6 @@ RSpec.describe ServiceProviderSessionDecorator do
     end
   end
 
-  describe '#sp_agency' do
-    it 'returns the SP agency if present' do
-      expect(subject.sp_agency).to eq sp.agency
-      expect(subject.sp_agency).to_not be_nil
-    end
-
-    it 'returns the friendly name if the agency is not present' do
-      sp = build_stubbed(:service_provider, friendly_name: 'friend', agency: nil)
-      subject = ServiceProviderSessionDecorator.new(
-        sp: sp,
-        view_context: view_context,
-        sp_session: {},
-        service_provider_request: ServiceProviderRequestProxy.new,
-      )
-      expect(subject.sp_agency).to eq sp.friendly_name
-      expect(subject.sp_agency).to_not be_nil
-    end
-  end
-
   describe '#sp_logo' do
     context 'service provider has a logo' do
       it 'returns the logo' do

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -43,9 +43,58 @@ describe 'sign_up/completions/show.html.erb' do
       )
       create_identities(@user)
     end
+
     it 'informs user they are logging into an SP for the first time' do
       render
       expect(rendered).to have_content(t('titles.sign_up.new_sp'))
+    end
+  end
+
+  context 'signing in through an SP' do
+    let(:service_provider) do
+      create(:service_provider,
+        friendly_name: 'My Agency App',
+        agency: 'Department of Agencies',
+      )
+    end
+
+    let(:view_context) { ActionController::Base.new.view_context }
+    let(:decorated_session) do
+      ServiceProviderSessionDecorator.new(
+        sp: service_provider,
+        view_context: view_context,
+        sp_session: {
+          requested_attributes: [:email],
+        },
+        service_provider_request: ServiceProviderRequestProxy.new,
+      )
+    end
+
+    before do
+      @user.save!
+      @view_model = SignUpCompletionsShow.new(
+        current_user: @user,
+        ial2_requested: false,
+        decorated_session: decorated_session,
+        handoff: true,
+        ialmax_requested: false,
+        consent_has_expired: false,
+      )
+      IdentityLinker.new(@user, service_provider.issuer).link_identity
+      allow(view).to receive(:decorated_session).and_return(decorated_session)
+      assign(:pii, {})
+    end
+
+
+    it 'shows the app name, not the agency name' do
+      render
+
+      text = view_context.strip_tags(rendered)
+      expect(text).to include('My Agency App')
+      expect(text).to_not include('Department of Agencies')
+      expect(text).to include(
+        I18n.t('help_text.requested_attributes.intro_html', app_name: APP_NAME, sp: 'My Agency App')
+      )
     end
   end
 

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -53,9 +53,8 @@ describe 'sign_up/completions/show.html.erb' do
   context 'signing in through an SP' do
     let(:service_provider) do
       create(:service_provider,
-        friendly_name: 'My Agency App',
-        agency: 'Department of Agencies',
-      )
+             friendly_name: 'My Agency App',
+             agency: 'Department of Agencies')
     end
 
     let(:view_context) { ActionController::Base.new.view_context }
@@ -84,16 +83,14 @@ describe 'sign_up/completions/show.html.erb' do
       assign(:pii, {})
     end
 
-
     it 'shows the app name, not the agency name' do
       render
 
       text = view_context.strip_tags(rendered)
       expect(text).to include('My Agency App')
       expect(text).to_not include('Department of Agencies')
-      expect(text).to include(
-        I18n.t('help_text.requested_attributes.intro_html', app_name: APP_NAME, sp: 'My Agency App')
-      )
+      expect(text).to include(I18n.t('help_text.requested_attributes.intro_html',
+                                     app_name: APP_NAME, sp: 'My Agency App'))
     end
   end
 

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -80,7 +80,6 @@ describe 'sign_up/completions/show.html.erb' do
         ialmax_requested: false,
         consent_has_expired: false,
       )
-      IdentityLinker.new(@user, service_provider.issuer).link_identity
       allow(view).to receive(:decorated_session).and_return(decorated_session)
       assign(:pii, {})
     end


### PR DESCRIPTION
**Before**

<img width="400" alt="Screen Shot 2020-08-12 at 1 07 43 PM" src="https://user-images.githubusercontent.com/458784/90062776-0a5c0380-dc9d-11ea-8c0e-eadae4953626.png">

**After**

<img width="400" alt="Screen Shot 2020-08-12 at 1 08 08 PM" src="https://user-images.githubusercontent.com/458784/90062760-04feb900-dc9d-11ea-84d5-daec0daf66ff.png">
