### PR TITLE
Prevent selfie step from being marked complete on failure

### DIFF
--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -22,9 +22,7 @@ module Idv
           instance_id: instance_id, image: image.read,
         )
 
-        if selfie_response.success?
-          handle_successful_selfie_match
-        end
+        handle_successful_selfie_match if selfie_response.success?
 
         selfie_response
       end

--- a/app/services/idv/steps/selfie_step.rb
+++ b/app/services/idv/steps/selfie_step.rb
@@ -4,8 +4,12 @@ module Idv
       def call
         add_cost(:acuant_result) if results_response.to_h[:billed]
         if results_response.success?
-          send_selfie_request
-          results_response
+          selfie_response = send_selfie_request
+          if selfie_response.success?
+            results_response
+          else
+            handle_selfie_step_failure(selfie_response)
+          end
         else
           handle_selfie_step_failure(results_response)
         end
@@ -17,11 +21,12 @@ module Idv
         selfie_response = DocAuth::Client.client.post_selfie(
           instance_id: instance_id, image: image.read,
         )
+
         if selfie_response.success?
           handle_successful_selfie_match
-        else
-          handle_selfie_step_failure(selfie_response)
         end
+
+        selfie_response
       end
 
       def handle_successful_selfie_match

--- a/spec/features/idv/doc_auth/selfie_step_spec.rb
+++ b/spec/features/idv/doc_auth/selfie_step_spec.rb
@@ -59,6 +59,16 @@ feature 'doc auth self image step' do
     expect(page).to have_current_path(idv_doc_auth_front_image_step)
     expect(page).to have_content(t('errors.doc_auth.selfie'))
     expect(page).to_not have_content('"results"') # don't show the error key, only messages
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_back_image_step)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_doc_auth_selfie_step)
   end
 
   it 'logs the last doc auth error' do

--- a/spec/features/idv/doc_capture/selfie_step_spec.rb
+++ b/spec/features/idv/doc_capture/selfie_step_spec.rb
@@ -50,5 +50,15 @@ feature 'doc auth self image step' do
 
     expect(page).to have_current_path(idv_capture_doc_mobile_front_image_step(nil))
     expect(page).to have_content(t('errors.doc_auth.selfie'))
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_capture_doc_capture_mobile_back_image_step)
+
+    attach_image
+    click_idv_continue
+
+    expect(page).to have_current_path(idv_capture_doc_capture_selfie_step)
   end
 end


### PR DESCRIPTION
This pull request seeks to resolve an issue where a failed selfie response would still result in the selfie step being marked complete. The user would be returned to upload the front and back of their document again, but would proceed from there to provide their SSN. Since the PII is only extracted upon successful selfie response, it would not be available in the flow session.

The changes here ensure that if the selfie request fails, it is handled as a failure in the return value of `SelfieStep#call`.