### PR TITLE
send user to account page when saml acs blank

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -81,6 +81,7 @@ class SamlIdpController < ApplicationController
   def handle_successful_handoff
     track_events
     delete_branded_experience
+    return redirect_to(account_url) if saml_request.response_url.blank?
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')
   end
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -270,6 +270,12 @@ module SamlAuthHelper
     post :auth, params: { SAMLRequest: CGI.unescape(saml_request) }
   end
 
+  def visit_saml_auth_path
+    visit api_saml_auth2019_path(
+      SAMLRequest: CGI.unescape(saml_request(saml_settings))
+    )
+  end
+
   private
 
   def link_user_to_identity(user, link, settings)

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -272,7 +272,7 @@ module SamlAuthHelper
 
   def visit_saml_auth_path
     visit api_saml_auth2019_path(
-      SAMLRequest: CGI.unescape(saml_request(saml_settings))
+      SAMLRequest: CGI.unescape(saml_request(saml_settings)),
     )
   end
 


### PR DESCRIPTION
LG-3358 The IRS pilot should end on account page. 
To accomplish this users will end on the account page if the SP acs_url is blank. 
