### PR TITLE
Do not check for pending migrations on each request in prod

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,10 +33,6 @@ module Upaya
       event.payload.except(:params, :headers)
     end
 
-    # Refuse to run if migraitons are pending. Migrations should be run out
-    # of band from launching the app
-    config.active_record.migration_error = :page_load
-
     # Use a custom log formatter to get timestamp
     config.log_formatter = Upaya::UpayaLogFormatter.new
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.active_support.deprecation = :log
+  config.active_record.migration_error = :page_load
   config.assets.debug = true
   config.assets.digest = true
   config.assets.raise_runtime_errors = true


### PR DESCRIPTION
Results in ~5ms saved on each request in deployed environments