### PR TITLE
Fix warning in test from i18n update

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe 'I18n' do
   end
 
   def extract_interpolation_arguments(translation)
-    translation.scan(I18n::INTERPOLATION_PATTERN).map(&:compact).map(&:first).to_set
+    translation.scan(Regexp.union(I18n::DEFAULT_INTERPOLATION_PATTERNS)).
+      map(&:compact).map(&:first).to_set
   end
 
   def flatten_hash(hash, parent_keys: [], out_hash: {}, &block)


### PR DESCRIPTION
The constant was deprecated, so we're getting a `warning: constant I18n::INTERPOLATION_PATTERN is deprecated` whenever that spec runs.

i18n introduced the deprecation here: https://github.com/ruby-i18n/i18n/pull/439
we updated i18n here: #4267 