### PR TITLE
Fixes a bug where canceling identity proofing would leave the user in an endless loop (LG-3520)

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -119,7 +119,7 @@ class ServiceProviderSessionDecorator
   end
 
   def failure_to_proof_url
-    sp.failure_to_proof_url || sp_return_url
+    sp.failure_to_proof_url.presence || sp_return_url
   end
 
   def sp_alert?(path)

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -202,9 +202,16 @@ RSpec.describe ServiceProviderSessionDecorator do
       expect(subject.failure_to_proof_url).to eq url
     end
 
-    it 'returns the return_to_sp_url if the failure_to_proof_url is not present on the sp' do
+    it 'returns the return_to_sp_url if the failure_to_proof_url is nil on the sp' do
       url = 'https://www.example.com/'
       allow_any_instance_of(ServiceProvider).to receive(:failure_to_proof_url).and_return(nil)
+      allow_any_instance_of(ServiceProvider).to receive(:return_to_sp_url).and_return(url)
+      expect(subject.failure_to_proof_url).to eq url
+    end
+
+    it 'returns the return_to_sp_url if the failure_to_proof_url is an blank string on the sp' do
+      url = 'https://www.example.com/'
+      allow_any_instance_of(ServiceProvider).to receive(:failure_to_proof_url).and_return('  ')
       allow_any_instance_of(ServiceProvider).to receive(:return_to_sp_url).and_return(url)
       expect(subject.failure_to_proof_url).to eq url
     end


### PR DESCRIPTION
Turns out that if the SP's `failure_to_proof_url` is the empty string, it gets passed to `link_to` and it links to the current path.