### PR TITLE
Configure ESLint `curly: all` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "@babel/no-unused-expressions": "error",
     "consistent-return": "off",
+    "curly": ["error", "all"],
     "prettier/prettier": "error",
     "func-names": 0,
     "function-paren-newline": "off",

--- a/app/javascript/app/acuant/document_capture_dom.js
+++ b/app/javascript/app/acuant/document_capture_dom.js
@@ -47,7 +47,9 @@ const showFallbackForm = () => {
 };
 
 export const showAcuantSdkContainer = (container) => {
-  if (documentCaptureFallbackModeEnabled()) return;
+  if (documentCaptureFallbackModeEnabled()) {
+    return;
+  }
 
   hideAcuantSdkContainers();
 

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -31,6 +31,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (desktopLink) languagePicker(desktopLink, desktopDropdown);
-  if (mobileLink) languagePicker(mobileLink, mobileDropdown);
+  if (desktopLink) {
+    languagePicker(desktopLink, desktopDropdown);
+  }
+  if (mobileLink) {
+    languagePicker(mobileLink, mobileDropdown);
+  }
 });

--- a/app/javascript/app/radio-btn.js
+++ b/app/javascript/app/radio-btn.js
@@ -16,11 +16,15 @@ function highlightRadioBtn() {
       const label = radio.parentNode.parentNode;
       const name = radio.getAttribute('name');
 
-      if (radio.checked) label.classList.add('bg-lightest-blue');
+      if (radio.checked) {
+        label.classList.add('bg-lightest-blue');
+      }
 
       radio.addEventListener('change', function () {
         clearHighlight(name);
-        if (radio.checked) label.classList.add('bg-lightest-blue');
+        if (radio.checked) {
+          label.classList.add('bg-lightest-blue');
+        }
       });
 
       radio.addEventListener('focus', function () {

--- a/app/javascript/app/utils/countdown-timer.js
+++ b/app/javascript/app/utils/countdown-timer.js
@@ -4,7 +4,9 @@ export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
   let remaining = timeLeft;
   let currentTime;
 
-  if (!el || !('innerHTML' in el)) return;
+  if (!el || !('innerHTML' in el)) {
+    return;
+  }
 
   function tick() {
     /* eslint-disable no-param-reassign */

--- a/app/javascript/app/utils/events.js
+++ b/app/javascript/app/utils/events.js
@@ -6,7 +6,9 @@ class Events {
   }
 
   on(eventName, handler = noOp, context = null) {
-    if (!eventName) return;
+    if (!eventName) {
+      return;
+    }
 
     const handlersForEvent = this.handlers[eventName] || [];
 

--- a/app/javascript/packages/document-capture/hooks/use-history-param.js
+++ b/app/javascript/packages/document-capture/hooks/use-history-param.js
@@ -22,7 +22,9 @@ export function getQueryParam(queryString, name) {
   const pairs = queryString.split('&');
   for (let i = 0; i < pairs.length; i += 1) {
     const [key, value = ''] = pairs[i].split('=').map(decodeURIComponent);
-    if (key === name) return value;
+    if (key === name) {
+      return value;
+    }
   }
 
   return null;

--- a/app/javascript/packages/document-capture/hooks/use-if-still-mounted.js
+++ b/app/javascript/packages/document-capture/hooks/use-if-still-mounted.js
@@ -20,7 +20,9 @@ function useIfStillMounted() {
   });
 
   const ifStillMounted = (fn) => (...args) => {
-    if (isMounted.current) fn(...args);
+    if (isMounted.current) {
+      fn(...args);
+    }
   };
 
   return ifStillMounted;

--- a/app/javascript/packs/personal-key-page-controller.js
+++ b/app/javascript/packs/personal-key-page-controller.js
@@ -27,7 +27,9 @@ const personalKey = scrapePersonalKey();
 // The following methods are strictly fallbacks for IE < 11. There is limited
 // support for HTML5 validation attributes in those browsers
 function setInvalidHTML() {
-  if (isInvalidForm) return;
+  if (isInvalidForm) {
+    return;
+  }
 
   document.getElementById('personal-key-alert').classList.remove('display-none');
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -35,7 +35,9 @@ function getStrength(z) {
 }
 
 function getFeedback(z) {
-  if (!z || z.score > 2) return '&nbsp;';
+  if (!z || z.score > 2) {
+    return '&nbsp;';
+  }
 
   const { warning, suggestions } = z.feedback;
 
@@ -43,14 +45,20 @@ function getFeedback(z) {
     return I18n.t(`zxcvbn.feedback.${I18n.key(str)}`);
   }
 
-  if (!warning && !suggestions.length) return '&nbsp;';
-  if (warning) return lookup(warning);
+  if (!warning && !suggestions.length) {
+    return '&nbsp;';
+  }
+  if (warning) {
+    return lookup(warning);
+  }
 
   return `${suggestions.map((s) => lookup(s)).join('')}`;
 }
 
 function disableSubmit(submitEl, length = 0, score = 0) {
-  if (!submitEl) return;
+  if (!submitEl) {
+    return;
+  }
 
   if (score < 3 || length < 12) {
     submitEl.setAttribute('disabled', true);

--- a/app/javascript/packs/verify-modal.js
+++ b/app/javascript/packs/verify-modal.js
@@ -6,8 +6,12 @@ function verifyModal() {
   const modal = new window.LoginGov.Modal({ el: '#verification-modal' });
   const modalDismiss = document.getElementById('js-close-modal');
 
-  if (flash) flash.classList.add('display-none');
-  if (modalSelector) modal.show();
+  if (flash) {
+    flash.classList.add('display-none');
+  }
+  if (modalSelector) {
+    modal.show();
+  }
 
   if (modalDismiss) {
     modalDismiss.addEventListener('click', () => {


### PR DESCRIPTION
**Why**: To more easily follow conditon block body by separating it onto own lines of code, and to have consistency in how block bodies are implemented.

See prior discussion: https://github.com/18F/identity-idp/pull/4090#discussion_r473149578

Existing issues were fixed automatically with `yarn lint --fix`.