### PR TITLE
LG-3423: Refactor doc capture (hybrid) polling to own endpoint

### DIFF
--- a/app/controllers/idv/capture_doc_status_controller.rb
+++ b/app/controllers/idv/capture_doc_status_controller.rb
@@ -1,0 +1,41 @@
+module Idv
+  class CaptureDocStatusController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    respond_to :json
+
+    def show
+      result = if FeatureManagement.document_capture_step_enabled?
+                 document_capture_session_poll_render_result
+               else
+                 doc_capture_poll_render_result
+               end
+
+      render result
+    end
+
+    private
+
+    def doc_capture_poll_render_result
+      doc_capture = DocCapture.find_by(user_id: current_user.id)
+      return { plain: 'Unauthorized', status: :unauthorized } if doc_capture.blank?
+      return { plain: 'Pending', status: :accepted } if doc_capture.acuant_token.blank?
+      { plain: 'Complete', status: :ok }
+    end
+
+    def document_capture_session_poll_render_result
+      session_uuid = flow_session[:document_capture_session_uuid]
+      document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
+      return { plain: 'Unauthorized', status: :unauthorized } unless document_capture_session
+
+      result = document_capture_session.load_result
+      return { plain: 'Pending', status: :accepted } if result.blank?
+      return { plain: 'Unauthorized', status: :unauthorized } unless result.success?
+      { plain: 'Complete', status: :ok }
+    end
+
+    def flow_session
+      user_session['idv/doc_auth']
+    end
+  end
+end

--- a/app/controllers/idv/doc_auth_controller.rb
+++ b/app/controllers/idv/doc_auth_controller.rb
@@ -16,34 +16,6 @@ module Idv
       analytics_id: Analytics::DOC_AUTH,
     }.freeze
 
-    def doc_capture_poll
-      result = if FeatureManagement.document_capture_step_enabled?
-                 document_capture_session_poll_render_result
-               else
-                 doc_capture_poll_render_result
-               end
-
-      render result
-    end
-
-    def doc_capture_poll_render_result
-      doc_capture = DocCapture.find_by(user_id: user_id)
-      return { plain: 'Not authorized', status: :not_authorized } if doc_capture.blank?
-      return { plain: 'Pending', status: :accepted } if doc_capture.acuant_token.blank?
-      { plain: 'Complete', status: :ok }
-    end
-
-    def document_capture_session_poll_render_result
-      session_uuid = flow_session[:document_capture_session_uuid]
-      document_capture_session = DocumentCaptureSession.find_by(uuid: session_uuid)
-      return { plain: 'Not authorized', status: :not_authorized } unless document_capture_session
-
-      result = document_capture_session.load_result
-      return { plain: 'Pending', status: :accepted } if result.blank?
-      return { plain: 'Not authorized', status: :not_authorized } unless result.success?
-      { plain: 'Complete', status: :ok }
-    end
-
     def redirect_if_mail_bounced
       redirect_to idv_usps_url if current_user.decorate.usps_mail_bounced?
     end

