### PR TITLE
Remove explicit dependency to identity-es5-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@18f/identity-es5-safe": "file:./app/javascript/packages/es5-safe",
     "@babel/core": "^7.11.1",
     "@babel/eslint-parser": "^7.11.3",
     "@babel/eslint-plugin": "^7.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@18f/identity-es5-safe@file:./app/javascript/packages/es5-safe":
-  version "1.0.0"
-  dependencies:
-    acorn "^6.4.2"
-    fast-glob "^3.2.4"
-    p-all "^3.0.0"
-
 "@babel/code-frame@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"


### PR DESCRIPTION
**Why**: Appears to cause issues with Yarn integrity, and not strictly necessary

**Testing Procedure:**

Verify `yarn check --integrity` results in no errors.

Verify `yarn es5-safe` runs without error.