### PR TITLE
Cache File to Base64 mappings for document capture previews

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -6,6 +6,7 @@ import FullScreen from './full-screen';
 import Button from './button';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
+import FileBase64CacheContext from '../context/file-base64-cache';
 
 /**
  * @typedef AcuantCaptureProps
@@ -82,6 +83,7 @@ function AcuantCapture({
   minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
   minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
 }) {
+  const fileCache = useContext(FileBase64CacheContext);
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
   const isForceUploading = useRef(false);
@@ -172,7 +174,9 @@ function AcuantCapture({
               } else if (nextCapture.sharpness < minimumSharpnessScore) {
                 setOwnError(t('errors.doc_auth.photo_blurry'));
               } else {
-                onChangeIfValid(toBlob(nextCapture.image.data));
+                const dataAsBlob = toBlob(nextCapture.image.data);
+                fileCache.set(dataAsBlob, nextCapture.image.data);
+                onChangeIfValid(dataAsBlob);
               }
 
               setIsCapturing(false);

--- a/app/javascript/packages/document-capture/components/file-image.jsx
+++ b/app/javascript/packages/document-capture/components/file-image.jsx
@@ -15,7 +15,7 @@ import FileBase64CacheContext from '../context/file-base64-cache';
  */
 function FileImage({ file, alt, className }) {
   const cache = useContext(FileBase64CacheContext);
-  const [, forceRender] = useState((prevState = 0) => 1 - prevState);
+  const [, forceRender] = useState();
   const imageData = cache.get(file);
   const ifStillMounted = useIfStillMounted();
 
@@ -23,7 +23,7 @@ function FileImage({ file, alt, className }) {
     const reader = new window.FileReader();
     reader.onload = ({ target }) => {
       cache.set(file, /** @type {string} */ (target?.result));
-      ifStillMounted(forceRender)();
+      ifStillMounted(forceRender)((prevState = 0) => 1 - prevState);
     };
     reader.readAsDataURL(file);
   }, [file]);

