### PR TITLE
LG-3267: Display success alert if ID submission is successful

### DIFF
--- a/app/views/idv/capture_doc/capture_complete.html.erb
+++ b/app/views/idv/capture_doc/capture_complete.html.erb
@@ -1,10 +1,9 @@
 <% title t('doc_auth.titles.doc_auth') %>
-<%= image_tag(asset_url('alert/success.svg'), width: 60) %>
 
-<h1 class='h2 mb2 mt3 my0'>
+<%= render 'shared/alert', { type: 'success', class: 'margin-bottom-4 margin-top-2' } do %>
   <%= t('doc_auth.headings.capture_complete') %>
-</h1>
-<hr />
+<% end %>
+
 <h1 class='h2 mb2 mt3 my0'>
   <%= t('doc_auth.instructions.switch_back') %>
 </h1>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -1,5 +1,9 @@
 <% title t('doc_auth.titles.doc_auth') %>
 
+<%= render 'shared/alert', { type: 'success', class: 'margin-bottom-4' } do %>
+  <%= t('doc_auth.headings.capture_complete') %>
+<% end %>
+
 <h1 class='h3 my0'>
   <%= t('doc_auth.headings.ssn') %>
 </h1>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -1,6 +1,9 @@
 <% title t('doc_auth.titles.doc_auth') %>
 
-<%= render 'shared/alert', { type: 'success', class: 'margin-bottom-4' } do %>
+<%= render 'shared/alert', {
+  type: 'success',
+  class: 'margin-bottom-4 margin-top-2 tablet:margin-top-0'
+} do %>
   <%= t('doc_auth.headings.capture_complete') %>
 <% end %>
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,8 +1,11 @@
-<% type = local_assigns.fetch(:type, 'other') %>
-<% classes = 'usa-alert usa-alert--' + type %>
-<% classes += ' ' + local_assigns[:class] if local_assigns[:class] %>
-<% role = type === 'error' ? 'alert' : 'status' %>
-<% message = yield.presence || local_assigns.fetch(:message) %>
+<%
+  type = local_assigns.fetch(:type, 'other')
+  role = type === 'error' ? 'alert' : 'status'
+
+  classes = 'usa-alert usa-alert--' + type
+  classes += ' ' + local_assigns[:class] if local_assigns[:class]
+  message = yield.presence || local_assigns.fetch(:message)
+%>
 
 <%= tag.div class: classes, role: role do %>
   <div class="usa-alert__body">

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -2,8 +2,11 @@
   type = local_assigns.fetch(:type, 'other')
   role = type === 'error' ? 'alert' : 'status'
 
-  classes = 'usa-alert usa-alert--' + type
-  classes += ' ' + local_assigns[:class] if local_assigns[:class]
+  classes = [
+    'usa-alert',
+    "usa-alert--#{type}",
+  ]
+  classes << local_assigns[:class] if local_assigns[:class]
   message = yield.presence || local_assigns.fetch(:message)
 %>
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,0 +1,11 @@
+<% type = local_assigns.fetch(:type, 'other') %>
+<% classes = 'usa-alert usa-alert--' + type %>
+<% classes += ' ' + local_assigns[:class] if local_assigns[:class] %>
+<% role = type === 'error' ? 'alert' : 'status' %>
+<% message = yield.presence || local_assigns.fetch(:message) %>
+
+<%= tag.div class: classes, role: role do %>
+  <div class="usa-alert__body">
+    <p class="usa-alert__text"><%= message %></p>
+  </div>
+<% end %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -31,7 +31,7 @@ en:
     headings:
       address: Mailing Address
       back: Back
-      capture_complete: We have verified your state issued ID
+      capture_complete: We have verified your state-issued ID
       document_capture: Add your state-issued ID
       document_capture_back: Back of your ID
       document_capture_front: Front of your ID

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -32,7 +32,7 @@ es:
     headings:
       address: Dirección de envio
       back: Parte posterior
