### PR TITLE
LG-3339: Extract submit-with-spinner pack from form-validation.js

### DIFF
--- a/app/javascript/app/form-validation.js
+++ b/app/javascript/app/form-validation.js
@@ -24,10 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
               button.disabled = true;
             });
           }
-          const submitSpinner = document.getElementById('submit-spinner');
-          if (submitSpinner) {
-            submitSpinner.className = '';
-          }
         },
         false,
       );

--- a/app/javascript/packages/polyfill/index.js
+++ b/app/javascript/packages/polyfill/index.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {"fetch"} SupportedPolyfills
+ * @typedef {"fetch"|"element-closest"} SupportedPolyfills
  */
 
 /**
@@ -16,6 +16,10 @@ const POLYFILLS = {
   fetch: {
     test: () => 'fetch' in window,
     load: () => import(/* webpackChunkName: "whatwg-fetch" */ 'whatwg-fetch'),
+  },
+  'element-closest': {
+    test: () => !!Element.prototype.closest,
+    load: () => import(/* webpackChunkName: "element-closest" */ 'element-closest'),
   },
 };
 

--- a/app/javascript/packages/polyfill/package.json
+++ b/app/javascript/packages/polyfill/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
+    "element-closest": "^3.0.2",
     "whatwg-fetch": "^3.4.0"
   }
 }

--- a/app/javascript/packs/submit-with-spinner.js
+++ b/app/javascript/packs/submit-with-spinner.js
@@ -1,0 +1,8 @@
+import { loadPolyfills } from '@18f/identity-polyfill';
+
+loadPolyfills(['element-closest']).then(() => {
+  const spinner = /** @type {HTMLDivElement} */ (document.getElementById('submit-spinner'));
+  spinner.closest('form')?.addEventListener('submit', () => {
+    spinner.className = '';
+  });
+});

--- a/app/views/idv/doc_auth/_submit_with_spinner.html.erb
+++ b/app/views/idv/doc_auth/_submit_with_spinner.html.erb
@@ -3,3 +3,4 @@
 </button>
 <%= render 'idv/doc_auth/spinner' %>
 <div class='clearfix'></div>
+<%= javascript_pack_tag 'submit-with-spinner' %>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "classlist.js": "^1.1.20150312",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
-    "element-closest": "^3.0.2",
     "focus-trap": "^6.0.1",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "classlist.js": "^1.1.20150312",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
+    "element-closest": "^3.0.2",
     "focus-trap": "^6.0.1",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",

--- a/spec/javascripts/packs/submit-with-spinner-spec.js
+++ b/spec/javascripts/packs/submit-with-spinner-spec.js
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/dom';
+import { useCleanDOM } from '../support/dom';
+
+describe('submit-with-spinner', () => {
+  useCleanDOM();
+
+  async function initialize({ withForm = true } = {}) {
+    const parent = withForm
+      ? document.body.appendChild(document.createElement('form'))
+      : document.body;
+
+    parent.innerHTML = `
+      <button type='submit' class='btn btn-primary btn-wide sm-col sm-col-6'>
+        Continue
+      </button>
+      <div class='pl1 sm-col sm-col-3'>
+      <div class='spinner hidden' id='submit-spinner'>
+        <img height="50" width="50" alt="Loading spinner" src="/assets/wait.gif">
+      </div>
+      <div class='clearfix'></div>
+    `;
+
+    delete require.cache[require.resolve('../../../app/javascript/packs/submit-with-spinner')];
+    await import('../../../app/javascript/packs/submit-with-spinner');
+  }
+
+  it('gracefully handles absence of form', async () => {
+    await initialize({ withForm: false });
+  });
+
+  it('should show spinner on form submit', async () => {
+    await initialize();
+
+    const form = document.querySelector('form');
+    const event = new window.Event('submit', { target: form });
+    form.dispatchEvent(event);
+
+    const spinner = screen.getByAltText('Loading spinner');
+
+    expect(spinner.parentNode.classList.contains('hidden')).to.be.false();
+  });
+});

--- a/spec/javascripts/packs/submit-with-spinner-spec.js
+++ b/spec/javascripts/packs/submit-with-spinner-spec.js
@@ -31,6 +31,8 @@ describe('submit-with-spinner', () => {
   it('should show spinner on form submit', async () => {
     await initialize();
 
+    // JSDOM doesn't support submitting a form natively.
+    // See: https://github.com/jsdom/jsdom/issues/123
     const form = document.querySelector('form');
     const event = new window.Event('submit', { target: form });
     form.dispatchEvent(event);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "module": "ESNext",
     "target": "ESNext"
   },
-  "include": ["app/javascript/packages"]
+  "include": ["app/javascript/packages", "app/javascript/packs/submit-with-spinner.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,6 +3486,11 @@ element-closest@^2.0.1:
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-2.0.2.tgz#72a740a107453382e28df9ce5dbb5a8df0f966ec"
   integrity sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw=
 
+element-closest@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-3.0.2.tgz#3814a69a84f30e48e63eaf57341f4dbf4227d2aa"
+  integrity sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g==
+
 elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"


### PR DESCRIPTION
**Why**: The behavior to display a spinner in response to a form submission is only used in a few screens, and should be an opt-in behavior.

Eventually, this code may be removed altogether, since it is only used in the existing production document capture flows, presumably to give feedback to the user in response to what may be a long form submission. This is handled in the updated React application by showing an interstitial screen while submission is in progress.