### PR TITLE
LG-3595: Deactivate on click outside FullScreen focus-trap

### DIFF
--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -43,6 +43,7 @@ function FullScreen({ onRequestClose = () => {}, children }) {
     if (node) {
       trapRef.current = createFocusTrap(node, {
         onDeactivate: () => onRequestCloseRef.current(),
+        clickOutsideDeactivates: true,
       });
 
       trapRef.current.activate();


### PR DESCRIPTION
**Why**: Account for edge cases where focus trap may still be activated if full screen container is removed. More sensible default value to deactivate trap on click outside, to strongly bind two-way relationship of FullScreen hiding in response to deactivate + deactivate in response to FullScreen removed.

This seeks to address an issue observed in some environments where focus-trap is preventing page interaction after a document capture camera capture.

This occurs here: https://github.com/focus-trap/focus-trap/blob/99f8021/index.js#L248

The expectation after these changes is that even if `checkPointerDown` is called, it would reach only this condition and not prevent the interaction: https://github.com/focus-trap/focus-trap/blob/99f8021/index.js#L231-L236

Related: #4257