### PR TITLE
Include agency_id in Lexis Nexis calls (LG-3289)

### DIFF
--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -49,7 +49,12 @@ module Idv
     def applicant
       @applicant ||= idv_session.applicant.merge(
         phone: normalized_phone,
+        uuid_prefix: uuid_prefix
       )
+    end
+
+    def uuid_prefix
+      ServiceProvider.from_issuer(idv_session.issuer).app_id
     end
 
     def normalized_phone

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -49,7 +49,7 @@ module Idv
     def applicant
       @applicant ||= idv_session.applicant.merge(
         phone: normalized_phone,
-        uuid_prefix: uuid_prefix
+        uuid_prefix: uuid_prefix,
       )
     end
 

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -36,7 +36,11 @@ module Idv
     end
 
     def applicant
-      step_params.merge(uuid: idv_session.current_user.uuid)
+      step_params.merge(uuid: idv_session.current_user.uuid, uuid_prefix: uuid_prefix)
+    end
+
+    def uuid_prefix
+      ServiceProvider.from_issuer(idv_session.issuer).app_id
     end
 
     def idv_throttle_params

--- a/lib/proofer_mocks/address_mock.rb
+++ b/lib/proofer_mocks/address_mock.rb
@@ -1,6 +1,8 @@
 class AddressMock < Proofer::Base
   required_attributes :phone
 
+  optional_attributes :uuid, :uuid_prefix
+
   stage :address
 
   proof do |applicant, result|

--- a/lib/proofer_mocks/resolution_mock.rb
+++ b/lib/proofer_mocks/resolution_mock.rb
@@ -1,6 +1,8 @@
 class ResolutionMock < Proofer::Base
   required_attributes :first_name, :ssn, :zipcode
 
+  optional_attributes :uuid, :uuid_prefix
+
   stage :resolution
 
   proof do |applicant, result|

--- a/lib/proofer_mocks/state_id_mock.rb
+++ b/lib/proofer_mocks/state_id_mock.rb
@@ -10,6 +10,8 @@ class StateIdMock < Proofer::Base
 
   required_attributes :state_id_number, :state_id_type, :state_id_jurisdiction
 
+  optional_attributes :uuid, :uuid_prefix
+
   stage :state_id
 
   proof do |applicant, result|

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -139,6 +139,7 @@ describe Idv::PhoneController do
             first_name: 'Some',
             last_name: 'One',
             phone: normalized_phone,
+            uuid_prefix: nil
           }.with_indifferent_access
 
           expect(subject.idv_session.applicant).to eq expected_applicant

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -139,7 +139,7 @@ describe Idv::PhoneController do
             first_name: 'Some',
             last_name: 'One',
             phone: normalized_phone,
-            uuid_prefix: nil
+            uuid_prefix: nil,
           }.with_indifferent_access
 
           expect(subject.idv_session.applicant).to eq expected_applicant

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -4,9 +4,15 @@ describe Idv::PhoneStep do
   include IdvHelper
 
   let(:user) { build(:user) }
-  let(:service_provider) { create(:service_provider, issuer: 'http://sp.example.com', app_id: '123') }
+  let(:service_provider) do
+    create(:service_provider,
+           issuer: 'http://sp.example.com',
+           app_id: '123')
+  end
   let(:idv_session) do
-    idvs = Idv::Session.new(user_session: {}, current_user: user, issuer: service_provider.issuer)
+    idvs = Idv::Session.new(user_session: {},
+                            current_user: user,
+                            issuer: service_provider.issuer)
     idvs.applicant = { first_name: 'Some' }
     idvs
   end
@@ -29,7 +35,9 @@ describe Idv::PhoneStep do
       expect(result.errors).to be_empty
       expect(result.extra).to eq(extra)
       expect(idv_session.vendor_phone_confirmation).to eq true
-      expect(idv_session.applicant).to eq(first_name: 'Some', phone: good_phone, uuid_prefix: service_provider.app_id)
+      expect(idv_session.applicant).to eq(first_name: 'Some',
+                                          phone: good_phone,
+                                          uuid_prefix: service_provider.app_id)
     end
 
     it 'fails with bad params' do

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -28,7 +28,7 @@ describe Idv::PhoneStep do
       expect(result.errors).to be_empty
       expect(result.extra).to eq(extra)
       expect(idv_session.vendor_phone_confirmation).to eq true
