### PR TITLE
LG-3333: Disallow upload for mobile document capture liveness

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -21,6 +21,7 @@ import DeviceContext from '../context/device';
  * @prop {number=} minimumGlareScore Minimum glare score to be considered acceptable.
  * @prop {number=} minimumSharpnessScore Minimum sharpness score to be considered acceptable.
  * @prop {number=} minimumFileSize Minimum file size (in bytes) to be considered acceptable.
+ * @prop {boolean=} allowUpload Whether to allow file upload. Defaults to `true`.
  */
 
 /**
@@ -81,6 +82,7 @@ function AcuantCapture({
   minimumGlareScore = DEFAULT_ACCEPTABLE_GLARE_SCORE,
   minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
   minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
+  allowUpload = true,
 }) {
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
@@ -108,15 +110,20 @@ function AcuantCapture({
    * @param {import('react').MouseEvent} event Click event.
    */
   function startCaptureOrTriggerUpload(event) {
-    if (event.target !== inputRef.current) {
-      inputRef.current?.click();
-    } else if (hasCapture) {
-      if (!capture && !isForceUploading.current) {
+    if (event.target === inputRef.current) {
+      const shouldStartCapture = hasCapture && !capture && !isForceUploading.current;
+
+      if (!allowUpload || shouldStartCapture) {
         event.preventDefault();
+      }
+
+      if (shouldStartCapture) {
         setIsCapturing(true);
       }
 
       isForceUploading.current = false;
+    } else {
+      inputRef.current?.click();
     }
   }
 
@@ -184,7 +191,7 @@ function AcuantCapture({
       <FileInput
         ref={inputRef}
         label={label}
-        hint={hasCapture ? undefined : t('doc_auth.tips.document_capture_hint')}
+        hint={hasCapture || !allowUpload ? undefined : t('doc_auth.tips.document_capture_hint')}
         bannerText={bannerText}
         accept={['image/*']}
         capture={capture}
@@ -203,15 +210,16 @@ function AcuantCapture({
             onClick={startCaptureOrTriggerUpload}
             className={value ? 'margin-right-1' : 'margin-right-2'}
           >
-            {hasCapture &&
+            {(hasCapture || !allowUpload) &&
               (value
                 ? t('doc_auth.buttons.take_picture_retry')
                 : t('doc_auth.buttons.take_picture'))}
-            {!hasCapture && t('doc_auth.buttons.upload_picture')}
+            {!hasCapture && allowUpload && t('doc_auth.buttons.upload_picture')}
           </Button>
         )}
         {isMobile &&
           hasCapture &&
+          allowUpload &&
           formatHTML(t('doc_auth.buttons.take_or_upload_picture'), {
             'lg-take-photo': () => null,
             'lg-upload': ({ children }) => (

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -41,6 +41,7 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
           bannerText={t('doc_auth.headings.photo')}
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+          allowUpload={false}
           required
         />
       ) : (

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -412,6 +412,30 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.start.called).to.be.false();
       expect(input.getAttribute('capture')).to.equal('environment');
     });
+
+    it('optionally disallows upload', () => {
+      const { getByText, getByLabelText } = render(
+        <I18nContext.Provider
+          value={{ 'doc_auth.buttons.take_or_upload_picture': '<lg-upload>Upload</lg-upload>' }}
+        >
+          <AcuantContextProvider sdkSrc="about:blank">
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <AcuantCapture label="Image" allowUpload={false} />
+            </DeviceContext.Provider>
+          </AcuantContextProvider>
+        </I18nContext.Provider>,
+      );
+
+      initialize();
+
+      const input = getByLabelText('Image');
+      const didClick = fireEvent.click(input);
+
+      expect(() => getByText('Upload')).to.throw();
+      expect(didClick).to.be.false();
+      expect(window.AcuantCameraUI.start.calledOnce).to.be.true();
+      expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
+    });
   });
 
   context('desktop', () => {
@@ -425,6 +449,20 @@ describe('document-capture/components/acuant-capture', () => {
       );
 
       expect(() => getByText('doc_auth.buttons.take_picture')).to.throw();
+    });
+
+    it('optionally disallows upload', () => {
+      const { getByText } = render(
+        <AcuantContextProvider sdkSrc="about:blank">
+          <DeviceContext.Provider value={{ isMobile: false }}>
+            <AcuantCapture label="Image" allowUpload={false} />
+          </DeviceContext.Provider>
+        </AcuantContextProvider>,
+      );
+
+      expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
+
+      initialize();
     });
   });
 


### PR DESCRIPTION
**Why:** As a user, I expect that I will not be presented with an option to upload a selfie, so that I am able to successfully prove liveness.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/90826380-57c51a00-e308-11ea-9c59-5ed85a993817.png)
