### PR TITLE
Bump TypeScript from ^3.9.7 to ^4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier": "^2.0.5",
     "react-test-renderer": "^16.13.1",
     "sinon": "^9.0.2",
-    "typescript": "^3.9.7",
+    "typescript": "^4.0.3",
     "webpack-dev-server": "^3.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9187,10 +9187,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
**Why**: Take advantage of latest and greatest, reduce burden in postponing a major version bump

**Testing Procedure:**

`yarn typecheck` succeeds.

**Resources:**

- Breaking changes changelog: https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#breaking-changes
   - There should be no impact for our usage