### PR TITLE
Show placeholder spacer for pending file preview

### DIFF
--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -26,6 +26,12 @@
       padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
     }
   }
+
+  .document-capture-file-image--loading {
+    display: block;
+    // 2.125" x 3.375" are common standard ID dimensions
+    padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
+  }
 }
 
 //================================================

--- a/app/javascript/packages/document-capture/components/file-image.jsx
+++ b/app/javascript/packages/document-capture/components/file-image.jsx
@@ -28,7 +28,19 @@ function FileImage({ file, alt, className }) {
     reader.readAsDataURL(file);
   }, [file]);
 
-  return imageData ? <img src={imageData} alt={alt} className={className} /> : null;
+  const classes = [
+    'document-capture-file-image',
+    !imageData && 'document-capture-file-image--loading',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return imageData ? (
+    <img src={imageData} alt={alt} className={classes} />
+  ) : (
+    <span className={classes} />
+  );
 }
 
 export default FileImage;

--- a/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-image-spec.jsx
@@ -3,12 +3,18 @@ import FileImage from '@18f/identity-document-capture/components/file-image';
 import render from '../../../support/render';
 
 describe('document-capture/components/file-image', () => {
-  it('renders nothing prior to load', () => {
+  it('renders span prior to load', () => {
     const { container } = render(
       <FileImage file={new window.File([''], 'demo', { type: 'image/png' })} alt="image" />,
     );
 
-    expect(container.childNodes).to.have.lengthOf(0);
+    expect(container.childNodes).to.have.lengthOf(1);
+    const loader = container.childNodes[0];
+    expect(loader.nodeName).to.equal('SPAN');
+    expect(Array.from(loader.classList.values())).to.have.members([
+      'document-capture-file-image',
+      'document-capture-file-image--loading',
+    ]);
   });
 
   it('renders a given file object as an image', async () => {
@@ -19,6 +25,7 @@ describe('document-capture/components/file-image', () => {
     const image = await findByAltText('image');
 
     expect(image.getAttribute('src')).to.match(/^data:image\/png;base64,/);
+    expect(Array.from(image.classList.values())).to.have.members(['document-capture-file-image']);
   });
 
   it('renders a a changed file object as an image', async () => {
@@ -48,6 +55,9 @@ describe('document-capture/components/file-image', () => {
 
     const image = await findByAltText('image');
 
-    expect(image.classList.contains('my-class')).to.be.true();
+    expect(Array.from(image.classList.values())).to.have.members([
+      'document-capture-file-image',
+      'my-class',
+    ]);
   });
 });


### PR DESCRIPTION
**Why**: As a user, I expect that the page doesn't scroll unpredictably, so that I'm not disoriented when uploading images.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/95089311-ff987a80-06f1-11eb-91d1-fd629e60fd92.png)

Note that the file preview is usually fast enough that you'll never actually visually perceive this placeholder state.

The proportions of the placeholder won't always match exactly with the precise image proportions, but the intent is to provide _enough_ of a space that the file input container no longer collapses and causes a stuttering effect.