### PR TITLE
Updated the error message for when the selfie check fails (LG-3469)

### DIFF
--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -67,7 +67,8 @@ en:
       photo_glare: Photo has glare, please try again.
       quota_reached: Sorry your service provider has reached its identity verification
         limit.  Please contact your service provider for more information.
-      selfie: Sorry, your photo was not accepted. Please try again.
+      selfie: We couldn't read the photo of yourself, or match the photo to your ID.
+        Try taking a new picture.
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
     invalid_authenticity_token: Oops, something went wrong. Please try again.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -68,7 +68,8 @@ es:
       quota_reached: Lo sentimos, su proveedor de servicios ha alcanzado su límite
         de verificación de identidad. Póngase en contacto con su proveedor de servicios
         para obtener más información.
-      selfie: Lo sentimos, tu foto no fue aceptada. Inténtalo de nuevo.
+      selfie: No pudimos leer tu foto ni hacer coincidir la foto con tu identificación.
+        Intente tomar una nueva foto.
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -68,7 +68,8 @@ fr:
       quota_reached: Désolé, votre fournisseur de services a atteint sa limite de
         vérification d'identité. Veuillez contacter votre fournisseur de services
         pour plus d'informations.
-      selfie: Désolé, votre photo n'a pas été acceptée. Veuillez réessayer.
+      selfie: Nous n'avons pas pu lire la photo de vous ni faire correspondre la photo
+        à votre pièce d'identité. Essayez de prendre une nouvelle photo.
       send_link_throttle: Vous avez essayé plusieurs fois, essayez à nouveau dans
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
         votre ordinateur.


### PR DESCRIPTION
Simple update to the error message for a failed selfie check. Note, I used Google translate for this since there is a plan in place to replace this message with separate error messages for different use cases.