### PR TITLE
LG-3419: Add background upload for images in document capture

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
     "no-plusplus": "off",
+    "no-restricted-syntax": "off",
     "no-unused-expressions": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -3,6 +3,7 @@ import AcuantCapture from './acuant-capture';
 import FormErrorMessage from './form-error-message';
 import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
+import withBackgroundEncryptedUpload from '../higher-order/with-background-encrypted-upload';
 
 /**
  * @typedef DocumentsStepValue
@@ -63,4 +64,4 @@ function DocumentsStep({
   );
 }
 
-export default DocumentsStep;
+export default withBackgroundEncryptedUpload(DocumentsStep);

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -5,6 +5,7 @@ import DeviceContext from '../context/device';
 import AcuantCapture from './acuant-capture';
 import SelfieCapture from './selfie-capture';
 import FormErrorMessage from './form-error-message';
+import withBackgroundEncryptedUpload from '../higher-order/with-background-encrypted-upload';
 
 /**
  * @typedef SelfieStepValue
@@ -58,4 +59,4 @@ function SelfieStep({
   );
 }
 
-export default SelfieStep;
+export default withBackgroundEncryptedUpload(SelfieStep);

--- a/app/javascript/packages/document-capture/components/submission.jsx
+++ b/app/javascript/packages/document-capture/components/submission.jsx
@@ -37,7 +37,7 @@ export async function resolveObjectValues(object) {
  * @return {(...args:any)=>Promise<any>} Promise resolving once all promise creators in series have
  * run.
  */
