### PR TITLE
Remove document_capture_react_enabled configuration key

### DIFF
--- a/app/views/idv/doc_auth/document_capture.html.erb
+++ b/app/views/idv/doc_auth/document_capture.html.erb
@@ -108,17 +108,15 @@
     <%= javascript_pack_tag 'image-preview' %>
   </div>
   <%= render 'idv/doc_auth/start_over_or_cancel' %>
-  <% unless Figaro.env.document_capture_react_enabled == 'false' %>
-    <%= nonced_javascript_tag do %>
-      <% asset_keys = [
-        'close-white-alt.svg',
-        'id-card.svg',
-        'spinner.gif',
-        'spinner@2x.gif'
-      ] %>
-      window.LoginGov = window.LoginGov || {};
-      window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
-    <% end %>
-    <%= javascript_pack_tag 'document-capture' %>
+  <%= nonced_javascript_tag do %>
+    <% asset_keys = [
+      'close-white-alt.svg',
+      'id-card.svg',
+      'spinner.gif',
+      'spinner@2x.gif'
+    ] %>
+    window.LoginGov = window.LoginGov || {};
+    window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
   <% end %>
+  <%= javascript_pack_tag 'document-capture' %>
 <% end %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -48,7 +48,6 @@ disallow_ial2_recovery:
 doc_capture_request_valid_for_minutes: '15'
 doc_auth_extend_timeout_by_minutes: '40'
 document_capture_step_enabled: 'false'
-document_capture_react_enabled: 'true'
 email_from: no-reply@login.gov
 email_from_display_name: Login.gov
 enable_load_testing_mode: 'false'

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -10,7 +10,6 @@ feature 'doc auth document capture step' do
   let(:liveness_enabled) { 'false' }
   let(:fake_analytics) { FakeAnalytics.new }
   before do
-    allow(Figaro.env).to receive(:document_capture_react_enabled).and_return('false')
     allow(Figaro.env).to receive(:document_capture_step_enabled).
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).


### PR DESCRIPTION
**Why**: As a developer, I want less ambiguity and fewer combinations of configuration keys, so that I can feel confident in knowing how to toggle the React-based document capture.

This configuration key was originally added in #3994 to make it easier to test the fallback for the updated document capture flow. It is equally possible and more realistic to test this by disabling JavaScript in the browser (for example, using Chrome DevTools's Disable JavaScript setting).

Previously:

- https://github.com/18F/identity-idp/pull/4124#discussion_r476595987
- #3994