### PR TITLE
LG-3284: Wire React document capture UI to doc auth endpoint 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "operator-linebreak": "off",
+    "react/jsx-curly-newline": "off",
     "react/jsx-one-expression-per-line": "off",
     "react/prop-types": "off"
   },

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -6,8 +6,8 @@ import DeviceContext from '../context/device';
 /**
  * @typedef DocumentsStepValue
  *
- * @prop {Blob=} front_image Front image value.
- * @prop {Blob=} back_image Back image value.
+ * @prop {Blob=} front Front image value.
+ * @prop {Blob=} back Back image value.
  */
 
 /**
@@ -42,24 +42,20 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
         <li>{t('doc_auth.tips.document_capture_id_text3')}</li>
         {!isMobile && <li>{t('doc_auth.tips.document_capture_id_text4')}</li>}
       </ul>
-      {DOCUMENT_SIDES.map((side) => {
-        const inputKey = `${side}_image`;
-
-        return (
-          <AcuantCapture
-            key={side}
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
-            /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
-            label={t(`doc_auth.headings.document_capture_${side}`)}
-            /* i18n-tasks-use t('doc_auth.headings.back') */
-            /* i18n-tasks-use t('doc_auth.headings.front') */
-            bannerText={t(`doc_auth.headings.${side}`)}
-            value={value[inputKey]}
-            onChange={(nextValue) => onChange({ [inputKey]: nextValue })}
-            className="id-card-file-input"
-          />
-        );
-      })}
+      {DOCUMENT_SIDES.map((side) => (
+        <AcuantCapture
+          key={side}
+          /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
+          /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
+          label={t(`doc_auth.headings.document_capture_${side}`)}
+          /* i18n-tasks-use t('doc_auth.headings.back') */
+          /* i18n-tasks-use t('doc_auth.headings.front') */
+          bannerText={t(`doc_auth.headings.${side}`)}
+          value={value[side]}
+          onChange={(nextValue) => onChange({ [side]: nextValue })}
+          className="id-card-file-input"
+        />
+      ))}
     </>
   );
 }
@@ -71,6 +67,6 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
  *
  * @return {boolean} Whether step is valid.
  */
-export const isValid = (value) => Boolean(value.front_image && value.back_image);
+export const isValid = (value) => Boolean(value.front && value.back);
 
 export default DocumentsStep;

--- a/app/javascript/packages/document-capture/context/upload.js
+++ b/app/javascript/packages/document-capture/context/upload.js
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-import upload from '../services/upload';
-
-const UploadContext = createContext(upload);
-
-export default UploadContext;

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -1,0 +1,54 @@
+import React, { createContext } from 'react';
+import defaultUpload from '../services/upload';
+
+const UploadContext = createContext(defaultUpload);
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef UploadOptions
+ *
+ * @prop {string} endpoint Endpoint to which payload should be sent.
+ * @prop {string} csrf CSRF token to send as parameter to upload implementation.
+ */
+
+/**
+ * @typedef UploadSuccessResponse
+ *
+ * @prop {true} success Whether request was successful.
+ */
+
+/**
+ * @typedef UploadErrorResponse
+ *
+ * @prop {false} success Whether request was successful.
+ * @prop {string[]} errors Error messages.
+ */
+
+/**
+ * @typedef {(
+ *   payload:Record<string,any>,
+ *   options:UploadOptions
+ * )=>Promise<UploadSuccessResponse>} UploadImplementation
+ */
+
+/**
+ * @typedef UploadContextProviderProps
+ *
+ * @prop {UploadImplementation=} upload Custom upload implementation.
+ * @prop {string} endpoint Endpoint to which payload should be sent.
+ * @prop {string} csrf CSRF token to send as parameter to upload implementation.
+ * @prop {ReactNode} children Child elements.
+ */
+
+/**
+ * @param {UploadContextProviderProps} props Props object.
+ */
+function UploadContextProvider({ upload = defaultUpload, endpoint, csrf, children }) {
+  const uploadWithCSRF = (payload) => upload(payload, { endpoint, csrf });
+
+  return <UploadContext.Provider value={uploadWithCSRF}>{children}</UploadContext.Provider>;
+}
+
+export default UploadContext;
+export { UploadContextProvider as Provider };

