### PR TITLE
Re-enable Slack notifications for prod/staging smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
           name: "Smoke tests"
           command: |
             bin/smoke_test --remote --no-source-env
-      # - notify-slack-smoke-test-status
+      - notify-slack-smoke-test-status
   smoketest-prod:
     working_directory: ~/identity-idp
     executor: ruby_browsers
@@ -252,7 +252,7 @@ jobs:
           name: "Smoke tests"
           command: |
             bin/smoke_test --remote --no-source-env
-      # - notify-slack-smoke-test-status
+      - notify-slack-smoke-test-status
   check-pinpoint-config:
     docker:
       - image: circleci/ruby:2.6-node-browsers


### PR DESCRIPTION
**Why**: They seem to have been passing reliably

Previously we had disabled these and left the ones in identity-monitor while migrating. I think we're ready to re-enable them and remove/pause identity-monitor.

The last few runs:

| Prod | Staging |
| --- | --- |
| <img width="1018" alt="Screen Shot 2020-10-27 at 10 30 51 AM" src="https://user-images.githubusercontent.com/458784/97339450-d4f89800-183f-11eb-9b59-0eeec6821562.png"> | <img width="1012" alt="Screen Shot 2020-10-27 at 10 31 05 AM" src="https://user-images.githubusercontent.com/458784/97339468-dcb83c80-183f-11eb-8e07-e0b4f305c139.png"> |

