### PR TITLE
Add RISC identifier-recyled event (LG-1905)

### DIFF
--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -12,6 +12,7 @@ class DeleteUserEmailForm
 
   def submit
     success = valid? && email_address_destroyed
+    notify_subscribers if success
     FormResponse.new(success: success, errors: errors.messages)
   end
 
@@ -41,5 +42,10 @@ class DeleteUserEmailForm
     user.email_addresses.reload
     update_user_email_column
     true
+  end
+
+  def notify_subscribers
+    event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address)
+    PushNotification::HttpPush.new(event).deliver
   end
 end

--- a/app/forms/delete_user_email_form.rb
+++ b/app/forms/delete_user_email_form.rb
@@ -46,6 +46,6 @@ class DeleteUserEmailForm
 
   def notify_subscribers
     event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email_address)
-    PushNotification::HttpPush.new(event).deliver
+    PushNotification::HttpPush.deliver(event)
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -6,14 +6,21 @@ class Identity < ApplicationRecord
 
   delegate :metadata, to: :sp, prefix: true
 
+  # rubocop:disable Rails/InverseOf
+  belongs_to :service_provider_record,
+             class_name: 'ServiceProvider',
+             foreign_key: 'service_provider',
+             primary_key: 'issuer'
+  # rubocop:enable Rails/InverseOf
+
+  scope :not_deleted, -> { where(deleted_at: nil) }
+
   CONSENT_EXPIRATION = 1.year
 
   IAL_MAX = 0
   IAL1 = 1
   IAL2 = 2
   IAL2_STRICT = 22
-
-  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def deactivate
     update!(session_uuid: nil)

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -11,6 +11,8 @@ class ServiceProvider < ApplicationRecord
   include IdentityValidations::ServiceProviderValidation
 
   scope(:active, -> { where(active: true) })
+  scope(:with_push_notification_urls,
+        -> { where.not(push_notification_url: nil).where.not(push_notification_url: '') })
 
   def self.from_issuer(issuer)
     return NullServiceProvider.new(issuer: nil) if issuer.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,6 @@ class User < ApplicationRecord
   has_one :registration_log, dependent: :destroy
   has_one :proofing_component, dependent: :destroy
   has_many :service_providers,
-           -> { merge(Identity.not_deleted) },
            through: :identities,
            source: :service_provider_record
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
   has_many :throttles, dependent: :destroy
   has_one :registration_log, dependent: :destroy
   has_one :proofing_component, dependent: :destroy
+  has_many :service_providers,
+           -> { merge(Identity.not_deleted) },
+           through: :identities,
+           source: :service_provider_record
 
   attr_accessor :asserted_attributes
 

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -1,0 +1,77 @@
+module PushNotification
+  # Delivers SETs (Security Event Tokens) via the HTTP Push protocol
+  # https://tools.ietf.org/html/draft-ietf-secevent-http-push-00
+  class HttpPush
+    include Rails.application.routes.url_helpers
+
+    attr_reader :event
+
+    def initialize(event, now: Time.zone.now)
+      @event = event
+      @now = now
+    end
+
+    def deliver
+      event.user.
+        service_providers.
+        includes(:agency).
+        with_push_notification_urls.each do |service_provider|
+          deliver_one(service_provider)
+        end
+    end
+
+    private
+
+    attr_reader :now
+
+    def deliver_one(service_provider)
+      response = faraday.post(
+        service_provider.push_notification_url,
+        jwt(service_provider),
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/secevent+jwt',
+      )
+
+      unless response.success?
+        raise PushNotification::PushNotificationError, "status=#{response.status}"
+      end
+    rescue Faraday::TimeoutError,
+           Faraday::ConnectionFailed,
+           PushNotification::PushNotificationError => err
+      NewRelic::Agent.notice_error(err)
+    end
+
+    def jwt(service_provider)
+      payload = jwt_payload(service_provider)
+
+      JWT.encode(payload, RequestKeyManager.private_key, 'RS256', typ: 'secevent+jwt')
+    end
+
+    def jwt_payload(service_provider)
+      {
+        iss: root_url,
+        iat: now.to_i,
+        exp: (now + 12.hours).to_i,
+        jti: SecureRandom.hex,
+        aud: service_provider.push_notification_url,
+        events: {
+          event.event_type => event.payload,
+        },
+      }
+    end
+
+    def faraday
+      Faraday.new { |faraday| faraday.adapter :net_http }
+    end
+  end
+end
+
+# (iss_sub: agency_uuid(service_provider))
+
+# def agency_uuid(service_provider)
+#   AgencyIdentity.find_by(user_id: user.id, agency_id: service_provider.agency_id)&.uuid ||
+#     Identity.where(user_id: user.id, service_provider: service_provider.issuer)&.uuid
+# end
+
+# event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email)
+# PushNotification::HttpPush.new(event).deliver

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -6,6 +6,11 @@ module PushNotification
 
     attr_reader :event
 
