### PR TITLE
Parse negative numbers in Acuant birthdays

### DIFF
--- a/app/services/doc_auth/acuant/pii_from_doc.rb
+++ b/app/services/doc_auth/acuant/pii_from_doc.rb
@@ -30,7 +30,7 @@ module DocAuth
         hash
       end
 
-      ACUANT_TIMESTAMP_FORMAT = %r{/Date\((?<milliseconds>\d+)\)/}.freeze
+      ACUANT_TIMESTAMP_FORMAT = %r{/Date\((?<milliseconds>-?\d+)\)/}.freeze
 
       # @api private
       def convert_date(date)

--- a/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
+++ b/spec/services/doc_auth/acuant/pii_from_doc_spec.rb
@@ -30,6 +30,10 @@ describe DocAuth::Acuant::PiiFromDoc do
       expect(pii_from_doc.convert_date('/Date(449625600000)/')).to eq('04/01/1984')
     end
 
+    it 'parses and formats negative numbers' do
+      expect(pii_from_doc.convert_date('/Date(-985824000000)/')).to eq('10/06/1938')
+    end
+
     it 'is nil for a bad format' do
       expect(pii_from_doc.convert_date('/Foobar(111111)/')).to eq(nil)
     end


### PR DESCRIPTION
**Why**: these are how timestamps before the Unix epoch
are encoded

(bug discovered in staging)