### PR TITLE
Refactor proofing and vendors to be more explicit in preparation for lambdas

### DIFF
--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -135,7 +135,7 @@ module Idv
     end
 
     def perform_resolution(pii_from_doc)
-      idv_result = Idv::Agent.new(pii_from_doc).proof(:resolution)
+      idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: false)
       success = idv_result[:success]
       throttle_failure unless success
       form_response(idv_result, success)

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -135,7 +135,7 @@ module Idv
     end
 
     def perform_resolution(pii_from_doc)
-      idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: false)
+      idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(should_proof_state_id: false)
       success = idv_result[:success]
       throttle_failure unless success
       form_response(idv_result, success)

--- a/app/jobs/vendor_proof_job.rb
+++ b/app/jobs/vendor_proof_job.rb
@@ -1,9 +1,8 @@
 class VendorProofJob
-  def self.perform(document_capture_session_id, stages)
+  def self.perform_resolution_proof(document_capture_session_id, proof_state_id)
     dcs = DocumentCaptureSession.find_by(uuid: document_capture_session_id)
     result = dcs.load_proofing_result
-    stages = stages.map(&:to_sym)
-    idv_result = Idv::Agent.new(result.pii).proof(*stages)
+    idv_result = Idv::Agent.new(result.pii).proof_resolution(proof_state_id: proof_state_id)
     dcs.store_proofing_result(result.pii, idv_result)
   end
 end

--- a/app/jobs/vendor_proof_job.rb
+++ b/app/jobs/vendor_proof_job.rb
@@ -2,7 +2,7 @@ class VendorProofJob
   def self.perform_resolution_proof(document_capture_session_id, proof_state_id)
     dcs = DocumentCaptureSession.find_by(uuid: document_capture_session_id)
     result = dcs.load_proofing_result
-    idv_result = Idv::Agent.new(result.pii).proof_resolution(proof_state_id: proof_state_id)
+    idv_result = Idv::Agent.new(result.pii).proof_resolution(should_proof_state_id: proof_state_id)
     dcs.store_proofing_result(result.pii, idv_result)
   end
 end

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -4,11 +4,11 @@ module Idv
       @applicant = applicant.symbolize_keys
     end
 
-    def proof_resolution(proof_state_id:)
+    def proof_resolution(should_proof_state_id:)
       vendor = Idv::Proofer.resolution_vendor.new
       results = submit_applicant(vendor: vendor, results: init_results)
 
-      return results unless results[:success] && proof_state_id
+      return results unless results[:success] && should_proof_state_id
 
       vendor = Idv::Proofer.state_id_vendor.new
       submit_applicant(vendor: vendor, results: results)

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -4,7 +4,6 @@ module Idv
       @applicant = applicant.symbolize_keys
     end
 
-
     def proof_resolution(proof_state_id:)
       vendor = Idv::Proofer.resolution_vendor.new
       results = submit_applicant(vendor: vendor, results: init_results)

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -1,26 +1,23 @@
 module Idv
   class Agent
-    class << self
-      def proofer_attribute?(key)
-        Idv::Proofer.attribute?(key)
-      end
-    end
-
     def initialize(applicant)
       @applicant = applicant.symbolize_keys
     end
 
-    def proof(*stages)
-      results = init_results
 
-      stages.each do |stage|
-        proofer_result = submit_applicant(applicant: @applicant, stage: stage, results: results)
-        track_exception_in_result(proofer_result)
-        results = merge_results(results, proofer_result)
-        results[:timed_out] = proofer_result.timed_out?
-        break unless proofer_result.success?
-      end
-      results
+    def proof_resolution(proof_state_id:)
+      vendor = Idv::Proofer.resolution_vendor.new
+      results = submit_applicant(vendor: vendor, results: init_results)
+
+      return results unless results[:success] && proof_state_id
+
+      vendor = Idv::Proofer.state_id_vendor.new
+      submit_applicant(vendor: vendor, results: results)
+    end
+
+    def proof_address
+      vendor = Idv::Proofer.address_vendor.new
+      submit_applicant(vendor: vendor, results: init_results)
     end
 
     private
