### PR TITLE
Update KMS clients to use different keys per AWS region (LG-3254)

### DIFF
--- a/app/services/encryption/multi_region_kms_client.rb
+++ b/app/services/encryption/multi_region_kms_client.rb
@@ -1,14 +1,26 @@
-require 'json'
 module Encryption
   class MultiRegionKMSClient
+    RegionClient = Struct.new(:region, :client, :key_id, keyword_init: true)
+
     def initialize
-      @aws_clients = {}
+      @region_client_configs = {}
       # Instantiate an array of aws clients based on the provided regions in the environment
-      JSON.parse(Figaro.env.aws_kms_regions).each do |region|
-        @aws_clients[region] = Aws::KMS::Client.new(
+      # Example expected config:
+      #   [{"region": "us-north-1", "key_id": "abc"}, {"region": "us-south-1", "key_id": "def"}]
+      JSON.parse(Figaro.env.aws_kms_region_configs).each do |region_config|
+        region = region_config['region']
+        key_id = region_config['key_id']
+
+        client = Aws::KMS::Client.new(
           instance_profile_credentials_timeout: 1, # defaults to 1 second
           instance_profile_credentials_retries: 5, # defaults to 0 retries
           region: region, # The region in which the client is being instantiated
+        )
+
+        region_client_configs[region] = RegionClient.new(
+          region: region,
+          client: client,
+          key_id: key_id,
         )
       end
     end
@@ -17,7 +29,7 @@ module Encryption
     # Region format example: '{"regions": {"us-east-1": "cipher", "us-west-2": "othercipher"}}'
     def encrypt(key_id, plaintext, encryption_context)
       if FeatureManagement.kms_multi_region_enabled?
-        encrypt_multi(key_id, plaintext, encryption_context)
+        encrypt_multi(plaintext, encryption_context)
       else
         encrypt_legacy(key_id, plaintext, encryption_context)
       end
@@ -25,7 +37,7 @@ module Encryption
 
     def decrypt(ciphertext, encryption_context)
       cipher_data = resolve_decryption(ciphertext)
-      cipher_data.region_client.decrypt(
+      cipher_data.region_client.client.decrypt(
         ciphertext_blob: cipher_data.resolved_ciphertext,
         encryption_context: encryption_context,
       ).plaintext
@@ -33,33 +45,35 @@ module Encryption
 
     private
 
-    def encrypt_multi(key_id, plaintext, encryption_context)
-      region_ciphers = {}
-      @aws_clients.each do |region, kms_client|
-        raw_region_ciphertext = kms_client.encrypt(key_id: key_id,
-                                                   plaintext: plaintext,
-                                                   encryption_context: encryption_context)
-        region_ciphers[region] = Base64.strict_encode64(raw_region_ciphertext.ciphertext_blob)
-      end
+    attr_reader :region_client_configs
+
+    def encrypt_multi(plaintext, encryption_context)
+      region_ciphers = region_client_configs.map do |region, region_client|
+        raw_region_ciphertext = region_client.client.encrypt(key_id: region_client.key_id,
+                                                             plaintext: plaintext,
+                                                             encryption_context: encryption_context)
+        [region, Base64.strict_encode64(raw_region_ciphertext.ciphertext_blob)]
+      end.to_h
+
       { regions: region_ciphers }.to_json
     end
 
     def encrypt_legacy(key_id, plaintext, encryption_context)
-      region_client = @aws_clients[Figaro.env.aws_region]
+      region_client = region_client_configs[Figaro.env.aws_region]
       unless region_client
         raise EncryptionError, 'Current region not found in clients for legacy encryption'
       end
-      region_client.encrypt(key_id: key_id,
-                            plaintext: plaintext,
-                            encryption_context: encryption_context).ciphertext_blob
+      region_client.client.encrypt(key_id: key_id,
+                                   plaintext: plaintext,
+                                   encryption_context: encryption_context).ciphertext_blob
     end
 
     CipherData = Struct.new(:region_client, :resolved_ciphertext)
 
     def find_available_region(regions)
       regions.each do |region, cipher|
-        region_client = @aws_clients[region]
-        return CipherData.new(region_client, cipher) if region_client
+        region_client = region_client_configs[region]
+        return CipherData.new(region_client, Base64.strict_decode64(cipher)) if region_client
       end
       raise EncryptionError, 'No supported region found in ciphertext'
     end
@@ -67,7 +81,7 @@ module Encryption
     def resolve_region_decryption(regions)
       # For each region that the ciphertext has a cipher for, check to see if that region is
       # represented in the clients available. Check default region before checking others
-      curr_region_client = @aws_clients[Figaro.env.aws_region]
+      curr_region_client = region_client_configs[Figaro.env.aws_region]
       curr_region_cipher = regions[Figaro.env.aws_region]
       if curr_region_cipher && curr_region_client
         CipherData.new(curr_region_client, Base64.strict_decode64(curr_region_cipher))
@@ -79,7 +93,7 @@ module Encryption
     def resolve_legacy_decryption(ciphertext)
       # Decode the raw ciphertext
       curr_region = Figaro.env.aws_region
-      region_client = @aws_clients[curr_region]
+      region_client = region_client_configs[curr_region]
       resolved_ciphertext = ciphertext
       return CipherData.new(region_client, resolved_ciphertext) if region_client
       raise EncryptionError, "No client found for region #{curr_region}"
@@ -96,7 +110,8 @@ module Encryption
         else
           raise EncryptionError, 'Malformed JSON ciphertext, not a hash'
         end
-      else resolve_legacy_decryption(ciphertext)
+      else
+        resolve_legacy_decryption(ciphertext)
       end
     end
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -159,7 +159,7 @@ development:
   aws_kms_key_id: alias/login-dot-gov-development-keymaker
   aws_logo_bucket:
   aws_region: us-east-1
-  aws_kms_regions: '["us-west-2", "us-east-1"]'
+  aws_kms_region_configs: '[]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user
@@ -267,7 +267,7 @@ production:
   attribute_encryption_key_queue:
   aws_kms_key_id:
   aws_region:
-  aws_kms_regions: '["us-west-2"]'
+  aws_kms_region_configs: '[]'
   aws_logo_bucket:
   backup_codes_as_only_2fa:
   basic_auth_password:
@@ -375,7 +375,7 @@ test:
     }]'
   aws_kms_key_id: alias/login-dot-gov-test-keymaker
   aws_region: us-east-1
