### PR TITLE
Refactor form step validation as required field

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "no-confusing-arrow": "off",
     "no-plusplus": "off",
     "no-unused-expressions": "off",
+    "no-use-before-define": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "operator-linebreak": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,6 @@
     "no-confusing-arrow": "off",
     "no-plusplus": "off",
     "no-unused-expressions": "off",
-    "no-use-before-define": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
     "operator-linebreak": "off",

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -2,8 +2,8 @@ import React, { useState, useContext } from 'react';
 import { Alert } from '@18f/identity-components';
 import FormSteps from './form-steps';
 import { UploadFormEntriesError } from '../services/upload';
-import DocumentsStep, { validate as validateDocumentsStep } from './documents-step';
-import SelfieStep, { validate as validateSelfieStep } from './selfie-step';
+import DocumentsStep from './documents-step';
+import SelfieStep from './selfie-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
 import Submission from './submission';
@@ -53,13 +53,11 @@ function DocumentCapture({ isLivenessEnabled = true }) {
       footer: isMobile
         ? undefined
         : () => <p>{t('doc_auth.info.document_capture_upload_image')}</p>,
-      validate: validateDocumentsStep,
     },
     isLivenessEnabled && {
       name: 'selfie',
       title: t('doc_auth.headings.selfie'),
       form: SelfieStep,
-      validate: validateSelfieStep,
     },
   ].filter(Boolean));
 
@@ -74,10 +72,6 @@ function DocumentCapture({ isLivenessEnabled = true }) {
   }
 
   const isFormEntriesError = submissionError && submissionError instanceof UploadFormEntriesError;
-  let initialStep;
-  if (submissionError) {
-    initialStep = isFormEntriesError || !isLivenessEnabled ? 'documents' : 'selfie';
-  }
 
   return formValues && !submissionError ? (
     <Submission
@@ -98,8 +92,8 @@ function DocumentCapture({ isLivenessEnabled = true }) {
       <FormSteps
         steps={steps}
         initialValues={submissionError && formValues ? formValues : undefined}
-        initialStep={initialStep}
         onComplete={submitForm}
+        autoFocus={!!submissionError}
       />
     </>
   );

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -1,14 +1,8 @@
 import React, { useContext } from 'react';
 import AcuantCapture from './acuant-capture';
 import FormErrorMessage from './form-error-message';
-import { RequiredValueMissingError } from './form-steps';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
-
-/**
- * @template V
- * @typedef {import('./form-steps').FormStepValidateResult<V>} FormStepValidateResult
- */
 
 /**
  * @typedef DocumentsStepValue
@@ -51,7 +45,7 @@ function DocumentsStep({
         return (
           <AcuantCapture
             key={side}
-            ref={registerField(side)}
+            ref={registerField(side, { isRequired: true })}
             /* i18n-tasks-use t('doc_auth.headings.document_capture_back') */
             /* i18n-tasks-use t('doc_auth.headings.document_capture_front') */
             label={t(`doc_auth.headings.document_capture_${side}`)}
@@ -67,16 +61,6 @@ function DocumentsStep({
       })}
     </>
   );
