### PR TITLE
Sync IAL2 consent button to checkbox

### DIFF
--- a/app/javascript/packs/ial2-consent-button.js
+++ b/app/javascript/packs/ial2-consent-button.js
@@ -2,17 +2,13 @@ function toggleButton() {
   const continueButton = document.querySelector('input[value="Continue"]');
   const checkbox = document.querySelector('input[name="ial2_consent_given"]');
 
-  continueButton.disabled = true;
-  continueButton.classList.add('btn-disabled');
+  function sync() {
+    continueButton.disabled = !checkbox.checked;
+    continueButton.classList.toggle('btn-disabled', continueButton.disabled);
+  }
 
-  checkbox.addEventListener('click', function () {
-    if (continueButton.disabled) {
-      continueButton.classList.remove('btn-disabled');
-    } else {
-      continueButton.classList.add('btn-disabled');
-    }
-    continueButton.disabled = !continueButton.disabled;
-  });
+  sync();
+  checkbox.addEventListener('change', sync);
 }
 
 document.addEventListener('DOMContentLoaded', toggleButton);


### PR DESCRIPTION
**Why**: As a user, I expect that regardless how long it takes for JavaScript on the consent screen to load, the "Continue" button will be made enabled as long as the consent checkbox is checked, so that there's a sensible relationship between the checkbox and button disabled state and so that I can continue with the proofing flow.

I had encountered this issue when testing the new document capture flow in Internet Explorer (LG-3241), where the script loaded rather slowly. Because I clicked the checkbox before the JavaScript had finished loading, the button was not enabled, and the checkbox fell out of sync with the button's enabled state.

Rather than assuming the button should be disabled at load and toggled in response to a click on the checkbox, keep the button's enabled state in sync with the checkbox value at all times, so there's a strong relationship between the two.