### PR TITLE
LG-3595: Retain document capture values in original format to avoid conversion

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -95,7 +95,7 @@ module Idv
 
     def as_readable(value)
       @readable ||= {}
-      return @readable[value] if @readable.has_key?(value)
+      return @readable[value] if @readable.key?(value)
 
       @readable[value] = begin
         if value.respond_to?(:read)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -44,15 +44,15 @@ module Idv
     end
 
     def front
-      as_readable(params[:front])
+      as_readable(:front)
     end
 
     def back
-      as_readable(params[:back])
+      as_readable(:back)
     end
 
     def selfie
-      as_readable(params[:selfie])
+      as_readable(:selfie)
     end
 
     def document_capture_session_uuid
@@ -94,10 +94,11 @@ module Idv
       errors.add(:selfie, t('doc_auth.errors.not_a_file')) if selfie.is_a? URI::InvalidURIError
     end
 
-    def as_readable(value)
-      return @readable[value] if @readable.key?(value)
+    def as_readable(image_key)
+      return @readable[image_key] if @readable.key?(image_key)
 
-      @readable[value] = begin
+      value = params[image_key]
+      @readable[image_key] = begin
         if value.respond_to?(:read)
           value
         elsif value.is_a? String

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -94,10 +94,18 @@ module Idv
     end
 
     def as_readable(value)
-      return value if value.respond_to?(:read)
-      return DataUrlImage.new(value) if value.is_a? String
-    rescue URI::InvalidURIError => error
-      error
+      @readable ||= {}
+      return @readable[value] if @readable.has_key?(value)
+
+      @readable[value] = begin
+        if value.respond_to?(:read)
+          value
+        elsif value.is_a? String
+          DataUrlImage.new(value)
+        end
+      rescue URI::InvalidURIError => error
+        error
+      end
     end
   end
 end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -14,6 +14,7 @@ module Idv
     def initialize(params, liveness_checking_enabled:)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
+      @readable = {}
     end
 
     def submit
@@ -94,7 +95,6 @@ module Idv
     end
 
     def as_readable(value)
-      @readable ||= {}
       return @readable[value] if @readable.key?(value)
 
       @readable[value] = begin

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -14,7 +14,6 @@ module Idv
     validates_presence_of :document_capture_session
     validates_presence_of :selfie, if: :liveness_checking_enabled?
 
-    validate :validate_images
     validate :throttle_if_rate_limited
 
     def initialize(params, liveness_checking_enabled:)
@@ -49,15 +48,15 @@ module Idv
     end
 
     def front
-      params[:front]
+      as_readable(params[:front])
     end
 
     def back
-      params[:back]
+      as_readable(params[:back])
     end
 
     def selfie
-      params[:selfie]
+      as_readable(params[:selfie])
     end
 
     def document_capture_session_uuid
@@ -93,17 +92,9 @@ module Idv
       )
     end
 
-    def validate_images
-      IMAGE_KEYS.each do |image_key|
-        validate_image(image_key) if params[image_key]
-      end
-    end
-
-    def validate_image(image_key)
-      file = params[image_key]
-
-      return if file.respond_to?(:read)
-      errors.add(image_key, t('doc_auth.errors.not_a_file'))
+    def as_readable(value)
+      return value if value.respond_to?(:read)
+      return DataUrlImage.new(value) if value.is_a? String
     end
   end
 end

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -7,8 +7,8 @@ import DeviceContext from '../context/device';
 /**
  * @typedef DocumentsStepValue
  *
- * @prop {Blob=} front Front image value.
- * @prop {Blob=} back Back image value.
+ * @prop {Blob|string|null|undefined} front Front image value.
+ * @prop {Blob|string|null|undefined} back Back image value.
  */
 
 /**

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -17,7 +17,7 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string=} bannerText Optional banner overlay text.
  * @prop {string[]=} accept Optional array of file input accept patterns.
  * @prop {'user'|'environment'=} capture Optional facing mode if file input is used for capture.
- * @prop {Blob?=} value Current value.
+ * @prop {Blob|string|null|undefined} value Current value.
  * @prop {ReactNode=} errorMessage Error to show.
  * @prop {(event:ReactMouseEvent)=>void=} onClick Input click handler.
  * @prop {(nextValue:Blob?)=>void=} onChange Input change handler.
@@ -54,13 +54,17 @@ export function getAcceptPattern(accept) {
 /**
  * Returns true if the given file represents an image, or false otherwise.
  *
- * @param {Blob} file File to test.
+ * @param {Blob|string} value File value to test.
  *
  * @return {boolean} Whether given file is an image.
  */
