### PR TITLE
fix wording of how https ensures security

### DIFF
--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -9,9 +9,8 @@ en:
       gov_heading: The .gov means it’s official.
       how: Here’s how you know
       official_site: An official website of the United States government.
-      secure_description_html: The <strong>https://</strong> ensures that you are
-        connecting to the official website and that any information you provide is
-        encrypted and transmitted securely.
+      secure_description_html: The <strong>https://</strong> ensures that any 
+        information you provide is encrypted and transmitted securely.
       secure_heading: The site is secure.
     footer_lite:
       gsa: US General Services Administration

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -10,9 +10,8 @@ es:
       gov_heading: La .gov significa que es oficial.
       how: Así es como sabes
       official_site: Un sitio oficial del Gobierno de Estados Unidos.
-      secure_description_html: El <strong>https://</strong> garantiza que se está
-        conectando al sitio web oficial y que toda la información que proporciona
-        está encriptada y transmitida de forma segura.
+      secure_description_html: El <strong>https://</strong> garantiza que cualquier
+        información que proporciones esté cifrada y transmitida de forma segura.
       secure_heading: El sitio es seguro.
     footer_lite:
       gsa: Administración General de Servicios de EE. UU.

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -10,9 +10,9 @@ fr:
       gov_heading: Le .gov signifie que c'est officiel.
       how: Voici comment vous savez
       official_site: Un site web officiel du gouvernement des États-Unis.
-      secure_description_html: Le <strong>https://</strong> garantit que vous vous
-        connectez au site officiel et que toutes les informations que vous fournissez
-        sont cryptées et transmises en toute sécurité.
+      secure_description_html: Le <strong>https://</strong> garantit que toutes les
+        informations que vous fournissez sont cryptées et transmises en toute
+        sécurité.
       secure_heading: Le site est sécurisé.
     footer_lite:
       gsa: Administration des services généraux des États-Unis


### PR DESCRIPTION
Revised the wording of how seeing "https://" in the address bar assures users the secure.login.gov site is "An official website of the United States government." to remove the section that states https can be used to ensure you are connecting to the official website.

While most users will little note the technical difference, all https can really ensure is that we are using TLS to secure what would otherwise be unencrypted web traffic. The ".gov" mentioned alongside this description is much more suited to giving a high level of confidence in the websites authenticity.

