### PR TITLE
do not show account banner on mobile (LG-3296)

### DIFF
--- a/app/assets/stylesheets/components/_nav.scss
+++ b/app/assets/stylesheets/components/_nav.scss
@@ -52,9 +52,9 @@
 }
 
 .top-banner {
-  text-align: center;
+  display: none;
 
   @include at-media('desktop') {
-    text-align: left;
+    display: flex;
   }
 }

--- a/app/views/layouts/account_side_nav.html.erb
+++ b/app/views/layouts/account_side_nav.html.erb
@@ -4,13 +4,13 @@
 
 <% content_for :content do %>
   <div class="top-banner grid-row grid-gap mb3">
-    <div class="desktop:grid-offset-3 desktop:grid-col-3 grid-col-6 grid-offset-3">
+    <div class="grid-offset-3 grid-col-3">
       <%= image_tag(
         asset_path('user-access.svg'),
         alt: '',
       ) %>
     </div>
-    <div class="desktop:grid-col-5 grid-col-12">
+    <div class="grid-col-5">
       <div>
         <%= t('account.navigation.access_services') %>
       </div>


### PR DESCRIPTION
following up on #4192, decision is to remove the banner on mobile

Desktop:

![image](https://user-images.githubusercontent.com/1430443/93102275-e95a4a00-f670-11ea-892d-ac305a423e83.png)

Mobile:

![image](https://user-images.githubusercontent.com/1430443/93101418-df841700-f66f-11ea-9cad-25b13fea04ae.png)
