### PR TITLE
LG-3334: Support failure testing for document capture in development environments

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -75,29 +75,8 @@ module Idv
     def validate_image(image_key)
       file = params[image_key]
 
-      unless file.respond_to?(:content_type)
-        errors.add(image_key, t('doc_auth.errors.not_a_file'))
-        return
-      end
-
-      data = file.read
-      file.rewind
-
-      return if file.content_type.start_with?('image/') && data.present?
-      error = error_from_yaml(data) if !Rails.env.production? && yaml_file?(file)
-      error ||= t('doc_auth.errors.must_be_image')
-      errors.add(image_key, error)
-    end
-
-    def yaml_file?(file)
-      file.original_filename =~ /\.ya?ml$/
-    end
-
-    def error_from_yaml(data)
-      parsed_yaml = YAML.safe_load(data)
-      parsed_yaml.dig('friendly_error')
-    rescue Psych::SyntaxError
-      nil
+      return if file.respond_to?(:read)
+      errors.add(image_key, t('doc_auth.errors.not_a_file'))
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -84,7 +84,20 @@ module Idv
       file.rewind
 
       return if file.content_type.start_with?('image/') && data.present?
-      errors.add(image_key, t('doc_auth.errors.must_be_image'))
+      error = error_from_yaml(data) if !Rails.env.production? && yaml_file?(file)
+      error ||= t('doc_auth.errors.must_be_image')
+      errors.add(image_key, error)
+    end
+
+    def yaml_file?(file)
+      file.original_filename =~ /\.ya?ml$/
+    end
+
+    def error_from_yaml(data)
+      parsed_yaml = YAML.safe_load(data)
+      parsed_yaml.dig('friendly_error')
+    rescue Psych::SyntaxError
+      nil
     end
   end
 end

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -15,6 +15,7 @@ import Button from './button';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import FileBase64CacheContext from '../context/file-base64-cache';
+import UploadContext from '../context/upload';
 
 /** @typedef {import('react').ReactNode} ReactNode */
 
@@ -52,15 +53,6 @@ const ACCEPTABLE_SHARPNESS_SCORE = 50;
  * @type {number}
  */
 export const ACCEPTABLE_FILE_SIZE_BYTES = 250 * 1024;
