### PR TITLE
Remove unused globals from ESLint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,16 +6,11 @@
     "browser": true,
     "commonjs": true,
     "es6": true,
-    "mocha": true
+    "mocha": true,
+    "jquery": true
   },
   "globals": {
-    "$": true,
-    "__DEV__": true,
-    "assert": true,
-    "chai": true,
-    "sinon": true,
-    "expect": true,
-    "fixture": true
+    "expect": true
   },
   "rules": {
     "prettier/prettier": "error",


### PR DESCRIPTION
**Why**: As a developer, I expect the ESLint configuration to be kept in sync with how globals are used in the codebase, so that I can avoid errors if globals are not actually available in the global scope.

This had affected me where ESLint did not report an issue for me in failing to import `sinon` into a test file. The test file would not run, since sinon wasn't declared as a global.

**Testing Instructions:**

`yarn lint` should pass.