### PR TITLE
LG-3285: Implement desktop liveness in React document capture

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,9 +2,8 @@
 
 ### Files licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/)
 
-The SVG element embedded in `app/javascript/packages/document-capture/components/selfie-capture.jsx`
-is an adaptation of icons provided by [Font Awesome](https://fontawesome.com/),
-licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
+The SVG elements embedded in `app/javascript/packages/components/icon.jsx` are adapted from icons
+provided by [Font Awesome](https://fontawesome.com/), licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## The rest of this project is in the worldwide public domain
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,13 @@
+## A few parts of this project are not in the public domain
+
+### Files licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+The SVG element embedded in `app/javascript/packages/document-capture/components/selfie-capture.jsx`
+is an adaptation of icons provided by [Font Awesome](https://fontawesome.com/),
+licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## The rest of this project is in the worldwide public domain
+
 As a work of the United States Government, this project is in the
 public domain within the United States.
 

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -39,6 +39,7 @@
 .usa-file-input:not(.usa-file-input--has-value) {
   .usa-file-input__target {
     border-color: color('primary');
+    border-radius: .375rem;
     border-width: 2px;
 
     &:hover {

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -1,0 +1,99 @@
+.selfie-capture {
+  align-items: center;
+  border: 2px dashed color('primary');
+  border-radius: .375rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+
+  &::after {
+    content: '';
+    padding-bottom: 100%;
+  }
+}
+
+.selfie-capture--capturing,
+.selfie-capture--has-value {
+  border-color: color('base-light');
+  border-radius: 0;
+  border-width: 1px;
+}
+
+.selfie-capture--has-value::after {
+  content: none;
+}
+
+.selfie-capture__frame-corner {
+  border: 3px solid color('primary');
+  height: 4rem;
+  left: 50%;
+  position: absolute;
+  top: 30%;
+  width: 3rem;
+
+  &:nth-child(1) {
+    border-bottom-width: 0;
+    border-right-width: 0;
+    transform: translate(-275%, -175%);
+  }
+
+  &:nth-child(2) {
+    border-bottom-width: 0;
+    border-left-width: 0;
+    transform: translate(175%, -175%);
+  }
+
+  &:nth-child(3) {
+    border-right-width: 0;
+    border-top-width: 0;
+    transform: translate(-275%, 175%);
+  }
+
+  &:nth-child(4) {
+    border-left-width: 0;
+    border-top-width: 0;
+    transform: translate(175%, 175%);
+  }
+}
+
+.selfie-capture__preview-image,
+.selfie-capture__video {
+  transform: scaleX(-1); // Mirror the video so that the user's head moves in anticipated direction.
+}
+
+.selfie-capture__video {
+  bottom: 0;
+  height: 100%;
+  position: absolute;
+  top: 0;
+}
+
+.selfie-capture__capture {
+  @include u-padding(2);
+  background-color: color('primary');
+  border: 3px solid color('white');
+  border-radius: 50%;
+  bottom: 5%;
+  color: color('white');
+  left: 50%;
+  line-height: 1;
+  position: absolute;
+  transform: translateX(-50%);
+
+  &:hover {
+    background-color: color('primary-dark');
+  }
+}
+
+.selfie-capture__capture-icon {
+  height: 2rem;
+  width: 2rem;
+}
+
+// Disable reason: The ID selector is temporary, and is only needed as long as Login Design System
+// has yet to be upgraded to USWDS 2.7+.
+#document-capture-form .selfie-capture__preview-heading.usa-file-input__preview-heading { // scss-lint:disable IdSelector
+  pointer-events: all;
+  width: 100%;
+}

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -1,4 +1,5 @@
 .selfie-capture {
+  @include u-margin-top(1);
   align-items: center;
   border: 2px dashed color('primary');
   border-radius: .375rem;

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -24,6 +24,22 @@
   content: none;
 }
 
+.selfie-capture__consent-prompt {
+  left: 11%;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 78%;
+}
+
+// Disable reason: The ID selector is temporary, and is only needed as long as Login Design System
+// has yet to be upgraded to USWDS 2.7+.
+#document-capture-form .selfie-capture__consent-prompt-banner.usa-file-input__banner-text { // scss-lint:disable IdSelector
+  @include u-margin-bottom(4);
+  text-transform: none;
+}
+
 .selfie-capture__frame-corner {
   border: 3px solid color('primary');
   height: 4rem;

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -85,21 +85,18 @@
   top: 0;
 }
 
-.selfie-capture__capture {
+.usa-button.selfie-capture__capture {
   @include u-padding(2);
-  background-color: color('primary');
   border: 3px solid color('white');
   border-radius: 50%;
-  bottom: 5%;
-  color: color('white');
-  left: 50%;
   line-height: 1;
+}
+
+.selfie-capture__capture {
+  bottom: 5%;
+  left: 50%;
   position: absolute;
   transform: translateX(-50%);
-
-  &:hover {
-    background-color: color('primary-dark');
-  }
 }
 
 .selfie-capture__capture-icon {

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -10,7 +10,7 @@
 
   &::after {
     content: '';
-    padding-bottom: 100%;
+    padding-bottom: 85%;
   }
 }
 
@@ -43,34 +43,34 @@
 
 .selfie-capture__frame-corner {
   border: 3px solid color('primary');
-  height: 4rem;
+  height: 3rem;
   left: 50%;
   position: absolute;
-  top: 30%;
-  width: 3rem;
+  top: 2rem;
+  width: 2rem;
 
   &:nth-child(1) {
     border-bottom-width: 0;
     border-right-width: 0;
-    transform: translate(-275%, -175%);
+    transform: translate(-8rem, 0);
   }
 
   &:nth-child(2) {
     border-bottom-width: 0;
     border-left-width: 0;
-    transform: translate(175%, -175%);
+    transform: translate(6rem, 0);
   }
 
   &:nth-child(3) {
     border-right-width: 0;
     border-top-width: 0;
-    transform: translate(-275%, 175%);
+    transform: translate(-8rem, 13rem);
   }
 
   &:nth-child(4) {
     border-left-width: 0;
     border-top-width: 0;
-    transform: translate(175%, 175%);
+    transform: translate(6rem, 13rem);
   }
 }
 
@@ -94,7 +94,7 @@
 }
 
 .selfie-capture__capture {
-  bottom: 5%;
+  bottom: 1.5rem;
   left: 50%;
   position: absolute;
   transform: translateX(-50%);

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -21,6 +21,15 @@
   border-width: 1px;
 }
 
+.selfie-capture--access-rejected {
+  border-color: color('error-dark');
+  border-width: 3px;
+
+  &:hover {
+    border-color: color('error-darker');
+  }
+}
+
 .selfie-capture--has-value::after {
   content: none;
 }
@@ -32,6 +41,10 @@
   top: 50%;
   transform: translateY(-50%);
   width: 78%;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 // Disable reason: The ID selector is temporary, and is only needed as long as Login Design System

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -25,7 +25,7 @@
 @import 'verification-badge';
 @import 'spinner';
 @import 'full-screen';
-
+@import 'selfie-capture';
 @import 'space-addon';
 @import 'space-misc';
 @import 'typography';

--- a/app/javascript/packages/components/icon.jsx
+++ b/app/javascript/packages/components/icon.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+/**
+ * @typedef IconProps
+ *
+ * @prop {string=} className Optional class name to apply to SVG element.
+ */
+
+/**
+ * Creates a new icon component, accepting common props, and applying common wrapping elements.
+ *
+ * @param {string} path SVG icon path definition.
+ *
+ * @return {import('react').FunctionComponent<IconProps>}
+ */
+function createIconComponent(path) {
+  return ({ className }) => (
+    <svg
+      aria-hidden
+      focusable={false}
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className={className}
+    >
+      <path fill="currentColor" d={path} />
+    </svg>
+  );
+}
+
+const Icon = {
+  Camera: createIconComponent(
+    'M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z',
+  ),
+};
+
+export default Icon;

--- a/app/javascript/packages/components/index.js
+++ b/app/javascript/packages/components/index.js
@@ -1,1 +1,2 @@
 export { default as Alert } from './alert';
+export { default as Icon } from './icon';

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -96,7 +96,7 @@ function SelfieCapture({ value, onChange }) {
               </div>
               <button
                 type="button"
-                className="selfie-capture__capture"
+                className="usa-button selfie-capture__capture"
                 aria-label={t('doc_auth.buttons.take_picture')}
                 onClick={onCapture}
               >

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -114,6 +114,7 @@ function SelfieCapture({ value, onChange }) {
   const classes = [
     'selfie-capture',
     isCapturing && 'selfie-capture--capturing',
+    isAccessRejected && 'selfie-capture--access-rejected',
     value && 'selfie-capture--has-value',
   ]
     .filter(Boolean)
@@ -133,7 +134,7 @@ function SelfieCapture({ value, onChange }) {
       </div>
       {isAccessRejected && (
         <span className="usa-error-message" role="alert">
-          {t('doc_auth.instructions.document_capture_selfie_consent_blocked')}
+          {t('errors.doc_auth.document_capture_selfie_consent_blocked')}
         </span>
       )}
       <div ref={wrapperRef} className={classes}>
@@ -178,9 +179,10 @@ function SelfieCapture({ value, onChange }) {
                 <strong className="selfie-capture__consent-prompt-banner usa-file-input__banner-text">
                   {t('doc_auth.instructions.document_capture_selfie_consent_banner')}
                 </strong>
-                <span className="usa-file-input__drag-text">
-                  {t('doc_auth.instructions.document_capture_selfie_consent_reason')}
-                </span>
+                <p>{t('doc_auth.instructions.document_capture_selfie_consent_reason')}</p>
+                {isAccessRejected && (
+                  <p>{t('doc_auth.instructions.document_capture_selfie_consent_blocked')}</p>
+                )}
               </div>
             )}
           </>

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react'
 import FileImage from './file-image';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useI18n from '../hooks/use-i18n';
+import useInstanceId from '../hooks/use-instance-id';
 
 /**
  * @typedef SelfieCaptureProps
@@ -14,6 +15,7 @@ import useI18n from '../hooks/use-i18n';
  * @param {SelfieCaptureProps} props Props object.
  */
 function SelfieCapture({ value, onChange }) {
+  const instanceId = useInstanceId();
   const { t } = useI18n();
 
   const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
@@ -94,8 +96,16 @@ function SelfieCapture({ value, onChange }) {
     .filter(Boolean)
     .join(' ');
 
+  const labelId = `selfie-capture-label-${instanceId}`;
+
   return (
     <>
+      <div
+        id={labelId}
+        className={['usa-label', isAccessRejected && 'usa-label--error'].filter(Boolean).join(' ')}
+      >
+        {t('doc_auth.headings.document_capture_selfie')}
+      </div>
       {isAccessRejected && (
         <span className="usa-error-message" role="alert">
           {t('doc_auth.instructions.document_capture_selfie_consent_blocked')}
@@ -120,7 +130,7 @@ function SelfieCapture({ value, onChange }) {
           <>
             {/* Disable reason: Video is used only for direct capture */}
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-            <video ref={setVideoRef} className="selfie-capture__video" />
+            <video ref={setVideoRef} className="selfie-capture__video" aria-describedby={labelId} />
             {isCapturing ? (
               <>
                 <div className="selfie-capture__frame">

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -1,0 +1,123 @@
+import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import FileImage from './file-image';
+import useIfStillMounted from '../hooks/use-if-still-mounted';
+import useI18n from '../hooks/use-i18n';
+
+/**
+ * @typedef SelfieCaptureProps
+ *
+ * @prop {Blob?=} value Current value.
+ * @prop {(nextValue:Blob?)=>void} onChange Change handler.
+ */
+
+/**
+ * @param {SelfieCaptureProps} props Props object.
+ */
+function SelfieCapture({ value, onChange }) {
+  const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
+  const assignVideoRef = useCallback((ref) => {
+    if (!ref && videoRef.current && videoRef.current.srcObject instanceof window.MediaStream) {
+      videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
+    }
+
+    videoRef.current = ref;
+  }, []);
+  const [isCapturing, setIsCapturing] = useState(false);
+  useMemo(() => setIsCapturing(isCapturing && !value), [value]);
+  const ifStillMounted = useIfStillMounted();
+  const { t } = useI18n();
+  useEffect(() => {
+    if (!value && !isCapturing) {
+      navigator.mediaDevices.getUserMedia({ video: true }).then(
+        ifStillMounted((/** @type {MediaStream} */ stream) => {
+          if (!videoRef.current) {
+            return;
+          }
+
+          videoRef.current.srcObject = stream;
+          videoRef.current.play();
+          setIsCapturing(true);
+        }),
+      );
+    }
+  }, [value]);
+
+  function onCapture() {
+    if (!videoRef.current) {
+      return;
+    }
+
+    const canvas = document.createElement('canvas');
+    const { videoWidth: width, videoHeight: height } = videoRef.current;
+    canvas.height = height;
+    canvas.width = height;
+    canvas
+      .getContext('2d')
+      ?.drawImage(videoRef.current, (width - height) / 2, 0, height, height, 0, 0, height, height);
+    canvas.toBlob(ifStillMounted(onChange));
+  }
+
+  const classes = [
+    'selfie-capture',
+    isCapturing && 'selfie-capture--capturing',
+    value && 'selfie-capture--has-value',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes}>
+      {value ? (
+        <>
+          <div className="selfie-capture__preview-heading usa-file-input__preview-heading">
+            <span />
+            <button
+              type="button"
+              onClick={() => onChange(null)}
+              className="usa-file-input__choose usa-button--unstyled"
+            >
+              {t('doc_auth.buttons.take_picture_retry')}
+            </button>
+          </div>
+          <FileImage file={value} alt="" className="selfie-capture__preview-image" />
+        </>
+      ) : (
+        <>
+          {/* Disable reason: Video is used only for direct capture */}
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video ref={assignVideoRef} className="selfie-capture__video" />
+          <div className="selfie-capture__frame">
+            <div className="selfie-capture__frame-corner" />
+            <div className="selfie-capture__frame-corner" />
+            <div className="selfie-capture__frame-corner" />
+            <div className="selfie-capture__frame-corner" />
+          </div>
+          <button
+            type="button"
+            className="selfie-capture__capture"
+            aria-label={t('doc_auth.buttons.take_picture')}
+            onClick={onCapture}
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              data-prefix="fas"
+              data-icon="camera"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              className="selfie-capture__capture-icon"
+            >
+              <path
+                fill="currentColor"
+                d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
+              />
+            </svg>
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SelfieCapture;

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -86,32 +86,45 @@ function SelfieCapture({ value, onChange }) {
           {/* Disable reason: Video is used only for direct capture */}
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <video ref={assignVideoRef} className="selfie-capture__video" />
-          <div className="selfie-capture__frame">
-            <div className="selfie-capture__frame-corner" />
-            <div className="selfie-capture__frame-corner" />
-            <div className="selfie-capture__frame-corner" />
-            <div className="selfie-capture__frame-corner" />
-          </div>
-          <button
-            type="button"
-            className="selfie-capture__capture"
-            aria-label={t('doc_auth.buttons.take_picture')}
-            onClick={onCapture}
-          >
-            <svg
-              aria-hidden
-              focusable={false}
-              role="img"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 512 512"
-              className="selfie-capture__capture-icon"
-            >
-              <path
-                fill="currentColor"
-                d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
-              />
-            </svg>
-          </button>
+          {isCapturing ? (
+            <>
+              <div className="selfie-capture__frame">
+                <div className="selfie-capture__frame-corner" />
+                <div className="selfie-capture__frame-corner" />
+                <div className="selfie-capture__frame-corner" />
+                <div className="selfie-capture__frame-corner" />
+              </div>
+              <button
+                type="button"
+                className="selfie-capture__capture"
+                aria-label={t('doc_auth.buttons.take_picture')}
+                onClick={onCapture}
+              >
+                <svg
+                  aria-hidden
+                  focusable={false}
+                  role="img"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 512 512"
+                  className="selfie-capture__capture-icon"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
+                  />
+                </svg>
+              </button>
+            </>
+          ) : (
+            <div className="selfie-capture__consent-prompt">
+              <strong className="selfie-capture__consent-prompt-banner usa-file-input__banner-text">
+                {t('doc_auth.instructions.document_capture_selfie_consent_banner')}
+              </strong>
+              <span className="usa-file-input__drag-text">
+                {t('doc_auth.instructions.document_capture_selfie_consent_reason')}
+              </span>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -14,6 +14,8 @@ import useI18n from '../hooks/use-i18n';
  * @param {SelfieCaptureProps} props Props object.
  */
 function SelfieCapture({ value, onChange }) {
+  const { t } = useI18n();
+
   const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
   const setVideoRef = useCallback((ref) => {
     // React will call an assigned `ref` callback with `null` at the time the element is being
@@ -25,6 +27,7 @@ function SelfieCapture({ value, onChange }) {
     videoRef.current = ref;
   }, []);
 
+  const [isAccessRejected, setIsAccessRejected] = useState(false);
   const [isCapturing, setIsCapturing] = useState(false);
   // Sync capturing state with the availability of a value. If a value is assigned while capture is
   // in progress, reset state. Most often, this is a direct result of calling `onChange` with the
@@ -32,24 +35,35 @@ function SelfieCapture({ value, onChange }) {
   useMemo(() => setIsCapturing(isCapturing && !value), [value]);
 
   const ifStillMounted = useIfStillMounted();
-  const { t } = useI18n();
+
   useEffect(() => {
     // Start capturing only if not already capturing, and if value has yet to be assigned.
     if (value || isCapturing) {
       return;
     }
 
-    navigator.mediaDevices.getUserMedia({ video: true }).then(
-      ifStillMounted((/** @type {MediaStream} */ stream) => {
-        if (!videoRef.current) {
-          return;
-        }
+    navigator.mediaDevices
+      .getUserMedia({ video: true })
+      .then(
+        ifStillMounted((/** @type {MediaStream} */ stream) => {
+          if (!videoRef.current) {
+            return;
+          }
 
-        videoRef.current.srcObject = stream;
-        videoRef.current.play();
-        setIsCapturing(true);
-      }),
-    );
+          videoRef.current.srcObject = stream;
+          videoRef.current.play();
+          setIsCapturing(true);
+        }),
+      )
+      .catch(
+        ifStillMounted((error) => {
+          if (error.name !== 'NotAllowedError') {
+            throw error;
+          }
+
+          setIsAccessRejected(true);
+        }),
+      );
   }, [value]);
 
   function onCapture() {
@@ -81,68 +95,75 @@ function SelfieCapture({ value, onChange }) {
     .join(' ');
 
   return (
-    <div className={classes}>
-      {value ? (
-        <>
-          <div className="selfie-capture__preview-heading usa-file-input__preview-heading">
-            <span />
-            <button
-              type="button"
-              onClick={() => onChange(null)}
-              className="usa-file-input__choose usa-button--unstyled"
-            >
-              {t('doc_auth.buttons.take_picture_retry')}
-            </button>
-          </div>
-          <FileImage file={value} alt="" className="selfie-capture__preview-image" />
-        </>
-      ) : (
-        <>
-          {/* Disable reason: Video is used only for direct capture */}
-          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-          <video ref={setVideoRef} className="selfie-capture__video" />
-          {isCapturing ? (
-            <>
-              <div className="selfie-capture__frame">
-                <div className="selfie-capture__frame-corner" />
-                <div className="selfie-capture__frame-corner" />
-                <div className="selfie-capture__frame-corner" />
-                <div className="selfie-capture__frame-corner" />
-              </div>
+    <>
+      {isAccessRejected && (
+        <span className="usa-error-message" role="alert">
+          {t('doc_auth.instructions.document_capture_selfie_consent_blocked')}
+        </span>
+      )}
+      <div className={classes}>
+        {value ? (
+          <>
+            <div className="selfie-capture__preview-heading usa-file-input__preview-heading">
+              <span />
               <button
                 type="button"
-                className="usa-button selfie-capture__capture"
-                aria-label={t('doc_auth.buttons.take_picture')}
-                onClick={onCapture}
+                onClick={() => onChange(null)}
+                className="usa-file-input__choose usa-button--unstyled"
               >
-                <svg
-                  aria-hidden
-                  focusable={false}
-                  role="img"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 512 512"
-                  className="selfie-capture__capture-icon"
-                >
-                  <path
-                    fill="currentColor"
-                    d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
-                  />
-                </svg>
+                {t('doc_auth.buttons.take_picture_retry')}
               </button>
-            </>
-          ) : (
-            <div className="selfie-capture__consent-prompt">
-              <strong className="selfie-capture__consent-prompt-banner usa-file-input__banner-text">
-                {t('doc_auth.instructions.document_capture_selfie_consent_banner')}
-              </strong>
-              <span className="usa-file-input__drag-text">
-                {t('doc_auth.instructions.document_capture_selfie_consent_reason')}
-              </span>
             </div>
-          )}
-        </>
-      )}
-    </div>
+            <FileImage file={value} alt="" className="selfie-capture__preview-image" />
+          </>
+        ) : (
+          <>
+            {/* Disable reason: Video is used only for direct capture */}
+            {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+            <video ref={setVideoRef} className="selfie-capture__video" />
+            {isCapturing ? (
+              <>
+                <div className="selfie-capture__frame">
+                  <div className="selfie-capture__frame-corner" />
+                  <div className="selfie-capture__frame-corner" />
+                  <div className="selfie-capture__frame-corner" />
+                  <div className="selfie-capture__frame-corner" />
+                </div>
+                <button
+                  type="button"
+                  className="usa-button selfie-capture__capture"
+                  aria-label={t('doc_auth.buttons.take_picture')}
+                  onClick={onCapture}
+                >
+                  <svg
+                    aria-hidden
+                    focusable={false}
+                    role="img"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 512 512"
+                    className="selfie-capture__capture-icon"
+                  >
+                    <path
+                      fill="currentColor"
+                      d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
+                    />
+                  </svg>
+                </button>
+              </>
+            ) : (
+              <div className="selfie-capture__consent-prompt">
+                <strong className="selfie-capture__consent-prompt-banner usa-file-input__banner-text">
+                  {t('doc_auth.instructions.document_capture_selfie_consent_banner')}
+                </strong>
+                <span className="usa-file-input__drag-text">
+                  {t('doc_auth.instructions.document_capture_selfie_consent_reason')}
+                </span>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import { Icon } from '@18f/identity-components';
 import FileImage from './file-image';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useI18n from '../hooks/use-i18n';
@@ -154,19 +155,7 @@ function SelfieCapture({ value, onChange }) {
                   aria-label={t('doc_auth.buttons.take_picture')}
                   onClick={onCapture}
                 >
-                  <svg
-                    aria-hidden
-                    focusable={false}
-                    role="img"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 512 512"
-                    className="selfie-capture__capture-icon"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"
-                    />
-                  </svg>
+                  <Icon.Camera className="selfie-capture__capture-icon" />
                 </button>
               </>
             ) : (

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -99,10 +99,8 @@ function SelfieCapture({ value, onChange }) {
             onClick={onCapture}
           >
             <svg
-              aria-hidden="true"
-              focusable="false"
-              data-prefix="fas"
-              data-icon="camera"
+              aria-hidden
+              focusable={false}
               role="img"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 512 512"

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -4,6 +4,7 @@ import FileImage from './file-image';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
 import useI18n from '../hooks/use-i18n';
 import useInstanceId from '../hooks/use-instance-id';
+import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
 
 /**
  * @typedef SelfieCaptureProps
@@ -20,6 +21,8 @@ function SelfieCapture({ value, onChange }) {
   const { t } = useI18n();
   const labelRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const wrapperRef = useRef(/** @type {HTMLDivElement?} */ (null));
+  const retryButtonRef = useFocusFallbackRef(labelRef);
+  const captureButtonRef = useFocusFallbackRef(labelRef);
 
   const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
   const setVideoRef = useCallback((ref) => {
@@ -31,19 +34,6 @@ function SelfieCapture({ value, onChange }) {
 
     videoRef.current = ref;
   }, []);
-
-  // A change in whether a value exists will render a different element hierarchy. If focus was
-  // contained within the element hierarchy at the time of this switch, ensure that focus is placed
-  // back to somewhere common, so that a focus loss does not occur.
-  const hadValue = useRef(!!value);
-  useMemo(() => {
-    const nextHadValue = !!value;
-    if (hadValue.current !== nextHadValue && wrapperRef.current?.contains(document.activeElement)) {
-      labelRef.current?.focus();
-    }
-
-    hadValue.current = nextHadValue;
-  }, [value]);
 
   const [isAccessRejected, setIsAccessRejected] = useState(false);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -150,6 +140,7 @@ function SelfieCapture({ value, onChange }) {
             <div className="selfie-capture__preview-heading usa-file-input__preview-heading">
               <span />
               <button
+                ref={retryButtonRef}
                 type="button"
                 onClick={() => onChange(null)}
                 className="usa-file-input__choose usa-button--unstyled"
@@ -173,6 +164,7 @@ function SelfieCapture({ value, onChange }) {
                   <div className="selfie-capture__frame-corner" />
                 </div>
                 <button
+                  ref={captureButtonRef}
                   type="button"
                   className="usa-button selfie-capture__capture"
                   aria-label={t('doc_auth.buttons.take_picture')}

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -163,7 +163,7 @@ function SelfieCapture({ value, onChange }) {
           <>
             {/* Disable reason: Video is used only for direct capture */}
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-            <video ref={setVideoRef} className="selfie-capture__video" aria-describedby={labelId} />
+            <video ref={setVideoRef} className="selfie-capture__video" aria-labelledby={labelId} />
             {isCapturing ? (
               <>
                 <div className="selfie-capture__frame">

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -17,13 +17,20 @@ import useInstanceId from '../hooks/use-instance-id';
 function SelfieCapture({ value, onChange }) {
   const instanceId = useInstanceId();
   const { t } = useI18n();
+  const labelRef = useRef(/** @type {HTMLDivElement?} */ (null));
 
   const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
   const setVideoRef = useCallback((ref) => {
-    // React will call an assigned `ref` callback with `null` at the time the element is being
-    // removed, which is an opportunity to stop any in-progress capture.
-    if (!ref && videoRef.current && videoRef.current.srcObject instanceof window.MediaStream) {
-      videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
+    // React will call an assigned `ref` callback with `null` at the time the element is removed.
+    if (!ref) {
+      // Stop any in-progress capture.
+      if (videoRef.current && videoRef.current.srcObject instanceof window.MediaStream) {
+        videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
+      }
+
+      // Shift focus back to label if it's assumed that the component will remain mounted, so that a
+      // focus loss does not occur.
+      if (labelRef.current) labelRef.current.focus();
     }
 
     videoRef.current = ref;
@@ -101,7 +108,9 @@ function SelfieCapture({ value, onChange }) {
   return (
     <>
       <div
+        ref={labelRef}
         id={labelId}
+        tabIndex={-1}
         className={['usa-label', isAccessRejected && 'usa-label--error'].filter(Boolean).join(' ')}
       >
         {t('doc_auth.headings.document_capture_selfie')}

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { hasMediaAccess } from '@18f/identity-device';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
@@ -35,7 +36,7 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
         <li>{t('doc_auth.tips.document_capture_selfie_text2')}</li>
         <li>{t('doc_auth.tips.document_capture_selfie_text3')}</li>
       </ul>
-      {isMobile ? (
+      {isMobile || !hasMediaAccess() ? (
         <AcuantCapture
           capture="user"
           label={t('doc_auth.headings.document_capture_selfie')}

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import useI18n from '../hooks/use-i18n';
+import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
+import SelfieCapture from './selfie-capture';
 
 /**
  * @typedef SelfieStepValue
@@ -20,6 +22,7 @@ import AcuantCapture from './acuant-capture';
  */
 function SelfieStep({ value = {}, onChange = () => {} }) {
   const { t } = useI18n();
+  const { isMobile } = useContext(DeviceContext);
 
   return (
     <>
@@ -32,13 +35,20 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
         <li>{t('doc_auth.tips.document_capture_selfie_text2')}</li>
         <li>{t('doc_auth.tips.document_capture_selfie_text3')}</li>
       </ul>
-      <AcuantCapture
-        capture="user"
-        label={t('doc_auth.headings.document_capture_selfie')}
-        bannerText={t('doc_auth.headings.photo')}
-        value={value.selfie}
-        onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
-      />
+      {isMobile ? (
+        <AcuantCapture
+          capture="user"
+          label={t('doc_auth.headings.document_capture_selfie')}
+          bannerText={t('doc_auth.headings.photo')}
+          value={value.selfie}
+          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+        />
+      ) : (
+        <SelfieCapture
+          value={value.selfie}
+          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+        />
+      )}
     </>
   );
 }

--- a/app/javascript/packages/document-capture/hooks/use-focus-fallback-ref.js
+++ b/app/javascript/packages/document-capture/hooks/use-focus-fallback-ref.js
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+
+/**
+ * Returns a ref callback to be assigned to a React element. Calls focus on the given fallbackRef
+ * argument if focus was on the assigned element at the time it's unmounted.
+ *
+ * @param {import('react').RefObject<HTMLElement>} fallbackRef Fallback ref to focus if element is
+ * active element at the time it is unmounted.
+ *
+ * @return {import('react').RefCallback<HTMLElement>}
+ */
+function useFocusFallbackRef(fallbackRef) {
+  const ref = useRef(/** @type {HTMLElement?} */ (null));
+
+  return (nextRef) => {
+    if (!nextRef && ref.current === document.activeElement) {
+      fallbackRef.current?.focus();
+    }
+
+    ref.current = nextRef;
+  };
+}
+
+export default useFocusFallbackRef;

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -31,6 +31,7 @@
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
 - errors.doc_auth.acuant_network_error
+- errors.doc_auth.document_capture_selfie_consent_blocked
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_file_size
 - errors.doc_auth.photo_glare

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -18,6 +18,7 @@
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks
 - doc_auth.instructions.document_capture_selfie_consent_banner
+- doc_auth.instructions.document_capture_selfie_consent_blocked
 - doc_auth.instructions.document_capture_selfie_consent_reason
 - doc_auth.instructions.document_capture_selfie_instructions
 - doc_auth.tips.document_capture_header_text

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -17,6 +17,8 @@
 - doc_auth.info.document_capture_intro_acknowledgment
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks
+- doc_auth.instructions.document_capture_selfie_consent_banner
+- doc_auth.instructions.document_capture_selfie_consent_reason
 - doc_auth.instructions.document_capture_selfie_instructions
 - doc_auth.tips.document_capture_header_text
 - doc_auth.tips.document_capture_hint

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -94,6 +94,9 @@ en:
       document_capture_fallback_link: Click here to upload an image
       document_capture_selfie_consent_banner: Allow login.gov to use your device's
         camera
+      document_capture_selfie_consent_blocked: Access to your camera is blocked, but
+        it is required to verify your identity. Please reset your settings for this
+        website, then refresh the page.
       document_capture_selfie_consent_reason: login.gov needs permission to use your
         camera so that you can prove your ID belongs to you.
       document_capture_selfie_instructions: Now take a picture of yourself. We'll

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -94,9 +94,8 @@ en:
       document_capture_fallback_link: Click here to upload an image
       document_capture_selfie_consent_banner: Allow login.gov to use your device's
         camera
-      document_capture_selfie_consent_blocked: Access to your camera is blocked, but
-        it is required to verify your identity. Please reset your settings for this
-        website, then refresh the page.
+      document_capture_selfie_consent_blocked: Check your web browser’s settings for
+        this site to allow login.gov to access the camera.
       document_capture_selfie_consent_reason: login.gov needs permission to use your
         camera so that you can prove your ID belongs to you.
       document_capture_selfie_instructions: Now take a picture of yourself. We'll

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -13,8 +13,8 @@ en:
       upload_picture: Upload a photo
       use_phone: Use your phone
     errors:
-      not_a_file: was not attached as a file
       must_be_image: must be an image
+      not_a_file: was not attached as a file
     forms:
       address1: Address
       change_file: Change file
@@ -92,6 +92,10 @@ en:
         and share your personal information. We will only use it to verify your identity.
       document_capture_fallback_html: Having trouble? %{link}
       document_capture_fallback_link: Click here to upload an image
+      document_capture_selfie_consent_banner: Allow login.gov to use your device's
+        camera
+      document_capture_selfie_consent_reason: login.gov needs permission to use your
+        camera so that you can prove your ID belongs to you.
       document_capture_selfie_instructions: Now take a picture of yourself. We'll
         compare it to the image on the front of your ID.
       email_sent: Link sent to %{email}. Please check your desktop email and follow

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -98,6 +98,9 @@ es:
       document_capture_fallback_link: Haga clic aquí para cargar una imagen.
       document_capture_selfie_consent_banner: Permita que login.gov use la cámara
         de su dispositivo
+      document_capture_selfie_consent_blocked: El acceso a su cámara está bloqueado,
+        pero es necesario para verificar su identidad. Restablezca la configuración
+        de este sitio web y luego actualice la página.
       document_capture_selfie_consent_reason: login.gov necesita permiso para usar
         su cámara para que pueda probar que su identificación le pertenece.
       document_capture_selfie_instructions: Ahora toma una foto de ti mismo. Lo compararemos

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -13,8 +13,8 @@ es:
       upload_picture: Sube una foto
       use_phone: Usa tu telefono
     errors:
-      not_a_file: no se adjuntó como un archivo
       must_be_image: debe ser una imagen
+      not_a_file: no se adjuntó como un archivo
     forms:
       address1: Dirección
       change_file: Cambiar archivo
@@ -96,6 +96,10 @@ es:
         su identidad.
       document_capture_fallback_html: "¿Teniendo problemas? %{link}"
       document_capture_fallback_link: Haga clic aquí para cargar una imagen.
+      document_capture_selfie_consent_banner: Permita que login.gov use la cámara
+        de su dispositivo
+      document_capture_selfie_consent_reason: login.gov necesita permiso para usar
+        su cámara para que pueda probar que su identificación le pertenece.
       document_capture_selfie_instructions: Ahora toma una foto de ti mismo. Lo compararemos
         con la imagen en el frente de su identificación.
       email_sent: Enlace enviado a %{email}. Compruebe el correo electrónico de su

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -98,9 +98,8 @@ es:
       document_capture_fallback_link: Haga clic aquí para cargar una imagen.
       document_capture_selfie_consent_banner: Permita que login.gov use la cámara
         de su dispositivo
-      document_capture_selfie_consent_blocked: El acceso a su cámara está bloqueado,
-        pero es necesario para verificar su identidad. Restablezca la configuración
-        de este sitio web y luego actualice la página.
+      document_capture_selfie_consent_blocked: Verifique la configuración de su navegador
+        web para este sitio para permitir que login.gov acceda a la cámara.
       document_capture_selfie_consent_reason: login.gov necesita permiso para usar
         su cámara para que pueda probar que su identificación le pertenece.
       document_capture_selfie_instructions: Ahora toma una foto de ti mismo. Lo compararemos

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -106,6 +106,9 @@ fr:
       document_capture_fallback_link: Cliquez ici pour télécharger une image
       document_capture_selfie_consent_banner: Autorisez login.gov à utiliser la caméra
         de votre appareil
+      document_capture_selfie_consent_blocked: L'accès à votre caméra est bloqué,
+        mais il est nécessaire de vérifier votre identité. Veuillez réinitialiser
+        vos paramètres pour ce site Web, puis actualiser la page.
       document_capture_selfie_consent_reason: login.gov a besoin d'une autorisation
         pour utiliser votre caméra afin que vous puissiez prouver que votre identifiant
         vous appartient.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -13,8 +13,8 @@ fr:
       upload_picture: Télécharger une photo
       use_phone: Utilisez votre téléphone
     errors:
-      not_a_file: n'a pas été joint en tant que fichier
       must_be_image: doit être une image
+      not_a_file: n'a pas été joint en tant que fichier
     forms:
       address1: Adresse
       change_file: Changer de fichier
@@ -104,6 +104,11 @@ fr:
         que pour vérifier votre identité.
       document_capture_fallback_html: Avoir des problèmes? %{link}
       document_capture_fallback_link: Cliquez ici pour télécharger une image
+      document_capture_selfie_consent_banner: Autorisez login.gov à utiliser la caméra
+        de votre appareil
+      document_capture_selfie_consent_reason: login.gov a besoin d'une autorisation
+        pour utiliser votre caméra afin que vous puissiez prouver que votre identifiant
+        vous appartient.
       document_capture_selfie_instructions: Maintenant, prenez une photo de vous.
         Nous le comparerons à l'image au recto de votre pièce d'identité.
       email_sent: Lien envoyé à %{email}. Veuillez vérifier votre email de bureau

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -106,9 +106,8 @@ fr:
       document_capture_fallback_link: Cliquez ici pour télécharger une image
       document_capture_selfie_consent_banner: Autorisez login.gov à utiliser la caméra
         de votre appareil
-      document_capture_selfie_consent_blocked: L'accès à votre caméra est bloqué,
-        mais il est nécessaire de vérifier votre identité. Veuillez réinitialiser
-        vos paramètres pour ce site Web, puis actualiser la page.
+      document_capture_selfie_consent_blocked: Vérifiez les paramètres de votre navigateur
+        Web pour ce site pour autoriser login.gov à accéder à la caméra.
       document_capture_selfie_consent_reason: login.gov a besoin d'une autorisation
         pour utiliser votre caméra afin que vous puissiez prouver que votre identifiant
         vous appartient.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -44,6 +44,7 @@ en:
         <li>Your selfie is taken in a well-lit area with a plain background</li>
         <li>You are not wearing a hat or glasses, and your head is fully visible</li>
         </ul>
+      document_capture_selfie_consent_blocked: Your camera is blocked
       general_error: We could not read or verify your ID. Try to take and upload new
         images of both the front and back of your ID. Make sure everything can be
         easily read, including the barcode.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -44,6 +44,7 @@ es:
         <li>Su selfie se toma en un área bien iluminada con un fondo liso</li>
         <li>No lleva puesto un sombrero o anteojos, y su cabeza es completamente visible</li>
         </ul>
+      document_capture_selfie_consent_blocked: El acceso a su cámara está bloqueado
       general_error: No pudimos leer ni verificar su identificación. Intenta tomar
         y subir nuevas imágenes de la parte delantera y trasera de tu ID. Asegúrese
         de que todo se pueda leer fácilmente, incluido el código de barras.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -44,6 +44,7 @@ fr:
         <li>Votre selfie est pris dans une zone bien éclairée avec un arrière-plan uni</li>
         <li>Vous ne portez pas de chapeau ni de lunettes et votre tête est entièrement visible</li>
         </ul>
+      document_capture_selfie_consent_blocked: L'accès à votre caméra est bloqué
       general_error: Nous n'avons pas pu lire ni vérifier votre identité. Essayez
         de prendre et de télécharger de nouvelles images des deux côtés de votre ID.
         Assurez-vous que tout peut être facilement lu, y compris le code à barres.

--- a/spec/javascripts/packages/device/index-spec.js
+++ b/spec/javascripts/packages/device/index-spec.js
@@ -40,7 +40,11 @@ describe('hasMediaAccess', () => {
   });
 
   afterEach(() => {
-    navigator.mediaDevices = originalMediaDevices;
+    if (originalMediaDevices === undefined) {
+      delete navigator.mediaDevices;
+    } else {
+      navigator.mediaDevices = originalMediaDevices;
+    }
   });
 
   it('returns false if no media device API access', () => {
@@ -74,7 +78,11 @@ describe('isCameraCapableMobile', () => {
 
   afterEach(() => {
     navigator.userAgent = originalUserAgent;
-    navigator.mediaDevices = originalMediaDevices;
+    if (originalMediaDevices === undefined) {
+      delete navigator.mediaDevices;
+    } else {
+      navigator.mediaDevices = originalMediaDevices;
+    }
   });
 
   it('returns false if not mobile', () => {

--- a/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import sinon from 'sinon';
+import { cleanup } from '@testing-library/react';
+import SelfieCapture from '@18f/identity-document-capture/components/selfie-capture';
+import render from '../../../support/render';
+import { useSandbox } from '../../../support/sinon';
+
+describe('document-capture/components/selfie-capture', () => {
+  // Since DOM globals are stubbed with sandbox, ensure that cleanup is the first task, as otherwise
+  // it will attempt to reference globals which had already been cleaned up and are undefined.
+  afterEach(cleanup);
+
+  const sandbox = useSandbox();
+
+  const track = { stop: sinon.stub() };
+  const value = new window.File([], 'image.png', { type: 'image/png' });
+
+  let originalMediaDevices;
+  let originalMediaStream;
+  beforeEach(() => {
+    originalMediaDevices = navigator.mediaDevices;
+
+    function MediaStream() {}
+    MediaStream.prototype = { play() {}, getTracks() {} };
+    sandbox.stub(MediaStream.prototype, 'play');
+    sandbox.stub(MediaStream.prototype, 'getTracks').returns([track]);
+
+    sandbox.stub(window.HTMLMediaElement.prototype, 'play');
+
+    navigator.mediaDevices = {
+      getUserMedia: () => Promise.resolve(new MediaStream()),
+    };
+
+    originalMediaStream = window.MediaStream;
+    window.MediaStream = MediaStream;
+
+    track.stop.resetHistory();
+  });
+
+  afterEach(() => {
+    if (originalMediaDevices === undefined) {
+      delete navigator.mediaDevices;
+    } else {
+      navigator.mediaDevices = originalMediaDevices;
+    }
+
+    if (originalMediaStream === undefined) {
+      delete window.MediaStream;
+    } else {
+      window.MediaStream = originalMediaStream;
+    }
+  });
+
+  it('renders video element that auto-plays when devices retrieved', async () => {
+    const { getByLabelText, findByLabelText } = render(<SelfieCapture />);
+
+    await findByLabelText('doc_auth.buttons.take_picture');
+    const video = getByLabelText('doc_auth.headings.document_capture_selfie');
+    expect(video.srcObject).to.be.instanceOf(window.MediaStream);
+  });
+
+  it('stops capture when unmounted', async () => {
+    const { findByLabelText, unmount } = render(<SelfieCapture />);
+
+    await findByLabelText('doc_auth.buttons.take_picture');
+    unmount();
+    expect(track.stop.calledOnce).to.be.true();
+  });
+
+  it('renders error state if devices access restricted', async () => {
+    const error = new Error();
+    error.name = 'NotAllowedError';
+    navigator.mediaDevices.getUserMedia = () => Promise.reject(error);
+    const { findByText } = render(<SelfieCapture />);
+
+    await findByText('doc_auth.instructions.document_capture_selfie_consent_blocked');
+  });
+
+  it('stops capture after rerendered with value', async () => {
+    const { findByLabelText, rerender } = render(<SelfieCapture />);
+
+    await findByLabelText('doc_auth.buttons.take_picture');
+    rerender(<SelfieCapture value={value} />);
+    expect(track.stop.calledOnce).to.be.true();
+  });
+
+  it('renders value preview', async () => {
+    const { findByText } = render(<SelfieCapture value={value} />);
+
+    await findByText('doc_auth.buttons.take_picture_retry');
+  });
+});

--- a/spec/javascripts/packages/document-capture/hooks/use-focus-fallback-ref-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-focus-fallback-ref-spec.jsx
@@ -1,0 +1,37 @@
+import React, { createRef } from 'react';
+import sinon from 'sinon';
+import useFocusFallbackRef from '@18f/identity-document-capture/hooks/use-focus-fallback-ref';
+import render from '../../../support/render';
+
+describe('document-capture/hooks/use-focus-fallback', () => {
+  function ButtonWithFocusFallback({ fallbackRef }) {
+    const ref = useFocusFallbackRef(fallbackRef);
+    return (
+      <button type="button" ref={ref}>
+        Click me
+      </button>
+    );
+  }
+
+  it('shifts focus to fallback when unmounting while focused', () => {
+    const fallbackRef = createRef();
+    fallbackRef.current = { focus: sinon.stub() };
+    const { getByText, unmount } = render(<ButtonWithFocusFallback fallbackRef={fallbackRef} />);
+
+    const button = getByText('Click me');
+    button.focus();
+    unmount();
+
+    expect(fallbackRef.current.focus.calledOnce).to.be.true();
+  });
+
+  it('does not shift focus to fallback when unmounted if not focused', () => {
+    const fallbackRef = createRef();
+    fallbackRef.current = { focus: sinon.stub() };
+    const { unmount } = render(<ButtonWithFocusFallback fallbackRef={fallbackRef} />);
+
+    unmount();
+
+    expect(fallbackRef.current.focus.called).to.be.false();
+  });
+});


### PR DESCRIPTION
**Why**: As a user who does not have a smart phone, but does have a web cam; I want to be able to use my desktop to conduct selfie/liveness checks so that I am able to proof.

<details><summary>(See outdated pending tasks)</summary>
**Status: Draft.** Remaining Tasks:

- [x] Implement pre-consent content ("Allow Login.gov to use your device's camera")
- [x] Ensure accurate to design specifications (need source files)
  - [x] Frame corners width and offset
  - [x] Button offset, padding, active, hover styles
- [x] Tests
</details>

**Screenshots:**

Access Prompt|Access Denied|Capture in Progress|Capture Finished
---|---|---|---
![prompt](https://user-images.githubusercontent.com/1779930/90807755-f6438200-e2ec-11ea-9d28-3f36ba7f204b.png)|![denied](https://user-images.githubusercontent.com/1779930/90805918-4cfb8c80-e2ea-11ea-8cb3-9d61b83a3e91.png)|![capture in progress](https://user-images.githubusercontent.com/1779930/90806031-77e5e080-e2ea-11ea-8678-b9d4005b9125.png)|![capture finished](https://user-images.githubusercontent.com/1779930/90805993-6ac8f180-e2ea-11ea-9a35-6b7f5f59eca1.png)