@@ -38,10 +35,15 @@ module Idv
       }
     end
 
-    def submit_applicant(applicant:, stage:, results:)
-      vendor = Idv::Proofer.get_vendor(stage).new
-      log_vendor(vendor, results, stage)
-      vendor.proof(applicant)
+    def submit_applicant(vendor:, results:)
+      log_vendor(vendor, results, vendor.class.stage)
+      proofer_result = vendor.proof(@applicant)
+
+      track_exception_in_result(proofer_result)
+      results = merge_results(results, proofer_result)
+      results[:timed_out] = proofer_result.timed_out?
+
+      results
     end
 
     def log_vendor(vendor, results, stage)

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -32,7 +32,7 @@ module Idv
     end
 
     def proof_address
-      self.idv_result = Idv::Agent.new(applicant).proof(:address)
+      self.idv_result = Idv::Agent.new(applicant).proof_address
       add_proofing_cost
     end
 

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -6,7 +6,7 @@ module Idv
 
     def submit(step_params)
       consume_step_params(step_params)
-      self.idv_result = Idv::Agent.new(applicant).proof(:resolution, :state_id)
+      self.idv_result = Idv::Agent.new(applicant).proof_resolution(proof_state_id: true)
       Throttler::Increment.call(*idv_throttle_params) unless failed_due_to_timeout_or_exception?
       update_idv_session if success?
       FormResponse.new(

--- a/app/services/idv/profile_step.rb
+++ b/app/services/idv/profile_step.rb
@@ -6,7 +6,7 @@ module Idv
 
     def submit(step_params)
       consume_step_params(step_params)
-      self.idv_result = Idv::Agent.new(applicant).proof_resolution(proof_state_id: true)
+      self.idv_result = Idv::Agent.new(applicant).proof_resolution(should_proof_state_id: true)
       Throttler::Increment.call(*idv_throttle_params) unless failed_due_to_timeout_or_exception?
       update_idv_session if success?
       FormResponse.new(

--- a/app/services/idv/proofer.rb
+++ b/app/services/idv/proofer.rb
@@ -1,75 +1,39 @@
 module Idv
   module Proofer
-    ATTRIBUTES = %i[
-      uuid
-      first_name last_name middle_name gen
-      address1 address2 city state zipcode
-      prev_address1 prev_address2 prev_city prev_state prev_zipcode
-      ssn dob phone email
-      state_id_number state_id_type state_id_jurisdiction
-    ].freeze
-
-    STAGES = %i[resolution state_id address].freeze
-
     @vendors = nil
 
     class << self
-      def attribute?(key)
-        ATTRIBUTES.include?(key&.to_sym)
-      end
-
-      def get_vendor(stage)
-        stage = stage.to_sym
-        vendor = vendors[stage]
-        return vendor if vendor.present?
-        return unless mock_fallback_enabled?
-        mock_vendors[stage]
-      end
-
       def validate_vendors!
-        return if mock_fallback_enabled?
-        missing_stages = STAGES - vendors.keys
-        return if missing_stages.empty?
-        raise "No proofer vendor configured for stage(s): #{missing_stages.join(', ')}"
+        resolution_vendor.new
+        state_id_vendor.new
+        address_vendor.new
+      end
+
+      def resolution_vendor
+        if mock_fallback_enabled?
+          ResolutionMock
+        else
+          LexisNexis::InstantVerify::Proofer
+        end
+      end
+
+      def state_id_vendor
+        if mock_fallback_enabled?
+          StateIdMock
+        else
+          Aamva::Proofer
+        end
+      end
+
+      def address_vendor
+        if mock_fallback_enabled?
+          AddressMock
+        else
+          LexisNexis::PhoneFinder::Proofer
+        end
       end
 
       private
-
-      def vendors
-        @vendors ||= begin
-          require_mock_vendors_if_enabled
-          available_vendors.each_with_object({}) do |vendor, result|
-            vendor_stage = vendor.stage&.downcase&.to_sym
-            next unless STAGES.include?(vendor_stage)
-            result[vendor_stage] = vendor
-          end
-        end
-      end
-
-      def available_vendors
-        external_vendors = ::Proofer::Base.descendants - mock_vendors.values
-        external_vendors.select do |vendor|
-          configured_vendor_names.include?(vendor.vendor_name)
-        end
-      end
-
-      def configured_vendor_names
-        JSON.parse(Figaro.env.proofer_vendors || '[]')
-      end
-
-      def mock_vendors
-        return {} unless mock_fallback_enabled?
-        {
-          resolution: ResolutionMock,
-          state_id: StateIdMock,
-          address: AddressMock,
-        }
-      end
-
-      def require_mock_vendors_if_enabled
-        return unless mock_fallback_enabled?
-        Dir[Rails.root.join('lib', 'proofer_mocks', '*')].sort.each { |file| require file }
-      end
 
       def mock_fallback_enabled?
         Figaro.env.proofer_mock_fallback == 'true'

--- a/app/services/idv/steps/cac/verify_step.rb
+++ b/app/services/idv/steps/cac/verify_step.rb
@@ -38,7 +38,7 @@ module Idv
         end
 
         def perform_resolution(pii_from_doc)
-          idv_result = Idv::Agent.new(pii_from_doc).proof(:resolution)
+          idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: false)
           FormResponse.new(
             success: idv_result[:success], errors: idv_result[:errors],
           )

--- a/app/services/idv/steps/cac/verify_step.rb
+++ b/app/services/idv/steps/cac/verify_step.rb
@@ -38,7 +38,7 @@ module Idv
         end
 
         def perform_resolution(pii_from_doc)
-          idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: false)
+          idv_result = Idv::Agent.new(pii_from_doc).proof_resolution(should_proof_state_id: false)
           FormResponse.new(
             success: idv_result[:success], errors: idv_result[:errors],
           )

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -54,8 +54,7 @@ module Idv
       end
 
       def perform_resolution(pii_from_doc)
