### PR TITLE
LG-3512: Apply link button styling to link element

### DIFF
--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -5,9 +5,11 @@
     </h2>
     <% if current_user.auth_app_configurations.count < Figaro.env.max_auth_apps_per_account.to_i %>
       <div class="right-align grid-col-6">
-        <div class="btn btn-account-action rounded-lg bg-light-blue">
-          <%= link_to t('forms.buttons.enable'), authenticator_setup_url %>
-        </div>
+        <%= link_to(
+          t('forms.buttons.enable'),
+          authenticator_setup_url,
+          class: 'btn btn-account-action rounded-lg bg-light-blue',
+        ) %>
       </div>
     <% end %>
   </div>

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -5,9 +5,11 @@
     </h2>
     <div class="right-align col col-6">
       <% if EmailPolicy.new(current_user).can_add_email? %>
-        <div class="btn btn-account-action rounded-lg bg-light-blue">
-          <%= link_to t('account.index.email_add'), add_email_path %>
-        </div>
+        <%= link_to(
+          t('account.index.email_add'),
+          add_email_path,
+          class: 'btn btn-account-action rounded-lg bg-light-blue',
+        ) %>
       <% end %>
     </div>
   </div>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -5,9 +5,11 @@
     </h2>
     <div class="right-align grid-col-6">
       <% if EmailPolicy.new(current_user).can_add_email? %>
-        <div class="btn btn-account-action rounded-lg bg-light-blue">
-          <%= link_to t('account.index.phone_add'), add_phone_path %>
-        </div>
+        <%= link_to(
+          t('account.index.phone_add'),
+          add_phone_path,
+          class: 'btn btn-account-action rounded-lg bg-light-blue',
+        ) %>
       <% end %>
     </div>
   </div>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -5,9 +5,11 @@
     </h2>
     <% if current_user.piv_cac_configurations.count < Figaro.env.max_piv_cac_per_account.to_i %>
       <div class="right-align grid-col-6">
-        <div class="btn btn-account-action rounded-lg bg-light-blue">
-          <%= link_to t('forms.buttons.enable'), setup_piv_cac_url %>
-        </div>
+        <%= link_to(
+          t('forms.buttons.enable'),
+          setup_piv_cac_url,
+          class: 'btn btn-account-action rounded-lg bg-light-blue',
+        ) %>
       </div>
     <% end %>
   </div>

--- a/app/views/accounts/_webauthn.html.erb
+++ b/app/views/accounts/_webauthn.html.erb
@@ -4,9 +4,11 @@
       <%= t('account.index.webauthn') %>
     </h2>
     <div class="right-align grid-col-6">
-      <div class="btn btn-account-action rounded-lg bg-light-blue">
-        <%= link_to t('account.index.webauthn_add'), webauthn_setup_path %>
-      </div>
+      <%= link_to(
+        t('account.index.webauthn_add'),
+        webauthn_setup_path,
+        class: 'btn btn-account-action rounded-lg bg-light-blue',
+      ) %>
     </div>
   </div>
 


### PR DESCRIPTION
**Why**: As a user, I expect that I can click anywhere within a visual button to trigger the button's behavior, so that I can proceed with the action I intended and expected.

Before|After
---|---
![Screen Shot 2020-10-08 at 12 07 49 PM](https://user-images.githubusercontent.com/1779930/95485402-aa61a080-095f-11eb-8408-4bdec353718e.png)|![Screen Shot 2020-10-08 at 12 07 54 PM](https://user-images.githubusercontent.com/1779930/95485403-aafa3700-095f-11eb-9e2a-e2cc7b0bb61a.png)

A user should not perceive any visual difference, except by noticing that the focusable outline surrounds the entire button, not the text within the button.