-export const series = (promiseCreators) => (value) =>
+export const series = (...promiseCreators) => (value) =>
   promiseCreators.reduce((current, next) => current.then(next), Promise.resolve(value));
 
 /**
@@ -52,7 +52,7 @@ export const series = (promiseCreators) => (value) =>
  */
 function Submission({ payload, onError }) {
   const { upload } = useContext(UploadContext);
-  const resource = useAsync(series([resolveObjectValues, upload]), payload);
+  const resource = useAsync(series(resolveObjectValues, upload), payload);
 
   return (
     <SuspenseErrorBoundary

--- a/app/javascript/packages/document-capture/components/submission.jsx
+++ b/app/javascript/packages/document-capture/components/submission.jsx
@@ -7,6 +7,40 @@ import SubmissionInterstitial from './submission-interstitial';
 import CallbackOnMount from './callback-on-mount';
 
 /**
+ * Given an object where some values may be promises, returns a promise which resolves to an object
+ * with the same keys and all resolved promise values.
+ *
+ * @template {Record<string, any>} T
+ *
+ * @param {T} object
+ *
+ * @return {Promise<Record<keyof T, any>>} Object with all values resolved.
+ */
+export async function resolveObjectValues(object) {
+  const resolved = {};
+
+  for (const [key, value] of Object.entries(object)) {
+    // Disable reason: While typically inadvisable since await blocks continued iteration of the
+    // loop, the intent of the function is to not resolve until all member values have settled.
+    // eslint-disable-next-line no-await-in-loop
+    resolved[key] = await value;
+  }
+
+  return /** @type {Record<keyof T, any>} */ (resolved);
+}
+
+/**
+ * Returns a function which runs an array of promise creator functions in series (sequential) order.
+ *
+ * @param {Array<(...args:any)=>Promise<any>>} promiseCreators Promise creator functions.
+ *
+ * @return {(...args:any)=>Promise<any>} Promise resolving once all promise creators in series have
+ * run.
+ */
+export const series = (promiseCreators) => (value) =>
+  promiseCreators.reduce((current, next) => current.then(next), Promise.resolve(value));
+
+/**
  * @typedef SubmissionProps
  *
  * @prop {Record<string,string>} payload Payload object.
@@ -18,7 +52,7 @@ import CallbackOnMount from './callback-on-mount';
  */
 function Submission({ payload, onError }) {
   const { upload } = useContext(UploadContext);
-  const resource = useAsync(upload, payload);
+  const resource = useAsync(series([resolveObjectValues, upload]), payload);
 
   return (
     <SuspenseErrorBoundary

--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -4,6 +4,7 @@ import defaultUpload from '../services/upload';
 const UploadContext = createContext({
   upload: defaultUpload,
   isMockClient: false,
+  backgroundUploadURLs: /** @type {Record<string,string>} */ ({}),
 });
 
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -50,6 +51,8 @@ const UploadContext = createContext({
  *
  * @prop {UploadImplementation=} upload Custom upload implementation.
  * @prop {boolean=} isMockClient Whether to treat upload as a mock implementation.
+ * @prop {Record<string,string>} backgroundUploadURLs URLs to which payload values corresponding to
+ * key should be uploaded as soon as possible.
  * @prop {string} endpoint Endpoint to which payload should be sent.
  * @prop {string} csrf CSRF token to send as parameter to upload implementation.
  * @prop {Record<string,any>} formData Extra form data to merge into the payload before uploading
@@ -62,13 +65,18 @@ const UploadContext = createContext({
 function UploadContextProvider({
   upload = defaultUpload,
   isMockClient = false,
+  backgroundUploadURLs = {},
   endpoint,
   csrf,
   formData,
   children,
 }) {
   const uploadWithCSRF = (payload) => upload({ ...payload, ...formData }, { endpoint, csrf });
-  const value = useMemo(() => ({ upload: uploadWithCSRF, isMockClient }), [upload, isMockClient]);
+  const value = useMemo(() => ({ upload: uploadWithCSRF, backgroundUploadURLs, isMockClient }), [
+    upload,
+    backgroundUploadURLs,
+    isMockClient,
+  ]);
 
   return <UploadContext.Provider value={value}>{children}</UploadContext.Provider>;
 }

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -13,10 +13,9 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
       nextValuesWithUpload[key] = value;
       const url = backgroundUploadURLs[key];
       if (url && value) {
-        nextValuesWithUpload[`${key}BackgroundUpload`] = window.fetch(url, {
-          method: 'POST',
-          body: value,
-        });
+        nextValuesWithUpload[`${key}BackgroundUpload`] = window
+          .fetch(url, { method: 'POST', body: value })
+          .then(() => undefined);
       }
     }
 

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+import UploadContext from '../context/upload';
+
+const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) => {
+  const { backgroundUploadURLs } = useContext(UploadContext);
+
+  /**
+   * @param {Record<string, string|Blob|null|undefined>} nextValues Next values.
+   */
+  function onChangeWithBackgroundEncryptedUpload(nextValues) {
+    const nextValuesWithUpload = {};
+    for (const [key, value] of Object.entries(nextValues)) {
+      nextValuesWithUpload[key] = value;
+      const url = backgroundUploadURLs[key];
+      if (url && value) {
+        nextValuesWithUpload[`${key}BackgroundUpload`] = window.fetch(url, {
+          method: 'POST',
+          body: value,
+        });
+      }
+    }
+
+    onChange(nextValuesWithUpload);
+  }
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <Component {...props} onChange={onChangeWithBackgroundEncryptedUpload} />;
+};
+
+export default withBackgroundEncryptedUpload;

--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -21,7 +21,11 @@ export class UploadFormEntriesError extends Error {
  */
 export function toFormData(object) {
   return Object.keys(object).reduce((form, key) => {
-    form.append(key, object[key]);
+    const value = object[key];
+    if (value !== undefined) {
+      form.append(key, value);
+    }
+
     return form;
   }, new window.FormData());
 }

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -30,6 +30,20 @@ function getServiceProvider() {
   return { name, failureToProofURL, isLivenessRequired };
 }
 
+/**
+ * @return {Record<'front'|'back'|'selfie', string>}
+ */
+function getBackgroundUploadURLs() {
+  return ['front', 'back', 'selfie'].reduce((result, key) => {
+    const url = appRoot.getAttribute(`data-${key}-image-upload-url`);
+    if (url) {
+      result[key] = url;
+    }
+
+    return result;
+  }, {});
+}
+
 function getMetaContent(name) {
   return document.querySelector(`meta[name="${name}"]`)?.content ?? null;
 }
@@ -49,6 +63,7 @@ loadPolyfills(['fetch']).then(() => {
         endpoint={appRoot.getAttribute('data-endpoint')}
         csrf={getMetaContent('csrf-token')}
         isMockClient={isMockClient}
+        backgroundUploadURLs={getBackgroundUploadURLs()}
         formData={{
           document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
           locale: i18n.currentLocale(),

--- a/spec/javascripts/packages/document-capture/components/submission-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-spec.jsx
@@ -18,10 +18,10 @@ describe('resolveObjectValues', () => {
 
 describe('series', () => {
   it('runs promise in chain series', async () => {
-    const run = series([
+    const run = series(
       (current) => Promise.resolve(`${current}b`),
       (current) => Promise.resolve(`${current}c`),
-    ]);
+    );
 
     const result = await run('a');
 

--- a/spec/javascripts/packages/document-capture/components/submission-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-spec.jsx
@@ -1,0 +1,30 @@
+import { resolveObjectValues, series } from '@18f/identity-document-capture/components/submission';
+
+describe('resolveObjectValues', () => {
+  it('returns an object with resolved values', async () => {
+    const result = await resolveObjectValues({
+      a: 1,
+      b: Promise.resolve(2),
+      c: 3,
+    });
+
+    expect(result).to.deep.equal({
+      a: 1,
+      b: 2,
+      c: 3,
+    });
+  });
+});
+
+describe('series', () => {
+  it('runs promise in chain series', async () => {
+    const run = series([
+      (current) => Promise.resolve(`${current}b`),
+      (current) => Promise.resolve(`${current}c`),
+    ]);
+
+    const result = await run('a');
+
+    expect(result).to.equal('abc');
+  });
+});

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react';
+import sinon from 'sinon';
+import { UploadContextProvider } from '@18f/identity-document-capture';
+import withBackgroundEncryptedUpload from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
+import { useSandbox } from '../../../support/sinon';
+import render from '../../../support/render';
+
+describe('withBackgroundEncryptedUpload', () => {
+  const sandbox = useSandbox();
+
+  const Component = withBackgroundEncryptedUpload(({ onChange }) => {
+    useEffect(() => {
+      onChange({ foo: 'bar', baz: 'quux' });
+    }, []);
+
+    return null;
+  });
+
+  it('intercepts onChange to include background uploads', async () => {
+    const onChange = sinon.spy();
+    sandbox.stub(window, 'fetch').callsFake(() => Promise.resolve({}));
+    render(
+      <UploadContextProvider backgroundUploadURLs={{ foo: 'about:blank' }}>
+        <Component onChange={onChange} />)
+      </UploadContextProvider>,
+    );
+
+    expect(onChange.calledOnce).to.be.true();
+    const patch = onChange.getCall(0).args[0];
+    expect(patch).to.have.keys(['foo', 'baz', 'fooBackgroundUpload']);
+    expect(patch.foo).to.equal('bar');
+    expect(patch.baz).to.equal('quux');
+    expect(patch.fooBackgroundUpload).to.be.an.instanceOf(Promise);
+    expect(window.fetch.calledOnce).to.be.true();
+    expect(window.fetch.getCall(0).args).to.deep.equal([
+      'about:blank',
+      {
+        method: 'POST',
+        body: 'bar',
+      },
+    ]);
+    expect(await patch.fooBackgroundUpload).to.be.undefined();
+  });
+});

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -16,6 +16,12 @@ describe('document-capture/services/upload', () => {
       expect(result).to.be.instanceOf(window.FormData);
       expect(/** @type {FormData} */ (result).get('foo')).to.equal('bar');
     });
+
+    it('omits undefined values', () => {
+      const result = toFormData({ foo: 'bar', bar: null, baz: undefined });
+
+      expect([...result.keys()]).to.have.members(['foo', 'bar']);
+    });
   });
 
   describe('toFormEntryError', () => {


### PR DESCRIPTION
**Why**: In anticipation to support async upload to S3, use presigned URLs (if available) to upload images at time of value change. Submission will only occur once all images have completed uploading, and will error appropriately if async upload fails.

This is intended to be compatible with environments configured both with and without presigned S3 URL usage.

**Not implemented here:**

- Encryption