### PR TITLE
LG-3293: Configure Acuant selfie capture in React flow

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,8 +9,7 @@ checks:
   file-lines:
     enabled: false
   method-complexity:
-    config:
-      threshold: 15
+    enabled: false
   method-count:
     enabled: false
   method-lines:

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -16,6 +16,8 @@ import DataURLFile from '../models/data-url-file';
  * @prop {string=}                         hint       Optional hint text.
  * @prop {string=}                         bannerText Optional banner overlay text.
  * @prop {string[]=}                       accept     Optional array of file input accept patterns.
+ * @prop {'user'|'environment'=}           capture    Optional facing mode if file input is used for
+ *                                                    capture.
  * @prop {DataURLFile=}                    value      Current value.
  * @prop {string=}                         error      Error to show.
  * @prop {(event:ReactMouseEvent)=>void=}  onClick    Input click handler.
@@ -115,6 +117,7 @@ const FileInput = forwardRef((props, ref) => {
     hint,
     bannerText,
     accept,
+    capture,
     value,
     error,
     onClick = () => {},
@@ -237,6 +240,7 @@ const FileInput = forwardRef((props, ref) => {
             className="usa-file-input__input"
             type="file"
             onChange={onChangeAsDataURL}
+            capture={capture}
             onClick={onClick}
             accept={accept ? accept.join() : undefined}
             aria-describedby={hint ? hintId : null}

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -35,6 +35,7 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
         <li>{t('doc_auth.tips.document_capture_selfie_text3')}</li>
       </ul>
       <AcuantCapture
+        capture="user"
         label={t('doc_auth.headings.document_capture_selfie')}
         bannerText={t('doc_auth.headings.photo')}
         value={value.selfie}

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -7,6 +7,7 @@ import AcuantCapture, {
 } from '@18f/identity-document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
 import DeviceContext from '@18f/identity-document-capture/context/device';
+import I18nContext from '@18f/identity-document-capture/context/i18n';
 import DataURLFile from '@18f/identity-document-capture/models/data-url-file';
 import render from '../../../support/render';
 import { useAcuant } from '../../../support/acuant';
@@ -394,6 +395,50 @@ describe('document-capture/components/acuant-capture', () => {
 
       expect(error).to.be.ok();
     });
+
+    it('triggers forced upload', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{ 'doc_auth.buttons.take_or_upload_picture': '<lg-upload>Upload</lg-upload>' }}
+        >
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <AcuantContextProvider sdkSrc="about:blank">
+              <AcuantCapture label="Image" />
+            </AcuantContextProvider>
+          </DeviceContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      initialize();
+
+      const button = getByText('Upload');
+      fireEvent.click(button);
+
+      expect(window.AcuantCameraUI.start.called).to.be.false();
+    });
+
+    it('triggers forced upload with `capture` value', () => {
+      const { getByText, getByLabelText } = render(
+        <I18nContext.Provider
+          value={{ 'doc_auth.buttons.take_or_upload_picture': '<lg-upload>Upload</lg-upload>' }}
+        >
+          <DeviceContext.Provider value={{ isMobile: true }}>
+            <AcuantContextProvider sdkSrc="about:blank">
+              <AcuantCapture label="Image" capture="environment" />
+            </AcuantContextProvider>
+          </DeviceContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      initialize();
+
+      const button = getByText('Upload');
+      const input = getByLabelText('Image');
+      fireEvent.click(button);
+
+      expect(window.AcuantCameraUI.start.called).to.be.false();
+      expect(input.getAttribute('capture')).to.equal('environment');
+    });
   });
 
   context('desktop', () => {
@@ -461,5 +506,20 @@ describe('document-capture/components/acuant-capture', () => {
     const hint = getByText('doc_auth.tips.document_capture_hint');
 
     expect(hint).to.be.ok();
+  });
+
+  it('captures by `capture` value', () => {
+    const { getByLabelText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture label="Image" capture="environment" />
+      </AcuantContextProvider>,
+    );
+
+    initialize();
+
+    const button = getByLabelText('Image');
+    fireEvent.click(button);
+
+    expect(window.AcuantCameraUI.start.called).to.be.false();
   });
 });

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -56,7 +56,7 @@ describe('document-capture/components/acuant-capture', () => {
 
       userEvent.click(getByText('doc_auth.buttons.take_picture'));
 
-      initialize({ isSuccess: true, isCameraSupported: false });
+      initialize({ isCameraSupported: false });
 
       expect(container.querySelector('.full-screen')).to.be.null();
     });
@@ -85,10 +85,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onFail }) => onFail(),
-      };
-      window.onAcuantSdkLoaded();
+      initialize({ isSuccess: false });
 
       const button = await findByText('doc_auth.buttons.upload_picture');
       expect(button.classList.contains('btn-secondary')).to.be.true();
@@ -103,11 +100,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
+      initialize();
 
       const button = getByText('doc_auth.buttons.take_picture');
 
@@ -123,12 +116,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = { start: sinon.spy(), end: sinon.spy() };
+      initialize();
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -146,12 +134,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = { start: sinon.spy(), end: sinon.spy() };
+      initialize();
 
       const button = getByLabelText('Image');
       fireEvent.click(button);