-        stages = should_use_aamva?(pii_from_doc) ? %i[resolution state_id] : [:resolution]
-        Idv::Agent.new(pii_from_doc).proof(*stages)
+        Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: should_use_aamva?(pii_from_doc))
       end
 
       def idv_result_to_form_response(idv_result)

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -54,7 +54,7 @@ module Idv
       end
 
       def perform_resolution(pii_from_doc)
-        Idv::Agent.new(pii_from_doc).proof_resolution(proof_state_id: should_use_aamva?(pii_from_doc))
+        Idv::Agent.new(pii_from_doc).proof_resolution(should_proof_state_id: should_use_aamva?(pii_from_doc))
       end
 
       def idv_result_to_form_response(idv_result)

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -54,7 +54,9 @@ module Idv
       end
 
       def perform_resolution(pii_from_doc)
-        Idv::Agent.new(pii_from_doc).proof_resolution(should_proof_state_id: should_use_aamva?(pii_from_doc))
+        Idv::Agent.new(pii_from_doc).proof_resolution(
+          should_proof_state_id: should_use_aamva?(pii_from_doc),
+        )
       end
 
       def idv_result_to_form_response(idv_result)

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -16,7 +16,8 @@ module Idv
 
         flow_session[:idv_verify_step_document_capture_session_uuid] = document_capture_session.uuid
 
-        VendorProofJob.perform_resolution_proof(document_capture_session.uuid, should_use_aamva?(pii_from_doc))
+        VendorProofJob.perform_resolution_proof(document_capture_session.uuid,
+                                                should_use_aamva?(pii_from_doc))
       end
     end
   end

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -16,8 +16,7 @@ module Idv
 
         flow_session[:idv_verify_step_document_capture_session_uuid] = document_capture_session.uuid
 
