### PR TITLE
LG-3473: Log analytics for the image upload API

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -9,7 +9,7 @@ module Idv
     def create
       form_response = image_form.submit
 
-      analytics.track_event(Analytics::IDV_DOC_AUTH_SUBMITTED_FORM, form_response.to_h)
+      analytics.track_event(Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM, form_response.to_h)
 
       if form_response.success?
         client_response = doc_auth_client.post_images(
@@ -19,7 +19,10 @@ module Idv
           liveness_checking_enabled: liveness_checking_enabled?,
         )
 
-        analytics.track_event(Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR, client_response.to_h)
+        analytics.track_event(
+          Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+          client_response.to_h,
+        )
 
         store_pii(client_response) if client_response.success?
         status = :bad_request unless client_response.success?

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -109,6 +109,8 @@ class Analytics
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
+  IDV_DOC_AUTH_SUBMITTED_FORM = 'IdV: doc auth form submitted'.freeze
+  IDV_DOC_AUTH_SUBMITTED_VENDOR = 'IdV: doc auth vendor submitted'.freeze
   IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -109,8 +109,8 @@ class Analytics
   IDV_CANCELLATION = 'IdV: cancellation visited'.freeze
   IDV_CANCELLATION_CONFIRMED = 'IdV: cancellation confirmed'.freeze
   IDV_COME_BACK_LATER_VISIT = 'IdV: come back later visited'.freeze
-  IDV_DOC_AUTH_SUBMITTED_FORM = 'IdV: doc auth form submitted'.freeze
-  IDV_DOC_AUTH_SUBMITTED_VENDOR = 'IdV: doc auth vendor submitted'.freeze
+  IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM = 'IdV: doc auth image upload form submitted'.freeze
+  IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR = 'IdV: doc auth image upload vendor submitted'.freeze
   IDV_MAX_ATTEMPTS_EXCEEDED = 'IdV: max attempts exceeded'.freeze
   IDV_FINAL = 'IdV: final resolution'.freeze
   IDV_FORGOT_PASSWORD = 'IdV: forgot password visited'.freeze

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Idv::ImageUploadsController do
-  include DocAuthHelper
-
   describe '#create' do
     before do
       sign_in_as_user
@@ -50,6 +48,28 @@ describe Idv::ImageUploadsController do
             { field: 'front', message: 'Please fill in this field.' },
           ]
         end
+
+        it 'tracks analytics' do
+          stub_analytics
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: false,
+              errors: {
+                front: ['Please fill in this field.'],
+              },
+              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            },
+          )
+
+          expect(@analytics).not_to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            any_args,
+          )
+
+          action
+        end
       end
 
       context 'when a value is not a file' do
@@ -77,6 +97,28 @@ describe Idv::ImageUploadsController do
               { field: 'front', message: I18n.t('doc_auth.errors.not_a_file', locale: 'es') },
             ]
           end
+        end
+
+        it 'tracks analytics' do
+          stub_analytics
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: false,
+              errors: {
+                front: [I18n.t('doc_auth.errors.not_a_file')],
+              },
+              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            },
+          )
+
+          expect(@analytics).not_to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            any_args,
+          )
+
+          action
         end
       end
 
@@ -113,6 +155,31 @@ describe Idv::ImageUploadsController do
                                remaining_attempts: 0,
                              })
         end
+
+        it 'tracks analytics' do
+          allow(Throttler::IsThrottledElseIncrement).to receive(:call).once.and_return(true)
+          allow(Throttler::RemainingCount).to receive(:call).and_return(0)
+
+          stub_analytics
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: false,
+              errors: {
+                limit: [I18n.t('errors.doc_auth.acuant_throttle')],
+              },
+              remaining_attempts: 0,
+            },
+          )
+
+          expect(@analytics).not_to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            any_args,
+          )
+
+          action
+        end
       end
 
       context 'when image upload succeeds' do