-      capture_complete: Hemos verificado la identificación emitida por su estado
+      capture_complete: Hemos verificado su identificación emitida por el estado
       document_capture: Agregue su identificación emitida por el estado
       document_capture_back: Detrás de su identificación
       document_capture_front: Frente de su identificación

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -33,7 +33,7 @@ fr:
     headings:
       address: Adresse mail
       back: Verso
-      capture_complete: Nous avons vérifié votre ID émis par l'état
+      capture_complete: Nous avons vérifié votre pièce d'identité officielle
       document_capture: Ajoutez votre pièce d'identité émise par l'État
       document_capture_back: Dos de votre pièce d'identité
       document_capture_front: Recto de votre pièce d'identité

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -14,6 +14,7 @@ feature 'doc auth ssn step' do
     it 'is on the correct page' do
       expect(page).to have_current_path(idv_doc_auth_ssn_step)
       expect(page).to have_content(t('doc_auth.headings.ssn'))
+      expect(page).to have_content(t('doc_auth.headings.capture_complete'))
     end
 
     it 'proceeds to the next page with valid info' do
@@ -51,6 +52,7 @@ feature 'doc auth ssn step' do
       it 'is on the correct page' do
         expect(page).to have_current_path(idv_doc_auth_ssn_step)
         expect(page).to have_content(t('doc_auth.headings.ssn'))
+        expect(page).to have_content(t('doc_auth.headings.capture_complete'))
       end
 
       it 'proceeds to the next page with valid info' do

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'shared/_alert.html.erb' do
+  it 'renders message from param' do
+    render 'shared/alert', { message: 'FYI' }
+
+    expect(rendered).to have_content('FYI')
+  end
+
+  it 'renders message from block' do
+    render 'shared/alert' do 'FYI' end
+
+    expect(rendered).to have_content('FYI')
+  end
+
+  it 'defaults to type "other"' do
+    render 'shared/alert', { message: 'FYI' }
+
+    expect(rendered).to have_selector('.usa-alert.usa-alert--other')
+  end
+
+  it 'accepts alert type param' do
+    render 'shared/alert', { type: 'success', message: 'Hooray!' }
+
+    expect(rendered).to have_selector('.usa-alert.usa-alert--success')
+  end
+
+  it 'accepts custom class names' do
+    render 'shared/alert', { message: 'FYI', class: 'my-custom-class' }
+
+    expect(rendered).to have_selector('.usa-alert.my-custom-class')
+  end
+
+  it 'assigns role="status"' do
+    render 'shared/alert', { message: 'FYI' }
+
+    expect(rendered).to have_selector('.usa-alert[role="status"]')
+  end
+
+  it 'assigns role="alert" for error type' do
+    render 'shared/alert', { type: 'error', message: 'Attention!' }
+
+    expect(rendered).to have_selector('.usa-alert[role="alert"]')
+  end
+end

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe 'shared/_alert.html.erb' do
   end
 
   it 'renders message from block' do
-    render 'shared/alert' do 'FYI' end
+    render('shared/alert') { 'FYI' }
 
     expect(rendered).to have_content('FYI')
   end


### PR DESCRIPTION
**Why**: As a user, I want to see an alert message that lets me know if my ID passed, so that I know my upload was successful as I move on to the next step in verifying my identity.

**Screenshots:**

Mobile|Hybrid|Desktop
---|---|---
![Image from iOS (1)](https://user-images.githubusercontent.com/1779930/92173112-edcd6a00-ee09-11ea-9626-8cbd844a2e17.png)|![Image from iOS](https://user-images.githubusercontent.com/1779930/92173135-eefe9700-ee09-11ea-9982-f733f7551803.png)|![Screen Shot 2020-09-03 at 4 53 59 PM](https://user-images.githubusercontent.com/1779930/92173183-f1f98780-ee09-11ea-9aff-b481fc0e3a45.png)
