### PR TITLE
Return array of error objects from document capture image upload API

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -48,8 +48,8 @@ module Idv
           success: true,
         }
       else
-        errors = form_response.errors.map do |key, errs|
-          { field_name: key, error_messages: Array(errs) }
+        errors = form_response.errors.flat_map do |key, errs|
+          Array(errs).map { |err| { field_name: key, error_message: err } }
         end
 
         render json: form_response.to_h.merge(errors: errors),

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -49,7 +49,7 @@ module Idv
         }
       else
         errors = form_response.errors.flat_map do |key, errs|
-          Array(errs).map { |err| { field_name: key, error_message: err } }
+          Array(errs).map { |err| { field: key, message: err } }
         end
 
         render json: form_response.to_h.merge(errors: errors),

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -48,12 +48,11 @@ module Idv
           success: true,
         }
       else
-        # FOLLOWUP: refactor the client to accept a hash of errors
-        errors_arr = form_response.errors.flat_map do |key, errs|
-          Array(errs).map { |err| "#{key} #{err}" }
+        errors = form_response.errors.map do |key, errs|
+          { field_name: key, error_messages: Array(errs) }
         end
 
-        render json: form_response.to_h.merge(errors: errors_arr),
+        render json: form_response.to_h.merge(errors: errors),
                status: :bad_request
       end
     end

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -28,7 +28,7 @@ import useI18n from '../hooks/use-i18n';
  * @return {ReactNode[]} Formatted error messages.
  */
 export function getFormattedErrorMessages(errors) {
-  return errors.flatMap((error, i) => [<br key={i} />, error.errorMessage]).slice(1);
+  return errors.flatMap((error, i) => [<br key={i} />, error.message]).slice(1);
 }
 
 /**

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -28,8 +28,7 @@ import useI18n from '../hooks/use-i18n';
  * @return {ReactNode[]} Formatted error messages.
  */
 export function getFormattedErrorMessages(errors) {
-  const errorMessages = errors.flatMap((error) => error.errorMessages);
-  return errorMessages.flatMap((errorMessage, i) => [<br key={i} />, errorMessage]).slice(1);
+  return errors.flatMap((error, i) => [<br key={i} />, error.errorMessage]).slice(1);
 }
 
 /**

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -11,6 +11,7 @@ import useI18n from '../hooks/use-i18n';
 
 /** @typedef {import('react').ReactNode} ReactNode */
 /** @typedef {import('./form-steps').FormStep} FormStep */
+/** @typedef {import('../context/upload').UploadFieldError} UploadFieldError */
 
 /**
  * @typedef DocumentCaptureProps
@@ -22,12 +23,13 @@ import useI18n from '../hooks/use-i18n';
 /**
  * Returns error messages interspersed with line break React element.
  *
- * @param {string[]} errors Error messages.
+ * @param {UploadFieldError[]} errors Error messages.
  *
  * @return {ReactNode[]} Formatted error messages.
  */
 export function getFormattedErrorMessages(errors) {
-  return errors.flatMap((error, i) => [<br key={i} />, error]).slice(1);
+  const errorMessages = errors.flatMap((error) => error.errorMessages);
+  return errorMessages.flatMap((errorMessage, i) => [<br key={i} />, errorMessage]).slice(1);
 }
 
 /**
@@ -86,7 +88,7 @@ function DocumentCapture({ isLivenessEnabled = true }) {
         <Alert type="error" className="margin-bottom-2">
           {isFormEntriesError
             ? getFormattedErrorMessages(
-                /** @type {UploadFormEntriesError} */ (submissionError).rawErrorMessages,
+                /** @type {UploadFormEntriesError} */ (submissionError).rawErrors,
               )
             : t('errors.doc_auth.acuant_network_error')}
         </Alert>

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -10,17 +10,8 @@ const UploadContext = createContext(defaultUpload);
  *
  * @typedef UploadFieldError
  *
