### PR TITLE
Remove docker branch builds, leave "build-release-container"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,12 +259,6 @@ workflows:
     jobs:
       - build
       - lints
-      - build-latest-dev-container:
-          requires:
-            - build
-      - build-latest-container:
-          requires:
-            - build
       - build-release-container:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,32 +184,6 @@ jobs:
             bundle exec rubocop
             bundle exec slim-lint app/views
             make check_asset_strings
-  build-latest-container:
-    working_directory: ~/identity-idp
-    docker:
-      - image: circleci/ruby:2.6
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: |
-          rev=$(git rev-parse --short HEAD)
-          docker build -t logindotgov/idp:latest -t logindotgov/idp:"${rev}" -f production.Dockerfile .
-          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-          docker push logindotgov/idp:"${rev}"
-          docker push logindotgov/idp:latest
-  build-latest-dev-container:
-    working_directory: ~/identity-idp
-    docker:
-      - image: circleci/ruby:2.6
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: |
-          rev=$(git rev-parse --short HEAD)
-          docker build -t logindotgov/dev:latest -t logindotgov/dev:"${rev}" -f development.Dockerfile .
-          echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-          docker push logindotgov/dev:"${rev}"
-          docker push logindotgov/dev:latest
   build-release-container:
     working_directory: ~/identity-idp
     docker:


### PR DESCRIPTION
Checked with @pauldoomgov, the branch builds aren't used but the release one is