### PR TITLE
LG-3336: Always show enabled Continue/Submit in document capture

### DIFF
--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -21,8 +21,9 @@
   border-width: 1px;
 }
 
-.selfie-capture--access-rejected {
+.selfie-capture--error {
   border-color: color('error');
+  border-radius: .375rem;
   border-width: 3px;
 
   &:hover {

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -24,7 +24,7 @@ import FileBase64CacheContext from '../context/file-base64-cache';
  * @prop {number=} minimumSharpnessScore Minimum sharpness score to be considered acceptable.
  * @prop {number=} minimumFileSize Minimum file size (in bytes) to be considered acceptable.
  * @prop {boolean=} allowUpload Whether to allow file upload. Defaults to `true`.
- * @prop {ReactNode=} error Error to show.
+ * @prop {ReactNode=} errorMessage Error to show.
  */
 
 /**
@@ -85,15 +85,15 @@ function AcuantCapture({
   minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
   minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
   allowUpload = true,
-  error,
+  errorMessage,
 }) {
   const fileCache = useContext(FileBase64CacheContext);
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
   const isForceUploading = useRef(false);
   const [isCapturing, setIsCapturing] = useState(false);
-  const [ownError, setOwnError] = useState(/** @type {?string} */ (null));
-  useMemo(() => setOwnError(null), [value]);
+  const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {?string} */ (null));
+  useMemo(() => setOwnErrorMessage(null), [value]);
   const { isMobile } = useContext(DeviceContext);
   const { t, formatHTML } = useI18n();
   const hasCapture = !isError && (isReady ? isCameraSupported : isMobile);
@@ -140,9 +140,9 @@ function AcuantCapture({
    */
   function onChangeIfValid(nextValue) {
     if (nextValue && nextValue.size < minimumFileSize) {
-      setOwnError(t('errors.doc_auth.photo_file_size'));
+      setOwnErrorMessage(t('errors.doc_auth.photo_file_size'));
     } else {
-      setOwnError(null);
+      setOwnErrorMessage(null);
       onChange(nextValue);
     }
   }
@@ -179,9 +179,9 @@ function AcuantCapture({
           <AcuantCaptureCanvas
             onImageCaptureSuccess={(nextCapture) => {
               if (nextCapture.glare < minimumGlareScore) {
-                setOwnError(t('errors.doc_auth.photo_glare'));
+                setOwnErrorMessage(t('errors.doc_auth.photo_glare'));
               } else if (nextCapture.sharpness < minimumSharpnessScore) {
-                setOwnError(t('errors.doc_auth.photo_blurry'));
+                setOwnErrorMessage(t('errors.doc_auth.photo_blurry'));
               } else {
                 const dataAsBlob = toBlob(nextCapture.image.data);
                 fileCache.set(dataAsBlob, nextCapture.image.data);
@@ -191,7 +191,7 @@ function AcuantCapture({
               setIsCapturing(false);
             }}
             onImageCaptureFailure={() => {
-              setOwnError(t('errors.doc_auth.capture_failure'));
+              setOwnErrorMessage(t('errors.doc_auth.capture_failure'));
               setIsCapturing(false);
             }}
           />
@@ -205,10 +205,10 @@ function AcuantCapture({
         accept={['image/*']}
         capture={capture}
         value={value}
-        error={ownError ?? error}
+        errorMessage={ownErrorMessage ?? errorMessage}
         onClick={startCaptureOrTriggerUpload}
         onChange={onChangeIfValid}
-        onError={() => setOwnError(null)}
+        onError={() => setOwnErrorMessage(null)}
       />
       <div className="margin-top-2">
         {isMobile && (

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -8,6 +8,8 @@ import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import FileBase64CacheContext from '../context/file-base64-cache';
 
+/** @typedef {import('react').ReactNode} ReactNode */
+
 /**
  * @typedef AcuantCaptureProps
  *
@@ -22,6 +24,7 @@ import FileBase64CacheContext from '../context/file-base64-cache';
  * @prop {number=} minimumSharpnessScore Minimum sharpness score to be considered acceptable.
  * @prop {number=} minimumFileSize Minimum file size (in bytes) to be considered acceptable.
  * @prop {boolean=} allowUpload Whether to allow file upload. Defaults to `true`.
+ * @prop {ReactNode=} error Error to show.
  */
 
 /**
@@ -82,6 +85,7 @@ function AcuantCapture({
   minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
   minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
   allowUpload = true,
+  error,
 }) {
   const fileCache = useContext(FileBase64CacheContext);
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
@@ -201,7 +205,7 @@ function AcuantCapture({
         accept={['image/*']}
         capture={capture}
         value={value}
-        error={ownError ?? undefined}
+        error={ownError ?? error}
         onClick={startCaptureOrTriggerUpload}
         onChange={onChangeIfValid}
         onError={() => setOwnError(null)}

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -26,7 +26,7 @@ import useI18n from '../hooks/use-i18n';
  *
  * @return {ReactNode[]} Formatted error messages.
  */
-export function getFormattedErrors(errors) {
+export function getFormattedErrorMessages(errors) {
   return errors.flatMap((error, i) => [<br key={i} />, error]).slice(1);
 }
 
@@ -85,7 +85,9 @@ function DocumentCapture({ isLivenessEnabled = true }) {
       {submissionError && (
         <Alert type="error" className="margin-bottom-2">
           {isFormEntriesError
-            ? getFormattedErrors(/** @type {UploadFormEntriesError} */ (submissionError).rawErrors)
+            ? getFormattedErrorMessages(
+                /** @type {UploadFormEntriesError} */ (submissionError).rawErrorMessages,
+              )
             : t('errors.doc_auth.acuant_network_error')}
         </Alert>
       )}

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -2,8 +2,8 @@ import React, { useState, useContext } from 'react';
 import { Alert } from '@18f/identity-components';
 import FormSteps from './form-steps';
 import { UploadFormEntriesError } from '../services/upload';
-import DocumentsStep, { isValid as isDocumentsStepValid } from './documents-step';
-import SelfieStep, { isValid as isSelfieStepValid } from './selfie-step';
+import DocumentsStep, { validate as validateDocumentsStep } from './documents-step';
+import SelfieStep, { validate as validateSelfieStep } from './selfie-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
@@ -49,13 +49,13 @@ function DocumentCapture({ isLivenessEnabled = true }) {
       name: 'documents',
       title: t('doc_auth.headings.document_capture'),
       component: DocumentsStep,
-      isValid: isDocumentsStepValid,
+      validate: validateDocumentsStep,
     },
     isLivenessEnabled && {
       name: 'selfie',
       title: t('doc_auth.headings.selfie'),
       component: SelfieStep,
-      isValid: isSelfieStepValid,
+      validate: validateSelfieStep,
     },
   ].filter(Boolean));
 

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -60,7 +60,7 @@ function DocumentsStep({ value = {}, onChange = () => {}, errors = {} }) {
           value={value[side]}
           onChange={(nextValue) => onChange({ [side]: nextValue })}
           className="id-card-file-input"
-          error={errors[side] ? <FormErrorMessage error={errors[side]} /> : undefined}
+          errorMessage={errors[side] ? <FormErrorMessage error={errors[side]} /> : undefined}
         />
       ))}
     </>

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,7 +1,14 @@
 import React, { useContext } from 'react';
 import AcuantCapture from './acuant-capture';
+import FormErrorMessage from './form-error-message';
+import { RequiredValueMissingError } from './form-steps';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
+
+/**
+ * @template V
+ * @typedef {import('./form-steps').FormStepValidateResult<V>} FormStepValidateResult
+ */
 
 /**
  * @typedef DocumentsStepValue
@@ -13,8 +20,9 @@ import DeviceContext from '../context/device';
 /**
  * @typedef DocumentsStepProps
  *
- * @prop {DocumentsStepValue=}                            value Current value.
+ * @prop {DocumentsStepValue=} value Current value.
  * @prop {(nextValue:Partial<DocumentsStepValue>)=>void=} onChange Value change handler.
+ * @prop {Partial<FormStepValidateResult<DocumentsStepValue>>=} errors Current validation errors.
  */
 
 /**
@@ -27,7 +35,7 @@ const DOCUMENT_SIDES = ['front', 'back'];
 /**
  * @param {DocumentsStepProps} props Props object.
  */
-function DocumentsStep({ value = {}, onChange = () => {} }) {
+function DocumentsStep({ value = {}, onChange = () => {}, errors = {} }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -52,6 +60,7 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
           value={value[side]}
           onChange={(nextValue) => onChange({ [side]: nextValue })}
           className="id-card-file-input"
+          error={errors[side] ? <FormErrorMessage error={errors[side]} /> : undefined}
         />
       ))}
     </>
@@ -59,12 +68,20 @@ function DocumentsStep({ value = {}, onChange = () => {} }) {
 }
 
 /**
- * Returns true if the step is valid for the given values, or false otherwise.
- *
- * @param {Record<string,string>} value Current form values.
- *
- * @return {boolean} Whether step is valid.
+ * @type {import('./form-steps').FormStepValidate<DocumentsStepValue>}
  */
-export const isValid = (value) => Boolean(value.front && value.back);
+export function validate(values) {
+  const errors = {};
+
+  if (!values.front) {
+    errors.front = new RequiredValueMissingError();
+  }
+
+  if (!values.back) {
+    errors.back = new RequiredValueMissingError();
+  }
+
+  return errors;
+}
 
 export default DocumentsStep;

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -18,10 +18,10 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string[]=} accept Optional array of file input accept patterns.
  * @prop {'user'|'environment'=} capture Optional facing mode if file input is used for capture.
  * @prop {Blob?=} value Current value.
- * @prop {ReactNode=} error Error to show.
+ * @prop {ReactNode=} errorMessage Error to show.
  * @prop {(event:ReactMouseEvent)=>void=} onClick Input click handler.
  * @prop {(nextValue:Blob?)=>void=} onChange Input change handler.
- * @prop {(message:string)=>void=} onError Callback to trigger if upload error occurs.
+ * @prop {(message:ReactNode)=>void=} onError Callback to trigger if upload error occurs.
  */
 
 /**
@@ -89,7 +89,7 @@ const FileInput = forwardRef((props, ref) => {
     accept,
     capture,
     value,
-    error,
+    errorMessage,
     onClick = () => {},
     onChange = () => {},
     onError = () => {},
@@ -98,8 +98,8 @@ const FileInput = forwardRef((props, ref) => {
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const [ownError, setOwnError] = useState(/** @type {string?} */ (null));
-  useMemo(() => setOwnError(null), [value]);
+  const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {string?} */ (null));
+  useMemo(() => setOwnErrorMessage(null), [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
 
@@ -115,20 +115,22 @@ const FileInput = forwardRef((props, ref) => {
       if (isValidForAccepts(file.type, accept)) {
         onChange(file);
       } else {
-        const nextOwnError = t('errors.doc_auth.selfie');
-        setOwnError(nextOwnError);
-        onError(nextOwnError);
+        const nextOwnErrorMessage = t('errors.doc_auth.selfie');
+        setOwnErrorMessage(nextOwnErrorMessage);
+        onError(nextOwnErrorMessage);
       }
     } else {
       onChange(null);
     }
   }
 
-  const shownError = error ?? ownError;
+  const shownErrorMessage = errorMessage ?? ownErrorMessage;
 
   return (
     <div
-      className={[shownError && 'usa-form-group usa-form-group--error'].filter(Boolean).join(' ')}
+      className={[shownErrorMessage && 'usa-form-group usa-form-group--error']
+        .filter(Boolean)
+        .join(' ')}
     >
       {/*
        * Disable reason: The Airbnb configuration of the `jsx-a11y` rule is strict in that it
@@ -143,13 +145,13 @@ const FileInput = forwardRef((props, ref) => {
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label
         htmlFor={inputId}
-        className={['usa-label', shownError && 'usa-label--error'].filter(Boolean).join(' ')}
+        className={['usa-label', shownErrorMessage && 'usa-label--error'].filter(Boolean).join(' ')}
       >
         {label}
       </label>
-      {shownError && (
+      {shownErrorMessage && (
         <span className="usa-error-message" role="alert">
-          {shownError}
+          {shownErrorMessage}
         </span>
       )}
       {hint && (

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -7,6 +7,7 @@ import useI18n from '../hooks/use-i18n';
 /** @typedef {import('react').MouseEvent} ReactMouseEvent */
 /** @typedef {import('react').ChangeEvent} ReactChangeEvent */
 /** @typedef {import('react').RefAttributes} ReactRefAttributes */
+/** @typedef {import('react').ReactNode} ReactNode */
 
 /**
  * @typedef FileInputProps
@@ -17,7 +18,7 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string[]=} accept Optional array of file input accept patterns.
  * @prop {'user'|'environment'=} capture Optional facing mode if file input is used for capture.
  * @prop {Blob?=} value Current value.
- * @prop {string=} error Error to show.
+ * @prop {ReactNode=} error Error to show.
  * @prop {(event:ReactMouseEvent)=>void=} onClick Input click handler.
  * @prop {(nextValue:Blob?)=>void=} onChange Input change handler.
  * @prop {(message:string)=>void=} onError Callback to trigger if upload error occurs.

--- a/app/javascript/packages/document-capture/components/form-error-message.jsx
+++ b/app/javascript/packages/document-capture/components/form-error-message.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { RequiredValueMissingError } from './form-steps';
+import useI18n from '../hooks/use-i18n';
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef FormErrorMessageProps
+ *
+ * @prop {Error} error Error for which message should be generated.
+ */
+
+/**
+ * @param {FormErrorMessageProps} props Props object.
+ */
+function FormErrorMessage({ error }) {
+  const { t } = useI18n();
+
+  if (error instanceof RequiredValueMissingError) {
+    return <>{t('simple_form.required.text')}</>;
+  }
+
+  return null;
+}
+
+export default FormErrorMessage;

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -13,13 +13,13 @@ import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
  *
  * @prop {Blob?=} value Current value.
  * @prop {(nextValue:Blob?)=>void} onChange Change handler.
- * @prop {ReactNode=} error Error to show.
+ * @prop {ReactNode=} errorMessage Error to show.
  */
 
 /**
  * @param {SelfieCaptureProps} props Props object.
  */
-function SelfieCapture({ value, onChange, error }) {
+function SelfieCapture({ value, onChange, errorMessage }) {
   const instanceId = useInstanceId();
   const { t } = useI18n();
   const labelRef = useRef(/** @type {HTMLDivElement?} */ (null));
@@ -67,9 +67,9 @@ function SelfieCapture({ value, onChange, error }) {
         }),
       )
       .catch(
-        ifStillMounted((mediaError) => {
-          if (mediaError.name !== 'NotAllowedError') {
-            throw mediaError;
+        ifStillMounted((error) => {
+          if (error.name !== 'NotAllowedError') {
+            throw error;
           }
 
           setIsAccessRejected(true);
@@ -111,17 +111,17 @@ function SelfieCapture({ value, onChange, error }) {
     canvas.toBlob(ifStillMounted(onChange));
   }
 
-  let shownError;
+  let shownErrorMessage;
   if (isAccessRejected) {
-    shownError = t('errors.doc_auth.document_capture_selfie_consent_blocked');
-  } else if (error) {
-    shownError = error;
+    shownErrorMessage = t('errors.doc_auth.document_capture_selfie_consent_blocked');
+  } else if (errorMessage) {
+    shownErrorMessage = errorMessage;
   }
 
   const classes = [
     'selfie-capture',
     isCapturing && 'selfie-capture--capturing',
-    shownError && 'selfie-capture--error',
+    shownErrorMessage && 'selfie-capture--error',
     value && 'selfie-capture--has-value',
   ]
     .filter(Boolean)
@@ -135,15 +135,15 @@ function SelfieCapture({ value, onChange, error }) {
         ref={labelRef}
         id={labelId}
         tabIndex={-1}
-        className={['selfie-capture__label', 'usa-label', shownError && 'usa-label--error']
+        className={['selfie-capture__label', 'usa-label', shownErrorMessage && 'usa-label--error']
           .filter(Boolean)
           .join(' ')}
       >
         {t('doc_auth.headings.document_capture_selfie')}
       </div>
-      {shownError && (
+      {shownErrorMessage && (
         <span className="usa-error-message" role="alert">
-          {shownError}
+          {shownErrorMessage}
         </span>
       )}
       <div ref={wrapperRef} className={classes}>

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -51,13 +51,13 @@ function SelfieStep({ value = {}, onChange = () => {}, errors = {} }) {
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
           className="id-card-file-input"
-          error={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
+          errorMessage={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
         />
       ) : (
         <SelfieCapture
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
-          error={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
+          errorMessage={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
         />
       )}
     </>

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -1,9 +1,16 @@
 import React, { useContext } from 'react';
 import { hasMediaAccess } from '@18f/identity-device';
+import { RequiredValueMissingError } from './form-steps';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
 import SelfieCapture from './selfie-capture';
+import FormErrorMessage from './form-error-message';
+
+/**
+ * @template V
+ * @typedef {import('./form-steps').FormStepValidateResult<V>} FormStepValidateResult
+ */
 
 /**
  * @typedef SelfieStepValue
@@ -14,14 +21,15 @@ import SelfieCapture from './selfie-capture';
 /**
  * @typedef SelfieStepProps
  *
- * @prop {SelfieStepValue=}                            value    Current value.
+ * @prop {SelfieStepValue=} value Current value.
  * @prop {(nextValue:Partial<SelfieStepValue>)=>void=} onChange Change handler.
+ * @prop {Partial<FormStepValidateResult<SelfieStepValue>>=} errors Current validation errors.
  */
 
 /**
  * @param {SelfieStepProps} props Props object.
  */
-function SelfieStep({ value = {}, onChange = () => {} }) {
+function SelfieStep({ value = {}, onChange = () => {}, errors = {} }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -43,11 +51,13 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
           className="id-card-file-input"
+          error={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
         />
       ) : (
         <SelfieCapture
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+          error={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
         />
       )}
     </>
@@ -55,12 +65,16 @@ function SelfieStep({ value = {}, onChange = () => {} }) {
 }
 
 /**
- * Returns true if the step is valid for the given values, or false otherwise.
- *
- * @param {Record<string,string>} value Current form values.
- *
- * @return {boolean} Whether step is valid.
+ * @type {import('./form-steps').FormStepValidate<SelfieStepValue>}
  */
-export const isValid = (value) => Boolean(value.selfie);
+export function validate(values) {
+  const errors = {};
+
+  if (!values.selfie) {
+    errors.selfie = new RequiredValueMissingError();
+  }
+
+  return errors;
+}
 
 export default SelfieStep;

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -3,7 +3,7 @@
 
 export class UploadFormEntriesError extends Error {
   /** @type {string[]} */
-  rawErrors = [];
+  rawErrorMessages = [];
 }
 
 /**
@@ -43,7 +43,7 @@ async function upload(payload, { endpoint, csrf }) {
     /** @type {UploadErrorResponse} */
     const errorResult = result;
     const error = new UploadFormEntriesError(errorResult.errors.join(', '));
-    error.rawErrors = errorResult.errors;
+    error.rawErrorMessages = errorResult.errors;
     throw error;
   }
 

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -5,7 +5,7 @@ import { fireEvent } from '@testing-library/react';
 import { UploadFormEntriesError } from '@18f/identity-document-capture/services/upload';
 import { AcuantProvider } from '@18f/identity-document-capture';
 import DocumentCapture, {
-  getFormattedErrors,
+  getFormattedErrorMessages,
 } from '@18f/identity-document-capture/components/document-capture';
 import render from '../../../support/render';
 import { useAcuant } from '../../../support/acuant';
@@ -27,15 +27,15 @@ describe('document-capture/components/document-capture', () => {
     window.location.hash = originalHash;
   });
 
-  describe('getFormattedErrors', () => {
+  describe('getFormattedErrorMessages', () => {
     it('formats one message', () => {
-      const { container } = render(getFormattedErrors(['Boom!']));
+      const { container } = render(getFormattedErrorMessages(['Boom!']));
 
       expect(container.innerHTML).to.equal('Boom!');
     });
 
     it('formats many messages', () => {
-      const { container } = render(getFormattedErrors(['Boom!', 'Wham!', 'Ka-pow!']));
+      const { container } = render(getFormattedErrorMessages(['Boom!', 'Wham!', 'Ka-pow!']));
 
       expect(container.innerHTML).to.equal('Boom!<br>Wham!<br>Ka-pow!');
     });
@@ -178,7 +178,7 @@ describe('document-capture/components/document-capture', () => {
 
   it('renders handled submission failure', async () => {
     const uploadError = new UploadFormEntriesError('Front image has glare, Back image is missing');
-    uploadError.rawErrors = ['Front image has glare', 'Back image is missing'];
+    uploadError.rawErrorMessages = ['Front image has glare', 'Back image is missing'];
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
       <DocumentCapture />,
       {

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -2,33 +2,36 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import DeviceContext from '@18f/identity-document-capture/context/device';
-import DocumentsStep, { isValid } from '@18f/identity-document-capture/components/documents-step';
+import DocumentsStep, { validate } from '@18f/identity-document-capture/components/documents-step';
 import render from '../../../support/render';
 
 describe('document-capture/components/documents-step', () => {
-  describe('isValid', () => {
-    it('returns false if both front and back are unset', () => {
+  describe('validate', () => {
+    it('returns errors if both front and back are unset', () => {
       const value = {};
-      const result = isValid(value);
+      const result = validate(value);
 
-      expect(result).to.be.false();
+      expect(result).to.have.keys(['front', 'back']);
+      expect(result.front).to.be.instanceOf(Error);
+      expect(result.back).to.be.instanceOf(Error);
     });
 
-    it('returns false if one of front and back are unset', () => {
+    it('returns error if one of front and back are unset', () => {
       const value = { front: new window.File([], 'upload.png', { type: 'image/png' }) };
-      const result = isValid(value);
+      const result = validate(value);
 
-      expect(result).to.be.false();
+      expect(result).to.have.keys(['back']);
+      expect(result.back).to.be.instanceOf(Error);
     });
 
-    it('returns true if both front and back are set', () => {
+    it('returns empty object if both front and back are set', () => {
       const value = {
         front: new window.File([], 'upload.png', { type: 'image/png' }),
         back: new window.File([], 'upload.png', { type: 'image/png' }),
       };
-      const result = isValid(value);
+      const result = validate(value);
 
-      expect(result).to.be.true();
+      expect(result).to.deep.equal({});
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -274,7 +274,7 @@ describe('document-capture/components/file-input', () => {
     expect(getByText('errors.doc_auth.selfie')).to.be.ok();
     expect(onError.getCall(0).args[0]).to.equal('errors.doc_auth.selfie');
 
-    rerender(<FileInput {...props} error="Oops!" />);
+    rerender(<FileInput {...props} errorMessage="Oops!" />);
 
     expect(getByText('Oops!')).to.be.ok();
     expect(() => getByText('errors.doc_auth.selfie')).to.throw();

--- a/spec/javascripts/packages/document-capture/components/form-error-message.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-error-message.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
+import FormErrorMessage from '@18f/identity-document-capture/components/form-error-message';
+import render from '../../../support/render';
+
+describe('document-capture/components/form-error-message', () => {
+  it('returns formatted RequiredValueMissingError', () => {
+    const { getByText } = render(<FormErrorMessage error={new RequiredValueMissingError()} />);
+
+    expect(getByText('simple_form.required.text')).to.be.ok();
+  });
+
+  it('returns null if error is of an unknown type', () => {
+    const { container } = render(<FormErrorMessage error={new Error()} />);
+
+    expect(container.childNodes).to.be.empty();
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -27,7 +27,7 @@ describe('document-capture/components/form-steps', () => {
           />
         </label>
       ),
-      isValid: (value) => Boolean(value.second),
+      validate: (value) => (value.second ? undefined : { second: new Error() }),
     },
     { name: 'last', title: 'Last Title', component: () => <span>Last</span> },
   ];
@@ -52,7 +52,10 @@ describe('document-capture/components/form-steps', () => {
     });
 
     it('returns the result of the validity function given form values', () => {
-      const step = { name: 'example', isValid: (value) => value.ok };
+      const step = {
+        name: 'example',
+        validate: (values) => (values.ok ? undefined : { ok: new Error() }),
+      };
 
       const result = isStepValid(step, { ok: false });
 
@@ -82,7 +85,10 @@ describe('document-capture/components/form-steps', () => {
     });
 
     it('returns -1 if all steps are invalid', () => {
-      const steps = [...STEPS].map((step) => ({ ...step, isValid: () => false }));
+      const steps = [...STEPS].map((step) => ({
+        ...step,
+        validate: () => ({ missing: new Error() }),
+      }));
       const result = getLastValidStepIndex(steps, {});
 
       expect(result).to.be.equal(-1);

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -1,25 +1,26 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import SelfieStep, { isValid } from '@18f/identity-document-capture/components/selfie-step';
+import SelfieStep, { validate } from '@18f/identity-document-capture/components/selfie-step';
 import render from '../../../support/render';
 
 describe('document-capture/components/selfie-step', () => {
-  describe('isValid', () => {
-    it('returns false if selfie is unset', () => {
+  describe('validate', () => {
+    it('returns object with error if selfie is unset', () => {
       const value = {};
-      const result = isValid(value);
+      const result = validate(value);
 
-      expect(result).to.be.false();
+      expect(result).to.have.keys(['selfie']);
+      expect(result.selfie).to.be.instanceof(Error);
     });
 
-    it('returns true if selfie is set', () => {
+    it('returns empty object if selfie is set', () => {
       const value = {
         selfie: new window.File([], 'upload.png', { type: 'image/png' }),
       };
-      const result = isValid(value);
+      const result = validate(value);
 
-      expect(result).to.be.true();
+      expect(result).to.deep.equal({});
     });
   });
 


### PR DESCRIPTION
**Why**: As a user, I expect that the "Continue" and "Submit" buttons shown at the bottom of each step in the React-based document capture form should be enabled, so that I can be better informed of the reasoning behind whether I can continue to the next step by required fields becoming highlighted.

**[Screen Recording](https://user-images.githubusercontent.com/1779930/91223813-2fb22e00-e6ef-11ea-8260-1ad1d84b3982.gif)** (5.4mb)
