### PR TITLE
LG-3470: Fix document capture to occupy full screen

### DIFF
--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -18,6 +18,7 @@ body.has-full-screen-overlay { // scss-lint:disable QualifyingElement
   right: 0;
   top: 0;
   width: auto;
+  z-index: 10;
 
   &:hover,
   &:focus {

--- a/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture-canvas.jsx
@@ -172,7 +172,16 @@ function AcuantCaptureCanvas({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video id="acuant-player" controls autoPlay playsInline style={{ display: 'none' }} />
       <div id="acuant-sdk-capture-view">
-        <canvas id="acuant-video-canvas" width="100%" height="auto" />
+        <canvas
+          id="acuant-video-canvas"
+          style={{
+            width: '100%',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
**Why**: As a user, I expect the video from document capture to occupy the full screen, so that I can most easily take a photo of my documents.

**Technical Details:**

The reason that this happens it because Acuant is scaling the width of the video feed proportional to the native camera aspect ratio, often resulting in a width which is not quite 100% of the screen.

You can see this in the function `onLoadedMetaData` from lines 787 to 821 of the [Acuant SDK source code](https://raw.githubusercontent.com/Acuant/JavascriptWebSDKV11/master/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js):

```js
targetHeight = document.body.clientHeight;

videoCanvas.width = targetHeight * (player.videoWidth / player.videoHeight);
videoCanvas.height = targetHeight;
```

The changes introduced here will override the width of the canvas to always occupy 100% width. This causes the height to scale (increase) accordingly, which will result in some clipping of the overflow. This is offset by centering the canvas, such that the video is at least capturing the centered camera input.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/1779930/94147728-b0299300-fe43-11ea-9637-bf07dca51e09.png" width="240" alt="screenshot">
