### PR TITLE
Fix a NoMethodError that occurred while adding costs in the hybrid flow

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -63,7 +63,7 @@ module Idv
 
     def add_costs(client_response)
       Db::AddDocumentVerificationAndSelfieCosts.
-        new(user_id: current_user.id,
+        new(user_id: image_form.document_capture_session.user.id,
             issuer: sp_session[:issuer].to_s,
             liveness_checking_enabled: liveness_checking_enabled?).
         call(client_response)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -2,14 +2,10 @@ require 'rails_helper'
 
 describe Idv::ImageUploadsController do
   describe '#create' do
-    before do
-      sign_in_as_user
-      controller.current_user.document_capture_sessions.create!
-    end
-
     subject(:action) { post :create, params: params }
 
-    let(:document_capture_session) { controller.current_user.document_capture_sessions.last }
+    let(:user) { create(:user) }
+    let!(:document_capture_session) { user.document_capture_sessions.create! }
     let(:params) do
       {
         front: DocAuthImageFixtures.document_front_image_multipart,


### PR DESCRIPTION
The old code to add the cost components used `#current_user` which returns nil if there is no user signed in. There is not user in the hybrid flow so this raised `NoMethodError` when `current_user.id` was called.

This commit fixes the bug by reading the user off of the document capture session.

This commit also adjusts the controller tests to fail if there is an assumption the user is logged in.