### PR TITLE
Update document capture styling per design feedback

### DIFF
--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -43,7 +43,7 @@
     border-width: 2px;
 
     &:hover {
-      border-color: color('primary-darker');
+      border-color: color('primary-dark');
     }
   }
 

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -62,13 +62,17 @@
 
 .usa-file-input__banner-text {
   @include u-font-family('sans');
-  @include u-margin-bottom(2);
   color: color('primary');
   display: block;
   font-size: 1.625rem;
   letter-spacing: .4px;
   line-height: 1.5rem;
   text-transform: uppercase;
+
+  + .usa-file-input__drag-text {
+    @include u-display('block');
+    @include u-margin-top(2);
+  }
 }
 
 .usa-file-input.usa-file-input--single-value {

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -61,10 +61,13 @@
 }
 
 .usa-file-input__banner-text {
-  @include u-font('sans', 'xl');
-  @include u-margin-bottom(1);
+  @include u-font-family('sans');
+  @include u-margin-bottom(2);
   color: color('primary');
   display: block;
+  font-size: 1.625rem;
+  letter-spacing: .4px;
+  line-height: 1.5rem;
   text-transform: uppercase;
 }
 

--- a/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
+++ b/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
@@ -10,6 +10,7 @@ function MobileIntroStep() {
       <p>
         <a href="/verify/jurisdiction/errors/no_id">{t('idv.messages.jurisdiction.no_id')}</a>
       </p>
+      <p className="margin-bottom-0">{t('doc_auth.tips.document_capture_header_text')}</p>
       <ul>
         <li>{t('doc_auth.tips.document_capture_id_text1')}</li>
         <li>{t('doc_auth.tips.document_capture_id_text2')}</li>

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -42,6 +42,7 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           required
+          className="id-card-file-input"
         />
       ) : (
         <SelfieCapture


### PR DESCRIPTION
Previously: #4104

---

1. Set FileInput border color to primary-dark on hover

**Why**: Per design specifications

Was previously `primary-darker`

Before|After
---|---
![hover-before](https://user-images.githubusercontent.com/1779930/91053345-ad434480-e5f0-11ea-9120-6e0ef914979a.png)|![hover-after](https://user-images.githubusercontent.com/1779930/91053343-ad434480-e5f0-11ea-8380-025c441189a7.png)

---

2. Style FileInput banner text as per design

**Why**: Per design specification

Specifics:

- Font size `1.625rem` (previously `xl` token `34.1px`)
- Character spacing `0.4px` (previously `0`)
- Line-height `1.5rem` (previously inherited `1.5` multiplier)

Before|After
---|---
![banner-before](https://user-images.githubusercontent.com/1779930/91053405-c21fd800-e5f0-11ea-9dbe-2bd095ee9d50.png)|![banner-after](https://user-images.githubusercontent.com/1779930/91053403-c21fd800-e5f0-11ea-8bb7-569375a145a6.png)

---

3. Add missing text "For best results"

**Why**: Per design, mobile introductory text should include leading heading for best results instructions.

---

4. Show margin between banner and drag text

**Why**: Drag text may not always be present, and margin should not appear if not present, so that the banner text appears vertically at center.

Before|After
---|---
![file-input-margin-before](https://user-images.githubusercontent.com/1779930/91053502-e8457800-e5f0-11ea-908a-0d9a52d018ca.png)|![file-input-margin-after](https://user-images.githubusercontent.com/1779930/91053499-e8457800-e5f0-11ea-94e8-b65df3d1b275.png)

---

5. Show selfie file input proportioned as card input

**Why**: Consistency with prior steps

Before|After
---|---
![selfie-before](https://user-images.githubusercontent.com/1779930/91053538-f5fafd80-e5f0-11ea-8b02-0e8cb1086132.png)|![selfie-after](https://user-images.githubusercontent.com/1779930/91053536-f5626700-e5f0-11ea-9901-90181e416eb6.png)