### PR TITLE
Unset active document capture steps errors when empty

### DIFF
--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -115,10 +115,10 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
   /**
    * Returns array of form errors for the current set of values.
    *
-   * @return {FormStepError<Record<string,Error>>[]}
+   * @return {FormStepError<Record<string,Error>>[]|undefined}
    */
   function getValidationErrors() {
-    return Object.keys(fields.current).reduce((result, key) => {
+    const errors = Object.keys(fields.current).reduce((result, key) => {
       const { element, isRequired } = fields.current[key];
       const isActive = !!element;
 
@@ -128,6 +128,10 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
 
       return result;
     }, /** @type {FormStepError<Record<string,Error>>[]} */ ([]));
+
+    if (errors.length) {
+      return errors;
+    }
   }
 
   useEffect(() => {

--- a/app/javascript/packages/document-capture/components/form-steps.jsx
+++ b/app/javascript/packages/document-capture/components/form-steps.jsx
@@ -25,7 +25,7 @@ import useHistoryParam from '../hooks/use-history-param';
  * @prop {(nextValues:Partial<V>)=>void} onChange Values change callback, merged with
  * existing values.
  * @prop {Partial<V>} value Current values.
- * @prop {FormStepError<V>[]=} errors Current active errors.
+ * @prop {FormStepError<V>[]} errors Current active errors.
  * @prop {(
  *   field:string,
  *   options?:Partial<FormStepRegisterFieldOptions>
@@ -85,7 +85,7 @@ export function getStepIndexByName(steps, name) {
 function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, autoFocus }) {
   const [values, setValues] = useState(initialValues);
   const [activeErrors, setActiveErrors] = useState(
-    /** @type {FormStepError<Record<string,Error>>[]=} */ (undefined),
+    /** @type {FormStepError<Record<string,Error>>[]} */ ([]),
   );
   const formRef = useRef(/** @type {?HTMLFormElement} */ (null));
   const headingRef = useRef(/** @type {?HTMLHeadingElement} */ (null));
@@ -94,7 +94,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
   const fields = useRef(/** @type {Record<string,FieldsRefEntry>} */ ({}));
   const didSubmitWithErrors = useRef(false);
   useEffect(() => {
-    if (activeErrors?.length && didSubmitWithErrors.current) {
+    if (activeErrors.length && didSubmitWithErrors.current) {
       const firstActiveError = activeErrors[0];
       fields.current[firstActiveError.field]?.element?.focus();
     }
@@ -115,10 +115,10 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
   /**
    * Returns array of form errors for the current set of values.
    *
-   * @return {FormStepError<Record<string,Error>>[]|undefined}
+   * @return {FormStepError<Record<string,Error>>[]}
    */
   function getValidationErrors() {
-    const errors = Object.keys(fields.current).reduce((result, key) => {
+    return Object.keys(fields.current).reduce((result, key) => {
       const { element, isRequired } = fields.current[key];
       const isActive = !!element;
 
@@ -128,16 +128,12 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
 
       return result;
     }, /** @type {FormStepError<Record<string,Error>>[]} */ ([]));
-
-    if (errors.length) {
-      return errors;
-    }
   }
 
   useEffect(() => {
     // Errors are assigned at the first attempt to submit. Once errors are assigned, track value
     // changes to remove validation errors as they become resolved.
-    if (activeErrors) {
+    if (activeErrors.length) {
       const nextActiveErrors = getValidationErrors();
       setActiveErrors(nextActiveErrors);
     }
@@ -160,7 +156,7 @@ function FormSteps({ steps = [], onComplete = () => {}, initialValues = {}, auto
     const nextActiveErrors = getValidationErrors();
     setActiveErrors(nextActiveErrors);
     didSubmitWithErrors.current = true;
-    if (nextActiveErrors?.length) {
+    if (nextActiveErrors.length) {
       return;
     }
 

--- a/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/form-steps-spec.jsx
@@ -237,6 +237,15 @@ describe('document-capture/components/form-steps', () => {
     expect(document.activeElement).to.equal(getByText('Last Title'));
   });
 
+  it('distinguishes empty errors from progressive error removal', async () => {
+    const { getByText, getByLabelText, container } = render(<FormSteps steps={STEPS} />);
+
+    userEvent.click(getByText('forms.buttons.continue'));
+
+    await userEvent.type(getByLabelText('Second Input One'), 'one');
+    expect(container.querySelectorAll('[data-is-error]')).to.have.lengthOf(0);
+  });
+
   it('renders with optional footer', () => {
     const steps = [
       {


### PR DESCRIPTION
Fixes regression introduced in #4243 (see https://github.com/18F/identity-idp/pull/4243#issuecomment-700778420, https://github.com/18F/identity-idp/pull/4243#discussion_r496811044)

**Why**: In `FormSteps` `toNextStep`, we always assign `setActiveErrors(getValidationErrors())`. In the mobile flow this happens when continuing from the first "Mobile Intro" step. There are no actual errors, but it still sets an empty array, which is considered truthy by `if (activeErrors) {`. The idea with this code was to try to "chip away at" any active errors. With these changes, active errors will be unset if and when empty, to avoid being treated as truthy.