### PR TITLE
LG-3328: Display Friendly Error Message

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "prefer-arrow-callback": 0,
     "import/prefer-default-export": "off",
     "import/extensions": ["off", "never"],
+    "indent": "off",
     "newline-per-chained-call": "off",
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
@@ -30,6 +31,7 @@
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "react/jsx-curly-newline": "off",
+    "react/jsx-indent": "off",
     "react/jsx-one-expression-per-line": "off",
     "react/prop-types": "off"
   },

--- a/app/javascript/packages/document-capture/components/submission.jsx
+++ b/app/javascript/packages/document-capture/components/submission.jsx
@@ -10,7 +10,7 @@ import CallbackOnMount from './callback-on-mount';
  * @typedef SubmissionProps
  *
  * @prop {Record<string,string>} payload Payload object.
- * @prop {()=>void}              onError Error callback.
+ * @prop {(error:Error)=>void} onError Error callback.
  */
 
 /**
@@ -23,7 +23,7 @@ function Submission({ payload, onError }) {
   return (
     <SuspenseErrorBoundary
       fallback={<SubmissionPending />}
-      errorFallback={<CallbackOnMount onMount={onError} />}
+      errorFallback={({ error }) => <CallbackOnMount onMount={() => onError(error)} />}
     >
       <SubmissionComplete resource={resource} />
     </SuspenseErrorBoundary>

--- a/app/javascript/packages/document-capture/components/suspense-error-boundary.jsx
+++ b/app/javascript/packages/document-capture/components/suspense-error-boundary.jsx
@@ -1,13 +1,15 @@
-import React, { Component, Suspense } from 'react';
+import React, { Component, Suspense, createElement } from 'react';
 
 /** @typedef {import('react').ReactNode} ReactNode */
+/** @typedef {import('react').FunctionComponent} FunctionComponent */
 
 /**
  * @typedef SuspenseErrorBoundaryProps
  *
- * @prop {NonNullable<ReactNode>|null} fallback      Fallback to show while suspense pending.
- * @prop {NonNullable<ReactNode>|null} errorFallback Fallback to show if suspense resolves as error.
- * @prop {ReactNode} children                        Suspense child.
+ * @prop {NonNullable<ReactNode>|null} fallback Fallback to show while suspense pending.
+ * @prop {NonNullable<ReactNode>|FunctionComponent|null} errorFallback Fallback to show if suspense
+ * resolves as error.
+ * @prop {ReactNode} children Suspense child.
  */
 
 /**
@@ -20,17 +22,25 @@ class SuspenseErrorBoundary extends Component {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError() {
+  static getDerivedStateFromError(error) {
     return {
       hasError: true,
+      error,
     };
   }
 
   render() {
     const { fallback, errorFallback, children } = this.props;
-    const { hasError } = this.state;
+    const { hasError, error } = this.state;
 
-    return hasError ? errorFallback : <Suspense fallback={fallback}>{children}</Suspense>;
+    if (hasError) {
+      const isErrorFallbackComponent = typeof errorFallback === 'function';
+      return isErrorFallbackComponent
+        ? createElement(/** @type {FunctionComponent} */ (errorFallback), { error })
+        : errorFallback;
+    }
+
+    return <Suspense fallback={fallback}>{children}</Suspense>;
   }
 }
 

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -1,6 +1,11 @@
 /** @typedef {import('../context/upload').UploadSuccessResponse} UploadSuccessResponse */
 /** @typedef {import('../context/upload').UploadErrorResponse} UploadErrorResponse */
 
+export class UploadFormEntriesError extends Error {
+  /** @type {string[]} */
+  rawErrors = [];
+}
+
 /**
  * Returns a FormData representation of the given object.
  *
@@ -35,7 +40,11 @@ async function upload(payload, { endpoint, csrf }) {
 
   const result = /** @type {UploadSuccessResponse|UploadErrorResponse} */ (await response.json());
   if (!result.success) {
-    throw Error(/** @type {UploadErrorResponse} */ (result).errors.join(', '));
+    /** @type {UploadErrorResponse} */
+    const errorResult = result;
+    const error = new UploadFormEntriesError(errorResult.errors.join(', '));
+    error.rawErrors = errorResult.errors;
+    throw error;
   }
 
   return /** @type {UploadSuccessResponse} */ (result);

--- a/spec/javascripts/packages/document-capture/components/suspense-error-boundary-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/suspense-error-boundary-spec.jsx
@@ -40,4 +40,19 @@ describe('document-capture/components/suspense-error-boundary', () => {
     expect(await findByText('Error')).to.be.ok();
     expect(console).to.have.loggedError();
   });
