### PR TITLE
LG-3470: Hide overflow on both HTML and BODY elements

### DIFF
--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -1,4 +1,4 @@
-body.has-full-screen-overlay { // scss-lint:disable QualifyingElement
+.has-full-screen-overlay {
   overflow: hidden;
 }
 

--- a/app/javascript/packages/document-capture/components/full-screen.jsx
+++ b/app/javascript/packages/document-capture/components/full-screen.jsx
@@ -52,11 +52,13 @@ function FullScreen({ onRequestClose = () => {}, children }) {
   useEffect(() => {
     if (activeInstances++ === 0) {
       document.body.classList.add('has-full-screen-overlay');
+      document.documentElement.classList.add('has-full-screen-overlay');
     }
 
     return () => {
       if (--activeInstances === 0) {
         document.body.classList.remove('has-full-screen-overlay');
+        document.documentElement.classList.remove('has-full-screen-overlay');
       }
     };
   }, []);


### PR DESCRIPTION
**Why**: In Safari on iOS, applying hidden overflow to the body element does not appear to be sufficient to prevent scrolling, and can cause FullScreen contents to appear as offset from the top of the page.

See: https://stackoverflow.com/questions/3047337/does-overflowhidden-applied-to-body-work-on-iphone-safari

**Steps to Reproduce:**

1. Navigate to document capture on mobile
2. At "Add your state-issued ID" step, without scrolling the page, click "Front"
3. Allow camera access
4. Exit the full screen modal
5. Scroll down on the page
6. Click either "Front" or "Back"

In `master`, observe a gap above the camera feed, and if you try to scroll up, you may notice a scrollbar on the right edge of the page.

In this branch, observe no gap, and no scrollbar.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/94927973-fceb1a80-0490-11eb-9bf2-9b90ede6eecf.png)|![after](https://user-images.githubusercontent.com/1779930/94927988-007ea180-0491-11eb-9df5-7d6be33d1275.png)

