### PR TITLE
Generate desktop selfie as JPEG at original (constrained) capture size

### DIFF
--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -94,31 +94,22 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
 
     const canvas = document.createElement('canvas');
     const { videoWidth, videoHeight } = videoRef.current;
-    const { clientWidth: width, clientHeight: height } = wrapperRef.current;
+    const { clientWidth, clientHeight } = wrapperRef.current;
 
-    // The capture is shown as a square, even if the video input aspect ratio is not square. To
-    // ensure that the captured image matches what is shown to the user, offset the source to X
-    // corresponding with centered squared height.
-    const downsizeRatio = height / videoHeight;
-    const sourceX = (videoWidth - width / downsizeRatio) / 2;
+    const height = Math.min(videoHeight, 720);
+    const aspectRatio = clientWidth / clientHeight;
+    const width = height * aspectRatio;
+
+    const sourceX = (videoWidth - width) / 2;
 
     canvas.height = height;
     canvas.width = width;
 
     canvas
       .getContext('2d')
-      ?.drawImage(
-        videoRef.current,
-        sourceX,
-        0,
-        width / downsizeRatio,
-        height / downsizeRatio,
-        0,
-        0,
-        width,
-        height,
-      );
-    canvas.toBlob(ifStillMounted(onChange));
+      ?.drawImage(videoRef.current, sourceX, 0, width, height, 0, 0, width, height);
+
+    onChange(canvas.toDataURL('image/jpeg', 0.8));
   }
 
   let shownErrorMessage;


### PR DESCRIPTION
**Why**: Higher-quality images in a format more aligned with how selfies are generated by Acuant SDK in mobile contexts.

The intention with these changes is to try to improve the likelihood of success of desktop selfie matching.

Previously, images would be generated at a size exactly as shown on the user's screen, which can often be smaller than Acuant's own constraints (max 1024px width, 720px height). In most cases, this would have been 460px width x 390px height, and is now 847px width x 720px height for any native video input of at least 720px height.

Previously, images would be saved in PNG format ([`HTMLCanvasElement.toBlob` default](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob)). To align with Acuant's SDK, images are now saved in JPG format at 80% quality (see line 1390 of [AcuantJavaScriptWebSdk.js](https://github.com/Acuant/JavascriptWebSDKV11/blob/master/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js)).