### PR TITLE
Clean up Acuant date parsing

### DIFF
--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -30,14 +30,20 @@ module DocAuth
         hash
       end
 
+      ACUANT_TIMESTAMP_FORMAT = %r{/Date\((?<milliseconds>\d+)\)/}.freeze
+
+      # @api private
+      def convert_date(date)
+        match = ACUANT_TIMESTAMP_FORMAT.match(date)
+        return if !match || !match[:milliseconds]
+
+        Time.zone.at(match[:milliseconds].to_f / 1000).utc.strftime('%m/%d/%Y')
+      end
+
       private
 
       def hash
         @hash ||= {}
-      end
-
-      def convert_date(date)
-        Time.zone.at(date[6..-3].to_f / 1000).utc.strftime('%m/%d/%Y')
       end
     end
   end

--- a/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
+++ b/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 describe DocAuth::Acuant::PiiFromDoc do
   include DocAuthHelper
 
+  subject(:pii_from_doc) { described_class.new(response_body) }
   let(:response_body) { JSON.parse(AcuantFixtures.get_results_response_success) }
 
   describe '#call' do
     it 'correctly parses the pii data from acuant and returns a hash' do
-      results = described_class.new(response_body).call
+      results = pii_from_doc.call
       expect(results).to eq(
         first_name: 'JANE',
         middle_name: nil,
@@ -21,6 +22,16 @@ describe DocAuth::Acuant::PiiFromDoc do
         state_id_jurisdiction: 'ND',
         state_id_type: 'drivers_license',
       )
+    end
+  end
+
+  describe '#convert_date' do
+    it 'parses and formats a date from the Acuant format' do
+      expect(pii_from_doc.convert_date('/Date(449625600000)/')).to eq('04/01/1984')
+    end
+
+    it 'is nil for a bad format' do
+      expect(pii_from_doc.convert_date('/Foobar(111111)/')).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
I spotted the old parsing in: https://github.com/18F/identity-idp/pull/4129#discussion_r477421924


and I think the `date[6..-3]` is really hard to understand, so I decided to use a regex with a named capture and also add a spec that as a clearer example