-export function isImage(file) {
-  const pattern = /** @type {RegExp} */ (getAcceptPattern('image/*'));
-  return pattern.test(file.type);
+export function isImage(value) {
+  if (value instanceof window.Blob) {
+    const pattern = /** @type {RegExp} */ (getAcceptPattern('image/*'));
+    return pattern.test(value.type);
+  }
+
+  return /^data:image\//.test(value);
 }
 
 /**
@@ -172,7 +176,7 @@ const FileInput = forwardRef((props, ref) => {
         onDrop={() => setIsDraggingOver(false)}
       >
         <div className="usa-file-input__target">
-          {value && value instanceof window.Blob && !isMobile && (
+          {value && !isMobile && (
             <div className="usa-file-input__preview-heading">
               <span>
                 {value instanceof window.File && (
@@ -187,7 +191,11 @@ const FileInput = forwardRef((props, ref) => {
           )}
           {value && isImage(value) && (
             <div className="usa-file-input__preview" aria-hidden="true">
-              <FileImage file={value} alt="" className="usa-file-input__preview__image" />
+              {value instanceof window.Blob ? (
+                <FileImage file={value} alt="" className="usa-file-input__preview__image" />
+              ) : (
+                <img src={value} alt="" className="usa-file-input__preview__image" />
+              )}
             </div>
           )}
           {!value && (

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -10,9 +10,9 @@ import ServiceProviderContext from '../context/service-provider';
 /**
  * @typedef ReviewIssuesStepValue
  *
- * @prop {Blob=} front Front image value.
- * @prop {Blob=} back Back image value.
- * @prop {Blob?=} selfie Back image value.
+ * @prop {Blob|string|null|undefined} front Front image value.
+ * @prop {Blob|string|null|undefined} back Back image value.
+ * @prop {Blob|string|null|undefined} selfie Back image value.
  */
 
 /**

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -19,8 +19,8 @@ import useFocusFallbackRef from '../hooks/use-focus-fallback-ref';
 /**
  * @typedef SelfieCaptureProps
  *
- * @prop {Blob?=} value Current value.
- * @prop {(nextValue:Blob?)=>void} onChange Change handler.
+ * @prop {Blob|string|null|undefined} value Current value.
+ * @prop {(nextValue:Blob|string|null)=>void} onChange Change handler.
  * @prop {ReactNode=} errorMessage Error to show.
  */
 
@@ -169,7 +169,11 @@ function SelfieCapture({ value, onChange, errorMessage }, ref) {
                 {t('doc_auth.buttons.take_picture_retry')}
               </button>
             </div>
-            <FileImage file={value} alt="" className="selfie-capture__preview-image" />
+            {value instanceof window.Blob ? (
+              <FileImage file={value} alt="" className="selfie-capture__preview-image" />
+            ) : (
+              <img src={value} alt="" className="selfie-capture__preview-image" />
+            )}
           </>
         ) : (
           <>

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -9,7 +9,7 @@ import FormErrorMessage from './form-error-message';
 /**
  * @typedef SelfieStepValue
  *
- * @prop {Blob?=} selfie Selfie value.
+ * @prop {Blob|string|null|undefined} selfie Selfie value.
  */
 
 /**

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
 
-    context 'when an image is not a multipart file' do
-      let(:selfie_image) { 'aaaa' }
+    context 'when any image is a base64 file' do
+      let(:selfie_image) { DocAuthImageFixtures.selfie_image_data_url }
 
-      it 'is not valid' do
-        expect(form.valid?).to eq(false)
-        expect(form.errors[:selfie]).to eq(['The selection was not a valid file'])
+      it 'is valid' do
+        expect(form.valid?).to eq(true)
+        expect(form.errors).to be_blank
       end
     end
 

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -175,8 +175,9 @@ describe('document-capture/components/acuant-capture', () => {
       await new Promise((resolve) => onChange.callsFake(resolve));
 
       expect(onChange.getCall(0).args).to.have.lengthOf(1);
-      expect(onChange.getCall(0).args[0]).to.be.instanceOf(window.Blob);
-      expect(onChange.getCall(0).args[0].type).to.be.equal('image/svg+xml');
+      expect(onChange.getCall(0).args[0]).to.equal(
+        'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"/%3E',
+      );
       expect(window.AcuantCameraUI.end.calledOnce).to.be.true();
     });
 

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -139,6 +139,21 @@ describe('document-capture/components/file-input', () => {
     expect(hint).to.equal('Must be small');
   });
 
+  it('renders a value preview for a blob', async () => {
+    const { container, findByRole, getByLabelText } = render(
+      <FileInput label="File" value={new window.Blob([], { type: 'image/png' })} />,
+    );
+
+    const preview = await findByRole('img', { hidden: true });
+    const input = getByLabelText('File');
+
+    expect(input).to.be.ok();
+    expect(preview.getAttribute('src')).to.match(/^data:image\/png;base64,/);
+    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
+      'doc_auth.forms.change_file',
+    );
+  });
+
   it('renders a value preview for a file', async () => {
     const { container, findByRole, getByLabelText } = render(
       <FileInput label="File" value={new window.File([], 'demo.png', { type: 'image/png' })} />,
@@ -151,6 +166,21 @@ describe('document-capture/components/file-input', () => {
     expect(preview.getAttribute('src')).to.match(/^data:image\/png;base64,/);
     expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
       'doc_auth.forms.selected_file: demo.png doc_auth.forms.change_file',
+    );
+  });
+
+  it('renders a value preview for a data URL', async () => {
+    const { container, findByRole, getByLabelText } = render(
+      <FileInput label="File" value="data:image/jpeg;base64,8J+Riw==" />,
+    );
+
+    const preview = await findByRole('img', { hidden: true });
+    const input = getByLabelText('File');
+
+    expect(input).to.be.ok();
+    expect(preview.getAttribute('src')).to.match(/^data:image\/jpeg;base64,/);
+    expect(container.querySelector('.usa-file-input__preview-heading').textContent).to.equal(
+      'doc_auth.forms.change_file',
     );
   });
 

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -69,12 +69,24 @@ describe('document-capture/components/file-input', () => {
   });
 
   describe('isImage', () => {
-    it('returns false if given file is not an image', () => {
-      expect(isImage(new window.File([], 'demo.txt', { type: 'text/plain' }))).to.be.false();
+    context('file', () => {
+      it('returns false if not an image', () => {
+        expect(isImage(new window.File([], 'demo.txt', { type: 'text/plain' }))).to.be.false();
+      });
+
+      it('returns true if an image', () => {
+        expect(isImage(new window.File([], 'demo.png', { type: 'image/png' }))).to.be.true();
+      });
     });
 
-    it('returns true if given file is an image', () => {
-      expect(isImage(new window.File([], 'demo.png', { type: 'image/png' }))).to.be.true();
+    context('data URL', () => {
+      it('returns false if not an image', () => {
+        expect(isImage('data:text/plain;base64,8J+Riw==')).to.be.false();
+      });
+
+      it('returns true if an image', () => {
+        expect(isImage('data:image/jpeg;base64,8J+Riw==')).to.be.true();
+      });
     });
   });
 

--- a/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-step-spec.jsx
@@ -18,10 +18,12 @@ describe('document-capture/components/selfie-step', () => {
       </AcuantProvider>,
     );
     initialize();
-    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '');
+    window.AcuantPassiveLiveness.startSelfieCapture.callsArgWithAsync(0, '8J+Riw==');
 
     userEvent.click(getByLabelText('doc_auth.headings.document_capture_selfie'));
 
-    await waitFor(() => expect(onChange.getCall(0).args[0].selfie).to.be.instanceOf(window.Blob));
+    await waitFor(() =>
+      expect(onChange.getCall(0).args[0].selfie).to.equal('data:image/jpeg;base64,8J+Riw=='),
+    );
   });
 });

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -7,12 +7,20 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(fixture_path('id-front.jpg'), 'image/jpeg')
   end
 
+  def self.document_front_image_data_url
+    "data:image/jpeg,#{CGI.escape(document_front_image)}"
+  end
+
   def self.document_back_image
     load_image_data('id-back.jpg')
   end
 
   def self.document_back_image_multipart
     Rack::Test::UploadedFile.new(fixture_path('id-back.jpg'), 'image/jpeg')
+  end
+
+  def self.document_back_image_data_url
+    "data:image/jpeg,#{CGI.escape(document_back_image)}"
   end
 
   def self.document_face_image
@@ -29,6 +37,10 @@ module DocAuthImageFixtures
 
   def self.selfie_image_multipart
     Rack::Test::UploadedFile.new(fixture_path('selfie.jpg'), 'image/jpeg')
+  end
+
+  def self.selfie_image_data_url
+    "data:image/jpeg,#{CGI.escape(selfie_image)}"
   end
 
   def self.error_yaml_multipart


### PR DESCRIPTION
**Why**: Less computationally- and memory-intensive on client to avoid normalizing and managing files between multiple formats.

**Open Questions:**

- Since the server will now need to decode Data URL files, does this put too much load on the server?
   - Note: Since these changes bring the implementation closer to what exists in the _current_ (pre-React) document capture flow, it's no more load than what exists today in production.
- With upcoming work for async uploads, does this make future work more difficult if uploaded files could be either Data URL strings or files?

**Alternatives considered:**

See also: https://github.com/18F/identity-idp/pull/4109#issuecomment-679169988

Most compelling alternative is to move the conversion of data URL to file into a web worker. While this would prevent the operation from blocking the UI, it would likely still involve multiple copies of the same image (in different formats) being held in memory.

**To Do:**

Tests could be improved slightly to better verify the behaviors of supporting _both_ data URLs and file values.