@@ -124,11 +191,43 @@ describe Idv::ImageUploadsController do
           expect(json[:success]).to eq(true)
           expect(document_capture_session.reload.load_result.success?).to eq(true)
         end
+
+        it 'tracks analytics' do
+          stub_analytics
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: true,
+              errors: {},
+              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            },
+          )
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            {
+              success: true,
+              errors: {},
+              billed: true,
+              exception: nil,
+              result: 'Passed',
+            },
+          )
+
+          action
+        end
       end
 
       context 'when image upload fails' do
         before do
-          mock_doc_auth_acuant_error_unknown
+          DocAuth::Mock::DocAuthMockClient.mock_response!(
+            method: :post_images,
+            response: DocAuth::Response.new(
+              success: false,
+              errors: { front: ['Too blurry', 'Wrong document'] },
+            ),
+          )
         end
 
         it 'returns an error response' do
@@ -138,32 +237,36 @@ describe Idv::ImageUploadsController do
           expect(response.status).to eq(400)
           expect(json[:success]).to eq(false)
           expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
-          # This is the error message for the error in the response fixture
-          message = I18n.t('friendly_errors.doc_auth.document_type_could_not_be_determined')
-          expect(json[:errors]).to eq [{ field: 'results', message: message }]
+          expect(json[:errors]).to eq [
+            { field: 'front', message: 'Too blurry' },
+            { field: 'front', message: 'Wrong document' },
+          ]
         end
 
-        context 'with active doc auth funnel' do
-          before do
-            Funnel::DocAuth::RegisterStep.new(
-              controller.current_user.id,
-              'issuer',
-            ).call('welcome', :view, true)
-          end
+        it 'tracks analytics' do
+          stub_analytics
 
-          it 'logs the last doc auth error' do
-            action
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: true,
+              errors: {},
+              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            },
+          )
 
-            expect(DocAuthLog.first.last_document_error).to eq('Unknown')
-          end
-        end
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            {
+              success: false,
+              errors: {
+                front: ['Too blurry', 'Wrong document'],
+              },
+              exception: nil,
+            },
+          )
 
-        context 'without active doc auth funnel' do
-          it 'does not log' do
-            action
-
-            expect(DocAuthLog.count).to eq(0)
-          end
+          action
         end
       end
 
@@ -181,6 +284,34 @@ describe Idv::ImageUploadsController do
               message: I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read'),
             },
           ]
+        end
+
+        it 'tracks analytics' do
+          stub_analytics
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
+            {
+              success: true,
+              errors: {},
+              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            },
+          )
+
+          expect(@analytics).to receive(:track_event).with(
+            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            {
+              success: false,
+              errors: {
+                results: [I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read')],
+              },
+              billed: true,
+              result: 'Caution',
+              exception: nil,
+            },
+          )
+
+          action
         end
       end
     end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -53,18 +53,18 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: false,
               errors: {
                 front: ['Please fill in this field.'],
               },
               remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
             },
           )
 
           expect(@analytics).not_to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
             any_args,
           )
 
@@ -103,18 +103,18 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: false,
               errors: {
                 front: [I18n.t('doc_auth.errors.not_a_file')],
               },
               remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
             },
           )
 
           expect(@analytics).not_to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
             any_args,
           )
 
@@ -163,18 +163,18 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: false,
               errors: {
                 limit: [I18n.t('errors.doc_auth.acuant_throttle')],
               },
               remaining_attempts: 0,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
             },
           )
 
           expect(@analytics).not_to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
             any_args,
           )
 
@@ -196,16 +196,15 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: true,
               errors: {},
               remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
             },
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
             {
               success: true,
               errors: {},
@@ -213,6 +212,7 @@ describe Idv::ImageUploadsController do
               exception: nil,
               result: 'Passed',
             },
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
           )
 
           action
