### PR TITLE
Update Idv::DataUrlImage to be more robust

### DIFF
--- a/app/services/idv/data_url_image.rb
+++ b/app/services/idv/data_url_image.rb
@@ -19,7 +19,9 @@ module Idv
       if base64_encoded?
         Base64.decode64(@data)
       else
-        URI.decode_www_form_component(@data)
+        # rubocop:disable Lint/UriEscapeUnescape
+        URI.decode(@data)
+        # rubocop:enable Lint/UriEscapeUnescape
       end
     end
 

--- a/app/services/idv/data_url_image.rb
+++ b/app/services/idv/data_url_image.rb
@@ -1,16 +1,32 @@
 module Idv
   class DataUrlImage
     def initialize(data_url)
-      @header, base64_data = data_url.split(',', 2)
-      @data = Base64.decode64(base64_data || '')
+      header, data = URI(data_url.chomp).opaque.to_s.split(',', 2)
+      @header = header.to_s
+      @data = data.to_s
     end
 
+    BASE64_CONTENT_TYPE = /;base64$/.freeze
+
+    # @return [String]
     def content_type
-      @header.gsub(/^data:/, '').gsub(/;base64$/, '')
+      content_type, *_rest = @header.split(';')
+      content_type.to_s
     end
 
+    # @return [String]
     def read
-      @data
+      if base64_encoded?
+        Base64.decode64(@data)
+      else
+        URI.decode_www_form_component(@data)
+      end
+    end
+
+    private
+
+    def base64_encoded?
+      !!@header.match(BASE64_CONTENT_TYPE)
     end
   end
 end

--- a/spec/services/idv/data_url_image_spec.rb
+++ b/spec/services/idv/data_url_image_spec.rb
@@ -33,10 +33,10 @@ describe Idv::DataUrlImage do
     end
 
     context 'when data is not base64-encoded' do
-      let(:data_url) { 'data:image/png,a%20b%20c%20%3F' }
+      let(:data_url) { 'data:image/png,a%20+%20b' }
 
       it 'URI component unescapes the data' do
-        expect(data_url_image.read).to eq('a b c ?')
+        expect(data_url_image.read).to eq('a + b')
       end
     end
 

--- a/spec/services/idv/data_url_image_spec.rb
+++ b/spec/services/idv/data_url_image_spec.rb
@@ -1,19 +1,51 @@
 require 'rails_helper'
 
 describe Idv::DataUrlImage do
-  include DocAuthHelper
+  let(:data) { 'abcdef' }
+  let(:data_url) { "data:image/jpeg;base64,#{Base64.encode64(data)}" }
+  subject(:data_url_image) { described_class.new(data_url) }
 
-  subject { described_class.new(doc_auth_image_data_url) }
-
-  describe 'content_type' do
+  describe '#content_type' do
     it 'returns the content type from the header' do
-      expect(subject.content_type).to eq('image/jpeg')
+      expect(data_url_image.content_type).to eq('image/jpeg')
+    end
+
+    context 'with bad data' do
+      let(:data_url) { 'not_a_url' }
+
+      it 'is the empty string' do
+        expect(data_url_image.content_type).to eq('')
+      end
+    end
+
+    context 'with a character encoding' do
+      let(:data_url) { 'data:text/plain;charset=US-ASCII;base64,SGVsbG8gd29ybGQ=' }
+
+      it 'returns just the content type' do
+        expect(data_url_image.content_type).to eq('text/plain')
+      end
     end
   end
 
-  describe 'read' do
+  describe '#read' do
     it 'returns the data associated with the image' do
-      expect(subject.read).to eq(doc_auth_image_data_url_data)
+      expect(data_url_image.read).to eq(data)
+    end
+
+    context 'when data is not base64-encoded' do
+      let(:data_url) { 'data:image/png,a%20b%20c%20%3F' }
+
+      it 'URI component unescapes the data' do
+        expect(data_url_image.read).to eq('a b c ?')
+      end
+    end
+
+    context 'with bad data' do
+      let(:data_url) { 'not_a_url' }
+
+      it 'is the empty string' do
+        expect(data_url_image.read).to eq('')
+      end
     end
   end
 end


### PR DESCRIPTION
Now that #4069 is using multipart file uploads, we no longer need these updates for that PR.

But the class already exists, and is in use for our existing document capture API, so I figure I would break out these updaters separately and we could bring them in if we want.
