### PR TITLE
LG-3427: Add review step for document capture errors

### DIFF
--- a/app/javascript/packages/document-capture/components/desktop-document-disclosure.jsx
+++ b/app/javascript/packages/document-capture/components/desktop-document-disclosure.jsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import DeviceContext from '../context/device';
+import useI18n from '../hooks/use-i18n';
+
+/**
+ * Renders a document usage disclosure for desktop devices only. On mobile devices, an equivalent
+ * message is displayed on the introductory step.
+ *
+ * @type {import('react').FC}
+ */
+function DesktopDocumentDisclosure() {
+  const { isMobile } = useContext(DeviceContext);
+  const { t } = useI18n();
+
+  return isMobile ? null : <p>{t('doc_auth.info.document_capture_upload_image')}</p>;
+}
+
+export default DesktopDocumentDisclosure;

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -91,7 +91,7 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   ) : (
     <>
       {submissionError && (
-        <Alert type="error" className="margin-bottom-4">
+        <Alert type="error" className="margin-bottom-4 margin-top-2 tablet:margin-top-0">
           {isFormEntriesError
             ? getFormattedErrorMessages(
                 /** @type {UploadFormEntriesError} */ (submissionError).rawErrors,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -91,7 +91,7 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   ) : (
     <>
       {submissionError && (
-        <Alert type="error" className="margin-bottom-2">
+        <Alert type="error" className="margin-bottom-4">
           {isFormEntriesError
             ? getFormattedErrorMessages(
                 /** @type {UploadFormEntriesError} */ (submissionError).rawErrors,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -4,9 +4,11 @@ import FormSteps from './form-steps';
 import { UploadFormEntriesError } from '../services/upload';
 import DocumentsStep from './documents-step';
 import SelfieStep from './selfie-step';
+import ReviewIssuesStep from './review-issues-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
+import DesktopDocumentDisclosure from './desktop-document-disclosure';
 import useI18n from '../hooks/use-i18n';
 
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -40,27 +42,6 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
 
-  const steps = /** @type {FormStep[]} */ ([
-    isMobile && {
-      name: 'intro',
-      title: t('doc_auth.headings.document_capture'),
-      form: MobileIntroStep,
-    },
-    {
-      name: 'documents',
-      title: t('doc_auth.headings.document_capture'),
-      form: DocumentsStep,
-      footer: isMobile
-        ? undefined
-        : () => <p>{t('doc_auth.info.document_capture_upload_image')}</p>,
-    },
-    isLivenessEnabled && {
-      name: 'selfie',
-      title: t('doc_auth.headings.selfie'),
-      form: SelfieStep,
-    },
-  ].filter(Boolean));
-
   /**
    * Clears error state and sets form values for submission.
    *
@@ -72,6 +53,35 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   }
 
   const isFormEntriesError = submissionError && submissionError instanceof UploadFormEntriesError;
+
+  /** @type {FormStep[]} */
+  const steps = submissionError
+    ? [
+        {
+          name: 'review',
+          title: t('doc_auth.headings.review_issues'),
+          form: ReviewIssuesStep,
+          footer: DesktopDocumentDisclosure,
+        },
+      ]
+    : /** @type {FormStep[]} */ ([
+        isMobile && {
+          name: 'intro',
+          title: t('doc_auth.headings.document_capture'),
+          form: MobileIntroStep,
+        },
+        {
+          name: 'documents',
+          title: t('doc_auth.headings.document_capture'),
+          form: DocumentsStep,
+          footer: DesktopDocumentDisclosure,
+        },
+        isLivenessEnabled && {
+          name: 'selfie',
+          title: t('doc_auth.headings.selfie'),
+          form: SelfieStep,
+        },
+      ].filter(Boolean));
 
   return formValues && !submissionError ? (
     <Submission

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { hasMediaAccess } from '@18f/identity-device';
-import { RequiredValueMissingError } from './form-steps';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -65,7 +65,7 @@ function ReviewIssuesStep({
         return (
           <AcuantCapture
             key={side}
-            ref={registerField(side, { required: true })}
+            ref={registerField(side, { isRequired: true })}
             /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
             /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
             label={t(`doc_auth.headings.document_capture_${side}`)}
@@ -89,7 +89,7 @@ function ReviewIssuesStep({
       </ul>
       {isMobile || !hasMediaAccess() ? (
         <AcuantCapture
-          ref={registerField('selfie', { required: true })}
+          ref={registerField('selfie', { isRequired: true })}
           capture="user"
           label={t('doc_auth.headings.document_capture_selfie')}
           bannerText={t('doc_auth.headings.photo')}
@@ -101,7 +101,7 @@ function ReviewIssuesStep({
         />
       ) : (
         <SelfieCapture
-          ref={registerField('selfie', { required: true })}
+          ref={registerField('selfie', { isRequired: true })}
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -1,0 +1,115 @@
+import React, { useContext } from 'react';
+import { hasMediaAccess } from '@18f/identity-device';
+import { RequiredValueMissingError } from './form-steps';
+import useI18n from '../hooks/use-i18n';
+import DeviceContext from '../context/device';
+import AcuantCapture from './acuant-capture';
+import SelfieCapture from './selfie-capture';
+import FormErrorMessage from './form-error-message';
+import ServiceProviderContext from '../context/service-provider';
+
+/**
+ * @typedef ReviewIssuesStepValue
+ *
+ * @prop {Blob=} front Front image value.
+ * @prop {Blob=} back Back image value.
+ * @prop {Blob?=} selfie Back image value.
+ */
+
+/**
+ * Sides of document to present as file input.
+ */
+const DOCUMENT_SIDES = ['front', 'back'];
+
+/**
+ * @param {import('./form-steps').FormStepComponentProps<ReviewIssuesStepValue>} props Props object.
+ */
+function ReviewIssuesStep({
+  value = {},
+  onChange = () => {},
+  errors = [],
+  registerField = () => undefined,
+}) {
+  const { t, formatHTML } = useI18n();
+  const { isMobile } = useContext(DeviceContext);
+  const serviceProvider = useContext(ServiceProviderContext);
+  const selfieError = errors.find(({ field }) => field === 'selfie')?.error;
+
+  return (
+    <>
+      <p>
+        {formatHTML(t('doc_auth.info.id_worn_html'), {
+          strong: 'strong',
+        })}
+      </p>
+      {serviceProvider && (
+        <p>
+          {formatHTML(
+            t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
+            {
+              strong: 'strong',
+              a: ({ children }) => <a href={serviceProvider.failureToProofURL}>{children}</a>,
+            },
+          )}
+        </p>
+      )}
+      <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_id_header_text')}</p>
+      <ul>
+        <li>{t('doc_auth.tips.review_issues_id_text1')}</li>
+        <li>{t('doc_auth.tips.review_issues_id_text2')}</li>
+        <li>{t('doc_auth.tips.review_issues_id_text3')}</li>
+        <li>{t('doc_auth.tips.review_issues_id_text4')}</li>
+      </ul>
+      {DOCUMENT_SIDES.map((side) => {
+        const sideError = errors.find(({ field }) => field === side)?.error;
+
+        return (
+          <AcuantCapture
+            key={side}
+            ref={registerField(side, { required: true })}
+            /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
+            /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
+            label={t(`doc_auth.headings.document_capture_${side}`)}
+            /* i18n-tasks-use t('doc_auth.headings.back') */
+            /* i18n-tasks-use t('doc_auth.headings.front') */
+            bannerText={t(`doc_auth.headings.${side}`)}
+            value={value[side]}
+            onChange={(nextValue) => onChange({ [side]: nextValue })}
+            className="id-card-file-input"
+            errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}
+          />
+        );
+      })}
+      <hr className="margin-y-4" />
+      <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>
+      <ul>
+        <li>{t('doc_auth.tips.review_issues_selfie_text1')}</li>
+        <li>{t('doc_auth.tips.review_issues_selfie_text2')}</li>
+        <li>{t('doc_auth.tips.review_issues_selfie_text3')}</li>
+        <li>{t('doc_auth.tips.review_issues_selfie_text4')}</li>
+      </ul>
+      {isMobile || !hasMediaAccess() ? (
+        <AcuantCapture
+          ref={registerField('selfie', { required: true })}
+          capture="user"
+          label={t('doc_auth.headings.document_capture_selfie')}
+          bannerText={t('doc_auth.headings.photo')}
+          value={value.selfie}
+          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+          allowUpload={false}
+          className="id-card-file-input"
+          errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
+        />
+      ) : (
+        <SelfieCapture
+          ref={registerField('selfie', { required: true })}
+          value={value.selfie}
+          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+          errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
+        />
+      )}
+    </>
+  );
+}
+
+export default ReviewIssuesStep;

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -47,7 +47,7 @@ function ReviewIssuesStep({
           {formatHTML(
             t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
             {
-              strong: 'strong',
+              strong: ({ children }) => <>{children}</>,
               a: ({ children }) => <a href={serviceProvider.failureToProofURL}>{children}</a>,
             },
           )}

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -10,6 +10,7 @@
 - doc_auth.headings.document_capture_back
 - doc_auth.headings.document_capture_front
 - doc_auth.headings.document_capture_selfie
+- doc_auth.headings.review_issues
 - doc_auth.headings.front
 - doc_auth.headings.interstitial
 - doc_auth.headings.photo
@@ -37,6 +38,16 @@
 - doc_auth.tips.document_capture_selfie_text1
 - doc_auth.tips.document_capture_selfie_text2
 - doc_auth.tips.document_capture_selfie_text3
+- doc_auth.tips.review_issues_id_header_text
+- doc_auth.tips.review_issues_id_text1
+- doc_auth.tips.review_issues_id_text2
+- doc_auth.tips.review_issues_id_text3
+- doc_auth.tips.review_issues_id_text4
+- doc_auth.tips.review_issues_selfie_header_text
+- doc_auth.tips.review_issues_selfie_text1
+- doc_auth.tips.review_issues_selfie_text2
+- doc_auth.tips.review_issues_selfie_text3
+- doc_auth.tips.review_issues_selfie_text4
 - errors.doc_auth.acuant_network_error
 - errors.doc_auth.capture_failure
 - errors.doc_auth.document_capture_selfie_consent_blocked

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -81,6 +81,7 @@ en:
       front: Front
       interstitial: We are processing your images…
       photo: Photo
+      review_issues: Check your images and try again
       selfie: Take a photo of yourself
       ssn: Please enter your social security number.
       take_pic_back: Take a photo of the back of your ID
@@ -186,6 +187,17 @@ en:
       document_capture_selfie_text2: Take a photo against a plain background
       document_capture_selfie_text3: Do not wear a hat or sunglasses
       header_text: Guidelines for taking a photo of your ID
+      review_issues_id_header_text: 'Review the images of your state-issued ID:'
+      review_issues_id_text1: Did you use a dark background?
+      review_issues_id_text2: Did you take the photo on a flat surface?
+      review_issues_id_text3: Is the flash on your camera off?
+      review_issues_id_text4: Are all details sharp and clearly visible?
+      review_issues_selfie_header_text: 'Review the photo of yourself:'
+      review_issues_selfie_text1: Are you facing the camera?
+      review_issues_selfie_text2: Is your entire head and face in the photo?
+      review_issues_selfie_text3: Is the photo against a plain background?
+      review_issues_selfie_text4: Is your face fully visible, not covered by a hat
+        or glasses?
       text1: Take it in a room with lots of light. Indirect sunlight is best.
       text2: Make sure your ID doesn't have dirt or damaged barcodes.
       text3: Place your ID on a dark solid-colored surface that makes it easy to see

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -87,6 +87,7 @@ es:
       front: Frente
       interstitial: Estamos procesando tus imágenes…
       photo: Foto
+      review_issues: Revisa tus imágenes y vuelve a intentarlo
       selfie: Toma una foto de ti mismo
       ssn: Por favor ingrese su número de seguro social.
       take_pic_back: Toma una foto de la parte posterior de tu identificación
@@ -198,6 +199,18 @@ es:
       document_capture_selfie_text2: Toma una foto sobre un fondo liso
       document_capture_selfie_text3: No use sombrero o lentes de sol
       header_text: Pautas para tomar una foto de su identificación
+      review_issues_id_header_text: 'Revise las imágenes de su identificación emitida
+        por el estado:'
+      review_issues_id_text1: "¿Usaste un fondo oscuro?"
+      review_issues_id_text2: "¿Hiciste la foto en una superficie plana?"
+      review_issues_id_text3: "¿Está apagado el flash de la cámara?"
+      review_issues_id_text4: "¿Son todos los detalles nítidos y claramente visibles?"
+      review_issues_selfie_header_text: 'Revisa la foto tuya:'
+      review_issues_selfie_text1: "¿Estás frente a la cámara?"
+      review_issues_selfie_text2: "¿Está toda tu cabeza y tu cara en la foto?"
+      review_issues_selfie_text3: "¿La foto tiene un fondo liso?"
+      review_issues_selfie_text4: "¿Su cara es completamente visible, no está cubierta
+        por un sombrero o anteojos?"
       text1: Tómalo en una habitación con mucha luz. La luz solar indirecta es la
         mejor.
       text2: Asegúrese de que su identificación no tenga suciedad o códigos de barras

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -90,6 +90,7 @@ fr:
       front: De face
       interstitial: Nous traitons vos images…
       photo: Photo
+      review_issues: Vérifiez vos images et réessayez
       selfie: Prenez une photo de vous
       ssn: S'il vous plaît entrez votre numéro de sécurité sociale.
       take_pic_back: Prenez une photo au verso de votre identifiant
@@ -210,6 +211,19 @@ fr:
       document_capture_selfie_text2: Prenez une photo sur un fond uni
       document_capture_selfie_text3: Ne portez pas de chapeau ni de lunettes de soleil
       header_text: Directives pour prendre une photo de votre identité
+      review_issues_id_header_text: 'Examinez les images de votre pièce d''identité
+        délivrée par l''État:'
+      review_issues_id_text1: Avez-vous utilisé un fond sombre?
+      review_issues_id_text2: Avez-vous pris la photo sur une surface plane?
+      review_issues_id_text3: Le flash de votre appareil photo est-il éteint?
+      review_issues_id_text4: Tous les détails sont-ils nets et clairement visibles?
+      review_issues_selfie_header_text: 'Examinez la photo de vous-même:'
+      review_issues_selfie_text1: Êtes-vous face à la caméra?
+      review_issues_selfie_text2: Votre tête et votre visage sont-ils entiers sur
+        la photo?
+      review_issues_selfie_text3: La photo est-elle sur un fond uni?
+      review_issues_selfie_text4: Votre visage est-il entièrement visible, non couvert
+        par un chapeau ou des lunettes?
       text1: Prenez-le dans une pièce très éclairée. La lumière solaire indirecte
         est la meilleure.
       text2: Assurez-vous que votre identité n’a pas de poussière ni de codes à barres

--- a/spec/javascripts/packages/document-capture/components/desktop-document-disclosure-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/desktop-document-disclosure-spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { DeviceContext } from '@18f/identity-document-capture';
+import DesktopDocumentDisclosure from '@18f/identity-document-capture/components/desktop-document-disclosure';
+import render from '../../../support/render';
+
+describe('document-capture/components/desktop-document-disclosure', () => {
+  context('mobile', () => {
+    it('renders nothing', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: true }}>
+          <DesktopDocumentDisclosure />
+        </DeviceContext.Provider>,
+      );
+
+      expect(() => getByText('doc_auth.info.document_capture_upload_image')).to.throw();
+    });
+  });
+
+  context('desktop', () => {
+    it('renders disclosure text', () => {
+      const { getByText } = render(
+        <DeviceContext.Provider value={{ isMobile: false }}>
+          <DesktopDocumentDisclosure />
+        </DeviceContext.Provider>,
+      );
+
+      expect(getByText('doc_auth.info.document_capture_upload_image')).to.be.ok();
+    });
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -188,7 +188,7 @@ describe('document-capture/components/document-capture', () => {
     initialize({ isCameraSupported: false });
     window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
-    let continueButton = getByText('forms.buttons.continue');
+    const continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
     userEvent.upload(
@@ -218,12 +218,10 @@ describe('document-capture/components/document-capture', () => {
       /React will try to recreate this component tree from scratch using the error boundary you provided/,
     );
 
-    const heading = getByText('doc_auth.headings.document_capture');
+    const heading = getByText('doc_auth.headings.review_issues');
     expect(document.activeElement).to.equal(heading);
-    continueButton = getByText('forms.buttons.continue');
-    userEvent.click(continueButton);
 
-    const hasValueSelected = !!getByText('doc_auth.forms.change_file');
+    const hasValueSelected = getAllByText('doc_auth.forms.change_file').length === 3;
     expect(hasValueSelected).to.be.true();
 
     // Verify re-submission. It will fail again, but test can at least assure that the interstitial
@@ -292,7 +290,7 @@ describe('document-capture/components/document-capture', () => {
       /React will try to recreate this component tree from scratch using the error boundary you provided/,
     );
 
-    const heading = getByText('doc_auth.headings.document_capture');
+    const heading = getByText('doc_auth.headings.review_issues');
     expect(document.activeElement).to.equal(heading);
 
     const hasValueSelected = !!getByLabelText('doc_auth.headings.document_capture_front');

--- a/spec/javascripts/packages/document-capture/components/mobile-intro-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/mobile-intro-step-spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { I18nContext, ServiceProviderContext } from '@18f/identity-document-capture';
+import MobileIntroStep from '@18f/identity-document-capture/components/mobile-intro-step';
+import render from '../../../support/render';
+
+describe('document-capture/components/mobile-intro-step', () => {
+  context('service provider context', () => {
+    it('renders with help link', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{
+            'doc_auth.info.no_other_id_help_bold_html':
+              '<strong>If you do not have another state-issued ID</strong>, ' +
+              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
+          }}
+        >
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: 'https://example.com',
+            }}
+          >
+            <MobileIntroStep />
+          </ServiceProviderContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      const help = getByText(
+        (_content, element) =>
+          element.innerHTML ===
+          '<strong>If you do not have another state-issued ID</strong>, ' +
+            '<a href="https://example.com">get help at Example App.</a>',
+      );
+
+      expect(help).to.be.ok();
+    });
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import sinon from 'sinon';
+import { I18nContext, ServiceProviderContext } from '@18f/identity-document-capture';
+import ReviewIssuesStep from '@18f/identity-document-capture/components/review-issues-step';
+import render from '../../../support/render';
+
+describe('document-capture/components/review-issues-step', () => {
+  it('renders with front, back, and selfie inputs', () => {
+    const { getByLabelText } = render(<ReviewIssuesStep />);
+
+    const front = getByLabelText('doc_auth.headings.document_capture_front');
+    const back = getByLabelText('doc_auth.headings.document_capture_back');
+    const selfie = getByLabelText('doc_auth.headings.document_capture_selfie');
+
+    expect(front).to.be.ok();
+    expect(back).to.be.ok();
+    expect(selfie).to.be.ok();
+  });
+
+  it('calls onChange callback with uploaded image', () => {
+    const onChange = sinon.stub();
+    const { getByLabelText } = render(<ReviewIssuesStep onChange={onChange} />);
+    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+
+    userEvent.upload(getByLabelText('doc_auth.headings.document_capture_front'), file);
+    expect(onChange.getCall(0).args[0]).to.deep.equal({ front: file });
+  });
+
+  context('service provider context', () => {
+    it('renders with help link', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{
+            'doc_auth.info.no_other_id_help_bold_html':
+              '<strong>If you do not have another state-issued ID</strong>, ' +
+              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
+          }}
+        >
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: 'https://example.com',
+            }}
+          >
+            <ReviewIssuesStep />
+          </ServiceProviderContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      const help = getByText(
+        (_content, element) =>
+          element.innerHTML ===
+          '<strong>If you do not have another state-issued ID</strong>, ' +
+            '<a href="https://example.com">get help at Example App.</a>',
+      );
+
+      expect(help).to.be.ok();
+    });
+  });
+});

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -33,7 +33,7 @@ describe('document-capture/components/review-issues-step', () => {
         <I18nContext.Provider
           value={{
             'doc_auth.info.no_other_id_help_bold_html':
-              '<strong>If you do not have another state-issued ID</strong>, ' +
+              'If you do not have another state-issued ID, ' +
               '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
           }}
         >
@@ -51,7 +51,7 @@ describe('document-capture/components/review-issues-step', () => {
       const help = getByText(
         (_content, element) =>
           element.innerHTML ===
-          '<strong>If you do not have another state-issued ID</strong>, ' +
+          'If you do not have another state-issued ID, ' +
             '<a href="https://example.com">get help at Example App.</a>',
       );
 


### PR DESCRIPTION
**Why**: As a user, I need to know if my ID and selfie images have failed during processing with the new vendor, and understand any details about what went wrong, so that I can easily correct and resubmit my images.

**Includes:**

- Show review step with error and pre-filled values after failed submission.

**Does not include:** (to be submitted as follow-up pull requests)

- Scale down desktop selfie capture to match design.
- Show field-specific errors or successful update states

**Screenshot:**

<img src="https://user-images.githubusercontent.com/1779930/94187301-c05a6600-fe75-11ea-8514-7389aa31e2bd.png" width="398" height="1166" alt="screenshot">

