### PR TITLE
LG-3286: Show timely error messages for React document capture

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,5 +51,13 @@
       "app/i18n-dropdown"
     ],
     "import/internal-regex": "^@18f/identity-"
-  }
+  },
+  "overrides": [
+    {
+      "files": "spec/javascripts/**/*",
+      "rules": {
+        "react/jsx-props-no-spreading": "off"
+      }
+    }
+  ]
 }

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -19,11 +19,18 @@ import DataURLFile from '../models/data-url-file';
  */
 
 /**
- * The minimal glare score value to be considered acceptable.
+ * The minimum glare score value to be considered acceptable.
  *
  * @type {number}
  */
 const ACCEPTABLE_GLARE_SCORE = 50;
+
+/**
+ * The minimum sharpness score value to be considered acceptable.
+ *
+ * @type {number}
+ */
+const ACCEPTABLE_SHARPNESS_SCORE = 50;
 
 /**
  * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK
@@ -80,6 +87,8 @@ function AcuantCapture({ label, bannerText, value, onChange = () => {}, classNam
             onImageCaptureSuccess={(nextCapture) => {
               if (nextCapture.glare < ACCEPTABLE_GLARE_SCORE) {
                 setOwnError(t('errors.doc_auth.photo_glare'));
+              } else if (nextCapture.sharpness < ACCEPTABLE_SHARPNESS_SCORE) {
+                setOwnError(t('errors.doc_auth.photo_blurry'));
               } else {
                 onChange(new DataURLFile(nextCapture.image.data));
               }

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -106,7 +106,7 @@ function AcuantCapture({ label, bannerText, value, onChange = () => {}, classNam
         bannerText={bannerText}
         accept={['image/*']}
         value={value}
-        errors={ownError ? [ownError] : undefined}
+        error={ownError}
         onClick={startCaptureOrTriggerUpload}
         onChange={onChange}
       />

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -18,9 +18,12 @@ import DataURLFile from '../models/data-url-file';
  * @prop {(nextValue:DataURLFile)=>void} onChange              Callback receiving next value on
  *                                                             change.
  * @prop {string=}                       className             Optional additional class names.
- * @prop {number=}                       minimumGlareScore
- * @prop {number=}                       minimumSharpnessScore
- * @prop {number=}                       minimumFileSize
+ * @prop {number=}                       minimumGlareScore     Minimum glare score to be considered
+ *                                                             acceptable.
+ * @prop {number=}                       minimumSharpnessScore Minimum sharpness score to be
+ *                                                             considered acceptable.
+ * @prop {number=}                       minimumFileSize       Minimum file size (in bytes) to be
+ *                                                             considered acceptable.
  */
 
 /**

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -60,9 +60,10 @@ const DEFAULT_ACCEPTABLE_SHARPNESS_SCORE = 50;
  *
  * @type {number}
  */