-}
-
-/**
- * @type {import('./form-steps').FormStepValidate<DocumentsStepValue>}
- */
-export function validate(values) {
-  return DOCUMENT_SIDES.filter((side) => !values[side]).map((side) => ({
-    field: side,
-    error: new RequiredValueMissingError(),
-  }));
 }
 
 export default DocumentsStep;

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -14,28 +14,25 @@ import useHistoryParam from '../hooks/use-history-param';
  */
 
 /**
+ * @typedef FormStepRegisterFieldOptions
+ *
+ * @prop {boolean} isRequired Whether field is required.
+ */
+
+/**
  * @typedef FormStepComponentProps
  *
  * @prop {(nextValues:Partial<V>)=>void} onChange Values change callback, merged with
  * existing values.
  * @prop {Partial<V>} value Current values.
  * @prop {FormStepError<V>[]=} errors Current active errors.
- * @prop {(field:string)=>undefined|((fieldNode:HTMLElement?)=>void)} registerField Registers field
+ * @prop {(
+ *   field:string,
+ *   options?:Partial<FormStepRegisterFieldOptions>
+ * )=>undefined|import('react').RefCallback<HTMLElement>} registerField Registers field
  * by given name, returning ref assignment function.
  *
  * @template V
- */
-
-/**
- * @template {Record<string,any>} V
- *
- * @typedef {FormStepError<V>[]} FormStepValidateResult
- */
-
-/**
- * @template {Record<string,any>} V
- *
- * @typedef {(values:V)=>undefined|FormStepValidateResult<V>} FormStepValidate
  */
 
 /**
@@ -45,15 +42,13 @@ import useHistoryParam from '../hooks/use-history-param';
  * @prop {string} title Step title, shown as heading.
  * @prop {import('react').FC<FormStepComponentProps<Record<string,any>>>} form Step form component.
  * @prop {import('react').FC=} footer Optional step footer component.
- * @prop {FormStepValidate<Record<string,any>>} validate Step validity function. Given set of form
- * values, returns an object with keys from form values mapped to an error, if applicable. Returns
- * undefined or an empty object if there are no errors.
  */
 
 /**
  * @typedef FieldsRefEntry
  *
  * @prop {import('react').RefCallback<HTMLElement>} refCallback Ref callback.
+ * @prop {boolean} isRequired Whether field is required.
  * @prop {HTMLElement?=} element Element assigned by ref callback.
  */
 
@@ -62,7 +57,7 @@ import useHistoryParam from '../hooks/use-history-param';
  *
  * @prop {FormStep[]=} steps Form steps.
  * @prop {Record<string,any>=} initialValues Form values to populate initial state.
- * @prop {string=} initialStep Step to start from.
+ * @prop {boolean=} autoFocus Whether to automatically focus heading on mount.
  * @prop {(values:Record<string,any>)=>void=} onComplete Form completion callback.
  */
 
@@ -70,30 +65,6 @@ import useHistoryParam from '../hooks/use-history-param';
  * An error representing a state where a required form value is missing.
  */
 export class RequiredValueMissingError extends Error {}
-
-/**
- * Given a step object and current set of form values, returns true if the form values would satisfy
- * the validity requirements of the step.
- *
- * @param {FormStep} step Form step.
- * @param {Record<string,any>} values Current form values.
- */
-function getValidationErrors(step, values) {
-  const { validate = () => undefined } = step;
-  return validate(values);
-}
-
-/**
- * Given a step object and current set of form values, returns true if the form values would satisfy
- * the validity requirements of the step.
- *
- * @param {FormStep} step Form step.
- * @param {Record<string,any>} values Current form values.
- */
-export function isStepValid(step, values) {
-  const errors = getValidationErrors(step, values);
-  return !errors || !Object.keys(errors).length;
-}
 
 /**
  * Returns the index of the step in the array which matches the given name. Returns `-1` if there is
@@ -109,31 +80,16 @@ export function getStepIndexByName(steps, name) {
 }
 
 /**
- * Returns the index of the last step in the array where the values satisfy the requirements of the
- * step. If all steps are valid, returns the index of the last member. Returns `-1` if all steps are
- * invalid, or if the array is empty.
- *
- * @param {FormStep[]} steps  Form steps.
- * @param {object}     values Current form values.
- *
- * @return {number} Step index.
- */
-export function getLastValidStepIndex(steps, values) {
-  const index = steps.findIndex((step) => !isStepValid(step, values));
-  return index === -1 ? steps.length - 1 : index - 1;
-}
-
-/**
  * @param {FormStepsProps} props Props object.
  */
-function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, initialStep }) {
+function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, autoFocus }) {
   const [values, setValues] = useState(initialValues);
   const [activeErrors, setActiveErrors] = useState(
-    /** @type {FormStepValidateResult<Record<string,Error>>=} */ (undefined),
+    /** @type {FormStepError<Record<string,Error>>[]=} */ (undefined),
   );
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
   const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
-  const [stepName, setStepName] = useHistoryParam('step', initialStep);
+  const [stepName, setStepName] = useHistoryParam('step', null);
   const { t } = useI18n();
   const fields = useRef(/** @type {Record<string,FieldsRefEntry>} */ ({}));
   const didSubmitWithErrors = useRef(false);
@@ -146,23 +102,12 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     didSubmitWithErrors.current = false;
   }, [activeErrors]);
 
