### PR TITLE
LG-3339: Remove unused submit auto-enable form validation

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -31,20 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         false,
       );
-      const elements = form.querySelectorAll('input');
-      if (elements.length !== 0) {
-        [].forEach.call(elements, function (input) {
-          input.addEventListener('input', function () {
-            if (buttons.length !== 0 && input.checkValidity()) {
-              [].forEach.call(buttons, function (button) {
-                if (button.disabled && !button.classList.contains('no-auto-enable')) {
-                  button.disabled = false;
-                }
-              });
-            }
-          });
-        });
-      }
 
       const inputs = form.querySelectorAll('.field');
 

--- a/app/views/idv/doc_auth/overview.html.erb
+++ b/app/views/idv/doc_auth/overview.html.erb
@@ -64,7 +64,7 @@
       <%= link_to(t('recover.instructions.learn_more'), 'https://login.gov/policy/', target: '_blank') %>
     </div>
   </label>
-  <%= f.button :submit, t('recover.buttons.continue'), class: 'btn btn-primary btn-wide sm-col-6 col-6 no-auto-enable' %>
+  <%= f.button :submit, t('recover.buttons.continue'), class: 'btn btn-primary btn-wide sm-col-6 col-6' %>
 <% end %>
 
 <br/>

--- a/app/views/idv/doc_auth/welcome.html.erb
+++ b/app/views/idv/doc_auth/welcome.html.erb
@@ -96,7 +96,7 @@
         <%= link_to(t('doc_auth.instructions.learn_more'), 'https://login.gov/policy/', target: '_blank') %>
       </div>
     </label>
-    <%= f.button :submit, t('doc_auth.buttons.continue'), class: 'btn btn-primary btn-wide sm-col-6 col-6 no-auto-enable' %>
+    <%= f.button :submit, t('doc_auth.buttons.continue'), class: 'btn btn-primary btn-wide sm-col-6 col-6' %>
   <% end %>
 
   <br/>

--- a/app/views/users/edit_phone/edit.html.erb
+++ b/app/views/users/edit_phone/edit.html.erb
@@ -15,7 +15,7 @@
   <%= render 'delivery_preference_selection' %>
   <%= render 'make_default_number' %>
 
-  <%= f.button :submit, t('forms.buttons.submit.confirm_change'), class: 'no-auto-enable btn-wide' %>
+  <%= f.button :submit, t('forms.buttons.submit.confirm_change'), class: 'btn-wide' %>
 <% end %>
 
 <%= render 'remove_phone' %>

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -29,7 +29,7 @@
     <%= render 'users/shared/otp_make_default_number',
                form_obj: @new_phone_form%>
   <% end %>
-  <%= f.button :submit, t('forms.buttons.send_security_code'), class: 'no-auto-enable btn-wide' %>
+  <%= f.button :submit, t('forms.buttons.send_security_code'), class: 'btn-wide' %>
 <% end %>
 
 

--- a/app/views/users/phones/add.html.erb
+++ b/app/views/users/phones/add.html.erb
@@ -23,7 +23,7 @@
     <%= render 'users/shared/otp_make_default_number',
                form_obj: @new_phone_form %>
   <% end %>
-  <%= f.button :submit, t('forms.buttons.continue'), class: 'no-auto-enable btn-wide' %>
+  <%= f.button :submit, t('forms.buttons.continue'), class: 'btn-wide' %>
 <% end %>
 
 <%= render 'shared/cancel', link: account_path %>

--- a/spec/views/phone_setup/index.html.slim_spec.rb
+++ b/spec/views/phone_setup/index.html.slim_spec.rb
@@ -25,9 +25,4 @@ describe 'users/phone_setup/index.html.erb' do
       href: two_factor_options_path,
     )
   end
-
-  it 'it has auto enable off for the submit button' do
-    expect(rendered).
-      to have_xpath('//input[@type="submit" and contains(@class, "no-auto-enable")]')
-  end
 end


### PR DESCRIPTION
**Why**: While some forms implement custom auto-enable behavior for submit buttons, they do so by bypassing the default auto-enable behavior. There does not appear to be any instances of forms which rely on this core behavior.

Examples:

- Phone validation uses [`phone-validation.js`](https://github.com/18F/identity-idp/blob/master/app/javascript/app/phone-validation.js)
- IAL2 proofing consent screen uses [`ial2-consent-button.js`](https://github.com/18F/identity-idp/blob/master/app/javascript/packs/ial2-consent-button.js)