-  aws_kms_regions: '["us-west-2", "us-east-1"]'
+  aws_kms_region_configs: '[]'
   backup_codes_as_only_2fa: 'true'
   basic_auth_password: secret
   basic_auth_user_name: user

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -103,8 +103,18 @@ describe Encryption::ContextlessKmsClient do
       allow(Encryption::Encryptors::AesEncryptor).to receive(:new).and_return(encryptor)
 
       stub_mapped_aws_kms_client(
-        long_kms_plaintext[0..long_kms_plaintext_chunksize - 1] => 'chunk1',
-        long_kms_plaintext[long_kms_plaintext_chunksize..-1] => 'chunk2',
+        [
+          {
+            plaintext: long_kms_plaintext[0..long_kms_plaintext_chunksize - 1],
+            ciphertext: 'chunk1',
+            key_id: Figaro.env.aws_kms_key_id,
+          },
+          {
+            plaintext: long_kms_plaintext[long_kms_plaintext_chunksize..-1],
+            ciphertext: 'chunk2',
+            key_id: Figaro.env.aws_kms_key_id,
+          },
+        ],
       )
       allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
     end

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -91,6 +91,8 @@ describe Encryption::KmsClient do
       end
       context 'with multi region disabled' do
         let(:kms_multi_region_enabled) { false }
+        before { allow(Figaro.env).to receive(:aws_kms_key_id).and_return('key1') }
+
         it 'encrypts with KMS legacy single region' do
           result = subject.encrypt(plaintext, encryption_context)
           expect(result).to eq(kms_legacy_ciphertext)

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -40,9 +40,9 @@ describe Encryption::MultiRegionKMSClient do
 
   let(:legacy_kms_ciphertext) { 'key1:kms1' }
 
-  let(:aws_key_id) { Figaro.env.aws_kms_key_id }
-
   describe '#encrypt' do
