### PR TITLE
Pass locale as form data in doc auth upload

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -8,7 +8,7 @@ import useI18n from '../hooks/use-i18n';
  *
  * @prop {string} NONE No document detected.
  * @prop {string} SMALL_DOCUMENT Document does not fill frame.
- * @prop {null} GOOD_DOCUMENT Document is good and capture is pending.
+ * @prop {string?} GOOD_DOCUMENT Document is good and capture is pending.
  * @prop {string} CAPTURING Document is being captured.
  * @prop {string} TAP_TO_CAPTURE Explicit user action to capture after delay.
  */

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -38,6 +38,7 @@ loadPolyfills(['fetch']).then(() => {
         csrf={getMetaContent('csrf-token')}
         formData={{
           document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
+          locale: i18n.currentLocale(),
         }}
       >
         <I18nContext.Provider value={i18n.strings}>


### PR DESCRIPTION
**Why**: The image upload endpoint will return localized error strings if given a locale parameter to use.

Previous discussion: https://github.com/18F/identity-idp/pull/4143#pullrequestreview-477832062

**Screenshot:**

![Screen Shot 2020-08-28 at 1 25 08 PM](https://user-images.githubusercontent.com/1779930/91596068-91160f00-e932-11ea-9ff5-0329df5cfcbb.png)
