### PR TITLE
Refactor DocAuth::Response#errors to be a hash (LG-3359)

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -48,7 +48,12 @@ module Idv
           success: true,
         }
       else
-        render json: form_response.to_h,
+        # FOLLOWUP: refactor the client to accept a hash of errors
+        errors_arr = form_response.errors.flat_map do |key, errs|
+          Array(errs).map { |err| "#{key} #{err}" }
+        end
+
+        render json: form_response.to_h.merge(errors: errors_arr),
                status: :bad_request
       end
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -25,7 +25,7 @@ module Idv
       FormResponse.new(
         success: valid?,
         errors: errors.messages,
-        extra: {}
+        extra: {},
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -21,14 +21,11 @@ module Idv
       @liveness_checking_enabled = liveness_checking_enabled
     end
 
-    # Normally we'd return FormResponse, but that has errors as a hash,
-    # where the proofer reponses have errors as an array. This is easier to compare
-    # with the proofer responses
-    # @return [DocAuth::Response]
     def submit
-      DocAuth::Response.new(
+      FormResponse.new(
         success: valid?,
-        errors: errors.full_messages,
+        errors: errors.messages,
+        extra: {}
       )
     end
 

--- a/app/services/doc_auth/acuant/request.rb
+++ b/app/services/doc_auth/acuant/request.rb
@@ -94,7 +94,7 @@ module DocAuth
         NewRelic::Agent.notice_error(exception)
         DocAuth::Response.new(
           success: false,
-          errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+          errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
           exception: exception,
         )
       end
@@ -103,7 +103,7 @@ module DocAuth
         NewRelic::Agent.notice_error(exception)
         DocAuth::Response.new(
           success: false,
-          errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+          errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
           exception: exception,
         )
       end

--- a/app/services/doc_auth/acuant/responses/facial_match_response.rb
+++ b/app/services/doc_auth/acuant/responses/facial_match_response.rb
@@ -16,8 +16,10 @@ module DocAuth
         private
 
         def error_messages
-          return [] if successful_result?
-          [I18n.t('errors.doc_auth.selfie')]
+          return {} if successful_result?
+          {
+            facial_match: I18n.t('errors.doc_auth.selfie')
+          }
         end
 
         def extra_attributes

--- a/app/services/doc_auth/acuant/responses/facial_match_response.rb
+++ b/app/services/doc_auth/acuant/responses/facial_match_response.rb
@@ -18,7 +18,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
           {
-            facial_match: I18n.t('errors.doc_auth.selfie')
+            facial_match: I18n.t('errors.doc_auth.selfie'),
           }
         end
 

--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -44,9 +44,9 @@ module DocAuth
         attr_reader :http_response
 
         def error_messages_from_alerts
-          return [] if successful_result?
+          return {} if successful_result?
 
-          raw_alerts.map do |raw_alert|
+          messages = raw_alerts.map do |raw_alert|
             # If a friendly message exists for this alert, we want to return that.
             # If a friendly message does not exist, FriendlyError::Message will return the raw alert
             # to us. In that case we respond with a general error.
@@ -55,6 +55,8 @@ module DocAuth
             next I18n.t('errors.doc_auth.general_error') if friendly_message == raw_alert_message
             friendly_message
           end
+
+          { results: messages }
         end
 
         def parsed_response_body

--- a/app/services/doc_auth/acuant/responses/liveness_response.rb
+++ b/app/services/doc_auth/acuant/responses/liveness_response.rb
@@ -23,8 +23,10 @@ module DocAuth
         end
 
         def error_messages
-          return [] if successful_result?
-          [I18n.t('errors.doc_auth.selfie')]
+          return {} if successful_result?
+          {
+            liveness: I18n.t('errors.doc_auth.selfie')
+          }
         end
 
         def extra_attributes

--- a/app/services/doc_auth/acuant/responses/liveness_response.rb
+++ b/app/services/doc_auth/acuant/responses/liveness_response.rb
@@ -25,7 +25,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
           {
-            liveness: I18n.t('errors.doc_auth.selfie')
+            liveness: I18n.t('errors.doc_auth.selfie'),
           }
         end
 

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -25,7 +25,7 @@ module DocAuth
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
         instance_id = SecureRandom.uuid
-        Responses::CreateDocumentResponse.new(success: true, errors: [], instance_id: instance_id)
+        Responses::CreateDocumentResponse.new(success: true, errors: {}, instance_id: instance_id)
       end
 
       def post_front_image(image:, instance_id:)

--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -38,9 +38,9 @@ module DocAuth
       private
 
       def errors
-      error = parsed_yaml_from_uploaded_file&.dig('friendly_error')
-      return {} if error.blank?
-      { results: [error] }
+        error = parsed_yaml_from_uploaded_file&.dig('friendly_error')
+        return {} if error.blank?
+        { results: [error] }
       end
 
       def parsed_yaml_from_uploaded_file

--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -38,8 +38,9 @@ module DocAuth
       private
 
       def errors
-        return [] if parsed_yaml_from_uploaded_file.blank?
-        [parsed_yaml_from_uploaded_file['friendly_error']].compact
+      error = parsed_yaml_from_uploaded_file&.dig('friendly_error')
+      return {} if error.blank?
+      { results: [error] }
       end
 
       def parsed_yaml_from_uploaded_file
@@ -57,7 +58,7 @@ module DocAuth
       end
 
       def success?
-        errors.none?
+        errors.blank?
       end
     end
   end

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -2,9 +2,9 @@ module DocAuth
   class Response
     attr_reader :errors, :exception, :extra, :pii_from_doc
 
-    def initialize(success:, errors: [], exception: nil, extra: {}, pii_from_doc: {})
+    def initialize(success:, errors: {}, exception: nil, extra: {}, pii_from_doc: {})
       @success = success
-      @errors = errors
+      @errors = errors.to_h
       @exception = exception
       @extra = extra
       @pii_from_doc = pii_from_doc
@@ -13,7 +13,7 @@ module DocAuth
     def merge(other)
       Response.new(
         success: success? && other.success?,
-        errors: [*errors, *other.errors],
+        errors: errors.merge(other.errors),
         exception: exception || other.exception,
         extra: extra.merge(other.extra),
         pii_from_doc: pii_from_doc.merge(other.pii_from_doc),

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -16,11 +16,9 @@ class FormResponse
   end
 
   def merge(other)
-    errors = @errors.presence || other.errors
-    errors = { other: other.errors } if other.errors.is_a?(Array)
     FormResponse.new(
       success: success? && other.success?,
-      errors: errors,
+      errors: errors.merge(other.errors),
       extra: extra.merge(other.extra),
     )
   end

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -119,7 +119,7 @@ module Idv
         redirect_to throttled_url
         DocAuth::Response.new(
           success: false,
-          errors: [I18n.t('errors.doc_auth.acuant_throttle')],
+          errors: { limit: I18n.t('errors.doc_auth.acuant_throttle') },
         )
       end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -43,7 +43,7 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq(['Front of your ID Please fill in this field.'])
+          expect(json[:errors]).to eq(['front Please fill in this field.'])
         end
       end
 
@@ -55,7 +55,7 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:errors]).
-            to eq(["Front of your ID #{I18n.t('doc_auth.errors.not_a_file')}"])
+            to eq(["front #{I18n.t('doc_auth.errors.not_a_file')}"])
         end
 
         context 'with a locale param' do
@@ -66,8 +66,7 @@ describe Idv::ImageUploadsController do
 
             json = JSON.parse(response.body, symbolize_names: true)
             expect(json[:errors]).
-              to eq(['Frente de su identificación ' +
-                      I18n.t('doc_auth.errors.not_a_file', locale: 'es')])
+              to eq(["front #{I18n.t('doc_auth.errors.not_a_file', locale: 'es')}"])
           end
         end
       end
@@ -89,7 +88,7 @@ describe Idv::ImageUploadsController do
             method: :post_images,
             response: DocAuth::Response.new(
               success: false,
-              errors: ['Too blurry', 'Wrong document'],
+              errors: { front: ['Too blurry', 'Wrong document'] },
             ),
           )
         end
