### PR TITLE
Switch RISC notifications from iss_sub to iss-sub

### DIFF
--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -165,11 +165,11 @@ class SecurityEventForm
   end
 
   def validate_subject_type
-    return if subject_type == 'iss_sub'
+    return if subject_type == 'iss-sub'
 
     errors.add(
       :subject_type,
-      t('risc.security_event.errors.subject_type_unsupported', expected_subject_type: 'iss_sub'),
+      t('risc.security_event.errors.subject_type_unsupported', expected_subject_type: 'iss-sub'),
     )
   end
 

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Risc::SecurityEventsController do
         events: {
           event_type => {
             subject: {
-              subject_type: 'iss_sub',
+              subject_type: 'iss-sub',
               iss: root_url,
               sub: AgencyIdentityLinker.new(identity).link_identity.uuid,
             },

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SecurityEventForm do
       events: {
         SecurityEvent::AUTHORIZATION_FRAUD_DETECTED => {
           subject: {
-            subject_type: 'iss_sub',
+            subject_type: 'iss-sub',
             iss: root_url,
             sub: subject_sub,
           },
@@ -263,7 +263,7 @@ RSpec.describe SecurityEventForm do
 
         it 'is invalid' do
           expect(valid?).to eq(false)
-          expect(form.errors[:subject_type]).to include('subject_type must be iss_sub')
+          expect(form.errors[:subject_type]).to include('subject_type must be iss-sub')
         end
       end
     end


### PR DESCRIPTION
**Why**: Matches the spec more closely:
- https://openid.net/specs/openid-risc-event-types-1_0-ID1.html