### PR TITLE
Use Acuant SDK for selfie capture

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -152,6 +152,7 @@ function AcuantCapture(
         /** @type {AcuantGlobal} */ (window).AcuantPassiveLiveness.startSelfieCapture(
           ifStillMounted((nextImageData) => {
             const dataAsBlob = toBlob(`data:image/jpeg;base64,${nextImageData}`);
+            fileCache.set(dataAsBlob, nextImageData);
             onChangeAndResetError(dataAsBlob);
           }),
         );

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -143,12 +143,13 @@ function AcuantCapture(
     if (event.target === inputRef.current) {
       const shouldStartEnvironmentCapture =
         hasCapture && capture !== 'user' && !isForceUploading.current;
+      const shouldStartSelfieCapture = capture === 'user' && !isForceUploading.current;
 
-      if (!allowUpload || capture === 'user' || shouldStartEnvironmentCapture) {
+      if (!allowUpload || shouldStartSelfieCapture || shouldStartEnvironmentCapture) {
         event.preventDefault();
       }
 
-      if (capture === 'user') {
+      if (shouldStartSelfieCapture) {
         /** @type {AcuantGlobal} */ (window).AcuantPassiveLiveness.startSelfieCapture(
           ifStillMounted((nextImageData) => {
             const dataAsBlob = toBlob(`data:image/jpeg;base64,${nextImageData}`);

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -172,11 +172,15 @@ const FileInput = forwardRef((props, ref) => {
         onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
-          {value && value instanceof window.File && !isMobile && (
+          {value && value instanceof window.Blob && !isMobile && (
             <div className="usa-file-input__preview-heading">
               <span>
-                <span className="usa-sr-only">{t('doc_auth.forms.selected_file')}: </span>
-                {value.name}{' '}
+                {value instanceof window.File && (
+                  <>
+                    <span className="usa-sr-only">{t('doc_auth.forms.selected_file')}: </span>
+                    {value.name}{' '}
+                  </>
+                )}
               </span>
               <span className="usa-file-input__choose">{t('doc_auth.forms.change_file')}</span>
             </div>

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { waitForElementToBeRemoved } from '@testing-library/dom';
+import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import sinon from 'sinon';
 import AcuantCapture from '@18f/identity-document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
@@ -408,8 +408,9 @@ describe('document-capture/components/acuant-capture', () => {
       initialize();
 
       const button = getByText('Upload');
-      fireEvent.click(button);
+      const defaultPrevented = !fireEvent.click(button);
 
+      expect(defaultPrevented).to.be.false();
       expect(window.AcuantCameraUI.start.called).to.be.false();
     });
 
@@ -420,7 +421,7 @@ describe('document-capture/components/acuant-capture', () => {
         >
           <DeviceContext.Provider value={{ isMobile: true }}>
             <AcuantContextProvider sdkSrc="about:blank">
-              <AcuantCapture label="Image" capture="environment" />
+              <AcuantCapture label="Image" capture="user" />
             </AcuantContextProvider>
           </DeviceContext.Provider>
         </I18nContext.Provider>,
@@ -430,10 +431,12 @@ describe('document-capture/components/acuant-capture', () => {
 
       const button = getByText('Upload');
       const input = getByLabelText('Image');
-      fireEvent.click(button);
+      const defaultPrevented = !fireEvent.click(button);
 
+      expect(defaultPrevented).to.be.false();
       expect(window.AcuantCameraUI.start.called).to.be.false();
-      expect(input.getAttribute('capture')).to.equal('environment');
+      expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.false();
+      expect(input.getAttribute('capture')).to.equal('user');
     });
 
     it('optionally disallows upload', () => {
@@ -460,10 +463,10 @@ describe('document-capture/components/acuant-capture', () => {
       expect(() => getByText('doc_auth.tips.document_capture_hint')).to.throw();
     });
 
-    it('still captures by `capture` value when upload disallowed', () => {
+    it('still captures selfie value when upload disallowed', () => {
       const { getByLabelText } = render(
         <AcuantContextProvider sdkSrc="about:blank">
-          <AcuantCapture label="Image" capture="environment" allowUpload={false} />
+          <AcuantCapture label="Image" capture="user" allowUpload={false} />
         </AcuantContextProvider>,
       );
 
@@ -472,8 +475,9 @@ describe('document-capture/components/acuant-capture', () => {
       const button = getByLabelText('Image');
       const defaultPrevented = !fireEvent.click(button);
 
-      expect(defaultPrevented).to.be.false();
+      expect(defaultPrevented).to.be.true();
       expect(window.AcuantCameraUI.start.called).to.be.false();
+      expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.true();
     });
   });
 
@@ -556,26 +560,31 @@ describe('document-capture/components/acuant-capture', () => {
     expect(hint).to.be.ok();
   });
 
-  it('captures by `capture` value', () => {
+  it('captures selfie', async () => {
+    const onChange = sinon.stub();
     const { getByLabelText } = render(
       <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" capture="environment" />
+        <AcuantCapture label="Image" capture="user" onChange={onChange} />
       </AcuantContextProvider>,
     );
 
-    initialize();
+    initialize({
+      startSelfieCapture: sinon.stub().callsArgWithAsync(0, ''),
+    });
 
     const button = getByLabelText('Image');
     const defaultPrevented = !fireEvent.click(button);
 
-    expect(defaultPrevented).to.be.false();
+    expect(defaultPrevented).to.be.true();
     expect(window.AcuantCameraUI.start.called).to.be.false();
+    expect(window.AcuantPassiveLiveness.startSelfieCapture.called).to.be.true();
+    await waitFor(() => expect(onChange.calledOnce).to.be.true());
   });
 
   it('restricts accepted file types', () => {
     const { getByLabelText } = render(
       <AcuantContextProvider sdkSrc="about:blank">
-        <AcuantCapture label="Image" capture="environment" />
+        <AcuantCapture label="Image" />
       </AcuantContextProvider>,
       { isMockClient: false },
     );

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -112,6 +112,7 @@ describe('document-capture/components/document-capture', () => {
         },
       });
     });
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
     // Continue is enabled, but attempting to proceed without providing values will trigger error
     // messages.
@@ -153,13 +154,7 @@ describe('document-capture/components/document-capture', () => {
 
     // Provide value.
     const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
-    const didClick = fireEvent.click(selfieInput);
-    expect(didClick).to.be.true();
-    fireEvent.change(selfieInput, {
-      target: {
-        files: [new window.File([''], 'upload.png', { type: 'image/png' })],
-      },
-    });
+    fireEvent.click(selfieInput);
 
     // Continue only once all errors have been removed.
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
@@ -181,12 +176,17 @@ describe('document-capture/components/document-capture', () => {
 
   it('renders unhandled submission failure', async () => {
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
-      <DocumentCapture />,
+      <AcuantProvider sdkSrc="about:blank">
+        <DocumentCapture />
+      </AcuantProvider>,
       {
         uploadError: new Error('Server unavailable'),
         expectedUploads: 2,
       },
     );
+
+    initialize({ isCameraSupported: false });
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
@@ -205,10 +205,8 @@ describe('document-capture/components/document-capture', () => {
     let submitButton = getByText('forms.buttons.submit.default');
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_selfie'),
-      new window.File([''], 'selfie.png', { type: 'image/png' }),
-    );
+    const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
+    fireEvent.click(selfieInput);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 
@@ -249,11 +247,16 @@ describe('document-capture/components/document-capture', () => {
       { field: 'back', message: 'Please fill in this field' },
     ];
     const { getByLabelText, getByText, getAllByText, findAllByText, findByRole } = render(
-      <DocumentCapture />,
+      <AcuantProvider sdkSrc="about:blank">
+        <DocumentCapture />
+      </AcuantProvider>,
       {
         uploadError,
       },
     );
+
+    initialize({ isCameraSupported: false });
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
     const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
@@ -272,10 +275,8 @@ describe('document-capture/components/document-capture', () => {
     const submitButton = getByText('forms.buttons.submit.default');
     userEvent.click(submitButton);
     await findAllByText('simple_form.required.text');
-    userEvent.upload(
-      getByLabelText('doc_auth.headings.document_capture_selfie'),
-      new window.File([''], 'selfie.png', { type: 'image/png' }),
-    );
+    const selfieInput = getByLabelText('doc_auth.headings.document_capture_selfie');
+    fireEvent.click(selfieInput);
     await waitFor(() => expect(() => getAllByText('simple_form.required.text')).to.throw());
     userEvent.click(submitButton);
 

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/dom';
 import sinon from 'sinon';
+import { AcuantProvider } from '@18f/identity-document-capture';
 import SelfieStep, { validate } from '@18f/identity-document-capture/components/selfie-step';
 import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
 import render from '../../../support/render';
+import { useAcuant } from '../../../support/acuant';
 
 describe('document-capture/components/selfie-step', () => {
+  const { initialize } = useAcuant();
+
   describe('validate', () => {
     it('returns object with error if selfie is unset', () => {
       const value = {};
@@ -26,13 +31,18 @@ describe('document-capture/components/selfie-step', () => {
     });
   });
 
-  it('calls onChange callback with uploaded image', () => {
+  it('calls onChange callback with uploaded image', async () => {
     const onChange = sinon.stub();
-    const { getByLabelText } = render(<SelfieStep onChange={onChange} />);
-    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const { getByLabelText } = render(
+      <AcuantProvider sdkSrc="about:blank">
+        <SelfieStep onChange={onChange} />
+      </AcuantProvider>,
+    );
+    initialize();
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
-    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_selfie'), file);
+    userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
 
-    expect(onChange.getCall(0).args[0]).to.deep.equal({ selfie: file });
+    await waitFor(() => expect(onChange.getCall(0).args[0].selfie).to.be.instanceOf(window.Blob));
   });
 });

--- a/spec/javascripts/support/acuant.js
+++ b/spec/javascripts/support/acuant.js
@@ -10,6 +10,7 @@ export function useAcuant() {
     delete window.AcuantJavascriptWebSdk;
     delete window.AcuantCamera;
     delete window.AcuantCameraUI;
+    delete window.AcuantPassiveLiveness;
   });
 
   return {
@@ -18,6 +19,7 @@ export function useAcuant() {
       isCameraSupported = true,
       start = sinon.stub(),
       end = sinon.stub(),
+      startSelfieCapture = sinon.stub(),
     } = {}) {
       window.AcuantJavascriptWebSdk = {
         initialize: (_credentials, _endpoint, { onSuccess, onFail }) =>
@@ -25,6 +27,7 @@ export function useAcuant() {
       };
       window.AcuantCamera = { isCameraSupported };
       window.AcuantCameraUI = { start, end };
+      window.AcuantPassiveLiveness = { startSelfieCapture };
       act(window.onAcuantSdkLoaded);
     },
   };


### PR DESCRIPTION
**Why**: It appears that Acuant has a problem with images which are image values passed verbatim from `<input capture="user">`. [Perusing the source](https://github.com/Acuant/JavascriptWebSDKV11/tree/master/SimpleHTMLApp/webSdk/dist) reveals that, while largely the same, Acuant does apply some post-processing to downscale and convert the captured image to Base64. Preliminary testing seems to indicate that this does not conflict as much with Acuant, or at the very least is identical in behavior to the current (pre-React) doc auth flow.