### PR TITLE
remove unused proofing_lambda_http_callback config key

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -109,7 +109,6 @@ pinpoint_voice_longcode_pool:
 pinpoint_voice_region:
 poll_rate_for_verify_in_seconds: '10'
 proofer_mock_fallback: 'true'
-proofing_lambda_http_callback:
 push_notifications_enabled:
 reauthn_window: '120'
 recaptcha_enabled_percent: '0'
@@ -209,7 +208,6 @@ development:
   otp_delivery_blocklist_maxretry: '10'
   participate_in_dap:
   password_pepper: f22d4b2cafac9066fe2f4416f5b7a32c
-  proofing_lambda_http_callback: 'true'
   identity_pki_disabled: 'false'
   identity_pki_local_dev: 'true'
   piv_cac_service_url: https://localhost:8443/
@@ -324,7 +322,6 @@ production:
   piv_cac_service_url:
   piv_cac_verify_token_secret:
   piv_cac_verify_token_url:
-  proofing_lambda_http_callback:
   rack_mini_profiler:
   recurring_jobs_disabled_names: "[]"
   redis_throttle_url: redis://redis.login.gov.internal:6379/1
@@ -438,7 +435,6 @@ test:
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   piv_cac_verify_token_url: https://localhost:8443/
-  proofing_lambda_http_callback: false
   rack_mini_profiler:
   recurring_jobs_disabled_names: '["disabled job"]'
   redis_throttle_url: redis://localhost:6379/1


### PR DESCRIPTION
It's emitting a warning per https://github.com/18F/identity-idp/pull/4273#discussion_r512670820 and we don't use it, so let's remove it 🙂 