+    # shorthand for creating an instance then calling #deliver, easier to stub
+    def self.deliver(event, now: now)
+      new(event, now: now).deliver
+    end
+
     def initialize(event, now: Time.zone.now)
       @event = event
       @now = now
@@ -14,7 +19,6 @@ module PushNotification
     def deliver
       event.user.
         service_providers.
-        includes(:agency).
         with_push_notification_urls.each do |service_provider|
           deliver_one(service_provider)
         end

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -7,7 +7,7 @@ module PushNotification
     attr_reader :event
 
     # shorthand for creating an instance then calling #deliver, easier to stub
-    def self.deliver(event, now: now)
+    def self.deliver(event, now: Time.zone.now)
       new(event, now: now).deliver
     end
 

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -65,13 +65,3 @@ module PushNotification
     end
   end
 end
-
-# (iss_sub: agency_uuid(service_provider))
-
-# def agency_uuid(service_provider)
-#   AgencyIdentity.find_by(user_id: user.id, agency_id: service_provider.agency_id)&.uuid ||
-#     Identity.where(user_id: user.id, service_provider: service_provider.issuer)&.uuid
-# end
-
-# event = PushNotification::IdentifierRecycledEvent.new(user: user, email: email)
-# PushNotification::HttpPush.new(event).deliver

--- a/app/services/push_notification/http_push.rb
+++ b/app/services/push_notification/http_push.rb
@@ -19,6 +19,7 @@ module PushNotification
     def deliver
       event.user.
         service_providers.
+        merge(Identity.not_deleted).
         with_push_notification_urls.each do |service_provider|
           deliver_one(service_provider)
         end

--- a/app/services/push_notification/identifier_recycled_event.rb
+++ b/app/services/push_notification/identifier_recycled_event.rb
@@ -1,0 +1,25 @@
+module PushNotification
+  class IdentifierRecycledEvent
+    EVENT_TYPE = 'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled'.freeze
+
+    attr_reader :user, :email
+
+    def initialize(user:, email:)
+      @user = user
+      @email = email
+    end
+
+    def event_type
+      EVENT_TYPE
+    end
+
+    def payload
+      {
+        subject: {
+          subject_type: 'email',
+          email: email,
+        },
+      }
+    end
+  end
+end

--- a/spec/forms/delete_user_email_form_spec.rb
+++ b/spec/forms/delete_user_email_form_spec.rb
@@ -2,18 +2,27 @@ require 'rails_helper'
 
 describe DeleteUserEmailForm do
   describe '#submit' do