-        stages = should_use_aamva?(pii_from_doc) ? %w[resolution state_id] : ['resolution']
-        VendorProofJob.perform(document_capture_session.uuid, stages)
+        VendorProofJob.perform_resolution_proof(document_capture_session.uuid, should_use_aamva?(pii_from_doc))
       end
     end
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -108,7 +108,6 @@ pinpoint_voice_longcode_pool:
 pinpoint_voice_region:
 poll_rate_for_verify_in_seconds: '10'
 proofer_mock_fallback: 'true'
-proofer_vendors:
 push_notifications_enabled:
 reauthn_window: '120'
 recaptcha_enabled_percent: '0'

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -133,7 +133,7 @@ feature 'doc auth verify step' do
     it 'performs a resolution and state ID check' do
       agent = instance_double(Idv::Agent)
       allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof).and_return(
+      allow(agent).to receive(:proof_resolution).and_return(
         success: true, errors: {}, context: { stages: [] },
       )
 
@@ -147,7 +147,7 @@ feature 'doc auth verify step' do
       complete_doc_auth_steps_before_verify_step
       click_idv_continue
 
-      expect(agent).to have_received(:proof).with(:resolution, :state_id)
+      expect(agent).to have_received(:proof_resolution).with(should_proof_state_id: true)
     end
   end
 
@@ -155,7 +155,7 @@ feature 'doc auth verify step' do
     it 'does not perform the state ID check' do
       agent = instance_double(Idv::Agent)
       allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof).and_return(
+      allow(agent).to receive(:proof_resolution).and_return(
         success: true, errors: {}, context: { stages: [] },
       )
 
@@ -169,7 +169,7 @@ feature 'doc auth verify step' do
       complete_doc_auth_steps_before_verify_step
       click_idv_continue
 
-      expect(agent).to have_received(:proof).with(:resolution)
+      expect(agent).to have_received(:proof_resolution).with(should_proof_state_id: false)
     end
   end
 
@@ -177,7 +177,7 @@ feature 'doc auth verify step' do
     it 'does not perform the state ID check' do
       agent = instance_double(Idv::Agent)
       allow(Idv::Agent).to receive(:new).and_return(agent)
-      allow(agent).to receive(:proof).and_return(
+      allow(agent).to receive(:proof_resolution).and_return(
         success: true, errors: {}, context: { stages: [] },
       )
 
@@ -189,7 +189,7 @@ feature 'doc auth verify step' do
       complete_doc_auth_steps_before_verify_step
       click_idv_continue
 
-      expect(agent).to have_received(:proof).with(:resolution)
+      expect(agent).to have_received(:proof_resolution).with(should_proof_state_id: false)
     end
   end
 end

--- a/spec/features/idv/steps/phone_otp_delivery_selection_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_delivery_selection_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'IdV phone OTP deleivery method selection' do
+feature 'IdV phone OTP delivery method selection' do
   include IdvStepHelper
 
   context 'the users chooses sms' do

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -83,8 +83,8 @@ describe Idv::Agent do
       it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
         exception = Proofer::TimeoutError
 
-        agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: 'Time Exception',
-                                 zipcode: '11111' })
+        agent = Idv::Agent.new(ssn: '444-55-8888', first_name: 'Time Exception',
+                               zipcode: '11111')
 
         expect(NewRelic::Agent).to receive(:notice_error).with(exception)
         expect(ExceptionNotifier).to receive(:notify_exception).with(exception)

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -89,9 +89,11 @@ describe Idv::Agent do
         expect(NewRelic::Agent).to receive(:notice_error).with(exception)
         expect(ExceptionNotifier).to receive(:notify_exception).with(exception)
 
