### PR TITLE
Remove redundant "Connect your key" header

### DIFF
--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -29,9 +29,6 @@
                 alt: '') %>
       </div>
     </div>
-    <h2 class="h4 half-center">
-      <%= t('forms.webauthn_setup.instructions_title') %>
-    </h2>
     <p class="half-center">
       <%= t('forms.webauthn_setup.login_text') %>
     </p>


### PR DESCRIPTION
**Why**: We changed the context of the header on the page, making this header duplicative

Screenshot:
![image](https://user-images.githubusercontent.com/963654/93264295-e5175500-f774-11ea-9065-9e0a692b312d.png)