@@ -247,22 +247,22 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: true,
               errors: {},
               remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
             },
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
             {
               success: false,
               errors: {
                 front: ['Too blurry', 'Wrong document'],
               },
               exception: nil,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
             },
           )
 
@@ -290,16 +290,15 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_FORM,
             {
               success: true,
               errors: {},
               remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
             },
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            Analytics::IDV_DOC_AUTH_SUBMITTED_VENDOR,
             {
               success: false,
               errors: {
@@ -308,6 +307,7 @@ describe Idv::ImageUploadsController do
               billed: true,
               result: 'Caution',
               exception: nil,
+            Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
             },
           )
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -138,13 +138,9 @@ describe Idv::ImageUploadsController do
           expect(response.status).to eq(400)
           expect(json[:success]).to eq(false)
           expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
-          expect(json[:errors]).to eq([
-            # This is the error message for the error in the response fixture
-            {
-              field: 'results',
-              message: I18n.t('friendly_errors.doc_auth.document_type_could_not_be_determined'),
-            },
-          ])
+          # This is the error message for the error in the response fixture
+          message = I18n.t('friendly_errors.doc_auth.document_type_could_not_be_determined')
+          expect(json[:errors]).to eq [{ field: 'results', message: message }]
         end
 
         context 'with active doc auth funnel' do

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -53,14 +53,12 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: false,
-              errors: {
-                front: ['Please fill in this field.'],
-              },
-              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: false,
+            errors: {
+              front: ['Please fill in this field.'],
             },
+            remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
           )
 
           expect(@analytics).not_to receive(:track_event).with(
@@ -103,14 +101,12 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: false,
-              errors: {
-                front: [I18n.t('doc_auth.errors.not_a_file')],
-              },
-              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: false,
+            errors: {
+              front: [I18n.t('doc_auth.errors.not_a_file')],
             },
+            remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
           )
 
           expect(@analytics).not_to receive(:track_event).with(
@@ -163,14 +159,12 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: false,
-              errors: {
-                limit: [I18n.t('errors.doc_auth.acuant_throttle')],
-              },
-              remaining_attempts: 0,
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: false,
+            errors: {
+              limit: [I18n.t('errors.doc_auth.acuant_throttle')],
             },
+            remaining_attempts: 0,
           )
 
           expect(@analytics).not_to receive(:track_event).with(
@@ -196,23 +190,19 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: true,
-              errors: {},
-              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
-            },
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: true,
+            errors: {},
+            remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: true,
-              errors: {},
-              billed: true,
-              exception: nil,
-              result: 'Passed',
-            },
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+            success: true,
+            errors: {},
+            billed: true,
+            exception: nil,
+            result: 'Passed',
           )
 
           action
@@ -247,23 +237,19 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: true,
-              errors: {},
-              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
-            },
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: true,
+            errors: {},
+            remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: false,
-              errors: {
-                front: ['Too blurry', 'Wrong document'],
-              },
-              exception: nil,
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+            success: false,
+            errors: {
+              front: ['Too blurry', 'Wrong document'],
             },
+            exception: nil,
           )
 
           action
@@ -290,25 +276,21 @@ describe Idv::ImageUploadsController do
           stub_analytics
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: true,
-              errors: {},
-              remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
-            },
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM,
+            success: true,
+            errors: {},
+            remaining_attempts: Figaro.env.acuant_max_attempts.to_i - 1,
           )
 
           expect(@analytics).to receive(:track_event).with(
-            {
-              success: false,
-              errors: {
-                results: [I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read')],
-              },
-              billed: true,
-              result: 'Caution',
-              exception: nil,
             Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_VENDOR,
+            success: false,
+            errors: {
+              results: [I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read')],
             },
+            billed: true,
+            result: 'Caution',
+            exception: nil,
           )
 
           action


### PR DESCRIPTION
**Why**: As a user, I want login.gov to log analytics for the doc auth image upload API, so that if I am having an issue the login.gov team can debug it
