### PR TITLE
File Input: Show error message after hint

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -153,14 +153,14 @@ const FileInput = forwardRef((props, ref) => {
       >
         {label}
       </label>
-      {shownErrorMessage && (
-        <span className="usa-error-message" role="alert">
-          {shownErrorMessage}
-        </span>
-      )}
       {hint && (
         <span className="usa-hint" id={hintId}>
           {hint}
+        </span>
+      )}
+      {shownErrorMessage && (
+        <span className="usa-error-message" role="alert">
+          {shownErrorMessage}
         </span>
       )}
       <div


### PR DESCRIPTION
**Why**: Per design feedback, for consistency with USWDS

See: https://designsystem.digital.gov/components/form-controls/#file-input

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/94962152-fe820600-04c3-11eb-96ec-22d91e7acb1b.png)|![after](https://user-images.githubusercontent.com/1779930/94962150-fde96f80-04c3-11eb-9677-103c13962ae6.png)

