### PR TITLE
Allow users to refresh session without reloading page (LG-3530)

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,7 +7,7 @@ module Users
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_signin
 
-    skip_before_action :session_expires_at, only: [:active, :keepalive]
+    skip_before_action :session_expires_at, only: %i[active keepalive]
     skip_before_action :require_no_authentication, only: [:new]
     before_action :store_sp_metadata_in_session, only: [:new]
     before_action :check_user_needs_redirect, only: [:new]

--- a/app/javascript/app/utils/countdown-timer.js
+++ b/app/javascript/app/utils/countdown-timer.js
@@ -19,7 +19,7 @@ export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
     el.innerHTML = msFormatter(remaining);
 
     if (remaining <= 0) {
-      clearInterval(timer)
+      clearInterval(timer);
       return;
     }
 

--- a/app/javascript/app/utils/countdown-timer.js
+++ b/app/javascript/app/utils/countdown-timer.js
@@ -26,6 +26,7 @@ export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
     remaining -= interval;
   }
 
+  tick();
   timer = setInterval(tick, interval);
   return timer;
 };

--- a/app/javascript/app/utils/countdown-timer.js
+++ b/app/javascript/app/utils/countdown-timer.js
@@ -3,6 +3,7 @@ const msFormatter = require('./ms-formatter').default;
 export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
   let remaining = timeLeft;
   let currentTime;
+  let timer;
 
   if (!el || !('innerHTML' in el)) {
     return;
@@ -18,10 +19,13 @@ export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
     el.innerHTML = msFormatter(remaining);
 
     if (remaining <= 0) {
+      cancelInterval(timer);
       return;
     }
+
     remaining -= interval;
-    setTimeout(tick, interval);
   }
-  tick();
+
+  timer = setInterval(tick, interval);
+  return timer;
 };

