### PR TITLE
Create a password_invalidated event (LG-3344 follow-up)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
   end
 
   def user_event_creator
-    @user_event_creator ||= UserEventCreator.new(request, current_user)
+    @user_event_creator ||= UserEventCreator.new(request: request, current_user: current_user)
   end
   delegate :create_user_event, :create_user_event_with_disavowal, to: :user_event_creator
   delegate :remember_device_default, to: :decorated_session

--- a/app/controllers/risc/security_events_controller.rb
+++ b/app/controllers/risc/security_events_controller.rb
@@ -10,10 +10,6 @@ module Risc
       analytics.track_event(Analytics::SECURITY_EVENT_RECEIVED, result.to_h)
 
       if result.success?
-        if form.event_type == SecurityEvent::AUTHORIZATION_FRAUD_DETECTED
-          ResetUserPassword.new(user: form.user).call
-        end
-
         head :accepted
       else
         render status: :bad_request,

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -4,7 +4,7 @@ EventDecorator = Struct.new(:event) do
   end
 
   def event_type
-    I18n.t("event_types.#{event.event_type}")
+    I18n.t("event_types.#{event.event_type}", app_name: APP_NAME)
   end
 
   def happened_at

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -4,7 +4,7 @@ EventDecorator = Struct.new(:event) do
   end
 
   def event_type
-    I18n.t("event_types.#{event.event_type}", app_name: APP_NAME)
+    I18n.t("event_types.#{event.event_type}")
   end
 
   def happened_at

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -4,7 +4,7 @@ EventDecorator = Struct.new(:event) do
   end
 
   def event_type
-    I18n.t("event_types.#{event.event_type}")
+    I18n.t("event_types.#{event.event_type}", app_name: APP_NAME)
   end
 
   def happened_at
@@ -16,12 +16,12 @@ EventDecorator = Struct.new(:event) do
   end
 
   def last_sign_in_location_and_ip
-    return '' unless event&.respond_to?(:ip)
+    return '' if !event&.respond_to?(:ip) || event.ip.blank?
     I18n.t('account.index.sign_in_location_and_ip', location: last_location, ip: event.ip)
   end
 
   def last_location
-    return '' unless event&.respond_to?(:ip)
+    return '' if !event&.respond_to?(:ip) || event.ip.blank?
     IpGeocoder.new(event.ip).location
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,6 +26,7 @@ class Event < ApplicationRecord
     sign_in_after_2fa: 19,
     email_deleted: 20,
     phone_added: 21,
+    password_invalidated: 22,
   }
 
   validates :event_type, presence: true

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -1,7 +1,7 @@
 class UserEventCreator
   attr_reader :request, :current_user
 
-  def initialize(request, current_user)
+  def initialize(request: nil, current_user:)
     @request = request
     @current_user = current_user
   end
@@ -14,6 +14,11 @@ class UserEventCreator
     else
       create_event_for_new_device(event_type: event_type, user: user)
     end
+  end
+
+  # Create an event without a device or IP address
+  def create_out_of_band_user_event(event_type)
+    create_event_for_device(event_type: event_type, user: current_user, device: nil)
   end
 
   def create_user_event_with_disavowal(event_type, user = current_user)
@@ -60,7 +65,7 @@ class UserEventCreator
 
   def create_event_for_device(event_type:, user:, device:)
     Event.create(
-      user_id: user.id, device_id: device.id, ip: request.remote_ip, event_type: event_type,
+      user_id: user.id, device_id: device&.id, ip: request&.remote_ip, event_type: event_type,
     )
   end
 

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -13,7 +13,7 @@ en:
     email_deleted: Email address deleted
     new_personal_key: Personal key changed
     password_changed: Password changed
-    password_invalidated: Password invalidated by %{app_name}
+    password_invalidated: Password reset
     personal_key_used: Personal key used to sign in
     phone_added: Phone number added
     phone_changed: Phone number changed

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -13,7 +13,7 @@ en:
     email_deleted: Email address deleted
     new_personal_key: Personal key changed
     password_changed: Password changed
