### PR TITLE
LG-3337: Show error message if Acuant SDK capture reports failure

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -182,7 +182,10 @@ function AcuantCapture({
 
               setIsCapturing(false);
             }}
-            onImageCaptureFailure={() => setIsCapturing(false)}
+            onImageCaptureFailure={() => {
+              setOwnError(t('errors.doc_auth.capture_failure'));
+              setIsCapturing(false);
+            }}
           />
         </FullScreen>
       )}

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -31,6 +31,7 @@
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
 - errors.doc_auth.acuant_network_error
+- errors.doc_auth.capture_failure
 - errors.doc_auth.document_capture_selfie_consent_blocked
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_file_size

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -22,6 +22,7 @@ en:
         try again later.
       acuant_throttle: To prevent abuse we limit the number of times you can attempt
         to validate a document.  Please try again later.
+      capture_failure: Camera failed to initialize, please try again.
       consent_form: Before you can continue, you must give us permission. Please check
         the box below and then click continue.
       document_capture_info_html: |-

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -22,6 +22,7 @@ es:
         Por favor, inténtelo de nuevo más tarde.
       acuant_throttle: Para evitar abusos, limitamos el número de veces que puede
         intentar validar un documento. Por favor, inténtelo de nuevo más tarde.
+      capture_failure: La cámara no se pudo inicializar. Vuelva a intentarlo.
       consent_form: Antes de continuar, debe darnos permiso. Marque la casilla a continuación
         y luego haga clic en continuar.
       document_capture_info_html: |-

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -22,6 +22,7 @@ fr:
         réessayer plus tard.
       acuant_throttle: Pour éviter les abus, nous limitons le nombre de fois où vous
         pouvez essayer de valider un document. Veuillez réessayer plus tard.
+      capture_failure: La caméra n'a pas pu s'initialiser, veuillez réessayer.
       consent_form: Avant de pouvoir continuer, vous devez nous donner la permission.
         Veuillez cocher la case ci-dessous puis cliquez sur continuer.
       document_capture_info_html: |-

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -124,6 +124,27 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end.called).to.be.false();
     });
 