-  // An "effective" step is computed in consideration of the facts that (1) there may be no history
-  // parameter present, in which case the first step should be used, and (2) the values may not be
-  // valid for previous steps, in which case the furthest valid step should be set.
-  const effectiveStepIndex = Math.max(
-    Math.min(getStepIndexByName(steps, stepName), getLastValidStepIndex(steps, values) + 1),
-    0,
-  );
-  const effectiveStep = steps[effectiveStepIndex];
-  useEffect(() => {
-    // The effective step is used in the initial render, but since it may be out of sync with the
-    // history parameter, it is synced after mount.
-    if (effectiveStep && stepName && effectiveStep.name !== stepName) {
-      setStepName(effectiveStep.name);
-    }
+  const stepIndex = Math.max(getStepIndexByName(steps, stepName), 0);
+  const step = steps[stepIndex];
 
+  useEffect(() => {
     // Treat explicit initial step the same as step transition, placing focus to header.
-    if (initialStep && headingRef.current) {
+    if (autoFocus && headingRef.current) {
       headingRef.current.focus();
     }
   }, []);
@@ -171,14 +116,32 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     // Errors are assigned at the first attempt to submit. Once errors are assigned, track value
     // changes to remove validation errors as they become resolved.
     if (activeErrors) {
-      const nextActiveErrors = getValidationErrors(effectiveStep, values);
+      const nextActiveErrors = getValidationErrors();
       setActiveErrors(nextActiveErrors);
     }
   }, [values]);
 
   // An empty steps array is allowed, in which case there is nothing to render.
-  if (!effectiveStep) {
+  if (!step) {
     return null;
+  }
+
+  /**
+   * Returns array of form errors for the current set of values.
+   *
+   * @return {FormStepError<Record<string,Error>>[]}
+   */
+  function getValidationErrors() {
+    return Object.keys(fields.current).reduce((result, key) => {
+      const { element, isRequired } = fields.current[key];
+      const isActive = !!element;
+
+      if (isActive && isRequired && !values[key]) {
+        result = result.concat({ field: key, error: new RequiredValueMissingError() });
+      }
+
+      return result;
+    }, /** @type {FormStepError<Record<string,Error>>[]} */ ([]));
   }
 
   /**
@@ -190,14 +153,14 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
   function toNextStep(event) {
     event.preventDefault();
 
-    const nextActiveErrors = getValidationErrors(effectiveStep, values);
+    const nextActiveErrors = getValidationErrors();
     setActiveErrors(nextActiveErrors);
     didSubmitWithErrors.current = true;
     if (nextActiveErrors?.length) {
       return;
     }
 
-    const nextStepIndex = effectiveStepIndex + 1;
+    const nextStepIndex = stepIndex + 1;
     const isComplete = nextStepIndex === steps.length;
     if (isComplete) {
       // Clear step parameter from URL.
@@ -211,8 +174,8 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
     headingRef.current?.focus();
   }
 
-  const { form: Form, footer: Footer, name, title } = effectiveStep;
-  const isLastStep = effectiveStepIndex + 1 === steps.length;
+  const { form: Form, footer: Footer, name, title } = step;
+  const isLastStep = stepIndex + 1 === steps.length;
 
   return (
     <form ref={formRef} onSubmit={toNextStep}>
@@ -226,12 +189,13 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, init
         onChange={(nextValuesPatch) => {
           setValues((prevValues) => ({ ...prevValues, ...nextValuesPatch }));
         }}
-        registerField={(field) => {
+        registerField={(field, options = {}) => {
           if (!fields.current[field]) {
             fields.current[field] = {
               refCallback(fieldNode) {
                 fields.current[field].element = fieldNode;
               },
+              isRequired: !!options.isRequired,
             };
           }
 

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -112,20 +112,6 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
     }
   }, []);
 
-  useEffect(() => {
-    // Errors are assigned at the first attempt to submit. Once errors are assigned, track value
-    // changes to remove validation errors as they become resolved.
-    if (activeErrors) {
-      const nextActiveErrors = getValidationErrors();
-      setActiveErrors(nextActiveErrors);
-    }
-  }, [values]);
-
-  // An empty steps array is allowed, in which case there is nothing to render.
-  if (!step) {
-    return null;
-  }
-
   /**
    * Returns array of form errors for the current set of values.
    *
@@ -142,6 +128,20 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
 
       return result;
     }, /** @type {FormStepError<Record<string,Error>>[]} */ ([]));
+  }
+
+  useEffect(() => {
+    // Errors are assigned at the first attempt to submit. Once errors are assigned, track value
+    // changes to remove validation errors as they become resolved.
+    if (activeErrors) {
+      const nextActiveErrors = getValidationErrors();
+      setActiveErrors(nextActiveErrors);
+    }
+  }, [values]);
+
+  // An empty steps array is allowed, in which case there is nothing to render.
+  if (!step) {
+    return null;
   }
 
   /**

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -1,16 +1,10 @@
 import React, { useContext } from 'react';
 import { hasMediaAccess } from '@18f/identity-device';
-import { RequiredValueMissingError } from './form-steps';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
 import SelfieCapture from './selfie-capture';
 import FormErrorMessage from './form-error-message';
-
-/**
- * @template V
- * @typedef {import('./form-steps').FormStepValidateResult<V>} FormStepValidateResult
- */
 
 /**
  * @typedef SelfieStepValue
@@ -42,7 +36,7 @@ function SelfieStep({
       </ul>
       {isMobile || !hasMediaAccess() ? (
         <AcuantCapture
-          ref={registerField('selfie')}
+          ref={registerField('selfie', { isRequired: true })}
           capture="user"
           label={t('doc_auth.headings.document_capture_selfie')}
           bannerText={t('doc_auth.headings.photo')}
@@ -54,7 +48,7 @@ function SelfieStep({
         />
       ) : (
         <SelfieCapture
-          ref={registerField('selfie')}
+          ref={registerField('selfie', { isRequired: true })}
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
@@ -62,13 +56,6 @@ function SelfieStep({
       )}
     </>
   );
-}
-
-/**
- * @type {import('./form-steps').FormStepValidate<SelfieStepValue>}
- */
-export function validate(values) {
-  return values.selfie ? [] : [{ field: 'selfie', error: new RequiredValueMissingError() }];
 }
 
 export default SelfieStep;

