### PR TITLE
Update identity-doc-auth gem to extract translation logic from Acuant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'foundation_emails'
 gem 'gibberish'
 gem 'hiredis'
 gem 'http_accept_language'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'ee8dafb97db4226287f7651cc596f69f59ecf58c' # TODO: use tag
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.2.0'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.1'
 require File.join(__dir__, 'app', 'services', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'foundation_emails'
 gem 'gibberish'
 gem 'hiredis'
 gem 'http_accept_language'
-gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.1.0'
+gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'ee8dafb97db4226287f7651cc596f69f59ecf58c' # TODO: use tag
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.1'
 require File.join(__dir__, 'app', 'services', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: f61b5b76c71659d33a40b87e769252dc80d2af43
-  tag: v0.1.0
+  revision: ee8dafb97db4226287f7651cc596f69f59ecf58c
+  tag: ee8dafb97db4226287f7651cc596f69f59ecf58c
   specs:
-    identity-doc-auth (0.1.0)
+    identity-doc-auth (0.2.0)
       activesupport
       faraday
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-doc-auth.git
-  revision: ee8dafb97db4226287f7651cc596f69f59ecf58c
-  tag: ee8dafb97db4226287f7651cc596f69f59ecf58c
+  revision: f4d5bcecd3c14d3d3183d1bb88ddccfff296f4c1
+  tag: v0.2.0
   specs:
     identity-doc-auth (0.2.0)
       activesupport

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -45,6 +45,7 @@ module DocAuthRouter
       end&.uniq!
     end
 
+    # rubocop:disable Style/GuardClause
     def translate_generic_errors!(response)
       if response.errors[:network] == true
         response.errors[:network] = ::I18n.t('errors.doc_auth.acuant_network_error')
@@ -54,6 +55,7 @@ module DocAuthRouter
         response.errors[:selfie] = ::I18n.t('errors.doc_auth.selfie')
       end
     end
+    # rubocop:enable Style/GuardClause
   end
 
   def self.client
@@ -69,7 +71,7 @@ module DocAuthRouter
           passlive_url: Figaro.env.acuant_passlive_url,
           timeout: Figaro.env.acuant_timeout,
           exception_notifier: method(:notify_exception),
-        )
+        ),
       )
     when 'lexisnexis'
       # i18n-tasks-use t('doc_auth.errors.lexis_nexis.barcode_content_check')

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -1,6 +1,6 @@
 # Helps route between various doc auth backends, provided by the identity-doc-auth gem
 module DocAuthRouter
-  class AcuantErrorTranslatorProxy < BasicObject
+  class AcuantErrorTranslatorProxy
     def initialize(client)
       @client = client
     end
@@ -26,7 +26,7 @@ module DocAuthRouter
 
     # Translates IdentityDocAuth::GetResultsResponse errors
     def translate_form_response!(response)
-      return response unless response.is_a?(::IdentityDocAuth::Response)
+      return response unless response.is_a?(IdentityDocAuth::Response)
 
       translate_friendly_errors!(response)
       translate_generic_errors!(response)
@@ -36,9 +36,9 @@ module DocAuthRouter
 
     def translate_friendly_errors!(response)
       response.errors[:results]&.map! do |untranslated_error|
-        friendly_message = ::FriendlyError::Message.call(untranslated_error, 'doc_auth')
+        friendly_message = FriendlyError::Message.call(untranslated_error, 'doc_auth')
         if friendly_message == untranslated_error
-          ::I18n.t('errors.doc_auth.general_error')
+          I18n.t('errors.doc_auth.general_error')
         else
           friendly_message
         end
@@ -48,11 +48,11 @@ module DocAuthRouter
     # rubocop:disable Style/GuardClause
     def translate_generic_errors!(response)
       if response.errors[:network] == true
-        response.errors[:network] = ::I18n.t('errors.doc_auth.acuant_network_error')
+        response.errors[:network] = I18n.t('errors.doc_auth.acuant_network_error')
       end
 
       if response.errors[:selfie] == true
-        response.errors[:selfie] = ::I18n.t('errors.doc_auth.selfie')
+        response.errors[:selfie] = I18n.t('errors.doc_auth.selfie')
       end
     end
     # rubocop:enable Style/GuardClause

--- a/app/services/doc_auth_router.rb
+++ b/app/services/doc_auth_router.rb
@@ -1,13 +1,11 @@
 # Helps route between various doc auth backends, provided by the identity-doc-auth gem
 module DocAuthRouter
+  # Adds translations to responses from Acuant
   class AcuantErrorTranslatorProxy
+    attr_reader :client
+
     def initialize(client)
       @client = client
-    end
-
-    # Used for detecting if we have a proxy or the real thing
-    def proxy?
-      true
     end
 
     def method_missing(name, *args, &block)

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe DocAuthRouter do
       let(:acuant_simulator) { '' }
 
       it 'is a translation-proxied acuant client' do
-        expect(DocAuthRouter.client).to be_a(IdentityDocAuth::Acuant::AcuantClient)
-        expect(DocAuthRouter.client.proxy?).to eq(true)
+        expect(DocAuthRouter.client).to be_a(DocAuthRouter::AcuantErrorTranslatorProxy)
+        expect(DocAuthRouter.client.client).to be_a(IdentityDocAuth::Acuant::AcuantClient)
       end
     end
 

--- a/spec/services/doc_auth_router_spec.rb
+++ b/spec/services/doc_auth_router_spec.rb
@@ -88,10 +88,12 @@ RSpec.describe DocAuthRouter do
       response = I18n.with_locale(:es) { proxy.get_results(instance_id: 'abcdef') }
 
       expect(response.errors[:some_other_key]).to eq(['will not be translated'])
-      expect(response.errors[:results]).to match_array([
-        I18n.t('errors.doc_auth.general_error', locale: :es),
-        I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read', locale: :es),
-      ])
+      expect(response.errors[:results]).to match_array(
+        [
+          I18n.t('errors.doc_auth.general_error', locale: :es),
+          I18n.t('friendly_errors.doc_auth.barcode_could_not_be_read', locale: :es),
+        ],
+      )
     end
 
     it 'translates generic network errors' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -207,15 +207,11 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
       Faraday::Response,
       body: AcuantFixtures.get_results_response_failure,
     )
-    config = IdentityDocAuth::Acuant::Config.new(
-      friendly_error_message: FriendlyError::Message,
-      friendly_error_find_key: FriendlyError::FindKey,
-    )
     IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
       method: :get_results,
       response: IdentityDocAuth::Acuant::Responses::GetResultsResponse.new(
         failed_http_response,
-        config,
+        IdentityDocAuth::Acuant::Config.new,
       ),
     )
   end


### PR DESCRIPTION
**Why**: Simplify the gem and its logic, makes that code more
useful as part of an async job outside the IDP

--

See https://github.com/18F/identity-doc-auth/pull/2 for the gem changes

The changes:
- The gem returns literal `true` for generic errors instead of a string
- The gem returns untranslated error messages for `:results` key