### PR TITLE
LG-3532: Add updated state to file picker component

### DIFF
--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -30,6 +30,15 @@
   }
 }
 
+.usa-form-group--success .usa-file-input .usa-file-input__target {
+  border-color: color('success');
+  border-width: 2px;
+
+  &:hover {
+    border-color: color('success-dark');
+  }
+}
+
 .usa-file-input__banner-text {
   @include u-font-family('sans');
   color: color('primary');

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -6,11 +6,16 @@
   outline-offset: 2px;
 }
 
+.usa-file-input:not(.usa-file-input--has-value) .usa-file-input__target,
+.usa-form-group--error .usa-file-input .usa-file-input__target,
+.usa-form-group--success .usa-file-input .usa-file-input__target {
+  border-width: 3px;
+}
+
 .usa-file-input:not(.usa-file-input--has-value) {
   .usa-file-input__target {
     border-color: color('primary');
     border-radius: .375rem;
-    border-width: 2px;
 
     &:hover {
       border-color: color('primary-dark');
@@ -32,7 +37,6 @@
 
 .usa-form-group--success .usa-file-input .usa-file-input__target {
   border-color: color('success');
-  border-width: 2px;
 
   &:hover {
     border-color: color('success-dark');

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -194,3 +194,10 @@ input::-webkit-inner-spin-button {
     margin-left: 0;
   }
 }
+
+.usa-success-message {
+  @include u-padding-y(.5);
+  color: color('success');
+  display: block;
+  font-weight: font-weight('bold');
+}

--- a/app/assets/stylesheets/components/_selfie-capture.scss
+++ b/app/assets/stylesheets/components/_selfie-capture.scss
@@ -21,13 +21,25 @@
   border-width: 1px;
 }
 
+.selfie-capture--error,
+.selfie-capture--updated {
+  border-width: 3px;
+}
+
 .selfie-capture--error {
   border-color: color('error');
   border-radius: .375rem;
-  border-width: 3px;
 
   &:hover {
     border-color: color('error-dark');
+  }
+}
+
+.selfie-capture--updated {
+  border-color: color('success');
+
+  &:hover {
+    border-color: color('success-dark');
   }
 }
 

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -202,6 +202,7 @@ function AcuantCapture(
         hint={hasCapture || !allowUpload ? undefined : t('doc_auth.tips.document_capture_hint')}
         bannerText={bannerText}
         invalidTypeText={t('errors.doc_auth.invalid_file_input_type')}
+        fileUpdatedText={t('doc_auth.info.image_updated')}
         accept={isMockClient ? undefined : ['image/jpeg', 'image/png', 'image/bmp', 'image/tiff']}
         capture={capture}
         value={value}

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useMemo, forwardRef } from 'react';
+import React, { useContext, useState, useRef, useMemo, forwardRef } from 'react';
 import FileImage from './file-image';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
@@ -16,6 +16,7 @@ import useI18n from '../hooks/use-i18n';
  * @prop {string=} hint Optional hint text.
  * @prop {string=} bannerText Optional banner overlay text.
  * @prop {string=} invalidTypeText Error message text to show on invalid file type selection.
+ * @prop {string=} fileUpdatedText Success message text to show when selected file is updated.
  * @prop {string[]=} accept Optional array of file input accept patterns.
  * @prop {'user'|'environment'=} capture Optional facing mode if file input is used for capture.
  * @prop {Blob|string|null|undefined} value Current value.
@@ -92,6 +93,7 @@ const FileInput = forwardRef((props, ref) => {
     hint,
     bannerText,
     invalidTypeText,
+    fileUpdatedText,
     accept,
     capture,
     value,
@@ -104,6 +106,12 @@ const FileInput = forwardRef((props, ref) => {
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const hadValue = useRef(false);
+  const isUpdated = useMemo(() => {
+    const nextIsUpdated = Boolean(value && hadValue.current);
+    hadValue.current = Boolean(value);
+    return nextIsUpdated;
+  }, [value]);
   const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {string?} */ (null));
   useMemo(() => setOwnErrorMessage(null), [value]);
   const inputId = `file-input-${instanceId}`;
@@ -134,7 +142,11 @@ const FileInput = forwardRef((props, ref) => {
 
   return (
     <div
-      className={[shownErrorMessage && 'usa-form-group usa-form-group--error']
+      className={[
+        (shownErrorMessage || isUpdated) && 'usa-form-group',
+        shownErrorMessage && 'usa-form-group--error',
+        isUpdated && !shownErrorMessage && 'usa-form-group--success',
+      ]
         .filter(Boolean)
         .join(' ')}
     >
@@ -163,6 +175,11 @@ const FileInput = forwardRef((props, ref) => {
       {shownErrorMessage && (
         <span className="usa-error-message" role="alert">
           {shownErrorMessage}
+        </span>
+      )}
+      {isUpdated && !shownErrorMessage && (
+        <span className="usa-success-message" role="alert">
+          {fileUpdatedText ?? t('forms.file_input.file_updated')}
         </span>
       )}
       <div

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -108,11 +108,13 @@ const FileInput = forwardRef((props, ref) => {
   const { isMobile } = useContext(DeviceContext);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const previousValue = usePrevious(value);
+  const isUpdated = useMemo(() => Boolean(previousValue && value && previousValue !== value), [
+    value,
+  ]);
   const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {string?} */ (null));
   useMemo(() => setOwnErrorMessage(null), [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
-  const isUpdated = Boolean(previousValue && value && previousValue !== value);
 
   /**
    * In response to a file input change event, confirms that the file is valid before calling

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -1,8 +1,9 @@
-import React, { useContext, useState, useRef, useMemo, forwardRef } from 'react';
+import React, { useContext, useState, useMemo, forwardRef } from 'react';
 import FileImage from './file-image';
 import DeviceContext from '../context/device';
 import useInstanceId from '../hooks/use-instance-id';
 import useI18n from '../hooks/use-i18n';
+import usePrevious from '../hooks/use-previous';
 
 /** @typedef {import('react').MouseEvent} ReactMouseEvent */
 /** @typedef {import('react').ChangeEvent} ReactChangeEvent */
@@ -106,16 +107,12 @@ const FileInput = forwardRef((props, ref) => {
   const instanceId = useInstanceId();
   const { isMobile } = useContext(DeviceContext);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const hadValue = useRef(false);
-  const isUpdated = useMemo(() => {
-    const nextIsUpdated = Boolean(value && hadValue.current);
-    hadValue.current = Boolean(value);
-    return nextIsUpdated;
-  }, [value]);
+  const previousValue = usePrevious(value);
   const [ownErrorMessage, setOwnErrorMessage] = useState(/** @type {string?} */ (null));
   useMemo(() => setOwnErrorMessage(null), [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
+  const isUpdated = Boolean(previousValue && value && previousValue !== value);
 
   /**
    * In response to a file input change event, confirms that the file is valid before calling

--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -33,6 +33,12 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
   const { t } = useI18n();
   const labelRef = useRef(/** @type {HTMLDivElement?} */ (null));
   const wrapperRef = useRef(/** @type {HTMLDivElement?} */ (null));
+  const hadValue = useRef(false);
+  const isUpdated = useMemo(() => {
+    const nextIsUpdated = Boolean(value && hadValue.current);
+    hadValue.current = hadValue.current || Boolean(value);
+    return nextIsUpdated;
+  }, [value]);
   const retryButtonRef = useFocusFallbackRef(labelRef);
   const captureButtonRef = useFocusFallbackRef(labelRef);
   useImperativeHandle(ref, () => labelRef.current);
@@ -123,6 +129,7 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
     'selfie-capture',
     isCapturing && 'selfie-capture--capturing',
     shownErrorMessage && 'selfie-capture--error',
+    isUpdated && !shownErrorMessage && 'selfie-capture--updated',
     value && 'selfie-capture--has-value',
     className,
   ]
@@ -146,6 +153,11 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
       {shownErrorMessage && (
         <span className="usa-error-message" role="alert">
           {shownErrorMessage}
+        </span>
+      )}
+      {isUpdated && !shownErrorMessage && (
+        <span className="usa-success-message" role="alert">
+          {t('doc_auth.info.image_updated')}
         </span>
       )}
       <div ref={wrapperRef} className={classes}>

--- a/app/javascript/packages/document-capture/hooks/use-previous.js
+++ b/app/javascript/packages/document-capture/hooks/use-previous.js
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Returns the value from the previous render's same hook call argument.
+ *
+ * @template T
+ *
+ * @param {T} value Value to recall later.
+ *
+ * @return {T=} Previous value, or undefined on first render.
+ */
+function usePrevious(value) {
+  const ref = useRef(/** @type {T=} */ (undefined));
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
+export default usePrevious;

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -21,6 +21,7 @@
 - doc_auth.info.capture_status_tap_to_capture
 - doc_auth.info.document_capture_intro_acknowledgment
 - doc_auth.info.document_capture_upload_image
+- doc_auth.info.image_updated
 - doc_auth.info.id_worn_html
 - doc_auth.info.interstitial_eta
 - doc_auth.info.interstitial_thanks

--- a/config/js_locale_strings.yml
+++ b/config/js_locale_strings.yml
@@ -59,6 +59,7 @@
 - errors.messages.missing_field
 - forms.buttons.continue
 - forms.buttons.submit.default
+- forms.file_input.file_updated
 - forms.passwords.show
 - forms.ssn.show
 - idv.errors.pattern_mismatch.dob

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -114,6 +114,7 @@ en:
         and we will not save any images.
       id_worn_html: "<strong>Is your ID worn or damaged?</strong> Use another state-issued
         ID if you have one."
+      image_updated: Image updated
       interstitial_eta: This might take up to a minute. We’ll load the next step automatically
         when it’s done.
       interstitial_thanks: Thanks for your patience!

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -121,6 +121,7 @@ es:
         y no guardaremos ninguna imagen.
       id_worn_html: "<strong>¿Su identificación está desgastada o dañada?</strong>
         Use otra identificación emitida por el estado si tiene una."
+      image_updated: Imagen actualizada
       interstitial_eta: Esto puede tardar hasta un minuto. Cargaremos el siguiente
         paso automáticamente cuando esté listo.
       interstitial_thanks: "¡Gracias por su paciencia!"

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -127,6 +127,7 @@ fr:
         votre identité, et nous n'enregistrerons aucune image.
       id_worn_html: "<strong>Votre pièce d'identité est-elle usée ou endommagée?</strong>
         Utilisez un autre identifiant émis par l'État si vous en avez un."
+      image_updated: Image mise à jour
       interstitial_eta: Cela peut prendre jusqu'à une minute. Nous chargerons automatiquement
         l’étape suivante une fois celle-ci terminée.
       interstitial_thanks: Merci pour votre patience!

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -56,6 +56,8 @@ en:
       buttons:
         delete: Delete email address
     example: 'example:'
+    file_input:
+      file_updated: File updated
     messages:
       remember_device: Remember this browser
     passwords:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -61,6 +61,8 @@ es:
       buttons:
         delete: Eliminar correo electrónico
     example: 'ejemplo:'
+    file_input:
+      file_updated: Archivo actualizado
     messages:
       remember_device: Recuerde este navegador
     passwords:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -60,6 +60,8 @@ fr:
       buttons:
         delete: Supprimer l'email
     example: 'exemple:'
+    file_input:
+      file_updated: Fichier mis à jour
     messages:
       remember_device: Enregistrer ce navigateur
     passwords:

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -356,6 +356,10 @@ describe('document-capture/components/file-input', () => {
 
     expect(() => getByText('forms.file_input.file_updated')).to.throw();
 
+    rerender(<FileInput label="File" value={file1} />);
+
+    expect(() => getByText('forms.file_input.file_updated')).to.throw();
+
     rerender(<FileInput label="File" value={file2} />);
 
     expect(getByText('forms.file_input.file_updated')).to.be.ok();

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -363,6 +363,10 @@ describe('document-capture/components/file-input', () => {
     rerender(<FileInput label="File" value={file2} />);
 
     expect(getByText('forms.file_input.file_updated')).to.be.ok();
+
+    rerender(<FileInput label="File" value={file2} />);
+
+    expect(getByText('forms.file_input.file_updated')).to.be.ok();
   });
 
   it('allows customization of updated file text', () => {

--- a/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/file-input-spec.jsx
@@ -344,6 +344,40 @@ describe('document-capture/components/file-input', () => {
     expect(onError.callCount).to.equal(1);
   });
 
+  it('shows an updated state', () => {
+    const file1 = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file2 = new window.File([''], 'upload.png', { type: 'image/png' });
+
+    const { getByText, rerender } = render(<FileInput label="File" />);
+
+    expect(() => getByText('forms.file_input.file_updated')).to.throw();
+
+    rerender(<FileInput label="File" value={file1} />);
+
+    expect(() => getByText('forms.file_input.file_updated')).to.throw();
+
+    rerender(<FileInput label="File" value={file2} />);
+
+    expect(getByText('forms.file_input.file_updated')).to.be.ok();
+  });
+
+  it('allows customization of updated file text', () => {
+    const file1 = new window.File([''], 'upload.png', { type: 'image/png' });
+    const file2 = new window.File([''], 'upload.png', { type: 'image/png' });
+
+    const { getByText, rerender } = render(<FileInput label="File" fileUpdatedText="Updated" />);
+
+    expect(() => getByText('Updated')).to.throw();
+
+    rerender(<FileInput label="File" fileUpdatedText="Updated" value={file1} />);
+
+    expect(() => getByText('Updated')).to.throw();
+
+    rerender(<FileInput label="File" fileUpdatedText="Updated" value={file2} />);
+
+    expect(getByText('Updated')).to.be.ok();
+  });
+
   it('forwards ref', () => {
     const ref = createRef();
     render(<FileInput ref={ref} label="File" />);

--- a/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/selfie-capture-spec.jsx
@@ -76,6 +76,14 @@ describe('document-capture/components/selfie-capture', () => {
     await findByText('doc_auth.instructions.document_capture_selfie_consent_blocked');
   });
 
+  it('renders updated state after retaking photo', async () => {
+    const { rerender, findByText } = render(<SelfieCapture value={value} />);
+    rerender(<SelfieCapture />);
+    rerender(<SelfieCapture value={value} />);
+
+    await findByText('doc_auth.info.image_updated');
+  });
+
   it('stops capture after rerendered with value', async () => {
     const { findByLabelText, rerender } = render(<SelfieCapture />);
 

--- a/spec/javascripts/packages/document-capture/hooks/use-previous-spec.test.js
+++ b/spec/javascripts/packages/document-capture/hooks/use-previous-spec.test.js
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react-hooks';
+import usePrevious from '@18f/identity-document-capture/hooks/use-previous';
+
+describe('document-capture/hooks/use-previous', () => {
+  it('returns undefined on first render', () => {
+    const { result } = renderHook(({ value }) => usePrevious(value), {
+      initialProps: { value: 10 },
+    });
+
+    expect(result.current).to.be.undefined();
+  });
+
+  it('returns previous value', () => {
+    const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+      initialProps: { value: 10 },
+    });
+
+    rerender({ value: 20 });
+
+    expect(result.current).to.equal(10);
+  });
+});


### PR DESCRIPTION
**Why:** As an end user, I want to see feedback if I have added a new image, so that I understand that my new image has successfully replaced the old one. 

**Screenshots:**

Desktop|Mobile
---|---
![desktop](https://user-images.githubusercontent.com/1779930/97340074-b4d5d280-1859-11eb-902d-66cdfeca9701.png)|![mobile](https://user-images.githubusercontent.com/1779930/97340081-b7382c80-1859-11eb-91b9-320f3311a175.png)

**Design Notes:**

I noticed that 'til now we've been using a 2px border for error states on the file input component. The designs have this at 3px, which I've updated here.

This introduces new patterns which may warrant inclusion upstream to Login Design System:

- `usa-success-message` (extended from `usa-error-message`)
- `usa-form-group--success` (extended from `usa-form-group--error`)