### PR TITLE
LG-3416 API to verify documents

### DIFF
--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -6,6 +6,9 @@ module Idv
     validates_presence_of :encryption_key
     validate :validate_image_urls
     validates_presence_of :document_capture_session
+    validates_presence_of :front_image_iv
+    validates_presence_of :back_image_iv
+    validates_presence_of :selfie_image_iv, if: :liveness_checking_enabled?
 
     validate :throttle_if_rate_limited
 
@@ -58,6 +61,18 @@ module Idv
 
     def encryption_key
       params[:encryption_key]
+    end
+
+    def front_image_iv
+      params[:front_image_iv]
+    end
+
+    def back_image_iv
+      params[:back_image_iv]
+    end
+
+    def selfie_image_iv
+      params[:selfie_image_iv]
     end
 
     def valid_url?(key)

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -1,0 +1,93 @@
+module Idv
+  class ApiDocumentVerificationForm
+    include ActiveModel::Model
+    include ActionView::Helpers::TranslationHelper
+
+    validates_presence_of :encryption_key
+    validate :validate_image_urls
+    validates_presence_of :document_capture_session
+
+    validate :throttle_if_rate_limited
+
+    def initialize(params, liveness_checking_enabled:)
+      @params = params
+      @liveness_checking_enabled = liveness_checking_enabled
+      @readable = {}
+    end
+
+    def submit
+      throttled_else_increment
+
+      FormResponse.new(
+        success: valid?,
+        errors: errors.messages,
+        extra: {
+          remaining_attempts: remaining_attempts,
+        },
+      )
+    end
+
+    def status
+      return :ok if valid?
+      return :too_many_requests if errors.key?(:limit)
+      :bad_request
+    end
+
+    def remaining_attempts
+      Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
+    end
+
+    def liveness_checking_enabled?
+      @liveness_checking_enabled
+    end
+
+    def document_capture_session_uuid
+      params[:document_capture_session_uuid]
+    end
+
+    def document_capture_session
+      @document_capture_session ||= DocumentCaptureSession.find_by(
+        uuid: document_capture_session_uuid,
+      )
+    end
+
+    private
+
+    attr_reader :params
+
+    def encryption_key
+      params[:encryption_key]
+    end
+
+    def valid_url?(key)
+      uri = params[key]
+      parsed_uri = URI.parse(uri)
+      parsed_uri.scheme.present? && parsed_uri.host.present?
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def throttle_if_rate_limited
+      return unless @throttled
+      errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
+    end
+
+    def throttled_else_increment
+      @throttled = Throttler::IsThrottledElseIncrement.call(
+        document_capture_session.user_id,
+        :idv_acuant,
+      )
+    end
+
+    def validate_image_urls
+      errors.add(:front_image_url, invalid_link) unless valid_url?(:front_image_url)
+      errors.add(:back_image_url, invalid_link) unless valid_url?(:back_image_url)
+      return if valid_url?(:selfie_image_url)
+      errors.add(:selfie_image_url, invalid_link) unless liveness_checking_enabled?
+    end
+
+    def invalid_link
+      t('doc_auth.errors.not_a_file')
+    end
+  end
+end

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -34,6 +34,7 @@ module Idv
     end
 
     def remaining_attempts
+      return unless document_capture_session
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end
 
@@ -73,6 +74,7 @@ module Idv
     end
 
     def throttled_else_increment
