### PR TITLE
Use default USWDS pseudo-class for banner collapse button

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -18,29 +18,17 @@
   }
 }
 
-.close-banner-how-you-know {
-  display: none;
-}
-
 @media #{$mobile} {
   .usa-banner__header--expanded .usa-banner__inner {
     margin-left: auto;
   }
+}
 
-  .usa-banner__button[aria-expanded=true]::after {
-    display: none;
-  }
-
-  .close-banner-how-you-know {
-    background: url(image-path('#{$image-path}/close-primary.svg')) top left no-repeat;
-    background-size: contain;
-    border: 0;
-    display: inline-block;
-    height: 1rem;
-    margin-left: 1.5rem;
-    position: absolute;
-    right: 1rem;
-    top: 1rem;
-    width: 1rem;
+.usa-banner__button[aria-expanded="true"]::after {
+  @include at-media-max('tablet') {
+    background-color: transparent;
+    right: 0;
+    top: 100%;
+    z-index: 10;
   }
 }

--- a/app/javascript/app/header.js
+++ b/app/javascript/app/header.js
@@ -1,7 +1,0 @@
-import $ from 'jquery';
-
-document.addEventListener('DOMContentLoaded', function () {
-  $('.close-banner-how-you-know').click(function () {
-    $('.usa-proof').click();
-  });
-});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,4 +10,3 @@ require('../app/print-personal-key');
 require('../app/i18n-dropdown');
 require('../app/platform-authenticator');
 require('../app/accessible-forms');
-require('../app/header');

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -16,7 +16,7 @@
             %></p>
             <p class="usa-banner__header-action" aria-hidden="true"><%= t('shared.banner.how') %></p>
           </div>
-          <button class="usa-accordion__button usa-banner__button usa-proof" aria-expanded="false" aria-controls="gov-banner">
+          <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
             <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
           </button>
         </div>
@@ -50,7 +50,6 @@
             </div>
           </div>
         </div>
-        <button class="mobile close-banner-how-you-know" aria-label="<%= t('shared.banner.close') %>"></button>
       </div>
     </div>
   </section>

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -2,7 +2,6 @@
 en:
   shared:
     banner:
-      close: Close banner popup
       fake_site: A DEMO website of the United States government.
       gov_description: Federal government websites often end in .gov or .mil. Before
         sharing sensitive information, make sure you’re on a federal government site.

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -2,7 +2,6 @@
 es:
   shared:
     banner:
-      close: Cerrar ventana emergente de banner
       fake_site: Un sitio web de DEMO del gobierno de Estados Unidos.
       gov_description: Los sitios web del gobierno federal a menudo terminan en .gov
         o .mil. Antes de compartir información confidencial, asegúrese de estar en

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -2,7 +2,6 @@
 fr:
   shared:
     banner:
-      close: Fermer la fenêtre contextuelle de la bannière
       fake_site: Un site de DEMO du gouvernement des États-Unis.
       gov_description: Les sites Web du gouvernement fédéral se terminent souvent
         par .gov ou .mil. Avant de partager des informations sensibles, assurez-vous


### PR DESCRIPTION
Previously: #4171

**Why**: Consistency with USWDS, eliminate redundant (duplicate) button controls, reduce localization string maintenance overhead, eliminate jQuery dependency from application JavaScript pack (reduction of ~35kb minified and gzipped).

**Screenshots:**

_Mobile:_

&nbsp;|Before|After
---|---|---
Collapsed|![mobile-before-collapsed](https://user-images.githubusercontent.com/1779930/95224484-b7985700-07c8-11eb-8b58-be82e7df9f0a.png)|![mobile-after-collapsed](https://user-images.githubusercontent.com/1779930/95224481-b6ffc080-07c8-11eb-9801-4f2e9fc5a88a.png)
Expanded|![mobile-before-expanded](https://user-images.githubusercontent.com/1779930/95224486-b7985700-07c8-11eb-9a30-52abf552fa2f.png)|![mobile-after-expanded](https://user-images.githubusercontent.com/1779930/95224482-b6ffc080-07c8-11eb-9544-cddd9c5b9781.png)

_Desktop:_

&nbsp;|Before|After
---|---|---
Collapsed|![desktop-before-collapsed](https://user-images.githubusercontent.com/1779930/95224559-caab2700-07c8-11eb-9866-53799e8c5638.png)|![desktop-after-collapsed](https://user-images.githubusercontent.com/1779930/95224555-caab2700-07c8-11eb-9f26-526816a111ba.png)
Expanded|![desktop-before-expanded](https://user-images.githubusercontent.com/1779930/95224560-cb43bd80-07c8-11eb-8ca0-63f4219c17ba.png)|![desktop-after-expanded](https://user-images.githubusercontent.com/1779930/95224557-caab2700-07c8-11eb-840a-bece48be9c7c.png)

In above screenshots, observe that the only expected visual change is the restoration of the upward collapsing caret button in the desktop display. This is consistent with USWDS, and does not appear to have been a requirement of the original ticket LG-3104.