### PR TITLE
Fix intermittent IAA Billing Report test failures by sorting SPs

### DIFF
--- a/app/services/reports/iaa_billing_report.rb
+++ b/app/services/reports/iaa_billing_report.rb
@@ -55,7 +55,11 @@ module Reports
     def unique_iaa_sps
       iaa_done = {}
       sps = []
-      ServiceProvider.where.not(iaa: nil, iaa_start_date: nil, iaa_end_date: nil).each do |sp|
+      ServiceProvider.where.not(
+        iaa: nil,
+        iaa_start_date: nil,
+        iaa_end_date: nil,
+      ).sort_by(&:issuer).each do |sp|
         iaa = sp.iaa
         (sps_for_iaa[iaa] ||= []) << sp
         next if iaa_done[iaa]


### PR DESCRIPTION
**Why**: Ensure tests pass consistently

I've observed this test to occasionally fail in CircleCI:

```
  1) Reports::IaaBillingReport rolls up 2 issuers in a single IAA
     Failure/Error: expect(subject.call).to eq(results_for_1_iaa.to_json)
     
       expected: "[{\"iaa\":\"iaa\",\"iaa_start_date\":\"2020-02-01\",\"iaa_end_date\":\"2021-02-01\",\"ial2_active_co...unt\":0},{\"issuer\":\"foo2\",\"ial\":1,\"count\":0},{\"issuer\":\"foo2\",\"ial\":2,\"count\":0}]}]"
            got: "[{\"iaa\":\"iaa\",\"iaa_start_date\":\"2020-02-01\",\"iaa_end_date\":\"2021-02-01\",\"ial2_active_co...count\":0},{\"issuer\":\"foo\",\"ial\":1,\"count\":0},{\"issuer\":\"foo\",\"ial\":2,\"count\":0}]}]"
     
       (compared using ==)
     # ./spec/services/reports/iaa_billing_report_spec.rb:137:in `block (2 levels) in <top (required)>'
```

The expectation is that while the [members of the `auth_counts` array are the same](https://github.com/18F/identity-idp/blob/c8b47ab8b88cc82a982128569645698969fbdb30/spec/services/reports/iaa_billing_report_spec.rb#L27-L49), because there is no enforced order on [the `ServiceProvider` query](https://github.com/18F/identity-idp/blob/c8b47ab8b88cc82a982128569645698969fbdb30/app/services/reports/iaa_billing_report.rb#L58), the `auth_counts` may be ordered non-deterministically.

Sorting by `issuer` should match the expectations from the test data.