### PR TITLE
Return x509 attributes in SAML responses if SP configured to include them and user presents PIV/CAC (LG-3186)

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -97,7 +97,7 @@ module SamlIdpAuthConcern
       name_id_format: name_id_format,
       authn_request: saml_request,
       decrypted_pii: decrypted_pii,
-      session: user_session,
+      user_session: user_session,
     )
   end
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -97,6 +97,7 @@ module SamlIdpAuthConcern
       name_id_format: name_id_format,
       authn_request: saml_request,
       decrypted_pii: decrypted_pii,
+      session: user_session,
     )
   end
 

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -140,6 +140,7 @@ class AttributeAsserter
   end
 
   def x509_data
+    return @x509_data if defined?(@x509_data)
     @x509_data ||= begin
       x509_hash = user_session[:decrypted_x509]
       X509::Attributes.new_from_json(x509_hash) if x509_hash

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -21,13 +21,13 @@ class AttributeAsserter
                  name_id_format:,
                  authn_request:,
                  decrypted_pii:,
-                 session:)
+                 user_session:)
     self.user = user
     self.service_provider = service_provider
     self.name_id_format = name_id_format
     self.authn_request = authn_request
     self.decrypted_pii = decrypted_pii
-    self.session = session
+    self.user_session = user_session
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -49,7 +49,7 @@ class AttributeAsserter
                 :name_id_format,
                 :authn_request,
                 :decrypted_pii,
-                :session
+                :user_session
 
   def ial_context
     @ial_context ||= IalContext.new(ial: authn_context, service_provider: service_provider)
@@ -141,7 +141,7 @@ class AttributeAsserter
 
   def x509_data
     @x509_data ||= begin
-      x509_hash = session[:decrypted_x509]
+      x509_hash = user_session[:decrypted_x509]
       X509::Attributes.new_from_json(x509_hash) if x509_hash
     end
   end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -146,11 +146,6 @@ class AttributeAsserter
     end
   end
 
-  def session_store
-    config = Rails.application.config
-    config.session_store.new({}, config.session_options)
-  end
-
   def ascii?
     bundle.include?(:ascii)
   end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -14,9 +14,6 @@ class AttributeAsserter
     dob
     ssn
     phone
-    x509
-    x509:subject
-    x509:presented
   ].freeze
 
   def initialize(user:,
@@ -40,7 +37,7 @@ class AttributeAsserter
     add_bundle(attrs) if user.active_profile.present? && ial_context.ial2_or_greater?
     add_verified_at(attrs) if bundle.include?(:verified_at) && ial_context.ial2_service_provider?
     add_aal(attrs) if authn_request.requested_aal_authn_context || !service_provider.aal.nil?
-    add_x509(attrs) if x509_data
+    add_x509(attrs) if bundle.include?(:x509_presented) && x509_data
     user.asserted_attributes = attrs
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -125,7 +125,7 @@ describe SamlIdpController do
           authn_request: this_authn_request,
           name_id_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           decrypted_pii: pii,
-          session: {},
+          user_session: {},
         )
       end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -125,6 +125,7 @@ describe SamlIdpController do
           authn_request: this_authn_request,
           name_id_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
           decrypted_pii: pii,
+          session: {},
         )
       end
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -5,6 +5,7 @@ describe AttributeAsserter do
 
   let(:ial1_user) { create(:user, :signed_up) }
   let(:user) { create(:profile, :active, :verified).user }
+  let(:session) { {} }
   let(:identity) do
     build(
       :identity,
@@ -50,6 +51,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
+          session: session,
         )
       end
 
@@ -145,6 +147,42 @@ describe AttributeAsserter do
           expect(user.asserted_attributes.keys).to eq(%i[uuid email verified_at])
         end
       end
+
+      context 'x509 attributes included in the SP attribute bundle' do
+        before do
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+            and_return(%w[email x509_subject x509_presented])
+          subject.build
+        end
+
+        context 'user did not presented piv/cac' do
+          let(:session) do
+            {
+              decrypted_x509: nil,
+            }
+          end
+
+          it 'does not include x509_subject and x509_presented' do
+            expect(user.asserted_attributes.keys).to eq %i[uuid email verified_at]
+          end
+        end
+
+        context 'user presented piv/cac' do
+          let(:session) do
+            {
+              decrypted_x509: {
+                subject: 'x509 subject',
+                presented: true,
+              }.to_json,
+            }
+          end
+
+          it 'includes x509_subject and x509_presented' do
+            expected = %i[uuid email verified_at x509_subject x509_presented]
+            expect(user.asserted_attributes.keys).to eq expected
+          end
+        end
+      end
     end
 
     context 'verified user and IAL1 request' do
@@ -155,6 +193,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,
+          session: session,
         )
       end
 
