### PR TITLE
Update identity-idp-functions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '~> 2.6.5'
 
 gem 'rails', '~> 5.2.4', '>= 5.2.4.4'
 
+gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
 gem 'ahoy_matey', '~> 2.2', '>= 2.2.1'
 gem 'american_date'
 gem 'aws-sdk-kms', '~> 1.4'
@@ -28,6 +29,7 @@ gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.5'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'master'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'
+gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.3.0'
 gem 'local_time'
 gem 'lograge', '>= 0.11.2'
 gem 'maxminddb'
@@ -118,9 +120,4 @@ group :test do
   gem 'webdrivers', '~> 3.0'
   gem 'webmock'
   gem 'zonebie'
-end
-
-group :production do
-  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
-  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.3.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby '~> 2.6.5'
 
 gem 'rails', '~> 5.2.4', '>= 5.2.4.4'
 
-gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
 gem 'ahoy_matey', '~> 2.2', '>= 2.2.1'
 gem 'american_date'
 gem 'aws-sdk-kms', '~> 1.4'
@@ -29,7 +28,6 @@ gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.5'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'master'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'
-gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.3.0'
 gem 'local_time'
 gem 'lograge', '>= 0.11.2'
 gem 'maxminddb'
@@ -120,4 +118,9 @@ group :test do
   gem 'webdrivers', '~> 3.0'
   gem 'webmock'
   gem 'zonebie'
+end
+
+group :production do
+  gem 'aamva', github: '18F/identity-aamva-api-client-gem', tag: 'v3.4.1'
+  gem 'lexisnexis', github: '18F/identity-lexisnexis-api-client-gem', tag: 'v2.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: dcf845f09aba43addb8891676288e3e7ed4cc0de
-  ref: dcf845f09aba43addb8891676288e3e7ed4cc0de
+  revision: 1ffdce9da7fd2d69de2b51a04873bc8bbd9c3f4b
+  ref: 1ffdce9da7fd2d69de2b51a04873bc8bbd9c3f4b
   specs:
-    identity-idp-functions (0.2.1)
+    identity-idp-functions (0.3.0)
 
 GIT
   remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: 97a07927e96d17e5ec204e5476de25ca52e5bf01
-  ref: 97a07927e96d17e5ec204e5476de25ca52e5bf01
+  revision: dcf845f09aba43addb8891676288e3e7ed4cc0de
+  ref: dcf845f09aba43addb8891676288e3e7ed4cc0de
   specs:
-    identity-idp-functions (0.1.0)
+    identity-idp-functions (0.2.1)
 
 GIT
   remote: https://github.com/18F/identity-lexisnexis-api-client-gem.git

--- a/app/services/lambda_jobs/git_ref.rb
+++ b/app/services/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = '97a07927e96d17e5ec204e5476de25ca52e5bf01'
+  GIT_REF = 'dcf845f09aba43addb8891676288e3e7ed4cc0de'
 end

--- a/app/services/lambda_jobs/git_ref.rb
+++ b/app/services/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = 'dcf845f09aba43addb8891676288e3e7ed4cc0de'
+  GIT_REF = '1ffdce9da7fd2d69de2b51a04873bc8bbd9c3f4b'
 end

--- a/app/services/lambda_jobs/runner.rb
+++ b/app/services/lambda_jobs/runner.rb
@@ -8,8 +8,8 @@ module LambdaJobs
       @args = args
     end
 
-    def run
-      if LoginGov::Hostdata.in_datacenter?
+    def run(&local_callback)
+      if LoginGov::Hostdata.in_datacenter? && Figaro.env.aws_lambda_proofing_enabled == 'true'
         aws_lambda_client.invoke(
           function_name: function_name,
           invocation_type: 'Event',
@@ -20,6 +20,7 @@ module LambdaJobs
         job_class.handle(
           event: { body: args.to_json },
           context: nil,
+          &local_callback
         )
       end
     end

--- a/spec/services/lambda_jobs/runner_spec.rb
+++ b/spec/services/lambda_jobs/runner_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe LambdaJobs::Runner do
   let(:job_name) { 'my-job' }
   let(:args) { { foo: 'bar' } }
   let(:job_class) { double('JobClass') }
+  let(:aws_lambda_proofing_enabled) { 'true' }
 
   let(:git_ref) { '1234567890abcdefghijklmnop' }
   before do
@@ -23,25 +24,44 @@ RSpec.describe LambdaJobs::Runner do
   describe '#run' do
     before do
       allow(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(in_datacenter)
+      allow(Figaro.env).to receive(:aws_lambda_proofing_enabled).
+        and_return(aws_lambda_proofing_enabled)
     end
 
     context 'when run in a deployed environment' do
       let(:in_datacenter) { true }
 
-      let(:aws_lambda_client) { instance_double(Aws::Lambda::Client) }
-      before do
-        expect(runner).to receive(:aws_lambda_client).and_return(aws_lambda_client)
+      context 'when aws_lambda_proofing_enabled is true' do
+        let(:aws_lambda_proofing_enabled) { 'true' }
+
+        let(:aws_lambda_client) { instance_double(Aws::Lambda::Client) }
+        before do
+          expect(runner).to receive(:aws_lambda_client).and_return(aws_lambda_client)
+        end
+
+        it 'involves a lambda in AWS' do
+          expect(aws_lambda_client).to receive(:invoke).with(
+            function_name: 'my-job:1234567890',
+            invocation_type: 'Event',
+            log_type: 'None',
+            payload: args.to_json,
+          )
+
+          runner.run
+        end
       end
 
-      it 'involves a lambda in AWS' do
-        expect(aws_lambda_client).to receive(:invoke).with(
-          function_name: 'my-job:1234567890',
-          invocation_type: 'Event',
-          log_type: 'None',
-          payload: args.to_json,
-        )
+      context 'when aws_lambda_proofing_enabled is false' do
+        let(:aws_lambda_proofing_enabled) { 'false' }
 
-        runner.run
+        it 'calls JobClass.handle' do
+          expect(job_class).to receive(:handle).with(
+            event: { body: args.to_json },
+            context: nil,
+          )
+
+          runner.run
+        end
       end
     end
 
@@ -55,6 +75,24 @@ RSpec.describe LambdaJobs::Runner do
         )
 
         runner.run
+      end
+
+      context 'when run locally with a block' do
+        it 'passes the block to the handler' do
+          result = Object.new
+
+          expect(job_class).to receive(:handle).with(
+            event: { body: args.to_json },
+            context: nil,
+          ).and_yield(result)
+
+          yielded_result = nil
+          runner.run do |callback_result|
+            yielded_result = callback_result
+          end
+
+          expect(yielded_result).to eq(result)
+        end
       end
     end
   end


### PR DESCRIPTION
- Also add support for local callback via block

Once https://github.com/18F/identity-idp/pull/4261 lands, I think we can combine the two (or maybe merge this PR into that one), and then we can call the `AddressProof` job. In prod we can pass the callback_url, and locally we can use the block just to write the result to redis