### PR TITLE
LG-3118 Change "Sign in" to "Continue" on user authorization confirmation

### DIFF
--- a/config/locales/user_authorization_confirmation/en.yml
+++ b/config/locales/user_authorization_confirmation/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   user_authorization_confirmation:
-    continue: Sign in
+    continue: Continue
     currently_logged_in: 'You are already signed in with the following email:'
     or: Or
     sign_in: Switch emails

--- a/config/locales/user_authorization_confirmation/es.yml
+++ b/config/locales/user_authorization_confirmation/es.yml
@@ -1,7 +1,7 @@
 ---
 es:
   user_authorization_confirmation:
-    continue: Sign in
-    currently_logged_in: 'You are already signed in with the following email:'
-    or: Or
-    sign_in: Switch emails
+    continue: Continuar
+    currently_logged_in: 'Ya estás registrado con el siguiente correo electrónico:'
+    or: O
+    sign_in: Cambiar de correo electrónico

--- a/config/locales/user_authorization_confirmation/fr.yml
+++ b/config/locales/user_authorization_confirmation/fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   user_authorization_confirmation:
-    continue: Sign in
-    currently_logged_in: 'You are already signed in with the following email:'
-    or: Or
-    sign_in: Switch emails
+    continue: Continuer
+    currently_logged_in: 'Vous êtes déjà connecté avec l''e-mail suivant:'
+    or: ou
+    sign_in: Changer d'e-mail


### PR DESCRIPTION
The "Sign in" button on this page should say "Continue".

While I was in there I noticed the rest of the text on the page was not translated so I went ahead and took care of that.

This was found as part of LG-3118.