### PR TITLE
Update string usage from doc auth gem

### DIFF
--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -3,7 +3,9 @@ module DocAuthRouter
   def self.client
     case doc_auth_vendor
     when 'acuant'
+      # i18n-tasks-use t('errors.doc_auth.acuant_network_error')
       # i18n-tasks-use t('errors.doc_auth.general_error')
+      # i18n-tasks-use t('errors.doc_auth.selfie')
       IdentityDocAuth::Acuant::AcuantClient.new(
         assure_id_password: Figaro.env.acuant_assure_id_password,
         assure_id_subscription_id: Figaro.env.acuant_assure_id_subscription_id,

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -53,7 +53,6 @@
 - errors.doc_auth.document_capture_selfie_consent_blocked
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_glare
-- errors.doc_auth.selfie
 - errors.file_input.invalid_type
 - errors.messages.format_mismatch
 - errors.messages.missing_field


### PR DESCRIPTION
**Why**: A race condition between merges of #4317 and #4307 result in a build failure on the main branch.

```
Failures:

  1) I18n does not have unused keys
     Failure/Error:
       expect(unused_keys).to(
         be_empty,
         "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them",
       )
     
       3 unused i18n keys, run `i18n-tasks unused' to show them
     # ./spec/i18n_spec.rb:19:in `block (2 levels) in <top (required)>'
```

Specifically, the usage of `errors.doc_auth.selfie` is left unused after a combination of both #4317 and #4307.

The string [is still used](https://github.com/18F/identity-doc-auth/blob/f61b5b76c71659d33a40b87e769252dc80d2af43/lib/identity_doc_auth/acuant/responses/liveness_response.rb#L28), but was not included in the set of override strings listed in #4307. Additionally, it was not removed from the set of strings included in the JavaScript startup in #4317.