### PR TITLE
LG-3342: Rate limit image uploads during doc auth API response

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -44,17 +44,15 @@ module Idv
 
     def render_form_response(form_response, status = nil)
       if form_response.success?
-        status ||= :ok
         render json: { success: true },
-               status: status
+               status: status || :ok
       else
-        status ||= :bad_request
         errors = form_response.errors.flat_map do |key, errs|
           Array(errs).map { |err| { field: key, message: err } }
         end
 
         render json: form_response.to_h.merge(errors: errors),
-               status: status
+               status: status || :bad_request
       end
     end
 

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -52,8 +52,8 @@ module Idv
           Array(errs).map { |err| { field: key, message: err } }
         end
 
-        render json: form_response.to_h.merge(errors: errors),
-               status: :bad_request
+        render json: form_response.to_h.except(:status).merge(errors: errors),
+               status: form_response.extra.fetch(:status, :bad_request)
       end
     end
 

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -10,19 +10,26 @@ module Idv
       form_response = image_form.submit
 
       if form_response.success?
-        doc_response = doc_auth_client.post_images(
+        client_response = doc_auth_client.post_images(
           front_image: image_form.front.read,
           back_image: image_form.back.read,
           selfie_image: image_form.selfie&.read,
           liveness_checking_enabled: liveness_checking_enabled?,
         )
 
-        store_pii(doc_response) if doc_response.success?
-
-        render_form_response(doc_response)
+        store_pii(client_response) if client_response.success?
+        status = :bad_request unless client_response.success?
       else
-        render_form_response(form_response, image_form.status)
+        status = image_form.status
       end
+
+      presenter = ImageUploadResponsePresenter.new(
+        form: image_form,
+        form_response: client_response || form_response,
+      )
+
+      render json: presenter,
+             status: status || :ok
     end
 
     private
@@ -40,20 +47,6 @@ module Idv
 
     def store_pii(doc_response)
       image_form.document_capture_session.store_result_from_response(doc_response)
-    end
-
-    def render_form_response(form_response, status = nil)
-      if form_response.success?
-        render json: { success: true },
-               status: status || :ok
-      else
-        errors = form_response.errors.flat_map do |key, errs|
-          Array(errs).map { |err| { field: key, message: err } }
-        end
-
-        render json: form_response.to_h.merge(errors: errors),
-               status: status || :bad_request
-      end
     end
 
     def doc_auth_client

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -21,7 +21,7 @@ module Idv
 
         render_form_response(doc_response)
       else
-        render_form_response(form_response)
+        render_form_response(form_response, image_form.status)
       end
     end
 
@@ -42,18 +42,19 @@ module Idv
       image_form.document_capture_session.store_result_from_response(doc_response)
     end
 
-    def render_form_response(form_response)
+    def render_form_response(form_response, status = nil)
       if form_response.success?
-        render json: {
-          success: true,
-        }
+        status ||= :ok
+        render json: { success: true },
+               status: status
       else
+        status ||= :bad_request
         errors = form_response.errors.flat_map do |key, errs|
           Array(errs).map { |err| { field: key, message: err } }
         end
 
-        render json: form_response.to_h.except(:status).merge(errors: errors),
-               status: form_response.extra.fetch(:status, :bad_request)
+        render json: form_response.to_h.merge(errors: errors),
+               status: status
       end
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -23,6 +23,8 @@ module Idv
     end
 
     def submit
+      throttled_else_increment
+
       FormResponse.new(
         success: valid?,
         errors: errors.messages,
@@ -81,12 +83,12 @@ module Idv
     attr_reader :params
 
     def throttle_if_rate_limited
-      return unless document_capture_session && throttled_else_increment
+      return unless @throttled
       errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 
     def throttled_else_increment
-      @throttled ||= Throttler::IsThrottledElseIncrement.call(
+      @throttled = Throttler::IsThrottledElseIncrement.call(
         document_capture_session.user_id,
         :idv_acuant,
       )

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -27,7 +27,6 @@ module Idv
         success: valid?,
         errors: errors.messages,
         extra: {
-          status: status,
           remaining_attempts: remaining_attempts,
         },
       )

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -86,7 +86,10 @@ module Idv
     end
 
     def throttled_else_increment
-      Throttler::IsThrottledElseIncrement.call(document_capture_session.user_id, :idv_acuant)
+      @throttled ||= Throttler::IsThrottledElseIncrement.call(
+        document_capture_session.user_id,
+        :idv_acuant,
+      )
     end
 
     def validate_images

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -41,7 +41,6 @@ module Idv
     end
 
     def remaining_attempts
-      return if valid?
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end
 

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -1,0 +1,28 @@
+class ImageUploadResponsePresenter
+  def initialize(form:, form_response:)
+    @form = form
+    @form_response = form_response
+  end
+
+  def success
+    @form_response.success?
+  end
+
+  def errors
+    @form_response.errors.flat_map do |key, errs|
+      Array(errs).map { |err| { field: key, message: err } }
+    end
+  end
+
+  def remaining_attempts
+    @form.remaining_attempts
+  end
+
+  def as_json(*)
+    {
+      success: success,
+      errors: errors,
+      remaining_attempts: remaining_attempts,
+    }
+  end
+end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -95,7 +95,7 @@ describe Idv::ImageUploadsController do
         end
 
         it 'returns an error when throttled' do
-          allow(Throttler::IsThrottledElseIncrement).to receive(:call).and_return(true)
+          allow(Throttler::IsThrottledElseIncrement).to receive(:call).once.and_return(true)
           allow(Throttler::RemainingCount).to receive(:call).and_return(0)
 
           action

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -141,6 +141,7 @@ describe Idv::ImageUploadsController do
           json = JSON.parse(response.body, symbolize_names: true)
           expect(response.status).to eq(400)
           expect(json[:success]).to eq(false)
+          expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
           expect(json[:errors]).to eq [
             { field: 'front', message: 'Too blurry' },
             { field: 'front', message: 'Wrong document' },
@@ -155,6 +156,7 @@ describe Idv::ImageUploadsController do
           action
 
           json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
           expect(json[:errors]).to eq [
             {
               field: 'results',

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
     context 'when throttled' do
       before do
-        allow(Throttler::IsThrottledElseIncrement).to receive(:call).and_return(true)
+        allow(Throttler::IsThrottledElseIncrement).to receive(:call).once.and_return(true)
       end
 
       it 'is not valid' do

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -76,5 +76,16 @@ RSpec.describe Idv::ApiImageUploadForm do
         expect(form.errors[:document_capture_session]).to eq(['Please fill in this field.'])
       end
     end
+
+    context 'when throttled' do
+      before do
+        allow(Throttler::IsThrottledElseIncrement).to receive(:call).and_return(true)
+      end
+
+      it 'is not valid' do
+        expect(form.valid?).to eq(false)
+        expect(form.errors[:limit]).to eq([I18n.t('errors.doc_auth.acuant_throttle')])
+      end
+    end
   end
 end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -89,4 +89,11 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
   end
+
+  describe '#submit' do
+    it 'includes remaining_attempts' do
+      response = form.submit
+      expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+    end
+  end
 end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -77,9 +77,10 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
-    context 'when throttled' do
+    context 'when throttled from submission' do
       before do
         allow(Throttler::IsThrottledElseIncrement).to receive(:call).once.and_return(true)
+        form.submit
       end
 
       it 'is not valid' do

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe ImageUploadResponsePresenter do
+  let(:form) { Idv::ApiImageUploadForm.new({}, liveness_checking_enabled: false) }
+  let(:form_response) { FormResponse.new(success: true, errors: {}, extra: {}) }
+  let(:presenter) { described_class.new(form: form, form_response: form_response) }
+
+  before do
+    allow(Throttler::RemainingCount).to receive(:call).and_return(3)
+    allow(DocumentCaptureSession).to receive(:find_by).and_return(
+      DocumentCaptureSession.create!(requested_at: Time.zone.now),
+    )
+  end
+
+  describe '#success' do
+    context 'failure' do
+      let(:form_response) { FormResponse.new(success: false, errors: {}, extra: {}) }
+
+      it 'returns false' do
+        expect(presenter.success).to eq false
+      end
+    end
+
+    context 'success' do
+      it 'returns true' do
+        expect(presenter.success).to eq true
+      end
+    end
+  end
+
+  describe '#errors' do
+    context 'failure' do
+      let(:form_response) do
+        FormResponse.new(
+          success: false,
+          errors: {
+            front: t('doc_auth.errors.not_a_file'),
+          },
+          extra: {},
+        )
+      end
+
+      it 'returns formatted errors' do
+        expect(presenter.errors).to eq [{ field: :front, message: t('doc_auth.errors.not_a_file') }]
+      end
+    end
+
+    context 'success' do
+      it 'returns empty array' do
+        expect(presenter.errors).to eq []
+      end
+    end
+  end
+
+  describe '#remaining_attempts' do
+    it 'returns remaining attempts' do
+      expect(presenter.remaining_attempts).to eq 3
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns hash of properties' do
+      expected = {
+        success: true,
+        errors: [],
+        remaining_attempts: 3,
+      }
+
+      expect(presenter.as_json).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
**Why:** As a legitimate user doing doc auth, I want the image uploads in the react flow to be uploaded, so that users attempting to steal an identity have a harder time proofing.