- * @prop {'front'|'back'|'selfie'|'network'} fieldName Field name.
- * @prop {string[]} errorMessage Error message.
- */
-
-/**
- * Upload field error, as received from server response.
- *
- * @typedef UploadFieldResponseError
- *
- * @prop {'front'|'back'|'selfie'|'network'} field_name Field name.
- * @prop {string} error_message Error message.
+ * @prop {'front'|'back'|'selfie'|'network'} field Field name.
+ * @prop {string} message Error message.
  */
 
 /**
@@ -40,7 +31,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadErrorResponse
  *
  * @prop {false} success Whether request was successful.
- * @prop {UploadFieldResponseError[]} errors Error messages.
+ * @prop {UploadFieldError[]} errors Error messages.
  */
 
 /**

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -6,6 +6,13 @@ const UploadContext = createContext(defaultUpload);
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
+ * @typedef UploadFieldError
+ *
+ * @prop {'front'|'back'|'selfie'|'network'} fieldName Field name.
+ * @prop {string[]} errorMessages Error messages.
+ */
+
+/**
  * @typedef UploadOptions
  *
  * @prop {string} endpoint Endpoint to which payload should be sent.
@@ -22,7 +29,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadErrorResponse
  *
  * @prop {false} success Whether request was successful.
- * @prop {string[]} errors Error messages.
+ * @prop {UploadFieldError[]} errors Error messages.
  */
 
 /**

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -6,10 +6,21 @@ const UploadContext = createContext(defaultUpload);
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
+ * Upload field error, after normalized to error instance.
+ *
  * @typedef UploadFieldError
  *
  * @prop {'front'|'back'|'selfie'|'network'} fieldName Field name.
  * @prop {string[]} errorMessages Error messages.
+ */
+
+/**
+ * Upload field error, as received from server response.
+ *
+ * @typedef UploadFieldResponseError
+ *
+ * @prop {'front'|'back'|'selfie'|'network'} field_name Field name.
+ * @prop {string[]} error_messages Error messages.
  */
 
 /**
@@ -29,7 +40,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadErrorResponse
  *
  * @prop {false} success Whether request was successful.
- * @prop {UploadFieldError[]} errors Error messages.
+ * @prop {UploadFieldResponseError[]} errors Error messages.
  */
 
 /**

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -11,7 +11,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadFieldError
  *
  * @prop {'front'|'back'|'selfie'|'network'} fieldName Field name.
- * @prop {string[]} errorMessages Error messages.
+ * @prop {string[]} errorMessage Error message.
  */
 
 /**
@@ -20,7 +20,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadFieldResponseError
  *
  * @prop {'front'|'back'|'selfie'|'network'} field_name Field name.
- * @prop {string[]} error_messages Error messages.
+ * @prop {string} error_message Error message.
  */
 
 /**

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -46,7 +46,7 @@ async function upload(payload, { endpoint, csrf }) {
     const error = new UploadFormEntriesError();
     error.rawErrors = errorResult.errors.map((rawError) => ({
       fieldName: rawError.field_name,
-      errorMessages: rawError.error_messages,
+      errorMessage: rawError.error_message,
     }));
     throw error;
   }

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -44,10 +44,7 @@ async function upload(payload, { endpoint, csrf }) {
     /** @type {UploadErrorResponse} */
     const errorResult = result;
     const error = new UploadFormEntriesError();
-    error.rawErrors = errorResult.errors.map((rawError) => ({
-      fieldName: rawError.field_name,
-      errorMessage: rawError.error_message,
-    }));
+    error.rawErrors = errorResult.errors;
     throw error;
   }
 

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -1,9 +1,10 @@
 /** @typedef {import('../context/upload').UploadSuccessResponse} UploadSuccessResponse */
 /** @typedef {import('../context/upload').UploadErrorResponse} UploadErrorResponse */
+/** @typedef {import('../context/upload').UploadFieldError} UploadFieldError */
 
 export class UploadFormEntriesError extends Error {
-  /** @type {string[]} */
-  rawErrorMessages = [];
+  /** @type {UploadFieldError[]} */
+  rawErrors = [];
 }
 
 /**
@@ -42,8 +43,11 @@ async function upload(payload, { endpoint, csrf }) {
   if (!result.success) {
     /** @type {UploadErrorResponse} */
     const errorResult = result;
