### PR TITLE
Fix status code 401 symbol usage in doc capture polling

### DIFF
--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -28,7 +28,7 @@ module Idv
 
     def doc_capture_poll_render_result
       doc_capture = DocCapture.find_by(user_id: user_id)
-      return { plain: 'Not authorized', status: :not_authorized } if doc_capture.blank?
+      return { plain: 'Unauthorized', status: :unauthorized } if doc_capture.blank?
       return { plain: 'Pending', status: :accepted } if doc_capture.acuant_token.blank?
       { plain: 'Complete', status: :ok }
     end
@@ -36,11 +36,11 @@ module Idv
     def document_capture_session_poll_render_result
       session_uuid = flow_session[:document_capture_session_uuid]
       document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
-      return { plain: 'Not authorized', status: :not_authorized } unless document_capture_session
+      return { plain: 'Unauthorized', status: :unauthorized } unless document_capture_session
 
       result = document_capture_session.load_result
       return { plain: 'Pending', status: :accepted } if result.blank?
-      return { plain: 'Not authorized', status: :not_authorized } unless result.success?
+      return { plain: 'Unauthorized', status: :unauthorized } unless result.success?
       { plain: 'Complete', status: :ok }
     end
 


### PR DESCRIPTION
**Why**: So that the server returns the expected status code (401) and doesn't error on an unrecognized status code

There doesn't appear to be much test coverage for this behavior, but I will plan to include some. I'd discovered this in the course of implementing tests for LG-3423 (dedicated controller for doc capture polling).

Reference: https://guides.rubyonrails.org/layouts_and_rendering.html#the-status-option

Because the front-end polling behavior checks only for `200` status code, it likely does not have a user-facing impact:

https://github.com/18F/identity-idp/blob/d391f774c31595c80c1438cf4e83caa1cf65c39d/app/javascript/packs/doc_capture_polling.js#L25-L30

However, the use of an unrecognized status code symbol could produce errors in the server response.