### PR TITLE
Revert document capture fields as assigned "required" attribute

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -14,7 +14,6 @@ import DeviceContext from '../context/device';
  * @prop {string=} bannerText Optional banner text to show in file input.
  * @prop {Blob?=} value Current value.
  * @prop {(nextValue:Blob?)=>void} onChange Callback receiving next value on change.
- * @prop {boolean=} required Whether value is required for file input.
  * @prop {'user'|'environment'=} capture Facing mode of capture. If capture is not specified and a
  * camera is supported, defaults to the Acuant environment camera capture.
  * @prop {string=} className Optional additional class names.
@@ -75,7 +74,6 @@ function AcuantCapture({
   label,
   bannerText,
   value,
-  required,
   onChange = () => {},
   capture,
   className,
@@ -196,7 +194,6 @@ function AcuantCapture({
         accept={['image/*']}
         capture={capture}
         value={value}
-        required={required}
         error={ownError ?? undefined}
         onClick={startCaptureOrTriggerUpload}
         onChange={onChangeIfValid}

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -51,7 +51,6 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
           bannerText={t(`doc_auth.headings.${side}`)}
           value={value[side]}
           onChange={(nextValue) => onChange({ [side]: nextValue })}
-          required
           className="id-card-file-input"
         />
       ))}

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -20,7 +20,6 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string=} error Error to show.
  * @prop {(event:ReactMouseEvent)=>void=} onClick Input click handler.
  * @prop {(nextValue:Blob?)=>void=} onChange Input change handler.
- * @prop {boolean=} required Whether value is required for file input.
  * @prop {(message:string)=>void=} onError Callback to trigger if upload error occurs.
  */
 
@@ -89,7 +88,6 @@ const FileInput = forwardRef((props, ref) => {
     accept,
     capture,
     value,
-    required,
     error,
     onClick = () => {},
     onChange = () => {},
@@ -206,7 +204,6 @@ const FileInput = forwardRef((props, ref) => {
             className="usa-file-input__input"
             type="file"
             onChange={onChangeIfValid}
-            required={required}
             capture={capture}
             onClick={onClick}
             accept={accept ? accept.join() : undefined}

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -42,7 +42,6 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
-          required
           className="id-card-file-input"
         />
       ) : (

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -531,18 +531,4 @@ describe('document-capture/components/acuant-capture', () => {
 
     expect(window.AcuantCameraUI.start.called).to.be.false();
   });
-
-  it('can mark the input as required', () => {
-    const { getByLabelText } = render(
-      <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" capture="environment" required />
-      </AcuantContextProvider>,
-    );
-
-    initialize();
-
-    const input = getByLabelText('Image');
-
-    expect(input.required).to.be.true();
-  });
 });

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -40,8 +40,6 @@ describe('document-capture/components/documents-step', () => {
 
     expect(front).to.be.ok();
     expect(back).to.be.ok();
-    expect(front.required).to.be.true();
-    expect(back.required).to.be.true();
   });
 
   it('calls onChange callback with uploaded image', () => {

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -287,12 +287,4 @@ describe('document-capture/components/file-input', () => {
 
     expect(ref.current.nodeName).to.equal('INPUT');
   });
-
-  it('can mark the input as required', () => {
-    const { getByLabelText } = render(<FileInput label="File" required />);
-
-    const input = getByLabelText('File');
-
-    expect(input.required).to.be.true();
-  });
 });

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -23,15 +23,6 @@ describe('document-capture/components/selfie-step', () => {
     });
   });
 
-  it('renders with required input', () => {
-    const { getByLabelText } = render(<SelfieStep />);
-
-    const input = getByLabelText('doc_auth.headings.document_capture_selfie');
-
-    expect(input).to.be.ok();
-    expect(input.required).to.be.true();
-  });
-
   it('calls onChange callback with uploaded image', () => {
     const onChange = sinon.stub();
     const { getByLabelText } = render(<SelfieStep onChange={onChange} />);


### PR DESCRIPTION
**Why**: When capturing via Acuant SDK, we're not assigning a value to the underlying HTML input field, which prevents submission because it is marked as required.

This resolves an issue where "Continue" does not work on the document capture flow when capturing images via Acuant.

This reverts part of the changes from #4083 (specifically 870da37c4bd0103e9fa17c454d135f07a141618f).

Note that this does still not allow a user to progress to the next screen without first providing values for the documents step. The addition of a `required` attribute was an enhancement intended to provide additional semantic details which could benefit users of assistive technology.

We may want to restore parts of this in the future, but it will require additional consideration:

- Could we assign a value to the input when an image is captured via Acuant, so that it satisfies the "required" check?
- Could we at least assign `required` when Acuant SDK is not going to be used (i.e. desktop)?