### PR TITLE
Remove unused Webpack loaders

### DIFF
--- a/app/javascript/packages/document-capture/package.json
+++ b/app/javascript/packages/document-capture/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
-    "focus-trap": "^6.1.0",
+    "focus-trap": "^6.1.3",
     "react": "^16.13.1"
   }
 }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,7 @@
 const { environment } = require('@rails/webpacker');
 
+environment.loaders.delete('file');
+environment.loaders.delete('nodeModules');
 environment.loaders.delete('moduleSass');
 environment.loaders.delete('moduleCss');
 environment.loaders.delete('css');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
-    "focus-trap": "^6.1.0",
+    "focus-trap": "^6.1.3",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",
     "intl-tel-input": "^16.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,12 +4251,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.0.tgz#836a4851b389b71fe26d4dcdfb43d5c8d6f2bfc6"
-  integrity sha512-TQf1gJ5UgAY2ZMXrTDls6ah10kJmh35w/4COQHncLILwAK7hme4tiOwYnq2JOU88pqu1LoPqO9Yn7EbvmnzRRQ==
+focus-trap@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.3.tgz#38b79099bec42b9efa9ee47b646a21033dd030fd"
+  integrity sha512-UXrRlMIZVwLRt4t/fdhExuD3nanc2oHlyJrjbUl01iR2Z59/uPOAj4V9A6k2aelLb/aKb3YKJG+S4HBTrnTWHA==
   dependencies:
-    tabbable "^5.1.0"
+    tabbable "^5.1.2"
 
 follow-redirects@^1.0.0:
   version "1.13.0"
@@ -8917,10 +8917,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
-  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
+tabbable@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.2.tgz#3c4eac2901d0000913d13ce147229eb1405b59ca"
+  integrity sha512-DNmnX4XgkjK7kxDnQ5IbyYoNke2izMk5b62All0qxzoCF3wE7H9CuZ2IPdfAN8v79E0rpjv2k78uWuIXupGa9g==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
**Why**: Build performance, improved compatibility with future Webpacker v6 release, improved interoperability with future addition of loaders e.g. source-map-loader

See pending release notes for Webpacker v6: https://github.com/rails/webpacker/blob/master/CHANGELOG.md#600---2020-tbd

>`node_modules` will no longer be compiled by default. This primarily fixes rails issue #35501 as well as numerous other webpacker issues. The disabled loader can still be required explicitly via:

**Context:** I'd encountered conflicts with the `nodeModules` default loader when attempting to add  [`source-map-loader`](https://www.npmjs.com/package/source-map-loader) in trying to debug our dependencies (`identity-style-guide`). As alluded to in the Webpacker release notes, compiling `node_modules` by Babel can cause odd conflicts. It is common practice that modules published to NPM should not expect a build process on the consuming project in order to be used.

