### PR TITLE
LG-3249: Remove environment variable acuant_sdk_document_capture_enabled

### DIFF
--- a/app/views/idv/_acuant_sdk_document_capture_form.html.erb
+++ b/app/views/idv/_acuant_sdk_document_capture_form.html.erb
@@ -1,66 +1,64 @@
-<% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
-  <% content_for :meta_tags do %>
-    <meta
-      name='acuant-sdk-initialization-endpoint'
-      content='<%= Figaro.env.acuant_sdk_initialization_endpoint %>'
-    >
-    <meta
-      name='acuant-sdk-initialization-creds'
-      content='<%= Figaro.env.acuant_sdk_initialization_creds %>'
-    >
-  <% end %>
-
-  <div id='acuant-sdk-upload-form' class='hidden'>
-    <button id='acuant-sdk-capture' class='btn btn-primary'>
-      <%= capture_button_label %>
-    </button>
-  </div>
-
-  <div id='acuant-sdk-spinner' class='hidden'>
-    <%= image_tag(
-      asset_url('wait.gif'),
-      srcset: asset_url('wait.gif'),
-      height: 50,
-      width: 50,
-      alt: t('image_description.spinner')
-    ) %>
-  </div>
-
-  <!-- This view is never displayed, but it needs to be present in the DOM for
-  the SDK to capture the feed from the camera -->
-  <video id="acuant-player" controls autoPlay playsInline class='hidden'></video>
-  <div id='acuant-sdk-capture-view' class='hidden full-screen full-screen-fallback' >
-    <div id='acuant-sdk-capture-view-close' class="full-screen-close-button full-screen-close-button-fallback" >
-      <%= image_tag(
-              asset_url('close-white-alt.svg'),
-              srcset: asset_url('close-white-alt.svg'),
-              class: 'full-screen-close-icon full-screen-close-icon-fallback',
-              alt: t('image_description.close')
-          ) %>
-    </div>
-    <canvas id="acuant-video-canvas" class="full-screen-canvas-fallback"></canvas>
-  </div>
-
-  <div id='acuant-sdk-continue-form' class='hidden'>
-    <img id='acuant-sdk-preview' class='mb2'>
-    <%= submit_tag t('forms.buttons.continue'), class: 'block btn btn-primary btn-wide' %>
-    <%= link_to(
-      retry_capture_button_label,
-      url_for,
-      class: 'center btn btn-secondary btn-wide mt2',
-    ) %>
-  </div>
-
-  <p id='acuant-fallback-text' class='my3 hidden'>
-    <%= t(
-      'doc_auth.instructions.document_capture_fallback_html',
-      link: link_to(
-        t('doc_auth.instructions.document_capture_fallback_link'),
-        '#',
-        id: 'acuant-fallback-link'
-      )
-    ) %>
-  </p>
-
-  <%= javascript_pack_tag 'acuant_document_capture' %>
+<% content_for :meta_tags do %>
+  <meta
+    name='acuant-sdk-initialization-endpoint'
+    content='<%= Figaro.env.acuant_sdk_initialization_endpoint %>'
+  >
+  <meta
+    name='acuant-sdk-initialization-creds'
+    content='<%= Figaro.env.acuant_sdk_initialization_creds %>'
+  >
 <% end %>
+
+<div id='acuant-sdk-upload-form' class='hidden'>
+  <button id='acuant-sdk-capture' class='btn btn-primary'>
+    <%= capture_button_label %>
+  </button>
+</div>
+
+<div id='acuant-sdk-spinner' class='hidden'>
+  <%= image_tag(
+    asset_url('wait.gif'),
+    srcset: asset_url('wait.gif'),
+    height: 50,
+    width: 50,
+    alt: t('image_description.spinner')
+  ) %>
+</div>
+
+<!-- This view is never displayed, but it needs to be present in the DOM for
+the SDK to capture the feed from the camera -->
+<video id="acuant-player" controls autoPlay playsInline class='hidden'></video>
+<div id='acuant-sdk-capture-view' class='hidden full-screen full-screen-fallback' >
+  <div id='acuant-sdk-capture-view-close' class="full-screen-close-button full-screen-close-button-fallback" >
+    <%= image_tag(
+            asset_url('close-white-alt.svg'),
+            srcset: asset_url('close-white-alt.svg'),
+            class: 'full-screen-close-icon full-screen-close-icon-fallback',
+            alt: t('image_description.close')
+        ) %>
+  </div>
+  <canvas id="acuant-video-canvas" class="full-screen-canvas-fallback"></canvas>
+</div>
+
+<div id='acuant-sdk-continue-form' class='hidden'>
+  <img id='acuant-sdk-preview' class='mb2'>
+  <%= submit_tag t('forms.buttons.continue'), class: 'block btn btn-primary btn-wide' %>
+  <%= link_to(
+    retry_capture_button_label,
+    url_for,
+    class: 'center btn btn-secondary btn-wide mt2',
+  ) %>
+</div>
+
+<p id='acuant-fallback-text' class='my3 hidden'>
+  <%= t(
+    'doc_auth.instructions.document_capture_fallback_html',
+    link: link_to(
+      t('doc_auth.instructions.document_capture_fallback_link'),
+      '#',
+      id: 'acuant-fallback-link'
+    )
+  ) %>
+</p>
+
+<%= javascript_pack_tag 'acuant_document_capture' %>

