### PR TITLE
Show/Hide SSN field (LG-3641)

### DIFF
--- a/app/javascript/app/form-field-format.js
+++ b/app/javascript/app/form-field-format.js
@@ -23,14 +23,6 @@ function formatForm() {
     });
   }
 
-  if (document.querySelector('.ssn')) {
-    new Cleave('.ssn', {
-      numericOnly: true,
-      blocks: [3, 2, 4],
-      delimiter: '-',
-    });
-  }
-
   if (document.querySelector('.zipcode')) {
     new Cleave('.zipcode', {
       numericOnly: true,

--- a/app/javascript/app/pw-toggle.js
+++ b/app/javascript/app/pw-toggle.js
@@ -1,7 +1,7 @@
 const { I18n } = window.LoginGov;
 
 function togglePw() {
-  const inputs = document.querySelectorAll('input[type="password"]');
+  const inputs = document.querySelectorAll('input.password-toggle[type="password"]');
 
   if (inputs) {
     [].slice.call(inputs).forEach((input, i) => {

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -20,12 +20,7 @@ function formatSSNField() {
         </div>`;
       input.insertAdjacentHTML('afterend', el);
 
-      let ssnCleave = new Cleave(input, {
-        numericOnly: true,
-        blocks: [3, 2, 4],
-        delimiter: '',
-      });
-
+      let ssnCleave;
       const toggle = document.getElementById(`ssn-toggle-${i}`);
       toggle.addEventListener('change', function () {
         input.type = toggle.checked ? 'text' : 'password';
@@ -33,12 +28,6 @@ function formatSSNField() {
         if (!toggle.checked) {
           if (ssnCleave) {
             ssnCleave.destroy();
-
-            ssnCleave = new Cleave(input, {
-              numericOnly: true,
-              blocks: [3, 2, 4],
-              delimiter: '',
-            });
           }
 
           input.value = input.value.replace(/-/g, '');

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -45,6 +45,7 @@ function formatSSNField() {
 
           input.maxLength = 9;
         } else {
+          // SSN is 9 characters plus 2 for dashes
           input.maxLength = 11;
 
           ssnCleave.destroy();

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -42,12 +42,7 @@ function formatSSNField() {
           }
 
           input.value = input.value.replace(/-/g, '');
-
-          input.maxLength = 9;
         } else {
-          // SSN is 9 characters plus 2 for dashes
-          input.maxLength = 11;
-
           ssnCleave.destroy();
           ssnCleave = new Cleave(input, {
             numericOnly: true,

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -1,0 +1,62 @@
+import Cleave from 'cleave.js';
+const { I18n } = window.LoginGov;
+
+/* eslint-disable no-new */
+function formatSSNField() {
+  const inputs = document.querySelectorAll('input.ssn-toggle[type="password"]');
+
+  if (inputs) {
+    [].slice.call(inputs).forEach((input, i) => {
+      const el = `
+        <div class="mt1 right">
+          <label class="btn-border" for="ssn-toggle-${i}">
+            <div class="checkbox">
+              <input id="ssn-toggle-${i}" type="checkbox">
+              <span class="indicator"></span>
+              ${I18n.t('forms.ssn.show')}
+            </div>
+          </label>
+        </div>`;
+      input.insertAdjacentHTML('afterend', el);
+
+      let ssnCleave = new Cleave(input, {
+        numericOnly: true,
+        blocks: [3, 2, 4],
+        delimiter: '',
+      });
+
+      const toggle = document.getElementById(`ssn-toggle-${i}`);
+      toggle.addEventListener('change', function () {
+
+        input.type = toggle.checked ? 'text' : 'password';
+
+        if(!toggle.checked) {
+          if (ssnCleave) {
+            ssnCleave.destroy();
+
+            ssnCleave = new Cleave(input, {
+              numericOnly: true,
+              blocks: [3, 2, 4],
+              delimiter: '',
+            });
+          }
+
+          input.value = input.value.replace(/-/g, '');
+
+          input.maxLength = 9;
+        } else {
+          input.maxLength = 11;
+
+          ssnCleave.destroy();
+          ssnCleave = new Cleave(input, {
+            numericOnly: true,
+            blocks: [3, 2, 4],
+            delimiter: '-',
+          });
+        }
+      });
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', formatSSNField);

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -1,4 +1,5 @@
 import Cleave from 'cleave.js';
+
 const { I18n } = window.LoginGov;
 
 /* eslint-disable no-new */
@@ -27,10 +28,9 @@ function formatSSNField() {
 
       const toggle = document.getElementById(`ssn-toggle-${i}`);
       toggle.addEventListener('change', function () {
-
         input.type = toggle.checked ? 'text' : 'password';
 
-        if(!toggle.checked) {
+        if (!toggle.checked) {
           if (ssnCleave) {
             ssnCleave.destroy();
 

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -2,6 +2,23 @@ import Cleave from 'cleave.js';
 
 const { I18n } = window.LoginGov;
 
+function sync(input, toggle, ssnCleave) {
+  input.type = toggle.checked ? 'text' : 'password';
+
+  ssnCleave?.destroy();
+
+  if (toggle.checked) {
+    return new Cleave(input, {
+      numericOnly: true,
+      blocks: [3, 2, 4],
+      delimiter: '-',
+    });
+  }
+  input.value = input.value.replace(/-/g, '');
+
+  return null;
+}
+
 /* eslint-disable no-new */
 function formatSSNField() {
   const inputs = document.querySelectorAll('input.ssn-toggle[type="password"]');
@@ -20,25 +37,13 @@ function formatSSNField() {
         </div>`;
       input.insertAdjacentHTML('afterend', el);
 
-      let ssnCleave;
       const toggle = document.getElementById(`ssn-toggle-${i}`);
+      let ssnCleave;
+
+      ssnCleave = sync(input, toggle, ssnCleave);
+
       toggle.addEventListener('change', function () {
-        input.type = toggle.checked ? 'text' : 'password';
-
-        if (!toggle.checked) {
-          if (ssnCleave) {
-            ssnCleave.destroy();
-          }
-
-          input.value = input.value.replace(/-/g, '');
-        } else {
-          ssnCleave.destroy();
-          ssnCleave = new Cleave(input, {
-            numericOnly: true,
-            blocks: [3, 2, 4],
-            delimiter: '-',
-          });
-        }
+        ssnCleave = sync(input, toggle, ssnCleave);
       });
     });
   }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,3 +10,4 @@ require('../app/print-personal-key');
 require('../app/i18n-dropdown');
 require('../app/platform-authenticator');
 require('../app/accessible-forms');
+require('../app/ssn-field');

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -11,7 +11,8 @@
     role: 'form' }) do |f| %>
   <%= f.input :reset_password_token, as: :hidden %>
   <%= f.full_error :reset_password_token %>
-  <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true %>
+  <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
+              input_html: { class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength' %>
   <%= f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3' %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,7 +29,7 @@
   <%= f.input :password,
               label: t('account.index.password'),
               required: true,
-              input_html: { aria: { invalid: false } } %>
+              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <%= f.input :request_id, as: :hidden, input_html: { value: request_id } %>
   <div class='mb3'>
     <%= submit_tag t('links.next'), class: 'usa-button usa-button--primary grid-col-12 mb2' %>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -11,7 +11,8 @@
     role: 'form' }) do |f| %>
     <%= f.input :disavowal_token, as: :hidden,
                 input_html: { value: @disavowal_token, name: :disavowal_token } %>
-    <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true, input_html: { aria: { invalid: false } } %>
+    <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
+                input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
     <%= render 'devise/shared/password_strength' %>
     <%= f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3' %>
 <% end %>

--- a/app/views/idv/cac/enter_info.html.erb
+++ b/app/views/idv/cac/enter_info.html.erb
@@ -36,7 +36,7 @@
       </div>
     </div>
     <div class="clearfix mxn1">
-      <div class="sm-col sm-col-6 px1">
+      <div class="sm-col sm-col-8 px1">
         <div class="mb3 tel required profile_ssn">
           <label class="bold tel required" for="profile_ssn"><abbr title="required" class="red display-none">*</abbr>
             <%= t('in_person_proofing.forms.ssn') %>

--- a/app/views/idv/cac/enter_info.html.erb
+++ b/app/views/idv/cac/enter_info.html.erb
@@ -41,7 +41,7 @@
           <label class="bold tel required" for="profile_ssn"><abbr title="required" class="red display-none">*</abbr>
             <%= t('in_person_proofing.forms.ssn') %>
           </label>
-          <input class="block col-12 field string tel required ssn" required="required" aria-invalid="false" aria-required="true" pattern="^\d{3}-?\d{2}-?\d{4}$" type="tel" name="doc_auth[ssn]" id="profile_ssn"/>
+          <input class="block col-12 field string tel required ssn ssn-toggle" required="required" aria-invalid="false" aria-required="true" pattern="^\d{3}-?\d{2}-?\d{4}$" type="password" name="doc_auth[ssn]" id="profile_ssn"/>
         </div>
       </div>
     </div>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -23,12 +23,12 @@
       <!-- maxlength set and includes '-' delimiters to work around cleave bug -->
       <%= f.input(
         :ssn,
-        as: :tel,
+        as: :password,
         label: t('idv.form.ssn_label_html'),
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
-        maxlength: 11,
-        input_html: { aria: { invalid: false }, class: 'ssn', value: '' }
+        maxlength: 9,
+        input_html: { aria: { invalid: false }, class: 'ssn ssn-toggle', value: '' }
       ) %>
     </div>
   </div>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -19,8 +19,6 @@
 ) do |f| %>
   <div class='clearfix mxn1'>
     <div class='sm-col sm-col-8 px1 mt2'>
-      <!-- using :tel for mobile numeric keypad -->
-      <!-- maxlength set and includes '-' delimiters to work around cleave bug -->
       <%= f.input(
         :ssn,
         as: :password,

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -19,13 +19,14 @@
 ) do |f| %>
   <div class='clearfix mxn1'>
     <div class='sm-col sm-col-8 px1 mt2'>
+      <!-- maxlength set and includes '-' delimiters to work around cleave bug -->
       <%= f.input(
         :ssn,
         as: :password,
         label: t('idv.form.ssn_label_html'),
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
-        maxlength: 9,
+        maxlength: 11,
         input_html: { aria: { invalid: false }, class: 'ssn ssn-toggle', value: '' }
       ) %>
     </div>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -18,7 +18,7 @@
   html: { autocomplete: 'off', role: 'form', class: 'mt2' }
 ) do |f| %>
   <div class='clearfix mxn1'>
-    <div class='sm-col sm-col-6 px1 mt2'>
+    <div class='sm-col sm-col-8 px1 mt2'>
       <!-- using :tel for mobile numeric keypad -->
       <!-- maxlength set and includes '-' delimiters to work around cleave bug -->
       <%= f.input(

--- a/app/views/idv/in_person/encrypt.html.erb
+++ b/app/views/idv/in_person/encrypt.html.erb
@@ -19,7 +19,8 @@
 
 <%= validated_form_for(:in_person_proofing, url: url_for, method: 'PUT',
                        html: { autocomplete: 'off', method: :put, role: 'form' }) do |f| %>
-  <%= f.input :password, label: t('idv.form.password'), required: true, input_html: { aria: { invalid: false } } %>
+  <%= f.input :password, label: t('idv.form.password'), required: true,
+              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div class="right-align mtn2 mb4">
                 <%= t('idv.forgot_password.link_html',
                       link: link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url,

--- a/app/views/idv/in_person/enter_info.html.erb
+++ b/app/views/idv/in_person/enter_info.html.erb
@@ -33,7 +33,7 @@
           <label class="bold tel required" for="profile_ssn"><abbr title="required" class="red display-none">*</abbr>
             <%= t('in_person_proofing.forms.ssn') %>
           </label>
-          <input class="block col-12 field string tel required ssn" required="required" aria-invalid="false" aria-required="true" pattern="^\d{3}-?\d{2}-?\d{4}$" type="tel" name="in_person[ssn]" id="profile_ssn"/>
+          <input class="block col-12 field string tel required ssn ssn-toggle" required="required" aria-invalid="false" aria-required="true" pattern="^\d{3}-?\d{2}-?\d{4}$" type="password" name="in_person[ssn]" id="profile_ssn"/>
         </div>
       </div>
     </div>

--- a/app/views/idv/review/new.html.erb
+++ b/app/views/idv/review/new.html.erb
@@ -13,7 +13,8 @@
 
 <%= validated_form_for(current_user, url: idv_review_path,
                        html: { autocomplete: 'off', method: :put, role: 'form' }) do |f| %>
-  <%= f.input :password, label: t('idv.form.password'), required: true, input_html: { aria: { invalid: false } } %>
+  <%= f.input :password, label: t('idv.form.password'), required: true,
+              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div class="right-align mtn2 mb4">
     <%= t('idv.forgot_password.link_html',
           link: link_to(t('idv.forgot_password.link_text'), idv_forgot_password_url,

--- a/app/views/mfa_confirmation/new.html.erb
+++ b/app/views/mfa_confirmation/new.html.erb
@@ -10,7 +10,7 @@
 <%= validated_form_for(current_user,
                        url: reauthn_user_password_path,
                        html: { autocomplete: 'off', role: 'form', method: 'post' }) do |f| %>
-  <%= f.input :password, required: true, input_html: { aria: { invalid: false } } %>
+  <%= f.input :password, required: true, input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'btn-wide mt2' %>
 <% end %>
 <%= render 'shared/cancel', link: account_path %>

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -5,7 +5,8 @@
                        url: capture_password_url,
                        method: :post,
                        html: { autocomplete: 'off', role: 'form' }) do |f| %>
-  <%= f.input :password, label: t('account.index.password'), required: true, input_html: { aria: { invalid: false } } %>
+  <%= f.input :password, label: t('account.index.password'), required: true,
+              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div>
     <%= f.button :submit, t('links.next'), class: 'sm-col-6 col-12 btn-wide mb3' %>
   </div>

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -8,7 +8,7 @@ p.mt2.mb0#password-description
     method: :post,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.input :password, required: true,
-      input_html: { aria: { invalid: false, describedby: 'password-description' } }
+      input_html: { aria: { invalid: false, class: 'password-toggle', describedby: 'password-description' } }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -8,8 +8,8 @@ p.mt2.mb0#password-description
     method: :post,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.input :password, required: true,
-      input_html: { aria: { invalid: false,
-                  class: 'password-toggle', describedby: 'password-description' } }
+      input_html: { aria: { invalid: false, describedby: 'password-description' },
+                  class: 'password-toggle' }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }

--- a/app/views/sign_up/passwords/new.html.slim
+++ b/app/views/sign_up/passwords/new.html.slim
@@ -8,7 +8,8 @@ p.mt2.mb0#password-description
     method: :post,
     html: { role: 'form', autocomplete: 'off' }) do |f|
   = f.input :password, required: true,
-      input_html: { aria: { invalid: false, class: 'password-toggle', describedby: 'password-description' } }
+      input_html: { aria: { invalid: false,
+                  class: 'password-toggle', describedby: 'password-description' } }
   = render 'devise/shared/password_strength'
   = hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token'
   = f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id }

--- a/app/views/users/delete/show.html.erb
+++ b/app/views/users/delete/show.html.erb
@@ -17,7 +17,8 @@
       <div class="mb3">
         <%= t('users.delete.instructions') %>
       </div>
-      <%= f.input :password, label: t('idv.form.password'), required: true, input_html: { aria: { invalid: false } } %>
+      <%= f.input :password, label: t('idv.form.password'), required: true,
+                  input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
       <%= f.button :submit,
                    t('users.delete.actions.delete'),
                    class: 'btn btn-primary col-12 mb2 p2 rounded-lg' %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -12,7 +12,7 @@
                        html: { autocomplete: 'off', method: :patch, role: 'form' }) do |f| %>
   <%= f.error_notification %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
-              input_html: { aria: { invalid: false, describedby: 'password-description' } } %>
+              input_html: { aria: { invalid: false, class: 'password-toggle', describedby: 'password-description' } } %>
   <%= render 'devise/shared/password_strength' %>
   <%= f.button :submit, t('forms.buttons.submit.update'), class: 'mt2 mb3' %>
 <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -12,7 +12,7 @@
                        html: { autocomplete: 'off', method: :patch, role: 'form' }) do |f| %>
   <%= f.error_notification %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
-              input_html: { aria: { invalid: false, class: 'password-toggle', describedby: 'password-description' } } %>
+              input_html: { aria: { invalid: false, describedby: 'password-description' }, class: 'password-toggle' } %>
   <%= render 'devise/shared/password_strength' %>
   <%= f.button :submit, t('forms.buttons.submit.update'), class: 'mt2 mb3' %>
 <% end %>