--- a/app/javascript/packages/document-capture/index.js
+++ b/app/javascript/packages/document-capture/index.js
@@ -3,3 +3,4 @@ export { default as AssetContext } from './context/asset';
 export { default as I18nContext } from './context/i18n';
 export { default as DeviceContext } from './context/device';
 export { Provider as AcuantProvider } from './context/acuant';
+export { Provider as UploadContextProvider } from './context/upload';

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -1,8 +1,44 @@
-function upload(payload) {
-  return new Promise((resolve, reject) => {
-    const isFailure = window.location.search === '?fail';
-    setTimeout(isFailure ? reject : () => resolve({ ...payload, saved: true }), 2000);
+/** @typedef {import('../context/upload').UploadSuccessResponse} UploadSuccessResponse */
+/** @typedef {import('../context/upload').UploadErrorResponse} UploadErrorResponse */
+
+/**
+ * Returns a FormData representation of the given object.
+ *
+ * @param {Record<string,any>} object Object to serialize.
+ *
+ * @return {FormData}
+ */
+export function toFormData(object) {
+  return Object.keys(object).reduce((form, key) => {
+    form.append(key, object[key]);
+    return form;
+  }, new window.FormData());
+}
+
+/**
+ * @type {import('../context/upload').UploadImplementation}
+ */
+async function upload(payload, { endpoint, csrf }) {
+  const response = await window.fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'X-CSRF-Token': csrf,
+    },
+    body: toFormData(payload),
   });
+
+  if (!response.ok && response.status !== 400) {
+    // 400 is an expected error state, handled after JSON deserialization. Anything else not OK
+    // should be treated as an unhandled error.
+    throw new Error(response.statusText);
+  }
+
+  const result = /** @type {UploadSuccessResponse|UploadErrorResponse} */ (await response.json());
+  if (!result.success) {
+    throw Error(/** @type {UploadErrorResponse} */ (result).errors.join(', '));
+  }
+
+  return /** @type {UploadSuccessResponse} */ (result);
 }
 
 export default upload;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -6,6 +6,7 @@ import {
   I18nContext,
   DeviceContext,
   AcuantProvider,
+  UploadContextProvider,
 } from '@18f/identity-document-capture';
 import { loadPolyfills } from '@18f/identity-polyfill';
 import { isCameraCapableMobile } from '@18f/identity-device';
