### PR TITLE
Assign LexisNexis account ID environment variable as string

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -77,7 +77,7 @@ lexisnexis_password: test_password
 lexisnexis_phone_finder_workflow: customers.gsa.phonefinder.workflow
 lexisnexis_instant_verify_workflow: customers.gsa.instant.verify.workflow
 # TrueID DocAuth Integration
-lexisnexis_trueid_account_id: 12345
+lexisnexis_trueid_account_id: '12345'
 lexisnexis_trueid_username: test_username
 lexisnexis_trueid_password: test_password
 lexisnexis_trueid_liveness_workflow: customers.gsa.instant.verify.workflow


### PR DESCRIPTION
Previously: #4184

**Why**: Avoid warnings in output of `make run`

Resolves warning:

```
11:46:10 web.1         | WARNING: Use strings for Figaro configuration. 12345 was converted to "12345".
```