+    let(:aws_key_id) { 'key1' }
+
     context 'with multi region enabled' do
       it 'encrypts with KMS' do
         result = subject.encrypt(aws_key_id, plaintext, encryption_context)

--- a/spec/services/encryption/multi_region_kms_client_spec.rb
+++ b/spec/services/encryption/multi_region_kms_client_spec.rb
@@ -1,49 +1,58 @@
 require 'rails_helper'
 
 describe Encryption::MultiRegionKMSClient do
-  before do
-    stub_mapped_aws_kms_client(
-      'a' * 3000 => 'kms1',
-      'b' * 3000 => 'kms2',
-    )
-
-    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
-    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).and_return(kms_multi_region_enabled) # rubocop:disable Layout/LineLength
-  end
-
-  let(:first_plaintext) { 'a' * 3000 }
-  let(:second_plaintext) { 'b' * 3000 }
-  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
-
-  let(:kms_regions) { %w[us-west-2 us-east-1] }
-  let(:current_aws_region) { 'us-east-1' }
-
-  let(:regionalized_kms_ciphertext) do
-    region_hash = {}
-    kms_regions.each do |r|
-      region_hash[r] = Base64.strict_encode64('kms1')
-    end
-    { regions: region_hash }.to_json
-  end
-
-  let(:legacy_kms_ciphertext) { 'kms1' }
-
   let(:kms_enabled) { true }
   let(:kms_multi_region_enabled) { true }
+  let(:kms_region_configs) do
+    [
+      { region: 'us-north-by-northwest-1', key_id: 'key1' },
+      { region: 'us-south-by-southwest-1', key_id: 'key2' },
+    ]
+  end
+  let(:aws_region) { 'us-north-by-northwest-1' }
+
+  before do
+    allow(FeatureManagement).to receive(:use_kms?).and_return(kms_enabled)
+    allow(FeatureManagement).to receive(:kms_multi_region_enabled?).
+      and_return(kms_multi_region_enabled)
+    allow(Figaro.env).to receive(:aws_kms_region_configs).and_return(kms_region_configs.to_json)
+    allow(Figaro.env).to receive(:aws_region).and_return(aws_region)
+
+    stub_mapped_aws_kms_client(
+      [
+        { plaintext: plaintext, ciphertext: 'key1:kms1', key_id: 'key1' },
+        { plaintext: plaintext, ciphertext: 'key2:kms1', key_id: 'key2' },
+      ],
+    )
+  end
+
+  let(:plaintext) { 'a' * 3000 }
+  let(:encryption_context) { { 'context' => 'attribute-bundle', 'user_id' => '123-abc-456-def' } }
+
+  let(:regionalized_kms_ciphertext) do
+    {
+      regions: {
+        'us-north-by-northwest-1' => Base64.strict_encode64('key1:kms1'),
+        'us-south-by-southwest-1' => Base64.strict_encode64('key2:kms1'),
+      },
+    }.to_json
+  end
+
+  let(:legacy_kms_ciphertext) { 'key1:kms1' }
 
   let(:aws_key_id) { Figaro.env.aws_kms_key_id }
 
   describe '#encrypt' do
     context 'with multi region enabled' do
       it 'encrypts with KMS' do
-        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
+        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
         expect(result).to eq(regionalized_kms_ciphertext)
       end
     end
     context 'with multi region disabled' do
       let(:kms_multi_region_enabled) { false }
       it 'encrypts with KMS' do
-        result = subject.encrypt(aws_key_id, first_plaintext, encryption_context)
+        result = subject.encrypt(aws_key_id, plaintext, encryption_context)
         expect(result).to eq(legacy_kms_ciphertext)
       end
     end
@@ -53,23 +62,23 @@ describe Encryption::MultiRegionKMSClient do
     context 'with a multi region ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(regionalized_kms_ciphertext, encryption_context)
-        expect(result).to eq(first_plaintext)
+        expect(result).to eq(plaintext)
       end
     end
 
     context 'with a legacy ciphertext' do
       it 'decrypts the ciphertext with KMS' do
         result = subject.decrypt(legacy_kms_ciphertext, encryption_context)