@@ -256,6 +295,42 @@ describe AttributeAsserter do
           expect(user.asserted_attributes.keys).to eq(%i[uuid email])
         end
       end
+
+      context 'x509 attributes included in the SP attribute bundle' do
+        before do
+          allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+            and_return(%w[email x509_subject x509_presented])
+          subject.build
+        end
+
+        context 'user did not presented piv/cac' do
+          let(:session) do
+            {
+              decrypted_x509: nil,
+            }
+          end
+
+          it 'does not include x509_subject and x509_presented' do
+            expect(user.asserted_attributes.keys).to eq %i[uuid email]
+          end
+        end
+
+        context 'user presented piv/cac' do
+          let(:session) do
+            {
+              decrypted_x509: {
+                subject: 'x509 subject',
+                presented: true,
+              }.to_json,
+            }
+          end
+
+          it 'includes x509_subject and x509_presented' do
+            expected = %i[uuid email x509_subject x509_presented]
+            expect(user.asserted_attributes.keys).to eq expected
+          end
+        end
+      end
     end
 
     context 'verified user and IAL1 AAL3 request' do
@@ -268,6 +343,7 @@ describe AttributeAsserter do
             service_provider: service_provider,
             authn_request: ial1_authn_request,
             decrypted_pii: decrypted_pii,
+            session: session,
           )
         end
 
@@ -296,6 +372,7 @@ describe AttributeAsserter do
             service_provider: service_provider,
             authn_request: ial1_aal3_authn_request,
             decrypted_pii: decrypted_pii,
+            session: session,
           )
         end
 
@@ -353,6 +430,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
+          session: session,
         )
       end
 
@@ -367,6 +445,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,
+          session: session,
         )
       end
 

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -155,7 +155,7 @@ describe AttributeAsserter do
           subject.build
         end
 
-        context 'user did not presented piv/cac' do
+        context 'user did not present piv/cac' do
           let(:user_session) do
             {
               decrypted_x509: nil,
@@ -303,7 +303,7 @@ describe AttributeAsserter do
           subject.build
         end
 
-        context 'user did not presented piv/cac' do
+        context 'user did not present piv/cac' do
           let(:user_session) do
             {
               decrypted_x509: nil,

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -5,7 +5,7 @@ describe AttributeAsserter do
 
   let(:ial1_user) { create(:user, :signed_up) }
   let(:user) { create(:profile, :active, :verified).user }
-  let(:session) { {} }
+  let(:user_session) { {} }
   let(:identity) do
     build(
       :identity,
@@ -51,7 +51,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
-          session: session,
+          user_session: user_session,
         )
       end
 
@@ -156,7 +156,7 @@ describe AttributeAsserter do
         end
 
         context 'user did not presented piv/cac' do
-          let(:session) do
+          let(:user_session) do
             {
               decrypted_x509: nil,
             }
@@ -168,7 +168,7 @@ describe AttributeAsserter do
         end
 
         context 'user presented piv/cac' do
-          let(:session) do
+          let(:user_session) do
             {
               decrypted_x509: {
                 subject: 'x509 subject',
@@ -193,7 +193,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,
-          session: session,
+          user_session: user_session,
         )
       end
 
@@ -304,7 +304,7 @@ describe AttributeAsserter do
         end
 
         context 'user did not presented piv/cac' do
-          let(:session) do
+          let(:user_session) do
             {
               decrypted_x509: nil,
             }
@@ -316,7 +316,7 @@ describe AttributeAsserter do
         end
 
         context 'user presented piv/cac' do
-          let(:session) do
+          let(:user_session) do
             {
               decrypted_x509: {
                 subject: 'x509 subject',
@@ -343,7 +343,7 @@ describe AttributeAsserter do
             service_provider: service_provider,
             authn_request: ial1_authn_request,
             decrypted_pii: decrypted_pii,
-            session: session,
+            user_session: user_session,
           )
         end
 
@@ -372,7 +372,7 @@ describe AttributeAsserter do
             service_provider: service_provider,
             authn_request: ial1_aal3_authn_request,
             decrypted_pii: decrypted_pii,
-            session: session,
+            user_session: user_session,
           )
         end
 
@@ -430,7 +430,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial2_authn_request,
           decrypted_pii: decrypted_pii,
-          session: session,
+          user_session: user_session,
         )
       end
 
@@ -445,7 +445,7 @@ describe AttributeAsserter do
           service_provider: service_provider,
           authn_request: ial1_authn_request,
           decrypted_pii: decrypted_pii,
-          session: session,
+          user_session: user_session,
         )
       end
 


### PR DESCRIPTION
If a SAML service provider is configured with x509_presented and x509_subject in its attribute bundle, and the user presents their PIV/CAC to authenticate, the attributes are now returned in the SAML assertion.