### PR TITLE
Focus first error input after validated doc auth submission

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -1,4 +1,12 @@
-import React, { useContext, useRef, useState, useMemo, useEffect } from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useRef,
+  useState,
+  useMemo,
+  useEffect,
+  useImperativeHandle,
+} from 'react';
 import AcuantContext from '../context/acuant';
 import AcuantCaptureCanvas from './acuant-capture-canvas';
 import FileInput from './file-input';
@@ -74,19 +82,22 @@ function toBlob(dataURL) {
  *
  * @param {AcuantCaptureProps} props Props object.
  */
-function AcuantCapture({
-  label,
-  bannerText,
-  value,
-  onChange = () => {},
-  capture,
-  className,
-  minimumGlareScore = DEFAULT_ACCEPTABLE_GLARE_SCORE,
-  minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
-  minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
-  allowUpload = true,
-  errorMessage,
-}) {
+function AcuantCapture(
+  {
+    label,
+    bannerText,
+    value,
+    onChange = () => {},
+    capture,
+    className,
+    minimumGlareScore = DEFAULT_ACCEPTABLE_GLARE_SCORE,
+    minimumSharpnessScore = DEFAULT_ACCEPTABLE_SHARPNESS_SCORE,
+    minimumFileSize = DEFAULT_ACCEPTABLE_FILE_SIZE_BYTES,
+    allowUpload = true,
+    errorMessage,
+  },
+  ref,
+) {
   const fileCache = useContext(FileBase64CacheContext);
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
@@ -105,6 +116,7 @@ function AcuantCapture({
       setIsCapturing(false);
     }
   }, [hasCapture]);
+  useImperativeHandle(ref, () => inputRef.current);
 
   /**
    * Responds to a click by starting capture if supported in the environment, or triggering the
@@ -241,4 +253,4 @@ function AcuantCapture({
   );
 }
 
-export default AcuantCapture;
+export default forwardRef(AcuantCapture);

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -20,7 +20,7 @@ import DeviceContext from '../context/device';
 /**
  * Sides of document to present as file input.
  *
- * @type {string[]}
+ * @type {Array<keyof DocumentsStepValue>}
  */
 const DOCUMENT_SIDES = ['front', 'back'];
 
@@ -30,7 +30,7 @@ const DOCUMENT_SIDES = ['front', 'back'];
 function DocumentsStep({
   value = {},
   onChange = () => {},
-  errors = {},
+  errors = [],
   registerField = () => undefined,
 }) {
   const { t } = useI18n();
@@ -45,22 +45,26 @@ function DocumentsStep({
         <li>{t('doc_auth.tips.document_capture_id_text3')}</li>
         {!isMobile && <li>{t('doc_auth.tips.document_capture_id_text4')}</li>}
       </ul>
-      {DOCUMENT_SIDES.map((side) => (
-        <AcuantCapture
-          key={side}
-          ref={registerField(side)}
-          /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
-          /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
-          label={t(`doc_auth.headings.document_capture_${side}`)}
-          /* i18n-tasks-use t('doc_auth.headings.back') */
-          /* i18n-tasks-use t('doc_auth.headings.front') */
-          bannerText={t(`doc_auth.headings.${side}`)}
-          value={value[side]}
-          onChange={(nextValue) => onChange({ [side]: nextValue })}
-          className="id-card-file-input"
-          errorMessage={errors[side] ? <FormErrorMessage error={errors[side]} /> : undefined}
-        />
-      ))}
+      {DOCUMENT_SIDES.map((side) => {
+        const error = errors.find(({ fieldName }) => fieldName === side)?.error;
+
+        return (
+          <AcuantCapture
+            key={side}
+            ref={registerField(side)}
+            /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
+            /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
+            label={t(`doc_auth.headings.document_capture_${side}`)}
+            /* i18n-tasks-use t('doc_auth.headings.back') */
+            /* i18n-tasks-use t('doc_auth.headings.front') */
+            bannerText={t(`doc_auth.headings.${side}`)}
+            value={value[side]}
+            onChange={(nextValue) => onChange({ [side]: nextValue })}
+            className="id-card-file-input"
+            errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
+          />
+        );
+      })}
     </>
   );
 }
@@ -69,17 +73,10 @@ function DocumentsStep({
  * @type {import('./form-steps').FormStepValidate<DocumentsStepValue>}
  */
 export function validate(values) {
-  const errors = {};
-
-  if (!values.front) {
-    errors.front = new RequiredValueMissingError();
-  }
-
-  if (!values.back) {
-    errors.back = new RequiredValueMissingError();
-  }
-
-  return errors;
+  return DOCUMENT_SIDES.filter((side) => !values[side]).map((side) => ({
+    fieldName: side,
+    error: new RequiredValueMissingError(),
+  }));
 }
 
 export default DocumentsStep;

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -18,14 +18,6 @@ import DeviceContext from '../context/device';
  */
 
 /**
- * @typedef DocumentsStepProps
- *
- * @prop {DocumentsStepValue=} value Current value.
- * @prop {(nextValue:Partial<DocumentsStepValue>)=>void=} onChange Value change handler.
- * @prop {Partial<FormStepValidateResult<DocumentsStepValue>>=} errors Current validation errors.
- */
-
-/**
  * Sides of document to present as file input.
  *
  * @type {string[]}
@@ -33,9 +25,14 @@ import DeviceContext from '../context/device';
 const DOCUMENT_SIDES = ['front', 'back'];
 
 /**
- * @param {DocumentsStepProps} props Props object.
+ * @param {import('./form-steps').FormStepComponentProps<DocumentsStepValue>} props Props object.
  */
-function DocumentsStep({ value = {}, onChange = () => {}, errors = {} }) {
+function DocumentsStep({
+  value = {},
+  onChange = () => {},
+  errors = {},
+  registerField = () => undefined,
+}) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -51,6 +48,7 @@ function DocumentsStep({ value = {}, onChange = () => {}, errors = {} }) {
       {DOCUMENT_SIDES.map((side) => (
         <AcuantCapture
           key={side}
+          ref={registerField(side)}
           /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
           /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
           label={t(`doc_auth.headings.document_capture_${side}`)}

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -46,7 +46,7 @@ function DocumentsStep({
         {!isMobile && <li>{t('doc_auth.tips.document_capture_id_text4')}</li>}
       </ul>
       {DOCUMENT_SIDES.map((side) => {
-        const error = errors.find(({ fieldName }) => fieldName === side)?.error;
+        const error = errors.find(({ field }) => field === side)?.error;
 
         return (
           <AcuantCapture
@@ -74,7 +74,7 @@ function DocumentsStep({
  */
 export function validate(values) {
   return DOCUMENT_SIDES.filter((side) => !values[side]).map((side) => ({
-    fieldName: side,
+    field: side,
     error: new RequiredValueMissingError(),
   }));
 }

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -7,7 +7,7 @@ import useHistoryParam from '../hooks/use-history-param';
 /**
  * @typedef FormStepError
  *
- * @prop {keyof V} fieldName Name of field for which error occurred.
+ * @prop {keyof V} field Name of field for which error occurred.
  * @prop {Error} error Error object.
  *
  * @template V
@@ -20,8 +20,8 @@ import useHistoryParam from '../hooks/use-history-param';
  * existing values.
  * @prop {Partial<V>} value Current values.
  * @prop {FormStepError<V>[]=} errors Current active errors.
- * @prop {(fieldName:string)=>undefined|((fieldNode:HTMLElement?)=>void)} registerField Registers
- * field by given name, returning ref assignment function.
+ * @prop {(field:string)=>undefined|((fieldNode:HTMLElement?)=>void)} registerField Registers field
+ * by given name, returning ref assignment function.
  *
  * @template V
  */
@@ -139,7 +139,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
   useEffect(() => {
     if (activeErrors?.length && didSubmitWithErrors.current) {
       const firstActiveError = activeErrors[0];
-      fields.current[firstActiveError.fieldName]?.element?.focus();
+      fields.current[firstActiveError.field]?.element?.focus();
     }
 
     didSubmitWithErrors.current = false;
@@ -225,16 +225,16 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
         onChange={(nextValuesPatch) => {
           setValues((prevValues) => ({ ...prevValues, ...nextValuesPatch }));
         }}
-        registerField={(fieldName) => {
-          if (!fields.current[fieldName]) {
-            fields.current[fieldName] = {
+        registerField={(field) => {
+          if (!fields.current[field]) {
+            fields.current[field] = {
               refCallback(fieldNode) {
-                fields.current[fieldName].element = fieldNode;
+                fields.current[field].element = fieldNode;
               },
             };
           }
 
-          return fields.current[fieldName].refCallback;
+          return fields.current[field].refCallback;
         }}
       />
       <Button type="submit" isPrimary className="margin-y-5">

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -5,12 +5,21 @@ import useI18n from '../hooks/use-i18n';
 import useHistoryParam from '../hooks/use-history-param';
 
 /**
+ * @typedef FormStepError
+ *
+ * @prop {keyof V} fieldName Name of field for which error occurred.
+ * @prop {Error} error Error object.
+ *
+ * @template V
+ */
+
+/**
  * @typedef FormStepComponentProps
  *
  * @prop {(nextValues:Partial<V>)=>void} onChange Values change callback, merged with
  * existing values.
  * @prop {Partial<V>} value Current values.
- * @prop {Partial<Record<keyof V,Error>>=} errors Current active errors.
+ * @prop {FormStepError<V>[]=} errors Current active errors.
  * @prop {(fieldName:string)=>undefined|((fieldNode:HTMLElement?)=>void)} registerField Registers
  * field by given name, returning ref assignment function.
  *
@@ -20,7 +29,7 @@ import useHistoryParam from '../hooks/use-history-param';
 /**
  * @template {Record<string,any>} V
  *
- * @typedef {Partial<Record<keyof V,Error>>} FormStepValidateResult
+ * @typedef {FormStepError<V>[]} FormStepValidateResult
  */
 
 /**
@@ -124,9 +133,9 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
   }, [stepName]);
   const didSubmitWithErrors = useRef(false);
   useEffect(() => {
-    if (activeErrors && didSubmitWithErrors.current) {
-      const firstActiveError = Object.keys(activeErrors)[0];
-      fields.current[firstActiveError]?.focus();
+    if (activeErrors?.length && didSubmitWithErrors.current) {
+      const firstActiveError = activeErrors[0];
+      fields.current[firstActiveError.fieldName]?.focus();
     }
 
     didSubmitWithErrors.current = false;
@@ -179,7 +188,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     const nextActiveErrors = getValidationErrors(effectiveStep, values);
     setActiveErrors(nextActiveErrors);
     didSubmitWithErrors.current = true;
-    if (nextActiveErrors && Object.keys(nextActiveErrors).length) {
+    if (nextActiveErrors?.length) {
       return;
     }
 

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -1,4 +1,12 @@
-import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import React, {
+  forwardRef,
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useImperativeHandle,
+} from 'react';
 import { Icon } from '@18f/identity-components';
 import FileImage from './file-image';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
@@ -19,23 +27,24 @@ import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
 /**
  * @param {SelfieCaptureProps} props Props object.
  */
-function SelfieCapture({ value, onChange, errorMessage }) {
+function SelfieCapture({ value, onChange, errorMessage }, ref) {
   const instanceId = useInstanceId();
   const { t } = useI18n();
   const labelRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const wrapperRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const retryButtonRef = useFocusFallbackRef(labelRef);
   const captureButtonRef = useFocusFallbackRef(labelRef);
+  useImperativeHandle(ref, () => labelRef.current);
 
   const videoRef = useRef(/** @type {HTMLVideoElement?} */ (null));
-  const setVideoRef = useCallback((ref) => {
+  const setVideoRef = useCallback((nextVideoRef) => {
     // React will call an assigned `ref` callback with `null` at the time the element is being
     // removed, which is an opportunity to stop any in-progress capture.
-    if (!ref && videoRef.current && videoRef.current.srcObject instanceof window.MediaStream) {
+    if (!nextVideoRef && videoRef.current?.srcObject instanceof window.MediaStream) {
       videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
     }
 
-    videoRef.current = ref;
+    videoRef.current = nextVideoRef;
   }, []);
 
   const [isAccessRejected, setIsAccessRejected] = useState(false);
@@ -203,4 +212,4 @@ function SelfieCapture({ value, onChange, errorMessage }) {
   );
 }
 
-export default SelfieCapture;
+export default forwardRef(SelfieCapture);

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -19,17 +19,14 @@ import FormErrorMessage from './form-error-message';
  */
 
 /**
- * @typedef SelfieStepProps
- *
- * @prop {SelfieStepValue=} value Current value.
- * @prop {(nextValue:Partial<SelfieStepValue>)=>void=} onChange Change handler.
- * @prop {Partial<FormStepValidateResult<SelfieStepValue>>=} errors Current validation errors.
+ * @param {import('./form-steps').FormStepComponentProps<SelfieStepValue>} props Props object.
  */
-
-/**
- * @param {SelfieStepProps} props Props object.
- */
-function SelfieStep({ value = {}, onChange = () => {}, errors = {} }) {
+function SelfieStep({
+  value = {},
+  onChange = () => {},
+  errors = {},
+  registerField = () => undefined,
+}) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
@@ -44,6 +41,7 @@ function SelfieStep({ value = {}, onChange = () => {}, errors = {} }) {
       </ul>
       {isMobile || !hasMediaAccess() ? (
         <AcuantCapture
+          ref={registerField('selfie')}
           capture="user"
           label={t('doc_auth.headings.document_capture_selfie')}
           bannerText={t('doc_auth.headings.photo')}
@@ -55,6 +53,7 @@ function SelfieStep({ value = {}, onChange = () => {}, errors = {} }) {
         />
       ) : (
         <SelfieCapture
+          ref={registerField('selfie')}
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           errorMessage={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -29,7 +29,7 @@ function SelfieStep({
 }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
-  const error = errors.find(({ fieldName }) => fieldName === 'selfie')?.error;
+  const error = errors.find(({ field }) => field === 'selfie')?.error;
 
   return (
     <>
@@ -68,7 +68,7 @@ function SelfieStep({
  * @type {import('./form-steps').FormStepValidate<SelfieStepValue>}
  */
 export function validate(values) {
-  return values.selfie ? [] : [{ fieldName: 'selfie', error: new RequiredValueMissingError() }];
+  return values.selfie ? [] : [{ field: 'selfie', error: new RequiredValueMissingError() }];
 }
 
 export default SelfieStep;

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -24,11 +24,12 @@ import FormErrorMessage from './form-error-message';
 function SelfieStep({
   value = {},
   onChange = () => {},
-  errors = {},
+  errors = [],
   registerField = () => undefined,
 }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
+  const error = errors.find(({ fieldName }) => fieldName === 'selfie')?.error;
 
   return (
     <>
@@ -49,14 +50,14 @@ function SelfieStep({
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
           className="id-card-file-input"
-          errorMessage={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
+          errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
         />
       ) : (
         <SelfieCapture
           ref={registerField('selfie')}
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
-          errorMessage={errors.selfie ? <FormErrorMessage error={errors.selfie} /> : undefined}
+          errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
         />
       )}
     </>
@@ -67,13 +68,7 @@ function SelfieStep({
  * @type {import('./form-steps').FormStepValidate<SelfieStepValue>}
  */
 export function validate(values) {
-  const errors = {};
-
-  if (!values.selfie) {
-    errors.selfie = new RequiredValueMissingError();
-  }
-
-  return errors;
+  return values.selfie ? [] : [{ fieldName: 'selfie', error: new RequiredValueMissingError() }];
 }
 
 export default SelfieStep;

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -13,9 +13,9 @@ describe('document-capture/components/documents-step', () => {
       const result = validate(value);
 
       expect(result).to.have.lengthOf(2);
-      expect(result[0].fieldName).to.equal('front');
+      expect(result[0].field).to.equal('front');
       expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
-      expect(result[1].fieldName).to.equal('back');
+      expect(result[1].field).to.equal('back');
       expect(result[1].error).to.be.instanceOf(RequiredValueMissingError);
     });
 
@@ -24,7 +24,7 @@ describe('document-capture/components/documents-step', () => {
       const result = validate(value);
 
       expect(result).to.have.lengthOf(1);
-      expect(result[0].fieldName).to.equal('back');
+      expect(result[0].field).to.equal('back');
       expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
     });
 

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import DocumentsStep, { validate } from '@18f/identity-document-capture/components/documents-step';
+import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
 import render from '../../../support/render';
 
 describe('document-capture/components/documents-step', () => {
@@ -11,27 +12,30 @@ describe('document-capture/components/documents-step', () => {
       const value = {};
       const result = validate(value);
 
-      expect(result).to.have.keys(['front', 'back']);
-      expect(result.front).to.be.instanceOf(Error);
-      expect(result.back).to.be.instanceOf(Error);
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].fieldName).to.equal('front');
+      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
+      expect(result[1].fieldName).to.equal('back');
+      expect(result[1].error).to.be.instanceOf(RequiredValueMissingError);
     });
 
     it('returns error if one of front and back are unset', () => {
       const value = { front: new window.File([], 'upload.png', { type: 'image/png' }) };
       const result = validate(value);
 
-      expect(result).to.have.keys(['back']);
-      expect(result.back).to.be.instanceOf(Error);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].fieldName).to.equal('back');
+      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
     });
 
-    it('returns empty object if both front and back are set', () => {
+    it('returns empty array if both front and back are set', () => {
       const value = {
         front: new window.File([], 'upload.png', { type: 'image/png' }),
         back: new window.File([], 'upload.png', { type: 'image/png' }),
       };
       const result = validate(value);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal([]);
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -14,11 +14,12 @@ describe('document-capture/components/form-steps', () => {
     {
       name: 'second',
       title: 'Second Title',
-      component: ({ value = {}, onChange }) => (
+      component: ({ value = {}, onChange, registerField }) => (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
         <label>
           Second
           <input
+            ref={registerField('second')}
             value={value.second || ''}
             onChange={(event) => {
               onChange({ changed: true });
@@ -240,5 +241,14 @@ describe('document-capture/components/form-steps', () => {
     const input = getByLabelText('Second');
 
     expect(input.value).to.equal('prefilled');
+  });
+
+  it('prevents submission if step is invalid', () => {
+    const { getByText, getByLabelText } = render(<FormSteps steps={STEPS} initialStep="second" />);
+
+    userEvent.click(getByText('forms.buttons.continue'));
+
+    expect(window.location.hash).to.equal('#step=second');
+    expect(document.activeElement).to.equal(getByLabelText('Second'));
   });
 });

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -28,7 +28,7 @@ describe('document-capture/components/form-steps', () => {
           />
         </label>
       ),
-      validate: (value) => (value.second ? [] : [{ fieldName: 'second', error: new Error() }]),
+      validate: (value) => (value.second ? [] : [{ field: 'second', error: new Error() }]),
     },
     { name: 'last', title: 'Last Title', component: () => <span>Last</span> },
   ];

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -28,7 +28,7 @@ describe('document-capture/components/form-steps', () => {
           />
         </label>
       ),
-      validate: (value) => (value.second ? undefined : { second: new Error() }),
+      validate: (value) => (value.second ? [] : [{ fieldName: 'second', error: new Error() }]),
     },
     { name: 'last', title: 'Last Title', component: () => <span>Last</span> },
   ];

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -12,7 +12,7 @@ describe('document-capture/components/selfie-step', () => {
       const result = validate(value);
 
       expect(result).to.have.lengthOf(1);
-      expect(result[0].fieldName).to.equal('selfie');
+      expect(result[0].field).to.equal('selfie');
       expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
     });
 

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import SelfieStep, { validate } from '@18f/identity-document-capture/components/selfie-step';
+import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
 import render from '../../../support/render';
 
 describe('document-capture/components/selfie-step', () => {
@@ -10,17 +11,18 @@ describe('document-capture/components/selfie-step', () => {
       const value = {};
       const result = validate(value);
 
-      expect(result).to.have.keys(['selfie']);
-      expect(result.selfie).to.be.instanceof(Error);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].fieldName).to.equal('selfie');
+      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
     });
 
-    it('returns empty object if selfie is set', () => {
+    it('returns empty array if selfie is set', () => {
       const value = {
         selfie: new window.File([], 'upload.png', { type: 'image/png' }),
       };
       const result = validate(value);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
**Why**: As a user, after I've attempted to continue or submit the current document capture step, if there is an error preventing me from proceeding, focus should transition to that field, so that I can perceive it and act to resolve the validation error.

**Screen recording:**

![validate focus](https://user-images.githubusercontent.com/1779930/91467990-5b542600-e85f-11ea-8b1e-a9f3e6ebf635.gif)

This implements the first of the two follow-up tasks mentioned at https://github.com/18F/identity-idp/pull/4125#issuecomment-681966419.