### PR TITLE
LG-3158 Force people with invalid doc auth configs to upgrade

### DIFF
--- a/config/initializers/acuant_simulator_config_validation.rb
+++ b/config/initializers/acuant_simulator_config_validation.rb
@@ -7,7 +7,7 @@
 # from starting if the acuant simulator is enabled but the mock doc auth vendor
 # vendor is not turned on.
 #
-FORCE_ACUANT_CONFIG_UPGRADE = false
+FORCE_ACUANT_CONFIG_UPGRADE = true
 
 if Figaro.env.acuant_simulator == 'true' &&
    Figaro.env.doc_auth_vendor != 'mock'


### PR DESCRIPTION
**Why**: All of the sandbox / personal envs should be using the new config. This change will help us identify environments that were missed and prevent instances from launching with an inconsistent config