### PR TITLE
Disable page scroll while full screen overlay active

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
     "newline-per-chained-call": "off",
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
+    "no-plusplus": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "operator-linebreak": "off",

--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -1,3 +1,7 @@
+body.has-full-screen-overlay {
+  overflow: hidden; 
+}
+
 .full-screen {
   bottom: 0;
   left: 0;

--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -1,4 +1,4 @@
-body.has-full-screen-overlay {
+body.has-full-screen-overlay { // scss-lint:disable QualifyingElement
   overflow: hidden;
 }
 

--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -1,5 +1,5 @@
 body.has-full-screen-overlay {
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .full-screen {

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -34,6 +34,11 @@ function FullScreen({ onRequestClose = () => {}, children }) {
     return trapRef.current.deactivate;
   }, []);
 
+  useEffect(() => {
+    document.body.classList.add('has-full-screen-overlay');
+    return () => document.body.classList.remove('has-full-screen-overlay');
+  }, []);
+
   return (
     <div ref={modalRef} aria-modal="true" className="full-screen bg-white">
       <button

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -13,6 +13,14 @@ import useI18n from '../hooks/use-i18n';
  */
 
 /**
+ * Number of active instances of FullScreen currently mounted, used in determining when overlay body
+ * class should be added or removed.
+ *
+ * @type {number}
+ */
+let activeInstances = 0;
+
+/**
  * @param {FullScreenProps} props Props object.
  */
 function FullScreen({ onRequestClose = () => {}, children }) {
@@ -35,8 +43,15 @@ function FullScreen({ onRequestClose = () => {}, children }) {
   }, []);
 
   useEffect(() => {
-    document.body.classList.add('has-full-screen-overlay');
-    return () => document.body.classList.remove('has-full-screen-overlay');
+    if (activeInstances++ === 0) {
+      document.body.classList.add('has-full-screen-overlay');
+    }
+
+    return () => {
+      if (--activeInstances === 0) {
+        document.body.classList.remove('has-full-screen-overlay');
+      }
+    };
   }, []);
 
   return (

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -81,4 +81,14 @@ describe('document-capture/components/full-screen', () => {
 
     expect(onRequestClose.calledOnce).to.be.true();
   });
+
+  it('toggles modal class on body while mounted', () => {
+    const { unmount } = render(<FullScreen>Content</FullScreen>);
+
+    expect(document.body.classList.contains('has-full-screen-overlay')).to.be.true();
+
+    unmount();
+
+    expect(document.body.classList.contains('has-full-screen-overlay')).to.be.false();
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/full-screen-spec.jsx
@@ -91,4 +91,25 @@ describe('document-capture/components/full-screen', () => {
 
     expect(document.body.classList.contains('has-full-screen-overlay')).to.be.false();
   });
+
+  it('only removes body class when last mounted modal is removed', () => {
+    const { rerender } = render(
+      <>
+        <FullScreen>Please don’t</FullScreen>
+        <FullScreen>do this.</FullScreen>
+      </>,
+    );
+
+    rerender(
+      <>
+        <FullScreen>Please don’t</FullScreen>
+      </>,
+    );
+
+    expect(document.body.classList.contains('has-full-screen-overlay')).to.be.true();
+
+    rerender(<></>);
+
+    expect(document.body.classList.contains('has-full-screen-overlay')).to.be.false();
+  });
 });


### PR DESCRIPTION
**Why**: As a user, I expect that when a full screen overlay is present I can no longer scroll the page, so that I'm not confused by the presence of scrollbars that don't control overlay content, and so that the page scroll position after the overlay is dismissed is where I had left it.

Reference implementation: https://github.com/uswds/uswds/blob/ab9d2502e654e3abedfd2bb3a232df52b7f4e7eb/src/stylesheets/components/_navigation.scss#L346-L348