--- a/app/views/idv/_acuant_sdk_document_capture_form.html.erb
+++ b/app/views/idv/_acuant_sdk_document_capture_form.html.erb
@@ -1,12 +1,6 @@
 <% content_for :meta_tags do %>
-  <meta
-    name='acuant-sdk-initialization-endpoint'
-    content='<%= Figaro.env.acuant_sdk_initialization_endpoint %>'
-  >
-  <meta
-    name='acuant-sdk-initialization-creds'
-    content='<%= Figaro.env.acuant_sdk_initialization_creds %>'
-  >
+  <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: Figaro.env.acuant_sdk_initialization_endpoint %>
+  <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
 <% end %>
 
 <div id='acuant-sdk-upload-form' class='hidden'>

--- a/app/views/idv/_acuant_sdk_selfie_capture_form.html.erb
+++ b/app/views/idv/_acuant_sdk_selfie_capture_form.html.erb
@@ -1,41 +1,39 @@
-<% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
-  <% content_for :meta_tags do %>
-    <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: Figaro.env.acuant_sdk_initialization_endpoint %>
-    <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
-  <% end %>
-
-  <div id='acuant-sdk-upload-form' class='hidden'>
-    <button id='acuant-sdk-capture' class='btn btn-primary'>
-      <%= capture_button_label %>
-    </button>
-  </div>
-
-  <div id='acuant-sdk-spinner' class='hidden'>
-    <%= image_tag(
-      asset_url('wait.gif'),
-      srcset: asset_url('wait.gif'),
-      height: 50,
-      width: 50,
-      alt: t('image_description.spinner')
-    ) %>
-  </div>
-
-  <!-- This view is never displayed, but it needs to be present in the DOM for
-  the SDK to capture the feed from the camer -->
-  <video id="acuant-player" controls autoPlay playsInline class='hidden'></video>
-  <div id='acuant-sdk-capture-view' class='hidden'>
-    <canvas id="acuant-video-canvas" style='width: 100%;'></canvas>
-  </div>
-
-  <div id='acuant-sdk-continue-form' class='hidden'>
-    <img id='acuant-sdk-preview' class='mb2'>
-    <%= submit_tag t('forms.buttons.continue'), class: 'block btn btn-primary btn-wide' %>
-    <%= link_to(
-      retry_capture_button_label,
-      url_for,
-      class: 'center btn btn-secondary btn-wide mt2',
-    ) %>
-  </div>
-
-  <%= javascript_pack_tag 'acuant_selfie_capture' %>
+<% content_for :meta_tags do %>
+  <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: Figaro.env.acuant_sdk_initialization_endpoint %>
+  <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
 <% end %>
+
+<div id='acuant-sdk-upload-form' class='hidden'>
+  <button id='acuant-sdk-capture' class='btn btn-primary'>
+    <%= capture_button_label %>
+  </button>
+</div>
+
+<div id='acuant-sdk-spinner' class='hidden'>
+  <%= image_tag(
+    asset_url('wait.gif'),
+    srcset: asset_url('wait.gif'),
+    height: 50,
+    width: 50,
+    alt: t('image_description.spinner')
+  ) %>
+</div>
+
+<!-- This view is never displayed, but it needs to be present in the DOM for
+the SDK to capture the feed from the camer -->
+<video id="acuant-player" controls autoPlay playsInline class='hidden'></video>
+<div id='acuant-sdk-capture-view' class='hidden'>
+  <canvas id="acuant-video-canvas" style='width: 100%;'></canvas>
+</div>
+
+<div id='acuant-sdk-continue-form' class='hidden'>
+  <img id='acuant-sdk-preview' class='mb2'>
+  <%= submit_tag t('forms.buttons.continue'), class: 'block btn btn-primary btn-wide' %>
+  <%= link_to(
+    retry_capture_button_label,
+    url_for,
+    class: 'center btn btn-secondary btn-wide mt2',
+  ) %>
+</div>
+
+<%= javascript_pack_tag 'acuant_selfie_capture' %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -1,13 +1,7 @@
 <% title t('doc_auth.titles.doc_auth') %>
 <% content_for :meta_tags do %>
