### PR TITLE
One liner to fix local docker building.

### DIFF
--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -9,6 +9,7 @@ ENV MAKEFLAGS "-j$(nproc)"
 
 # Install dev and test gems
 COPY Gemfile Gemfile.lock ./
+COPY app/services/lambda_jobs/git_ref.rb ./app/services/lambda_jobs/
 RUN bundle install -j $(nproc) --system --with development test
 
 # Install NPM packages


### PR DESCRIPTION
One liner to fix local docker building. With the async work being done there was a file dependency added to the gemfile. Bundle install is run in the container before the directory tree is copied into the container.