### PR TITLE
Add document_capture step to capture_steps arrays

### DIFF
--- a/app/controllers/idv/capture_doc_controller.rb
+++ b/app/controllers/idv/capture_doc_controller.rb
@@ -22,7 +22,14 @@ module Idv
     end
 
     def add_unsafe_eval_to_capture_steps
-      return unless %w[mobile_front_image capture_mobile_back_image selfie].include?(current_step)
+      return unless %w[
+        front_image
+        back_image
+        mobile_front_image
+        mobile_back_image
+        selfie
+        document_capture
+      ].include?(current_step)
 
       # required to run wasm until wasm-eval is available
       SecureHeaders.append_content_security_policy_directives(

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -53,7 +53,14 @@ module Idv
     end
 
     def add_unsafe_eval_to_capture_steps
-      capture_steps = %w[front_image back_image mobile_front_image mobile_back_image selfie]
+      capture_steps = %w[
+        front_image
+        back_image
+        mobile_front_image
+        mobile_back_image
+        selfie
+        document_capture
+      ]
       return unless capture_steps.include?(params[:step])
 
       # required to run wasm until wasm-eval is available

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -113,7 +113,7 @@ describe Idv::CaptureDocController do
       end
 
       it 'add unsafe-eval to the CSP for capture steps' do
-        steps = %i[mobile_front_image capture_mobile_back_image selfie document_capture]
+        steps = %i[mobile_front_image capture_mobile_back_image selfie]
         steps.each do |step|
           mock_next_step(step)
 

--- a/spec/controllers/idv/capture_doc_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_controller_spec.rb
@@ -113,7 +113,7 @@ describe Idv::CaptureDocController do
       end
 
       it 'add unsafe-eval to the CSP for capture steps' do
-        steps = %i[mobile_front_image capture_mobile_back_image selfie]
+        steps = %i[mobile_front_image capture_mobile_back_image selfie document_capture]
         steps.each do |step|
           mock_next_step(step)
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -80,7 +80,14 @@ describe Idv::DocAuthController do
     end
 
     it 'add unsafe-eval to the CSP for capture steps' do
-      capture_steps = %i[front_image back_image mobile_front_image mobile_back_image selfie]
+      capture_steps = %i[
+        front_image
+        back_image
+        mobile_front_image
+        mobile_back_image
+        selfie
+        document_capture
+      ]
       capture_steps.each do |step|
         mock_next_step(step)
 


### PR DESCRIPTION
**Why**: Required to include unsafe-eval for WASM loading of Acuant SDK on React-based document capture flow