-    password_invalidated: Password reset
+    password_invalidated: Password invalidated by %{app_name}
     personal_key_used: Personal key used to sign in
     phone_added: Phone number added
     phone_changed: Phone number changed

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -13,7 +13,7 @@ en:
     email_deleted: Email address deleted
     new_personal_key: Personal key changed
     password_changed: Password changed
-    password_invalidated: Password invalidated by %{app_name}
+    password_invalidated: Password reset by %{app_name}
     personal_key_used: Personal key used to sign in
     phone_added: Phone number added
     phone_changed: Phone number changed

--- a/config/locales/event_types/en.yml
+++ b/config/locales/event_types/en.yml
@@ -13,6 +13,7 @@ en:
     email_deleted: Email address deleted
     new_personal_key: Personal key changed
     password_changed: Password changed
+    password_invalidated: Password invalidated by %{app_name}
     personal_key_used: Personal key used to sign in
     phone_added: Phone number added
     phone_changed: Phone number changed

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -13,7 +13,7 @@ es:
     email_deleted: Dirección de correo electrónico eliminada
     new_personal_key: Clave personal cambiado
     password_changed: Contraseña cambiada
-    password_invalidated: Contraseña invalidada
+    password_invalidated: Contraseña invalidada por %{app_name}
     personal_key_used: Clave personal utilizada para iniciar sesión
     phone_added: Teléfono añadido
     phone_changed: Número de teléfono cambiado

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -13,7 +13,7 @@ es:
     email_deleted: Dirección de correo electrónico eliminada
     new_personal_key: Clave personal cambiado
     password_changed: Contraseña cambiada
-    password_invalidated: Contraseña invalidada por %{app_name}
+    password_invalidated: Restablecimiento de contraseña por %{app_name}
     personal_key_used: Clave personal utilizada para iniciar sesión
     phone_added: Teléfono añadido
     phone_changed: Número de teléfono cambiado

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -13,6 +13,7 @@ es:
     email_deleted: Dirección de correo electrónico eliminada
     new_personal_key: Clave personal cambiado
     password_changed: Contraseña cambiada
+    password_invalidated: Contraseña invalidada por %{app_name}
     personal_key_used: Clave personal utilizada para iniciar sesión
     phone_added: Teléfono añadido
     phone_changed: Número de teléfono cambiado

--- a/config/locales/event_types/es.yml
+++ b/config/locales/event_types/es.yml
@@ -13,7 +13,7 @@ es:
     email_deleted: Dirección de correo electrónico eliminada
     new_personal_key: Clave personal cambiado
     password_changed: Contraseña cambiada
-    password_invalidated: Contraseña invalidada por %{app_name}
+    password_invalidated: Contraseña invalidada
     personal_key_used: Clave personal utilizada para iniciar sesión
     phone_added: Teléfono añadido
     phone_changed: Número de teléfono cambiado

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -13,6 +13,7 @@ fr:
     email_deleted: Adresse e-mail supprimée
     new_personal_key: Clé personnelle modifié
     password_changed: Mot de passe modifié
+    password_invalidated: Mot de passe invalidé par %{app_name}
     personal_key_used: Clé personnelle utilisée pour la connexion
     phone_added: Numéro de téléphone ajouté
     phone_changed: Numéro de téléphone modifié

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -13,7 +13,7 @@ fr:
     email_deleted: Adresse e-mail supprimée
     new_personal_key: Clé personnelle modifié
     password_changed: Mot de passe modifié
-    password_invalidated: Mot de passe invalidé
+    password_invalidated: Mot de passe invalidé par %{app_name}
     personal_key_used: Clé personnelle utilisée pour la connexion
     phone_added: Numéro de téléphone ajouté
     phone_changed: Numéro de téléphone modifié

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -13,7 +13,7 @@ fr:
     email_deleted: Adresse e-mail supprimée
     new_personal_key: Clé personnelle modifié
     password_changed: Mot de passe modifié
-    password_invalidated: Mot de passe invalidé par %{app_name}
+    password_invalidated: Mot de passe invalidé
     personal_key_used: Clé personnelle utilisée pour la connexion
     phone_added: Numéro de téléphone ajouté
     phone_changed: Numéro de téléphone modifié

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -13,7 +13,7 @@ fr:
     email_deleted: Adresse e-mail supprimée
     new_personal_key: Clé personnelle modifié
     password_changed: Mot de passe modifié