-
-/**
- * Returns attribute value to assign to the input field, depending on the current environment.
- *
- * @return {string[]=} Minimum file size, in bytes.
- */
-export function getInputAccept() {
-  return process.env.NODE_ENV === 'production' ? ['image/*'] : undefined;
-}
 
 /**
  * Given a file, returns minimum acceptable file size in bytes, depending on the type of file and
@@ -112,6 +104,7 @@ function AcuantCapture(
 ) {
   const fileCache = useContext(FileBase64CacheContext);
   const { isReady, isError, isCameraSupported } = useContext(AcuantContext);
+  const { isMockClient } = useContext(UploadContext);
   const inputRef = useRef(/** @type {?HTMLInputElement} */ (null));
   const isForceUploading = useRef(false);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -226,7 +219,7 @@ function AcuantCapture(
         label={label}
         hint={hasCapture || !allowUpload ? undefined : t('doc_auth.tips.document_capture_hint')}
         bannerText={bannerText}
-        accept={getInputAccept()}
+        accept={isMockClient ? undefined : ['image/*']}
         capture={capture}
         value={value}
         errorMessage={ownErrorMessage ?? errorMessage}

--- a/app/javascript/packages/document-capture/components/submission.jsx
+++ b/app/javascript/packages/document-capture/components/submission.jsx
@@ -17,7 +17,7 @@ import CallbackOnMount from './callback-on-mount';
  * @param {SubmissionProps} props Props object.
  */
 function Submission({ payload, onError }) {
-  const upload = useContext(UploadContext);
+  const { upload } = useContext(UploadContext);
   const resource = useAsync(upload, payload);
 
   return (

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -1,7 +1,10 @@
-import React, { createContext } from 'react';
+import React, { createContext, useMemo } from 'react';
 import defaultUpload from '../services/upload';
 
-const UploadContext = createContext(defaultUpload);
+const UploadContext = createContext({
+  upload: defaultUpload,
+  isMockClient: false,
+});
 
 /** @typedef {import('react').ReactNode} ReactNode */
 
@@ -45,6 +48,7 @@ const UploadContext = createContext(defaultUpload);
  * @typedef UploadContextProviderProps
  *
  * @prop {UploadImplementation=} upload Custom upload implementation.
+ * @prop {boolean=} isMockClient Whether to treat upload as a mock implementation.
  * @prop {string} endpoint Endpoint to which payload should be sent.
  * @prop {string} csrf CSRF token to send as parameter to upload implementation.
  * @prop {Record<string,any>} formData Extra form data to merge into the payload before uploading
@@ -54,10 +58,18 @@ const UploadContext = createContext(defaultUpload);
 /**
  * @param {UploadContextProviderProps} props Props object.
  */
-function UploadContextProvider({ upload = defaultUpload, endpoint, csrf, formData, children }) {
+function UploadContextProvider({
+  upload = defaultUpload,
+  isMockClient = false,
+  endpoint,
+  csrf,
+  formData,
+  children,
+}) {
   const uploadWithCSRF = (payload) => upload({ ...payload, ...formData }, { endpoint, csrf });
+  const value = useMemo(() => ({ upload: uploadWithCSRF, isMockClient }), [upload, isMockClient]);
 
-  return <UploadContext.Provider value={uploadWithCSRF}>{children}</UploadContext.Provider>;
+  return <UploadContext.Provider value={value}>{children}</UploadContext.Provider>;
 }
 
 export default UploadContext;

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -27,6 +27,7 @@ document.body.classList.add('js-skip-form-validation');
 loadPolyfills(['fetch']).then(() => {
   const appRoot = document.getElementById('document-capture-form');
   const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
+  const isMockClient = appRoot.hasAttribute('data-mock-client');
 
   render(
     <AcuantProvider
@@ -36,6 +37,7 @@ loadPolyfills(['fetch']).then(() => {
       <UploadContextProvider
         endpoint={appRoot.getAttribute('data-endpoint')}
         csrf={getMetaContent('csrf-token')}
+        isMockClient={isMockClient}
         formData={{
           document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
           locale: i18n.currentLocale(),

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -12,6 +12,7 @@
   <% end %>
   <%= tag.div id: 'document-capture-form', data: {
     liveness: liveness_checking_enabled?.presence,
+    mock_client: (DocAuth::Client.doc_auth_vendor == 'mock').presence,
     document_capture_session_uuid: flow_session[:document_capture_session_uuid],
     endpoint: api_verify_images_url
   } %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -13,7 +13,6 @@ en:
       upload_picture: Upload a photo
       use_phone: Use your phone
     errors:
-      must_be_image: File must be an image
       not_a_file: The selection was not a valid file
     forms:
       address1: Address

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -13,7 +13,6 @@ es:
       upload_picture: Sube una foto
       use_phone: Usa tu telefono
     errors:
-      must_be_image: El archivo debe ser una imagen
       not_a_file: La selección no era un archivo válido
     forms:
       address1: Dirección

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -13,7 +13,6 @@ fr:
       upload_picture: Télécharger une photo
       use_phone: Utilisez votre téléphone
     errors:
-      must_be_image: Le fichier doit être une image
       not_a_file: La sélection n'était pas un fichier valide
     forms:
       address1: Adresse

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -106,7 +106,10 @@ describe Idv::ImageUploadsController do
 
             json = JSON.parse(response.body, symbolize_names: true)
             expect(json[:errors]).to eq [
-              { field: 'front', message: I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read') },
+              {
+                field: 'front',
+                message: I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read'),
+              },
             ]
           end
         end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -52,25 +52,90 @@ describe Idv::ImageUploadsController do
       context 'when a value is not a file' do
         before { params.merge!(front: 'some string') }
 
-        it 'returns an error' do
-          action
-
-          json = JSON.parse(response.body, symbolize_names: true)
-          expect(json[:errors]).to eq [
-            { field: 'front', message: I18n.t('doc_auth.errors.not_a_file') },
-          ]
-        end
-
-        context 'with a locale param' do
-          before { params.merge!(locale: 'es') }
-
-          it 'translates errors using the locale param' do
+        shared_examples 'failed non-file response' do
+          it 'returns an error' do
             action
 
             json = JSON.parse(response.body, symbolize_names: true)
             expect(json[:errors]).to eq [
-              { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
+              { field: 'front', message: I18n.t('doc_auth.errors.not_a_file') },
             ]
+          end
+
+          context 'with a locale param' do
+            before { params.merge!(locale: 'es') }
+
+            it 'translates errors using the locale param' do
+              action
+
+              json = JSON.parse(response.body, symbolize_names: true)
+              expect(json[:errors]).to eq [
+                { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
+              ]
+            end
+          end
+        end
+
+        context 'development' do
+          before do
+            allow(Rails.env).to receive(:production?).and_return(false)
+          end
+
+          it_behaves_like 'failed non-file response'
+        end
+
+        context 'production' do
+          before do
+            allow(Rails.env).to receive(:production?).and_return(true)
+          end
+
+          it_behaves_like 'failed non-file response'
+        end
+      end
+
+      context 'when a value is an error-formatted yaml file' do
+        before { params.merge!(front: DocAuthImageFixtures.error_yaml_multipart) }
+
+        context 'development' do
+          before do
+            allow(Rails.env).to receive(:production?).and_return(false)
+          end
+
+          it 'returns error from yaml file' do
+            action
+
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:errors]).to eq [
+              { field: 'front', message: I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read') },
+            ]
+          end
+        end
+
+        context 'production' do
+          before do
+            allow(Rails.env).to receive(:production?).and_return(true)
+          end
+
+          it 'returns non-image error' do
+            action
+
+            json = JSON.parse(response.body, symbolize_names: true)
+            expect(json[:errors]).to eq [
+              { field: 'front', message: I18n.t('doc_auth.errors.must_be_image') },
+            ]
+          end
+
+          context 'with a locale param' do
+            before { params.merge!(locale: 'es') }
+
+            it 'translates errors using the locale param' do
+              action
+
+              json = JSON.parse(response.body, symbolize_names: true)
+              expect(json[:errors]).to eq [
+                { field: 'front', message: I18n.t('doc_auth.errors.must_be_image', locale: 'es') },
+              ]
+            end
           end
         end
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -59,33 +59,6 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
-    context 'when file does not have an image content type' do
-      let(:tempfile) do
-        Tempfile.new.tap do |f|
-          f.write('test')
-          f.close
-        end
-      end
-      let(:selfie_image) { Rack::Test::UploadedFile.new(tempfile.path, 'text/plain') }
-
-      it 'is not valid' do
-        expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['File must be an image'])
-      end
-    end
-
-    context 'when file is empty' do
-      let(:tempfile) { Tempfile.new }
-      let(:selfie_image) { Rack::Test::UploadedFile.new(tempfile.path, 'image/jpeg') }
-
-      it 'is not valid' do
-        expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['File must be an image'])
-      end
-
-      after { tempfile.unlink }
-    end
-
     context 'when document_capture_session_uuid param is missing' do
       let(:document_capture_session_uuid) { nil }
 

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { waitForElementToBeRemoved } from '@testing-library/dom';
 import sinon from 'sinon';
 import AcuantCapture, {
-  getInputAccept,
   getMinimumFileSize,
   ACCEPTABLE_FILE_SIZE_BYTES,
 } from '@18f/identity-document-capture/components/acuant-capture';
@@ -18,38 +17,6 @@ import { useSandbox } from '../../../support/sinon';
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
   const sandbox = useSandbox();
-
-  describe('getInputAccept', () => {
-    context('NODE_ENV=production', () => {
-      beforeEach(() => {
-        sandbox.stub(process.env, 'NODE_ENV').value('production');
-      });
-
-      it('returns array', () => {
-        expect(getInputAccept()).to.be.instanceOf(Array);
-      });
-    });
-
-    context('NODE_ENV=test', () => {
-      beforeEach(() => {
-        sandbox.stub(process.env, 'NODE_ENV').value('test');
-      });
-
-      it('returns undefined', () => {
-        expect(getInputAccept()).to.be.undefined();
-      });
-    });
-
-    context('NODE_ENV=development', () => {
-      beforeEach(() => {
-        sandbox.stub(process.env, 'NODE_ENV').value('development');
-      });
-
-      it('returns undefined', () => {
-        expect(getInputAccept()).to.be.undefined();
-      });
-    });
-  });
 
   describe('getMinimumFileSize', () => {
     it('returns zero for non-image file', () => {
@@ -357,14 +324,13 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('shows at most one error message between AcuantCapture and FileInput', async () => {
-      sandbox.stub(process.env, 'NODE_ENV').value('production');
-
       const { getByLabelText, getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
             <AcuantCapture label="Image" />
           </AcuantContextProvider>
         </DeviceContext.Provider>,
+        { isMockClient: false },
       );
 
       initialize({
@@ -660,12 +626,11 @@ describe('document-capture/components/acuant-capture', () => {
   });
 
   it('restricts accepted file types', () => {
-    sandbox.stub(process.env, 'NODE_ENV').value('production');
-
     const { getByLabelText } = render(
       <AcuantContextProvider sdkSrc="about:blank">
         <AcuantCapture label="Image" capture="environment" />
       </AcuantContextProvider>,
+      { isMockClient: false },
     );
 
     const input = getByLabelText('Image');

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -3,15 +3,65 @@ import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitForElementToBeRemoved } from '@testing-library/dom';
 import sinon from 'sinon';
-import AcuantCapture from '@18f/identity-document-capture/components/acuant-capture';
+import AcuantCapture, {
+  getInputAccept,
+  getMinimumFileSize,
+  ACCEPTABLE_FILE_SIZE_BYTES,
+} from '@18f/identity-document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import I18nContext from '@18f/identity-document-capture/context/i18n';
 import render from '../../../support/render';
 import { useAcuant } from '../../../support/acuant';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
+  const sandbox = useSandbox();
+
+  describe('getInputAccept', () => {
+    context('NODE_ENV=production', () => {
+      beforeEach(() => {
+        sandbox.stub(process.env, 'NODE_ENV').value('production');
+      });
+
+      it('returns array', () => {
+        expect(getInputAccept()).to.be.instanceOf(Array);
+      });
+    });
+
+    context('NODE_ENV=test', () => {
+      beforeEach(() => {
+        sandbox.stub(process.env, 'NODE_ENV').value('test');
+      });
+
+      it('returns undefined', () => {
+        expect(getInputAccept()).to.be.undefined();
+      });
+    });
+
+    context('NODE_ENV=development', () => {
+      beforeEach(() => {
+        sandbox.stub(process.env, 'NODE_ENV').value('development');
+      });
+
+      it('returns undefined', () => {
+        expect(getInputAccept()).to.be.undefined();
+      });
+    });
+  });
+
+  describe('getMinimumFileSize', () => {
+    it('returns zero for non-image file', () => {
+      const file = new window.File([], 'file.yml', { type: 'application/x-yaml' });
+      expect(getMinimumFileSize(file)).to.equal(0);
+    });
+
+    it('returns non-zero for image file', () => {
+      const file = new window.File([], 'file.png', { type: 'image/png' });
+      expect(getMinimumFileSize(file)).to.be.gt(0);
+    });
+  });
 
   context('mobile', () => {
     it('renders with assumed capture button support while acuant is not ready and on mobile', () => {
@@ -146,6 +196,8 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('calls onChange with the captured image on successful capture', async () => {
+      sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
+
       const onChange = sinon.mock();
       const { getByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
@@ -305,6 +357,8 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('shows at most one error message between AcuantCapture and FileInput', async () => {
+      sandbox.stub(process.env, 'NODE_ENV').value('production');
+
       const { getByLabelText, getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
@@ -343,6 +397,8 @@ describe('document-capture/components/acuant-capture', () => {
     });
 
     it('removes error message once image is corrected', async () => {
+      sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
+
       const { getByText, findByText } = render(
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AcuantContextProvider sdkSrc="about:blank">
@@ -601,5 +657,19 @@ describe('document-capture/components/acuant-capture', () => {
 
     expect(defaultPrevented).to.be.false();
     expect(window.AcuantCameraUI.start.called).to.be.false();
+  });
+
+  it('restricts accepted file types', () => {
+    sandbox.stub(process.env, 'NODE_ENV').value('production');
+
+    const { getByLabelText } = render(
+      <AcuantContextProvider sdkSrc="about:blank">
+        <AcuantCapture label="Image" capture="environment" />
+      </AcuantContextProvider>,
+    );
+
+    const input = getByLabelText('Image');
+
+    expect(input.getAttribute('accept')).to.equal('image/*');
   });
 });

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { fireEvent } from '@testing-library/react';
+import { ACCEPTABLE_FILE_SIZE_BYTES } from '@18f/identity-document-capture/components/acuant-capture';
 import { UploadFormEntriesError } from '@18f/identity-document-capture/services/upload';
 import { AcuantProvider, DeviceContext } from '@18f/identity-document-capture';
 import DocumentCapture, {
@@ -9,9 +10,11 @@ import DocumentCapture, {
 } from '@18f/identity-document-capture/components/document-capture';
 import render from '../../../support/render';
 import { useAcuant } from '../../../support/acuant';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/document-capture', () => {
   const { initialize } = useAcuant();
+  const sandbox = useSandbox();
 
   function isFormValid(form) {
     return [...form.querySelectorAll('input')].every((input) => input.checkValidity());
@@ -21,6 +24,8 @@ describe('document-capture/components/document-capture', () => {
 
   beforeEach(() => {
     originalHash = window.location.hash;
+    sandbox.stub(process.env, 'NODE_ENV').value('production');
+    sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
   });
 
   afterEach(() => {

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -24,7 +24,6 @@ describe('document-capture/components/document-capture', () => {
 
   beforeEach(() => {
     originalHash = window.location.hash;
-    sandbox.stub(process.env, 'NODE_ENV').value('production');
     sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
   });
 

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -58,15 +58,6 @@ describe('document-capture/components/documents-step', () => {
     expect(onChange.getCall(0).args[0]).to.deep.equal({ front: file });
   });
 
-  it('restricts accepted file types', () => {
-    const onChange = sinon.spy();
-    const { getByLabelText } = render(<DocumentsStep onChange={onChange} />);
-
-    const input = getByLabelText('doc_auth.headings.document_capture_front');
-
-    expect(input.getAttribute('accept')).to.equal('image/*');
-  });
-
   it('renders device-specific instructions', () => {
     let { getByText } = render(
       <DeviceContext.Provider value={{ isMobile: true }}>

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
+import { ACCEPTABLE_FILE_SIZE_BYTES } from '@18f/identity-document-capture/components/acuant-capture';
 import DeviceContext from '@18f/identity-document-capture/context/device';
 import DocumentsStep, { validate } from '@18f/identity-document-capture/components/documents-step';
 import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
 import render from '../../../support/render';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/documents-step', () => {
+  const sandbox = useSandbox();
+
+  beforeEach(() => {
+    sandbox.stub(process.env, 'NODE_ENV').value('production');
+    sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
+  });
+
   describe('validate', () => {
     it('returns errors if both front and back are unset', () => {
       const value = {};

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -12,7 +12,6 @@ describe('document-capture/components/documents-step', () => {
   const sandbox = useSandbox();
 
   beforeEach(() => {
-    sandbox.stub(process.env, 'NODE_ENV').value('production');
     sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
   });
 

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -35,13 +35,4 @@ describe('document-capture/components/selfie-step', () => {
 
     expect(onChange.getCall(0).args[0]).to.deep.equal({ selfie: file });
   });
-
-  it('restricts accepted file types', () => {
-    const onChange = sinon.spy();
-    const { getByLabelText } = render(<SelfieStep onChange={onChange} />);
-
-    const input = getByLabelText('doc_auth.headings.document_capture_selfie');
-
-    expect(input.getAttribute('accept')).to.equal('image/*');
-  });
 });

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
+import { ACCEPTABLE_FILE_SIZE_BYTES } from '@18f/identity-document-capture/components/acuant-capture';
 import SelfieStep, { validate } from '@18f/identity-document-capture/components/selfie-step';
 import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
 import render from '../../../support/render';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/selfie-step', () => {
+  const sandbox = useSandbox();
+
+  beforeEach(() => {
+    sandbox.stub(process.env, 'NODE_ENV').value('production');
+    sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
+  });
+
   describe('validate', () => {
     it('returns object with error if selfie is unset', () => {
       const value = {};

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -11,7 +11,6 @@ describe('document-capture/components/selfie-step', () => {
   const sandbox = useSandbox();
 
   beforeEach(() => {
-    sandbox.stub(process.env, 'NODE_ENV').value('production');
     sandbox.stub(window.Blob.prototype, 'size').value(ACCEPTABLE_FILE_SIZE_BYTES);
   });
 

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -10,8 +10,9 @@ describe('document-capture/context/upload', () => {
   it('defaults to the default upload service', () => {
     baseRender(
       createElement(() => {
-        const upload = useContext(UploadContext);
+        const { upload, isMockClient } = useContext(UploadContext);
         expect(upload).to.equal(defaultUpload);
+        expect(isMockClient).to.equal(false);
         return null;
       }),
     );
@@ -21,13 +22,25 @@ describe('document-capture/context/upload', () => {
     render(
       <UploadContextProvider upload={(payload) => Promise.resolve({ ...payload, received: true })}>
         {createElement(() => {
-          const upload = useContext(UploadContext);
+          const { upload } = useContext(UploadContext);
           useEffect(() => {
             upload({ sent: true }).then((result) => {
               expect(result).to.deep.equal({ sent: true, received: true });
               done();
             });
           }, [upload]);
+          return null;
+        })}
+      </UploadContextProvider>,
+    );
+  });
+
+  it('can be overridden with isMockClient value', () => {
+    render(
+      <UploadContextProvider isMockClient>
+        {createElement(() => {
+          const { isMockClient } = useContext(UploadContext);
+          expect(isMockClient).to.equal(true);
           return null;
         })}
       </UploadContextProvider>,
@@ -48,7 +61,7 @@ describe('document-capture/context/upload', () => {
         endpoint="https://example.com"
       >
         {createElement(() => {
-          const upload = useContext(UploadContext);
+          const { upload } = useContext(UploadContext);
           useEffect(() => {
             upload({ sent: true }).then((result) => {
               expect(result).to.deep.equal({
@@ -72,7 +85,7 @@ describe('document-capture/context/upload', () => {
         formData={{ foo: 'bar' }}
       >
         {createElement(() => {
-          const upload = useContext(UploadContext);
+          const { upload } = useContext(UploadContext);
           useEffect(() => {
             upload({ sent: true }).then((result) => {
               expect(result).to.deep.equal({

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -18,7 +18,5 @@ global.document = window.document;
 global.getComputedStyle = window.getComputedStyle;
 global.self = window;
 
-process.env.ACUANT_MINIMUM_FILE_SIZE = '0';
-
 useCleanDOM();
 useConsoleLogSpy();

--- a/spec/javascripts/support/render.jsx
+++ b/spec/javascripts/support/render.jsx
@@ -9,6 +9,7 @@ import { UploadContextProvider } from '@18f/identity-document-capture';
  * @typedef RenderOptions
  *
  * @prop {Error=} uploadError Whether to simulate upload failure.
+ * @prop {boolean=} isMockClient Whether to treat upload as a mock implementation.
  * @prop {number=} expectedUploads Number of times upload is expected to be called. Defaults to `1`.
  */
 
@@ -24,7 +25,7 @@ import { UploadContextProvider } from '@18f/identity-document-capture';
  * @return {import('@testing-library/react').RenderResult}
  */
 function renderWithDefaultContext(element, options = {}) {
-  const { uploadError, expectedUploads = 1, ...baseRenderOptions } = options;
+  const { uploadError, expectedUploads = 1, isMockClient = true, ...baseRenderOptions } = options;
 
   const upload = sinon
     .stub()
@@ -41,7 +42,9 @@ function renderWithDefaultContext(element, options = {}) {
   return render(element, {
     ...baseRenderOptions,
     wrapper: ({ children }) => (
-      <UploadContextProvider upload={upload}>{children}</UploadContextProvider>
+      <UploadContextProvider upload={upload} isMockClient={isMockClient}>
+        {children}
+      </UploadContextProvider>
     ),
   });
 }

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -31,6 +31,14 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(fixture_path('selfie.jpg'), 'image/jpeg')
   end
 
+  def self.error_yaml_multipart
+    path = File.join(
+      File.dirname(__FILE__),
+      '../fixtures/ial2_test_credential_forces_error.yml',
+    )
+    Rack::Test::UploadedFile.new(path, Mime[:yaml])
+  end
+
   def self.fixture_path(filename)
     File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
**Why**: As a developer, I expect that I can upload files which simulate expected failures which can occur during document capture, so that I can reliably test non-happy-path flows.

Relevant documentation: https://developers.login.gov/testing/#data-testing

**Screenshot:**

![Screen Shot 2020-09-09 at 5 58 21 PM](https://user-images.githubusercontent.com/1779930/92659393-4bf4c400-f2c6-11ea-9e57-d9712d2a40b4.png)

**Implementation Notes:**

There are a few possible alternatives I considered trying with the image upload API implementation:

- Reuse [`DocAuth::Mock::ResultResponseBuilder`](https://github.com/18F/identity-idp/blob/master/app/services/doc_auth/mock/result_response_builder.rb) for parsing the errors.
   - Opted not to because: feels very client-implementation-specific, and the response builder handles much more than simply error handling.
- Detect whether to allow YAML upload via other factor (e.g. `DocAuth::Client.client.is_a? DocAuth::Mock::DocAuthMockClient`, `Figaro.env.doc_auth_vendor == 'mock'`, etc)
  - Opted not to because: for consistency with client-side implementation, which should be the same, and where we may not want to expose these environment variables in raw form. And because [the testing documentation](https://developers.login.gov/testing/) makes delineation on production vs. non-production