--- a/app/javascript/packages/document-capture/hooks/use-history-param.js
+++ b/app/javascript/packages/document-capture/hooks/use-history-param.js
@@ -55,8 +55,8 @@ function scrollTo(left, top) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
  *
- * @param {string}  name         Parameter name to sync.
- * @param {string=} initialValue Value to use as initial in absence of another value.
+ * @param {string} name Parameter name to sync.
+ * @param {string?=} initialValue Value to use as initial in absence of another value.
  *
  * @return {[any,(nextParamValue:any)=>void]} Tuple of current state, state setter.
  */
@@ -87,8 +87,8 @@ function useHistoryParam(name, initialValue) {
       setValue(getCurrentQueryParam());
     }
 
-    if (value === undefined && initialValue) {
-      setValue(initialValue);
+    if (initialValue !== undefined) {
+      setValue(initialValue ?? undefined);
       window.history.replaceState(null, '', getValueURL(initialValue));
     }
 

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -188,7 +188,7 @@ describe('document-capture/components/document-capture', () => {
     initialize({ isCameraSupported: false });
     window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
 
-    const continueButton = getByText('forms.buttons.continue');
+    let continueButton = getByText('forms.buttons.continue');
     userEvent.click(continueButton);
     await findAllByText('simple_form.required.text');
     userEvent.upload(
@@ -218,8 +218,10 @@ describe('document-capture/components/document-capture', () => {
       /React will try to recreate this component tree from scratch using the error boundary you provided/,
     );
 
-    const heading = getByText('doc_auth.headings.selfie');
+    const heading = getByText('doc_auth.headings.document_capture');
     expect(document.activeElement).to.equal(heading);
+    continueButton = getByText('forms.buttons.continue');
+    userEvent.click(continueButton);
 
     const hasValueSelected = !!getByText('doc_auth.forms.change_file');
     expect(hasValueSelected).to.be.true();

--- a/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/documents-step-spec.jsx
@@ -2,43 +2,10 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import DeviceContext from '@18f/identity-document-capture/context/device';
-import DocumentsStep, { validate } from '@18f/identity-document-capture/components/documents-step';
-import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
+import DocumentsStep from '@18f/identity-document-capture/components/documents-step';
 import render from '../../../support/render';
 
 describe('document-capture/components/documents-step', () => {
-  describe('validate', () => {
-    it('returns errors if both front and back are unset', () => {
-      const value = {};
-      const result = validate(value);
-
-      expect(result).to.have.lengthOf(2);
-      expect(result[0].field).to.equal('front');
-      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
-      expect(result[1].field).to.equal('back');
-      expect(result[1].error).to.be.instanceOf(RequiredValueMissingError);
-    });
-
-    it('returns error if one of front and back are unset', () => {
-      const value = { front: new window.File([], 'upload.png', { type: 'image/png' }) };
-      const result = validate(value);
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].field).to.equal('back');
-      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
-    });
-
-    it('returns empty array if both front and back are set', () => {
-      const value = {
-        front: new window.File([], 'upload.png', { type: 'image/png' }),
-        back: new window.File([], 'upload.png', { type: 'image/png' }),
-      };
-      const result = validate(value);
-
-      expect(result).to.deep.equal([]);
-    });
-  });
-
   it('renders with front and back inputs', () => {
     const { getByLabelText } = render(<DocumentsStep />);
 

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -3,33 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import sinon from 'sinon';
 import { AcuantProvider } from '@18f/identity-document-capture';
-import SelfieStep, { validate } from '@18f/identity-document-capture/components/selfie-step';
-import { RequiredValueMissingError } from '@18f/identity-document-capture/components/form-steps';
+import SelfieStep from '@18f/identity-document-capture/components/selfie-step';
 import render from '../../../support/render';
 import { useAcuant } from '../../../support/acuant';
 
 describe('document-capture/components/selfie-step', () => {
   const { initialize } = useAcuant();
-
-  describe('validate', () => {
-    it('returns object with error if selfie is unset', () => {
-      const value = {};
-      const result = validate(value);
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].field).to.equal('selfie');
-      expect(result[0].error).to.be.instanceOf(RequiredValueMissingError);
-    });
-
-    it('returns empty array if selfie is set', () => {
-      const value = {
-        selfie: new window.File([], 'upload.png', { type: 'image/png' }),
-      };
-      const result = validate(value);
-
-      expect(result).to.deep.equal([]);
-    });
-  });
 
   it('calls onChange callback with uploaded image', async () => {
     const onChange = sinon.stub();

--- a/spec/javascripts/packages/document-capture/hooks/use-history-param-spec.jsx
+++ b/spec/javascripts/packages/document-capture/hooks/use-history-param-spec.jsx
@@ -68,11 +68,18 @@ describe('useHistoryParam', () => {
     expect(getByDisplayValue('5')).to.be.ok();
   });
 
-  it('accepts an initial value to use in absence of an initial URL', () => {
+  it('accepts an initial value', () => {
     const { getByDisplayValue } = render(<TestComponent initialValue="5" />);
 
     expect(window.location.hash).to.equal('#the%20count=5');
     expect(getByDisplayValue('5')).to.be.ok();
+  });
+
+  it('accepts empty initial value', () => {
+    const { getByDisplayValue } = render(<TestComponent initialValue={null} />);
+
+    expect(window.location.hash).to.equal('');
+    expect(getByDisplayValue('0')).to.be.ok();
   });
 
   it('syncs by setter', () => {


### PR DESCRIPTION
**Why**: Reduces responsibility of step where "is required" is the only validation currently in use, and allows validation of conditionally-registered fields.

Specifically, this would be needed for the use-case described at https://github.com/18F/identity-idp/pull/4237#issuecomment-700173689, where in the review screen introduced in #4237, the "Selfie" field is required, but only if liveness checking is enabled for the service provider. The current step validation behavior has no direct awareness of whether liveness is enabled. 

**Alternatives considered:**

- It could be possible to pre-bind a validation function with an argument controlling whether selfie should be checked.

```
const reviewStep = { validate: validateReviewStep.bind(null, isLivenessEnabled);
// ...
function validate(isLivenessEnabled, values) {
  const valuesToCheck = isLivenessEnabled ? ['front', 'back', 'selfie'] : ['front', 'back'];
  // ...
}
```

Note that some of the changes here assume or otherwise depend on changes from #4237 (e.g. `initialStep` -> `autoFocus`).