### PR TITLE
Reduce minimum acceptable document file size to 250kb

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -62,7 +62,7 @@ const DEFAULT_ACCEPTABLE_SHARPNESS_SCORE = 50;
  */
 const DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES =
   process.env.ACUANT_MINIMUM_FILE_SIZE === undefined
-    ? 500 * 1024
+    ? 250 * 1024
     : Number(process.env.ACUANT_MINIMUM_FILE_SIZE);
 
 /**


### PR DESCRIPTION
Related to: LG-3286 (#4057)

**Why**: Images generated from Acuant SDK's own image capture are often smaller than the 500kb minimum, leading to a strange outcome for the user that they're warned about file size being too small, despite the fact they don't have the option to choose a file, or select the quality at which the image is saved.

**Alternatives considered:**

- Allow images generated from Acuant SDK to bypass the file size check.
- Remove the file size check altogether.

The choice of 250kb is motivated by what was previously documented as being their minimum requirement. Refer to "Image compression" section of AssureID Connect Documentation PDF for recommended increase of minimum 250kb to 500kb.