### PR TITLE
LG-3118 Update the webauthn verification headers

### DIFF
--- a/config/locales/titles/en.yml
+++ b/config/locales/titles/en.yml
@@ -43,7 +43,7 @@ en:
         invalid: PIV/CAC certificate error
         missing: Internal error
     present_piv_cac: Present your PIV/CAC
-    present_webauthn: Present your hardware security key
+    present_webauthn: Connect your hardware security key
     reactivate_account: Reactivate your account
     registrations:
       new: Sign up for an account

--- a/config/locales/titles/es.yml
+++ b/config/locales/titles/es.yml
@@ -44,7 +44,7 @@ es:
         invalid: Error en el certificado PIV/CAC
         missing: Error interno
     present_piv_cac: Presenta tu PIV/CAC
-    present_webauthn: Presente su clave de seguridad de hardware
+    present_webauthn: Conecte su clave de seguridad de hardware
     reactivate_account: Reactive su cuenta
     registrations:
       new: Regístrese para una cuenta

--- a/config/locales/titles/fr.yml
+++ b/config/locales/titles/fr.yml
@@ -43,7 +43,7 @@ fr:
         invalid: Erreur de certificat PIV/CAC
         missing: Erreur interne
     present_piv_cac: Veuillez présenter votre carte PIV/CAC
-    present_webauthn: Présentez votre clé de sécurité physique
+    present_webauthn: Branchez votre clé de sécurité physique
     reactivate_account: Réactiver le profil
     registrations:
       new: S'inscrire et créer un compte

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -162,7 +162,7 @@ en:
       access your information.
     webauthn_fallback:
       question: Don't have your security key available?
-    webauthn_header_text: Present your security key
+    webauthn_header_text: Connect your security key
     webauthn_piv_available: Use your government employee ID
     webauthn_verified:
       header: Security key verified

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -174,7 +174,7 @@ es:
       gubernamental (PIV/CAC)
     webauthn_fallback:
       question: "¿No tienes tu llave de seguridad disponible?"
-    webauthn_header_text: Presenta tu llave de seguridad
+    webauthn_header_text: Conecte tu llave de seguridad
     webauthn_piv_available: Use su identificación de empleado del gobierno
     webauthn_verified:
       header: Llave de seguridad verificada

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -172,7 +172,7 @@ fr:
       pour accéder à vos informations.
     webauthn_fallback:
       question: Votre clé de sécurité n'est-elle pas disponible?
-    webauthn_header_text: Présentez votre clé de sécurité
+    webauthn_header_text: Branchez votre clé de sécurité
     webauthn_piv_available: Utilisez votre identifiant d'employé du gouvernement
     webauthn_verified:
       header: Clé de sécurité vérifiée


### PR DESCRIPTION
This was discovered during LG-3118. The headers on the WebAuthn verification screen are supposed to ask you to connect instead of present your key.

Before:
![image](https://user-images.githubusercontent.com/963654/92970145-2e516700-f44c-11ea-9f59-9053043a31c7.png)

After:
![image](https://user-images.githubusercontent.com/963654/92970164-34474800-f44c-11ea-9c28-fb3999ea17aa.png)
