### PR TITLE
Use react-hooks-testing-library to test React context, hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@rails/webpacker": "^4.1.0",
     "@testing-library/dom": "^7.21.8",
     "@testing-library/react": "^10.4.8",
+    "@testing-library/react-hooks": "^3.4.1",
     "@testing-library/user-event": "^12.0.11",
     "@types/react": "^16.9.46",
     "chai": "^3.5.0",
@@ -56,6 +57,7 @@
     "jsdom": "^16.2.2",
     "mocha": "^6.1.4",
     "prettier": "^2.0.5",
+    "react-test-renderer": "^16.13.1",
     "sinon": "^9.0.2",
     "typescript": "^3.9.7",
     "webpack-dev-server": "^3.11.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@testing-library/react": "^10.4.8",
     "@testing-library/react-hooks": "^3.4.1",
     "@testing-library/user-event": "^12.0.11",
-    "@types/react": "^16.9.46",
+    "@types/react": "^16.9.49",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
     "eslint": "^7.6.0",

--- a/spec/javascripts/packages/document-capture/context/asset-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/asset-spec.jsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import AssetContext from '@18f/identity-document-capture/context/asset';
-import render from '../../../support/render';
 
 describe('document-capture/context/asset', () => {
-  const ContextValue = () => JSON.stringify(useContext(AssetContext));
-
   it('defaults to empty object', () => {
-    const { container } = render(<ContextValue />);
+    const { result } = renderHook(() => useContext(AssetContext));
 
-    expect(container.textContent).to.equal('{}');
+    expect(result.current).to.deep.equal({});
   });
 });

--- a/spec/javascripts/packages/document-capture/context/device-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/device-spec.jsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import DeviceContext from '@18f/identity-document-capture/context/device';
-import render from '../../../support/render';
 
 describe('document-capture/context/device', () => {
-  const ContextValue = () => JSON.stringify(useContext(DeviceContext));
-
   it('defaults to an object shape of device supports', () => {
-    const { container } = render(<ContextValue />);
+    const { result } = renderHook(() => useContext(DeviceContext));
 
-    expect(container.textContent).to.equal('{"isMobile":false}');
+    expect(result.current).to.deep.equal({ isMobile: false });
   });
 });

--- a/spec/javascripts/packages/document-capture/context/file-base64-cache-spec.js
+++ b/spec/javascripts/packages/document-capture/context/file-base64-cache-spec.js
@@ -1,15 +1,11 @@
-import { createElement, useContext } from 'react';
+import { useContext } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import FileBase64Cache from '@18f/identity-document-capture/context/file-base64-cache';
-import render from '../../../support/render';
 
 describe('document-capture/context/file-base64-cache', () => {
   it('defaults to WeakMap', () => {
-    render(
-      createElement(() => {
-        const cache = useContext(FileBase64Cache);
-        expect(cache).to.be.instanceof(WeakMap);
-        return null;
-      }),
-    );
+    const { result } = renderHook(() => useContext(FileBase64Cache));
+
+    expect(result.current).to.be.instanceof(WeakMap);
   });
 });

--- a/spec/javascripts/packages/document-capture/context/i18n-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/i18n-spec.jsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import I18nContext from '@18f/identity-document-capture/context/i18n';
-import render from '../../../support/render';
 
 describe('document-capture/context/i18n', () => {
-  const ContextValue = () => JSON.stringify(useContext(I18nContext));
-
   it('defaults to empty object', () => {
-    const { container } = render(<ContextValue />);
+    const { result } = renderHook(() => useContext(I18nContext));
 
-    expect(container.textContent).to.equal('{}');
+    expect(result.current).to.deep.equal({});
   });
 });

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -1,103 +1,87 @@
-import React, { createElement, useContext, useEffect } from 'react';
-import { render as baseRender } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import UploadContext, {
   Provider as UploadContextProvider,
 } from '@18f/identity-document-capture/context/upload';
 import defaultUpload from '@18f/identity-document-capture/services/upload';
