### PR TITLE
Pull list of supported countries for JS dropdown from server

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -82,6 +82,10 @@ module FormHelper
     end
   end
 
+  def supported_country_codes
+    PhoneNumberCapabilities::INTERNATIONAL_CODES.keys
+  end
+
   def state_name_for_abbrev(abbrev)
     us_states_territories.find([]) { |state| state.second == abbrev }.first
   end

--- a/app/javascript/packs/intl-tel-input.js
+++ b/app/javascript/packs/intl-tel-input.js
@@ -6,8 +6,8 @@ const intlCode = document.querySelector('#new_phone_form_international_code');
 
 // initialise plugin
 intlTelInput(telInput, {
-  preferredCountries: ['us', 'ca'],
-  excludeCountries: ['io', 'ki', 'nf', 'nr', 'nu', 'sh', 'sx', 'tk', 'wf'],
+  preferredCountries: ['US', 'CA'],
+  onlyCountries: JSON.parse(intlCode.getAttribute('data-countries')),
 });
 
 // OnChange event

--- a/app/views/users/shared/_phone_number_edit.html.erb
+++ b/app/views/users/shared/_phone_number_edit.html.erb
@@ -2,7 +2,10 @@
   <%= f.input :international_code,
               collection: international_phone_codes,
               include_blank: false,
-              input_html: { class: 'international-code' }%>
+              input_html: {
+                class: 'international-code',
+                data: { countries: supported_country_codes },
+              } %>
 </div>
 <div class="sm-col-8 mb3">
   <%= f.label :phone do %>

--- a/spec/views/shared/_phone_number_edit.html.erb_spec.rb
+++ b/spec/views/shared/_phone_number_edit.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'users/shared/_phone_number_edit.html.erb' do
+  include SimpleForm::ActionViewExtensions::FormHelper
+  include FormHelper
+
+  subject(:render_partial) do
+    simple_form_for(NewPhoneForm.new(build(:user)), url: '/') do |f|
+      render partial: 'users/shared/phone_number_edit', locals: { f: f }
+    end
+  end
+
+  it 'puts the US as the first country code option' do
+    render_partial
+
+    doc = Nokogiri::HTML(rendered)
+    expect(doc.css('#new_phone_form_international_code > option').first[:value]).to eq('US')
+  end
+
+  it 'includes supported countries as a data attribute for the Javascript' do
+    render_partial
+
+    doc = Nokogiri::HTML(rendered)
+    countries_data = doc.css('.international-code').first['data-countries']
+    expect(countries_data).to eq(supported_country_codes.to_json)
+  end
+end


### PR DESCRIPTION
**Why**: To keep the list of supported countries in the browser
in sync with the server config

---

Unsure why these weren't linked in the first place! But seems like as good of a time as any to match them

