### PR TITLE
Handle nil user on reset disavowal

### DIFF
--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -40,7 +40,7 @@ class EventDisavowalController < ApplicationController
     result = EventDisavowal::ValidateDisavowedEvent.new(disavowed_event).call
     return if result.success?
     analytics.track_event(Analytics::EVENT_DISAVOWAL_TOKEN_INVALID, result.to_h)
-    flash[:error] = result.errors[:event].first
+    flash[:error] = (result.errors[:event] || result.errors.first.last).first
     redirect_to root_url
   end
 

--- a/app/services/event_disavowal/validate_disavowed_event.rb
+++ b/app/services/event_disavowal/validate_disavowed_event.rb
@@ -2,11 +2,18 @@ module EventDisavowal
   class ValidateDisavowedEvent
     include ActiveModel::Model
 
-    validates :event, presence: { message: I18n.t('event_disavowals.errors.event_not_found') }
+    validates :event, presence: {
+      message: proc { I18n.t('event_disavowals.errors.event_not_found') },
+    }
     validate :event_is_not_already_disavowed
     validate :event_disavowment_is_not_expired
+    validates_presence_of :user, {
+      message: proc { I18n.t('event_disavowals.errors.no_account') },
+    }
 
     attr_reader :event
+
+    delegate :user, to: :event
 
     def initialize(event)
       @event = event

--- a/app/services/event_disavowal/validate_disavowed_event.rb
+++ b/app/services/event_disavowal/validate_disavowed_event.rb
@@ -13,7 +13,7 @@ module EventDisavowal
 
     attr_reader :event
 
-    delegate :user, to: :event
+    delegate :user, to: :event, allow_nil: true
 
     def initialize(event)
       @event = event

--- a/config/locales/event_disavowals/en.yml
+++ b/config/locales/event_disavowals/en.yml
@@ -8,3 +8,4 @@ en:
         in to change your password.
       event_not_found: The link to change your password is invalid. Sign in to change
         your password.
+      no_account: There is no account associated with this event.

--- a/config/locales/event_disavowals/es.yml
+++ b/config/locales/event_disavowals/es.yml
@@ -8,3 +8,4 @@ es:
         sesión para cambiar tu contraseña.
       event_not_found: El enlace para cambiar su contraseña no es válido. Inicia sesión
         para cambiar tu contraseña.
+      no_account: No hay ninguna cuenta asociada con este evento.

--- a/config/locales/event_disavowals/fr.yml
+++ b/config/locales/event_disavowals/fr.yml
@@ -8,3 +8,4 @@ fr:
         pour changer votre mot de passe.
       event_not_found: Le lien pour changer votre mot de passe est invalide. Connectez-vous
         pour changer votre mot de passe.
+      no_account: Aucun compte n'est associé à cet événement.

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -110,7 +110,7 @@ describe EventDisavowalController do
             errors: {
               user: [t('event_disavowals.errors.no_account')],
             },
-          )
+          ),
         )
 
         post :create, params: {

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -108,7 +108,7 @@ describe EventDisavowalController do
           build_analytics_hash(
             success: false,
             errors: {
-              user: ["There is no account associated with this event."],
+              user: [t('event_disavowals.errors.no_account')],
             },
           )
         )

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -97,7 +97,7 @@ describe EventDisavowalController do
       end
     end
 
-    context 'with an user that has been deleted' do
+    context 'with an event whose user has been deleted' do
       before do
         event.user.delete
       end

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -43,7 +43,7 @@ describe EventDisavowalController do
   end
 
   describe '#create' do
-    context 'with a valid passowrd' do
+    context 'with a valid password' do
       it 'tracks an analytics event' do
         expect(@analytics).to receive(:track_event).with(
           Analytics::EVENT_DISAVOWAL_PASSWORD_RESET,
@@ -94,6 +94,29 @@ describe EventDisavowalController do
         }
 
         post :create, params: params
+      end
+    end
+
+    context 'with an user that has been deleted' do
+      before do
+        event.user.delete
+      end
+
+      it 'errors' do
+        expect(@analytics).to receive(:track_event).with(
+          Analytics::EVENT_DISAVOWAL_TOKEN_INVALID,
+          build_analytics_hash(
+            success: false,
+            errors: {
+              user: ["There is no account associated with this event."],
+            },
+          )
+        )
+
+        post :create, params: {
+          disavowal_token: disavowal_token,
+          event_disavowal_password_reset_from_disavowal_form: { password: 'salty pickles' },
+        }
       end
     end
   end


### PR DESCRIPTION
**Why**: We observed errors in production due to nil users