### PR TITLE
LG-3368 Don't show duplicate Acuant error messages

### DIFF
--- a/app/services/doc_auth/acuant/responses/get_results_response.rb
+++ b/app/services/doc_auth/acuant/responses/get_results_response.rb
@@ -10,6 +10,7 @@ module DocAuth
             extra: {
               result: result_code.name,
               billed: result_code.billed,
+              raw_alerts: raw_alerts,
             },
           )
         end
@@ -25,6 +26,7 @@ module DocAuth
             exception: exception,
             result: result_code.name,
             billed: result_code.billed,
+            raw_alerts: raw_alerts,
           }
         end
 
@@ -56,7 +58,7 @@ module DocAuth
             friendly_message
           end
 
-          { results: messages }
+          { results: messages.uniq }
         end
 
         def parsed_response_body


### PR DESCRIPTION
**Why**: Acuant can render a wide range of errors on a get results response. We try to render a plain language error message for the most common ones. If there is an error we don't have an error message for, we render a generic error message. If Acuant rendered multiple messages that did not have a plain language we would show the generic error twice. This commit de-dupes the error message array so that doesn't happen.

As a bonus, I fixed a regression where we stopped logging the raw alerts we got from Acuant.

This commit fixes this:
![image](https://user-images.githubusercontent.com/963654/91601771-397aa200-e938-11ea-8779-e89c30d9f288.png)