-import render from '../../../support/render';
 
 describe('document-capture/context/upload', () => {
   it('defaults to the default upload service', () => {
-    baseRender(
-      createElement(() => {
-        const { upload, isMockClient } = useContext(UploadContext);
-        expect(upload).to.equal(defaultUpload);
-        expect(isMockClient).to.equal(false);
-        return null;
-      }),
-    );
+    const { result } = renderHook(() => useContext(UploadContext));
+    const { upload, isMockClient } = result.current;
+
+    expect(upload).to.equal(defaultUpload);
+    expect(isMockClient).to.equal(false);
   });
 
-  it('can be overridden with custom upload behavior', (done) => {
-    render(
-      <UploadContextProvider upload={(payload) => Promise.resolve({ ...payload, received: true })}>
-        {createElement(() => {
-          const { upload } = useContext(UploadContext);
-          useEffect(() => {
-            upload({ sent: true }).then((result) => {
-              expect(result).to.deep.equal({ sent: true, received: true });
-              done();
-            });
-          }, [upload]);
-          return null;
-        })}
-      </UploadContextProvider>,
-    );
+  it('can be overridden with custom upload behavior', async () => {
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider
+          upload={(payload) => Promise.resolve({ ...payload, received: true })}
+        >
+          {children}
+        </UploadContextProvider>
+      ),
+    });
+
+    const uploadResult = await result.current.upload({ sent: true });
+    expect(uploadResult).to.deep.equal({ sent: true, received: true });
   });
 
   it('can be overridden with isMockClient value', () => {
-    render(
-      <UploadContextProvider isMockClient>
-        {createElement(() => {
-          const { isMockClient } = useContext(UploadContext);
-          expect(isMockClient).to.equal(true);
-          return null;
-        })}
-      </UploadContextProvider>,
-    );
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider isMockClient>{children}</UploadContextProvider>
+      ),
+    });
+
+    expect(result.current.isMockClient).to.be.true();
   });
 
-  it('can provide endpoint and csrf to make available to uploader', (done) => {
-    render(
-      <UploadContextProvider
-        upload={(payload, { endpoint, csrf }) =>
-          Promise.resolve({
-            ...payload,
-            receivedEndpoint: endpoint,
-            receivedCSRF: csrf,
-          })
-        }
-        csrf="example"
-        endpoint="https://example.com"
-      >
-        {createElement(() => {
-          const { upload } = useContext(UploadContext);
-          useEffect(() => {
-            upload({ sent: true }).then((result) => {
-              expect(result).to.deep.equal({
-                sent: true,
-                receivedEndpoint: 'https://example.com',
-                receivedCSRF: 'example',
-              });
-              done();
-            });
-          }, [upload]);
-          return null;
-        })}
-      </UploadContextProvider>,
-    );
+  it('can provide endpoint and csrf to make available to uploader', async () => {
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider
+          upload={(payload, { endpoint, csrf }) =>
+            Promise.resolve({
+              ...payload,
+              receivedEndpoint: endpoint,
+              receivedCSRF: csrf,
+            })
+          }
+          csrf="example"
+          endpoint="https://example.com"
+        >
+          {children}
+        </UploadContextProvider>
+      ),
+    });
+
+    const uploadResult = await result.current.upload({ sent: true });
+    expect(uploadResult).to.deep.equal({
+      sent: true,
+      receivedEndpoint: 'https://example.com',
+      receivedCSRF: 'example',
+    });
   });
 