-    const error = new UploadFormEntriesError(errorResult.errors.join(', '));
-    error.rawErrorMessages = errorResult.errors;
+    const error = new UploadFormEntriesError();
+    error.rawErrors = errorResult.errors.map((rawError) => ({
+      fieldName: rawError.field_name,
+      errorMessages: rawError.error_messages,
+    }));
     throw error;
   }
 

--- a/app/services/doc_auth/acuant/responses/facial_match_response.rb
+++ b/app/services/doc_auth/acuant/responses/facial_match_response.rb
@@ -18,7 +18,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
           {
-            facial_match: I18n.t('errors.doc_auth.selfie'),
+            selfie: I18n.t('errors.doc_auth.selfie'),
           }
         end
 

--- a/app/services/doc_auth/acuant/responses/liveness_response.rb
+++ b/app/services/doc_auth/acuant/responses/liveness_response.rb
@@ -25,7 +25,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
           {
-            liveness: I18n.t('errors.doc_auth.selfie'),
+            selfie: I18n.t('errors.doc_auth.selfie'),
           }
         end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -44,7 +44,7 @@ describe Idv::ImageUploadsController do
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
           expect(json[:errors]).to eq([
-            { front: ['Please fill in this field.'] },
+            { field_name: 'front', error_message: 'Please fill in this field.' },
           ])
         end
       end
@@ -57,7 +57,7 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:errors]).to eq([
-            { front: [I18n.t('doc_auth.errors.not_a_file')] },
+            { field_name: 'front', error_message: I18n.t('doc_auth.errors.not_a_file') },
           ])
         end
 
@@ -69,7 +69,7 @@ describe Idv::ImageUploadsController do
 
             json = JSON.parse(response.body, symbolize_names: true)
             expect(json[:errors]).to eq([
-              { front: [I18n.t('doc_auth.errors.not_a_file', locale: 'es')] },
+              { field_name: 'front', error_message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
             ])
           end
         end
@@ -103,7 +103,8 @@ describe Idv::ImageUploadsController do
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
           expect(json[:errors]).to eq([
-            { field_name: 'front', error_messages: ['Too blurry', 'Wrong document'] }
+            { field_name: 'front', error_message: 'Too blurry' },
+            { field_name: 'front', error_message: 'Wrong document' }
           ])
         end
       end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -43,7 +43,9 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq(['front Please fill in this field.'])
+          expect(json[:errors]).to eq([
+            { front: ['Please fill in this field.'] },
+          ])
         end
       end
 
@@ -54,8 +56,9 @@ describe Idv::ImageUploadsController do
           action
 
           json = JSON.parse(response.body, symbolize_names: true)
-          expect(json[:errors]).
-            to eq(["front #{I18n.t('doc_auth.errors.not_a_file')}"])
+          expect(json[:errors]).to eq([
+            { front: [I18n.t('doc_auth.errors.not_a_file')] },
+          ])
         end
 
         context 'with a locale param' do
@@ -65,8 +68,9 @@ describe Idv::ImageUploadsController do
             action
 
             json = JSON.parse(response.body, symbolize_names: true)
-            expect(json[:errors]).
-              to eq(["front #{I18n.t('doc_auth.errors.not_a_file', locale: 'es')}"])
+            expect(json[:errors]).to eq([
+              { front: [I18n.t('doc_auth.errors.not_a_file', locale: 'es')] },
+            ])
           end
         end
       end
@@ -98,7 +102,9 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq(['front Too blurry', 'front Wrong document'])
+          expect(json[:errors]).to eq([
+            { field_name: 'front', error_messages: ['Too blurry', 'Wrong document'] }
+          ])
         end
       end
     end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -43,9 +43,9 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq([
+          expect(json[:errors]).to eq [
             { field: 'front', message: 'Please fill in this field.' },
-          ])
+          ]
         end
       end
 
@@ -56,9 +56,9 @@ describe Idv::ImageUploadsController do
           action
 
           json = JSON.parse(response.body, symbolize_names: true)
-          expect(json[:errors]).to eq([
+          expect(json[:errors]).to eq [
             { field: 'front', message: I18n.t('doc_auth.errors.not_a_file') },
-          ])
+          ]
         end
 
         context 'with a locale param' do
@@ -68,9 +68,9 @@ describe Idv::ImageUploadsController do
             action
 
             json = JSON.parse(response.body, symbolize_names: true)
-            expect(json[:errors]).to eq([
+            expect(json[:errors]).to eq [
               { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
-            ])
+            ]
           end
         end
       end
@@ -102,10 +102,10 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
-          expect(json[:errors]).to eq([
+          expect(json[:errors]).to eq [
             { field: 'front', message: 'Too blurry' },
-            { field: 'front', message: 'Wrong document' }
-          ])
+            { field: 'front', message: 'Wrong document' },
+          ]
         end
       end
     end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -44,7 +44,7 @@ describe Idv::ImageUploadsController do
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
           expect(json[:errors]).to eq([
-            { field_name: 'front', error_message: 'Please fill in this field.' },
+            { field: 'front', message: 'Please fill in this field.' },
           ])
         end
       end
@@ -57,7 +57,7 @@ describe Idv::ImageUploadsController do
 
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:errors]).to eq([
-            { field_name: 'front', error_message: I18n.t('doc_auth.errors.not_a_file') },
+            { field: 'front', message: I18n.t('doc_auth.errors.not_a_file') },
           ])
         end
 
