### PR TITLE
Handle document capture form submission error

### DIFF
--- a/app/javascript/packages/components/alert.jsx
+++ b/app/javascript/packages/components/alert.jsx
@@ -18,7 +18,7 @@ import React from 'react';
  */
 function Alert({ type = 'other', children }) {
   return (
-    <div className={`usa-alert usa-alert--${type}`}>
+    <div className={`usa-alert usa-alert--${type}`} role="alert">
       <div className="usa-alert__body">
         <p className="usa-alert__text">{children}</p>
       </div>

--- a/app/javascript/packages/components/alert.jsx
+++ b/app/javascript/packages/components/alert.jsx
@@ -9,16 +9,19 @@ import React from 'react';
 /**
  * @typedef AlertProps
  *
- * @prop {AlertType=} type     Alert type. Defaults to "other".
- * @prop {ReactNode}  children Child elements.
+ * @prop {AlertType=} type Alert type. Defaults to "other".
+ * @prop {string=} className Optional additional class names to add to element.
+ * @prop {ReactNode} children Child elements.
  */
 
 /**
  * @param {AlertProps} props Props object.
  */
-function Alert({ type = 'other', children }) {
+function Alert({ type = 'other', className, children }) {
+  const classes = [`usa-alert usa-alert--${type}`, className].filter(Boolean).join(' ');
+
   return (
-    <div className={`usa-alert usa-alert--${type}`} role="alert">
+    <div className={classes} role="alert">
       <div className="usa-alert__body">
         <p className="usa-alert__text">{children}</p>
       </div>

--- a/app/javascript/packages/components/alert.jsx
+++ b/app/javascript/packages/components/alert.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef {"success"|"warning"|"error"|"info"|"other"} AlertType
+ */
+
+/**
+ * @typedef AlertProps
+ *
+ * @prop {AlertType=} type     Alert type. Defaults to "other".
+ * @prop {ReactNode}  children Child elements.
+ */
+
+/**
+ * @param {AlertProps} props Props object.
+ */
+function Alert({ type = 'other', children }) {
+  return (
+    <div className={`usa-alert usa-alert--${type}`}>
+      <div className="usa-alert__body">
+        <p className="usa-alert__text">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+export default Alert;

--- a/app/javascript/packages/components/index.js
+++ b/app/javascript/packages/components/index.js
@@ -1,0 +1,1 @@
+export { default as Alert } from './alert';

--- a/app/javascript/packages/components/package.json
+++ b/app/javascript/packages/components/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@18f/identity-components",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^16.13.1"
+  }
+}

--- a/app/javascript/packages/document-capture/components/callback-on-mount.jsx
+++ b/app/javascript/packages/document-capture/components/callback-on-mount.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+function CallbackOnMount({ onMount }) {
+  useEffect(() => {
+    onMount();
+  }, []);
+
+  return null;
+}
+
+export default CallbackOnMount;

--- a/app/javascript/packages/document-capture/components/callback-on-mount.jsx
+++ b/app/javascript/packages/document-capture/components/callback-on-mount.jsx
@@ -1,5 +1,14 @@
 import { useEffect } from 'react';
 
+/**
+ * @typedef CallbackOnMountProps
+ *
+ * @prop {()=>void} onMount Callback to trigger on mount.
+ */
+
+/**
+ * @param {CallbackOnMountProps} props Props object.
+ */
 function CallbackOnMount({ onMount }) {
   useEffect(() => {
     onMount();

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { Alert } from '@18f/identity-components';
 import FormSteps from './form-steps';
 import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
 import SelfieStep, { isValid as isSelfieStepValid } from './selfie-step';
@@ -21,6 +22,7 @@ import useI18n from '../hooks/use-i18n';
  */
 function DocumentCapture({ isLivenessEnabled = true }) {
   const [formValues, setFormValues] = useState(/** @type {Record<string,any>?} */ (null));
+  const [isSubmissionError, setIsSubmissionError] = useState(false);
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -44,10 +46,23 @@ function DocumentCapture({ isLivenessEnabled = true }) {
     },
   ].filter(Boolean));
 
-  return formValues ? (
-    <Submission payload={formValues} />
+  /**
+   * Clears error state and sets form values for submission.
+   *
+   * @param {Record<string,any>} nextFormValues Submitted form values.
+   */
+  function submitForm(nextFormValues) {
+    setIsSubmissionError(false);
+    setFormValues(nextFormValues);
+  }
+
+  return formValues && !isSubmissionError ? (
+    <Submission payload={formValues} onError={() => setIsSubmissionError(true)} />
   ) : (
-    <FormSteps steps={steps} onComplete={setFormValues} />
+    <>
+      {isSubmissionError && <Alert type="error">{t('errors.doc_auth.acuant_network_error')}</Alert>}
+      <FormSteps steps={steps} initialValues={formValues ?? undefined} onComplete={submitForm} />
+    </>
   );
 }
 

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -61,7 +61,12 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   ) : (
     <>
       {isSubmissionError && <Alert type="error">{t('errors.doc_auth.acuant_network_error')}</Alert>}
-      <FormSteps steps={steps} initialValues={formValues ?? undefined} onComplete={submitForm} />
+      <FormSteps
+        steps={steps}
+        initialValues={isSubmissionError && formValues ? formValues : undefined}
+        initialStep={isSubmissionError ? 'selfie' : undefined}
+        onComplete={submitForm}
+      />
     </>
   );
 }

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -60,7 +60,11 @@ function DocumentCapture({ isLivenessEnabled = true }) {
     <Submission payload={formValues} onError={() => setIsSubmissionError(true)} />
   ) : (
     <>
-      {isSubmissionError && <Alert type="error">{t('errors.doc_auth.acuant_network_error')}</Alert>}
+      {isSubmissionError && (
+        <Alert type="error" className="margin-bottom-2">
+          {t('errors.doc_auth.acuant_network_error')}
+        </Alert>
+      )}
       <FormSteps
         steps={steps}
         initialValues={isSubmissionError && formValues ? formValues : undefined}

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -19,7 +19,7 @@ import useHistoryParam from '../hooks/use-history-param';
  * @typedef FormStepsProps
  *
  * @prop {FormStep[]=}                        steps         Form steps.
- * @prop {Record<string,any>}                 initialValues Form values to populate initial state.
+ * @prop {Record<string,any>=}                initialValues Form values to populate initial state.
  * @prop {(values:Record<string,any>)=>void=} onComplete    Form completion callback.
  */
 

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -88,6 +88,11 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     if (effectiveStep && stepName && effectiveStep.name !== stepName) {
       setStepName(effectiveStep.name);
     }
+
+    // Treat explicit initial step the same as step transition, placing focus to header.
+    if (initialStep && headingRef.current) {
+      headingRef.current.focus();
+    }
   }, []);
 
   // An empty steps array is allowed, in which case there is nothing to render.

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -20,6 +20,7 @@ import useHistoryParam from '../hooks/use-history-param';
  *
  * @prop {FormStep[]=}                        steps         Form steps.
  * @prop {Record<string,any>=}                initialValues Form values to populate initial state.
+ * @prop {string=}                            initialStep   Step to start from.
  * @prop {(values:Record<string,any>)=>void=} onComplete    Form completion callback.
  */
 
@@ -66,11 +67,11 @@ export function getLastValidStepIndex(steps, values) {
 /**
  * @param {FormStepsProps} props Props object.
  */
-function FormSteps({ steps = [], onComplete = () => {}, initialValues = {} }) {
+function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, initialStep }) {
   const [values, setValues] = useState(initialValues);
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
   const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
-  const [stepName, setStepName] = useHistoryParam('step');
+  const [stepName, setStepName] = useHistoryParam('step', initialStep);
   const { t } = useI18n();
 
   // An "effective" step is computed in consideration of the facts that (1) there may be no history

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -18,8 +18,9 @@ import useHistoryParam from '../hooks/use-history-param';
 /**
  * @typedef FormStepsProps
  *
- * @prop {FormStep[]=}                        steps      Form steps.
- * @prop {(values:Record<string,any>)=>void=} onComplete Form completion callback.
+ * @prop {FormStep[]=}                        steps         Form steps.
+ * @prop {Record<string,any>}                 initialValues Form values to populate initial state.
+ * @prop {(values:Record<string,any>)=>void=} onComplete    Form completion callback.
  */
 
 /**
@@ -65,8 +66,8 @@ export function getLastValidStepIndex(steps, values) {
 /**
  * @param {FormStepsProps} props Props object.
  */
-function FormSteps({ steps = [], onComplete = () => {} }) {
-  const [values, setValues] = useState({});
+function FormSteps({ steps = [], onComplete = () => {}, initialValues = {} }) {
+  const [values, setValues] = useState(initialValues);
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
   const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
   const [stepName, setStepName] = useHistoryParam('step');

--- a/app/javascript/packages/document-capture/components/submission.jsx
+++ b/app/javascript/packages/document-capture/components/submission.jsx
@@ -4,22 +4,27 @@ import UploadContext from '../context/upload';
 import SuspenseErrorBoundary from './suspense-error-boundary';
 import SubmissionComplete from './submission-complete';
 import SubmissionPending from './submission-pending';
+import CallbackOnMount from './callback-on-mount';
 
 /**
  * @typedef SubmissionProps
  *
  * @prop {Record<string,string>} payload Payload object.
+ * @prop {()=>void}              onError Error callback.
  */
 
 /**
  * @param {SubmissionProps} props Props object.
  */
-function Submission({ payload }) {
+function Submission({ payload, onError }) {
   const upload = useContext(UploadContext);
   const resource = useAsync(upload, payload);
 
   return (
-    <SuspenseErrorBoundary fallback={<SubmissionPending />} errorFallback="Error">
+    <SuspenseErrorBoundary
+      fallback={<SubmissionPending />}
+      errorFallback={<CallbackOnMount onMount={onError} />}
+    >
       <SubmissionComplete resource={resource} />
     </SuspenseErrorBoundary>
   );

--- a/app/javascript/packages/document-capture/hooks/use-history-param.js
+++ b/app/javascript/packages/document-capture/hooks/use-history-param.js
@@ -53,24 +53,27 @@ function scrollTo(left, top) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
  *
- * @param {string} name Parameter name to sync.
+ * @param {string}  name         Parameter name to sync.
+ * @param {string=} initialValue Value to use as initial in absence of another value.
  *
  * @return {[any,(nextParamValue:any)=>void]} Tuple of current state, state setter.
  */
-function useHistoryParam(name) {
+function useHistoryParam(name, initialValue) {
   const getCurrentQueryParam = () =>
     getQueryParam(window.location.hash.slice(1), name) ?? undefined;
 
   const [value, setValue] = useState(getCurrentQueryParam);
 
-  function setParamValue(nextValue) {
-    const nextURL = nextValue
+  function getValueURL(nextValue) {
+    return nextValue
       ? `#${[name, nextValue].map(encodeURIComponent).join('=')}`
       : window.location.pathname + window.location.search;
+  }
 
+  function setParamValue(nextValue) {
     // Push the next value to history, both to update the URL, and to allow the user to return to
     // an earlier value (see `popstate` sync behavior).
-    window.history.pushState(null, '', nextURL);
+    window.history.pushState(null, '', getValueURL(nextValue));
 
     scrollTo(0, 0);
 
@@ -80,6 +83,11 @@ function useHistoryParam(name) {
   useEffect(() => {
     function syncValue() {
       setValue(getCurrentQueryParam());
+    }
+
+    if (value === undefined && initialValue) {
+      setValue(initialValue);
+      window.history.replaceState(null, '', getValueURL(initialValue));
     }
 
     window.addEventListener('popstate', syncValue);

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -27,6 +27,7 @@
 - doc_auth.tips.document_capture_selfie_text1
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
+- errors.doc_auth.acuant_network_error
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_file_size
 - errors.doc_auth.photo_glare

--- a/spec/javascripts/packages/components/alert-spec.jsx
+++ b/spec/javascripts/packages/components/alert-spec.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Alert } from '@18f/identity-components';
+import render from '../../support/render';
+
+describe('identity-components/alert', () => {
+  it('should apply alert role', () => {
+    const { getByRole } = render(<Alert type="warning">Uh oh!</Alert>);
+
+    const alert = getByRole('alert');
+
+    expect(alert).to.be.ok();
+  });
+});

--- a/spec/javascripts/packages/components/alert-spec.jsx
+++ b/spec/javascripts/packages/components/alert-spec.jsx
@@ -10,4 +10,16 @@ describe('identity-components/alert', () => {
 
     expect(alert).to.be.ok();
   });
+
+  it('accepts additional class names', () => {
+    const { getByRole } = render(
+      <Alert type="warning" className="my-class">
+        Uh oh!
+      </Alert>,
+    );
+
+    const alert = getByRole('alert');
+
+    expect(alert.classList.contains('my-class')).to.be.true();
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/callback-on-mount-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/callback-on-mount-spec.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import sinon from 'sinon';
+import CallbackOnMount from '@18f/identity-document-capture/components/callback-on-mount';
+import render from '../../../support/render';
+
+describe('document-capture/components/callback-on-mount', () => {
+  it('calls callback once on mount', () => {
+    const callback = sinon.spy();
+
+    render(<CallbackOnMount onMount={callback} />);
+
+    expect(callback.calledOnce).to.be.true();
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -55,6 +55,7 @@ describe('document-capture/components/document-capture', () => {
   it('handles submission failure', async () => {
     const { getByLabelText, getByText, findByRole } = render(<DocumentCapture />, {
       isUploadFailure: true,
+      expectedUploads: 2,
     });
 
     userEvent.upload(
@@ -72,18 +73,33 @@ describe('document-capture/components/document-capture', () => {
       getByLabelText('doc_auth.headings.document_capture_selfie'),
       new window.File([''], 'selfie.png', { type: 'image/png' }),
     );
-    const submitButton = getByText('forms.buttons.submit.default');
+    let submitButton = getByText('forms.buttons.submit.default');
     await waitFor(() => expect(submitButton.disabled).to.be.false());
     userEvent.click(submitButton);
 
     const notice = await findByRole('alert');
     expect(notice.textContent).to.equal('errors.doc_auth.acuant_network_error');
 
+    expect(console).to.have.loggedError(/^Error: Uncaught/);
+    expect(console).to.have.loggedError(
+      /React will try to recreate this component tree from scratch using the error boundary you provided/,
+    );
+
     const heading = getByText('doc_auth.headings.selfie');
     expect(document.activeElement).to.equal(heading);
 
     const hasValueSelected = !!getByText('doc_auth.forms.change_file');
     expect(hasValueSelected).to.be.true();
+
+    // Verify re-submission. It will fail again, but test can at least assure that the interstitial
+    // screen is shown once more.
+
+    submitButton = getByText('forms.buttons.submit.default');
+    userEvent.click(submitButton);
+    const interstitialHeading = getByText('doc_auth.headings.interstitial');
+    expect(interstitialHeading).to.be.ok();
+
+    await findByRole('alert');
 
     expect(console).to.have.loggedError(/^Error: Uncaught/);
     expect(console).to.have.loggedError(

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -217,4 +217,21 @@ describe('document-capture/components/form-steps', () => {
 
     expect(window.location.hash).to.equal('#step=second');
   });
+
+  it('accepts initial step', () => {
+    const { getByText } = render(<FormSteps steps={STEPS} initialStep="second" />);
+
+    expect(window.location.hash).to.equal('#step=second');
+    expect(getByText('Second')).to.be.ok();
+  });
+
+  it('accepts initial values', () => {
+    const { getByLabelText } = render(
+      <FormSteps steps={STEPS} initialStep="second" initialValues={{ second: 'prefilled' }} />,
+    );
+
+    const input = getByLabelText('Second');
+
+    expect(input.value).to.equal('prefilled');
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -222,6 +222,7 @@ describe('document-capture/components/form-steps', () => {
     const { getByText } = render(<FormSteps steps={STEPS} initialStep="second" />);
 
     expect(window.location.hash).to.equal('#step=second');
+    expect(document.activeElement).to.equal(getByText('Second Title'));
     expect(getByText('Second')).to.be.ok();
   });
 

--- a/spec/javascripts/packages/document-capture/hooks/use-history-param-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-history-param-spec.jsx
@@ -28,8 +28,8 @@ describe('getQueryParam', () => {
 });
 
 describe('useHistoryParam', () => {
-  function TestComponent() {
-    const [count = 0, setCount] = useHistoryParam('the count');
+  function TestComponent({ initialValue }) {
+    const [count = 0, setCount] = useHistoryParam('the count', initialValue);
 
     return (
       <>
@@ -65,6 +65,13 @@ describe('useHistoryParam', () => {
     window.location.hash = '#the%20count=5';
     const { getByDisplayValue } = render(<TestComponent />);
 
+    expect(getByDisplayValue('5')).to.be.ok();
+  });
+
+  it('accepts an initial value to use in absence of an initial URL', () => {
+    const { getByDisplayValue } = render(<TestComponent initialValue="5" />);
+
+    expect(window.location.hash).to.equal('#the%20count=5');
     expect(getByDisplayValue('5')).to.be.ok();
   });
 

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -6,7 +6,8 @@ import UploadContext from '@18f/identity-document-capture/context/upload';
 /**
  * @typedef RenderOptions
  *
- * @prop {boolean=} isUploadFailure Whether to simulate upload failure.
+ * @prop {boolean=} isUploadFailure Whether to simulate upload failure. Defaults to `false`.
+ * @prop {number=} expectedUploads Number of times upload is expected to be called. Defaults to `1`.
  */
 
 /**
@@ -21,16 +22,21 @@ import UploadContext from '@18f/identity-document-capture/context/upload';
  * @return {import('@testing-library/react').RenderResult}
  */
 function renderWithDefaultContext(element, options = {}) {
-  const { isUploadFailure } = options;
+  const { isUploadFailure = false, expectedUploads = 1 } = options;
 
   const upload = sinon
     .stub()
-    .onCall(0)
     .callsFake((payload) =>
       isUploadFailure ? Promise.reject(new Error('Failure!')) : Promise.resolve(payload),
     )
-    .onCall(1)
-    .throws();
+    .onCall(expectedUploads)
+    .throws(
+      new Error(
+        `Expected upload to have been called at most ${expectedUploads} times. It was called ${
+          expectedUploads + 1
+        } times.`,
+      ),
+    );
 
   return render(<UploadContext.Provider value={upload}>{element}</UploadContext.Provider>);
 }

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -4,20 +4,31 @@ import sinon from 'sinon';
 import UploadContext from '@18f/identity-document-capture/context/upload';
 
 /**
+ * @typedef RenderOptions
+ *
+ * @prop {boolean=} isUploadFailure Whether to simulate upload failure.
+ */
+
+/**
  * Pass-through to React Testing Library, which applies default context values
  * to stub behavior for testing environment.
  *
  * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
  *
  * @param {import('react').ReactElement} element Element to render.
+ * @param {RenderOptions=}               options Optional options.
  *
  * @return {import('@testing-library/react').RenderResult}
  */
-function renderWithDefaultContext(element) {
+function renderWithDefaultContext(element, options = {}) {
+  const { isUploadFailure } = options;
+
   const upload = sinon
     .stub()
     .onCall(0)
-    .callsFake((payload) => Promise.resolve(payload))
+    .callsFake((payload) =>
+      isUploadFailure ? Promise.reject(new Error('Failure!')) : Promise.resolve(payload),
+    )
     .onCall(1)
     .throws();
 


### PR DESCRIPTION
**Why**: If a document capture submission fails, the user should be returned to the form steps to make any necessary corrections.

**Screen recording:**

![submit-failure mov](https://user-images.githubusercontent.com/1779930/90401645-4233c400-e06c-11ea-94bb-2104493671b7.gif)

**Testing instructions:**

1. (Prerequisite) Ensure `document_capture_step_enabled: 'true'` in `config/application.yml`
2. Log in and navigate to `/verify`
3. Progress to the beginning of the React application (URL "/verify/doc_auth/document_capture")
4. Add `?fail` to URL
5. Navigate through document capture steps and submit
6. Observe error

<details><summary>Outdated pending tasks</summary>
To do:

- [x] Accessible focus or announcement of notice text
- [x] Unit tests
- [x] Type details on `CallbackOnMount`
- [x] Contemplate pulling in a third-party solution like [`@trussworks/react-uswds`](https://github.com/trussworks/react-uswds), even if `@18f/identity-components` should still exist, but act as a pass-through for non-customized USWDS components.
   - **Conclusion:** It might be worth considering at some point, if maintenance overhead becomes high, or if featureset needs expand. It should also depend if featureset _offered by_ third-party solution fits our needs.
</details>