-        expect(agent.proof_resolution(should_proof_state_id: false)).to include(
+        result = agent.proof_resolution(should_proof_state_id: false)
+
+        expect(result[:exception]).to be_instance_of(exception)
+        expect(result).to include(
           success: false,
-          exception: exception,
           timed_out: true,
         )
       end

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -50,7 +50,7 @@ describe Idv::Agent do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new({ ssn: '444-55-6666', first_name: Faker::Name.first_name,
                                    zipcode: '11111' })
-          result = agent.proof_resolution(proof_state_id: true)
+          result = agent.proof_resolution(should_proof_state_id: true)
           expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
           expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
         end
@@ -58,7 +58,7 @@ describe Idv::Agent do
         it 'does proof state_id if resolution succeeds' do
           agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: Faker::Name.first_name,
                                    zipcode: '11111' })
-          result = agent.proof_resolution(proof_state_id: true)
+          result = agent.proof_resolution(should_proof_state_id: true)
           expect(result[:context][:stages]).to include({ state_id: 'StateIdMock' })
         end
       end
@@ -67,7 +67,7 @@ describe Idv::Agent do
         it 'does not proof state_id if resolution fails' do
           agent = Idv::Agent.new({ ssn: '444-55-6666', first_name: Faker::Name.first_name,
                                    zipcode: '11111' })
-          result = agent.proof_resolution(proof_state_id: false)
+          result = agent.proof_resolution(should_proof_state_id: false)
           expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
           expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
         end
@@ -75,7 +75,7 @@ describe Idv::Agent do
         it 'does not proof state_id if resolution succeeds' do
           agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: Faker::Name.first_name,
                                    zipcode: '11111' })
-          result = agent.proof_resolution(proof_state_id: false)
+          result = agent.proof_resolution(should_proof_state_id: false)
           expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
         end
       end
@@ -89,7 +89,7 @@ describe Idv::Agent do
         expect(NewRelic::Agent).to receive(:notice_error).with(exception)
         expect(ExceptionNotifier).to receive(:notify_exception).with(exception)
 
-        expect(agent.proof_resolution(proof_state_id: false)).to include(
+        expect(agent.proof_resolution(should_proof_state_id: false)).to include(
           success: false,
           exception: exception,
           timed_out: true,

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -2,14 +2,6 @@ require 'rails_helper'
 require 'ostruct'
 
 describe Idv::Agent do
-  describe '.proofer_attribute?' do
-    it 'returns whether the attribute is available in Idv::Proofer::ATTRIBUTES' do
-      key = :foobarbaz
-      expect(Idv::Proofer).to receive(:attribute?).with(key)
-      Idv::Agent.proofer_attribute?(key)
-    end
-  end
-
   describe 'instance' do
     let(:applicant) { { foo: 'bar' } }
 
@@ -53,88 +45,71 @@ describe Idv::Agent do
       end
     end
 
-    describe '#proof' do
-      let(:resolution_message) { 'reason 1' }
-      let(:state_id_message) { 'reason 2' }
-      let(:failed_message) { 'bah humbug' }
-      let(:error) { { bad: 'stuff' } }
-      let(:exception) { StandardError.new }
+    describe '#proof_resolution' do
+      context 'proofing state_id enabled' do
+        it 'does not proof state_id if resolution fails' do
+          agent = Idv::Agent.new({ ssn: '444-55-6666', first_name: Faker::Name.first_name,
+                                   zipcode: '11111' })
+          result = agent.proof_resolution(proof_state_id: true)
+          expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
+          expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
+        end
 
-      subject { agent.proof(*stages) }
-
-      before do
-        exception_instance = exception
-        allow(Idv::Proofer).to receive(:get_vendor) do |stage|
-          logic = case stage
-                  when :resolution
-                    proc { |_, r| r.add_message('reason 1') }
-                  when :state_id
-                    proc { |_, r| r.add_message('reason 2') }
-                  when :failed
-                    proc { |_, r| r.add_message('bah humbug').add_error(:bad, 'stuff') }
-                  when :timed_out
-                    proc { |_, r| r.instance_variable_set(:@exception, Proofer::TimeoutError.new) }
-                  when :exception
-                    proc { |_, r| r.instance_variable_set(:@exception, exception_instance) }
-                  end
-          Class.new(Proofer::Base) do
-            required_attributes(:foo)
-            proof(&logic)
-          end
+        it 'does proof state_id if resolution succeeds' do
+          agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: Faker::Name.first_name,
+                                   zipcode: '11111' })
+          result = agent.proof_resolution(proof_state_id: true)
+          expect(result[:context][:stages]).to include({ state_id: 'StateIdMock' })
         end
       end
 
