### PR TITLE
Change Email Display Name (Resolves #3791)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,8 +3,8 @@ class UserMailer < ActionMailer::Base
   include Mailable
   include LocaleHelper
   before_action :attach_images
-  default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from),
-          reply_to: email_with_name(Figaro.env.email_from, Figaro.env.email_from)
+  default from: email_with_name(Figaro.env.email_from, Figaro.env.email_from_display_name),
+          reply_to: email_with_name(Figaro.env.email_from, Figaro.env.email_from_display_name)
 
   def email_confirmation_instructions(user, email, token, request_id:, instructions:)
     presenter = ConfirmationEmailPresenter.new(user, view_context)

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Upaya
     config.action_mailer.default_options = {
       from: Mail::Address.new.tap do |mail|
         mail.address = Figaro.env.email_from
-        mail.display_mail = Figaro.env.email_from_display_name
+        mail.display_name = Figaro.env.email_from_display_name
       end.to_s,
     }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,13 @@ module Upaya
 
     routes.default_url_options[:host] = Figaro.env.domain_name
 
+    config.action_mailer.default_options = {
+      from: Mail::Address.new.tap do |mail|
+        mail.address = Figaro.env.email_from
+        mail.display_mail = Figaro.env.email_from_display_name
+      end.to_s,
+    }
+
     config.lograge.custom_options = lambda do |event|
       event.payload[:timestamp] = Time.zone.now.iso8601
       event.payload[:uuid] = SecureRandom.uuid

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -50,6 +50,7 @@ doc_auth_extend_timeout_by_minutes: '40'
 document_capture_step_enabled: 'false'
 document_capture_react_enabled: 'true'
 email_from: no-reply@login.gov
+email_from_display_name: Login.gov
 enable_load_testing_mode: 'false'
 event_disavowal_expiration_hours: '240'
 google_analytics_key:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
-  config.action_mailer.default_options = { from: Figaro.env.email_from }
+  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
 
   config.lograge.enabled = true
   config.lograge.ignore_actions = ['Users::SessionsController#active']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
-  config.action_mailer.default_options = { 
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  config.action_mailer.default_options = {
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
   }
 
   config.lograge.enabled = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,9 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
-  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
+  config.action_mailer.default_options = { 
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  }
 
   config.lograge.enabled = true
   config.lograge.ignore_actions = ['Users::SessionsController#active']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,9 +23,6 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.smtp_settings = { address: ENV['SMTP_HOST'] || 'localhost', port: 1025 }
-  config.action_mailer.default_options = {
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
-  }
 
   config.lograge.enabled = true
   config.lograge.ignore_actions = ['Users::SessionsController#active']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,8 +25,8 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.asset_host || Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_options = { 
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  config.action_mailer.default_options = {
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
   }
   config.action_mailer.delivery_method = if Figaro.env.disable_email_sending == 'true'
                                            :test

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,9 +25,6 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.asset_host || Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_options = {
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
-  }
   config.action_mailer.delivery_method = if Figaro.env.disable_email_sending == 'true'
                                            :test
                                          else

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,9 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.asset_host || Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
+  config.action_mailer.default_options = { 
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  }
   config.action_mailer.delivery_method = if Figaro.env.disable_email_sending == 'true'
                                            :test
                                          else

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   }
   config.action_mailer.asset_host = Figaro.env.asset_host || Figaro.env.mailer_domain_name
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_options = { from: Figaro.env.email_from }
+  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
   config.action_mailer.delivery_method = if Figaro.env.disable_email_sending == 'true'
                                            :test
                                          else

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,8 +15,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Figaro.env.domain_name }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
-  config.action_mailer.default_options = { 
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  config.action_mailer.default_options = {
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
   }
 
   config.assets.debug = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Figaro.env.domain_name }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
-  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
+  config.action_mailer.default_options = { 
+    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" 
+  }
 
   config.assets.debug = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,9 +15,6 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Figaro.env.domain_name }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
-  config.action_mailer.default_options = {
-    from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>",
-  }
 
   config.assets.debug = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Figaro.env.domain_name }
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
-  config.action_mailer.default_options = { from: Figaro.env.email_from }
+  config.action_mailer.default_options = { from: "#{Figaro.env.email_from_display_name} <#{Figaro.env.email_from}>" }
 
   config.assets.debug = true
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   config.case_insensitive_keys = []
   config.confirm_within = 24.hours
   config.expire_all_remember_me_on_sign_out = true
-  config.mailer_sender = email_with_name(Figaro.env.email_from, Figaro.env.email_from)
+  config.mailer_sender = email_with_name(Figaro.env.email_from, Figaro.env.email_from_display_name)
   config.paranoid = true
   config.password_length = 12..128
   config.reset_password_within = 6.hours

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -1,6 +1,6 @@
 shared_examples 'a system email' do
   it 'is from the default email' do
     expect(mail.from).to eq [Figaro.env.email_from]
-    expect(mail[:from].display_names).to eq [Figaro.env.email_from]
+    expect(mail[:from].display_names).to eq [Figaro.env.email_from_display_name]
   end
 end


### PR DESCRIPTION
This PR creates an environment variable which will set the sender name of the email to `Login.gov`. Currently, it's `no-reply@login.gov`  

See #3791 for discussion surrounding this feature.