+      return unless document_capture_session
       @throttled = Throttler::IsThrottledElseIncrement.call(
         document_capture_session.user_id,
         :idv_acuant,

--- a/app/jobs/vendor_document_verification_job.rb
+++ b/app/jobs/vendor_document_verification_job.rb
@@ -1,6 +1,9 @@
 class VendorDocumentVerificationJob
   def self.perform(_document_capture_session_result_id:,
                    _encryption_key:,
+                   _front_image_iv:,
+                   _back_image_iv:,
+                   _selfie_image_iv:,
                    _front_image_url:,
                    _back_image_url:,
                    _selfie_image_url:,

--- a/app/jobs/vendor_document_verification_job.rb
+++ b/app/jobs/vendor_document_verification_job.rb
@@ -1,0 +1,11 @@
+class VendorDocumentVerificationJob
+  def self.perform(_document_capture_session_uuid:,
+                   _encryption_key:,
+                   _front_image_url:,
+                   _back_image_url:,
+                   _selfie_image_url:,
+                   _liveness_checking_enabled:)
+
+    FormResponse.new(success: true, errors: {})
+  end
+end

--- a/app/jobs/vendor_document_verification_job.rb
+++ b/app/jobs/vendor_document_verification_job.rb
@@ -1,5 +1,5 @@
 class VendorDocumentVerificationJob
-  def self.perform(_document_capture_session_uuid:,
+  def self.perform(_document_capture_session_result_id:,
                    _encryption_key:,
                    _front_image_url:,
                    _back_image_url:,

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -1,13 +1,14 @@
 module Flow
   class BaseFlow
     attr_accessor :flow_session
-    attr_reader :steps, :actions, :current_user, :params, :request
+    attr_reader :steps, :actions, :current_user, :params, :request, :json
 
     def initialize(controller, steps, actions, session)
       @controller = controller
       @steps = steps.with_indifferent_access
       @actions = actions.with_indifferent_access
       @redirect = nil
+      @json = nil
       @flow_session = session
     end
 
@@ -21,6 +22,10 @@ module Flow
 
     def redirect_to(url)
       @redirect = url
+    end
+
+    def render_json(json)
+      @json = json
     end
 
     def handle(step)

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -1,7 +1,7 @@
 module Flow
   class BaseFlow
     attr_accessor :flow_session
-    attr_reader :steps, :actions, :current_user, :params, :request, :json
+    attr_reader :steps, :actions, :current_user, :params, :request, :json, :http_status
 
     def initialize(controller, steps, actions, session)
       @controller = controller
@@ -24,8 +24,9 @@ module Flow
       @redirect = url
     end
 
-    def render_json(json)
+    def render_json(json, status: nil)
       @json = json
+      @http_status = status || :ok
     end
 
     def handle(step)

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -68,8 +68,8 @@ module Flow
       @flow.redirect_to(url)
     end
 
-    def render_json(json)
-      @flow.render_json(json)
+    def render_json(json, status: nil)
+      @flow.render_json(json, status: status)
     end
 
     def reset

--- a/app/services/flow/base_step.rb
+++ b/app/services/flow/base_step.rb
@@ -68,6 +68,10 @@ module Flow
       @flow.redirect_to(url)
     end
 
+    def render_json(json)
+      @flow.render_json(json)
+    end
+
     def reset
       @flow.flow_session = {}
     end

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -27,7 +27,7 @@ module Flow
       analytics.track_event(analytics_submitted, result.to_h.merge(step: step)) if @analytics_id
       register_update_step(step, result)
       if flow.json
-        render json: flow.json
+        render json: flow.json, status: flow.http_status
         return
       end
       flow_finish and return unless next_step

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -26,6 +26,10 @@ module Flow
       result = flow.handle(step)
       analytics.track_event(analytics_submitted, result.to_h.merge(step: step)) if @analytics_id
       register_update_step(step, result)
+      if flow.json
+        render json: flow.json
+        return
+      end
       flow_finish and return unless next_step
       render_update(step, result)
     end

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -5,6 +5,15 @@ module Idv
         enqueue_job
       end
 
+      private
+
+      def form_submit
+        render_json Idv::ApiDocumentVerificationForm.new(
+          params,
+          liveness_checking_enabled: liveness_checking_enabled?,
+        ).submit
+      end
+
       def enqueue_job
         document_capture_session = create_document_capture_session(
           verify_document_capture_session_uuid_key,

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -30,6 +30,9 @@ module Idv
         VendorDocumentVerificationJob.perform(
           _document_capture_session_result_id: document_capture_session.result_id,
           _encryption_key: params[:encryption_key],
+          _front_image_iv: params[:front_image_iv],
+          _back_image_iv: params[:back_image_iv],
+          _selfie_image_iv: params[:selfie_image_iv],
           _front_image_url: params[:front_image_url],
           _back_image_url: params[:back_image_url],
           _selfie_image_url: params[:selfie_image_url],

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -28,7 +28,7 @@ module Idv
         document_capture_session.store_proofing_pii_from_doc({})
 
         VendorDocumentVerificationJob.perform(
-          _document_capture_session_uuid: params[:document_capture_session_uuid],
+          _document_capture_session_result_id: document_capture_session.result_id,
           _encryption_key: params[:encryption_key],
           _front_image_url: params[:front_image_url],
           _back_image_url: params[:back_image_url],

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -1,0 +1,26 @@
+module Idv
+  module Actions
+    class VerifyDocumentAction < Idv::Steps::DocAuthBaseStep
+      def call
+        enqueue_job
+      end
+
+      def enqueue_job
+        document_capture_session = create_document_capture_session(
+          verify_document_capture_session_uuid_key,
+        )
+        document_capture_session.requested_at = Time.zone.now
+        document_capture_session.store_proofing_pii_from_doc({})
+
+        VendorDocumentVerificationJob.perform(
+          _document_capture_session_uuid: params[:document_capture_session_uuid],
+          _encryption_key: params[:encryption_key],
+          _front_image_url: params[:front_image_url],
+          _back_image_url: params[:back_image_url],
+          _selfie_image_url: params[:selfie_image_url],
+          _liveness_checking_enabled: params[:liveness_checking_enabled],
+        )
+      end
+    end
+  end
+end

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -8,10 +8,16 @@ module Idv
       private
 
       def form_submit
-        render_json Idv::ApiDocumentVerificationForm.new(
+        json = form.submit
+        render_json(json, status: form.status)
+        json
+      end
+
+      def form
+        @form ||= Idv::ApiDocumentVerificationForm.new(
           params,
           liveness_checking_enabled: liveness_checking_enabled?,
-        ).submit
+        )
       end
 
       def enqueue_job

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -16,19 +16,16 @@ module Idv
                     when :timed_out
                       { success: false, status: nil, errors: ['timeout'] }
                     when :done
-                      status = async_state_done(current_async_state)
-                      { success: true, status: status ? 'success' : 'fail' }
+                      success = process_result(current_async_state.result)
+                      async_state_done if success
+                      { success: true, status: success ? 'success' : 'fail' }
                     end
       end
 
-      def async_state_done(current_async_state)
-        result = current_async_state.result
-        return false unless process_result(result)
-
+      def async_state_done
         delete_async
         mark_step_complete(:document_capture)
         save_proofing_components
-        true
       end
 
       def process_result(result)

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -28,7 +28,6 @@ module Idv
         delete_async
         mark_step_complete(:document_capture)
         save_proofing_components
-        # extract_pii_from_doc(result)
         true
       end
 

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -8,7 +8,7 @@ module Idv
       private
 
       def process_async_state(current_async_state)
-        case current_async_state.status
+        render_json case current_async_state.status
         when :none
           { success: true, status: nil }
         when :in_progress

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -1,0 +1,62 @@
+module Idv
+  module Actions
+    class VerifyDocumentStatusAction < Idv::Steps::DocAuthBaseStep
+      def call
+        process_async_state(async_state)
+      end
+
+      private
+
+      def process_async_state(current_async_state)
+        case current_async_state.status
+        when :none
+          { success: true, status: nil }
+        when :in_progress
+          { success: true, status: 'in_progress' }
+        when :timed_out
+          { success: false, status: nil, errors: ['timeout'] }
+        when :done
+          status = async_state_done(current_async_state)
+          { success: true, status: status ? 'success' : 'fail' }
+        end
+      end
+
+      def async_state_done(current_async_state)
+        result = current_async_state.result
+        return false unless process_result(result)
+
+        delete_async
+        mark_step_complete(:document_capture)
+        save_proofing_components
+        extract_pii_from_doc(result)
+        true
+      end
+
+      def process_result(result)
+        add_cost(:acuant_result) if result.to_h[:billed]
+        response = idv_result_to_form_response(current_async_state.result)
+        response.success?
+      end
+
+      def async_state
+        dcs_uuid = flow_session[verify_document_capture_session_uuid_key]
+        dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
+        return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
+        return ProofingDocumentCaptureSessionResult.timed_out if dcs.nil?
+
+        proofing_job_result = dcs.load_proofing_result
+        return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+
+        if proofing_job_result.result
+          proofing_job_result.done
+        elsif proofing_job_result.pii
+          ProofingDocumentCaptureSessionResult.in_progress
+        end
+      end
+
+      def delete_async
+        flow_session.delete(verify_document_capture_session_uuid_key)
+      end
+    end
+  end
+end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -28,7 +28,7 @@ module Idv
         delete_async
         mark_step_complete(:document_capture)
         save_proofing_components
-        extract_pii_from_doc(result)
+        # extract_pii_from_doc(result)
         true
       end
 

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -9,16 +9,16 @@ module Idv
 
       def process_async_state(current_async_state)
         render_json case current_async_state.status
-        when :none
-          { success: true, status: nil }
-        when :in_progress
-          { success: true, status: 'in_progress' }
-        when :timed_out
-          { success: false, status: nil, errors: ['timeout'] }
-        when :done
-          status = async_state_done(current_async_state)
-          { success: true, status: status ? 'success' : 'fail' }
-        end
+                    when :none
+                      { success: true, status: nil }
+                    when :in_progress
+                      { success: true, status: 'in_progress' }
+                    when :timed_out
+                      { success: false, status: nil, errors: ['timeout'] }
+                    when :done
+                      status = async_state_done(current_async_state)
+                      { success: true, status: status ? 'success' : 'fail' }
+                    end
       end
 
       def async_state_done(current_async_state)

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -1,6 +1,6 @@
 module Idv
   module Actions
-    class VerifyDocumentStatusAction < Idv::Steps::DocAuthBaseStep
+    class VerifyDocumentStatusAction < Idv::Steps::VerifyBaseStep
       def call
         process_async_state(async_state)
       end
@@ -34,7 +34,7 @@ module Idv
 
       def process_result(result)
         add_cost(:acuant_result) if result.to_h[:billed]
-        response = idv_result_to_form_response(current_async_state.result)
+        response = idv_result_to_form_response(result)
         response.success?
       end
 

--- a/app/services/idv/flows/doc_auth_flow.rb
+++ b/app/services/idv/flows/doc_auth_flow.rb
@@ -25,6 +25,8 @@ module Idv
       ACTIONS = {
         reset: Idv::Actions::ResetAction,
         redo_ssn: Idv::Actions::RedoSsnAction,
+        verify_document: Idv::Actions::VerifyDocumentAction,
+        verify_document_status: Idv::Actions::VerifyDocumentStatusAction,
       }.freeze
 
       attr_reader :idv_session # this is needed to support (and satisfy) the current LOA3 flow

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -224,6 +224,10 @@ module Idv
         :idv_recover_verify_step_document_capture_session_uuid
       end
 
+      def verify_document_capture_session_uuid_key
+        :verify_document_action_document_capture_session_uuid
+      end
+
       delegate :idv_session, :session, to: :@flow
     end
   end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -161,21 +161,6 @@ describe Idv::DocAuthController do
     end
 
     it 'works' do
-      allow_any_instance_of(Flow::BaseFlow).to \
-        receive(:flow_session).and_return(
-          'Idv::Steps::FrontImageStep' => true,
-          'Idv::Steps::BackImageStep' => true,
-          'Idv::Steps::SelfieStep' => true,
-          'Idv::Steps::MobileFrontImageStep' => true,
-          'Idv::Steps::MobileBackImageStep' => true,
-          'document_capture_session_uuid' => 'foo',
-          'Idv::Steps::WelcomeStep' => true,
-          'Idv::Steps::SendLinkStep' => true,
-          'Idv::Steps::LinkSentStep' => true,
-          'Idv::Steps::EmailSentStep' => true,
-          'Idv::Steps::UploadStep' => true,
-        )
-
       put :update, params: { step: 'verify_document' }
 
       expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -171,10 +171,17 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
-    let(:good_result) { { pii_from_doc: {}, success: true, errors: {}, messages: ['some message'] } }
+    let(:good_result) { { pii_from_doc: {}, success: true, errors: {}, messages: ['message'] } }
 
     it 'returns status of success' do
       mock_document_capture_result(good_result)
+      put :update, params: { step: 'verify_document_status' }
+
+      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+    end
+
+    it 'returns status of pending' do
+      mock_document_capture_result(nil)
       put :update, params: { step: 'verify_document_status' }
 
       expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -159,11 +159,20 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
+    let(:successful_response) do
+      { success: true, errors: {}, extra: { remaining_attempts: 3 } }.to_json
+    end
 
     it 'successfully submits the images' do
-      put :update, params: { step: 'verify_document' }
+      put :update, params: { step: 'verify_document',
+                             document_capture_session_uuid: 'foo',
+                             encryption_key: 'bar',
+                             front_image_url: 'http://foo.com/bar1',
+                             back_image_url: 'http://foo.com/bar2',
+                             selfie_image_url: 'http://foo.com/bar3' }
 
-      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(successful_response)
     end
   end
 
@@ -177,14 +186,16 @@ describe Idv::DocAuthController do
       mock_document_capture_result(good_result)
       put :update, params: { step: 'verify_document_status' }
 
-      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+      expect(response.status).to eq(200)
+      expect(response.body).to eq({ success: true, status: 'success' }.to_json)
     end
 
-    it 'returns status of pending' do
+    it 'returns status of in progress' do
       mock_document_capture_result(nil)
       put :update, params: { step: 'verify_document_status' }
 
-      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+      expect(response.status).to eq(200)
+      expect(response.body).to eq({ success: true, status: 'in_progress' }.to_json)
     end
   end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -155,7 +155,63 @@ describe Idv::DocAuthController do
     end
   end
 
+  describe 'async document verify' do
+    before do
+      mock_document_capture_step
+    end
+
+    it 'works' do
+      allow_any_instance_of(Flow::BaseFlow).to \
+        receive(:flow_session).and_return(
+          'Idv::Steps::FrontImageStep' => true,
+          'Idv::Steps::BackImageStep' => true,
+          'Idv::Steps::SelfieStep' => true,
+          'Idv::Steps::MobileFrontImageStep' => true,
+          'Idv::Steps::MobileBackImageStep' => true,
+          'document_capture_session_uuid' => 'foo',
+          'Idv::Steps::WelcomeStep' => true,
+          'Idv::Steps::SendLinkStep' => true,
+          'Idv::Steps::LinkSentStep' => true,
+          'Idv::Steps::EmailSentStep' => true,
+          'Idv::Steps::UploadStep' => true,
+        )
+
+      put :update, params: { step: 'verify_document' }
+
+      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+    end
+  end
+
+  describe 'async document verify status' do
+    before do
+      mock_document_capture_step
+    end
+
+    it 'works' do
+      put :update, params: { step: 'verify_document_status' }
+
+      expect(response).to redirect_to idv_doc_auth_step_url(step: :welcome)
+    end
+  end
+
   def mock_next_step(step)
     allow_any_instance_of(Idv::Flows::DocAuthFlow).to receive(:next_step).and_return(step)
+  end
+
+  def mock_document_capture_step
+    allow_any_instance_of(Flow::BaseFlow).to \
+      receive(:flow_session).and_return(
+        'Idv::Steps::FrontImageStep' => true,
+        'Idv::Steps::BackImageStep' => true,
+        'Idv::Steps::SelfieStep' => true,
+        'Idv::Steps::MobileFrontImageStep' => true,
+        'Idv::Steps::MobileBackImageStep' => true,
+        'document_capture_session_uuid' => 'foo',
+        'Idv::Steps::WelcomeStep' => true,
+        'Idv::Steps::SendLinkStep' => true,
+        'Idv::Steps::LinkSentStep' => true,
+        'Idv::Steps::EmailSentStep' => true,
+        'Idv::Steps::UploadStep' => true,
+      )
   end
 end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -168,6 +168,9 @@ describe Idv::DocAuthController do
         put :update, params: { step: 'verify_document',
                                document_capture_session_uuid: 'foo',
                                encryption_key: 'bar',
+                               front_image_iv: 'iv1',
+                               back_image_iv: 'iv2',
+                               selfie_image_iv: 'iv3',
                                front_image_url: 'http://foo.com/bar1',
                                back_image_url: 'http://foo.com/bar2',
                                selfie_image_url: 'http://foo.com/bar3' }
@@ -192,6 +195,9 @@ describe Idv::DocAuthController do
         put :update, params: { step: 'verify_document',
                                document_capture_session_uuid: 'foo',
                                encryption_key: 'bar',
+                               front_image_iv: 'iv1',
+                               back_image_iv: 'iv2',
+                               selfie_image_iv: 'iv3',
                                front_image_url: 'http://foo.com/bar1',
                                back_image_url: 'http://foo.com/bar2',
                                selfie_image_url: 'http://foo.com/bar3' }

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -163,16 +163,48 @@ describe Idv::DocAuthController do
       { success: true, errors: {}, extra: { remaining_attempts: 3 } }.to_json
     end
 
-    it 'successfully submits the images' do
-      put :update, params: { step: 'verify_document',
-                             document_capture_session_uuid: 'foo',
-                             encryption_key: 'bar',
-                             front_image_url: 'http://foo.com/bar1',
-                             back_image_url: 'http://foo.com/bar2',
-                             selfie_image_url: 'http://foo.com/bar3' }
+    context 'with selfie checking disabled' do
+      it 'successfully submits the images' do
+        put :update, params: { step: 'verify_document',
+                               document_capture_session_uuid: 'foo',
+                               encryption_key: 'bar',
+                               front_image_url: 'http://foo.com/bar1',
+                               back_image_url: 'http://foo.com/bar2',
+                               selfie_image_url: 'http://foo.com/bar3' }
 
-      expect(response.status).to eq(200)
-      expect(response.body).to eq(successful_response)
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(successful_response)
+      end
+
+      it 'fails to submit the images' do
+        put :update, params: { step: 'verify_document' }
+
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context 'with selfie checking enabled' do
+      before do
+        allow(Figaro.env).to receive(:liveness_checking_enabled).and_return('true')
+      end
+
+      it 'successfully submits the images' do
+        put :update, params: { step: 'verify_document',
+                               document_capture_session_uuid: 'foo',
+                               encryption_key: 'bar',
+                               front_image_url: 'http://foo.com/bar1',
+                               back_image_url: 'http://foo.com/bar2',
+                               selfie_image_url: 'http://foo.com/bar3' }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(successful_response)
+      end
+
+      it 'fails to submit the images' do
+        put :update, params: { step: 'verify_document' }
+
+        expect(response.status).to eq(400)
+      end
     end
   end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -171,7 +171,7 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
-    let(:good_result) { { errors: {}, messages: ['some message'] } }
+    let(:good_result) { { pii_from_doc: {}, success: true, errors: {}, messages: ['some message'] } }
 
     it 'returns status of success' do
       mock_document_capture_result(good_result)

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -181,6 +181,7 @@ describe Idv::DocAuthController do
       mock_document_capture_step
     end
     let(:good_result) { { pii_from_doc: {}, success: true, errors: {}, messages: ['message'] } }
+    let(:fail_result) { { pii_from_doc: {}, success: false, errors: {}, messages: ['message'] } }
 
     it 'returns status of success' do
       mock_document_capture_result(good_result)
@@ -196,6 +197,14 @@ describe Idv::DocAuthController do
 
       expect(response.status).to eq(200)
       expect(response.body).to eq({ success: true, status: 'in_progress' }.to_json)
+    end
+
+    it 'returns status of fail' do
+      mock_document_capture_result(fail_result)
+      put :update, params: { step: 'verify_document_status' }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to eq({ success: true, status: 'fail' }.to_json)
     end
   end
 


### PR DESCRIPTION
**Why**: API for react client to submit image urls and encryption key of previously uploaded and encrypted images for async processing to background job and poll for results. 
**How**: Rather than create a new controller, modify FSM to be able to take actions and return JSON.  This allows us to get the full context and satisfy steps, etc.  