### PR TITLE
LG-3534: Image capture text revisions

### DIFF
--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -79,7 +79,7 @@ en:
         and selfie
       document_capture_selfie: Your photo
       front: Front
-      interstitial: We are processing your images…
+      interstitial: We are processing your images
       photo: Photo
       selfie: Take a photo of yourself
       ssn: Please enter your social security number.

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -184,7 +184,7 @@ en:
       document_capture_selfie_text1: Face the camera and ensure your entire head is
         in the photo
       document_capture_selfie_text2: Take a photo against a plain background
-      document_capture_selfie_text3: Do not wear a hat or sunglasses
+      document_capture_selfie_text3: Do not wear a hat or glasses
       header_text: Guidelines for taking a photo of your ID
       text1: Take it in a room with lots of light. Indirect sunlight is best.
       text2: Make sure your ID doesn't have dirt or damaged barcodes.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -196,7 +196,7 @@ es:
       document_capture_selfie_text1: Mira a la cámara y asegúrate de que toda tu cabeza
         esté en la foto
       document_capture_selfie_text2: Toma una foto sobre un fondo liso
-      document_capture_selfie_text3: No use sombrero o lentes de sol
+      document_capture_selfie_text3: No use sombrero ni anteojos
       header_text: Pautas para tomar una foto de su identificación
       text1: Tómalo en una habitación con mucha luz. La luz solar indirecta es la
         mejor.

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -85,7 +85,7 @@ es:
         por el estado y una foto suya
       document_capture_selfie: Tu foto
       front: Frente
-      interstitial: Estamos procesando tus imágenes…
+      interstitial: Estamos procesando tus imágenes
       photo: Foto
       selfie: Toma una foto de ti mismo
       ssn: Por favor ingrese su número de seguro social.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -208,7 +208,7 @@ fr:
       document_capture_selfie_text1: Faites face à la caméra et assurez-vous que toute
         votre tête est sur la photo
       document_capture_selfie_text2: Prenez une photo sur un fond uni
-      document_capture_selfie_text3: Ne portez pas de chapeau ni de lunettes de soleil
+      document_capture_selfie_text3: Ne portez pas de chapeau ni de lunettes
       header_text: Directives pour prendre une photo de votre identité
       text1: Prenez-le dans une pièce très éclairée. La lumière solaire indirecte
         est la meilleure.

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -88,7 +88,7 @@ fr:
         officielle et une photo de vous
       document_capture_selfie: Ta photo
       front: De face
-      interstitial: Nous traitons vos images…
+      interstitial: Nous traitons vos images
       photo: Photo
       selfie: Prenez une photo de vous
       ssn: S'il vous plaît entrez votre numéro de sécurité sociale.


### PR DESCRIPTION
**Why**: Clarify texts to improve success likelihood.

- On the "Take a photo of yourself" step, changes "Do not wear a hat or sunglasses" to "Do not wear a hat or glasses".
- On the "Processing images" step, removes ellipsis. 

&nbsp;|Desktop|Mobile
---|---|---
Selfie|![selfie desktop](https://user-images.githubusercontent.com/1779930/94578077-46dfc080-0245-11eb-8cd6-e2b8fa1e3f5b.png)|![selfie mobile](https://user-images.githubusercontent.com/1779930/94578114-4f37fb80-0245-11eb-8c8e-cda4520d6e10.png)
Interstitial|![interstitial desktop](https://user-images.githubusercontent.com/1779930/94578132-552ddc80-0245-11eb-8946-f180aea211c0.png)|![interstitial mobile](https://user-images.githubusercontent.com/1779930/94578153-5c54ea80-0245-11eb-88d0-1b04657f992b.png)