--- a/app/javascript/packs/doc_capture_polling.js
+++ b/app/javascript/packs/doc_capture_polling.js
@@ -20,7 +20,7 @@ const docCaptureComplete = () => {
 
 const sendDocAuthPollRequest = () => {
   const request = new XMLHttpRequest();
-  request.open('GET', '/verify/doc_auth/link_sent/poll/', true);
+  request.open('GET', '/verify/capture_doc_status/', true);
   request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
   request.onload = function () {
     // This endpoint renders a 202 for a pending request

--- a/app/javascript/packs/doc_capture_polling.js
+++ b/app/javascript/packs/doc_capture_polling.js
@@ -20,7 +20,7 @@ const docCaptureComplete = () => {
 
 const sendDocAuthPollRequest = () => {
   const request = new XMLHttpRequest();
-  request.open('GET', '/verify/capture_doc_status/', true);
+  request.open('GET', '/verify/doc_auth/link_sent/poll/', true);
   request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
   request.onload = function () {
     // This endpoint renders a 202 for a pending request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,13 +317,13 @@ Rails.application.routes.draw do
       get '/doc_auth' => 'doc_auth#index'
       get '/doc_auth/:step' => 'doc_auth#show', as: :doc_auth_step
       put '/doc_auth/:step' => 'doc_auth#update'
+      get '/doc_auth/link_sent/poll' => 'capture_doc_status#show'
       get '/capture_doc' => 'capture_doc#index'
       get '/capture-doc' => 'capture_doc#index',
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
-      get '/capture_doc_status' => 'capture_doc_status#show'
       unless FeatureManagement.disallow_ial2_recovery?
         get '/recovery' => 'recovery#index'
         get '/recovery/:step' => 'recovery#show', as: :recovery_step

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,13 +317,13 @@ Rails.application.routes.draw do
       get '/doc_auth' => 'doc_auth#index'
       get '/doc_auth/:step' => 'doc_auth#show', as: :doc_auth_step
       put '/doc_auth/:step' => 'doc_auth#update'
-      get '/doc_auth/link_sent/poll' => 'doc_auth#doc_capture_poll'
       get '/capture_doc' => 'capture_doc#index'
       get '/capture-doc' => 'capture_doc#index',
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
       get '/capture_doc/:step' => 'capture_doc#show', as: :capture_doc_step
       put '/capture_doc/:step' => 'capture_doc#update'
+      get '/capture_doc_status' => 'capture_doc_status#show'
       unless FeatureManagement.disallow_ial2_recovery?
         get '/recovery' => 'recovery#index'
         get '/recovery/:step' => 'recovery#show', as: :recovery_step

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+
+describe Idv::CaptureDocStatusController do
+  let(:user) { build(:user) }
+  let(:document_capture_step_enabled) { false }
+
+  before do |example|
+    stub_sign_in(user) unless example.metadata[:skip_sign_in]
+
+    allow(FeatureManagement).to receive(:document_capture_step_enabled?).
+      and_return(document_capture_step_enabled)
+  end
+
+  describe '#show' do
+    context 'when unauthenticated', :skip_sign_in do
+      it 'redirects to the root url' do
+        get :show
+
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'when document capture step is disabled' do
+      let(:document_capture_step_enabled) { false }
+      let(:doc_capture) { nil }
+
+      before do
+        allow(DocCapture).to receive(:find_by).and_return(doc_capture)
+      end
+
+      context 'when session does not exist' do
+        let(:doc_capture) { nil }
+
+        it 'returns unauthorized' do
+          get :show
+
+          expect(response.status).to eq(401)
+          expect(response.body).to eq('Unauthorized')
+        end
+      end
+
+      context 'when result is pending' do
+        let(:doc_capture) do
+          DocCapture.create(
+            user_id: user.id,
+            request_token: SecureRandom.uuid,
+            requested_at: Time.zone.now,
+          )
+        end
+
+        it 'returns pending result' do
+          get :show
+
+          expect(response.status).to eq(202)
+          expect(response.body).to eq('Pending')
+        end
+      end
+
+      context 'when capture is complete' do
+        let(:doc_capture) do
+          DocCapture.create(
+            user_id: user.id,
+            request_token: SecureRandom.uuid,
+            requested_at: Time.zone.now,
+            acuant_token: SecureRandom.uuid,
+          )
+        end
+
+        it 'returns success' do
+          get :show
+
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('Complete')
+        end
+      end
+    end
+
+    context 'when document capture step is enabled' do
+      let(:document_capture_step_enabled) { true }
+      let(:document_capture_session) { DocumentCaptureSession.create! }
+      let(:flow_session) { { document_capture_session_uuid: document_capture_session.uuid } }
+
+      before do
+        allow_any_instance_of(Flow::BaseFlow).to receive(:flow_session).and_return(flow_session)
+        controller.user_session['idv/doc_auth'] = flow_session
+      end
+
+      context 'when session does not exist' do
+        let(:flow_session) { {} }
+
+        it 'returns unauthorized' do
+          get :show
+
+          expect(response.status).to eq(401)
+          expect(response.body).to eq('Unauthorized')
+        end
+      end
+
+      context 'when result is pending' do
+        it 'returns pending result' do
+          get :show
+
+          expect(response.status).to eq(202)
+          expect(response.body).to eq('Pending')
+        end
+      end
+
+      context 'when capture failed' do
+        before do
+          allow(EncryptedRedisStructStorage).to receive(:load).and_return(
+            DocumentCaptureSessionResult.new(
+              id: SecureRandom.uuid,
+              success: false,
+              pii: {},
+            ),
+          )
+        end
+
+        it 'returns unauthorized' do
+          get :show
+
+          expect(response.status).to eq(401)
+          expect(response.body).to eq('Unauthorized')
+        end
+      end
+
+      context 'when capture succeeded' do
+        before do
+          allow(EncryptedRedisStructStorage).to receive(:load).and_return(
+            DocumentCaptureSessionResult.new(
+              id: SecureRandom.uuid,
+              success: true,
+              pii: {},
+            ),
+          )
+        end
+
+        it 'returns success' do
+          get :show
+
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('Complete')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/capture_doc_status_controller_spec.rb
+++ b/spec/controllers/idv/capture_doc_status_controller_spec.rb
@@ -4,15 +4,17 @@ describe Idv::CaptureDocStatusController do
   let(:user) { build(:user) }
   let(:document_capture_step_enabled) { false }
 
-  before do |example|
-    stub_sign_in(user) unless example.metadata[:skip_sign_in]
+  before do
+    stub_sign_in(user) if user
 
     allow(FeatureManagement).to receive(:document_capture_step_enabled?).
       and_return(document_capture_step_enabled)
   end
 
   describe '#show' do
-    context 'when unauthenticated', :skip_sign_in do
+    context 'when unauthenticated' do
+      let(:user) { nil }
+
       it 'redirects to the root url' do
         get :show
 


### PR DESCRIPTION
Related: #4292, https://github.com/18F/identity-idp/pull/4153#discussion_r482313933

**Why**: Isolate standalone polling behavior for easier disambiguation of controller as exclusively responding to JSON, improved ability to implement test specs for controller in isolation.