### PR TITLE
LG-3118 Fix bugs discovered while testing AAL3 flows

### DIFF
--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -95,6 +95,7 @@ module Users
       handle_remember_device
       Funnel::Registration::AddMfa.call(current_user.id, 'webauthn')
       flash[:success] = t('notices.webauthn_configured')
+      user_session[:auth_method] = 'webauthn'
       redirect_to after_mfa_setup_path
     end
 

--- a/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/piv_cac_authentication_presenter.rb
@@ -60,9 +60,9 @@ module TwoFactorAuthCode
     def fallback_question
       return if @hide_fallback_question
       if service_provider_mfa_policy.allow_user_to_switch_method?
-        ''
-      else
         t('two_factor_authentication.piv_cac_fallback.question')
+      else
+        ''
       end
     end
 

--- a/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
+++ b/app/presenters/two_factor_auth_code/webauthn_authentication_presenter.rb
@@ -57,9 +57,9 @@ module TwoFactorAuthCode
 
     def fallback_question
       if service_provider_mfa_policy.allow_user_to_switch_method?
-        ''
-      else
         t('two_factor_authentication.webauthn_fallback.question')
+      else
+        ''
       end
     end
   end

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'webauthn sign up' do
+  include OidcAuthHelper
   include WebAuthnHelper
 
   let!(:user) { sign_up_and_set_password }
@@ -21,4 +22,20 @@ feature 'webauthn sign up' do
   end
 
   it_behaves_like 'webauthn setup'
+
+  describe 'AAL3 setup' do
+    it 'marks the session AAL3 on setup and does not require authentication' do
+      mock_webauthn_setup_challenge
+
+      visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
+      select_2fa_option('webauthn', visible: :all)
+
+      expect(current_path).to eq webauthn_setup_path
+
+      fill_in_nickname_and_click_continue
+      mock_press_button_on_hardware_key_on_setup
+
+      expect(current_path).to eq(sign_up_completed_path)
+    end
+  end
 end

--- a/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/piv_cac_authentication_presenter_spec.rb
@@ -76,6 +76,26 @@ describe TwoFactorAuthCode::PivCacAuthenticationPresenter do
     end
   end
 
+  describe '#fallback_question' do
+    context 'when the user can switch to a different method' do
+      let(:allow_user_to_switch_method) { true }
+
+      it 'returns a question about switching methods' do
+        expect(presenter.fallback_question).to eq(
+          t('two_factor_authentication.piv_cac_fallback.question'),
+        )
+      end
+    end
+
+    context 'when the user cannot switch to a different method' do
+      let(:allow_user_to_switch_method) { false }
+
+      it 'returns an empty string' do
+        expect(presenter.fallback_question).to eq('')
+      end
+    end
+  end
+
   describe '#piv_cac_capture_text' do
     let(:expected_text) { t('forms.piv_cac_mfa.submit') }
 

--- a/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/webauthn_authentication_presenter_spec.rb
@@ -50,7 +50,7 @@ describe TwoFactorAuthCode::WebauthnAuthenticationPresenter do
   end
 
   describe '#fallback_question' do
-    let(:aal3_required) { false }
+    let(:allow_user_to_switch_method) { true }
 
     it 'supplies a fallback_question' do
       expect(presenter.fallback_question).to \


### PR DESCRIPTION
This commit fixes 2 bugs:

1.) The WebAuthn setup was not marking the session as AAL3, so the user was needed to interact with their token twice
2.) The "Don't have your <method>" text was appearing on the PIV/WebAuthn verification screen when the user did not have an option to change methods