@@ -99,7 +98,7 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq(['Too blurry', 'Wrong document'])
+          expect(json[:errors]).to eq(['front Too blurry', 'front Wrong document'])
         end
       end
     end

--- a/spec/features/idv/doc_auth/back_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/back_image_step_spec.rb
@@ -58,7 +58,7 @@ feature 'doc auth back image step' do
       method: :post_back_image,
       response: DocAuth::Response.new(
         success: false,
-        errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+        errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
       ),
     )
 
@@ -100,7 +100,7 @@ feature 'doc auth back image step' do
       method: :get_results,
       response: DocAuth::Response.new(
         success: false,
-        errors: [error_message],
+        errors: { result: [error_message] },
       ),
     )
 

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -140,7 +140,7 @@ feature 'doc auth document capture step' do
           method: :post_front_image,
           response: DocAuth::Response.new(
             success: false,
-            errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+            errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
           ),
         )
 
@@ -227,7 +227,7 @@ feature 'doc auth document capture step' do
           method: :post_front_image,
           response: DocAuth::Response.new(
             success: false,
-            errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+            errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
           ),
         )
 

--- a/spec/features/idv/doc_auth/front_image_step_spec.rb
+++ b/spec/features/idv/doc_auth/front_image_step_spec.rb
@@ -93,7 +93,7 @@ feature 'doc auth front image step' do
       method: :post_front_image,
       response: DocAuth::Response.new(
         success: false,
-        errors: [I18n.t('errors.doc_auth.acuant_network_error')],
+        errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
       ),
     )
 

