### PR TITLE
Remove proxyquire

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "jsdom": "^16.2.2",
     "mocha": "^6.1.4",
     "prettier": "^2.0.5",
-    "proxyquire": "^1.8.0",
     "sinon": "^9.0.2",
     "typescript": "^3.9.7",
     "webpack-dev-server": "^3.11.0"

--- a/spec/javascripts/app/utils/countdown-timer_spec.js
+++ b/spec/javascripts/app/utils/countdown-timer_spec.js
@@ -1,45 +1,48 @@
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
+import sinon from 'sinon';
+import countdownTimer from '../../../../app/javascript/app/utils/countdown-timer';
 
-const spy = sinon.spy();
-const countdownTimer = proxyquire('../../../../app/javascript/app/utils/countdown-timer.js', {
-  './ms-formatter': { default: spy },
-  '@noCallThru': true,
-}).default;
-
-const fakeEl = {
-  innerHTML: '',
-};
-
-describe('#countdownTimer', () => {
+describe('countdownTimer', () => {
   it('does nothing if a HTMLElement is not supplied as the first argument', () => {
     expect(countdownTimer(false)).to.be.undefined();
-    expect(spy.called).to.be.false();
   });
 
   describe('with clock', () => {
     let clock;
+    let el;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();
+      el = document.createElement('div');
     });
 
     afterEach(() => {
       clock.restore();
-      spy.resetHistory();
     });
 
-    it('with the default interval runs exactly once when given an HTMLElement', () => {
-      countdownTimer(fakeEl);
+    it('stays at 0s when time is exhausted', () => {
+      countdownTimer(el);
+
+      expect(el.innerHTML).to.equal('0:00');
       clock.tick(1000);
-      expect(spy.calledOnce).to.be.true();
+      expect(el.innerHTML).to.equal('0:00');
     });
 
-    it('calls the msFormatter function once per second', () => {
-      countdownTimer(fakeEl, 10000);
-      clock.tick(4000);
+    it('updates once per second', () => {
+      countdownTimer(el, 10000);
 
-      expect(spy.callCount).to.equal(5);
+      expect(el.innerHTML).to.equal('0:10');
+      clock.tick(1000);
+
+      expect(el.innerHTML).to.equal('0:09');
+      clock.tick(1000);
+
+      expect(el.innerHTML).to.equal('0:08');
+      clock.tick(1000);
+
+      expect(el.innerHTML).to.equal('0:07');
+      clock.tick(1000);
+
+      expect(el.innerHTML).to.equal('0:06');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,14 +4069,6 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
-fill-keys@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
-  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
-  dependencies:
-    is-object "~1.0.1"
-    merge-descriptors "~1.0.0"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -5143,11 +5135,6 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
-is-object@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
-  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
-
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
@@ -5788,7 +5775,7 @@ meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
+merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
@@ -6020,11 +6007,6 @@ mocha@^6.1.4:
     yargs "13.3.0"
     yargs-parser "13.1.1"
     yargs-unparser "1.6.0"
-
-module-not-found-error@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
-  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -7563,15 +7545,6 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxyquire@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
-  integrity sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=
-  dependencies:
-    fill-keys "^1.0.2"
-    module-not-found-error "^1.0.0"
-    resolve "~1.1.7"
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -8029,11 +8002,6 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1:
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
-
-resolve@~1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 ret@~0.1.10:
   version "0.1.15"


### PR DESCRIPTION
**Why**: While occasionally useful to mock out the behavior of underlying modules, it can give a false sense of security that the behavior of a mocked implementation will match the experience and expectations of the user-facing behavior.

I'd heard some feedback through the grapevine (@jmhooper) that the use of proxyquire in the JavaScript tests wasn't instilling a lot of confidence.

After #4211, there was only a single test spec which was using this dependency, and it was easy enough to move toward a more integration/functional-style testing approach.

This test was also written at a time prior to the introduction of broad availability of a DOM in the JavaScript tests (#3946), and can now more easily assert against real(-ish) DOM element content.