### PR TITLE
Remove unneeded rubocop disable

### DIFF
--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ModuleLength
 module Flow
   module FlowStateMachine
     extend ActiveSupport::Concern
@@ -149,7 +148,6 @@ module Flow
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength
 
 # sample usage:
 #


### PR DESCRIPTION
Must have been a merge artifact from previous PRs, this is failing on `master` branch