-const DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES = process.env.ACUANT_MINIMUM_FILE_SIZE
-  ? Number(process.env.ACUANT_MINIMUM_FILE_SIZE)
-  : 500 * 1024;
+const DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES =
+  process.env.ACUANT_MINIMUM_FILE_SIZE === undefined
+    ? 500 * 1024
+    : Number(process.env.ACUANT_MINIMUM_FILE_SIZE);
 
 /**
  * Returns an element serving as an enhanced FileInput, supporting direct capture using Acuant SDK

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -11,19 +11,19 @@ import DataURLFile from '../models/data-url-file';
 /**
  * @typedef AcuantCaptureProps
  *
- * @prop {string}                        label                 Label associated with file input.
- * @prop {string=}                       bannerText            Optional banner text to show in file
- *                                                             input.
- * @prop {DataURLFile=}                  value                 Current value.
- * @prop {(nextValue:DataURLFile)=>void} onChange              Callback receiving next value on
- *                                                             change.
- * @prop {string=}                       className             Optional additional class names.
- * @prop {number=}                       minimumGlareScore     Minimum glare score to be considered
- *                                                             acceptable.
- * @prop {number=}                       minimumSharpnessScore Minimum sharpness score to be
- *                                                             considered acceptable.
- * @prop {number=}                       minimumFileSize       Minimum file size (in bytes) to be
- *                                                             considered acceptable.
+ * @prop {string}                         label                 Label associated with file input.
+ * @prop {string=}                        bannerText            Optional banner text to show in file
+ *                                                              input.
+ * @prop {DataURLFile=}                   value                 Current value.
+ * @prop {(nextValue:DataURLFile?)=>void} onChange              Callback receiving next value on
+ *                                                              change.
+ * @prop {string=}                        className             Optional additional class names.
+ * @prop {number=}                        minimumGlareScore     Minimum glare score to be considered
+ *                                                              acceptable.
+ * @prop {number=}                        minimumSharpnessScore Minimum sharpness score to be
+ *                                                              considered acceptable.
+ * @prop {number=}                        minimumFileSize       Minimum file size (in bytes) to be
+ *                                                              considered acceptable.
  */
 
 /**
@@ -116,10 +116,10 @@ function AcuantCapture({
    * for common checks derived from DataURLFile properties (file size, etc). If invalid, error state
    * is assigned with appropriate error message.
    *
-   * @param {DataURLFile} nextValue Next value candidate.
+   * @param {DataURLFile?} nextValue Next value candidate.
    */
   function onChangeIfValid(nextValue) {
-    if (getDataURLFileSize(nextValue.data) < minimumFileSize) {
+    if (nextValue && getDataURLFileSize(nextValue.data) < minimumFileSize) {
       setOwnError(t('errors.doc_auth.photo_file_size'));
     } else {
       setOwnError(null);

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -12,14 +12,15 @@ import DataURLFile from '../models/data-url-file';
 /**
  * @typedef FileInputProps
  *
- * @prop {string}                    label      Input label.
- * @prop {string=}                   hint       Optional hint text.
- * @prop {string=}                   bannerText Optional banner overlay text.
- * @prop {string[]=}                 accept     Optional array of file input accept patterns.
- * @prop {DataURLFile=}              value      Current value.
- * @prop {string[]=}                 errors     Errors to show.
- * @prop {(ReactMouseEvent)=>void=}  onClick    Input click handler.
- * @prop {(ReactChangeEvent)=>void=} onChange   Input change handler.
+ * @prop {string}                          label      Input label.
+ * @prop {string=}                         hint       Optional hint text.
+ * @prop {string=}                         bannerText Optional banner overlay text.
+ * @prop {string[]=}                       accept     Optional array of file input accept patterns.
+ * @prop {DataURLFile=}                    value      Current value.
+ * @prop {string[]=}                       errors     Errors to show.
+ * @prop {(event:ReactMouseEvent)=>void=}  onClick    Input click handler.
+ * @prop {(nextValue:DataURLFile?)=>void=} onChange   Input change handler.
+ * @prop {(message:string)=>void=}         onError    Callback to trigger if upload error occurs.
  */
 
 /**
@@ -118,6 +119,7 @@ const FileInput = forwardRef((props, ref) => {
     errors = [],
     onClick = () => {},
     onChange = () => {},
+    onError = () => {},
   } = props;
   const { t, formatHTML } = useI18n();
   const ifStillMounted = useIfStillMounted();
@@ -144,9 +146,10 @@ const FileInput = forwardRef((props, ref) => {
         toDataURL(file).then(ifStillMounted((data) => onChange(new DataURLFile(data, file.name))));
       } else {
         setOwnErrors((previousErrors) => [...previousErrors, t('errors.doc_auth.selfie')]);
+        onError(t('errors.doc_auth.selfie'));
       }
     } else {
-      onChange(file);
+      onChange(null);
     }
   }
 

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -27,6 +27,7 @@
 - doc_auth.tips.document_capture_selfie_text1
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
+- errors.doc_auth.photo_file_size
 - errors.doc_auth.photo_glare
 - errors.doc_auth.selfie
 - errors.messages.format_mismatch

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -27,6 +27,7 @@
 - doc_auth.tips.document_capture_selfie_text1
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
+- errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_file_size
 - errors.doc_auth.photo_glare
 - errors.doc_auth.selfie

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -61,6 +61,7 @@ en:
         </ul>
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
+      photo_blurry: Photo is too blurry, please try again.
       photo_glare: Photo has glare, please try again.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -62,6 +62,7 @@ en:
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
       photo_blurry: Photo is too blurry, please try again.
+      photo_file_size: Photo is too compressed, please try again with a higher quality.
       photo_glare: Photo has glare, please try again.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -61,7 +61,7 @@ en:
         </ul>
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
-      photo_glare: Photo has too much glare. Please try again.
+      photo_glare: Photo has glare, please try again.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.
       selfie: Sorry, your photo was not accepted. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -61,7 +61,7 @@ es:
         </ul>
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
-      photo_glare: La foto tiene demasiado brillo. Inténtalo de nuevo.
+      photo_glare: La foto tiene un resplandor. Vuelve a intentarlo.
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite
         de verificación de identidad. Póngase en contacto con su proveedor de servicios
         para obtener más información.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -62,6 +62,8 @@ es:
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
       photo_blurry: La foto está demasiado borrosa. Vuelve a intentarlo.
+      photo_file_size: La foto está demasiado comprimida. Vuelve a intentarlo con
+        una calidad superior.
       photo_glare: La foto tiene un resplandor. Vuelve a intentarlo.
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite
         de verificación de identidad. Póngase en contacto con su proveedor de servicios

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -61,6 +61,7 @@ es:
         </ul>
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
+      photo_blurry: La foto está demasiado borrosa. Vuelve a intentarlo.
       photo_glare: La foto tiene un resplandor. Vuelve a intentarlo.
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite
         de verificación de identidad. Póngase en contacto con su proveedor de servicios

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -62,6 +62,8 @@ fr:
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.
       photo_blurry: La photo est trop floue, veuillez réessayer.
+      photo_file_size: La photo est trop compressée, veuillez réessayer avec une qualité
+        supérieure.
       photo_glare: La photo a des reflets, veuillez réessayer.
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d'identité. Veuillez contacter votre fournisseur de services

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -61,7 +61,7 @@ fr:
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.
-      photo_glare: La photo est trop éblouissante. Veuillez réessayer.
+      photo_glare: La photo a des reflets, veuillez réessayer.
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d'identité. Veuillez contacter votre fournisseur de services
         pour plus d'informations.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -61,6 +61,7 @@ fr:
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.
+      photo_blurry: La photo est trop floue, veuillez réessayer.
       photo_glare: La photo a des reflets, veuillez réessayer.
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d'identité. Veuillez contacter votre fournisseur de services

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -150,6 +150,7 @@ describe('document-capture/components/acuant-capture', () => {
         start(onImageCaptureSuccess) {
           const capture = {
             glare: 70,
+            sharpness: 70,
             image: {
               data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
             },
@@ -269,6 +270,7 @@ describe('document-capture/components/acuant-capture', () => {
         start(onImageCaptureSuccess) {
           const capture = {
             glare: 38,
+            sharpness: 70,
             image: {
               data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
             },
@@ -282,6 +284,42 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
 
       const error = getByText('errors.doc_auth.photo_glare');
+
+      expect(error).to.be.ok();
+    });
+
+    it('renders error message if capture succeeds but photo is too blurry', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      window.AcuantJavascriptWebSdk = {
+        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
+      };
+      window.AcuantCamera = { isCameraSupported: true };
+      window.onAcuantSdkLoaded();
+      window.AcuantCameraUI = {
+        start(onImageCaptureSuccess) {
+          const capture = {
+            glare: 70,
+            sharpness: 38,
+            image: {
+              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+            },
+          };
+          onImageCaptureSuccess(capture);
+        },
+        end: sinon.spy(),
+      };
+
+      const button = getByText('doc_auth.buttons.take_picture');
+      fireEvent.click(button);
+
+      const error = getByText('errors.doc_auth.photo_blurry');
 
       expect(error).to.be.ok();
     });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -483,6 +483,27 @@ describe('document-capture/components/acuant-capture', () => {
     expect(container.firstChild.classList.contains('my-custom-class')).to.be.true();
   });
 
+  it('clears a selected value', () => {
+    const onChange = sinon.spy();
+    const { getByLabelText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture
+          label="Image"
+          value={
+            new DataURLFile('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E')
+          }
+          onChange={onChange}
+        />
+      </AcuantContextProvider>,
+    );
+
+    const input = getByLabelText('Image');
+    fireEvent.change(input, { target: { files: [] } });
+
+    expect(onChange.getCall(0).args).to.have.lengthOf(1);
+    expect(onChange.getCall(0).args).to.deep.equal([null]);
+  });
+
   it('does not show hint if capture is supported', () => {
     const { getByText } = render(
       <AcuantContextProvider sdkSrc="about:blank">

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -328,6 +328,26 @@ describe('document-capture/components/file-input', () => {
     expect(onError.getCall(0).args[0]).to.equal('errors.doc_auth.selfie');
   });
 
+  it('shows an error from rendering parent', () => {
+    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const onChange = sinon.stub();
+    const onError = sinon.stub();
+    const props = { label: 'File', accept: ['text/*'], onChange, onError };
+    const { getByLabelText, getByText, rerender } = render(<FileInput {...props} />);
+
+    const input = getByLabelText('File');
+    userEvent.upload(input, file);
+
+    expect(getByText('errors.doc_auth.selfie')).to.be.ok();
+    expect(onError.getCall(0).args[0]).to.equal('errors.doc_auth.selfie');
+
+    rerender(<FileInput {...props} error="Oops!" />);
+
+    expect(getByText('Oops!')).to.be.ok();
+    expect(() => getByText('errors.doc_auth.selfie')).to.throw();
+    expect(onError.callCount).to.equal(1);
+  });
+
   it('forwards ref', () => {
     const ref = createRef();
     render(<FileInput ref={ref} label="File" />);

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -316,14 +316,16 @@ describe('document-capture/components/file-input', () => {
   it('shows an error state', () => {
     const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();
+    const onError = sinon.stub();
     const { getByLabelText, getByText } = render(
-      <FileInput label="File" accept={['text/*']} onChange={onChange} />,
+      <FileInput label="File" accept={['text/*']} onChange={onChange} onError={onError} />,
     );
 
     const input = getByLabelText('File');
     userEvent.upload(input, file);
 
     expect(getByText('errors.doc_auth.selfie')).to.be.ok();
+    expect(onError.getCall(0).args[0]).to.equal('errors.doc_auth.selfie');
   });
 
   it('forwards ref', () => {

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -17,5 +17,7 @@ global.document = window.document;
 global.getComputedStyle = window.getComputedStyle;
 global.self = window;
 
+process.env.ACUANT_MINIMUM_FILE_SIZE = 0;
+
 useCleanDOM();
 useConsoleLogSpy();

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -17,7 +17,7 @@ global.document = window.document;
 global.getComputedStyle = window.getComputedStyle;
 global.self = window;
 
-process.env.ACUANT_MINIMUM_FILE_SIZE = 0;
+process.env.ACUANT_MINIMUM_FILE_SIZE = '0';
 
 useCleanDOM();
 useConsoleLogSpy();

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -1,10 +1,10 @@
 module DocAuthImageFixtures
   def self.document_front_image
-    load_image_fixture('id-front.jpg')
+    load_image_fixture('id-front.png')
   end
 
   def self.document_back_image
-    load_image_fixture('id-back.jpg')
+    load_image_fixture('id-back.png')
   end
 
   def self.document_face_image

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -1,10 +1,10 @@
 module DocAuthImageFixtures
   def self.document_front_image
-    load_image_fixture('id-front.png')
+    load_image_fixture('id-front.jpg')
   end
 
   def self.document_back_image
-    load_image_fixture('id-back.png')
+    load_image_fixture('id-back.jpg')
   end
 
   def self.document_face_image


### PR DESCRIPTION
Related: #4039, #4021

**Why**: As a user, I expect that any issues with the images I select or capture during the proofing flow will be made obvious to me as soon as possible, so that I don't waste my time submitting images that will not be accepted, and so that the error messages are timely in their relevance to when I had made the selection/capture.

New error messages added for:

- Images smaller than 500kb
- Images with Acuant-reported sharpness score less than 50

Error handling which existed previously:

- Images of incorrect file type (#4021)
- Images with Acuant-reported glare score less than 50 (#4039)

**Screen Recording:**

![errors mov](https://user-images.githubusercontent.com/1779930/90069837-dd214c80-dcc0-11ea-885e-2e7fdb896260.gif)
