### PR TITLE
Set default geocoder stub

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -16,7 +16,7 @@ if !Rails.env.production? && !File.exist?(GEO_DATA_FILEPATH)
   Geocoder::Lookup::Test.set_default_stub(
     [
       { 'city' => '', 'country' => 'United States', 'state_code' => '' },
-    ]
+    ],
   )
 else
   Geocoder.configure(

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -13,13 +13,8 @@ GEO_DATA_FILEPATH = Rails.root.join('geo_data', 'GeoLite2-City.mmdb').freeze
 
 if !Rails.env.production? && !File.exist?(GEO_DATA_FILEPATH)
   Geocoder.configure(ip_lookup: :test)
-  Geocoder::Lookup::Test.add_stub(
-    '127.0.0.1', [
-      { 'city' => '', 'country' => 'United States', 'state_code' => '' },
-    ]
-  )
-  Geocoder::Lookup::Test.add_stub(
-    '::1', [
+  Geocoder::Lookup::Test.set_default_stub(
+    [
       { 'city' => '', 'country' => 'United States', 'state_code' => '' },
     ]
   )


### PR DESCRIPTION
**Why**: If developer changes their environment to use a different hostname (e.g. for device testing), visiting their account page will continue to show an error, since it's likely that hostname is not part of the implemented stubs, which include only 127.0.0.1 and ::1. Instead, set a default stub value to capture all hosts in the development environment.

Reference: https://github.com/alexreisner/geocoder

>You can also set a default stub, to be returned when no other stub matches a given query: