### PR TITLE
Periodically check config against AWS documentation (LG-3519)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,14 +283,6 @@ workflows:
   daily-external-pinpoint-checker:
     jobs:
       - check-pinpoint-config
-    triggers:
-      - schedule:
-          # Once a day at 12pm
-          cron: "0 12 * * *"
-          filters:
-            branches:
-              only:
-                - master
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo
   # because they share credentials and would mess each other up if run concurrently

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,14 @@ workflows:
   daily-external-pinpoint-checker:
     jobs:
       - check-pinpoint-config
+    triggers:
+      - schedule:
+          # Once a day at 12pm
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - master
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo
   # because they share credentials and would mess each other up if run concurrently

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             diff <(bundle exec ./scripts/pinpoint-supported-countries) config/country_dialing_codes.yml
       - slack/status:
           fail_only: true
-          failure_message: ":login-gov::red_circle: external link check failed"
+          failure_message: ":aws-emoji: :red_circle: AWS pinpoint configuration is out of date"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,12 +260,12 @@ jobs:
       - checkout
       - bundle-yarn-install
       - run:
-          name: Check current AWS Pinpoint Configs
+          name: Check current AWS Pinpoint country support
           command: |-
             diff <(bundle exec ./scripts/pinpoint-supported-countries) config/country_dialing_codes.yml
       - slack/status:
           fail_only: true
-          failure_message: ":aws-emoji: :red_circle: AWS pinpoint configuration is out of date"
+          failure_message: ":aws-emoji: :red_circle: AWS Pinpoint country configuration is out of date"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,19 @@ jobs:
           command: |
             bin/smoke_test --remote --no-source-env
       # - notify-slack-smoke-test-status
+  check-pinpoint-config:
+    docker:
+      - image: circleci/ruby:2.6-node-browsers
+    steps:
+      - checkout
+      - bundle-yarn-install
+      - run:
+          name: Check current AWS Pinpoint Configs
+          command: |-
+            diff <(bundle exec ./scripts/pinpoint-supported-countries) config/country_dialing_codes.yml
+      - slack/status:
+          fail_only: true
+          failure_message: ":login-gov::red_circle: external link check failed"
 
 workflows:
   version: 2
@@ -266,6 +279,18 @@ workflows:
           filters:
             tags:
               only: "/^[0-9]{4}-[0-9]{2}-[0-9]{2,}.*/"
+
+  daily-external-pinpoint-checker:
+    jobs:
+      - check-pinpoint-config
+    triggers:
+      - schedule:
+          # Once a day at 12pm
+          cron: "0 12 * * *"
+          filters:
+            branches:
+              only:
+                - master
 
   # Theses are staggered separately from the smoke tests in the identity-monitor repo
   # because they share credentials and would mess each other up if run concurrently

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -1,6 +1,6 @@
 ---
 AD:
-  country_code: '1111111111'
+  country_code: '376'
   name: Andorra
   supports_sms: true
   supports_voice: false

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -1,6 +1,6 @@
 ---
 AD:
-  country_code: '376'
+  country_code: '1111111111'
   name: Andorra
   supports_sms: true
   supports_voice: false


### PR DESCRIPTION
Adds a job that builds every day at noon and should post to Slack if our Pinpoint SMS/voice is out of date