-      expect(idv_session.applicant).to eq(first_name: 'Some', phone: good_phone)
+      expect(idv_session.applicant).to eq(first_name: 'Some', phone: good_phone, uuid_prefix: nil)
     end
 
     it 'fails with bad params' do

--- a/spec/services/idv/phone_step_spec.rb
+++ b/spec/services/idv/phone_step_spec.rb
@@ -4,8 +4,9 @@ describe Idv::PhoneStep do
   include IdvHelper
 
   let(:user) { build(:user) }
+  let(:service_provider) { create(:service_provider, issuer: 'http://sp.example.com', app_id: '123') }
   let(:idv_session) do
-    idvs = Idv::Session.new(user_session: {}, current_user: user, issuer: nil)
+    idvs = Idv::Session.new(user_session: {}, current_user: user, issuer: service_provider.issuer)
     idvs.applicant = { first_name: 'Some' }
     idvs
   end
@@ -28,7 +29,7 @@ describe Idv::PhoneStep do
       expect(result.errors).to be_empty
       expect(result.extra).to eq(extra)
       expect(idv_session.vendor_phone_confirmation).to eq true
-      expect(idv_session.applicant).to eq(first_name: 'Some', phone: good_phone, uuid_prefix: nil)
+      expect(idv_session.applicant).to eq(first_name: 'Some', phone: good_phone, uuid_prefix: service_provider.app_id)
     end
 
     it 'fails with bad params' do

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -40,7 +40,7 @@ describe Idv::ProfileStep do
       expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to eq true
       expect(idv_session.resolution_successful).to eq true
-      expect(idv_session.applicant).to eq(user_attrs.merge(uuid: user.uuid))
+      expect(idv_session.applicant).to eq(user_attrs.merge(uuid: user.uuid, uuid_prefix: nil))
     end
 
     it 'fails with bad params' do

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -4,7 +4,8 @@ describe Idv::ProfileStep do
   include IdvHelper
 
   let(:user) { create(:user) }
-  let(:idv_session) { Idv::Session.new(user_session: {}, current_user: user, issuer: nil) }
+  let(:service_provider) { create(:service_provider, issuer: 'http://sp.example.com', app_id: '123') }
+  let(:idv_session) { Idv::Session.new(user_session: {}, current_user: user, issuer: service_provider.issuer) }
   let(:user_attrs) do
     {
       first_name: 'Some',
@@ -40,7 +41,7 @@ describe Idv::ProfileStep do
       expect(result.extra).to eq(extra)
       expect(idv_session.profile_confirmation).to eq true
       expect(idv_session.resolution_successful).to eq true
-      expect(idv_session.applicant).to eq(user_attrs.merge(uuid: user.uuid, uuid_prefix: nil))
+      expect(idv_session.applicant).to eq(user_attrs.merge(uuid: user.uuid, uuid_prefix: '123'))
     end
 
     it 'fails with bad params' do

--- a/spec/services/idv/profile_step_spec.rb
+++ b/spec/services/idv/profile_step_spec.rb
@@ -4,8 +4,16 @@ describe Idv::ProfileStep do
   include IdvHelper
 
   let(:user) { create(:user) }
-  let(:service_provider) { create(:service_provider, issuer: 'http://sp.example.com', app_id: '123') }
-  let(:idv_session) { Idv::Session.new(user_session: {}, current_user: user, issuer: service_provider.issuer) }
+  let(:service_provider) do
+    create(:service_provider,
+           issuer: 'http://sp.example.com',
+           app_id: '123')
+  end
+  let(:idv_session) do
+    Idv::Session.new(user_session: {},
+                     current_user: user,
+                     issuer: service_provider.issuer)
+  end
   let(:user_attrs) do
     {
       first_name: 'Some',


### PR DESCRIPTION
Working on new release for Lexis Nexis gem to include changes in https://github.com/18F/identity-lexisnexis-api-client-gem/pull/14 and https://github.com/18F/identity-lexisnexis-api-client-gem/pull/15