@@ -69,7 +69,7 @@ describe Idv::ImageUploadsController do
 
             json = JSON.parse(response.body, symbolize_names: true)
             expect(json[:errors]).to eq([
-              { field_name: 'front', error_message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
+              { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
             ])
           end
         end
@@ -103,8 +103,8 @@ describe Idv::ImageUploadsController do
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:success]).to eq(false)
           expect(json[:errors]).to eq([
-            { field_name: 'front', error_message: 'Too blurry' },
-            { field_name: 'front', error_message: 'Wrong document' }
+            { field: 'front', message: 'Too blurry' },
+            { field: 'front', message: 'Wrong document' }
           ])
         end
       end

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -30,7 +30,7 @@ describe('document-capture/components/document-capture', () => {
   describe('getFormattedErrorMessages', () => {
     it('formats one message', () => {
       const error = new UploadFormEntriesError();
-      error.rawErrors = [{ fieldName: 'front', errorMessages: ['Too blurry'] }];
+      error.rawErrors = [{ fieldName: 'front', errorMessage: 'Too blurry' }];
       const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
       expect(container.innerHTML).to.equal('Too blurry');
@@ -38,10 +38,13 @@ describe('document-capture/components/document-capture', () => {
 
     it('formats many messages', () => {
       const error = new UploadFormEntriesError();
-      error.rawErrors = [{ fieldName: 'front', errorMessages: ['Too blurry', 'Wrong document'] }];
+      error.rawErrors = [
+        { fieldName: 'front', errorMessage: 'Too blurry' },
+        { fieldName: 'front', errorMessage: 'File size too small' },
+      ];
       const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
-      expect(container.innerHTML).to.equal('Too blurry<br>Wrong document');
+      expect(container.innerHTML).to.equal('Too blurry<br>File size too small');
     });
   });
 
@@ -188,8 +191,8 @@ describe('document-capture/components/document-capture', () => {
   it('renders handled submission failure', async () => {
     const uploadError = new UploadFormEntriesError();
     uploadError.rawErrors = [
-      { fieldName: 'front', errorMessages: ['Image has glare'] },
-      { fieldName: 'back', errorMessages: ['Please fill in this field'] },
+      { fieldName: 'front', errorMessage: 'Image has glare' },
+      { fieldName: 'back', errorMessage: 'Please fill in this field' },
     ];
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
       <DocumentCapture />,

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -29,15 +29,19 @@ describe('document-capture/components/document-capture', () => {
 
   describe('getFormattedErrorMessages', () => {
     it('formats one message', () => {
-      const { container } = render(getFormattedErrorMessages(['Boom!']));
+      const error = new UploadFormEntriesError();
+      error.rawErrors = [{ fieldName: 'front', errorMessages: ['Too blurry'] }];
+      const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
-      expect(container.innerHTML).to.equal('Boom!');
+      expect(container.innerHTML).to.equal('Too blurry');
     });
 
     it('formats many messages', () => {
-      const { container } = render(getFormattedErrorMessages(['Boom!', 'Wham!', 'Ka-pow!']));
+      const error = new UploadFormEntriesError();
+      error.rawErrors = [{ fieldName: 'front', errorMessages: ['Too blurry', 'Wrong document'] }];
+      const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
-      expect(container.innerHTML).to.equal('Boom!<br>Wham!<br>Ka-pow!');
+      expect(container.innerHTML).to.equal('Too blurry<br>Wrong document');
     });
   });
 
@@ -182,8 +186,11 @@ describe('document-capture/components/document-capture', () => {
   });
 
   it('renders handled submission failure', async () => {
-    const uploadError = new UploadFormEntriesError('Front image has glare, Back image is missing');
-    uploadError.rawErrorMessages = ['Front image has glare', 'Back image is missing'];
+    const uploadError = new UploadFormEntriesError();
+    uploadError.rawErrors = [
+      { fieldName: 'front', errorMessages: ['Image has glare'] },
+      { fieldName: 'back', errorMessages: ['Please fill in this field'] },
+    ];
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
       <DocumentCapture />,
       {
@@ -217,7 +224,7 @@ describe('document-capture/components/document-capture', () => {
 
     const notice = await findByRole('alert');
     expect(notice.querySelector('p').innerHTML).to.equal(
-      'Front image has glare<br>Back image is missing',
+      'Image has glare<br>Please fill in this field',
     );
 
     expect(console).to.have.loggedError(/^Error: Uncaught/);

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -30,7 +30,7 @@ describe('document-capture/components/document-capture', () => {
   describe('getFormattedErrorMessages', () => {
     it('formats one message', () => {
       const error = new UploadFormEntriesError();
-      error.rawErrors = [{ fieldName: 'front', errorMessage: 'Too blurry' }];
+      error.rawErrors = [{ field: 'front', message: 'Too blurry' }];
       const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
       expect(container.innerHTML).to.equal('Too blurry');
@@ -39,8 +39,8 @@ describe('document-capture/components/document-capture', () => {
     it('formats many messages', () => {
       const error = new UploadFormEntriesError();
       error.rawErrors = [
-        { fieldName: 'front', errorMessage: 'Too blurry' },
-        { fieldName: 'front', errorMessage: 'File size too small' },
+        { field: 'front', message: 'Too blurry' },
+        { field: 'front', message: 'File size too small' },
       ];
       const { container } = render(getFormattedErrorMessages(error.rawErrors));
 
@@ -191,8 +191,8 @@ describe('document-capture/components/document-capture', () => {
   it('renders handled submission failure', async () => {
     const uploadError = new UploadFormEntriesError();
     uploadError.rawErrors = [
-      { fieldName: 'front', errorMessage: 'Image has glare' },
-      { fieldName: 'back', errorMessage: 'Please fill in this field' },
+      { field: 'front', message: 'Image has glare' },
+      { field: 'back', message: 'Please fill in this field' },
     ];
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
       <DocumentCapture />,

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -52,8 +52,8 @@ describe('document-capture/services/upload', () => {
             Promise.resolve({
               success: false,
               errors: [
-                { field_name: 'front', error_messages: ['Please fill in this field'] },
-                { field_name: 'front', error_messages: ['Please fill in this field'] },
+                { field_name: 'front', error_message: 'Please fill in this field' },
+                { field_name: 'back', error_message: 'Please fill in this field' },
               ],
             }),
         }),
@@ -66,8 +66,8 @@ describe('document-capture/services/upload', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(UploadFormEntriesError);
       expect(error.rawErrors).to.deep.equal([
-        { fieldName: 'front', errorMessages: ['Please fill in this field'] },
-        { fieldName: 'front', errorMessages: ['Please fill in this field'] },
+        { fieldName: 'front', errorMessage: 'Please fill in this field' },
+        { fieldName: 'back', errorMessage: 'Please fill in this field' },
       ]);
     }
   });

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -51,7 +51,10 @@ describe('document-capture/services/upload', () => {
           json: () =>
             Promise.resolve({
               success: false,
-              errors: ['Foo missing', 'Baz missing'],
+              errors: [
+                { field_name: 'front', error_messages: ['Please fill in this field'] },
+                { field_name: 'front', error_messages: ['Please fill in this field'] },
+              ],
             }),
         }),
       ),
@@ -59,9 +62,13 @@ describe('document-capture/services/upload', () => {
 
     try {
       await upload({}, { endpoint: 'https://example.com', csrf: 'TYsqyyQ66Y' });
+      throw new Error('This is a safeguard and should never be reached, since upload should error');
     } catch (error) {
       expect(error).to.be.instanceOf(UploadFormEntriesError);
-      expect(error.message).to.equal('Foo missing, Baz missing');
+      expect(error.rawErrors).to.deep.equal([
+        { fieldName: 'front', errorMessages: ['Please fill in this field'] },
+        { fieldName: 'front', errorMessages: ['Please fill in this field'] },
+      ]);
     }
   });
 

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -52,8 +52,8 @@ describe('document-capture/services/upload', () => {
             Promise.resolve({
               success: false,
               errors: [
-                { field_name: 'front', error_message: 'Please fill in this field' },
-                { field_name: 'back', error_message: 'Please fill in this field' },
+                { field: 'front', message: 'Please fill in this field' },
+                { field: 'back', message: 'Please fill in this field' },
               ],
             }),
         }),
@@ -66,8 +66,8 @@ describe('document-capture/services/upload', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(UploadFormEntriesError);
       expect(error.rawErrors).to.deep.equal([
-        { fieldName: 'front', errorMessage: 'Please fill in this field' },
-        { fieldName: 'back', errorMessage: 'Please fill in this field' },
+        { field: 'front', message: 'Please fill in this field' },
+        { field: 'back', message: 'Please fill in this field' },
       ]);
     }
   });

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -273,7 +273,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
+        expect(result.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
       end
     end
   end

--- a/spec/services/doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/services/doc_auth/acuant/acuant_client_spec.rb
@@ -255,7 +255,7 @@ describe DocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
+        expect(result.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
       end
     end
 

--- a/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/facial_match_request_spec.rb
@@ -51,7 +51,7 @@ describe DocAuth::Acuant::Requests::FacialMatchRequest do
         ).fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
+        expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
+++ b/spec/services/doc_auth/acuant/requests/liveness_request_spec.rb
@@ -43,7 +43,7 @@ describe DocAuth::Acuant::Requests::LivenessRequest do
         response = described_class.new(image: DocAuthImageFixtures.selfie_image).fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
+        expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/services/doc_auth/acuant/responses/facial_match_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/facial_match_response_spec.rb
@@ -32,11 +32,11 @@ describe DocAuth::Acuant::Responses::FacialMatchResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq(facial_match: I18n.t('errors.doc_auth.selfie'))
+      expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: { facial_match: I18n.t('errors.doc_auth.selfie') },
+        errors: { selfie: I18n.t('errors.doc_auth.selfie') },
         exception: nil,
         match_score: 68,
       )

--- a/spec/services/doc_auth/acuant/responses/liveness_response_spec.rb
+++ b/spec/services/doc_auth/acuant/responses/liveness_response_spec.rb
@@ -34,11 +34,11 @@ describe DocAuth::Acuant::Responses::LivenessResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq(liveness: I18n.t('errors.doc_auth.selfie'))
+      expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: { liveness: I18n.t('errors.doc_auth.selfie') },
+        errors: { selfie: I18n.t('errors.doc_auth.selfie') },
         exception: nil,
         liveness_assessment: nil,
         liveness_score: nil,


### PR DESCRIPTION
**Why**: To be able to display errors at the field where the problem exists, the server needs to include both the error message itself, but also the input field for which the error is associated.

Co-authored-by: Zach Margolis <zachmargolis@users.noreply.github.com>