### PR TITLE
Fixing 2FA SMS code not autocompleting in Safari

### DIFF
--- a/app/views/idv/otp_verification/show.html.slim
+++ b/app/views/idv/otp_verification/show.html.slim
@@ -12,7 +12,7 @@ p == @presenter.phone_number_message
     = text_field_tag(:code, '', value: @code, required: true,
       autofocus: true, pattern: '[0-9]*', class: 'col-12 field monospace mfa',
       'aria-describedby': 'code-instructs', maxlength: Devise.direct_otp_length,
-      type: 'tel')
+      autocomplete: 'one-time-code', type: 'tel')
   = submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12'
   br
   br

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -22,7 +22,7 @@
                        class: 'col-12 field monospace mfa',
                        'aria-describedby': 'code-instructs',
                        maxlength: Devise.direct_otp_length,
-                       type: 'tel') %>
+                       autocomplete: 'one-time-code', type: 'tel') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.slim
+++ b/app/views/two_factor_authentication/totp_verification/show.html.slim
@@ -9,7 +9,8 @@ h1.h3.my0 = @presenter.header
   .col-12.sm-col-5.mb1.sm-mb0.sm-mr-20p.inline-block
     = text_field_tag :code, '', value: @code, required: true, autofocus: true,
       pattern: '[0-9]*', class: 'col-12 field monospace mfa', type: 'tel',
-      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length
+      'aria-describedby': 'code-instructs', maxlength: Devise.otp_length,
+      autocomplete: 'one-time-code'
   .border.border-light-blue.rounded-lg.py1.mt2.mb4.sm-my2.col-12.sm-col-7
     = hidden_field_tag 'remember_device', false, id: 'remember_device_preference'
     = check_box_tag 'remember_device', true, @presenter.remember_device_box_checked?,


### PR DESCRIPTION
**Why**:
- 2FA code field does not sugguest the code received via SMS in Safari browser both on mobile and on desktop. This is to fix the issue by adding the recommended autocomplete attribute.

**How**:
- Following recommendation suggested on Apple's website - https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element and on Mozilla https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