-    password_invalidated: Mot de passe invalidé par %{app_name}
+    password_invalidated: Réinitialisation du mot de passe par %{app_name}
     personal_key_used: Clé personnelle utilisée pour la connexion
     phone_added: Numéro de téléphone ajouté
     phone_changed: Numéro de téléphone modifié

--- a/spec/controllers/risc/security_events_controller_spec.rb
+++ b/spec/controllers/risc/security_events_controller_spec.rb
@@ -59,18 +59,6 @@ RSpec.describe Risc::SecurityEventsController do
       action
     end
 
-    it 'resets the user password for authorization fraud detected events' do
-      expect { action }.to(change { user.reload.encrypted_password_digest })
-    end
-
-    context 'for identity fraud events' do
-      let(:event_type) { SecurityEvent::IDENTITY_FRAUD_DETECTED }
-
-      it 'does not reset the user password' do
-        expect { action }.to_not(change { user.reload.encrypted_password_digest })
-      end
-    end
-
     context 'with a bad request' do
       before { jwt_payload[:aud] = 'http://bad.example' }
 

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -8,6 +8,15 @@ describe EventDecorator do
     it 'returns the localized event_type' do
       expect(decorator.event_type).to eq t('event_types.email_changed')
     end
+
+    context 'for an event type that interpolates the app name' do
+      let(:event) { build_stubbed(:event, event_type: :password_invalidated) }
+
+      it 'returns the localized event_type' do
+        expect(decorator.event_type).to eq t('event_types.password_invalidated', app_name: APP_NAME)
+        expect(decorator.event_type).to include(APP_NAME)
+      end
+    end
   end
 
   describe '#last_sign_in_location_and_ip' do

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -1,12 +1,62 @@
 require 'rails_helper'
 
 describe EventDecorator do
+  let(:event) { build_stubbed(:event, event_type: :email_changed) }
+  subject(:decorator) { EventDecorator.new(event) }
+
   describe '#event_type' do
     it 'returns the localized event_type' do
-      event = build_stubbed(:event, event_type: :email_changed)
-      decorator = EventDecorator.new(event)
-
       expect(decorator.event_type).to eq t('event_types.email_changed')
+    end
+
+    context 'for an event type that interpolates the app name' do
+      let(:event) { build_stubbed(:event, event_type: :password_invalidated) }
+
+      it 'returns the localized event_type' do
+        expect(decorator.event_type).to eq t('event_types.password_invalidated', app_name: APP_NAME)
+        expect(decorator.event_type).to include(APP_NAME)
+      end
+    end
+  end
+
+  describe '#last_sign_in_location_and_ip' do
+    let(:event) { build_stubbed(:event, event_type: :password_invalidated, ip: ip_address) }
+
+    context 'with an ip address' do
+      let(:ip_address) { '0.0.0.0' }
+
+      it 'is an approximate location' do
+        expect(decorator.last_sign_in_location_and_ip).
+          to eq('From 0.0.0.0 (IP address potentially located in United States)')
+      end
+    end
+
+    context 'with a blank ip address' do
+      let(:ip_address) { nil }
+
+      it 'is empty' do
+        expect(decorator.last_sign_in_location_and_ip).to eq('')
+      end
+    end
+  end
+
+  describe '#last_location' do
+    let(:event) { build_stubbed(:event, event_type: :password_invalidated, ip: ip_address) }
+
+    context 'with an ip address' do
+      let(:ip_address) { '0.0.0.0' }
+
+      it 'is the location' do
+        expect(decorator.last_location).to eq('United States')
+      end
+    end
+
+    context 'with a blank ip address' do
+      let(:ip_address) { nil }
+
+      it 'is empty' do
+        expect(decorator.last_location).to eq('')
+      end
     end
   end
 end

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -8,15 +8,6 @@ describe EventDecorator do
     it 'returns the localized event_type' do
       expect(decorator.event_type).to eq t('event_types.email_changed')
     end