+
+  it('returns errorFallback rendered component with error prop if an error is caught', async () => {
+    const Child = () => {
+      throw new Error('Ouch!');
+    };
+
+    const { findByText } = render(
+      <SuspenseErrorBoundary fallback="Loading" errorFallback={({ error }) => error.message}>
+        <Child />
+      </SuspenseErrorBoundary>,
+    );
+
+    expect(await findByText('Ouch!')).to.be.ok();
+    expect(console).to.have.loggedError();
+  });
 });

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -1,4 +1,7 @@
-import upload, { toFormData } from '@18f/identity-document-capture/services/upload';
+import upload, {
+  UploadFormEntriesError,
+  toFormData,
+} from '@18f/identity-document-capture/services/upload';
 import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/services/upload', () => {
@@ -57,6 +60,7 @@ describe('document-capture/services/upload', () => {
     try {
       await upload({}, { endpoint: 'https://example.com', csrf: 'TYsqyyQ66Y' });
     } catch (error) {
+      expect(error).to.be.instanceOf(UploadFormEntriesError);
       expect(error.message).to.equal('Foo missing, Baz missing');
     }
   });
@@ -75,6 +79,7 @@ describe('document-capture/services/upload', () => {
     try {
       await upload({}, { endpoint: 'https://example.com', csrf: 'TYsqyyQ66Y' });
     } catch (error) {
+      expect(error).to.be.instanceof(Error);
       expect(error.message).to.equal('Server error');
     }
   });

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -6,7 +6,7 @@ import { UploadContextProvider } from '@18f/identity-document-capture';
 /**
  * @typedef RenderOptions
  *
- * @prop {boolean=} isUploadFailure Whether to simulate upload failure. Defaults to `false`.
+ * @prop {Error=} uploadError Whether to simulate upload failure. Defaults to `false`.
  * @prop {number=} expectedUploads Number of times upload is expected to be called. Defaults to `1`.
  */
 
@@ -22,13 +22,11 @@ import { UploadContextProvider } from '@18f/identity-document-capture';
  * @return {import('@testing-library/react').RenderResult}
  */
 function renderWithDefaultContext(element, options = {}) {
-  const { isUploadFailure = false, expectedUploads = 1 } = options;
+  const { uploadError, expectedUploads = 1 } = options;
 
   const upload = sinon
     .stub()
-    .callsFake((payload) =>
-      isUploadFailure ? Promise.reject(new Error('Failure!')) : Promise.resolve(payload),
-    )
+    .callsFake((payload) => (uploadError ? Promise.reject(uploadError) : Promise.resolve(payload)))
     .onCall(expectedUploads)
     .throws(
       new Error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strictNullChecks": true,
     "jsx": "react",
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "lib": ["ES2020"]
   },
   "include": ["app/javascript/packages"]
 }


### PR DESCRIPTION
**Why**: As a user, I would like my error messages to be displayed to know why my process failed so I can try to address it to pass.

**Screenshot:**

![document error](https://user-images.githubusercontent.com/1779930/90823712-509c0d00-e304-11ea-8231-b2b0bd06b347.png)

**Open questions:**

Despite there being [friendly error messages](https://github.com/18F/identity-idp/blob/master/config/locales/friendly_errors/en.yml), from what I can tell, the endpoint will currently only return formatted messages of variety ["must be an image"](https://github.com/18F/identity-idp/blob/c2170c3a848016af62dbcb67aaba01567a8ea3d9/app/forms/idv/api_image_upload_form.rb#L90) or ["was not attached as a file"](https://github.com/18F/identity-idp/blob/c2170c3a848016af62dbcb67aaba01567a8ea3d9/app/forms/idv/api_image_upload_form.rb#L82). To be able to satisfy acceptance criteria that these messages be shown as plain text, we might need to include more detail about the error code passed from the vendor response.

**Testing Instructions:**

This is difficult to test because the current implementation of the React form is eager to disallow non-image files and files smaller than the acceptable minimum.

You must remove this line:

https://github.com/18F/identity-idp/blob/c2170c3a848016af62dbcb67aaba01567a8ea3d9/app/javascript/packages/document-capture/components/acuant-capture.jsx#L187

And start the server as:

```
ACUANT_MINIMUM_FILE_SIZE=0 make run
```

Then upload an error-formatted YML:

```yml
friendly_error: |
  We couldn't read the barcode on the back of your ID. Try taking a new picture.
  Make sure the entire barcode is visible, clean, and doesn't have glares.
  (Error code: 200)
```

And proceed to submit.