--- a/app/javascript/packages/document-capture/components/file-image.jsx
+++ b/app/javascript/packages/document-capture/components/file-image.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
+import FileBase64CacheContext from '../context/file-base64-cache';
 
 /**
  * @typedef FileImageProps
@@ -13,12 +14,17 @@ import useIfStillMounted from '../hooks/use-if-still-mounted';
  * @param {FileImageProps} props Props object.
  */
 function FileImage({ file, alt, className }) {
-  const [imageData, setImageData] = useState(/** @type {string?} */ (null));
+  const cache = useContext(FileBase64CacheContext);
+  const [, forceRender] = useState((prevState = 0) => 1 - prevState);
+  const imageData = cache.get(file);
   const ifStillMounted = useIfStillMounted();
 
   useEffect(() => {
     const reader = new window.FileReader();
-    reader.onload = ifStillMounted(({ target }) => setImageData(target.result));
+    reader.onload = ({ target }) => {
+      cache.set(file, /** @type {string} */ (target?.result));
+      ifStillMounted(forceRender)();
+    };
     reader.readAsDataURL(file);
   }, [file]);
 

--- a/app/javascript/packages/document-capture/context/file-base64-cache.js
+++ b/app/javascript/packages/document-capture/context/file-base64-cache.js
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
 
-const FileBase64Cache = createContext(/** @type {WeakMap<Blob,string>} */ (new WeakMap()));
+const FileBase64CacheContext = createContext(/** @type {WeakMap<Blob,string>} */ (new WeakMap()));
 
-export default FileBase64Cache;
+export default FileBase64CacheContext;

--- a/app/javascript/packages/document-capture/context/file-base64-cache.js
+++ b/app/javascript/packages/document-capture/context/file-base64-cache.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const FileBase64Cache = createContext(/** @type {WeakMap<Blob,string>} */ (new WeakMap()));
+
+export default FileBase64Cache;

--- a/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
@@ -21,6 +21,22 @@ describe('document-capture/components/file-image', () => {
     expect(image.getAttribute('src')).to.match(/^data:image\/png;base64,/);
   });
 
+  it('renders a a changed file object as an image', async () => {
+    const { findByAltText, rerender } = render(
+      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="first image" />,
+    );
+
+    await findByAltText('first image');
+
+    rerender(
+      <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="second image" />,
+    );
+
+    const image = await findByAltText('second image');
+
+    expect(image.getAttribute('src')).to.match(/^data:image\/png;base64,/);
+  });
+
   it('renders with className', async () => {
     const { findByAltText } = render(
       <FileImage

--- a/spec/javascripts/packages/document-capture/context/file-base64-cache-spec.js
+++ b/spec/javascripts/packages/document-capture/context/file-base64-cache-spec.js
@@ -1,0 +1,15 @@
+import { createElement, useContext } from 'react';
+import FileBase64Cache from '@18f/identity-document-capture/context/file-base64-cache';
+import render from '../../../support/render';
+
+describe('document-capture/context/file-base64-cache', () => {
+  it('defaults to WeakMap', () => {
+    render(
+      createElement(() => {
+        const cache = useContext(FileBase64Cache);
+        expect(cache).to.be.instanceof(WeakMap);
+        return null;
+      }),
+    );
+  });
+});

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import sinon from 'sinon';
 import { UploadContextProvider } from '@18f/identity-document-capture';
 
+/** @typedef {import('@testing-library/react').RenderOptions} BaseRenderOptions */
+
 /**
  * @typedef RenderOptions
  *
@@ -17,12 +19,12 @@ import { UploadContextProvider } from '@18f/identity-document-capture';
  * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
  *
  * @param {import('react').ReactElement} element Element to render.
- * @param {RenderOptions=}               options Optional options.
+ * @param {RenderOptions&BaseRenderOptions=} options Optional options.
  *
  * @return {import('@testing-library/react').RenderResult}
  */
 function renderWithDefaultContext(element, options = {}) {
-  const { uploadError, expectedUploads = 1 } = options;
+  const { uploadError, expectedUploads = 1, ...baseRenderOptions } = options;
 
   const upload = sinon
     .stub()
@@ -36,7 +38,17 @@ function renderWithDefaultContext(element, options = {}) {
       ),
     );
 
-  return render(<UploadContextProvider upload={upload}>{element}</UploadContextProvider>);
+  const result = render(
+    <UploadContextProvider upload={upload}>{element}</UploadContextProvider>,
+    baseRenderOptions,
+  );
+
+  return {
+    ...result,
+    rerender(nextElement, nextOptions) {
+      renderWithDefaultContext(nextElement, { ...nextOptions, container: result.container });
+    },
+  };
 }
 
 export default renderWithDefaultContext;

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -38,17 +38,12 @@ function renderWithDefaultContext(element, options = {}) {
       ),
     );
 
-  const result = render(
-    <UploadContextProvider upload={upload}>{element}</UploadContextProvider>,
-    baseRenderOptions,
-  );
-
-  return {
-    ...result,
-    rerender(nextElement, nextOptions) {
-      renderWithDefaultContext(nextElement, { ...nextOptions, container: result.container });
-    },
-  };
+  return render(element, {
+    ...baseRenderOptions,
+    wrapper: ({ children }) => (
+      <UploadContextProvider upload={upload}>{children}</UploadContextProvider>
+    ),
+  });
 }
 
 export default renderWithDefaultContext;


### PR DESCRIPTION
**Why**: Since Acuant gives us data as Base64 which we proceed to convert to a file Blob, it's wasted effort to only then convert that back to Base64 when displaying an image preview. Likewise, if a user were to use their Back or Forward buttons to navigate steps, the file values would be reencoded each time.

(Aside: Noticing some non-ideal delays in Acuant capture while testing this ☹️ )