-      context 'when all stages succeed' do
-        let(:stages) { %i[resolution state_id] }
+      context 'proofing state_id disabled' do
+        it 'does not proof state_id if resolution fails' do
+          agent = Idv::Agent.new({ ssn: '444-55-6666', first_name: Faker::Name.first_name,
+                                   zipcode: '11111' })
+          result = agent.proof_resolution(proof_state_id: false)
+          expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
+          expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
+        end
 
-        it 'results from all stages are included' do
-          expect(subject.to_h).to include(
-            errors: {},
-            messages: [resolution_message, state_id_message],
-            success: true,
-            exception: nil,
-            timed_out: false,
-          )
+        it 'does not proof state_id if resolution succeeds' do
+          agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: Faker::Name.first_name,
+                                   zipcode: '11111' })
+          result = agent.proof_resolution(proof_state_id: false)
+          expect(result[:context][:stages]).to_not include({ state_id: 'StateIdMock' })
         end
       end
 
-      context 'when the fist stage fails' do
-        let(:stages) { %i[failed state_id] }
+      it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
+        exception = Proofer::TimeoutError
 
-        it 'only the results from the first stage are included' do
-          expect(subject.to_h).to include(
-            errors: { bad: ['stuff'] },
-            messages: [failed_message],
-            success: false,
-            exception: nil,
-            timed_out: false,
-          )
-        end
+        agent = Idv::Agent.new({ ssn: '444-55-8888', first_name: 'Time Exception',
+                                 zipcode: '11111' })
+
+        expect(NewRelic::Agent).to receive(:notice_error).with(exception)
+        expect(ExceptionNotifier).to receive(:notify_exception).with(exception)
+
+        expect(agent.proof_resolution(proof_state_id: false)).to include(
+          success: false,
+          exception: exception,
+          timed_out: true,
+        )
+      end
+    end
+
+    describe '#proof_address' do
+      it 'proofs addresses successfully with valid information' do
+        agent = Idv::Agent.new({ phone: Faker::PhoneNumber.cell_phone })
+        result = agent.proof_address
+        expect(result[:context][:stages]).to include({ address: 'AddressMock' })
+        expect(result[:success]).to eq true
       end
 
-      context 'when the first stage times out' do
-        let(:stages) { %i[timed_out state_id] }
-
-        it 'returns a result where timed out is true' do
-          expect(subject.to_h).to include(
-            success: false,
-            timed_out: true,
-          )
-        end
-      end
-
-      context 'when there is an exception' do
-        let(:stages) { %i[exception state_id] }
-
-        it 'returns an unsuccessful result and notifies exception trackers' do
-          expect(NewRelic::Agent).to receive(:notice_error).with(exception)
-          expect(ExceptionNotifier).to receive(:notify_exception).with(exception)
-
-          expect(subject.to_h).to include(
-            success: false,
-            exception: exception,
-          )
-        end
+      it 'fails to proof addresses with invalid information' do
+        agent = Idv::Agent.new({ phone: '7035555555' })
+        result = agent.proof_address
+        expect(result[:context][:stages]).to include({ address: 'AddressMock' })
+        expect(result[:success]).to eq false
       end
     end
   end