-        expect(result).to eq(first_plaintext)
+        expect(result).to eq(plaintext)
       end
     end
 
     it 'decrypts successfully if the default region is not present' do
       non_default_ciphertext = {
-        regions: { 'us-east-1' => Base64.strict_encode64('kms1') },
+        regions: { 'us-north-by-northwest-1' => Base64.strict_encode64('key2:kms1') },
       }.to_json
       result = subject.decrypt(non_default_ciphertext, encryption_context)
-      expect(result).to eq(first_plaintext)
+      expect(result).to eq(plaintext)
     end
 
     it 'errors if none of the encryption regions are present' do
@@ -88,22 +97,22 @@ describe Encryption::MultiRegionKMSClient do
       partially_valid_ciphertext = {
         regions: {
           foo: 'kms1',
-          'us-west-2': 'kms2',
+          'us-south-by-southwest-1': Base64.strict_encode64('key2:kms1'),
         },
       }.to_json
       result = subject.decrypt(partially_valid_ciphertext, encryption_context)
-      expect(result).to eq(second_plaintext)
+      expect(result).to eq(plaintext)
     end
 
     it 'decrypts in default region where multiple regions present' do
       multi_region_ciphertext = {
         regions: {
-          'us-east-1': Base64.strict_encode64('kms1'),
-          'us-west-2': Base64.strict_encode64('kms2'),
+          'us-north-by-northwest-1': Base64.strict_encode64('key1:kms1'),
+          'us-south-by-southwest-1': Base64.strict_encode64('key2:kms1'),
         },
       }.to_json
       result = subject.decrypt(multi_region_ciphertext, encryption_context)
-      expect(result).to eq(first_plaintext)
+      expect(result).to eq(plaintext)
     end
   end
 end

--- a/spec/support/aws_kms_client.rb
+++ b/spec/support/aws_kms_client.rb
@@ -10,26 +10,41 @@ module AwsKmsClientHelper
     [random_key, ciphered_key]
   end
 
-  def stub_mapped_aws_kms_client(forward = {})
-    reverse = forward.invert
-    aws_key_id = Figaro.env.aws_kms_key_id
+  # Configs is an array of:
+  # [ { ciphertext:, plaintext:, key_id: }]
+  def stub_mapped_aws_kms_client(configs)
+    encryptor = proc do |context|
+      config = configs.find do |c|
+        c.slice(:key_id, :plaintext) == context.params.slice(:key_id, :plaintext)
+      end
+      { ciphertext_blob: config[:ciphertext], key_id: config[:key_id] }
+    end
+
+    decryptor = proc do |context|
+      config = configs.find do |c|
+        c[:ciphertext] == context.params[:ciphertext_blob]
+      end
+      { plaintext: config[:plaintext], key_id: config[:key_id] }
+    end
+
     Aws.config[:kms] = {
       stub_responses: {
-        encrypt: lambda { |context|
-          { ciphertext_blob: forward[context.params[:plaintext]], key_id: aws_key_id }
-        },
-        decrypt: lambda { |context|
-          { plaintext: reverse[context.params[:ciphertext_blob]], key_id: aws_key_id }
-        },
+        encrypt: encryptor,
+        decrypt: decryptor,
       },
     }
   end
 
   def stub_aws_kms_client_invalid_ciphertext(ciphered_key = random_str)
-    aws_key_id = Figaro.env.aws_kms_key_id
+    allow(Figaro.env).to receive(:aws_region).and_return('us-north-by-northwest-1')
+    allow(Figaro.env).to receive(:aws_kms_region_configs).and_return([
+      { region: 'us-north-by-northwest-1', key_id: 'key1' },
+      { region: 'us-south-by-southwest-1', key_id: 'key2' },
+    ].to_json)
+
     Aws.config[:kms] = {
       stub_responses: {
-        encrypt: { ciphertext_blob: ciphered_key, key_id: aws_key_id },
+        encrypt: { ciphertext_blob: ciphered_key, key_id: 'key1' },
         decrypt: 'InvalidCiphertextException',
       },
     }


### PR DESCRIPTION
- Goal: enable KMS in multiple regions
- Problem: KMS key ids are different per region, but our current code only accepts one global key id
- Solution: Update KMS region config to accept a key ID per region

I had to do some surgery on the KMS clients, I am going to try to deploy this to my personal env before merging, but would love some eyes on the code now