@@ -24,18 +25,24 @@ const device = {
 loadPolyfills(['fetch']).then(() => {
   const appRoot = document.getElementById('document-capture-form');
   const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
+
   render(
     <AcuantProvider
       credentials={getMetaContent('acuant-sdk-initialization-creds')}
       endpoint={getMetaContent('acuant-sdk-initialization-endpoint')}
     >
-      <I18nContext.Provider value={i18n.strings}>
-        <AssetContext.Provider value={assets}>
-          <DeviceContext.Provider value={device}>
-            <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
-          </DeviceContext.Provider>
-        </AssetContext.Provider>
-      </I18nContext.Provider>
+      <UploadContextProvider
+        endpoint={appRoot.getAttribute('data-endpoint')}
+        csrf={getMetaContent('csrf-token')}
+      >
+        <I18nContext.Provider value={i18n.strings}>
+          <AssetContext.Provider value={assets}>
+            <DeviceContext.Provider value={device}>
+              <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
+            </DeviceContext.Provider>
+          </AssetContext.Provider>
+        </I18nContext.Provider>
+      </UploadContextProvider>
     </AcuantProvider>,
     appRoot,
   );

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -10,7 +10,10 @@
       content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
     >
   <% end %>
-  <%= tag.div id: 'document-capture-form', data: { liveness: liveness_checking_enabled?.presence } %>
+  <%= tag.div id: 'document-capture-form', data: {
+    liveness: liveness_checking_enabled?.presence,
+    endpoint: verify_images_api_url
+  } %>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
 

--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <%= tag.div id: 'document-capture-form', data: {
     liveness: liveness_checking_enabled?.presence,
-    endpoint: verify_images_api_url
+    endpoint: api_verify_images_url
   } %>
   <noscript>
     <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
         via: %i[get post],
         format: :xml
 
-  post '/api/verify/images' => 'idv/image_uploads#create', as: :verify_images_api
+  post '/api/verify/images' => 'idv/image_uploads#create'
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   get '/openid_connect/logout' => 'openid_connect/logout#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
         via: %i[get post],
         format: :xml
 
-  post '/api/verify/images' => 'idv/image_uploads#create'
+  post '/api/verify/images' => 'idv/image_uploads#create', as: :verify_images_api
 
   get '/openid_connect/authorize' => 'openid_connect/authorization#index'
   get '/openid_connect/logout' => 'openid_connect/logout#index'

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -45,9 +45,7 @@ describe('document-capture/components/document-capture', () => {
     await waitFor(() => expect(submitButton.disabled).to.be.false());
     userEvent.click(submitButton);
 
-    const confirmation = await findByText(
-      'Finished sending: {"front_image":{},"back_image":{},"selfie":{}}',
-    );
+    const confirmation = await findByText('Finished sending: {"front":{},"back":{},"selfie":{}}');
 
     expect(confirmation).to.be.ok();
   });

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -22,7 +22,7 @@ describe('document-capture/components/documents-step', () => {
     const file = new window.File([''], 'upload.png', { type: 'image/png' });
 
     userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file);
-    expect(onChange.getCall(0).args[0]).to.deep.equal({ front_image: file });
+    expect(onChange.getCall(0).args[0]).to.deep.equal({ front: file });
   });
 
   it('restricts accepted file types', () => {

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -1,0 +1,67 @@
+import React, { createElement, useContext, useEffect } from 'react';
+import { render as baseRender } from '@testing-library/react';
+import UploadContext, {
+  Provider as UploadContextProvider,
+} from '@18f/identity-document-capture/context/upload';
+import defaultUpload from '@18f/identity-document-capture/services/upload';
+import render from '../../../support/render';
+
+describe('document-capture/context/upload', () => {
+  it('defaults to the default upload service', () => {
+    baseRender(
+      createElement(() => {
+        const upload = useContext(UploadContext);
+        expect(upload).to.equal(defaultUpload);
+        return null;
+      }),
+    );
+  });
+
+  it('can be overridden with custom upload behavior', (done) => {
+    render(
+      <UploadContextProvider upload={(payload) => Promise.resolve({ ...payload, received: true })}>
+        {createElement(() => {
+          const upload = useContext(UploadContext);
+          useEffect(() => {
+            upload({ sent: true }).then((result) => {
+              expect(result).to.deep.equal({ sent: true, received: true });
+              done();
+            });
+          }, [upload]);
+          return null;
+        })}
+      </UploadContextProvider>,
+    );
+  });
+
+  it('can provide endpoint and csrf to make available to uploader', (done) => {
+    render(
+      <UploadContextProvider
+        upload={(payload, { endpoint, csrf }) =>
+          Promise.resolve({
+            ...payload,
+            receivedEndpoint: endpoint,
+            receivedCSRF: csrf,
+          })
+        }
+        csrf="example"
+        endpoint="https://example.com"
+      >
+        {createElement(() => {
+          const upload = useContext(UploadContext);
+          useEffect(() => {
+            upload({ sent: true }).then((result) => {
+              expect(result).to.deep.equal({
+                sent: true,
+                receivedEndpoint: 'https://example.com',
+                receivedCSRF: 'example',
+              });
+              done();
+            });
+          }, [upload]);
+          return null;
+        })}
+      </UploadContextProvider>,
+    );
+  });
+});

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -1,0 +1,81 @@
+import upload, { toFormData } from '@18f/identity-document-capture/services/upload';
+import { useSandbox } from '../../../support/sinon';
+
+describe('document-capture/services/upload', () => {
+  const sandbox = useSandbox();
+
+  describe('toFormData', () => {
+    it('returns FormData representation of object', () => {
+      const result = toFormData({ foo: 'bar' });
+
+      expect(result).to.be.instanceOf(window.FormData);
+      expect(/** @type {FormData} */ (result).get('foo')).to.equal('bar');
+    });
+  });
+
+  it('submits payload to endpoint successfully', async () => {
+    const endpoint = 'https://example.com';
+    const csrf = 'TYsqyyQ66Y';
+
+    sandbox.stub(window, 'fetch').callsFake((url, init) => {
+      expect(url).to.equal(endpoint);
+      expect(init.headers['X-CSRF-Token']).to.equal(csrf);
+      expect(init.body).to.be.instanceOf(window.FormData);
+      expect(init.body.get('foo')).to.equal('bar');
+
+      return Promise.resolve(
+        /** @type {Partial<Response>} */ ({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              success: true,
+            }),
+        }),
+      );
+    });
+
+    const result = await upload({ foo: 'bar' }, { endpoint, csrf });
+    expect(result).to.deep.equal({ success: true });
+  });
+
+  it('handles invalid request', async () => {
+    sandbox.stub(window, 'fetch').callsFake(() =>
+      Promise.resolve(
+        /** @type {Partial<Response>} */ ({
+          ok: false,
+          status: 400,
+          json: () =>
+            Promise.resolve({
+              success: false,
+              errors: ['Foo missing', 'Baz missing'],
+            }),
+        }),
+      ),
+    );
+
+    try {
+      await upload({}, { endpoint: 'https://example.com', csrf: 'TYsqyyQ66Y' });
+    } catch (error) {
+      expect(error.message).to.equal('Foo missing, Baz missing');
+    }
+  });
+
+  it('throws unhandled response', async () => {
+    sandbox.stub(window, 'fetch').callsFake(() =>
+      Promise.resolve(
+        /** @type {Partial<Response>} */ ({
+          ok: false,
+          status: 500,
+          statusText: 'Server error',
+        }),
+      ),
+    );
+
+    try {
+      await upload({}, { endpoint: 'https://example.com', csrf: 'TYsqyyQ66Y' });
+    } catch (error) {
+      expect(error.message).to.equal('Server error');
+    }
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -12,6 +12,7 @@ global.expect = chai.expect;
 // managing history API (pushState, etc).
 const dom = createDOM();
 global.window = dom.window;
+global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
 global.navigator = window.navigator;
 global.document = window.document;
 global.getComputedStyle = window.getComputedStyle;

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import sinon from 'sinon';
-import UploadContext from '@18f/identity-document-capture/context/upload';
+import { UploadContextProvider } from '@18f/identity-document-capture';
 
 /**
  * @typedef RenderOptions
@@ -38,7 +38,7 @@ function renderWithDefaultContext(element, options = {}) {
       ),
     );
 
-  return render(<UploadContext.Provider value={upload}>{element}</UploadContext.Provider>);
+  return render(<UploadContextProvider upload={upload}>{element}</UploadContextProvider>);
 }
 
 export default renderWithDefaultContext;

--- a/spec/javascripts/support/sinon.js
+++ b/spec/javascripts/support/sinon.js
@@ -1,0 +1,15 @@
+import sinon from 'sinon';
+
+/**
+ * Returns an instance of a Sinon sandbox, and automatically restores all stubbed methods after each
+ * test case.
+ */
+export function useSandbox() {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  return sandbox;
+}


### PR DESCRIPTION
**Why:** As a user uploading documents for proofing, I expect that the React-based form flow will submit my chosen documents so that I can continue with proofing.

This pull request adds upload behavior to the new image API endpoint implemented in #4069.

It does not:

- ...present "handled" errors in a helpful manner (missing images, etc)
- ...redirect the user after the submission completes
- ...submit values in the format expected by the server (see #4082).
   - All submissions will currently fail.