### PR TITLE
Substitute classlist.js with classlist-polyfill

### DIFF
--- a/app/javascript/app/components/modal.js
+++ b/app/javascript/app/components/modal.js
@@ -1,4 +1,4 @@
-import 'classlist.js';
+import 'classlist-polyfill';
 import { createFocusTrap } from 'focus-trap';
 import Events from '../utils/events';
 

--- a/app/javascript/app/i18n-dropdown.js
+++ b/app/javascript/app/i18n-dropdown.js
@@ -1,4 +1,4 @@
-import 'classlist.js';
+import 'classlist-polyfill';
 
 document.addEventListener('DOMContentLoaded', () => {
   const mobileLink = document.querySelector('.i18n-mobile-toggle > a');

--- a/app/javascript/app/radio-btn.js
+++ b/app/javascript/app/radio-btn.js
@@ -1,4 +1,4 @@
-import 'classlist.js';
+import 'classlist-polyfill';
 
 function clearHighlight(name) {
   const radioGroup = document.querySelectorAll(`input[name='${name}']`);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "base32-crockford-browser": "^1.0.0",
     "basscss-sass": "^3.0.0",
-    "classlist.js": "^1.1.20150312",
+    "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
     "focus-trap": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,11 +2534,6 @@ classlist-polyfill@^1.0.3, classlist-polyfill@^1.2.0:
   resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
   integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
 
-classlist.js@^1.1.20150312:
-  version "1.1.20150312"
-  resolved "https://registry.yarnpkg.com/classlist.js/-/classlist.js-1.1.20150312.tgz#1d70842f7022f08d9ac086ce69e5b250f2c57789"
-  integrity sha1-HXCEL3Ai8I2awIbOaeWyUPLFd4k=
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4221#discussion_r491042947

> We currently also use [`classlist.js`](https://www.npmjs.com/package/classlist.js) elsewhere. I chose `classlist-polyfill` since it's [what USWDS uses](https://github.com/uswds/uswds/blob/45296db675672cd22171d4dcb7f663df023bc5fb/src/js/polyfills/index.js#L1-L2). We can and should update other use of `classlist.js` so we're not sending duplicate implementations.

Both packages originate from the same source reference implementation:

- https://unpkg.com/classlist-polyfill@1.2.0/src/index.js
- https://unpkg.com/classlist.js@1.1.20150312/classList.js

Expected outcome is that we ship less code, and have one fewer dependency.