### PR TITLE
LG-3340: Localize document capture (Acuant) label texts

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -1,6 +1,23 @@
 import React, { useContext, useEffect } from 'react';
 import AcuantContext from '../context/acuant';
 import useAsset from '../hooks/use-asset';
+import useI18n from '../hooks/use-i18n';
+
+/**
+ * @typedef AcuantCameraUIText
+ *
+ * @prop {string} NONE No document detected.
+ * @prop {string} SMALL_DOCUMENT Document does not fill frame.
+ * @prop {null} GOOD_DOCUMENT Document is good and capture is pending.
+ * @prop {string} CAPTURING Document is being captured.
+ * @prop {string} TAP_TO_CAPTURE Explicit user action to capture after delay.
+ */
+
+/**
+ * @typedef AcuantCameraUIOptions
+ *
+ * @prop {AcuantCameraUIText} text Camera UI text strings.
+ */
 
 /**
  * Document type.
@@ -26,7 +43,8 @@ import useAsset from '../hooks/use-asset';
  *
  * @prop {(
  *   callbacks: AcuantCameraUICallbacks,
- *   onError: AcuantFailureCallback
+ *   onFailure: AcuantFailureCallback,
+ *   options?: AcuantCameraUIOptions
  * )=>void} start Start capture.
  * @prop {()=>void} end End capture.
  */
@@ -93,6 +111,7 @@ function AcuantCaptureCanvas({
 }) {
   const { isReady } = useContext(AcuantContext);
   const { getAssetPath } = useAsset();
+  const { t } = useI18n();
 
   useEffect(() => {
     if (isReady) {
@@ -108,6 +127,15 @@ function AcuantCaptureCanvas({
           },
         },
         onImageCaptureFailure,
+        {
+          text: {
+            NONE: t('doc_auth.info.capture_status_none'),
+            SMALL_DOCUMENT: t('doc_auth.info.capture_status_small_document'),
+            GOOD_DOCUMENT: null,
+            CAPTURING: t('doc_auth.info.capture_status_capturing'),
+            TAP_TO_CAPTURE: t('doc_auth.info.capture_status_tap_to_capture'),
+          },
+        },
       );
     }
 

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -14,6 +14,10 @@
 - doc_auth.headings.interstitial
 - doc_auth.headings.photo
 - doc_auth.headings.selfie
+- doc_auth.info.capture_status_capturing
+- doc_auth.info.capture_status_none
+- doc_auth.info.capture_status_small_document
+- doc_auth.info.capture_status_tap_to_capture
 - doc_auth.info.document_capture_intro_acknowledgment
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -59,6 +59,10 @@ en:
       welcome: We need to verify your identity
     info:
       camera_required: Your mobile phone must have a camera and a web browser
+      capture_status_capturing: Capturing
+      capture_status_none: Align
+      capture_status_small_document: Move Closer
+      capture_status_tap_to_capture: Tap to Capture
       document_capture_intro_acknowledgment: We’ll collect information about you by
         reading your state-issued ID. We do not store images you upload. We only verify
         your identity.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -61,6 +61,10 @@ es:
       welcome: Nosotros necesitamos verificar tu identidad
     info:
       camera_required: Su teléfono móvil debe tener una cámara y un navegador web
+      capture_status_capturing: Capturando
+      capture_status_none: Alinea
+      capture_status_small_document: Muévete mas cerca
+      capture_status_tap_to_capture: Toque para capturar
       document_capture_intro_acknowledgment: Recopilaremos información sobre usted
         leyendo su identificación emitida por el estado. No almacenamos las imágenes
         que subes. Solo verificamos su identidad.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -66,6 +66,10 @@ fr:
     info:
       camera_required: Votre téléphone portable doit avoir une caméra et un navigateur
         Web
+      capture_status_capturing: Prendre la photo
+      capture_status_none: Alignez
+      capture_status_small_document: Approchez-vous
+      capture_status_tap_to_capture: Appuyez pour capturer
       document_capture_intro_acknowledgment: Nous collecterons des informations sur
         vous en lisant votre pièce d'identité officielle. Nous ne stockons pas les
         images que vous téléchargez. Nous vérifions uniquement votre identité.

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-canvas-spec.jsx
@@ -21,6 +21,15 @@ describe('document-capture/components/acuant-capture-canvas', () => {
     initialize();
 
     expect(window.AcuantCameraUI.start.calledOnce).to.be.true();
+    expect(window.AcuantCameraUI.start.getCall(0).args[2]).to.deep.equal({
+      text: {
+        CAPTURING: 'doc_auth.info.capture_status_capturing',
+        GOOD_DOCUMENT: null,
+        NONE: 'doc_auth.info.capture_status_none',
+        SMALL_DOCUMENT: 'doc_auth.info.capture_status_small_document',
+        TAP_TO_CAPTURE: 'doc_auth.info.capture_status_tap_to_capture',
+      },
+    });
   });
 
   it('ends on unmount', () => {


### PR DESCRIPTION
**Why**: As a user using Login.gov in French or Spanish, I expect that when I am capturing an image of my state-issued ID, I am presented with labels which are translated to my language.

**Screenshot:**

![IMG_0019](https://user-images.githubusercontent.com/1779930/91584488-b8fc7700-e920-11ea-8502-0dfa8c760a1c.png)
