### PR TITLE
LG-3571 LG-3572 LG-3573 Fix cost tracking add warnings for missing types

### DIFF
--- a/app/services/db/proofing_cost/add_user_proofing_cost.rb
+++ b/app/services/db/proofing_cost/add_user_proofing_cost.rb
@@ -1,6 +1,8 @@
 module Db
   module ProofingCost
     class AddUserProofingCost
+      class ProofingCostTypeError < StandardError; end
+
       TOKEN_WHITELIST = %i[
         acuant_front_image
         acuant_back_image
@@ -17,7 +19,7 @@ module Db
         return unless user_id
         proofing_cost = ::ProofingCost.find_or_create_by(user_id: user_id)
         unless TOKEN_WHITELIST.include?(token.to_sym)
-          NewRelic::Agent.notice_error("proofing_cost type ignored: #{token}")
+          NewRelic::Agent.notice_error(ProofingCostTypeError.new(token.to_s))
           return
         end
         proofing_cost["#{token}_count"] += 1

--- a/app/services/db/proofing_cost/add_user_proofing_cost.rb
+++ b/app/services/db/proofing_cost/add_user_proofing_cost.rb
@@ -5,6 +5,7 @@ module Db
         acuant_front_image
         acuant_back_image
         acuant_result
+        acuant_selfie
         aamva
         lexis_nexis_resolution
         lexis_nexis_address
@@ -15,7 +16,10 @@ module Db
       def self.call(user_id, token)
         return unless user_id
         proofing_cost = ::ProofingCost.find_or_create_by(user_id: user_id)
-        return unless TOKEN_WHITELIST.index(token.to_sym)
+        unless TOKEN_WHITELIST.index(token.to_sym)
+          NewRelic::Agent.notice_error("proofing_cost type ignored: #{token}")
+          return
+        end
         proofing_cost["#{token}_count"] += 1
         proofing_cost.save
       end

--- a/app/services/db/proofing_cost/add_user_proofing_cost.rb
+++ b/app/services/db/proofing_cost/add_user_proofing_cost.rb
@@ -16,7 +16,7 @@ module Db
       def self.call(user_id, token)
         return unless user_id
         proofing_cost = ::ProofingCost.find_or_create_by(user_id: user_id)
-        unless TOKEN_WHITELIST.index(token.to_sym)
+        unless TOKEN_WHITELIST.include?(token.to_sym)
           NewRelic::Agent.notice_error("proofing_cost type ignored: #{token}")
           return
         end

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -20,7 +20,7 @@ module Db
 
       def self.call(issuer, ial, token)
         return if issuer.nil? || token.blank?
-        unless TOKEN_WHITELIST.index(token.to_sym)
+        unless TOKEN_WHITELIST.include?(token.to_sym)
           NewRelic::Agent.notice_error("sp_cost type ignored: #{token}")
           return
         end

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -1,6 +1,8 @@
 module Db
   module SpCost
     class AddSpCost
+      class SpCostTypeError < StandardError; end
+
       TOKEN_WHITELIST = %i[
         aamva
         acuant_front_image
@@ -21,7 +23,7 @@ module Db
       def self.call(issuer, ial, token)
         return if issuer.nil? || token.blank?
         unless TOKEN_WHITELIST.include?(token.to_sym)
-          NewRelic::Agent.notice_error("sp_cost type ignored: #{token}")
+          NewRelic::Agent.notice_error(SpCostTypeError.new(token.to_s))
           return
         end
         sp = ServiceProvider.find_by(issuer: issuer)

--- a/app/services/db/sp_cost/add_sp_cost.rb
+++ b/app/services/db/sp_cost/add_sp_cost.rb
@@ -2,9 +2,11 @@ module Db
   module SpCost
     class AddSpCost
       TOKEN_WHITELIST = %i[
+        aamva
         acuant_front_image
         acuant_back_image
-        aamva
+        acuant_result
+        acuant_selfie
         authentication
         digest
         lexis_nexis_resolution
@@ -18,7 +20,10 @@ module Db
 
       def self.call(issuer, ial, token)
         return if issuer.nil? || token.blank?
-        return unless TOKEN_WHITELIST.index(token.to_sym)
+        unless TOKEN_WHITELIST.index(token.to_sym)
+          NewRelic::Agent.notice_error("sp_cost type ignored: #{token}")
+          return
+        end
         sp = ServiceProvider.find_by(issuer: issuer)
         agency_id = sp ? sp.agency_id : 0
         ::SpCost.create(issuer: issuer, ial: ial, agency_id: agency_id.to_i, cost_type: token)

--- a/db/migrate/20200924144755_add_acuant_selfie_to_proofing_costs.rb
+++ b/db/migrate/20200924144755_add_acuant_selfie_to_proofing_costs.rb
@@ -1,0 +1,10 @@
+class AddAcuantSelfieToProofingCosts < ActiveRecord::Migration[5.2]
+  def up
+    add_column :proofing_costs, :acuant_selfie_count, :integer
+    change_column_default :proofing_costs, :acuant_selfie_count, 0
+  end
+
+  def down
+    remove_column :proofing_costs, :acuant_selfie_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_144112) do
+ActiveRecord::Schema.define(version: 2020_09_24_144755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -394,6 +394,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_144112) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "acuant_result_count", default: 0
+    t.integer "acuant_selfie_count", default: 0
     t.index ["user_id"], name: "index_proofing_costs_on_user_id", unique: true
   end
 

--- a/spec/features/reports/proofing_costs_report_spec.rb
+++ b/spec/features/reports/proofing_costs_report_spec.rb
@@ -22,6 +22,7 @@ feature 'Proofing Costs report' do
       'acuant_front_image_count_average' => 1.0,
       'acuant_back_image_count_average' => 1.0,
       'acuant_result_count_average' => 1.0,
+      'acuant_selfie_count_average' => 0.0,
       'aamva_count_average' => 1.0,
       'lexis_nexis_resolution_count_average' => 1.0,
       'gpo_letter_count_average' => 0.0,

--- a/spec/features/sp_cost_tracking_spec.rb
+++ b/spec/features/sp_cost_tracking_spec.rb
@@ -26,11 +26,12 @@ feature 'SP Costing', :email do
     expect_sp_cost_type(0, 2, 'sms')
     expect_sp_cost_type(1, 2, 'acuant_front_image')
     expect_sp_cost_type(2, 2, 'acuant_back_image')
-    expect_sp_cost_type(3, 2, 'lexis_nexis_resolution')
-    expect_sp_cost_type(4, 2, 'aamva')
-    expect_sp_cost_type(5, 2, 'lexis_nexis_address')
-    expect_sp_cost_type(6, 2, 'user_added')
-    expect_sp_cost_type(7, 2, 'authentication')
+    expect_sp_cost_type(3, 2, 'acuant_result')
+    expect_sp_cost_type(4, 2, 'lexis_nexis_resolution')
+    expect_sp_cost_type(5, 2, 'aamva')
+    expect_sp_cost_type(6, 2, 'lexis_nexis_address')
+    expect_sp_cost_type(7, 2, 'user_added')
+    expect_sp_cost_type(8, 2, 'authentication')
   end
 
   it 'logs the cost to the SP for reproofing' do


### PR DESCRIPTION
**Why**: acuant_selfie and acuant_result need whitelisting and acuant_selfie needs to be added to user costs.  Also, we don't want to throw errors on these analytics calls but we do want to know when they happen.