-  <meta
-    name="acuant-sdk-initialization-endpoint"
-    content="<%= Figaro.env.acuant_sdk_initialization_endpoint %>"
-  >
-  <meta
-    name="acuant-sdk-initialization-creds"
-    content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
-  >
+  <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: Figaro.env.acuant_sdk_initialization_endpoint %>
+  <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
 <% end %>
 <%= tag.div id: 'document-capture-form', data: {
   liveness: liveness_checking_enabled?.presence,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -1,123 +1,121 @@
-<% if Figaro.env.acuant_sdk_document_capture_enabled == 'true' %>
-  <% title t('doc_auth.titles.doc_auth') %>
-  <% content_for :meta_tags do %>
-    <meta
-      name="acuant-sdk-initialization-endpoint"
-      content="<%= Figaro.env.acuant_sdk_initialization_endpoint %>"
-    >
-    <meta
-      name="acuant-sdk-initialization-creds"
-      content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
-    >
-  <% end %>
-  <%= tag.div id: 'document-capture-form', data: {
-    liveness: liveness_checking_enabled?.presence,
-    mock_client: (DocAuth::Client.doc_auth_vendor == 'mock').presence,
-    document_capture_session_uuid: flow_session[:document_capture_session_uuid],
-    endpoint: api_verify_images_url,
-  } %>
-  <div class="js-fallback">
-    <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
-
-    <h1 class="h3 my0">
-      <% if liveness_checking_enabled? %>
-        <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
-      <% else %>
-        <%= t('doc_auth.headings.document_capture_heading_html') %>
-      <% end %>
-    </h1>
-
-    <%= validated_form_for(
-      :doc_auth,
-      url: url_for,
-      method: 'PUT',
-      html: { autocomplete: 'off', role: 'form', class: 'mt2 js-document-capture-form' }
-    ) do |f| %>
-      <%# ---- Front Image ----- %>
-
-      <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
-      <ul>
-        <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
-        <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
-        <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
-        <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
-      </ul>
-
-      <div class="front-image mt2">
-        <p>
-          <strong>
-            <%= t('doc_auth.headings.document_capture_front') %><br/>
-          </strong>
-          <%= t('doc_auth.tips.document_capture_hint') %>
-        </p>
-
-        <%= f.input :front_image_data_url, as: :hidden %>
-        <%= f.input :front_image, label: false, as: :file, required: true %>
-        <div class='my2' id='front_target'></div>
-      </div>
-
-      <%# ---- Back Image ----- %>
-
-      <div class="back-image mt3">
-        <p>
-          <strong>
-            <%= t('doc_auth.headings.document_capture_back') %><br/>
-          </strong>
-          <%= t('doc_auth.tips.document_capture_hint') %>
-        </p>
-
-        <%= f.input :back_image_data_url, as: :hidden %>
-        <%= f.input :back_image, label: false, as: :file, required: true %>
-        <div class='my2' id='back_target'></div>
-      </div>
-
-      <%# ---- Selfie ----- %>
-      <% if liveness_checking_enabled? %>
-        <hr class="mt3 mb3"/>
-        <div class="selfie">
-          <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
-
-          <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
-          <ul>
-            <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
-            <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>
-            <li><%= t('doc_auth.tips.document_capture_selfie_text3') %></li>
-          </ul>
-
-          <p class='mt3'>
-            <strong>
-              <%= t('doc_auth.headings.document_capture_selfie') %><br/>
-            </strong>
-            <%= t('doc_auth.tips.document_capture_hint') %>
-          </p>
-
-          <%= f.input :selfie_image_data_url, as: :hidden %>
-          <%= f.input :selfie_image, label: false, as: :file, required: true %>
-          <div class='my2' id='selfie_target'></div>
-        </div>
-      <% end %>
-
-      <%# ---- Submit ----- %>
-
-      <div class='mt4 mb4'>
-        <%= render 'idv/doc_auth/submit_with_spinner' %>
-      </div>
-    <% end %> <%# end validated_form_for %>
-
-    <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
-
-    <%= javascript_pack_tag 'image-preview' %>
-  </div>
-  <%= render 'idv/doc_auth/start_over_or_cancel' %>
-  <%= nonced_javascript_tag do %>
-    <% asset_keys = [
-      'close-white-alt.svg',
-      'id-card.svg',
-      'spinner.gif',
-      'spinner@2x.gif'
-    ] %>
-    window.LoginGov = window.LoginGov || {};
-    window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
-  <% end %>
-  <%= javascript_pack_tag 'document-capture' %>
+<% title t('doc_auth.titles.doc_auth') %>
+<% content_for :meta_tags do %>
+  <meta
+    name="acuant-sdk-initialization-endpoint"
+    content="<%= Figaro.env.acuant_sdk_initialization_endpoint %>"
+  >
+  <meta
+    name="acuant-sdk-initialization-creds"
+    content="<%= Figaro.env.acuant_sdk_initialization_creds %>"
+  >
 <% end %>
+<%= tag.div id: 'document-capture-form', data: {
+  liveness: liveness_checking_enabled?.presence,
+  mock_client: (DocAuth::Client.doc_auth_vendor == 'mock').presence,
+  document_capture_session_uuid: flow_session[:document_capture_session_uuid],
+  endpoint: api_verify_images_url,
+} %>
+<div class="js-fallback">
+  <%= render 'idv/doc_auth/error_messages', flow_session: flow_session %>
+
+  <h1 class="h3 my0">
+    <% if liveness_checking_enabled? %>
+      <%= t('doc_auth.headings.document_capture_heading_with_selfie_html') %>
+    <% else %>
+      <%= t('doc_auth.headings.document_capture_heading_html') %>
+    <% end %>
+  </h1>
+
+  <%= validated_form_for(
+    :doc_auth,
+    url: url_for,
+    method: 'PUT',
+    html: { autocomplete: 'off', role: 'form', class: 'mt2 js-document-capture-form' }
+  ) do |f| %>
+    <%# ---- Front Image ----- %>
+
+    <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
+    <ul>
+      <li><%= t('doc_auth.tips.document_capture_id_text1') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text2') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text3') %></li>
+      <li><%= t('doc_auth.tips.document_capture_id_text4') %></li>
+    </ul>
+
+    <div class="front-image mt2">
+      <p>
+        <strong>
+          <%= t('doc_auth.headings.document_capture_front') %><br/>
+        </strong>
+        <%= t('doc_auth.tips.document_capture_hint') %>
+      </p>
+
+      <%= f.input :front_image_data_url, as: :hidden %>
+      <%= f.input :front_image, label: false, as: :file, required: true %>
+      <div class='my2' id='front_target'></div>
+    </div>
+
+    <%# ---- Back Image ----- %>
+
+    <div class="back-image mt3">
+      <p>
+        <strong>
+          <%= t('doc_auth.headings.document_capture_back') %><br/>
+        </strong>
+        <%= t('doc_auth.tips.document_capture_hint') %>
+      </p>
+
+      <%= f.input :back_image_data_url, as: :hidden %>
+      <%= f.input :back_image, label: false, as: :file, required: true %>
+      <div class='my2' id='back_target'></div>
+    </div>
+
+    <%# ---- Selfie ----- %>
+    <% if liveness_checking_enabled? %>
+      <hr class="mt3 mb3"/>
+      <div class="selfie">
+        <p><%= t('doc_auth.instructions.document_capture_selfie_instructions') %></p>
+
+        <p class="mt2 mb0"><%= t('doc_auth.tips.document_capture_header_text') %></p>
+        <ul>
+          <li><%= t('doc_auth.tips.document_capture_selfie_text1') %></li>
+          <li><%= t('doc_auth.tips.document_capture_selfie_text2') %></li>
+          <li><%= t('doc_auth.tips.document_capture_selfie_text3') %></li>
+        </ul>
+
+        <p class='mt3'>
+          <strong>
+            <%= t('doc_auth.headings.document_capture_selfie') %><br/>
+          </strong>
+          <%= t('doc_auth.tips.document_capture_hint') %>
+        </p>
+
+        <%= f.input :selfie_image_data_url, as: :hidden %>
+        <%= f.input :selfie_image, label: false, as: :file, required: true %>
+        <div class='my2' id='selfie_target'></div>
+      </div>
+    <% end %>
+
+    <%# ---- Submit ----- %>
+
+    <div class='mt4 mb4'>
+      <%= render 'idv/doc_auth/submit_with_spinner' %>
+    </div>
+  <% end %> <%# end validated_form_for %>
+
+  <p class='mt3 mb0'><%= t('doc_auth.info.document_capture_upload_image') %></p>
+
+  <%= javascript_pack_tag 'image-preview' %>
+</div>
+<%= render 'idv/doc_auth/start_over_or_cancel' %>
+<%= nonced_javascript_tag do %>
+  <% asset_keys = [
+    'close-white-alt.svg',
+    'id-card.svg',
+    'spinner.gif',
+    'spinner@2x.gif'
+  ] %>
+  window.LoginGov = window.LoginGov || {};
+  window.LoginGov.assets = <%= raw asset_keys.map { |key| [key, asset_path(key)] }.to_h.to_json %>;
+<% end %>
+<%= javascript_pack_tag 'document-capture' %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -150,7 +150,6 @@ development:
   acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