--- a/spec/services/idv/proofer_spec.rb
+++ b/spec/services/idv/proofer_spec.rb
@@ -1,134 +1,70 @@
 require 'rails_helper'
 
 describe Idv::Proofer do
-  let(:resolution_dummy) do
-    class_double('Proofer::Base', vendor_name: 'dummy:resolution', stage: :resolution)
-  end
-  let(:state_id_dummy) do
-    class_double('Proofer::Base', vendor_name: 'dummy:state_id', stage: :state_id)
-  end
-  let(:address_dummy) do
-    class_double('Proofer::Base', vendor_name: 'dummy:address', stage: :address)
-  end
-  let(:dummy_vendors) { [resolution_dummy, state_id_dummy, address_dummy] }
-
-  let(:proofer_vendors) { '["dummy:resolution", "dummy:state_id", "dummy:address"]' }
   let(:proofer_mock_fallback) { 'false' }
 
   before do
-    allow(Figaro.env).to receive(:proofer_vendors).
-      and_return(proofer_vendors)
     allow(Figaro.env).to receive(:proofer_mock_fallback).
       and_return(proofer_mock_fallback)
-
-    original_descendants = Proofer::Base.descendants
-    allow(Proofer::Base).to receive(:descendants).and_return(
-      original_descendants + dummy_vendors,
-    )
-
-    subject.instance_variable_set(:@vendors, nil)
-  end
-
-  after do
-    # This is necessary to prevent mocks created in these examples from leaking
-    # out with the memoized vendors value
-    subject.instance_variable_set(:@vendors, nil)
   end
 
   subject { described_class }
 
-  describe '.attribute?' do
-    context 'when the attribute exists' do
-      context 'and is passed as a string' do
-        let(:attribute) { 'last_name' }
+  describe '.resolution_vendor' do
+    context 'with mock proofers enabled' do
+      let(:proofer_mock_fallback) { 'true' }
 
-        it { expect(subject.attribute?(attribute)).to eq(true) }
-      end
-
-      context 'and is passed as a symbol' do
-        let(:attribute) { :last_name }
-
-        it { expect(subject.attribute?(attribute)).to eq(true) }
+      it 'returns the mock vendor' do
+        expect(subject.resolution_vendor).to eq(ResolutionMock)
       end
     end
 
-    context 'when the attribute does not exist' do
-      context 'and is passed as a string' do
-        let(:attribute) { 'fooobar' }
-
-        it { expect(subject.attribute?(attribute)).to eq(false) }
+    context 'with mock proofers disabled' do
+      before do
+        class_double('LexisNexis::InstantVerify::Proofer', new: {}).as_stubbed_const
       end
 
-      context 'and is passed as a symbol' do
-        let(:attribute) { :fooobar }
-
-        it { expect(subject.attribute?(attribute)).to eq(false) }
+      it 'returns the live vendor' do
+        expect(subject.resolution_vendor).to eq(LexisNexis::InstantVerify::Proofer)
       end
     end
   end
 
-  describe '.get_vendor' do
+  describe '.state_id_vendor' do
     context 'with mock proofers enabled' do
       let(:proofer_mock_fallback) { 'true' }
 
-      context 'with a vendor configured for the state' do
-        it 'returns the vendor' do
-          expect(subject.get_vendor(:resolution)).to eq(resolution_dummy)
-          expect(subject.get_vendor(:state_id)).to eq(state_id_dummy)
-          expect(subject.get_vendor(:address)).to eq(address_dummy)
-        end
-      end
-
-      context 'without a vendor configured for the state' do
-        let(:proofer_vendors) { '["dummy:state_id"]' }
-
-        it 'returns a mock vendor' do
-          expect(subject.get_vendor(:resolution)).to eq(ResolutionMock)
-          expect(subject.get_vendor(:state_id)).to eq(state_id_dummy)
-          expect(subject.get_vendor(:address)).to eq(AddressMock)
-        end
-      end
-
-      context 'without a proofer vendor configuration' do
-        let(:proofer_vendors) { nil }
-
-        it 'returns all mock proofers' do
-          expect(subject.get_vendor(:resolution)).to eq(ResolutionMock)
-          expect(subject.get_vendor(:state_id)).to eq(StateIdMock)
-          expect(subject.get_vendor(:address)).to eq(AddressMock)
-        end
+      it 'returns the mock vendor' do
+        expect(subject.state_id_vendor).to eq(StateIdMock)
       end
     end
 
