### PR TITLE
Render errors that come from a hash

### DIFF
--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -33,5 +33,11 @@ module DocAuth
         exception: exception,
       }.merge(extra)
     end
+
+    def first_error_message
+      return if errors.blank?
+      _key, message_or_messages = errors.first
+      Array(message_or_messages).first
+    end
   end
 end

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -10,7 +10,7 @@ module Flow
     def base_call
       form_response = form_submit
       unless form_response.success?
-        flow_session[:error_message] = form_response.errors.values.flatten.join(' ')
+        flow_session[:error_message] = form_response.first_error_message
         return form_response
       end
       create_response(form_response, call)

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -10,7 +10,7 @@ module Flow
     def base_call
       form_response = form_submit
       unless form_response.success?
-        flow_session[:error_message] = form_response.errors
+        flow_session[:error_message] = form_response.errors.values.flatten.join(' ')
         return form_response
       end
       create_response(form_response, call)

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -73,7 +73,7 @@ module Flow
 
     def set_error_and_render(step, result)
       flow_session = flow.flow_session
-      flow_session[:error_message] = result.errors.values.join(' ')
+      flow_session[:error_message] = result.errors.values.flatten.join(' ')
       render_step(step, flow_session)
     end
 

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -73,7 +73,7 @@ module Flow
 
     def set_error_and_render(step, result)
       flow_session = flow.flow_session
-      flow_session[:error_message] = result.errors.values.flatten.join(' ')
+      flow_session[:error_message] = result.first_error_message
       render_step(step, flow_session)
     end
 

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -23,6 +23,12 @@ class FormResponse
     )
   end
 
+  def first_error_message
+    return if errors.blank?
+    _key, message_or_messages = errors.first
+    Array(message_or_messages).first
+  end
+
   private
 
   attr_reader :success

--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
+          failure(back_image_response.first_error_message, back_image_response.to_h)
         end
       end
 
@@ -37,7 +37,7 @@ module Idv
           notice: I18n.t('errors.doc_auth.general_info'),
         )
         log_document_error(get_results_response)
-        failure(get_results_response.errors.values.flatten.join(' '), extra)
+        failure(get_results_response.first_error_message, extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/back_image_step.rb
+++ b/app/services/idv/steps/back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.first, back_image_response.to_h)
+          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
         end
       end
 
@@ -37,7 +37,7 @@ module Idv
           notice: I18n.t('errors.doc_auth.general_info'),
         )
         log_document_error(get_results_response)
-        failure(get_results_response.errors.first, extra)
+        failure(get_results_response.errors.values.flatten.join(' '), extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/capture_mobile_back_image_step.rb
+++ b/app/services/idv/steps/capture_mobile_back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
+          failure(back_image_response.first_error_message, back_image_response.to_h)
         end
       end
 
@@ -36,7 +36,7 @@ module Idv
           notice: I18n.t('errors.doc_auth.general_info'),
         )
         log_document_error(get_results_response)
-        failure(get_results_response.errors.values.flatten.join(' '), extra)
+        failure(get_results_response.first_error_message, extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/capture_mobile_back_image_step.rb
+++ b/app/services/idv/steps/capture_mobile_back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.first, back_image_response.to_h)
+          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
         end
       end
 
@@ -36,7 +36,7 @@ module Idv
           notice: I18n.t('errors.doc_auth.general_info'),
         )
         log_document_error(get_results_response)
