### PR TITLE
Show footer text for doc auth documents step on desktop

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -44,18 +44,18 @@ function DocumentCapture({ isLivenessEnabled = true }) {
     isMobile && {
       name: 'intro',
       title: t('doc_auth.headings.document_capture'),
-      component: MobileIntroStep,
+      form: MobileIntroStep,
     },
     {
       name: 'documents',
       title: t('doc_auth.headings.document_capture'),
-      component: DocumentsStep,
+      form: DocumentsStep,
       validate: validateDocumentsStep,
     },
     isLivenessEnabled && {
       name: 'selfie',
       title: t('doc_auth.headings.selfie'),
-      component: SelfieStep,
+      form: SelfieStep,
       validate: validateSelfieStep,
     },
   ].filter(Boolean));

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -50,6 +50,9 @@ function DocumentCapture({ isLivenessEnabled = true }) {
       name: 'documents',
       title: t('doc_auth.headings.document_capture'),
       form: DocumentsStep,
+      footer: isMobile
+        ? undefined
+        : () => <p>{t('doc_auth.info.document_capture_upload_image')}</p>,
       validate: validateDocumentsStep,
     },
     isLivenessEnabled && {

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -43,7 +43,7 @@ import useHistoryParam from '../hooks/use-history-param';
  *
  * @prop {string} name Step name, used in history parameter.
  * @prop {string} title Step title, shown as heading.
- * @prop {import('react').FC<FormStepComponentProps<Record<string,any>>>} component Step component.
+ * @prop {import('react').FC<FormStepComponentProps<Record<string,any>>>} form Step form component.
  * @prop {FormStepValidate<Record<string,any>>} validate Step validity function. Given set of form
  * values, returns an object with keys from form values mapped to an error, if applicable. Returns
  * undefined or an empty object if there are no errors.
@@ -210,7 +210,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     headingRef.current?.focus();
   }
 
-  const { component: Component, name, title } = effectiveStep;
+  const { form: Form, name, title } = effectiveStep;
   const isLastStep = effectiveStepIndex + 1 === steps.length;
 
   return (
@@ -218,7 +218,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
       <PageHeading key="title" ref={headingRef} tabIndex={-1}>
         {title}
       </PageHeading>
-      <Component
+      <Form
         key={name}
         value={values}
         errors={activeErrors}

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -44,6 +44,7 @@ import useHistoryParam from '../hooks/use-history-param';
  * @prop {string} name Step name, used in history parameter.
  * @prop {string} title Step title, shown as heading.
  * @prop {import('react').FC<FormStepComponentProps<Record<string,any>>>} form Step form component.
+ * @prop {import('react').FC=} footer Optional step footer component.
  * @prop {FormStepValidate<Record<string,any>>} validate Step validity function. Given set of form
  * values, returns an object with keys from form values mapped to an error, if applicable. Returns
  * undefined or an empty object if there are no errors.
@@ -210,7 +211,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     headingRef.current?.focus();
   }
 
-  const { form: Form, name, title } = effectiveStep;
+  const { form: Form, footer: Footer, name, title } = effectiveStep;
   const isLastStep = effectiveStepIndex + 1 === steps.length;
 
   return (
@@ -240,6 +241,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
       <Button type="submit" isPrimary className="margin-y-5">
         {t(isLastStep ? 'forms.buttons.submit.default' : 'forms.buttons.continue')}
       </Button>
+      {Footer && <Footer />}
     </form>
   );
 }

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -19,6 +19,7 @@
 - doc_auth.info.capture_status_small_document
 - doc_auth.info.capture_status_tap_to_capture
 - doc_auth.info.document_capture_intro_acknowledgment
+- doc_auth.info.document_capture_upload_image
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks
 - doc_auth.instructions.document_capture_selfie_consent_banner

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { fireEvent } from '@testing-library/react';
 import { UploadFormEntriesError } from '@18f/identity-document-capture/services/upload';
-import { AcuantProvider } from '@18f/identity-document-capture';
+import { AcuantProvider, DeviceContext } from '@18f/identity-document-capture';
 import DocumentCapture, {
   getFormattedErrorMessages,
 } from '@18f/identity-document-capture/components/document-capture';
@@ -54,6 +54,42 @@ describe('document-capture/components/document-capture', () => {
     const step = getByText('doc_auth.headings.document_capture_front');
 
     expect(step).to.be.ok();
+  });
+
+  context('mobile', () => {
+    it('starts with introductory step', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <DocumentCapture />
+        </DeviceContext.Provider>,
+      );
+
+      expect(getByText('doc_auth.info.document_capture_intro_acknowledgment')).to.be.ok();
+    });
+
+    it('does not show document step footer', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <DocumentCapture />
+        </DeviceContext.Provider>,
+      );
+
+      userEvent.click(getByText('forms.buttons.continue'));
+
+      expect(() => getByText('doc_auth.info.document_capture_upload_image')).to.throw();
+    });
+  });
+
+  context('desktop', () => {
+    it('shows document step footer', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: false }}>
+          <DocumentCapture />
+        </DeviceContext.Provider>,
+      );
+
+      expect(getByText('doc_auth.info.document_capture_upload_image')).to.be.ok();
+    });
   });
 
   it('progresses through steps to completion', async () => {

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -251,4 +251,18 @@ describe('document-capture/components/form-steps', () => {
     expect(window.location.hash).to.equal('#step=second');
     expect(document.activeElement).to.equal(getByLabelText('Second'));
   });
+
+  it('renders with optional footer', () => {
+    const steps = [
+      {
+        name: 'one',
+        title: 'Step One',
+        form: () => <span>Form Fields</span>,
+        footer: () => <span>Footer</span>,
+      },
+    ];
+    const { getByText } = render(<FormSteps steps={steps} />);
+
+    expect(getByText('Footer')).to.be.ok();
+  });
 });

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -10,11 +10,11 @@ import render from '../../../support/render';
 
 describe('document-capture/components/form-steps', () => {
   const STEPS = [
-    { name: 'first', title: 'First Title', component: () => <span>First</span> },
+    { name: 'first', title: 'First Title', form: () => <span>First</span> },
     {
       name: 'second',
       title: 'Second Title',
-      component: ({ value = {}, onChange, registerField }) => (
+      form: ({ value = {}, onChange, registerField }) => (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
         <label>
           Second
@@ -30,7 +30,7 @@ describe('document-capture/components/form-steps', () => {
       ),
       validate: (value) => (value.second ? [] : [{ field: 'second', error: new Error() }]),
     },
-    { name: 'last', title: 'Last Title', component: () => <span>Last</span> },
+    { name: 'last', title: 'Last Title', form: () => <span>Last</span> },
   ];
 
   let originalHash;


### PR DESCRIPTION
**Why**: Per design, the desktop document capture step should show additional text following the "Continue" button to inform the user that their images are not saved and only used to verify one's identity.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/91600164-7beeaf80-e935-11ea-87c7-016116c9c928.png)