--- a/app/views/users/verify_password/new.html.erb
+++ b/app/views/users/verify_password/new.html.erb
@@ -10,7 +10,8 @@
 
 <%= validated_form_for(current_user, url: update_verify_password_path,
                        html: { autocomplete: 'off', method: :put, role: 'form' }) do |f| %>
-  <%= f.input :password, label: t('idv.form.password'), required: true, input_html: { aria: { invalid: false } } %>
+  <%= f.input :password, label: t('idv.form.password'), required: true,
+              input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <%= f.button :submit, t('forms.buttons.continue'), class: 'btn btn-primary btn-wide sm-col-6 col-12' %>
 <% end %>
 

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -60,6 +60,7 @@
 - forms.buttons.continue
 - forms.buttons.submit.default
 - forms.passwords.show
+- forms.ssn.show
 - idv.errors.pattern_mismatch.dob
 - idv.errors.pattern_mismatch.personal_key
 - idv.errors.pattern_mismatch.ssn

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -118,6 +118,8 @@ en:
     registration:
       labels:
         email: Email address
+    ssn:
+      show: Show Social Security Number
     totp_delete:
       caution: If you remove your authentication app you won't be able to use it to
         access your login.gov account.

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -126,6 +126,8 @@ es:
     registration:
       labels:
         email: Email
