### PR TITLE
Await Acuant initialization before starting capture

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
+import AcuantContext from '../context/acuant';
 
 /**
  * @typedef AcuantCameraUI
@@ -59,16 +60,22 @@ function AcuantCaptureCanvas({
   onImageCaptureSuccess = () => {},
   onImageCaptureFailure = () => {},
 }) {
+  const { isReady } = useContext(AcuantContext);
+
   useEffect(() => {
-    /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
-      onImageCaptureSuccess,
-      onImageCaptureFailure,
-    );
+    if (isReady) {
+      /** @type {AcuantGlobal} */ (window).AcuantCameraUI.start(
+        onImageCaptureSuccess,
+        onImageCaptureFailure,
+      );
+    }
 
     return () => {
-      /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
+      if (isReady) {
+        /** @type {AcuantGlobal} */ (window).AcuantCameraUI.end();
+      }
     };
-  }, []);
+  }, [isReady]);
 
   // The video element is never visible to the user, but it needs to be present
   // in the DOM for the Acuant SDK to capture the feed from the camera.

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState, useMemo } from 'react';
+import React, { useContext, useRef, useState, useMemo, useEffect } from 'react';
 import AcuantContext from '../context/acuant';
 import AcuantCaptureCanvas from './acuant-capture-canvas';
 import FileInput from './file-input';
@@ -90,6 +90,14 @@ function AcuantCapture({
   const { isMobile } = useContext(DeviceContext);
   const { t, formatHTML } = useI18n();
   const hasCapture = !isError && (isReady ? isCameraSupported : isMobile);
+  useEffect(() => {
+    // If capture had started before Acuant was ready, stop capture if readiness reveals that no
+    // capture is supported. This takes advantage of the fact that state setter is noop if value of
+    // `isCapturing` is already false.
+    if (!hasCapture) {
+      setIsCapturing(false);
+    }
+  }, [hasCapture]);
 
   /**
    * Responds to a click by starting capture if supported in the environment, or triggering the

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -14,6 +14,10 @@ describe('document-capture/components/acuant-capture-canvas', () => {
       </AcuantContextProvider>,
     );
 
+    // At this point, it's assumed `window.AcuantCameraUI.start` has not been called. This can't be
+    // asserted, since the global is only assigned as part of `initialize` itself. But we can rely
+    // on the fact that if it was called, an error would be thrown, and the test would fail.
+
     initialize();
 
     expect(window.AcuantCameraUI.start.calledOnce).to.be.true();

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
+import AcuantCaptureCanvas from '@18f/identity-document-capture/components/acuant-capture-canvas';
+import render from '../../../support/render';
+import { useAcuant } from '../../../support/acuant';
+
+describe('document-capture/components/acuant-capture-canvas', () => {
+  const { initialize } = useAcuant();
+
+  it('waits for initialization', () => {
+    render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCaptureCanvas />
+      </AcuantContextProvider>,
+    );
+
+    initialize();
+
+    expect(window.AcuantCameraUI.start.calledOnce).to.be.true();
+  });
+
+  it('ends on unmount', () => {
+    const { unmount } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCaptureCanvas />
+      </AcuantContextProvider>,
+    );
+
+    initialize();
+    unmount();
+
+    expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -9,17 +9,10 @@ import { Provider as AcuantContextProvider } from '@18f/identity-document-captur
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import DataURLFile from '@18f/identity-document-capture/models/data-url-file';
 import render from '../../../support/render';
+import { useAcuant } from '../../../support/acuant';
 
 describe('document-capture/components/acuant-capture', () => {
-  afterEach(() => {
-    // While RTL will perform this automatically, it must to occur prior to
-    // resetting the global variables, since otherwise the component's effect
-    // unsubscribe will attempt to reference globals that no longer exist.
-    cleanup();
-    delete window.AcuantJavascriptWebSdk;
-    delete window.AcuantCamera;
-    delete window.AcuantCameraUI;
-  });
+  const { initialize } = useAcuant();
 
   describe('getDataURLFileSize', () => {
     it('returns file size in bytes', () => {
@@ -50,6 +43,22 @@ describe('document-capture/components/acuant-capture', () => {
       );
 
       expect(getByText('doc_auth.buttons.take_picture')).to.be.ok();
+    });
+
+    it('cancels capture if assumed support is not actually supported once ready', () => {
+      const { container, getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      userEvent.click(getByText('doc_auth.buttons.take_picture'));
+
+      initialize({ isSuccess: true, isCameraSupported: false });
+
+      expect(container.querySelector('.full-screen')).to.be.null();
     });
 
     it('renders with upload button as mobile-primary (secondary) button if acuant script fails to load', async () => {

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, cleanup } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import AcuantCapture, {

--- a/spec/javascripts/support/acuant.js
+++ b/spec/javascripts/support/acuant.js
@@ -1,0 +1,26 @@
+import sinon from 'sinon';
+import { cleanup } from '@testing-library/react';
+
+export function useAcuant() {
+  afterEach(() => {
+    // While RTL will perform this automatically, it must to occur prior to
+    // resetting the global variables, since otherwise the component's effect
+    // unsubscribe will attempt to reference globals that no longer exist.
+    cleanup();
+    delete window.AcuantJavascriptWebSdk;
+    delete window.AcuantCamera;
+    delete window.AcuantCameraUI;
+  });
+
+  return {
+    initialize({ isSuccess = true, isCameraSupported = false } = {}) {
+      window.AcuantJavascriptWebSdk = {
+        initialize: (_credentials, _endpoint, { onSuccess, onFail }) =>
+          isSuccess ? onSuccess() : onFail(),
+      };
+      window.AcuantCamera = { isCameraSupported };
+      window.AcuantCameraUI = { start: sinon.stub(), end: sinon.stub() };
+      window.onAcuantSdkLoaded();
+    },
+  };
+}

--- a/spec/javascripts/support/acuant.js
+++ b/spec/javascripts/support/acuant.js
@@ -3,9 +3,9 @@ import { cleanup } from '@testing-library/react';
 
 export function useAcuant() {
   afterEach(() => {
-    // While RTL will perform this automatically, it must to occur prior to
-    // resetting the global variables, since otherwise the component's effect
-    // unsubscribe will attempt to reference globals that no longer exist.
+    // While React Testing Library will perform this automatically, it must to occur prior to
+    // resetting the global variables, since otherwise the component's effect unsubscribe will
+    // attempt to reference globals that no longer exist.
     cleanup();
     delete window.AcuantJavascriptWebSdk;
     delete window.AcuantCamera;


### PR DESCRIPTION
**Why**: If a user is fast enough that they proceed through steps and attempt to start capture before Acuant is ready, an error would occur.

These changes allow the Acuant canvas to be rendered, but for the start of capture to be delayed until Acuant is ready.

It also cancels capture if, upon becoming ready, Acuant reports that the camera is not supported, if we had previously assumed the camera would be supported, and the user had initiated a full-screen capture.

**Why**: We use device detection to make assumptions about whether we expect Acuant camera to be supported, even prior to initialization. Since a user could click the capture button to display the full-screen modal, we should hide the modal if readiness reveals that the camera is not supported, as otherwise the user will be stuck staring at a blank full screen modal.