-  acuant_sdk_document_capture_enabled: 'true'
   async_job_refresh_interval_seconds: '5'
   attribute_cost: 4000$8$4$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
@@ -262,7 +261,6 @@ production:
   acuant_facial_match_url: ''
   acuant_max_attempts: '20'
   acuant_passlive_url: ''
-  acuant_sdk_document_capture_enabled: 'false'
   async_job_refresh_interval_seconds: '5'
   attribute_cost: 4000$8$4$
   attribute_encryption_key:
@@ -369,7 +367,6 @@ test:
   acuant_facial_match_url: https://facial_match.example.com
   acuant_max_attempts: '4'
   acuant_passlive_url: https://liveness.example.com
-  acuant_sdk_document_capture_enabled: 'false'
   async_job_refresh_interval_seconds: '1'
   attribute_cost: 800$8$1$
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -14,7 +14,6 @@ feature 'doc auth document capture step' do
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
-    allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).and_return('true')
     sign_in_and_2fa_user(user)
     complete_doc_auth_steps_before_document_capture_step
   end

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -34,20 +34,16 @@ feature 'doc auth ssn step' do
 
   context 'doc capture hand-off' do
     let(:document_capture_step_enabled) { true }
-    let(:acuant_sdk_document_capture_enabled) { 'true' }
 
     before do
       allow(FeatureManagement).to receive(:document_capture_step_enabled?).
         and_return(document_capture_step_enabled)