-        failure(get_results_response.errors.first, extra)
+        failure(get_results_response.errors.values.flatten.join(' '), extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -36,7 +36,7 @@ module Idv
                  end
         log_document_error(response)
         extra = response.to_h.merge(notice)
-        failure(response.errors.values.flatten.join(' '), extra)
+        failure(response.first_error_message, extra)
       end
 
       def handle_stored_result

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -36,7 +36,7 @@ module Idv
                  end
         log_document_error(response)
         extra = response.to_h.merge(notice)
-        failure(response.errors.first, extra)
+        failure(response.errors.values.flatten.join(' '), extra)
       end
 
       def handle_stored_result

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -8,7 +8,10 @@ module Idv
           flow_session[:instance_id] = create_document_response.instance_id
           upload_front_image
         else
-          failure(create_document_response.errors.values.flatten.join(' '), create_document_response.to_h)
+          failure(
+            create_document_response.errors.values.flatten.join(' '),
+            create_document_response.to_h,
+          )
         end
       end
 

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -9,7 +9,7 @@ module Idv
           upload_front_image
         else
           failure(
-            create_document_response.errors.values.flatten.join(' '),
+            create_document_response.first_error_message,
             create_document_response.to_h,
           )
         end
@@ -23,7 +23,7 @@ module Idv
 
       def upload_front_image
         response = post_front_image
-        failure(response.errors.values.flatten.join(' '), response.to_h) unless response.success?
+        failure(response.first_error_message, response.to_h) unless response.success?
       end
     end
   end

--- a/app/services/idv/steps/front_image_step.rb
+++ b/app/services/idv/steps/front_image_step.rb
@@ -8,7 +8,7 @@ module Idv
           flow_session[:instance_id] = create_document_response.instance_id
           upload_front_image
         else
-          failure(create_document_response.errors.first, create_document_response.to_h)
+          failure(create_document_response.errors.values.flatten.join(' '), create_document_response.to_h)
         end
       end
 
@@ -20,7 +20,7 @@ module Idv
 
       def upload_front_image
         response = post_front_image
-        failure(response.errors.first, response.to_h) unless response.success?
+        failure(response.errors.values.flatten.join(' '), response.to_h) unless response.success?
       end
     end
   end

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -30,7 +30,7 @@ module Idv
 
       def handle_document_verification_failure(get_results_response)
         mark_step_incomplete(:send_link)
-        failure(get_results_response.errors.values.flatten.join(' '), get_results_response.to_h)
+        failure(get_results_response.first_error_message, get_results_response.to_h)
       end
 
       def render_step_incomplete_error

--- a/app/services/idv/steps/link_sent_step.rb
+++ b/app/services/idv/steps/link_sent_step.rb
@@ -30,7 +30,7 @@ module Idv
 
       def handle_document_verification_failure(get_results_response)
         mark_step_incomplete(:send_link)
-        failure(get_results_response.errors.first, get_results_response.to_h)
+        failure(get_results_response.errors.values.flatten.join(' '), get_results_response.to_h)
       end
 
       def render_step_incomplete_error

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
+          failure(back_image_response.first_error_message, back_image_response.to_h)
         end
       end
 
@@ -35,7 +35,7 @@ module Idv
         extra = get_results_response.to_h.merge(
           notice: I18n.t('errors.doc_auth.general_info'),
         )
-        failure(get_results_response.errors.values.flatten.join(' '), extra)
+        failure(get_results_response.first_error_message, extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/mobile_back_image_step.rb
+++ b/app/services/idv/steps/mobile_back_image_step.rb
@@ -6,7 +6,7 @@ module Idv
         if back_image_response.success?
           fetch_doc_auth_results_or_redirect_to_selfie
         else
-          failure(back_image_response.errors.first, back_image_response.to_h)
+          failure(back_image_response.errors.values.flatten.join(' '), back_image_response.to_h)
         end
       end
 
@@ -35,7 +35,7 @@ module Idv
         extra = get_results_response.to_h.merge(
           notice: I18n.t('errors.doc_auth.general_info'),
         )
-        failure(get_results_response.errors.first, extra)
+        failure(get_results_response.errors.values.flatten.join(' '), extra)
       end
 
       def form_submit

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -8,7 +8,10 @@ module Idv
           flow_session[:instance_id] = create_document_response.instance_id
           upload_front_image
         else
-          failure(create_document_response.errors.values.flatten.join(' '), create_document_response.to_h)
+          failure(
+            create_document_response.errors.values.flatten.join(' '),
+            create_document_response.to_h,
+          )
         end
       end
 

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -9,7 +9,7 @@ module Idv
           upload_front_image
         else
           failure(
-            create_document_response.errors.values.flatten.join(' '),
+            create_document_response.first_error_message,
             create_document_response.to_h,
           )
         end
@@ -23,7 +23,7 @@ module Idv
 
       def upload_front_image
         response = post_front_image
-        failure(response.errors.values.flatten.join(' '), response.to_h) unless response.success?
+        failure(response.first_error_message, response.to_h) unless response.success?
       end
     end
   end

--- a/app/services/idv/steps/mobile_front_image_step.rb
+++ b/app/services/idv/steps/mobile_front_image_step.rb
@@ -8,7 +8,7 @@ module Idv
           flow_session[:instance_id] = create_document_response.instance_id
           upload_front_image
         else
-          failure(create_document_response.errors.first, create_document_response.to_h)
+          failure(create_document_response.errors.values.flatten.join(' '), create_document_response.to_h)
         end
       end
 
@@ -20,7 +20,7 @@ module Idv
 
       def upload_front_image
         response = post_front_image
-        failure(response.errors.first, response.to_h) unless response.success?
+        failure(response.errors.values.flatten.join(' '), response.to_h) unless response.success?
       end
     end
   end

--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -45,7 +45,7 @@ module Idv
           mark_step_incomplete(:back_image)
         end
         log_document_error(failure_response)
-        failure(failure_response.errors.first, failure_response.to_h)
+        failure(failure_response.errors.values.flatten.join(' '), failure_response.to_h)
       end
 
       def results_response

--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -45,7 +45,7 @@ module Idv
           mark_step_incomplete(:back_image)
         end
         log_document_error(failure_response)
-        failure(failure_response.errors.values.flatten.join(' '), failure_response.to_h)
+        failure(failure_response.first_error_message, failure_response.to_h)
       end
 
       def results_response

--- a/spec/features/idv/doc_auth/selfie_step_spec.rb
+++ b/spec/features/idv/doc_auth/selfie_step_spec.rb
@@ -58,6 +58,7 @@ feature 'doc auth self image step' do
 
     expect(page).to have_current_path(idv_doc_auth_front_image_step)
     expect(page).to have_content(t('errors.doc_auth.selfie'))
+    expect(page).to_not have_content('"results"') # don't show the error key, only messages
   end
 
   it 'logs the last doc auth error' do


### PR DESCRIPTION
Before https://github.com/18F/identity-idp/pull/4135, errors looked like:

```ruby
response.errors
['some error message']
```

After, to match the `FormResponse` errors, they looked like this:

```ruby
response.errors
{ result: ['some error message', 'other error message'] }
```

At the time, I thought this line would be sufficient to clean things up for rednering

https://github.com/18F/identity-idp/blob/master/app/services/flow/flow_state_machine.rb#L76

But I was wrong 😬, it turned into this:

<img width="689" alt="Screen Shot 2020-09-01 at 11 59 44 AM" src="https://user-images.githubusercontent.com/458784/91896397-a39f8980-ec4d-11ea-8fce-6342bfa0cb23.png">

So now after this PR, things are cleaned up

<img width="676" alt="Screen Shot 2020-09-01 at 12 04 34 PM" src="https://user-images.githubusercontent.com/458784/91896422-ab5f2e00-ec4d-11ea-94d8-fdc61e1999e4.png">
