### PR TITLE
LG-3476: Use ref callback to initialize FullScreen modal focus trap

### DIFF
--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import createFocusTrap from 'focus-trap';
 import useI18n from '../hooks/use-i18n';
 import useAsset from '../hooks/use-asset';
@@ -26,7 +26,6 @@ let activeInstances = 0;
 function FullScreen({ onRequestClose = () => {}, children }) {
   const { t } = useI18n();
   const { getAssetPath } = useAsset();
-  const modalRef = useRef(/** @type {?HTMLDivElement} */ (null));
   const trapRef = useRef(/** @type {?import('focus-trap').FocusTrap} */ (null));
   const onRequestCloseRef = useRef(onRequestClose);
   useEffect(() => {
@@ -35,13 +34,18 @@ function FullScreen({ onRequestClose = () => {}, children }) {
     // to reference in the deactivation.
     onRequestCloseRef.current = onRequestClose;
   }, [onRequestClose]);
-  useEffect(() => {
-    if (modalRef.current) {
-      trapRef.current = createFocusTrap(modalRef.current, {
+
+  const setFocusTrapRef = useCallback((node) => {
+    if (trapRef.current) {
+      trapRef.current.deactivate();
+    }
+
+    if (node) {
+      trapRef.current = createFocusTrap(node, {
         onDeactivate: () => onRequestCloseRef.current(),
       });
+
       trapRef.current.activate();
-      return trapRef.current.deactivate;
     }
   }, []);
 
@@ -58,7 +62,7 @@ function FullScreen({ onRequestClose = () => {}, children }) {
   }, []);
 
   return (
-    <div ref={modalRef} aria-modal="true" className="full-screen bg-white">
+    <div ref={setFocusTrapRef} aria-modal="true" className="full-screen bg-white">
       <button
         type="button"
         aria-label={t('users.personal_key.close')}


### PR DESCRIPTION
**Why**: This may resolve an issue where focus trap's event handling is not removed after a FullScreen dialog is hidden, under the assumption that the previous implementation could leave potential for desync between modalRef and useEffect, or between the useEffect's unsubscribe behavior and trapRef.current.deactivate.

Original bug report:

>an intermittent issue where all of the buttons that were part of the react component stopped working. They could refresh and restart document upload and try again. Sometimes this would enable them to continue, but other times the buttons would stop working again.

These changes are based on debugging information and recommendations detailed in LG-3476, and represent the second of the two suggestions:

>This has been especially tricky to track down, since I've not been able to determine a reliable set of steps to reproduce the issue.
>
>That being said, here are some of my findings:
>- I've only been able to reproduce it on the development sandbox, and not locally
>- It only happens on mobile
>- There are no errors logged in the console at the time the issue starts
>- The entire page becomes unresponsive when the issue happens, including links, demonstrating that it's not the React app crashing
>
>On further debugging, I was able to successfully trace it back to the [FocusTrap library](https://github.com/focus-trap/focus-trap) preventing the default click behavior for any clicks in the document ([source](https://github.com/focus-trap/focus-trap/blob/f7b33406d910a054330afc5c8bc2a91614a58e37/index.js#L183-L184])). We use this library for the [full screen Acuant capture](https://github.com/18F/identity-idp/blob/0ebeb69bcd667f6595fad0b0a3307b2adb6413a7/app/javascript/packages/document-capture/components/full-screen.jsx), which explains why it only occurs on mobile devices. The fact that FocusTrap is still preventing click events after the dialog is hidden is unexpected, since we'd expect this handling to be removed when the dialog is hidden ([source](https://github.com/focus-trap/focus-trap/blob/2.4.6/index.js#L68])). From what I can assume, these event listeners are not being removed because of [a condition checking whether the current trap instance is the same as expected](https://github.com/focus-trap/focus-trap/blob/2.4.6/index.js#L121). While it's not clear why there would be a desync, there are some possible leads:
>
>- FullScreen's [`modalRef`](https://github.com/18F/identity-idp/blob/0ebeb69bcd667f6595fad0b0a3307b2adb6413a7/app/javascript/packages/document-capture/components/full-screen.jsx#L61) and the corresponding [`useEffect`](https://github.com/18F/identity-idp/blob/0ebeb69bcd667f6595fad0b0a3307b2adb6413a7/app/javascript/packages/document-capture/components/full-screen.jsx#L38) are only loosely associated.
>   - [Some resources](https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780) and [official documentation](https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node) explain how this can be problematic.
>- The [`useEffect` unsubscribe handler](https://github.com/18F/identity-idp/blob/0ebeb69bcd667f6595fad0b0a3307b2adb6413a7/app/javascript/packages/document-capture/components/full-screen.jsx#L44) is a static reference to a property and only conditionally returned, not a consistent function return which references the `trapRef.current` at the time of unmount.
>- Our version of FocusTrap is very out of date (v2.4.6, vs. current version 6.0.0). While [the CHANGELOG](https://github.com/focus-trap/focus-trap/blob/master/CHANGELOG.md) doesn't mention anything especially related to this issue, there have been some significant refactorings of the library. Notably, the changes in [focus-trap/focus-trap#59](https://github.com/focus-trap/focus-trap/pull/59) include a significant overhaul of the focus management, including removal of the condition to compare trap instances in the event removal.
>- We are loading multiple copies of FocusTrap on the page: The other being the logout timer modal, in the `application` bundle. While it's not immediately apparent that the two copies would interfere with each other, there is a possibility.
>
>Suggestions to explore:
>
>- Upgrade FocusTrap
>- Refactor FullScreen to more reliably initialize and deinitialize the modal focus trap
>
>Upgrading FocusTrap will likely require revisions or removal of [focus-trap-proxy.js](https://github.com/18F/identity-idp/blob/master/app/javascript/app/components/focus-trap-proxy.js), since from what I can tell of its purpose in managing a queue of traps, this functionality was made core to FocusTrap itself in a later version ([see v4.0.0 changes](https://github.com/focus-trap/focus-trap/blob/master/CHANGELOG.md#400])).