-      allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).
-        and_return(acuant_sdk_document_capture_enabled)
       in_doc_capture_session { complete_doc_capture_steps_before_capture_complete_step }
       click_on t('forms.buttons.continue')
     end
 
     context 'document capture step enabled' do
       let(:document_capture_step_enabled) { true }
-      let(:acuant_sdk_document_capture_enabled) { 'true' }
 
       it 'is on the correct page' do
         expect(page).to have_current_path(idv_doc_auth_ssn_step)
@@ -72,7 +68,6 @@ feature 'doc auth ssn step' do
 
     context 'document capture step disabled' do
       let(:document_capture_step_enabled) { false }
-      let(:acuant_sdk_document_capture_enabled) { 'false' }
 
       it 'is on the correct page' do
         expect(page).to have_current_path(idv_doc_auth_ssn_step)

--- a/spec/features/idv/doc_capture/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_capture/document_capture_step_spec.rb
@@ -14,7 +14,6 @@ feature 'doc capture document capture step' do
     allow(Figaro.env).to receive(:document_capture_step_enabled).and_return('true')
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
-    allow(Figaro.env).to receive(:acuant_sdk_document_capture_enabled).and_return('true')
     if sp_requests_ial2_strict
       visit_idp_from_oidc_sp_with_ial2_strict
     else

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -30,7 +30,7 @@ module IdvHelper
   end
 
   def click_idv_continue
-    click_on t('forms.buttons.continue')
+    click_on t('forms.buttons.continue'), match: :first
   end
 
   def choose_idv_otp_delivery_method_sms


### PR DESCRIPTION
**Why**: The value is `true` in all environments, it's not expected to need to change, and it is incompatible with the introduction of the React-based document capture flow.

I've confirmed this myself by verifying the configuration value in all live environments, though a second look by a reviewer would be appreciated.

Most changes are indentation. Recommend to review file changes using ["Hide whitespace changes" GitHub option](https://user-images.githubusercontent.com/1779930/93888869-8a22b800-fcb6-11ea-9d56-083d865d9f16.png).