-  it('can merge form data to pass to uploader', (done) => {
-    render(
-      <UploadContextProvider
-        upload={(payload) => Promise.resolve(payload)}
-        formData={{ foo: 'bar' }}
-      >
-        {createElement(() => {
-          const { upload } = useContext(UploadContext);
-          useEffect(() => {
-            upload({ sent: true }).then((result) => {
-              expect(result).to.deep.equal({
-                sent: true,
-                foo: 'bar',
-              });
-              done();
-            });
-          }, [upload]);
-          return null;
-        })}
-      </UploadContextProvider>,
-    );
+  it('can merge form data to pass to uploader', async () => {
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider
+          upload={(payload) => Promise.resolve(payload)}
+          formData={{ foo: 'bar' }}
+        >
+          {children}
+        </UploadContextProvider>
+      ),
+    });
+
+    const uploadResult = await result.current.upload({ sent: true });
+    expect(uploadResult).to.deep.equal({
+      sent: true,
+      foo: 'bar',
+    });
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-asset-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-asset-spec.jsx
@@ -1,36 +1,30 @@
-import React, { createElement } from 'react';
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import useAsset from '@18f/identity-document-capture/hooks/use-asset';
 import AssetContext from '@18f/identity-document-capture/context/asset';
-import render from '../../../support/render';
 
 describe('document-capture/hooks/use-asset', () => {
   describe('getAssetPath', () => {
     it('returns undefined if the asset is not known', () => {
-      const { getByAltText } = render(
-        createElement(() => {
-          const { getAssetPath } = useAsset();
-          return <img src={getAssetPath('unknown.png')} alt="unknown" />;
-        }),
-      );
+      const { result } = renderHook(() => useAsset());
 
-      const img = getByAltText('unknown');
+      const { getAssetPath } = result.current;
 
-      expect(img.hasAttribute('src')).to.be.false();
+      expect(getAssetPath('unknown.png')).to.be.undefined();
     });
 
     it('returns mapped src if known by context', () => {
-      const { getByAltText } = render(
-        <AssetContext.Provider value={{ 'icon.png': 'icon-12345.png' }}>
-          {createElement(() => {
-            const { getAssetPath } = useAsset();
-            return <img src={getAssetPath('icon.png')} alt="icon" />;
-          })}
-        </AssetContext.Provider>,
-      );
+      const { result } = renderHook(() => useAsset(), {
+        wrapper: ({ children }) => (
+          <AssetContext.Provider value={{ 'icon.png': 'icon-12345.png' }}>
+            {children}
+          </AssetContext.Provider>
+        ),
+      });
 
-      const img = getByAltText('icon');
+      const { getAssetPath } = result.current;
 
-      expect(img.getAttribute('src')).to.equal('icon-12345.png');
+      expect(getAssetPath('icon.png')).to.equal('icon-12345.png');
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-i18n-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-i18n-spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import I18nContext from '@18f/identity-document-capture/context/i18n';
 import useI18n, { formatHTML } from '@18f/identity-document-capture/hooks/use-i18n';
 import render from '../../../support/render';
@@ -49,22 +50,24 @@ describe('document-capture/hooks/use-i18n', () => {
   });
 
   describe('t', () => {
-    const LocalizedString = ({ stringKey }) => useI18n().t(stringKey);
-
     it('returns localized key value', () => {
-      const { container } = render(
-        <I18nContext.Provider value={{ sample: 'translation' }}>
-          <LocalizedString stringKey="sample" />
-        </I18nContext.Provider>,
-      );
+      const { result } = renderHook(() => useI18n(), {
+        wrapper: ({ children }) => (
+          <I18nContext.Provider value={{ sample: 'translation' }}>{children}</I18nContext.Provider>
+        ),
+      });
 
-      expect(container.textContent).to.equal('translation');
+      const { t } = result.current;
+
+      expect(t('sample')).to.equal('translation');
     });
 
     it('falls back to key value', () => {
-      const { container } = render(<LocalizedString stringKey="sample" />);
+      const { result } = renderHook(() => useI18n());
 
-      expect(container.textContent).to.equal('sample');
+      const { t } = result.current;
+
+      expect(t('sample')).to.equal('sample');
     });
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-if-still-mounted-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-if-still-mounted-spec.jsx
@@ -1,43 +1,24 @@
-import React from 'react';
 import sinon from 'sinon';
-import { fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import useIfStillMounted from '@18f/identity-document-capture/hooks/use-if-still-mounted';
-import render from '../../../support/render';
 
 describe('document-capture/hooks/use-if-still-mounted', () => {
-  function TestComponent({ callback }) {
-    const ifStillMounted = useIfStillMounted();
-    const fn = ifStillMounted(callback);
-
-    return (
-      <button type="button" onClick={() => setTimeout(fn, 0)}>
-        trigger
-      </button>
-    );
-  }
-
-  it('returns function which executes callback if component is still mounted', (done) => {
+  it('returns function which executes callback if component is still mounted', () => {
     const spy = sinon.spy();
-
-    const { getByText } = render(<TestComponent callback={spy} />);
-    fireEvent.click(getByText('trigger'));
-
-    setTimeout(() => {
-      expect(spy.calledOnce).to.be.true();
-      done();
-    }, 0);
+    const { result } = renderHook(() => useIfStillMounted());
+    const ifStillMounted = result.current;
+    const fn = ifStillMounted(spy);
+    fn();
+    expect(spy.calledOnce).to.be.true();
   });
 
-  it('returns function which does not execute callback if component is unmounted', (done) => {
+  it('returns function which does not execute callback if component is unmounted', () => {
     const spy = sinon.spy();
-
-    const { getByText, unmount } = render(<TestComponent callback={spy} />);
-    fireEvent.click(getByText('trigger'));
+    const { result, unmount } = renderHook(() => useIfStillMounted());
+    const ifStillMounted = result.current;
+    const fn = ifStillMounted(spy);
     unmount();
-
-    setTimeout(() => {
-      expect(spy.called).to.be.false();
-      done();
-    }, 0);
+    fn();
+    expect(spy.called).to.be.false();
   });
 });

--- a/spec/javascripts/packages/document-capture/hooks/use-instance-id-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-instance-id-spec.jsx
@@ -1,28 +1,13 @@
-import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 import useInstanceId from '@18f/identity-document-capture/hooks/use-instance-id';
-import render from '../../../support/render';
 
 describe('document-capture/hooks/use-instance-id', () => {
-  function TestComponent() {
-    const instanceId = useInstanceId();
-
-    return `${typeof instanceId}${instanceId}`;
-  }
-
   it('returns a unique string id', () => {
-    const { getByText } = render(
-      <>
-        <span>First</span>
-        <TestComponent />
-        <span>Second</span>
-        <TestComponent />
-      </>,
-    );
+    const { result: result1 } = renderHook(() => useInstanceId());
+    const { result: result2 } = renderHook(() => useInstanceId());
 
-    const first = getByText('First').nextSibling.nodeValue;
-    const second = getByText('Second').nextSibling.nodeValue;
-    expect(first).to.match(/^string/);
-    expect(second).to.match(/^string/);
-    expect(first).to.not.equal(second);
+    expect(result1.current).to.be.a('string');
+    expect(result2.current).to.be.a('string');
+    expect(result1.current).to.not.equal(result2.current);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,6 +964,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.4":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1124,6 +1131,14 @@
     dom-accessibility-api "^0.4.6"
     pretty-format "^25.5.0"
 
+"@testing-library/react-hooks@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
+  integrity sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.3.0"
+
 "@testing-library/react@^10.4.8":
   version "10.4.8"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.8.tgz#5eb730291b8fd81cdb2d8877770d060b044ae4a4"
@@ -1218,6 +1233,21 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.9.49"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
+  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.46":
   version "16.9.46"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
@@ -1225,6 +1255,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/testing-library__react-hooks@^3.3.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz#be148b7fa7d19cd3349c4ef9d9534486bc582fcc"
+  integrity sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -7690,10 +7727,20 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.12.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-test-renderer@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
 
 react@^16.13.1:
   version "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,18 +1240,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@^16.9.49":
   version "16.9.49"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
   integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.9.46":
-  version "16.9.46"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
-  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
Related (extracts from): #4228 (specifically https://github.com/18F/identity-idp/pull/4228#discussion_r492722826)

**Why**: Better ergonomics, more direct access to context values in their native types without need for intermediate components.