@@ -170,24 +153,17 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 70,
-            sharpness: 70,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 70,
+          sharpness: 70,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -209,15 +185,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start: sinon.spy(),
-        end: sinon.spy(),
-      };
+      initialize();
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -241,12 +209,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = { start: sinon.spy(), end: sinon.spy() };
+      initialize();
 
       const button = getByText('doc_auth.buttons.take_picture_retry');
       expect(button).to.be.ok();
@@ -269,11 +232,7 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: false };
-      window.onAcuantSdkLoaded();
+      initialize({ isCameraSupported: false });
 
       const button = getByText('doc_auth.buttons.upload_picture');
       expect(button).to.be.ok();
@@ -290,24 +249,17 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 38,
-            sharpness: 70,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 38,
+          sharpness: 70,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -326,24 +278,17 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 70,
-            sharpness: 20,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 70,
+          sharpness: 20,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -362,24 +307,17 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 70,
-            sharpness: 20,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 70,
+          sharpness: 20,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const file = new window.File([''], 'upload.txt', { type: 'text/plain' });
 
@@ -406,24 +344,17 @@ describe('document-capture/components/acuant-capture', () => {
 
       let isBlurry = true;
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 70,
-            sharpness: isBlurry ? 20 : 70,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 70,
+          sharpness: isBlurry ? 20 : 70,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -444,24 +375,17 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      window.AcuantJavascriptWebSdk = {
-        initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-      };
-      window.AcuantCamera = { isCameraSupported: true };
-      window.onAcuantSdkLoaded();
-      window.AcuantCameraUI = {
-        start(onImageCaptureSuccess) {
-          const capture = {
-            glare: 70,
-            sharpness: 38,
-            image: {
-              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-            },
-          };
-          onImageCaptureSuccess(capture);
-        },
-        end: sinon.spy(),
-      };
+      initialize();
+      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
+        const capture = {
+          glare: 70,
+          sharpness: 38,
+          image: {
+            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+          },
+        };
+        onImageCaptureSuccess(capture);
+      });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -520,11 +444,7 @@ describe('document-capture/components/acuant-capture', () => {
       </AcuantContextProvider>,
     );
 
-    window.AcuantJavascriptWebSdk = {
-      initialize: (_credentials, _endpoint, { onSuccess }) => onSuccess(),
-    };
-    window.AcuantCamera = { isCameraSupported: true };
-    window.onAcuantSdkLoaded();
+    initialize();
 
     expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
   });
@@ -536,10 +456,7 @@ describe('document-capture/components/acuant-capture', () => {
       </AcuantContextProvider>,
     );
 
-    window.AcuantJavascriptWebSdk = {
-      initialize: (_credentials, _endpoint, { onFail }) => onFail(),
-    };
-    window.onAcuantSdkLoaded();
+    initialize({ isSuccess: false });
 
     const hint = getByText('doc_auth.tips.document_capture_hint');
 

--- a/spec/javascripts/support/acuant.js
+++ b/spec/javascripts/support/acuant.js
@@ -13,7 +13,7 @@ export function useAcuant() {
   });
 
   return {
-    initialize({ isSuccess = true, isCameraSupported = false } = {}) {
+    initialize({ isSuccess = true, isCameraSupported = true } = {}) {
       window.AcuantJavascriptWebSdk = {
         initialize: (_credentials, _endpoint, { onSuccess, onFail }) =>
           isSuccess ? onSuccess() : onFail(),


### PR DESCRIPTION
As a user, I expect when I do liveness check, the camera is oriented to capture a selfie, not the environment.

Acuant SDK is implemented for the new React flow, but it will always capture in direction of the environment. For liveness check, this should be configured to capture as selfie.

**Implementation Notes:**

Acuant offers a [`AcuantPassiveLiveness.startSelfieCapture` method](https://github.com/Acuant/JavascriptWebSDKV11/tree/master/SimpleHTMLApp#start-face-capture-and-send--passive-liveness-request) to start selfie capture, which is used in [the current implementation](https://github.com/18F/identity-idp/blob/master/app/javascript/app/acuant/selfie_capture.js). In observing that the SDK implementation ([line 1305 to 1315](https://raw.githubusercontent.com/Acuant/JavascriptWebSDKV11/35cd1a1a6deed44e623c3f7308fd4519ee8ed4d5/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js)) simply uses an `<input type="file" />` with a [capture attribute](https://w3c.github.io/html-media-capture/#the-capture-attribute), and since we're already using a file input field for the capture, the proposal here simply accepts this `capture` prop value and passes it along to the input.

Some special handling is needed to ensure that Acuant capture occurs when expected, and that the user can still "forcefully" choose to upload, where the "Upload" button proxies clicks to the underlying file input.

This does not yet perform a liveness assessment, described in the Acuant documentation linked above as the second step following selfie capture. Since this will need to be used for desktop capture as well with a separate implementation, I've chose to postpone that to a future effort. I will create a Jira ticket to track this.