### PR TITLE
LG-3427: Add ial2Strict to ServiceProviderContext to conditionally hide selfie in "Review Issues" step

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -7,6 +7,7 @@ import SelfieStep from './selfie-step';
 import ReviewIssuesStep from './review-issues-step';
 import MobileIntroStep from './mobile-intro-step';
 import DeviceContext from '../context/device';
+import ServiceProviderContext from '../context/service-provider';
 import Submission from './submission';
 import DesktopDocumentDisclosure from './desktop-document-disclosure';
 import useI18n from '../hooks/use-i18n';
@@ -14,13 +15,6 @@ import useI18n from '../hooks/use-i18n';
 /** @typedef {import('react').ReactNode} ReactNode */
 /** @typedef {import('./form-steps').FormStep} FormStep */
 /** @typedef {import('../context/upload').UploadFieldError} UploadFieldError */
-
-/**
- * @typedef DocumentCaptureProps
- *
- * @prop {boolean=} isLivenessEnabled Whether liveness capture should be expected from the user.
- *                                    Defaults to false.
- */
 
 /**
  * Returns error messages interspersed with line break React element.
@@ -33,14 +27,12 @@ export function getFormattedErrorMessages(errors) {
   return errors.flatMap((error, i) => [<br key={i} />, error.message]).slice(1);
 }
 
-/**
- * @param {DocumentCaptureProps} props Props object.
- */
-function DocumentCapture({ isLivenessEnabled = true }) {
+function DocumentCapture() {
   const [formValues, setFormValues] = useState(/** @type {Record<string,any>?} */ (null));
   const [submissionError, setSubmissionError] = useState(/** @type {Error?} */ (null));
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
+  const serviceProvider = useContext(ServiceProviderContext);
 
   /**
    * Clears error state and sets form values for submission.
@@ -76,7 +68,7 @@ function DocumentCapture({ isLivenessEnabled = true }) {
           form: DocumentsStep,
           footer: DesktopDocumentDisclosure,
         },
-        isLivenessEnabled && {
+        serviceProvider?.ial2Strict !== false && {
           name: 'selfie',
           title: t('doc_auth.headings.selfie'),
           form: SelfieStep,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -68,7 +68,7 @@ function DocumentCapture() {
           form: DocumentsStep,
           footer: DesktopDocumentDisclosure,
         },
-        serviceProvider?.isLivenessRequired && {
+        serviceProvider.isLivenessRequired && {
           name: 'selfie',
           title: t('doc_auth.headings.selfie'),
           form: SelfieStep,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -68,7 +68,7 @@ function DocumentCapture() {
           form: DocumentsStep,
           footer: DesktopDocumentDisclosure,
         },
-        serviceProvider?.ial2Strict !== false && {
+        serviceProvider?.isLivenessRequired !== false && {
           name: 'selfie',
           title: t('doc_auth.headings.selfie'),
           form: SelfieStep,

--- a/app/javascript/packages/document-capture/components/document-capture.jsx
+++ b/app/javascript/packages/document-capture/components/document-capture.jsx
@@ -68,7 +68,7 @@ function DocumentCapture() {
           form: DocumentsStep,
           footer: DesktopDocumentDisclosure,
         },
-        serviceProvider?.isLivenessRequired !== false && {
+        serviceProvider?.isLivenessRequired && {
           name: 'selfie',
           title: t('doc_auth.headings.selfie'),
           form: SelfieStep,

--- a/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
+++ b/app/javascript/packages/document-capture/components/mobile-intro-step.jsx
@@ -14,13 +14,18 @@ function MobileIntroStep() {
           strong: 'strong',
         })}
       </p>
-      {serviceProvider && (
+      {serviceProvider.name && (
         <p>
           {formatHTML(
             t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
             {
               strong: 'strong',
-              a: ({ children }) => <a href={serviceProvider.failureToProofURL}>{children}</a>,
+              a: ({ children }) =>
+                serviceProvider.failureToProofURL ? (
+                  <a href={serviceProvider.failureToProofURL}>{children}</a>
+                ) : (
+                  <>{children}</>
+                ),
             },
           )}
         </p>

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -41,13 +41,18 @@ function ReviewIssuesStep({
           strong: 'strong',
         })}
       </p>
-      {serviceProvider && (
+      {serviceProvider.name && (
         <p>
           {formatHTML(
             t('doc_auth.info.no_other_id_help_bold_html', { sp_name: serviceProvider.name }),
             {
               strong: ({ children }) => <>{children}</>,
-              a: ({ children }) => <a href={serviceProvider.failureToProofURL}>{children}</a>,
+              a: ({ children }) =>
+                serviceProvider.failureToProofURL ? (
+                  <a href={serviceProvider.failureToProofURL}>{children}</a>
+                ) : (
+                  <>{children}</>
+                ),
             },
           )}
         </p>

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -79,33 +79,37 @@ function ReviewIssuesStep({
           />
         );
       })}
-      <hr className="margin-y-4" />
-      <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>
-      <ul>
-        <li>{t('doc_auth.tips.review_issues_selfie_text1')}</li>
-        <li>{t('doc_auth.tips.review_issues_selfie_text2')}</li>
-        <li>{t('doc_auth.tips.review_issues_selfie_text3')}</li>
-        <li>{t('doc_auth.tips.review_issues_selfie_text4')}</li>
-      </ul>
-      {isMobile || !hasMediaAccess() ? (
-        <AcuantCapture
-          ref={registerField('selfie', { isRequired: true })}
-          capture="user"
-          label={t('doc_auth.headings.document_capture_selfie')}
-          bannerText={t('doc_auth.headings.photo')}
-          value={value.selfie}
-          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
-          allowUpload={false}
-          className="id-card-file-input"
-          errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
-        />
-      ) : (
-        <SelfieCapture
-          ref={registerField('selfie', { isRequired: true })}
-          value={value.selfie}
-          onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
-          errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
-        />
+      {serviceProvider?.ial2Strict !== false && (
+        <>
+          <hr className="margin-y-4" />
+          <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>
+          <ul>
+            <li>{t('doc_auth.tips.review_issues_selfie_text1')}</li>
+            <li>{t('doc_auth.tips.review_issues_selfie_text2')}</li>
+            <li>{t('doc_auth.tips.review_issues_selfie_text3')}</li>
+            <li>{t('doc_auth.tips.review_issues_selfie_text4')}</li>
+          </ul>
+          {isMobile || !hasMediaAccess() ? (
+            <AcuantCapture
+              ref={registerField('selfie', { isRequired: true })}
+              capture="user"
+              label={t('doc_auth.headings.document_capture_selfie')}
+              bannerText={t('doc_auth.headings.photo')}
+              value={value.selfie}
+              onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+              allowUpload={false}
+              className="id-card-file-input"
+              errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
+            />
+          ) : (
+            <SelfieCapture
+              ref={registerField('selfie', { isRequired: true })}
+              value={value.selfie}
+              onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
+              errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -79,7 +79,7 @@ function ReviewIssuesStep({
           />
         );
       })}
-      {serviceProvider?.ial2Strict !== false && (
+      {serviceProvider?.isLivenessRequired !== false && (
         <>
           <hr className="margin-y-4" />
           <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -84,7 +84,7 @@ function ReviewIssuesStep({
           />
         );
       })}
-      {serviceProvider?.isLivenessRequired !== false && (
+      {serviceProvider?.isLivenessRequired && (
         <>
           <hr className="margin-y-4" />
           <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -84,7 +84,7 @@ function ReviewIssuesStep({
           />
         );
       })}
-      {serviceProvider?.isLivenessRequired && (
+      {serviceProvider.isLivenessRequired && (
         <>
           <hr className="margin-y-4" />
           <p className="margin-bottom-0">{t('doc_auth.tips.review_issues_selfie_header_text')}</p>

--- a/app/javascript/packages/document-capture/context/service-provider.js
+++ b/app/javascript/packages/document-capture/context/service-provider.js
@@ -3,11 +3,17 @@ import { createContext } from 'react';
 /**
  * @typedef ServiceProviderContext
  *
- * @prop {string} name Service provider name.
- * @prop {string} failureToProofURL URL to redirect user on failure to proof.
+ * @prop {string?} name Service provider name.
+ * @prop {string?} failureToProofURL URL to redirect user on failure to proof.
  * @prop {boolean} isLivenessRequired Whether liveness capture should be expected from the user.
  */
 
-const ServiceProviderContext = createContext(/** @type {ServiceProviderContext=} */ (undefined));
+const ServiceProviderContext = createContext(
+  /** @type {ServiceProviderContext} */ ({
+    name: null,
+    failureToProofURL: null,
+    isLivenessRequired: true,
+  }),
+);
 
 export default ServiceProviderContext;

--- a/app/javascript/packages/document-capture/context/service-provider.js
+++ b/app/javascript/packages/document-capture/context/service-provider.js
@@ -5,7 +5,7 @@ import { createContext } from 'react';
  *
  * @prop {string} name Service provider name.
  * @prop {string} failureToProofURL URL to redirect user on failure to proof.
- * @prop {boolean} ial2Strict Whether liveness capture should be expected from the user.
+ * @prop {boolean} isLivenessRequired Whether liveness capture should be expected from the user.
  */
 
 const ServiceProviderContext = createContext(/** @type {ServiceProviderContext=} */ (undefined));

--- a/app/javascript/packages/document-capture/context/service-provider.js
+++ b/app/javascript/packages/document-capture/context/service-provider.js
@@ -5,6 +5,7 @@ import { createContext } from 'react';
  *
  * @prop {string} name Service provider name.
  * @prop {string} failureToProofURL URL to redirect user on failure to proof.
+ * @prop {boolean} ial2Strict Whether liveness capture should be expected from the user.
  */
 
 const ServiceProviderContext = createContext(/** @type {ServiceProviderContext=} */ (undefined));

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -20,9 +20,9 @@ const isMockClient = appRoot.hasAttribute('data-mock-client');
 function getServiceProvider() {
   const name = appRoot.getAttribute('data-sp-name');
   const failureToProofURL = appRoot.getAttribute('data-failure-to-proof-url');
-  const ial2Strict = appRoot.hasAttribute('data-ial2-strict');
+  const isLivenessRequired = appRoot.hasAttribute('data-liveness-required');
   if (name && failureToProofURL) {
-    return { name, failureToProofURL, ial2Strict };
+    return { name, failureToProofURL, isLivenessRequired };
   }
 }
 

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -15,14 +15,14 @@ import { isCameraCapableMobile } from '@18f/identity-device';
 const { I18n: i18n, assets } = window.LoginGov;
 
 const appRoot = document.getElementById('document-capture-form');
-const isLivenessEnabled = appRoot.hasAttribute('data-liveness');
 const isMockClient = appRoot.hasAttribute('data-mock-client');
 
 function getServiceProvider() {
   const name = appRoot.getAttribute('data-sp-name');
   const failureToProofURL = appRoot.getAttribute('data-failure-to-proof-url');
+  const ial2Strict = appRoot.hasAttribute('data-ial2-strict');
   if (name && failureToProofURL) {
-    return { name, failureToProofURL };
+    return { name, failureToProofURL, ial2Strict };
   }
 }
 
@@ -54,7 +54,7 @@ loadPolyfills(['fetch']).then(() => {
           <ServiceProviderContext.Provider value={getServiceProvider()}>
             <AssetContext.Provider value={assets}>
               <DeviceContext.Provider value={device}>
-                <DocumentCapture isLivenessEnabled={isLivenessEnabled} />
+                <DocumentCapture />
               </DeviceContext.Provider>
             </AssetContext.Provider>
           </ServiceProviderContext.Provider>

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -17,13 +17,17 @@ const { I18n: i18n, assets } = window.LoginGov;
 const appRoot = document.getElementById('document-capture-form');
 const isMockClient = appRoot.hasAttribute('data-mock-client');
 
+/**
+ * @return {import(
+ *   '@18f/identity-document-capture/context/service-provider'
+ * ).ServiceProviderContext}
+ */
 function getServiceProvider() {
   const name = appRoot.getAttribute('data-sp-name');
   const failureToProofURL = appRoot.getAttribute('data-failure-to-proof-url');
   const isLivenessRequired = appRoot.hasAttribute('data-liveness-required');
-  if (name && failureToProofURL) {
-    return { name, failureToProofURL, isLivenessRequired };
-  }
+
+  return { name, failureToProofURL, isLivenessRequired };
 }
 
 function getMetaContent(name) {

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -4,7 +4,7 @@
   <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
 <% end %>
 <%= tag.div id: 'document-capture-form', data: {
-  ial2_strict: liveness_checking_enabled?.presence,
+  liveness_required: liveness_checking_enabled?.presence,
   mock_client: (DocAuth::Client.doc_auth_vendor == 'mock').presence,
   document_capture_session_uuid: flow_session[:document_capture_session_uuid],
   endpoint: api_verify_images_url,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -4,7 +4,7 @@
   <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: Figaro.env.acuant_sdk_initialization_creds %>
 <% end %>
 <%= tag.div id: 'document-capture-form', data: {
-  liveness: liveness_checking_enabled?.presence,
+  ial2_strict: liveness_checking_enabled?.presence,
   mock_client: (DocAuth::Client.doc_auth_vendor == 'mock').presence,
   document_capture_session_uuid: flow_session[:document_capture_session_uuid],
   endpoint: api_verify_images_url,

--- a/spec/javascripts/packages/document-capture/components/mobile-intro-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/mobile-intro-step-spec.jsx
@@ -5,7 +5,7 @@ import render from '../../../support/render';
 
 describe('document-capture/components/mobile-intro-step', () => {
   context('service provider context', () => {
-    it('renders with help link', () => {
+    it('renders with name and help link', () => {
       const { getByText } = render(
         <I18nContext.Provider
           value={{
@@ -30,6 +30,35 @@ describe('document-capture/components/mobile-intro-step', () => {
           element.innerHTML ===
           '<strong>If you do not have another state-issued ID</strong>, ' +
             '<a href="https://example.com">get help at Example App.</a>',
+      );
+
+      expect(help).to.be.ok();
+    });
+
+    it('renders with name', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{
+            'doc_auth.info.no_other_id_help_bold_html':
+              '<strong>If you do not have another state-issued ID</strong>, ' +
+              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
+          }}
+        >
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: null,
+            }}
+          >
+            <MobileIntroStep />
+          </ServiceProviderContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      const help = getByText(
+        (_content, element) =>
+          element.innerHTML ===
+          '<strong>If you do not have another state-issued ID</strong>, get help at Example App.',
       );
 
       expect(help).to.be.ok();

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -37,7 +37,7 @@ describe('document-capture/components/review-issues-step', () => {
             value={{
               name: 'Example App',
               failureToProofURL: 'https://example.com',
-              ial2Strict: false,
+              isLivenessRequired: false,
             }}
           >
             <ReviewIssuesStep />
@@ -62,7 +62,7 @@ describe('document-capture/components/review-issues-step', () => {
             value={{
               name: 'Example App',
               failureToProofURL: 'https://example.com',
-              ial2Strict: false,
+              isLivenessRequired: false,
             }}
           >
             <ReviewIssuesStep />
@@ -82,7 +82,7 @@ describe('document-capture/components/review-issues-step', () => {
             value={{
               name: 'Example App',
               failureToProofURL: 'https://example.com',
-              ial2Strict: true,
+              isLivenessRequired: true,
             }}
           >
             <ReviewIssuesStep />

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -24,7 +24,7 @@ describe('document-capture/components/review-issues-step', () => {
   });
 
   context('service provider context', () => {
-    it('renders with help link', () => {
+    it('renders with name and help link', () => {
       const { getByText } = render(
         <I18nContext.Provider
           value={{
@@ -50,6 +50,36 @@ describe('document-capture/components/review-issues-step', () => {
           element.innerHTML ===
           'If you do not have another state-issued ID, ' +
             '<a href="https://example.com">get help at Example App.</a>',
+      );
+
+      expect(help).to.be.ok();
+    });
+
+    it('renders with name', () => {
+      const { getByText } = render(
+        <I18nContext.Provider
+          value={{
+            'doc_auth.info.no_other_id_help_bold_html':
+              'If you do not have another state-issued ID, ' +
+              '<a href=%{failure_to_proof_url}>get help at %{sp_name}.</a>',
+          }}
+        >
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: null,
+              isLivenessRequired: false,
+            }}
+          >
+            <ReviewIssuesStep />
+          </ServiceProviderContext.Provider>
+        </I18nContext.Provider>,
+      );
+
+      const help = getByText(
+        (_content, element) =>
+          element.innerHTML ===
+          'If you do not have another state-issued ID, get help at Example App.',
       );
 
       expect(help).to.be.ok();

--- a/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/review-issues-step-spec.jsx
@@ -9,13 +9,9 @@ describe('document-capture/components/review-issues-step', () => {
   it('renders with front, back, and selfie inputs', () => {
     const { getByLabelText } = render(<ReviewIssuesStep />);
 
-    const front = getByLabelText('doc_auth.headings.document_capture_front');
-    const back = getByLabelText('doc_auth.headings.document_capture_back');
-    const selfie = getByLabelText('doc_auth.headings.document_capture_selfie');
-
-    expect(front).to.be.ok();
-    expect(back).to.be.ok();
-    expect(selfie).to.be.ok();
+    expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
+    expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
+    expect(getByLabelText('doc_auth.headings.document_capture_selfie')).to.be.ok();
   });
 
   it('calls onChange callback with uploaded image', () => {
@@ -41,6 +37,7 @@ describe('document-capture/components/review-issues-step', () => {
             value={{
               name: 'Example App',
               failureToProofURL: 'https://example.com',
+              ial2Strict: false,
             }}
           >
             <ReviewIssuesStep />
@@ -56,6 +53,46 @@ describe('document-capture/components/review-issues-step', () => {
       );
 
       expect(help).to.be.ok();
+    });
+
+    context('ial2', () => {
+      it('renders with front and back inputs', () => {
+        const { getByLabelText } = render(
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: 'https://example.com',
+              ial2Strict: false,
+            }}
+          >
+            <ReviewIssuesStep />
+          </ServiceProviderContext.Provider>,
+        );
+
+        expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
+        expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
+        expect(() => getByLabelText('doc_auth.headings.document_capture_selfie')).to.throw();
+      });
+    });
+
+    context('ial2 strict', () => {
+      it('renders with front, back, and selfie inputs', () => {
+        const { getByLabelText } = render(
+          <ServiceProviderContext.Provider
+            value={{
+              name: 'Example App',
+              failureToProofURL: 'https://example.com',
+              ial2Strict: true,
+            }}
+          >
+            <ReviewIssuesStep />
+          </ServiceProviderContext.Provider>,
+        );
+
+        expect(getByLabelText('doc_auth.headings.document_capture_front')).to.be.ok();
+        expect(getByLabelText('doc_auth.headings.document_capture_back')).to.be.ok();
+        expect(getByLabelText('doc_auth.headings.document_capture_selfie')).to.be.ok();
+      });
     });
   });
 });


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4237#issuecomment-700173689

**Why**: If liveness is not required for the document capture flow, then the "Selfie" field should not be present in the "Review Issues" step

**Screenshot:**

Service Provider with IAL2|Service Provider with IAL2 Strict, or No Service Provider
---|---
![Service Provider with IAL2](https://user-images.githubusercontent.com/1779930/94597088-1c98fd80-025b-11eb-9cc3-ca7c287fbb9b.png)|![Service Provider with IAL2 Strict, or No Service Provider](https://user-images.githubusercontent.com/1779930/94597134-27ec2900-025b-11eb-8eb0-faf5833686c4.png)