-
-    context 'for an event type that interpolates the app name' do
-      let(:event) { build_stubbed(:event, event_type: :password_invalidated) }
-
-      it 'returns the localized event_type' do
-        expect(decorator.event_type).to eq t('event_types.password_invalidated', app_name: APP_NAME)
-        expect(decorator.event_type).to include(APP_NAME)
-      end
-    end
   end
 
   describe '#last_sign_in_location_and_ip' do

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -103,7 +103,6 @@ describe UserEventCreator do
     end
   end
 
-
   describe '#create_out_of_band_user_event' do
     let(:request) { nil }
     let(:event_type) { :password_invalidated }

--- a/spec/services/user_event_creator_spec.rb
+++ b/spec/services/user_event_creator_spec.rb
@@ -19,7 +19,7 @@ describe UserEventCreator do
   let(:device) { create(:device, user: user, cookie_uuid: existing_device_cookie) }
   let(:event_type) { 'account_created' }
 
-  subject { described_class.new(request, user) }
+  subject { UserEventCreator.new(request: request, current_user: user) }
 
   before do
     # Memoize user and device before specs run
@@ -100,6 +100,20 @@ describe UserEventCreator do
 
       expect(event.disavowal_token).to_not be_nil
       expect(event.disavowal_token_fingerprint).to_not be_nil
+    end
+  end
+
+
+  describe '#create_out_of_band_user_event' do
+    let(:request) { nil }
+    let(:event_type) { :password_invalidated }
+
+    it 'creates an event without a device and without an IP address' do
+      event = subject.create_out_of_band_user_event(event_type)
+
+      expect(event.event_type).to eq(event_type.to_s)
+      expect(event.ip).to be_blank
+      expect(event.device).to be_blank
     end
   end
 end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -135,14 +135,20 @@ describe 'accounts/show.html.erb' do
   context 'events' do
     let!(:event_without_ip) do
       create(:event, event_type: :password_invalidated,
-                     user: user, created_at: Time.zone.now - 30.days)
+                     user: user,
+                     ip: nil)
     end
 
     it 'contains user events' do
       render
 
-      expect(rendered).to have_content(event_without_ip.decorate.event_type)
-      expect(rendered).to_not have_content('IP address potentially located in')
+      page = Capybara.string(rendered)
+      events_section = page.find(
+        ".profile-info-box:contains('#{t('headings.account.account_history')}')"
+      )
+
+      expect(events_section).to have_content(event_without_ip.decorate.event_type)
+      expect(events_section).to_not have_content('IP address potentially located in')
     end
   end
 

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -139,12 +139,12 @@ describe 'accounts/show.html.erb' do
                      ip: nil)
     end
 
-    it 'contains user events' do
+    it 'contains user events that may not contain IP addresses' do
       render
 
       page = Capybara.string(rendered)
       events_section = page.find(
-        ".profile-info-box:contains('#{t('headings.account.account_history')}')"
+        ".profile-info-box:contains('#{t('headings.account.account_history')}')",
       )
 
       expect(events_section).to have_content(event_without_ip.decorate.event_type)

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -132,6 +132,20 @@ describe 'accounts/show.html.erb' do
     expect(rendered).to have_content t('headings.account.account_history')
   end
 
+  context 'events' do
+    let!(:event_without_ip) do
+      create(:event, event_type: :password_invalidated,
+                     user: user, created_at: Time.zone.now - 30.days)
+    end
+
+    it 'contains user events' do
+      render
+
+      expect(rendered).to have_content(event_without_ip.decorate.event_type)
+      expect(rendered).to_not have_content('IP address potentially located in')
+    end
+  end
+
   context 'connected apps' do
     it 'contains connected applications' do
       render


### PR DESCRIPTION
- Log this event when resetting a password in response
  to a RISC notification

(Based on feedback from @porta-antiporta)

In the account history section, it will look like this:

<img width="825" alt="Screen Shot 2020-09-03 at 2 44 49 PM" src="https://user-images.githubusercontent.com/458784/92178622-c8cffb80-edf7-11ea-9dc9-f750a84193a6.png">