--- a/spec/features/idv/doc_auth/selfie_step_spec.rb
+++ b/spec/features/idv/doc_auth/selfie_step_spec.rb
@@ -49,7 +49,7 @@ feature 'doc auth self image step' do
       method: :post_selfie,
       response: DocAuth::Response.new(
         success: false,
-        errors: [I18n.t('errors.doc_auth.selfie')],
+        errors: { results: I18n.t('errors.doc_auth.selfie') },
       ),
     )
 

--- a/spec/features/idv/doc_capture/selfie_step_spec.rb
+++ b/spec/features/idv/doc_capture/selfie_step_spec.rb
@@ -41,7 +41,7 @@ feature 'doc auth self image step' do
       method: :post_selfie,
       response: DocAuth::Response.new(
         success: false,
-        errors: [I18n.t('errors.doc_auth.selfie')],
+        errors: { results: I18n.t('errors.doc_auth.selfie') },
       ),
     )
 

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -171,7 +171,7 @@ describe DocAuth::Acuant::AcuantClient do
       result = subject.create_document
 
       expect(result.success?).to eq(false)
-      expect(result.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
+      expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
       expect(result.exception.message).to eq(
         'DocAuth::Acuant::Requests::CreateDocumentRequest Unexpected HTTP response 500',
       )
@@ -186,7 +186,7 @@ describe DocAuth::Acuant::AcuantClient do
       result = subject.create_document
 
       expect(result.success?).to eq(false)
-      expect(result.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
+      expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
       expect(result.exception.message).to eq(
         'Connection failed',
       )
@@ -219,7 +219,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(true)
-        expect(result.errors).to eq([])
+        expect(result.errors).to eq({})
         expect(result.class).to eq(DocAuth::Response)
         expect(get_face_stub).to have_been_requested
         expect(facial_match_stub).to have_been_requested
@@ -237,7 +237,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
+        expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
       end
     end
 
@@ -255,7 +255,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+        expect(result.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
       end
     end
 
@@ -273,7 +273,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+        expect(result.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
       end
     end
   end

--- a/spec/services/doc_auth/acuant/request_spec.rb
+++ b/spec/services/doc_auth/acuant/request_spec.rb
@@ -69,7 +69,7 @@ describe DocAuth::Acuant::Request do
         response = subject.fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
+        expect(response.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
         expect(response.exception.message).to eq(
           'DocAuth::Acuant::Request Unexpected HTTP response 404',
         )
@@ -182,7 +182,7 @@ describe DocAuth::Acuant::Request do
         response = subject.fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq([I18n.t('errors.doc_auth.acuant_network_error')])
+        expect(response.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
         expect(response.exception).to be_a(Faraday::ConnectionFailed)
       end
     end

--- a/spec/services/doc_auth/acuant/requests/create_document_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/create_document_request_spec.rb
@@ -38,7 +38,7 @@ describe DocAuth::Acuant::Requests::CreateDocumentRequest do
       response = described_class.new.fetch
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(response.instance_id).to eq('this-is-a-test-instance-id') # instance ID from fixture
       expect(request_stub).to have_been_requested

--- a/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
@@ -31,7 +31,7 @@ describe DocAuth::Acuant::Requests::FacialMatchRequest do
         ).fetch
 
         expect(response.success?).to eq(true)
-        expect(response.errors).to eq([])
+        expect(response.errors).to eq({})
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end
@@ -51,7 +51,7 @@ describe DocAuth::Acuant::Requests::FacialMatchRequest do
         ).fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+        expect(response.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/services/doc_auth/acuant/requests/get_face_image_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/get_face_image_request_spec.rb
@@ -18,7 +18,7 @@ describe DocAuth::Acuant::Requests::GetFaceImageRequest do
 
       expect(response.success?).to eq(true)
       expect(response.image).to eq(AcuantFixtures.get_face_image_response)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(request_stub).to have_been_requested
     end

--- a/spec/services/doc_auth/acuant/requests/get_results_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/get_results_request_spec.rb
@@ -14,7 +14,7 @@ describe DocAuth::Acuant::Requests::GetResultsRequest do
       response = described_class.new(instance_id: instance_id).fetch
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(response.pii_from_doc).to_not be_empty
       expect(request_stub).to have_been_requested

--- a/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
@@ -26,7 +26,7 @@ describe DocAuth::Acuant::Requests::LivenessRequest do
         response = described_class.new(image: DocAuthImageFixtures.selfie_image).fetch
 
         expect(response.success?).to eq(true)
-        expect(response.errors).to eq([])
+        expect(response.errors).to eq({})
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end
@@ -43,7 +43,7 @@ describe DocAuth::Acuant::Requests::LivenessRequest do
         response = described_class.new(image: DocAuthImageFixtures.selfie_image).fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+        expect(response.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/services/doc_auth/acuant/requests/upload_image_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/upload_image_request_spec.rb
@@ -21,7 +21,7 @@ describe DocAuth::Acuant::Requests::UploadImageRequest do
       response = request.fetch
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(request_stub).to have_been_requested
     end
@@ -42,7 +42,7 @@ describe DocAuth::Acuant::Requests::UploadImageRequest do
       response = request.fetch
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(request_stub).to have_been_requested
     end

--- a/spec/services/doc_auth/acuant/responses/create_document_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/create_document_response_spec.rb
@@ -11,7 +11,7 @@ describe DocAuth::Acuant::Responses::CreateDocumentResponse do
 
     expect(response.success?).to eq(true)
     expect(response.instance_id).to eq('this-is-a-test-instance-id') # Value from the fixture
-    expect(response.errors).to eq([])
+    expect(response.errors).to eq({})
     expect(response.exception).to be_nil
   end
 end

--- a/spec/services/doc_auth/acuant/responses/facial_match_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/facial_match_response_spec.rb
@@ -11,11 +11,11 @@ describe DocAuth::Acuant::Responses::FacialMatchResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: true,
-        errors: [],
+        errors: {},
         exception: nil,
         match_score: 83,
       )
@@ -32,11 +32,11 @@ describe DocAuth::Acuant::Responses::FacialMatchResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+      expect(response.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: [I18n.t('errors.doc_auth.selfie')],
+        errors: { facial_match: I18n.t('errors.doc_auth.selfie') },
         exception: nil,
         match_score: 68,
       )

--- a/spec/services/doc_auth/acuant/responses/get_face_image_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_face_image_response_spec.rb
@@ -11,7 +11,7 @@ describe DocAuth::Acuant::Responses::GetFaceImageResponse do
 
     expect(response.success?).to eq(true)
     expect(response.image).to eq(AcuantFixtures.get_face_image_response)
-    expect(response.errors).to eq([])
+    expect(response.errors).to eq({})
     expect(response.exception).to be_nil
   end
 end

--- a/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/get_results_response_spec.rb
@@ -13,11 +13,11 @@ describe DocAuth::Acuant::Responses::GetResultsResponse do
 
     it 'returns a successful response with no errors' do
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: true,
-        errors: [],
+        errors: {},
         exception: nil,
         billed: true,
         result: 'Passed',
@@ -58,7 +58,7 @@ describe DocAuth::Acuant::Responses::GetResultsResponse do
       expect(response.success?).to eq(false)
       expect(response.errors).to eq(
         # This is the error message for the error in the response fixture
-        [I18n.t('friendly_errors.doc_auth.document_type_could_not_be_determined')],
+        results: [I18n.t('friendly_errors.doc_auth.document_type_could_not_be_determined')],
       )
       expect(response.exception).to be_nil
       expect(response.result_code).to eq(DocAuth::Acuant::ResultCodes::UNKNOWN)
@@ -79,7 +79,7 @@ describe DocAuth::Acuant::Responses::GetResultsResponse do
         expect(response.success?).to eq(false)
         expect(response.errors).to eq(
           # This is the error message for the error in the response fixture
-          [I18n.t('errors.doc_auth.general_error')],
+          results: [I18n.t('errors.doc_auth.general_error')],
         )
         expect(response.exception).to be_nil
       end

--- a/spec/services/doc_auth/acuant/responses/liveness_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/liveness_response_spec.rb
@@ -11,11 +11,11 @@ describe DocAuth::Acuant::Responses::LivenessResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(true)
-      expect(response.errors).to eq([])
+      expect(response.errors).to eq({})
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: true,
-        errors: [],
+        errors: {},
         exception: nil,
         liveness_assessment: 'Live',
         liveness_score: 99,
@@ -34,11 +34,11 @@ describe DocAuth::Acuant::Responses::LivenessResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq([I18n.t('errors.doc_auth.selfie')])
+      expect(response.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: [I18n.t('errors.doc_auth.selfie')],
+        errors: { liveness: I18n.t('errors.doc_auth.selfie') },
         exception: nil,
         liveness_assessment: nil,
         liveness_score: nil,

--- a/spec/services/doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -116,9 +116,7 @@ describe DocAuth::Mock::DocAuthMockClient do
         method: :get_results,
         response: DocAuth::Response.new(
           success: false,
-          errors: [
-            { back_image: 'blurry' },
-          ],
+          errors: { back_image: 'blurry' },
         ),
       )
     end
@@ -131,7 +129,7 @@ describe DocAuth::Mock::DocAuthMockClient do
       )
 
       expect(post_images_response.success?).to eq(false)
-      expect(post_images_response.errors).to eq([{ back_image: 'blurry' }])
+      expect(post_images_response.errors).to eq(back_image: 'blurry')
     end
   end
 end

--- a/spec/services/doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_builder_spec.rb
@@ -9,7 +9,7 @@ describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(true)
-        expect(response.errors).to eq([])
+        expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq(
           first_name: 'FAKEY',
@@ -54,7 +54,7 @@ describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(true)
-        expect(response.errors).to eq([])
+        expect(response.errors).to eq({})
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq(
           first_name: 'Susan',
@@ -86,7 +86,7 @@ describe DocAuth::Mock::ResultResponseBuilder do
         response = builder.call
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(['This is a test error'])
+        expect(response.errors).to eq(results: ['This is a test error'])
         expect(response.exception).to eq(nil)
         expect(response.pii_from_doc).to eq({})
       end

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -50,7 +50,7 @@ describe FormResponse do
 
     it 'merges errors' do
       response1 = FormResponse.new(success: false, errors: { front: 'error' })
-      response2 = DocAuth::Response.new(success: true, errors: { back: 'error'})
+      response2 = DocAuth::Response.new(success: true, errors: { back: 'error' })
 
       combined_response = response1.merge(response2)
       expect(combined_response.errors).to eq(front: 'error', back: 'error')

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -48,12 +48,12 @@ describe FormResponse do
       expect(combined_response.extra).to eq({ step: 'foo', is_fallback_link: true })
     end
 
-    it 'handles both arrays and hashes' do
-      response1 = FormResponse.new(success: false, errors: {})
-      response2 = DocAuth::Response.new(success: true, errors: ['foo'])
+    it 'merges errors' do
+      response1 = FormResponse.new(success: false, errors: { front: 'error' })
+      response2 = DocAuth::Response.new(success: true, errors: { back: 'error'})
 
       combined_response = response1.merge(response2)
-      expect(combined_response.errors).to eq({ other: ['foo'] })
+      expect(combined_response.errors).to eq(front: 'error', back: 'error')
     end
 
     it 'returns true if one is false and one is true' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -198,7 +198,7 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
       method: method,
       response: DocAuth::Response.new(
         success: false,
-        errors: [I18n.t('errors.doc_auth.general_error')],
+        errors: { error: I18n.t('errors.doc_auth.general_error') },
       ),
     )
   end


### PR DESCRIPTION
**Why**: For consistency with FormResponse#errors

This came up, making https://github.com/18F/identity-idp/pull/4127 more complex