### PR TITLE
Wrap document capture error message at bounds of file input

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "prefer-arrow-callback": 0,
     "import/prefer-default-export": "off",
     "import/extensions": ["off", "never"],
+    "import/no-extraneous-dependencies": "error",
     "indent": "off",
     "max-classes-per-file": "off",
     "newline-per-chained-call": "off",

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -1,39 +1,3 @@
-.id-card-file-input .usa-file-input {
-  max-width: 375px;
-
-  &:not(.usa-file-input--has-value) {
-    @include u-margin-top(1);
-    position: relative;
-
-    .usa-file-input__target {
-      align-items: center;
-      bottom: 0;
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      justify-content: center;
-      left: 0;
-      margin-top: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-
-    &::after {
-      content: '';
-      display: block;
-      // 2.125" x 3.375" are common standard ID dimensions
-      padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
-    }
-  }
-
-  .document-capture-file-image--loading {
-    display: block;
-    // 2.125" x 3.375" are common standard ID dimensions
-    padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
-  }
-}
-
 //================================================
 // Pending upstream Login Design System revisions:
 //================================================

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -201,6 +201,7 @@ function AcuantCapture(
         label={label}
         hint={hasCapture || !allowUpload ? undefined : t('doc_auth.tips.document_capture_hint')}
         bannerText={bannerText}
+        invalidTypeText={t('errors.doc_auth.invalid_file_input_type')}
         accept={isMockClient ? undefined : ['image/jpeg', 'image/png', 'image/bmp', 'image/tiff']}
         capture={capture}
         value={value}

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -16,6 +16,7 @@ import useI18n from '../hooks/use-i18n';
 import DeviceContext from '../context/device';
 import UploadContext from '../context/upload';
 import useIfStillMounted from '../hooks/use-if-still-mounted';
+import './acuant-capture.scss';
 
 /** @typedef {import('react').ReactNode} ReactNode */
 
@@ -173,7 +174,7 @@ function AcuantCapture(
   }
 
   return (
-    <div className={className}>
+    <div className={[className, 'document-capture-acuant-capture'].filter(Boolean).join(' ')}>
       {isCapturingEnvironment && (
         <FullScreen onRequestClose={() => setIsCapturingEnvironment(false)}>
           <AcuantCaptureCanvas

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -2,6 +2,12 @@
 #document-capture-form .document-capture-acuant-capture { // scss-lint:disable IdSelector
   max-width: 375px;
 
+  %pad-common-id-card {
+    display: block;
+    // 2.125" x 3.375" are common standard ID dimensions
+    padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
+  }
+
   .usa-file-input:not(.usa-file-input--has-value) {
     @include u-margin-top(1);
     position: relative;
@@ -22,16 +28,12 @@
     }
 
     &::after {
+      @extend %pad-common-id-card;
       content: '';
-      display: block;
-      // 2.125" x 3.375" are common standard ID dimensions
-      padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
     }
   }
 
   .document-capture-file-image--loading {
-    display: block;
-    // 2.125" x 3.375" are common standard ID dimensions
-    padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
+    @extend %pad-common-id-card;
   }
 }

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -1,0 +1,37 @@
+// Note: ID specifier necessary only until USWDS upgraded.
+#document-capture-form .document-capture-acuant-capture { // scss-lint:disable IdSelector
+  max-width: 375px;
+
+  .usa-file-input:not(.usa-file-input--has-value) {
+    @include u-margin-top(1);
+    position: relative;
+
+    // Note: Lint disable is no longer necessary after above ID specifier is removed.
+    .usa-file-input__target { // scss-lint:disable SelectorDepth
+      align-items: center;
+      bottom: 0;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      justify-content: center;
+      left: 0;
+      margin-top: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    &::after {
+      content: '';
+      display: block;
+      // 2.125" x 3.375" are common standard ID dimensions
+      padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
+    }
+  }
+
+  .document-capture-file-image--loading {
+    display: block;
+    // 2.125" x 3.375" are common standard ID dimensions
+    padding-bottom: ((2.125 / 3.375) * 100) + unquote('%');
+  }
+}

--- a/app/javascript/packages/document-capture/components/documents-step.jsx
+++ b/app/javascript/packages/document-capture/components/documents-step.jsx
@@ -55,7 +55,6 @@ function DocumentsStep({
             bannerText={t(`doc_auth.headings.${side}`)}
             value={value[side]}
             onChange={(nextValue) => onChange({ [side]: nextValue })}
-            className="id-card-file-input"
             errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
           />
         );

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -15,6 +15,7 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string} label Input label.
  * @prop {string=} hint Optional hint text.
  * @prop {string=} bannerText Optional banner overlay text.
+ * @prop {string=} invalidTypeText Error message text to show on invalid file type selection.
  * @prop {string[]=} accept Optional array of file input accept patterns.
  * @prop {'user'|'environment'=} capture Optional facing mode if file input is used for capture.
  * @prop {Blob|string|null|undefined} value Current value.
@@ -90,6 +91,7 @@ const FileInput = forwardRef((props, ref) => {
     label,
     hint,
     bannerText,
+    invalidTypeText,
     accept,
     capture,
     value,
@@ -119,7 +121,7 @@ const FileInput = forwardRef((props, ref) => {
       if (isValidForAccepts(file.type, accept)) {
         onChange(file);
       } else {
-        const nextOwnErrorMessage = t('errors.file_input.invalid_type');
+        const nextOwnErrorMessage = invalidTypeText ?? t('errors.file_input.invalid_type');
         setOwnErrorMessage(nextOwnErrorMessage);
         onError(nextOwnErrorMessage);
       }

--- a/app/javascript/packages/document-capture/components/review-issues-step.jsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.jsx
@@ -80,7 +80,7 @@ function ReviewIssuesStep({
             bannerText={t(`doc_auth.headings.${side}`)}
             value={value[side]}
             onChange={(nextValue) => onChange({ [side]: nextValue })}
-            className="id-card-file-input document-capture-review-issues-step__input"
+            className="document-capture-review-issues-step__input"
             errorMessage={sideError ? <FormErrorMessage error={sideError} /> : undefined}
           />
         );
@@ -104,7 +104,7 @@ function ReviewIssuesStep({
               value={value.selfie}
               onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
               allowUpload={false}
-              className="id-card-file-input document-capture-review-issues-step__input"
+              className="document-capture-review-issues-step__input"
               errorMessage={selfieError ? <FormErrorMessage error={selfieError} /> : undefined}
             />
           ) : (

--- a/app/javascript/packages/document-capture/components/selfie-step.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.jsx
@@ -44,7 +44,6 @@ function SelfieStep({
           value={value.selfie}
           onChange={(nextSelfie) => onChange({ selfie: nextSelfie })}
           allowUpload={false}
-          className="id-card-file-input"
           errorMessage={error ? <FormErrorMessage error={error} /> : undefined}
         />
       ) : (

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -51,6 +51,7 @@
 - errors.doc_auth.acuant_network_error
 - errors.doc_auth.capture_failure
 - errors.doc_auth.document_capture_selfie_consent_blocked
+- errors.doc_auth.invalid_file_input_type
 - errors.doc_auth.photo_blurry
 - errors.doc_auth.photo_glare
 - errors.file_input.invalid_type

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -61,6 +61,8 @@ en:
         <li class="mxn3">The background behind your ID is a solid color</li>
         <li class="mxn3">Background is visible behind the document</li>
         </ul>
+      invalid_file_input_type: This file type is not accepted, please choose a JPG,
+        PNG, BMP, or TIFF file.
       phone_step_incomplete: You must go to your phone and upload photos of your ID
         before continuing. We sent you a link with instructions.
       photo_blurry: Photo is too blurry, please try again.

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -74,7 +74,7 @@ en:
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
     file_input:
-      invalid_type: This file type is not accepted, please choose another.
+      invalid_type: This file type is not accepted, please try again.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You've entered too many incorrect passwords. You

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -72,7 +72,7 @@ en:
       send_link_throttle: You tried too many times, please try again in 10 minutes.
         You can also click on Start Over and choose to use your computer instead.
     file_input:
-      invalid_type: This file type is not accepted, please choose another file.
+      invalid_type: This file type is not accepted, please choose another.
     invalid_authenticity_token: Oops, something went wrong. Please try again.
     invalid_totp: Invalid code. Please try again.
     max_password_attempts_reached: You've entered too many incorrect passwords. You

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -61,6 +61,8 @@ es:
         <li class="mxn3">El fondo detrás de su identificación es un color sólido</li>
         <li class="mxn3">El fondo es visible detrás del documento</li>
         </ul>
+      invalid_file_input_type: No se acepta este tipo de archivo, elija un archivo
+        JPG, PNG, BMP o TIFF.
       phone_step_incomplete: Debe ir a su teléfono y cargar fotos de su identificación
         antes de continuar. Te enviamos un enlace con instrucciones.
       photo_blurry: La foto está demasiado borrosa. Vuelve a intentarlo.
@@ -73,7 +75,7 @@ es:
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
     file_input:
-      invalid_type: Este tipo de archivo no es aceptado, elija otro archivo.
+      invalid_type: Este tipo de archivo no es aceptado, elija otro.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -75,7 +75,7 @@ es:
       send_link_throttle: Lo intentaste muchas veces, vuelve a intentarlo en 10 minutos.
         También puedes hacer clic en comenzar de nuevo y elegir usar tu computadora.
     file_input:
-      invalid_type: Este tipo de archivo no es aceptado, elija otro.
+      invalid_type: Este tipo de archivo no es aceptado, inténtalo de nuevo.
     invalid_authenticity_token: "¡Oops! Algo salió mal. Inténtelo de nuevo."
     invalid_totp: El código es inválido. Vuelva a intentarlo.
     max_password_attempts_reached: Ha ingresado demasiadas contraseñas incorrectas.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -60,6 +60,8 @@ fr:
         <li class="mxn3">Le fond derrière votre ID est une couleur unie</li>
         <li class="mxn3">Le fond est visible derrière le document</li>
         </ul>
+      invalid_file_input_type: Ce type de fichier n'est pas accepté, veuillez choisir
+        un fichier JPG, PNG, BMP ou TIFF.
       phone_step_incomplete: Vous devez aller sur votre téléphone et télécharger des
         photos de votre identifiant avant de continuer. Nous vous avons envoyé un
         lien avec des instructions.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -74,8 +74,7 @@ fr:
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
         votre ordinateur.
     file_input:
-      invalid_type: Ce type de fichier n'est pas accepté, veuillez choisir un autre
-        fichier.
+      invalid_type: Ce type de fichier n'est pas accepté, veuillez en choisir un autre.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -76,7 +76,7 @@ fr:
         10 minutes. Vous pouvez également cliquer sur recommencer et choisir d'utiliser
         votre ordinateur.
     file_input:
-      invalid_type: Ce type de fichier n'est pas accepté, veuillez en choisir un autre.
+      invalid_type: Ce type de fichier n'est pas accepté, veuillez réessayer.
     invalid_authenticity_token: Oups, une erreur s'est produite. Veuillez essayer
       de nouveau.
     invalid_totp: Code non valide. Veuillez essayer de nouveau.

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,6 +11,35 @@ babelLoader.include.push(/node_modules\/@18f\/identity-/);
 babelLoader.exclude = /node_modules\/(?!@18f\/identity-)/;
 
 const sassLoader = environment.loaders.get('sass');
+// Note: This option is renamed `additionalData` in newer versions of `sass-loader`.
+// Note: Import paths for USWDS required imports have improved in newer versions.
+//       See: https://github.com/uswds/uswds/blob/50f6ffd6/src/stylesheets/packages/_required.scss
+sassLoader.use.find(({ loader }) => loader === 'sass-loader').options.data = `
+$font-path: '~identity-style-guide/dist/assets/fonts';
+$image-path: '~identity-style-guide/dist/assets/img';
+@import '~identity-style-guide/dist/assets/scss/functions/asset-path';
+@import '~identity-style-guide/dist/assets/scss/functions/focus';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/custom-styles';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/general';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/typography';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/spacing';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/color';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/utilities';
+@import '~identity-style-guide/dist/assets/scss/uswds-theme/components';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-general';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-typography';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-color';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-spacing';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-utilities';
+@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-components';
+@import '~identity-style-guide/dist/assets/scss/uswds/core/functions';
+@import '~identity-style-guide/dist/assets/scss/uswds/core/system-tokens';
+@import '~identity-style-guide/dist/assets/scss/uswds/core/variables';
+@import '~identity-style-guide/dist/assets/scss/uswds/core/properties';
+@import '~identity-style-guide/dist/assets/scss/uswds/core/mixins/all';
+@import '~identity-style-guide/dist/assets/scss/uswds/utilities/palettes/all';
+@import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/all';
+@import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/package';`;
 
 const sourceMapLoader = {
   test: /\.js$/,

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,7 +11,6 @@ babelLoader.include.push(/node_modules\/@18f\/identity-/);
 babelLoader.exclude = /node_modules\/(?!@18f\/identity-)/;
 
 const sassLoader = environment.loaders.get('sass');
-sassLoader.use = sassLoader.use.filter(({ loader }) => loader !== 'postcss-loader');
 
 const sourceMapLoader = {
   test: /\.js$/,

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-react-hooks": "^4.0.6",
     "jsdom": "^16.2.2",
     "mocha": "^8.1.3",
+    "postcss-clean": "^1.1.0",
     "prettier": "^2.0.5",
     "react-test-renderer": "^16.13.1",
     "sinon": "^9.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+const clean = require('postcss-clean');
+
+module.exports = {
+  plugins: [
+    clean({
+      format: process.env.NODE_ENV === 'production' ? undefined : 'beautify',
+    }),
+  ],
+};

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -335,13 +335,13 @@ describe('document-capture/components/acuant-capture', () => {
       const input = getByLabelText('Image');
       userEvent.upload(input, file);
 
-      expect(await findByText('errors.file_input.invalid_type')).to.be.ok();
+      expect(await findByText('errors.doc_auth.invalid_file_input_type')).to.be.ok();
 
       const button = getByText('doc_auth.buttons.take_picture');
       fireEvent.click(button);
 
       expect(getByText('errors.doc_auth.photo_blurry')).to.be.ok();
-      expect(() => getByText('errors.file_input.invalid_type')).to.throw();
+      expect(() => getByText('errors.doc_auth.invalid_file_input_type')).to.throw();
     });
 
     it('removes error message once image is corrected', async () => {

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -303,6 +303,27 @@ describe('document-capture/components/file-input', () => {
     expect(onError.getCall(0).args[0]).to.equal('errors.file_input.invalid_type');
   });
 
+  it('allows customization of invalid file type error message', () => {
+    const file = new window.File([''], 'upload.png', { type: 'image/png' });
+    const onChange = sinon.stub();
+    const onError = sinon.stub();
+    const { getByLabelText, getByText } = render(
+      <FileInput
+        label="File"
+        accept={['text/*']}
+        onChange={onChange}
+        onError={onError}
+        invalidTypeText="Wrong type"
+      />,
+    );
+
+    const input = getByLabelText('File');
+    userEvent.upload(input, file);
+
+    expect(getByText('Wrong type')).to.be.ok();
+    expect(onError.getCall(0).args[0]).to.equal('Wrong type');
+  });
+
   it('shows an error from rendering parent', () => {
     const file = new window.File([''], 'upload.png', { type: 'image/png' });
     const onChange = sinon.stub();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,6 +3204,13 @@ classlist-polyfill@^1.0.3, classlist-polyfill@^1.2.0:
   resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
   integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
 
+clean-css@^4.x:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
+  integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
+  dependencies:
+    source-map "~0.6.0"
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -7617,6 +7624,14 @@ postcss-calc@^7.0.1:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.0.2"
 
+postcss-clean@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-clean/-/postcss-clean-1.1.0.tgz#c2d61d5d8caf19a585adba16897726c2674c4207"
+  integrity sha512-83g3GqMbCM5NL6MlbbPLJ/m2NrUepBF44MoDk4Gt04QGXeXKh9+ilQa0DzLnYnvqYHQCw83nckuEzBFr2muwbg==
+  dependencies:
+    clean-css "^4.x"
+    postcss "^6.x"
+
 postcss-color-functional-notation@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz#5efd37a88fbabeb00a2966d1e53d98ced93f74e0"
@@ -8234,6 +8249,15 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+
+postcss@^6.x:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.32"
@@ -9307,7 +9331,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -9647,7 +9671,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
**Why**: Per design feedback.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/96734294-640d3800-1388-11eb-8bb1-e7eab423012b.png)|![after](https://user-images.githubusercontent.com/1779930/96734065-23152380-1388-11eb-9390-32cc84a6f708.png)

**Implementation Notes:**

This turned out to require a messy cascade of unrelated revisions, triggered by a desire to adopt CSS imported via React components (introduced in #4260). I've made a point to describe the purpose of each of these changes in detailed commit history. Ultimately, it's made worse by outdated and implicit dependencies (see also https://github.com/18F/identity-style-guide/pull/159).

I think these are worth working through in order to benefit from advantages of granular CSS bundles, but for this purpose of this requirement, it might be best to either...

- Limit to contain changes to the main application CSS bundle (`app/assets/stylesheets/components/_file-input.scss`)
- Or: Split out some of the unrelated changes to separate pull requests
- Or: Wait for https://github.com/18F/identity-style-guide/pull/159, which will simplify some of the more unfortunate concessions