--- a/app/javascript/app/utils/countdown-timer.js
+++ b/app/javascript/app/utils/countdown-timer.js
@@ -19,7 +19,7 @@ export default (el, timeLeft = 0, endTime = null, interval = 1000) => {
     el.innerHTML = msFormatter(remaining);
 
     if (remaining <= 0) {
-      cancelInterval(timer);
+      clearInterval(timer)
       return;
     }
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -190,6 +190,7 @@ class Analytics
   BACKUP_CODE_SETUP_SUBMITTED = 'Backup Code Setup submitted'.freeze
   SAML_AUTH = 'SAML Auth'.freeze
   SESSION_TIMED_OUT = 'Session Timed Out'.freeze
+  SESSION_KEPT_ALIVE = 'Session Kept Alive'.freeze
   SIGN_IN_PAGE_VISIT = 'Sign in page visited'.freeze
   SP_REDIRECT_INITIATED = 'SP redirect initiated'.freeze
   TELEPHONY_OTP_SENT = 'Telephony: OTP sent'.freeze

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -45,7 +45,7 @@ function success(data) {
     modal.show();
 
     if(countdown_interval) {
-      cancelInterval(countdown_interval)
+      clearInterval(countdown_interval)
     }
     countdown_interval = window.LoginGov.countdownTimer(
       document.getElementById('countdown'), time_remaining, time_timeout

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -45,7 +45,7 @@ function success(data) {
     modal.show();
 
     if(countdown_interval) {
-      clearInterval(countdown_interval)
+      clearInterval(countdown_interval);
     }
     countdown_interval = window.LoginGov.countdownTimer(
       document.getElementById('countdown'), time_remaining, time_timeout

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -7,6 +7,7 @@ warningEl.insertAdjacentHTML('afterbegin', warning_info);
 
 var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
 var keepaliveEl = document.getElementById('session-keepalive-btn');
+var token = document.querySelector('meta[name="csrf-token"]').content
 
 keepaliveEl.addEventListener('click', keepalive, false);
 
@@ -62,8 +63,9 @@ function success(data) {
 
 function keepalive() {
   var request = new XMLHttpRequest();
-  request.open('GET', '/sessions/keepalive', true);
+  request.open('POST', '/sessions/keepalive', true);
   request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+  request.setRequestHeader('X-CSRF-Token', token);
 
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -6,7 +6,12 @@ var warningEl = document.getElementById('session-timeout-cntnr');
 warningEl.insertAdjacentHTML('afterbegin', warning_info);
 
 var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
+var keepaliveEl = document.getElementById('session-keepalive-btn');
+
+keepaliveEl.addEventListener('click', keepalive, false);
+
 var ping_timeout;
+var countdown_interval;
 
 function ping() {
   var request = new XMLHttpRequest();
@@ -38,7 +43,11 @@ function success(data) {
 
   if (show_warning && !modal.shown) {
     modal.show();
-    window.LoginGov.countdownTimer(
+
+    if(countdown_interval) {
+      cancelInterval(countdown_interval)
+    }
+    countdown_interval = window.LoginGov.countdownTimer(
       document.getElementById('countdown'), time_remaining, time_timeout
     );
   }
@@ -49,6 +58,21 @@ function success(data) {
     time_remaining = time_remaining < 0 ? 0 : time_remaining
     ping_timeout = setTimeout(ping, time_remaining)
   }
+}
+
+function keepalive() {
+  var request = new XMLHttpRequest();
+  request.open('GET', '/sessions/keepalive', true);
+  request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
+  request.onload = function() {
+    if (request.status >= 200 && request.status < 400) {
+      success(JSON.parse(request.responseText));
+      modal.hide();
+    }
+  };
+
+  request.send();
 }
 
 setTimeout(ping, start);

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -10,8 +10,8 @@ var keepaliveEl = document.getElementById('session-keepalive-btn');
 
 keepaliveEl.addEventListener('click', keepalive, false);
 
-var ping_timeout;
-var countdown_interval;
+var pingTimeout;
+var countdownInterval;
 
 function ping() {
   var request = new XMLHttpRequest();
@@ -25,7 +25,7 @@ function ping() {
   };
 
   request.send();
-  ping_timeout = setTimeout(ping, frequency)
+  pingTimeout = setTimeout(ping, frequency)
 }
 
 function success(data) {
@@ -44,10 +44,10 @@ function success(data) {
   if (show_warning && !modal.shown) {
     modal.show();
 
-    if(countdown_interval) {
-      clearInterval(countdown_interval);
+    if(countdownInterval) {
+      clearInterval(countdownInterval);
     }
-    countdown_interval = window.LoginGov.countdownTimer(
+    countdownInterval = window.LoginGov.countdownTimer(
       document.getElementById('countdown'), time_remaining, time_timeout
     );
   }

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -22,7 +22,6 @@ var countdownInterval;
 function ping() {
   var request = new XMLHttpRequest();
   request.open('GET', '/active', true);
-  request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {
@@ -69,7 +68,6 @@ function success(data) {
 function keepalive() {
   var request = new XMLHttpRequest();
   request.open('POST', '/sessions/keepalive', true);
-  request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
   request.setRequestHeader('X-CSRF-Token', csrfToken);
 
   request.onload = function() {

--- a/app/views/session_timeout/_ping.js.erb
+++ b/app/views/session_timeout/_ping.js.erb
@@ -7,7 +7,12 @@ warningEl.insertAdjacentHTML('afterbegin', warning_info);
 
 var modal = new window.LoginGov.Modal({ el: '#session-timeout-msg' });
 var keepaliveEl = document.getElementById('session-keepalive-btn');
-var token = document.querySelector('meta[name="csrf-token"]').content
+var csrfEl = document.querySelector('meta[name="csrf-token"]')
+
+var csrfToken = "";
+if (csrfEl) {
+  csrfToken = csrfEl.content
+}
 
 keepaliveEl.addEventListener('click', keepalive, false);
 
@@ -65,7 +70,7 @@ function keepalive() {
   var request = new XMLHttpRequest();
   request.open('POST', '/sessions/keepalive', true);
   request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-  request.setRequestHeader('X-CSRF-Token', token);
+  request.setRequestHeader('X-CSRF-Token', csrfToken);
 
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -11,9 +11,9 @@
         </p>
       </div>
       <div class='center'>
-        <%= link_to modal.continue,
-                    request.original_url,
-                    class: 'btn btn-primary col-12 mb2 p2 rounded-lg border-box' %>
+        <%= button_tag modal.continue,
+                       id: 'session-keepalive-btn',
+                       class: 'btn btn-primary col-12 mb2 p2 rounded-lg border-box' %>
         <%= link_to modal.sign_out,
                     destroy_user_session_path,
                     class: 'btn col-12 p2 rounded-lg border border-blue blue border-box' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       post '/' => 'users/sessions#create', as: :user_session
       get '/logout' => 'users/sessions#destroy', as: :destroy_user_session
       get '/active' => 'users/sessions#active'
+      get '/sessions/keepalive' => 'users/sessions#keepalive'
 
       if FeatureManagement.allow_piv_cac_login?
         get '/login/piv_cac' => 'users/piv_cac_login#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
       post '/' => 'users/sessions#create', as: :user_session
       get '/logout' => 'users/sessions#destroy', as: :destroy_user_session
       get '/active' => 'users/sessions#active'
-      get '/sessions/keepalive' => 'users/sessions#keepalive'
+      post '/sessions/keepalive' => 'users/sessions#keepalive'
 
       if FeatureManagement.allow_piv_cac_login?
         get '/login/piv_cac' => 'users/piv_cac_login#new'

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -512,19 +512,19 @@ describe Users::SessionsController, devise: true do
       end
 
       it 'returns a 200 status code' do
-        get :keepalive
+        post :keepalive
 
         expect(response.status).to eq(200)
       end
 
       it 'clears the Etag header' do
-        get :keepalive
+        post :keepalive
 
         expect(response.headers['Etag']).to eq ''
       end
 
       it 'renders json' do
-        get :keepalive
+        post :keepalive
 
         expect(response.content_type).to eq('application/json')
       end
@@ -532,7 +532,7 @@ describe Users::SessionsController, devise: true do
       it 'resets the timeout key' do
         timeout = Time.zone.now + 2
         controller.session[:session_expires_at] = timeout
-        get :keepalive
+        post :keepalive
 
         json ||= JSON.parse(response.body)
 
@@ -544,7 +544,7 @@ describe Users::SessionsController, devise: true do
 
       it 'resets the remaining key' do
         controller.session[:session_expires_at] = Time.zone.now + 10
-        get :keepalive
+        post :keepalive
 
         json ||= JSON.parse(response.body)
 
@@ -559,13 +559,13 @@ describe Users::SessionsController, devise: true do
 
         expect(@analytics).to receive(:track_event).with(Analytics::SESSION_KEPT_ALIVE)
 
-        get :keepalive
+        post :keepalive
       end
     end
 
     context 'when user is not present' do
       it 'sets live key to false' do
-        get :keepalive
+        post :keepalive
 
         json ||= JSON.parse(response.body)
 
@@ -573,7 +573,7 @@ describe Users::SessionsController, devise: true do
       end
 
       it 'includes session_expires_at' do
-        get :keepalive
+        post :keepalive
 
         json ||= JSON.parse(response.body)
 
@@ -581,7 +581,7 @@ describe Users::SessionsController, devise: true do
       end
 
       it 'includes the remaining time' do
-        get :keepalive
+        post :keepalive
 
         json ||= JSON.parse(response.body)
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -549,6 +549,15 @@ describe Users::SessionsController, devise: true do
 
         expect(json['remaining']).to be_within(1).of(Figaro.env.session_timeout_in_minutes.to_i * 60)
       end
+
+      it 'tracks session refresh visit' do
+        controller.session[:session_expires_at] = Time.zone.now + 10
+        stub_analytics
+
+        expect(@analytics).to receive(:track_event).with(Analytics::SESSION_KEPT_ALIVE)
+
+        get :keepalive
+      end
     end
 
     context 'when user is not present' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -505,7 +505,7 @@ describe Users::SessionsController, devise: true do
     end
   end
 
-  describe 'GET /sessions/keepalive' do
+  describe 'POST /sessions/keepalive' do
     context 'when user is present' do
       before do
         stub_sign_in

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -504,4 +504,86 @@ describe Users::SessionsController, devise: true do
       end
     end
   end
+
+
+  describe 'GET /sessions/keepalive' do
+    context 'when user is present' do
+      before do
+        stub_sign_in
+      end
+
+      it 'returns a 200 status code' do
+        get :keepalive
+
+        expect(response.status).to eq(200)
+      end
+
+      it 'clears the Etag header' do
+        get :keepalive
+
+        expect(response.headers['Etag']).to eq ''
+      end
+
+      it 'renders json' do
+        get :keepalive
+
+        expect(response.content_type).to eq('application/json')
+      end
+
+      it 'resets the timeout key' do
+        timeout =  Time.zone.now + 2
+        controller.session[:session_expires_at] = timeout
+        get :keepalive
+
+        json ||= JSON.parse(response.body)
+
+        expect(json['timeout'].to_datetime.to_i).to be >= timeout.to_i
+        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(Time.zone.now.to_i + Figaro.env.session_timeout_in_minutes.to_i * 60)
+      end
+
+      it 'resets the remaining key' do
+        controller.session[:session_expires_at] = Time.zone.now + 10
+        get :keepalive
+
+        json ||= JSON.parse(response.body)
+
+        expect(json['remaining']).to be_within(1).of(Figaro.env.session_timeout_in_minutes.to_i * 60)
+      end
+    end
+
+    context 'when user is not present' do
+      it 'sets live key to false' do
+        get :keepalive
+
+        json ||= JSON.parse(response.body)
+
+        expect(json['live']).to eq false
+      end
+
+      it 'includes session_expires_at' do
+        get :keepalive
+
+        json ||= JSON.parse(response.body)
+
+        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(Time.zone.now.to_i - 1)
+      end
+
+      it 'includes the remaining time' do
+        get :keepalive
+
+        json ||= JSON.parse(response.body)
+
+        expect(json['remaining']).to eq(-1)
+      end
+    end
+
+    it 'does not track analytics event' do
+      stub_sign_in
+      stub_analytics
+
+      expect(@analytics).to_not receive(:track_event)
+
+      get :active
+    end
+  end
 end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -505,7 +505,6 @@ describe Users::SessionsController, devise: true do
     end
   end
 
-
   describe 'GET /sessions/keepalive' do
     context 'when user is present' do
       before do
@@ -531,14 +530,16 @@ describe Users::SessionsController, devise: true do
       end
 
       it 'resets the timeout key' do
-        timeout =  Time.zone.now + 2
+        timeout = Time.zone.now + 2
         controller.session[:session_expires_at] = timeout
         get :keepalive
 
         json ||= JSON.parse(response.body)
 
         expect(json['timeout'].to_datetime.to_i).to be >= timeout.to_i
-        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(Time.zone.now.to_i + Figaro.env.session_timeout_in_minutes.to_i * 60)
+        expect(json['timeout'].to_datetime.to_i).to be_within(1).of(
+          Time.zone.now.to_i + Figaro.env.session_timeout_in_minutes.to_i * 60,
+        )
       end
 
       it 'resets the remaining key' do
@@ -547,7 +548,9 @@ describe Users::SessionsController, devise: true do
 
         json ||= JSON.parse(response.body)
 
-        expect(json['remaining']).to be_within(1).of(Figaro.env.session_timeout_in_minutes.to_i * 60)
+        expect(json['remaining']).to be_within(1).of(
+          Figaro.env.session_timeout_in_minutes.to_i * 60,
+        )
       end
 
       it 'tracks session refresh visit' do

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -29,4 +29,26 @@ feature 'Session Timeout' do
       expect(page).to have_css('img[src*=sp-logos]')
     end
   end
+
+  context 'allows extending session', js: true do
+    let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
+
+    before do
+      allow(Figaro.env).
+        to receive(:session_check_frequency).and_return('1')
+      allow(Figaro.env).
+        to receive(:session_check_delay).and_return('0')
+      allow(Figaro.env).
+        to receive(:session_timeout_warning_seconds).and_return('1000')
+      allow(Figaro.env).
+        to receive(:session_timeout_in_minutes).and_return('1')
+    end
+
+    it 'shows warning with button to extend' do
+      sign_in_and_2fa_user(user)
+
+      visit account_path
+      click_button(t('notices.timeout_warning.signed_in.continue'))
+    end
+  end
 end

--- a/spec/features/session/timeout_spec.rb
+++ b/spec/features/session/timeout_spec.rb
@@ -29,26 +29,4 @@ feature 'Session Timeout' do
       expect(page).to have_css('img[src*=sp-logos]')
     end
   end
-
-  context 'allows extending session', js: true do
-    let(:user) { create(:user, :signed_up, created_at: Time.zone.now - 100.days) }
-
-    before do
-      allow(Figaro.env).
-        to receive(:session_check_frequency).and_return('1')
-      allow(Figaro.env).
-        to receive(:session_check_delay).and_return('0')
-      allow(Figaro.env).
-        to receive(:session_timeout_warning_seconds).and_return('1000')
-      allow(Figaro.env).
-        to receive(:session_timeout_in_minutes).and_return('1')
-    end
-
-    it 'shows warning with button to extend' do
-      sign_in_and_2fa_user(user)
-
-      visit account_path
-      click_button(t('notices.timeout_warning.signed_in.continue'))
-    end
-  end
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -261,7 +261,7 @@ feature 'Sign in' do
     end
 
     scenario 'user can continue browsing' do
-      find_link(t('notices.timeout_warning.signed_in.continue')).click
+      find_button(t('notices.timeout_warning.signed_in.continue')).click
 
       expect(current_path).to eq account_path
     end


### PR DESCRIPTION
The "Keep me signed in" button on the session expiration warning modal now makes an XHR request to a new endpoint that updates the `session_expires_at` value. There is a bit of reworking the modal and countdown since these changes mean that the modal will be reused and timers may have to be cancelled and restarted.

The new endpoint returns the same data as the `/active` endpoint, which gets reused in the ping script to update the timer values there.

I wasn't 100% on the route name or how to handle the case where a user wasn't signed in that controller. It doesn't reset the session if the session isn't alive, but I'm not sure if it should return an error earlier instead of returning `{alive: false, ...}`