### PR TITLE
Don't use rack timeout for image upload API

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,6 +1,7 @@
 module Rack
   class Timeout
     @excludes = [
+      '/api/verify/images',
       '/verify/doc_auth/front_image',
       '/verify/doc_auth/back_image',
       '/verify/doc_auth/mobile_front_image',


### PR DESCRIPTION
**Why**: For not these are long running requests. We should not subject them to the 15 seconds timeout.