### PR TITLE
Load fetch polyfill in legacy browsers

### DIFF
--- a/app/javascript/packages/polyfill/index.js
+++ b/app/javascript/packages/polyfill/index.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef Polyfill
+ *
+ * @prop {()=>boolean} test Test function, returning true if feature is detected as supported.
+ * @prop {()=>Promise} load Function to load polyfill module.
+ */
+
+/**
+ * @typedef {"fetch"} SupportedPolyfills
+ */
+
+/**
+ * @type {Record<SupportedPolyfills,Polyfill>}
+ */
+const POLYFILLS = {
+  fetch: {
+    test: () => 'fetch' in window,
+    load: () => import(/* webpackChunkName: "whatwg-fetch" */ 'whatwg-fetch'),
+  },
+};
+
+/**
+ * Given an array of supported polyfill names, loads polyfill if necessary. Returns a promise which
+ * resolves once all have been loaded.
+ *
+ * @param {SupportedPolyfills[]} polyfills Names of polyfills to load, if necessary.
+ *
+ * @return {Promise}
+ */
+export function loadPolyfills(polyfills) {
+  return Promise.all(
+    polyfills.map((name) => {
+      const { test, load } = POLYFILLS[name];
+      return test() ? Promise.resolve() : load();
+    }),
+  );
+}

--- a/app/javascript/packages/polyfill/package.json
+++ b/app/javascript/packages/polyfill/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@18f/identity-polyfill",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "whatwg-fetch": "^3.4.0"
+  }
+}

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -7,6 +7,7 @@ import {
   DeviceContext,
   AcuantProvider,
 } from '@18f/identity-document-capture';
+import { loadPolyfills } from '@18f/identity-polyfill';
 
 const { I18n: i18n, assets } = window.LoginGov;
 
@@ -21,20 +22,22 @@ const device = {
     /ip(hone|ad|od)|android/i.test(window.navigator.userAgent),
 };
 
-const appRoot = document.getElementById('document-capture-form');
-const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
-render(
-  <AcuantProvider
-    credentials={getMetaContent('acuant-sdk-initialization-creds')}
-    endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
-  >
-    <I18nContext.Provider value={i18n.strings}>
-      <AssetContext.Provider value={assets}>
-        <DeviceContext.Provider value={device}>
-          <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
-        </DeviceContext.Provider>
-      </AssetContext.Provider>
-    </I18nContext.Provider>
-  </AcuantProvider>,
-  appRoot,
-);
+loadPolyfills(['fetch']).then(() => {
+  const appRoot = document.getElementById('document-capture-form');
+  const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
+  render(
+    <AcuantProvider
+      credentials={getMetaContent('acuant-sdk-initialization-creds')}
+      endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
+    >
+      <I18nContext.Provider value={i18n.strings}>
+        <AssetContext.Provider value={assets}>
+          <DeviceContext.Provider value={device}>
+            <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
+          </DeviceContext.Provider>
+        </AssetContext.Provider>
+      </I18nContext.Provider>
+    </AcuantProvider>,
+    appRoot,
+  );
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -30,7 +30,7 @@ module.exports = function (api) {
         '@babel/preset-env',
         {
           forceAllTransforms: true,
-          useBuiltIns: 'entry',
+          useBuiltIns: 'usage',
           corejs: 3,
           modules: false,
           exclude: ['transform-typeof-symbol'],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   const validEnv = ['development', 'test', 'production'];
   const currentEnv = api.env();
   const isDevelopmentEnv = api.env('development');
@@ -7,11 +7,11 @@ module.exports = function(api) {
 
   if (!validEnv.includes(currentEnv)) {
     throw new Error(
-      `${'Please specify a valid `NODE_ENV` or '
-        + '`BABEL_ENV` environment variables. Valid values are "development", '
-        + '"test", and "production". Instead, received: '}${
-        JSON.stringify(currentEnv)
-      }.`,
+      `${
+        'Please specify a valid `NODE_ENV` or ' +
+        '`BABEL_ENV` environment variables. Valid values are "development", ' +
+        '"test", and "production". Instead, received: '
+      }${JSON.stringify(currentEnv)}.`,
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "typecheck": "tsc",
-    "lint": "eslint app spec --ext .js,.jsx",
+    "lint": "eslint app spec babel.config.js --ext .js,.jsx",
     "test": "mocha 'spec/javascripts/**/**spec.js?(x)'",
     "build": "true"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9615,6 +9615,11 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
+  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
+
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
Related to: LG-3241

**Why:** Document submission will use fetch global, which should be polyfilled in legacy browsers which do not support it

**Screenshot:**

![Screen Shot 2020-08-17 at 10 53 53 AM](https://user-images.githubusercontent.com/1779930/90410808-d60b8d00-e078-11ea-84bf-f31415e7f1af.png)
