### PR TITLE
disable assets.debug in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   config.action_mailer.asset_host = Figaro.env.mailer_domain_name
   config.action_mailer.default_options = { from: Figaro.env.email_from }
 
-  config.assets.debug = true
+  config.assets.debug = false
 
   config.action_controller.asset_host = if ENV.key?('RAILS_ASSET_HOST')
                                           ENV['RAILS_ASSET_HOST']


### PR DESCRIPTION
`assets.debug` is disabled in the test environment on new Rails projects now (leaving dev as the only place it's enabled). 

Assets only get built once per test run, so it won't save much time when running all or many. It does save ~3 seconds on my machine when running a spec that builds assets, which is nice for repeatedly running the same test.

for `rspec spec/features/saml/saml_spec.rb:13`:

```
# assets.debug enabled
saml api
  it sets the sp_issuer cookie

Finished in 8.12 seconds (files took 4.22 seconds to load)
1 example, 0 failures
```

```
# assets.debug disabled
saml api
  it sets the sp_issuer cookie

Finished in 5.11 seconds (files took 3.16 seconds to load)
1 example, 0 failures
```