### PR TITLE
Change the logic used to determine if store result should be used

### DIFF
--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -267,7 +267,6 @@ feature 'doc auth document capture step' do
         submit_empty_form
 
         expect(page).to have_current_path(idv_doc_auth_document_capture_step)
-        expect(page).to have_content(I18n.t('errors.doc_auth.acuant_network_error'))
       end
 
       it 'uses the form params if form params are present' do
@@ -289,7 +288,10 @@ feature 'doc auth document capture step' do
   end
 
   def submit_empty_form
-    page.driver.put current_path
+    page.driver.put(
+      current_path,
+      doc_auth: { front_image: nil, back_image: nil, selfie_image: nil },
+    )
     visit current_path
   end
 end


### PR DESCRIPTION
**Why**: To enable us to submit the form that is already on the page after the image upload is complete. Now we use the stored result if a stored result is present AND all of the params are empty.