### PR TITLE
update rubocop to 0.91.0 from 0.85.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Metrics/AbcSize:
   Exclude:
   - spec/**/*
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Enabled: true
@@ -74,8 +77,8 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   CountComments: false
-  Max: 100
-  Description: Avoid modules longer than 100 lines of code.
+  Max: 200
+  Description: Avoid modules longer than 200 lines of code.
   Enabled: true
   Exclude:
   - spec/**/*
@@ -351,3 +354,129 @@ Style/SlicingWithRange:
 
 Rails/ApplicationMailer:
   Enabled: false
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+    Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RedundantRequireStatement:
+  Enabled: true
+
+Lint/RedundantSplatExpansion:
+  Enabled: true
+
+Lint/SafeNavigationWithEmpty:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: false
+
+Lint/UnreachableLoop:
+  Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/ArrayCoercion:
+  Enabled: false
+
+Style/BisectedAttrAccessor:
+  Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: false
+
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+Style/HashAsLastArrayItem:
+  Enabled: false
+
+Style/HashLikeCase:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false
+
+Style/MultilineWhenThen:
+  Enabled: true
+
+Style/KeywordParametersOrder:
+  Enabled: true
+
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/EmptyFile:
+  Enabled: false
+
+Lint/UselessMethodDefinition:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: false
+
+Style/RedundantSelfAssignment:
+  Enabled: false
+
+Style/SoleNestedConditional:
+  Enabled: false
+
+Lint/UselessTimes:
+  Enabled: true
+
+Layout/BeginEndAlignment:
+  Enabled: true
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/IdentityComparison:
+  Enabled: true
+
+Bundler/DuplicatedGem:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ group :development, :test do
   gem 'psych'
   gem 'puma'
   gem 'rspec-rails', '~> 3.9', '>= 3.9.1'
-  gem 'rubocop', '~> 0.85.0', require: false
+  gem 'rubocop', '~> 0.91.0', require: false
   gem 'rubocop-rails', '>= 2.5.2', require: false
   gem 'slim_lint'
 end
@@ -107,8 +107,8 @@ group :test do
   gem 'factory_bot_rails', '>= 5.2.0'
   gem 'faker'
   gem 'gmail'
-  gem 'rack-test', '>= 1.1.0'
   gem 'rack_session_access', '>= 0.2.0'
+  gem 'rack-test', '>= 1.1.0'
   gem 'rails-controller-testing', '>= 1.0.4'
   gem 'shoulda-matchers', '~> 4.0.1', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,16 +523,16 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.85.1)
+    rubocop (0.91.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.0.3)
+      rubocop-ast (>= 0.4.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.3.0)
+    rubocop-ast (0.4.1)
       parser (>= 2.7.1.4)
     rubocop-rails (2.5.2)
       activesupport
@@ -768,7 +768,7 @@ DEPENDENCIES
   rotp (~> 3.3.1)
   rqrcode
   rspec-rails (~> 3.9, >= 3.9.1)
-  rubocop (~> 0.85.0)
+  rubocop (~> 0.91.0)
   rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ModuleLength
 module SamlIdpAuthConcern
   extend ActiveSupport::Concern
   extend Forwardable
@@ -151,4 +150,3 @@ module SamlIdpAuthConcern
     url.to_s
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -30,7 +30,7 @@ class AttributeAsserter
     self.user_session = user_session
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def build
     attrs = default_attrs
     add_email(attrs) if bundle.include? :email
@@ -40,7 +40,7 @@ class AttributeAsserter
     add_x509(attrs) if bundle.include?(:x509_presented) && x509_data
     user.asserted_attributes = attrs
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/services/db/doc_auth_log/drop_off_rates_helper.rb
+++ b/app/services/db/doc_auth_log/drop_off_rates_helper.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ModuleLength
 module Db
   module DocAuthLog
     module DropOffRatesHelper
@@ -131,4 +130,3 @@ module Db
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -49,7 +49,6 @@ module DocAuth
         DocAuth::Response.new(success: true)
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
@@ -73,7 +72,6 @@ module DocAuth
           results_response
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def get_results(instance_id:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)

--- a/app/services/doc_auth/mock/responses/create_document_response.rb
+++ b/app/services/doc_auth/mock/responses/create_document_response.rb
@@ -4,7 +4,7 @@ module DocAuth
       class CreateDocumentResponse < DocAuth::Response
         attr_reader :instance_id
 
-        def initialize(success: true, errors: [], exception: nil, instance_id:)
+        def initialize(instance_id:, success: true, errors: [], exception: nil)
           @instance_id = instance_id
           super(
             success: success,

--- a/app/services/doc_auth/mock/result_response_builder.rb
+++ b/app/services/doc_auth/mock/result_response_builder.rb
@@ -45,10 +45,10 @@ module DocAuth
 
       def parsed_yaml_from_uploaded_file
         @parsed_yaml_from_uploaded_file ||= begin
-                                              YAML.safe_load(uploaded_file)
-                                            rescue Psych::SyntaxError
-                                              nil
-                                            end
+          YAML.safe_load(uploaded_file)
+        rescue Psych::SyntaxError
+          nil
+        end
       end
 
       def pii_from_doc

--- a/app/services/job_runner/job_configuration.rb
+++ b/app/services/job_runner/job_configuration.rb
@@ -16,7 +16,7 @@ module JobRunner
     # @param [Integer] failures_before_alarm The number of acceptable failed
     #   runs before the health check should alarm.
     #
-    def initialize(name:, interval:, timeout: nil, callback:, health_critical: false,
+    def initialize(name:, interval:, callback:, timeout: nil, health_critical: false,
                    failures_before_alarm: 1)
       @name = name
       @interval = interval

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -1,7 +1,7 @@
 class UserEventCreator
   attr_reader :request, :current_user
 
-  def initialize(request: nil, current_user:)
+  def initialize(current_user:, request: nil)
     @request = request
     @current_user = current_user
   end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -69,9 +69,9 @@ module IdvHelper
   end
 
   def visit_idp_from_oidc_sp_with_ial2(
-    state: SecureRandom.hex,
     client_id:,
     nonce:,
+    state: SecureRandom.hex,
     verified_within: nil
   )
     visit openid_connect_authorize_path(

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -315,7 +315,7 @@ module SamlAuthHelper
     end
   end
 
-  def visit_idp_from_oidc_sp_with_ial1(state: SecureRandom.hex, client_id:, nonce:)
+  def visit_idp_from_oidc_sp_with_ial1(client_id:, nonce:, state: SecureRandom.hex)
     visit openid_connect_authorize_path(
       client_id: client_id,
       response_type: 'code',


### PR DESCRIPTION
With enabling/disabling guidance taken from https://github.com/testdouble/standard/blob/master/CHANGELOG.md

They're all up for debate, but STDOUT and keyword parameter order are the two most disruptive, so I'm especially open to not enabling them if it's too much

I also expanded how long a module can be and disabled cyclomatic complexity because they get disabled a decent number of times