### PR TITLE
Use complete phrase for document capture errors

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -13,8 +13,8 @@ en:
       upload_picture: Upload a photo
       use_phone: Use your phone
     errors:
-      must_be_image: must be an image
-      not_a_file: was not attached as a file
+      must_be_image: File must be an image
+      not_a_file: The selection was not a valid file
     forms:
       address1: Address
       change_file: Change file

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -13,8 +13,8 @@ es:
       upload_picture: Sube una foto
       use_phone: Usa tu telefono
     errors:
-      must_be_image: debe ser una imagen
-      not_a_file: no se adjuntó como un archivo
+      must_be_image: El archivo debe ser una imagen
+      not_a_file: La selección no era un archivo válido
     forms:
       address1: Dirección
       change_file: Cambiar archivo

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -13,8 +13,8 @@ fr:
       upload_picture: Télécharger une photo
       use_phone: Utilisez votre téléphone
     errors:
-      must_be_image: doit être une image
-      not_a_file: n'a pas été joint en tant que fichier
+      must_be_image: Le fichier doit être une image
+      not_a_file: La sélection n'était pas un fichier valide
     forms:
       address1: Adresse
       change_file: Changer de fichier

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
       it 'is not valid' do
         expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['was not attached as a file'])
+        expect(form.errors[:selfie]).to eq(['The selection was not a valid file'])
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
       it 'is not valid' do
         expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['must be an image'])
+        expect(form.errors[:selfie]).to eq(['File must be an image'])
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
       it 'is not valid' do
         expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['must be an image'])
+        expect(form.errors[:selfie]).to eq(['File must be an image'])
       end
 
       after { tempfile.unlink }


### PR DESCRIPTION
**Why**: As a user, when presented with errors generated in response to invalid file selections during document capture, I expect to be presented with complete phrases, so that I can most easily understand the problem so that I can resolve the issue and continue with proofing.

The text was previously fragmented since they were combined with the field name. Since this is no longer the case as of #4141, the errors should be complete phrases.

Related: #4150 ([see screenshot](https://user-images.githubusercontent.com/1779930/91613499-a0ef1c80-e94d-11ea-858b-39fc4557a754.png))

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/91851880-f1a49500-ec2d-11ea-92a0-66be56976c5c.png)|![after](https://user-images.githubusercontent.com/1779930/91851941-054ffb80-ec2e-11ea-99ce-f3a6f3213824.png)
must be an image|File must be an image
was not attached as a file|The selection was not a valid file

I'd welcome any feedback on specific phrasing, cc @anniehirshman-gsa 
