### PR TITLE
Do not always make new phones default (LG-3173)

### DIFF
--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -56,8 +56,7 @@ class UpdateUser
   end
 
   def current_made_default_at
-    return phone_configuration.made_default_at if attributes[:phone_id].present?
-    nil
+    phone_configuration.made_default_at if attributes[:phone_id].present?
   end
 
   def phone_configuration

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -46,12 +46,17 @@ class UpdateUser
   end
 
   def made_default_at_date
-    return current_made_default_at if attributes[:otp_make_default_number].blank?
-    Time.zone.now
+    otp_make_default_number = attributes[:otp_make_default_number]
+
+    if otp_make_default_number.blank? || otp_make_default_number == 'false'
+      current_made_default_at
+    else
+      Time.zone.now
+    end
   end
 
   def current_made_default_at
-    phone_configuration.made_default_at if attributes[:phone_id].present?
+    return phone_configuration.made_default_at if attributes[:phone_id].present?
     nil
   end
 

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -46,12 +46,10 @@ class UpdateUser
   end
 
   def made_default_at_date
-    otp_make_default_number = attributes[:otp_make_default_number]
-
-    if otp_make_default_number.blank? || otp_make_default_number == 'false'
-      current_made_default_at
-    else
+    if attributes[:otp_make_default_number].to_s == 'true'
       Time.zone.now
+    else
+      current_made_default_at
     end
   end
 

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -70,6 +70,15 @@ describe UpdateUser do
           expect(phone_configuration.made_default_at).to eq nil
         end
       end
+
+      context 'when phone is not set as default' do
+        it 'updates made_default_at with nil value' do
+          attributes[:otp_make_default_number] = 'false'
+          UpdateUser.new(user: user, attributes: attributes).call
+          phone_configuration = user.phone_configurations.reload.first
+          expect(phone_configuration.made_default_at).to eq nil
+        end
+      end
     end
 
     context 'when updating an existing phone' do


### PR DESCRIPTION
`current_made_default_at` always returned nil, so `made_default_at` was always going updated to be now

`otp_make_default_number` also is a string "false" when adding a phone number, so doesn't get caught by the blank? check
