### PR TITLE
Use the stored result from the image upload API in document capture step

### DIFF
--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -8,12 +8,11 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   def store_result_from_response(doc_auth_response)
-    result = DocumentCaptureSessionResult.new(
+    DocumentCaptureSessionResult.store(
       id: generate_result_id,
       success: doc_auth_response.success?,
       pii: doc_auth_response.pii_from_doc,
     )
-    result.unload
   end
 
   private

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -1,0 +1,24 @@
+class DocumentCaptureSession < ApplicationRecord
+  include NonNullUuid
+
+  belongs_to :user
+
+  def load_result
+    DocumentCaptureSessionResult.load(result_id)
+  end
+
+  def store_result_from_response(doc_auth_response)
+    result = DocumentCaptureSessionResult.new(
+      id: generate_result_id,
+      success: doc_auth_response.success?,
+      pii: doc_auth_response.pii_from_doc,
+    )
+    result.unload
+  end
+
+  private
+
+  def generate_result_id
+    self.result_id = SecureRandom.uuid
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ApplicationRecord
   has_one :doc_auth, dependent: :destroy, inverse_of: :user
   has_many :backup_code_configurations, dependent: :destroy
   has_one :doc_capture, dependent: :destroy
+  has_many :document_capture_sessions, dependent: :destroy
   has_one :account_recovery_request, dependent: :destroy
   has_many :throttles, dependent: :destroy
   has_one :registration_log, dependent: :destroy

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -1,0 +1,63 @@
+class DocumentCaptureSessionResult
+  REDIS_KEY_PREFIX = 'dcs:result'.freeze
+
+  attr_reader :id, :success, :pii
+
+  alias success? success
+  alias pii_from_doc pii
+
+  class << self
+    def load(id)
+      ciphertext = REDIS_POOL.with { |client| client.read(key(id)) }
+      return nil if ciphertext.blank?
+      decrypt_and_deserialize(id, ciphertext)
+    end
+
+    def key(id)
+      [REDIS_KEY_PREFIX, id].join(':')
+    end
+
+    private
+
+    def decrypt_and_deserialize(id, ciphertext)
+      deserialize(
+        id,
+        Encryption::Encryptors::SessionEncryptor.new.decrypt(ciphertext),
+      )
+    end
+
+    def deserialize(id, json)
+      data = JSON.parse(json)
+      new(
+        id: id,
+        success: data['success'],
+        pii: data['pii'],
+      )
+    end
+  end
+
+  def initialize(id:, success:, pii:)
+    @id = id
+    @success = success
+    @pii = pii
+  end
+
+  def unload
+    REDIS_POOL.with do |client|
+      client.write(self.class.key(id), serialize_and_encrypt, expires_in: 60)
+    end
+  end
+
+  private
+
+  def serialize_and_encrypt
+    Encryption::Encryptors::SessionEncryptor.new.encrypt(serialize)
+  end
+
+  def serialize
+    {
+      success: success,
+      pii: pii,
+    }.to_json
+  end
+end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -174,6 +174,17 @@ module Idv
         FeatureManagement.liveness_checking_enabled? && (no_sp? || sp_session[:ial2_strict])
       end
 
+      def create_document_capture_session
+        document_capture_session = DocumentCaptureSession.create(user_id: user_id)
+        flow_session[:document_capture_session_uuid] = document_capture_session.uuid
+      end
+
+      def document_capture_session
+        @document_capture_session ||= DocumentCaptureSession.find_by(
+          uuid: flow_session[:document_capture_session_uuid],
+        )
+      end
+
       def no_sp?
         sp_session[:issuer].blank?
       end

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -50,7 +50,7 @@ module Idv
       end
 
       def request_includes_images?
-        params.keys.include?('doc_auth')
+        params.key?('doc_auth')
       end
 
       def form_submit

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -1,7 +1,22 @@
 module Idv
   module Steps
     class DocumentCaptureStep < DocAuthBaseStep
+      IMAGE_UPLOAD_PARAM_NAMES = %i[
+        front_image back_image selfie_image front_image_data_url back_image_data_url
+        selfie_image_data_url
+      ].freeze
+
       def call
+        if request_includes_images?
+          post_images_and_handle_result
+        else
+          handle_stored_response
+        end
+      end
+
+      private
+
+      def post_images_and_handle_result
         response = post_images
         if response.success?
           save_proofing_components
@@ -11,8 +26,6 @@ module Idv
           handle_document_verification_failure(response)
         end
       end
-
-      private
 
       def handle_document_verification_failure(response)
         mark_step_incomplete(:document_capture)
@@ -26,12 +39,26 @@ module Idv
         failure(response.errors.first, extra)
       end
 
+      def handle_stored_response
+        stored_result = document_capture_session&.load_result
+        if stored_result.present? && stored_result.success?
+          extract_pii_from_doc(stored_result)
+        else
+          extra = { stored_result_present: stored_result.present? }
+          failure(I18n.t('errors.doc_auth.acuant_network_error'), extra)
+        end
+      end
+
+      def request_includes_images?
+        params.keys.include?('doc_auth')
+      end
+
       def form_submit
+        return FormResponse.new(success: true, errors: {}) unless request_includes_images?
+
         Idv::DocumentCaptureForm.
           new(liveness_checking_enabled: liveness_checking_enabled?).
-          submit(permit(:front_image,  :front_image_data_url,
-                        :back_image,   :back_image_data_url,
-                        :selfie_image, :selfie_image_data_url))
+          submit(permit(IMAGE_UPLOAD_PARAM_NAMES))
       end
     end
   end

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -3,6 +3,7 @@ module Idv
     class WelcomeStep < DocAuthBaseStep
       def call
         mark_document_capture_or_image_upload_steps_complete
+        create_document_capture_session
       end
 
       def form_submit

--- a/db/migrate/20200811144552_create_document_capture_sessions.rb
+++ b/db/migrate/20200811144552_create_document_capture_sessions.rb
@@ -1,0 +1,13 @@
+class CreateDocumentCaptureSessions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :document_capture_sessions do |t|
+      t.string :uuid
+      t.string :result_id
+      t.references :user, foreign_key: true
+
+      t.timestamps
+
+      t.index :uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -206,6 +206,16 @@ ActiveRecord::Schema.define(version: 2020_08_14_144213) do
     t.index ["user_id"], name: "index_doc_captures_on_user_id", unique: true
   end
 
+  create_table "document_capture_sessions", force: :cascade do |t|
+    t.string "uuid"
+    t.string "result_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_document_capture_sessions_on_user_id"
+    t.index ["uuid"], name: "index_document_capture_sessions_on_uuid"
+  end
+
   create_table "email_addresses", force: :cascade do |t|
     t.bigint "user_id"
     t.string "confirmation_token", limit: 255
@@ -583,4 +593,5 @@ ActiveRecord::Schema.define(version: 2020_08_14_144213) do
     t.index ["user_id"], name: "index_webauthn_configurations_on_user_id"
   end
 
+  add_foreign_key "document_capture_sessions", "users"
 end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -246,8 +246,7 @@ feature 'doc auth document capture step' do
         document_capture_session.store_result_from_response(response)
         document_capture_session.save!
 
-        page.driver.put current_path
-        visit current_path
+        submit_empty_form
 
         expect(page).to have_current_path(next_step)
       end
@@ -258,16 +257,14 @@ feature 'doc auth document capture step' do
         document_capture_session.store_result_from_response(response)
         document_capture_session.save!
 
-        page.driver.put current_path
-        visit current_path
+        submit_empty_form
 
         expect(page).to have_current_path(idv_doc_auth_document_capture_step)
         expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
       end
 
       it 'does not proceed to the next step if there is no result' do
-        page.driver.put current_path
-        visit current_path
+        submit_empty_form
 
         expect(page).to have_current_path(idv_doc_auth_document_capture_step)
         expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
@@ -289,5 +286,10 @@ feature 'doc auth document capture step' do
 
   def next_step
     idv_doc_auth_ssn_step
+  end
+
+  def submit_empty_form
+    page.driver.put current_path
+    visit current_path
   end
 end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe DocumentCaptureSession do
+  let(:doc_auth_response) do
+    DocAuthClient::Response.new(
+      success: true,
+      pii_from_doc: {
+        first_name: 'Testy',
+        last_name: 'Testerson',
+      },
+    )
+  end
+
+  describe '#store_result_from_response' do
+    it 'generates a result ID stores the result encrypted in redis' do
+      record = DocumentCaptureSession.new
+
+      record.store_result_from_response(doc_auth_response)
+
+      result_id = record.result_id
+      data = REDIS_POOL.with { |client| client.read(DocumentCaptureSessionResult.key(result_id)) }
+      expect(data).to be_a(String)
+      expect(data).to_not include('Testy')
+      expect(data).to_not include('Testerson')
+    end
+  end
+
+  describe '#load_result' do
+    it 'loads the previously stored result' do
+      record = DocumentCaptureSession.new
+      record.store_result_from_response(doc_auth_response)
+      result = record.load_result
+
+      expect(result.success?).to eq(doc_auth_response.success?)
+      expect(result.pii).to eq(doc_auth_response.pii_from_doc.stringify_keys)
+    end
+
+    it 'returns nil if the previously stored result does not exist or expired' do
+      record = DocumentCaptureSession.new
+      result = record.load_result
+
+      expect(result).to eq(nil)
+    end
+  end
+end

--- a/spec/services/document_capture_session_result_spec.rb
+++ b/spec/services/document_capture_session_result_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe DocumentCaptureSessionResult do
+  describe '.key' do
+    it 'generates a key' do
+      id = 'test-id'
+      key = DocumentCaptureSessionResult.key(id)
+      expect(key).to eq('dcs:result:test-id')
+    end
+  end
+
+  describe '#unload' do
+    it 'writes encrypted data to redis' do
+      result = DocumentCaptureSessionResult.new(
+        id: SecureRandom.uuid,
+        success: true,
+        pii: { 'first_name' => 'Testy', 'last_name' => 'Testerson' },
+      )
+
+      result.unload
+
+      data = REDIS_POOL.with { |client| client.read(DocumentCaptureSessionResult.key(result.id)) }
+      expect(data).to be_a(String)
+      expect(data).to_not include('Testy')
+      expect(data).to_not include('Testerson')
+    end
+  end
+
+  describe '.load' do
+    it 'reads the unloaded result from the session' do
+      unloaded_result = DocumentCaptureSessionResult.new(
+        id: SecureRandom.uuid,
+        success: true,
+        pii: { 'first_name' => 'Testy', 'last_name' => 'Testerson' },
+      )
+      unloaded_result.unload
+
+      loaded_result = DocumentCaptureSessionResult.load(unloaded_result.id)
+
+      expect(loaded_result.id).to eq(unloaded_result.id)
+      expect(loaded_result.success?).to eq(unloaded_result.success?)
+      expect(loaded_result.pii).to eq(unloaded_result.pii)
+    end
+
+    it 'returns nil if no data exists in redis' do
+      loaded_result = DocumentCaptureSessionResult.load(SecureRandom.uuid)
+
+      expect(loaded_result).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To store the PII independent of the session. This allows us to read PII that was stored in the hybrid flow.