### PR TITLE
Update service_provider.agency to be an association

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -99,7 +99,7 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_name
-    sp.friendly_name || sp.agency
+    sp.friendly_name || sp.agency&.name
   end
 
   def sp_return_url

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,4 +1,7 @@
 class Agency < ApplicationRecord
   has_many :agency_identities, dependent: :destroy
+  # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :service_providers, inverse_of: :agency
+  # rubocop:enable Rails/HasManyOrHasOneDependent
   validates :name, presence: true
 end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -2,7 +2,9 @@ require 'fingerprinter'
 require 'identity_validations'
 
 class ServiceProvider < ApplicationRecord
-  self.ignored_columns = %w[deal_id]
+  self.ignored_columns = %w[deal_id agency]
+
+  belongs_to :agency
 
   # Do not define validations in this model.
   # See https://github.com/18F/identity_validations

--- a/app/services/service_provider_seeder.rb
+++ b/app/services/service_provider_seeder.rb
@@ -13,7 +13,8 @@ class ServiceProviderSeeder
                   active: true,
                   native: true,
                   friendly_name: config['friendly_name'])
-      end.update!(config.except('restrict_to_deploy_env',
+      end.update!(config.except('agency',
+                                'restrict_to_deploy_env',
                                 'uuid_priority',
                                 'protocol',
                                 'native'))

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :agency do
+    agency_name_templates = [
+      'Department of %{industry}',
+      'Bureau of %{industry}',
+      '%{industry} Administration',
+      '%{industry} Agency',
+    ]
+
+    id { Agency.last&.id.to_i + 1 } # autoincrementer is messed up for this table
+    name { format(agency_name_templates.sample, industry: Faker::Company.industry) }
+  end
+end

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     friendly_name { 'Test Service Provider' }
     issuer { SecureRandom.uuid }
     return_to_sp_url { '/' }
-    agency { 'Test Agency' }
     help_text do
       { 'sign_in': { en: '<b>custom sign in help text for %{sp_name}</b>' },
         'sign_up': { en: '<b>custom sign up help text for %{sp_name}</b>' },

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SecurityEventForm do
   subject(:form) { SecurityEventForm.new(body: jwt) }
 
   let(:user) { create(:user) }
-  let(:agency) { Agency.last || Agency.create(name: 'Test Agency') }
+  let(:agency) { create(:agency) }
   let(:service_provider) { create(:service_provider, agency_id: agency.id) }
   let(:rp_private_key) do
     OpenSSL::PKey::RSA.new(

--- a/spec/services/db/agency_identity/agency_user_counts_spec.rb
+++ b/spec/services/db/agency_identity/agency_user_counts_spec.rb
@@ -3,18 +3,17 @@ require 'rails_helper'
 describe Db::AgencyIdentity::AgencyUserCounts do
   subject { described_class }
 
-  let(:agency) { 'EOP' }
+  let(:agency) { create(:agency) }
 
   it 'is empty' do
     expect(subject.call.ntuples).to eq(0)
   end
 
   it 'returns the total user counts per agency' do
-    Agency.create(id: 3, name: 'EOP') unless Agency.find_by(id: 3)
-    AgencyIdentity.create(user_id: 1, agency_id: 3, uuid: 'foo1')
-    AgencyIdentity.create(user_id: 2, agency_id: 3, uuid: 'foo2')
+    AgencyIdentity.create(user_id: 1, agency_id: agency.id, uuid: 'foo1')
+    AgencyIdentity.create(user_id: 2, agency_id: agency.id, uuid: 'foo2')
 
-    result = { agency: agency, total: 2 }.to_json
+    result = { agency: agency.name, total: 2 }.to_json
 
     expect(subject.call.ntuples).to eq(1)
     expect(subject.call[0].to_json).to eq(result)

--- a/spec/services/reports/agency_user_counts_report_spec.rb
+++ b/spec/services/reports/agency_user_counts_report_spec.rb
@@ -3,17 +3,16 @@ require 'rails_helper'
 describe Reports::AgencyUserCountsReport do
   subject { described_class.new }
 
-  let(:agency) { 'EOP' }
+  let(:agency) { create(:agency) }
 
   it 'is empty' do
     expect(subject.call).to eq('[]')
   end
 
   it 'returns the total user counts per agency' do
-    Agency.create(id: 3, name: 'EOP') unless Agency.find_by(id: 3)
-    AgencyIdentity.create(user_id: 1, agency_id: 3, uuid: 'foo1')
-    AgencyIdentity.create(user_id: 2, agency_id: 3, uuid: 'foo2')
-    result = [{ agency: agency, total: 2 }].to_json
+    AgencyIdentity.create(user_id: 1, agency_id: agency.id, uuid: 'foo1')
+    AgencyIdentity.create(user_id: 2, agency_id: agency.id, uuid: 'foo2')
+    result = [{ agency: agency.name, total: 2 }].to_json
 
     expect(subject.call).to eq(result)
   end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -9,6 +9,10 @@ describe ServiceProviderUpdater do
   let(:openid_connect_issuer) { 'sp:test:foo:bar' }
   let(:openid_connect_redirect_uris) { %w[http://localhost:1234 my-app://result] }
 
+  let(:agency_1) { create(:agency) }
+  let(:agency_2) { create(:agency) }
+  let(:agency_3) { create(:agency) }
+
   # rubocop:disable Style/TrailingCommaInHashLiteral
   let(:friendly_sp) do
     {
@@ -16,7 +20,7 @@ describe ServiceProviderUpdater do
       created_at: '2010-01-01 00:00:00'.to_datetime,
       updated_at: '2010-01-01 00:00:00'.to_datetime,
       issuer: dashboard_sp_issuer,
-      agency: 'a service provider',
+      agency_id: agency_1.id,
       friendly_name: 'a friendly service provider',
       description: 'user friendly login.gov dashboard',
       acs_url: 'http://sp.example.org/saml/login',
@@ -37,7 +41,7 @@ describe ServiceProviderUpdater do
       id: 'small number',
       updated_at: '2010-01-01 00:00:00',
       issuer: inactive_dashboard_sp_issuer,
-      agency: 'an old service provider',
+      agency_id: agency_2.id,
       friendly_name: 'an old, stale service provider',
       description: 'forget about me',
       acs_url: 'http://oldsp.example.org/saml/login',
@@ -51,7 +55,7 @@ describe ServiceProviderUpdater do
     {
       issuer: 'http://localhost:3000',
       friendly_name: 'trying to override a test SP',
-      agency: 'trying to override a test SP',
+      agency_id: agency_3.id,
       acs_url: 'http://nasty-override.example.org/saml/login',
       active: true,
     }
@@ -60,7 +64,7 @@ describe ServiceProviderUpdater do
     {
       issuer: openid_connect_issuer,
       friendly_name: 'a service provider',
-      agency: 'a service provider',
+      agency_id: agency_1.id,
       redirect_uris: openid_connect_redirect_uris,
       active: true,
     }
@@ -90,7 +94,7 @@ describe ServiceProviderUpdater do
 
         sp = ServiceProvider.from_issuer(dashboard_sp_issuer)
 
-        expect(sp.agency).to eq friendly_sp[:agency]
+        expect(sp.agency).to eq agency_1
         expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
         expect(sp.active?).to eq true
         expect(sp.id).to_not eq 0
@@ -114,7 +118,7 @@ describe ServiceProviderUpdater do
 
         sp = ServiceProvider.from_issuer(dashboard_sp_issuer)
 
-        expect(sp.agency).to eq friendly_sp[:agency]
+        expect(sp.agency).to eq agency_1
         expect(sp.ssl_cert).to be_a OpenSSL::X509::Certificate
         expect(sp.active?).to eq true
         expect(sp.id).to eq old_id
@@ -181,7 +185,7 @@ describe ServiceProviderUpdater do
             created_at: '2010-01-01 00:00:00'.to_datetime,
             updated_at: '2010-01-01 00:00:00'.to_datetime,
             issuer: dashboard_sp_issuer,
-            agency: 'a service provider',
+            agency_id: agency_1.id,
             friendly_name: 'a friendly service provider',
             description: 'user friendly login.gov dashboard',
             acs_url: 'http://sp.example.org/saml/login',


### PR DESCRIPTION
**Why**: We added the agencies table but still were using the
denormalized column

A next step would be to add a migration to remove the `agency` string column on this table, and then we could clean up the agency name in the other repos if we wanted

- [x] All the agency names in our identity-idp-config are already required to have matching name & agency.name: https://github.com/18F/identity-idp-config/blob/master/validators/service_provider_config_validator.rb#L333-L335
- [x] The Dashboard API already sends `agency_id` and no longer sends string `agency`: https://dashboard.int.identitysandbox.gov/api/service_providers