+    subject(:submit) { form.submit }
+
     context 'with only a single email address' do
       let(:user) { create(:user, email: 'test@example.com ') }
       let(:email_address) { user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
-      let!(:result) { form.submit }
 
-      it 'returns success' do
+      it 'returns failure' do
+        result = submit
         expect(result.success?).to eq false
       end
 
       it 'leaves the last email alone' do
+        submit
         expect(user.email_addresses.reload).to_not be_empty
+      end
+
+      it 'does not notify subscribers that the identier was recycled' do
+        expect(PushNotification::HttpPush).to_not receive(:deliver)
+
+        submit
       end
     end
 
@@ -21,15 +30,22 @@ describe DeleteUserEmailForm do
       let(:user) { create(:user, :signed_up, :with_multiple_emails) }
       let(:email_address) { user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
-      let!(:result) { form.submit }
 
       it 'returns success' do
+        result = submit
         expect(result.success?).to eq true
       end
 
       it 'removes the email' do
+        submit
         deleted_email = user.email_addresses.reload.where(id: email_address.id)
         expect(deleted_email).to be_empty
+      end
+
+      it 'notifies subscribers that the identier was recycled' do
+        expect(PushNotification::HttpPush).to receive(:deliver)
+
+        submit
       end
     end
 
@@ -38,15 +54,22 @@ describe DeleteUserEmailForm do
       let(:other_user) { create(:user, :signed_up, :with_multiple_emails) }
       let(:email_address) { other_user.email_addresses.first }
       let(:form) { described_class.new(user, email_address) }
-      let!(:result) { form.submit }
 
       it 'returns failure' do
+        result = submit
         expect(result.success?).to eq false
       end
 
       it 'leaves the email alone' do
+        submit
         email = other_user.email_addresses.reload.where(id: email_address.id)
         expect(email).to_not be_empty
+      end
+
+      it 'does not subscribers that the identier was recycled' do
+        expect(PushNotification::HttpPush).to_not receive(:deliver)
+
+        submit
       end
     end
   end

--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+RSpec.describe PushNotification::HttpPush do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { create(:user) }
+
+  let(:sp_with_push_url) { create(:service_provider, push_notification_url: 'http://foo.bar/push') }
+  let(:sp_no_push_url) { create(:service_provider, push_notification_url: nil) }
+
+  before do
+    IdentityLinker.new(user, sp_with_push_url.issuer).link_identity
+    IdentityLinker.new(user, sp_no_push_url.issuer).link_identity
+  end
+
+  let(:event) do
+    PushNotification::IdentifierRecycledEvent.new(
+      user: user,
+      email: Faker::Internet.safe_email,
+    )
+  end
+  let(:now) { Time.zone.now }
+
+  subject(:http_push) { PushNotification::HttpPush.new(event, now: now) }
+
+  describe '#deliver' do
+    subject(:deliver) { http_push.deliver }
+
+    it 'makes an HTTP post to service providers with a push_notification_url' do
+      stub_request(:post, sp_with_push_url.push_notification_url).
+        with do |request|
+          expect(request.headers['Content-Type']).to eq('application/secevent+jwt')
+          expect(request.headers['Accept']).to eq('application/json')
+
+          payload, headers = JWT.decode(
+            request.body,
+            RequestKeyManager.public_key,
+            true,
+            algorithm: 'RS256',
+          )
+
+          expect(headers['typ']).to eq('secevent+jwt')
+
+          expect(payload['iss']).to eq(root_url)
+          expect(payload['iat']).to eq(now.to_i)
+          expect(payload['exp']).to eq((now + 12.hours).to_i)
+          expect(payload['aud']).to eq(sp_with_push_url.push_notification_url)
+          expect(payload['events']).to eq(event.event_type => event.payload.as_json)
+        end
+
+      deliver
+    end
+
+    context 'with a timeout when posting to one url' do
+      let(:third_sp) { create(:service_provider, push_notification_url: 'http://sp.url/push') }
+
+      before do
+        IdentityLinker.new(user, third_sp.issuer).link_identity
+
+        stub_request(:post, sp_with_push_url.push_notification_url).to_timeout
+        stub_request(:post, third_sp.push_notification_url).to_return(status: 200)
+      end
+
+      it 'still posts to the others' do
+        deliver
+
+        expect(WebMock).to have_requested(:post, third_sp.push_notification_url)
+      end
+
+      it 'notifies NewRelic' do
+        expect(NewRelic::Agent).to receive(:notice_error).
+          with(instance_of(Faraday::ConnectionFailed))
+
+        deliver
+      end
+    end
+
+    context 'with a non-200 response from a push notification url' do
+      before do
+        stub_request(:post, sp_with_push_url.push_notification_url).
+          to_return(status: 500)
+      end
+
+      it 'notifies NewRelic' do
+        expect(NewRelic::Agent).to receive(:notice_error).
+          with(instance_of(PushNotification::PushNotificationError))
+
+        deliver
+      end
+    end
+
+    context 'when a user has revoked access to an SP' do
+      before do
+        identity = user.identities.find_by(service_provider: sp_with_push_url.issuer)
+        RevokeServiceProviderConsent.new(identity).call
+      end
+
+      it 'does not notify that SP' do
+        deliver
+
+        expect(WebMock).not_to have_requested(:get, sp_with_push_url.push_notification_url)
+      end
+    end
+  end
+end

--- a/spec/services/push_notification/identifier_recycled_event_spec.rb
+++ b/spec/services/push_notification/identifier_recycled_event_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe PushNotification::IdentifierRecycledEvent do
+  subject(:event) do
+    PushNotification::IdentifierRecycledEvent.new(
+      user: user,
+      email: email,
+    )
+  end
+
+  let(:user) { build(:user) }
+  let(:email) { Faker::Internet.safe_email }
+
+  describe '#event_type' do
+    it 'is the RISC event type' do
+      expect(event.event_type).to eq(PushNotification::IdentifierRecycledEvent::EVENT_TYPE)
+    end
+  end
+
+  describe '#payload' do
+    it 'is a subject with an email' do
+      expect(event.payload).to eq(
+        subject: {
+          subject_type: 'email',
+          email: email,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a new event, for when a user changes their email, `identifier-recycled`

We already have existing "PushNotication" code in `AccountReset::DeleteAccount` (https://github.com/18F/identity-idp/blob/master/app/services/account_reset/delete_account.rb) and I had a few goals with this:

1. Use the [HTTP Push protocol](https://tools.ietf.org/html/draft-ietf-secevent-http-push-00) (not [WebPush](https://tools.ietf.org/html/draft-thomson-webpush-vapid-02)) because I think the docs are more readily available, and the [OpenID RISC Profile](https://openid.net/specs/openid-risc-profile-1_0.html) current draft points to this as DELIVERYPUSH)
   - This has the added bonus of matching our incoming RISC events endpoint: https://developers.login.gov/security-events/

2. Separate the event types from the delivery of those types, that way we can plug new event types in to the delivery system more easily
   - If this looks good, I would go in and refactor the old code to be a new kind of event class to plug in here.

A few open questions:

1. The old code writes failed pushes to a table, do we want to preserve that behavior?
2. The old code logs errors on failures (in addition to NewRelic), do we want to preserve that behavior?
3. The old code adds a separate header `Topic` HTTP header, the spec wasn't super clear on the need, but it would allow subscribers to filter out events without having to parse a JWT? Do we care? JWT's can be parsed and you can ignore the signature?
3. This is a great candidate for async code, do we want to discuss options for backgrounding these requests?