+    ssn:
+      show: Mostrar Número de Seguro Social
     totp_delete:
       caution: Si elimina su aplicación de autenticación, no podrá usarla para acceder
         a su cuenta login.gov.

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -131,6 +131,8 @@ fr:
     registration:
       labels:
         email: Adresse courriel
+    ssn:
+      show: Afficher le numéro de sécurité sociale
     totp_delete:
       caution: Si vous supprimez votre application d'authentification, vous ne pourrez
         plus l'utiliser pour accéder à votre compte login.gov.


### PR DESCRIPTION
The show/hide copies functionality from `pw-toggle.js`, and moves the previous `Cleave` functionality as well.

To keep the functionality consistent in only allowing numbers, the SSN field adds and removes different Cleave options and changes the max length of the field to accommodate dashes. The dashes are removed in the hidden state to avoid adding characters, which could mislead users about how many characters they'd entered.

`pw-toggle.js` automatically added "Show password" to every password input, which conflicted with using password for the SSN field, so I added the `password-toggle` class to the selector and existing password fields.

------
![image](https://user-images.githubusercontent.com/1430443/97224460-28ff7000-179f-11eb-8327-cb36441f858c.png)
![image](https://user-images.githubusercontent.com/1430443/97224497-33ba0500-179f-11eb-9589-6e5ac8de3e22.png)
------
![image](https://user-images.githubusercontent.com/1430443/97224748-97dcc900-179f-11eb-8aab-6236bfa799b6.png)
![image](https://user-images.githubusercontent.com/1430443/97224604-63690d00-179f-11eb-9478-9e36c1efbbc6.png)