-    context 'without mock proofers enabled' do
-      let(:proofer_mock_fallback) { 'false' }
-
-      context 'with a vendor configured for the state' do
-        it 'returns the vendor' do
-          expect(subject.get_vendor(:resolution)).to eq(resolution_dummy)
-          expect(subject.get_vendor(:state_id)).to eq(state_id_dummy)
-          expect(subject.get_vendor(:address)).to eq(address_dummy)
-        end
+    context 'with mock proofers disabled' do
+      before do
+        class_double('Aamva::Proofer', new: {}).as_stubbed_const
       end
 
-      context 'without a vendor configured for the state' do
-        let(:proofer_vendors) { '["dummy:state_id"]' }
-
-        it 'returns nil' do
-          expect(subject.get_vendor(:resolution)).to eq(nil)
-          expect(subject.get_vendor(:state_id)).to eq(state_id_dummy)
-          expect(subject.get_vendor(:address)).to eq(nil)
-        end
+      it 'returns the live vendor' do
+        expect(subject.state_id_vendor).to eq(Aamva::Proofer)
       end
+    end
+  end
 
-      context 'without a proofer vendor configuration' do
-        let(:proofer_vendors) { nil }
+  describe '.address_vendor' do
+    context 'with mock proofers enabled' do
+      let(:proofer_mock_fallback) { 'true' }
 
-        it 'returns nil' do
-          expect(subject.get_vendor(:resolution)).to eq(nil)
-          expect(subject.get_vendor(:state_id)).to eq(nil)
-          expect(subject.get_vendor(:address)).to eq(nil)
-        end
+      it 'returns the mock vendor' do
+        expect(subject.address_vendor).to eq(AddressMock)
+      end
+    end
+
+    context 'with mock proofers disabled' do
+      before do
+        class_double('LexisNexis::PhoneFinder::Proofer', new: {}).as_stubbed_const
+      end
+      it 'returns the live vendor' do
+        expect(subject.address_vendor).to eq(LexisNexis::PhoneFinder::Proofer)
       end
     end
   end
@@ -137,17 +73,21 @@ describe Idv::Proofer do
     let(:proofer_mock_fallback) { 'false' }
 
     context 'with vendors configured for each stage' do
+      before do
+        class_double('LexisNexis::InstantVerify::Proofer', new: {}).as_stubbed_const
+        class_double('LexisNexis::PhoneFinder::Proofer', new: {}).as_stubbed_const
+        class_double('Aamva::Proofer', new: {}).as_stubbed_const
+      end
+
       it 'does not raise' do
         expect { described_class.validate_vendors! }.to_not raise_error
       end
     end
 
     context 'without vendors configured for each stage' do
-      let(:proofer_vendors) { '["dummy:state_id"]' }
-
       it 'does raise' do
         expect { described_class.validate_vendors! }.to raise_error(
-          RuntimeError, 'No proofer vendor configured for stage(s): resolution, address'
+          NameError,
         )
       end
     end


### PR DESCRIPTION
Currently, the proofer selects vendors by classes that descend from `Proofer::Base`, but the lambdas will have very limited scope and won't be able to infer from the same configuration.

This PR turns `.proof(*stages)` into explicit calls for types of proofing since the lambdas will be organized around that behavior.