+    it('shows error if capture fails', async () => {
+      const { container, getByLabelText, findByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <AcuantContextProvider sdkSrc="about:blank">
+            <AcuantCapture label="Image" />
+          </AcuantContextProvider>
+        </DeviceContext.Provider>,
+      );
+
+      initialize({
+        start: sinon.stub().callsArgWithAsync(1, new Error()),
+      });
+
+      const button = getByLabelText('Image');
+      fireEvent.click(button);
+
+      await findByText('errors.doc_auth.capture_failure');
+      expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
+      expect(container.querySelector('.full-screen')).to.be.null();
+    });
+
     it('calls onChange with the captured image on successful capture', async () => {
       const onChange = sinon.mock();
       const { getByText } = render(

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { waitForElementToBeRemoved } from '@testing-library/dom';
 import sinon from 'sinon';
 import AcuantCapture from '@18f/identity-document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
@@ -123,8 +124,8 @@ describe('document-capture/components/acuant-capture', () => {
       expect(window.AcuantCameraUI.end.called).to.be.false();
     });
 
-    it('calls onChange with the captured image on successful capture', () => {
-      const onChange = sinon.spy();
+    it('calls onChange with the captured image on successful capture', async () => {
+      const onChange = sinon.mock();
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
@@ -133,20 +134,19 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
+      initialize({
+        start: sinon.stub().callsArgWithAsync(0, {
           glare: 70,
           sharpness: 70,
           image: {
             data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
           },
-        };
-        onImageCaptureSuccess(capture);
+        }),
       });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
+      await new Promise((resolve) => onChange.callsFake(resolve));
 
       expect(onChange.getCall(0).args).to.have.lengthOf(1);
       expect(onChange.getCall(0).args[0]).to.be.instanceOf(window.Blob);
@@ -214,8 +214,8 @@ describe('document-capture/components/acuant-capture', () => {
       userEvent.click(button);
     });
 
-    it('renders error message if capture succeeds but photo glare exceeds threshold', () => {
-      const { getByText } = render(
+    it('renders error message if capture succeeds but photo glare exceeds threshold', async () => {
+      const { getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
@@ -223,28 +223,26 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
+      initialize({
+        start: sinon.stub().callsArgWithAsync(0, {
           glare: 38,
           sharpness: 70,
           image: {
             data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
           },
-        };
-        onImageCaptureSuccess(capture);
+        }),
       });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
-      const error = getByText('errors.doc_auth.photo_glare');
+      const error = await findByText('errors.doc_auth.photo_glare');
 
       expect(error).to.be.ok();
     });
 
-    it('renders error message if capture succeeds but photo is too blurry', () => {
-      const { getByText } = render(
+    it('renders error message if capture succeeds but photo is too blurry', async () => {
+      const { getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
@@ -252,28 +250,26 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
+      initialize({
+        start: sinon.stub().callsArgWithAsync(0, {
           glare: 70,
           sharpness: 20,
           image: {
             data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
           },
-        };
-        onImageCaptureSuccess(capture);
+        }),
       });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
-      const error = getByText('errors.doc_auth.photo_blurry');
+      const error = await findByText('errors.doc_auth.photo_blurry');
 
       expect(error).to.be.ok();
     });
 
-    it('shows at most one error message between AcuantCapture and FileInput', () => {
-      const { getByLabelText, getByText } = render(
+    it('shows at most one error message between AcuantCapture and FileInput', async () => {
+      const { getByLabelText, getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
@@ -281,16 +277,14 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
+      initialize({
+        start: sinon.stub().callsArgWithAsync(0, {
           glare: 70,
           sharpness: 20,
           image: {
             data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
           },
-        };
-        onImageCaptureSuccess(capture);
+        }),
       });
 
       const file = new window.File([''], 'upload.txt', { type: 'text/plain' });
@@ -298,7 +292,7 @@ describe('document-capture/components/acuant-capture', () => {
       const input = getByLabelText('Image');
       userEvent.upload(input, file);
 
-      expect(getByText('errors.doc_auth.selfie')).to.be.ok();
+      expect(await findByText('errors.doc_auth.selfie')).to.be.ok();
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
@@ -307,8 +301,8 @@ describe('document-capture/components/acuant-capture', () => {
       expect(() => getByText('errors.doc_auth.selfie')).to.throw();
     });
 
-    it('removes error message once image is corrected', () => {
-      const { getByText } = render(
+    it('removes error message once image is corrected', async () => {
+      const { getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
@@ -316,32 +310,38 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      let isBlurry = true;
-
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
-          glare: 70,
-          sharpness: isBlurry ? 20 : 70,
-          image: {
-            data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
-          },
-        };
-        onImageCaptureSuccess(capture);
+      initialize({
+        start: sinon
+          .stub()
+          .onFirstCall()
+          .callsArgWithAsync(0, {
+            glare: 70,
+            sharpness: 20,
+            image: {
+              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+            },
+          })
+          .onSecondCall()
+          .callsArgWithAsync(0, {
+            glare: 70,
+            sharpness: 70,
+            image: {
+              data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+            },
+          }),
       });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
-      isBlurry = false;
+      const error = await findByText('errors.doc_auth.photo_blurry');
 
       fireEvent.click(button);
-
-      expect(() => getByText('errors.doc_auth.photo_file_size')).to.throw();
+      await waitForElementToBeRemoved(error);
     });
 
-    it('renders error message if capture succeeds but photo is too small', () => {
-      const { getByText } = render(
+    it('renders error message if capture succeeds but photo is too small', async () => {
+      const { getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" minimumFileSize={500 * 1024} />
@@ -349,22 +349,20 @@ describe('document-capture/components/acuant-capture', () => {
         </DeviceContext.Provider>,
       );
 
-      initialize();
-      window.AcuantCameraUI.start.callsFake((onImageCaptureSuccess) => {
-        const capture = {
+      initialize({
+        start: sinon.stub().callsArgWithAsync(0, {
           glare: 70,
           sharpness: 38,
           image: {
             data: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
           },
-        };
-        onImageCaptureSuccess(capture);
+        }),
       });
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
-      const error = getByText('errors.doc_auth.photo_blurry');
+      const error = await findByText('errors.doc_auth.photo_blurry');
 
       expect(error).to.be.ok();
     });

--- a/spec/javascripts/support/acuant.js
+++ b/spec/javascripts/support/acuant.js
@@ -13,13 +13,18 @@ export function useAcuant() {
   });
 
   return {
-    initialize({ isSuccess = true, isCameraSupported = true } = {}) {
+    initialize({
+      isSuccess = true,
+      isCameraSupported = true,
+      start = sinon.stub(),
+      end = sinon.stub(),
+    } = {}) {
       window.AcuantJavascriptWebSdk = {
         initialize: (_credentials, _endpoint, { onSuccess, onFail }) =>
           isSuccess ? onSuccess() : onFail(),
       };
       window.AcuantCamera = { isCameraSupported };
-      window.AcuantCameraUI = { start: sinon.stub(), end: sinon.stub() };
+      window.AcuantCameraUI = { start, end };
       act(window.onAcuantSdkLoaded);
     },
   };


### PR DESCRIPTION
**Why**: As a user, I expect that if I click "Take photo" during React-based IAL2 document proofing and an error occurs which prevents me from being able to take a picture, I am presented with a message informing me of this, so that I can understand what's happened and how I can proceed with proofing.

Currently, while unlikely, Acuant SDK may trigger an error after we start capture. While we do handle this gracefully by closing the full screen dialog, we do not inform the user that anything has happened. This may leave them confused as to why they saw a dialog appear briefly before disappearing.

**Screenshot:**

![Screen Shot 2020-08-25 at 9 12 15 AM](https://user-images.githubusercontent.com/1779930/91178529-3de25900-e6b3-11ea-8edd-57c2e998a909.png)

**Testing Instructions:**

This can be simulated by running through document capture using [Chrome DevTools' built-in mobile simulator](https://developers.google.com/web/tools/chrome-devtools/device-mode). Because Acuant thinks that the device is a supported mobile device, it will try to use the WebAssembly capture, but fail because Chrome does not support it.