### PR TITLE
LG-3595: Upgrade focus-trap from 6.0.1 to 6.1.0

### DIFF
--- a/app/javascript/packages/document-capture/package.json
+++ b/app/javascript/packages/document-capture/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
-    "focus-trap": "^6.0.1",
+    "focus-trap": "^6.1.0",
     "react": "^16.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
-    "focus-trap": "^6.0.1",
+    "focus-trap": "^6.1.0",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",
     "intl-tel-input": "^16.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,12 +4251,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.0.1.tgz#f90725e4bb62ddab16e685b02b43b823858a4c0a"
-  integrity sha512-BOksLMPK/jlXD389jYPlZHAqiDdy9W63EBQfVIouME8s3UZsCEmq3NA53qt30S4i72sRcDjc1FHtast0TmqhRA==
+focus-trap@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.0.tgz#836a4851b389b71fe26d4dcdfb43d5c8d6f2bfc6"
+  integrity sha512-TQf1gJ5UgAY2ZMXrTDls6ah10kJmh35w/4COQHncLILwAK7hme4tiOwYnq2JOU88pqu1LoPqO9Yn7EbvmnzRRQ==
   dependencies:
-    tabbable "^5.0.0"
+    tabbable "^5.1.0"
 
 follow-redirects@^1.0.0:
   version "1.13.0"
@@ -8917,10 +8917,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.0.0.tgz#862b6f33a625da45d7c648cff0262dab453d8b0c"
-  integrity sha512-+TJTMpkHRCWkMGczHHVEfzBYCsVOiBjd3vle55AT4H299BhdJDLFqcYmr7S6kt5EGhT8gAywSC5gPUBDNvtl7w==
+tabbable@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
+  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
**Why**: Changelog mentions bug fix relevant to our usage of focusables within fixed-position containers.

See: https://github.com/focus-trap/focus-trap/blob/master/CHANGELOG.md#610

>31bb28e: Update tabbable dependency to 5.1.0. The most significant update for focus-trap is a bug fix related to fixed-position containers.