### PR TITLE
Update profile spec to check for full ssn, with and without dashes

### DIFF
--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -30,7 +30,8 @@ describe Profile do
 
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match 'Jane'
-      expect(profile.encrypted_pii).to_not match '666'
+      expect(profile.encrypted_pii).to_not match(ssn)
+      expect(profile.encrypted_pii).to_not match(ssn.tr('-', ''))
     end
 
     it 'generates new personal key' do


### PR DESCRIPTION
**Why**: The shortened "666" is too common of a string and the build
flakes when the encrypted ciphertext contains the 3 digits

---

I just observed this flake on the `master` branch again, figured it's time to fix: https://app.circleci.com/pipelines/github/18F/identity-idp/11321/workflows/50b9e332-2de6-49fc-94fa-e14f46de0501/jobs/28918/parallel-runs/2?filterBy=FAILED