### PR TITLE
only generate presigned s3 urls if feature flagged in (LG-3415 - not needed for release notes)

### DIFF
--- a/app/services/doc_auth/image_upload_presigned_url_generator.rb
+++ b/app/services/doc_auth/image_upload_presigned_url_generator.rb
@@ -3,6 +3,8 @@ module DocAuth
     include AwsS3Helper
 
     def presigned_image_upload_url(image_type:, transaction_id:)
+      return nil unless Figaro.env.doc_auth_enable_presigned_s3_urls == 'true'
+
       s3_presigned_url(
         bucket_prefix: bucket_prefix,
         keyname: "#{transaction_id}-#{image_type}",

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -47,8 +47,9 @@ aws_kms_multi_region_enabled: 'false'
 cac_proofing_enabled: 'true'
 database_statement_timeout: '2500'
 disallow_ial2_recovery:
-doc_capture_request_valid_for_minutes: '15'
 doc_auth_extend_timeout_by_minutes: '40'
+doc_auth_enable_presigned_s3_urls: 'false'
+doc_capture_request_valid_for_minutes: '15'
 document_capture_step_enabled: 'false'
 email_from: no-reply@login.gov
 email_from_display_name: Login.gov
@@ -398,6 +399,7 @@ test:
   disable_email_sending:
   disallow_all_web_crawlers: 'true'
   disallow_ial2_recovery: 'false'
+  doc_auth_enable_presigned_s3_urls: 'true'
   doc_auth_vendor: 'mock'
   doc_capture_polling_enabled: 'false'
   domain_name: www.example.com


### PR DESCRIPTION
Unless enabled, the service will return `nil` instead of generating a presigned URL. In the view, nil data is automagically pruned out.