### PR TITLE
LG-3419: Encrypt images and upload to S3 from the client

### DIFF
--- a/app/javascript/packages/document-capture/context/upload.jsx
+++ b/app/javascript/packages/document-capture/context/upload.jsx
@@ -5,6 +5,7 @@ const UploadContext = createContext({
   upload: defaultUpload,
   isMockClient: false,
   backgroundUploadURLs: /** @type {Record<string,string>} */ ({}),
+  backgroundUploadEncryptKey: /** @type {CryptoKey=} */ (undefined),
 });
 
 /** @typedef {import('react').ReactNode} ReactNode */
@@ -53,6 +54,7 @@ const UploadContext = createContext({
  * @prop {boolean=} isMockClient Whether to treat upload as a mock implementation.
  * @prop {Record<string,string>} backgroundUploadURLs URLs to which payload values corresponding to
  * key should be uploaded as soon as possible.
+ * @prop {CryptoKey} backgroundUploadEncryptKey Background upload encryption key.
  * @prop {string} endpoint Endpoint to which payload should be sent.
  * @prop {string} csrf CSRF token to send as parameter to upload implementation.
  * @prop {Record<string,any>} formData Extra form data to merge into the payload before uploading
@@ -66,17 +68,22 @@ function UploadContextProvider({
   upload = defaultUpload,
   isMockClient = false,
   backgroundUploadURLs = {},
+  backgroundUploadEncryptKey,
   endpoint,
   csrf,
   formData,
   children,
 }) {
   const uploadWithCSRF = (payload) => upload({ ...payload, ...formData }, { endpoint, csrf });
-  const value = useMemo(() => ({ upload: uploadWithCSRF, backgroundUploadURLs, isMockClient }), [
-    upload,
-    backgroundUploadURLs,
-    isMockClient,
-  ]);
+  const value = useMemo(
+    () => ({
+      upload: uploadWithCSRF,
+      backgroundUploadURLs,
+      backgroundUploadEncryptKey,
+      isMockClient,
+    }),
+    [upload, backgroundUploadURLs, backgroundUploadEncryptKey, isMockClient],
+  );
 
   return <UploadContext.Provider value={value}>{children}</UploadContext.Provider>;
 }

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -14,7 +14,7 @@ export function blobToDataView(blob) {
     reader.onload = ({ target }) => {
       resolve(new DataView(/** @type {ArrayBuffer} */ (target?.result)));
     };
-    reader.onerror = () => reject();
+    reader.onerror = () => reject(reader.error);
     reader.readAsArrayBuffer(blob);
   });
 }

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -1,8 +1,49 @@
 import React, { useContext } from 'react';
 import UploadContext from '../context/upload';
 
+/**
+ * Returns a promise resolving to an DataView representation of the given Blob object.
+ *
+ * @param {Blob} blob Blob object.
+ *
+ * @return {Promise<DataView>}
+ */
+export function blobToDataView(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new window.FileReader();
+    reader.onload = ({ target }) => {
+      resolve(new DataView(/** @type {ArrayBuffer} */ (target?.result)));
+    };
+    reader.onerror = () => reject();
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/**
+ * Encrypt data.
+ *
+ * @param {CryptoKey} key Encryption key.
+ * @param {BufferSource} iv Initialization vector.
+ * @param {string|Blob} value Value to encrypt.
+ *
+ * @return {Promise<ArrayBuffer>} Encrypted data.
+ */
+export async function encrypt(key, iv, value) {
+  const data =
+    typeof value === 'string' ? new TextEncoder().encode(value) : await blobToDataView(value);
+
+  return window.crypto.subtle.encrypt(
+    /** @type {AesGcmParams} */ ({
+      name: 'AES-GCM',
+      iv,
+    }),
+    key,
+    data,
+  );
+}
+
 const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) => {
-  const { backgroundUploadURLs } = useContext(UploadContext);
+  const { backgroundUploadURLs, backgroundUploadEncryptKey } = useContext(UploadContext);
 
   /**
    * @param {Record<string, string|Blob|null|undefined>} nextValues Next values.
@@ -13,9 +54,15 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
       nextValuesWithUpload[key] = value;
       const url = backgroundUploadURLs[key];
       if (url && value) {
-        nextValuesWithUpload[`${key}BackgroundUpload`] = window
-          .fetch(url, { method: 'POST', body: value })
-          .then(() => undefined);
+        const iv = window.crypto.getRandomValues(new Uint8Array(12));
+        nextValuesWithUpload[`${key}_image_iv`] = window.btoa(String.fromCharCode(...iv));
+        nextValuesWithUpload[`${key}_image_url`] = encrypt(
+          /** @type {CryptoKey} */ (backgroundUploadEncryptKey),
+          iv,
+          value,
+        )
+          .then((encryptedValue) => window.fetch(url, { method: 'POST', body: encryptedValue }))
+          .then(() => url);
       }
     }
 

--- a/app/javascript/packages/polyfill/index.js
+++ b/app/javascript/packages/polyfill/index.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {"fetch"|"element-closest"|"classlist"} SupportedPolyfills
+ * @typedef {"fetch"|"element-closest"|"classlist"|"crypto"} SupportedPolyfills
  */
 
 /**
@@ -24,6 +24,10 @@ const POLYFILLS = {
   classlist: {
     test: () => 'classList' in Element.prototype,
     load: () => import(/* webpackChunkName: "classlist-polyfill" */ 'classlist-polyfill'),
+  },
+  crypto: {
+    test: () => 'crypto' in window,
+    load: () => import(/* webpackChunkName: "webcrypto-shim" */ 'webcrypto-shim'),
   },
 };
 

--- a/app/javascript/packages/polyfill/package.json
+++ b/app/javascript/packages/polyfill/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "classlist-polyfill": "^1.2.0",
     "element-closest": "^3.0.2",
+    "webcrypto-shim": "^0.1.6",
     "whatwg-fetch": "^3.4.0"
   }
 }

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -53,7 +53,7 @@ const device = {
   isMobile: isCameraCapableMobile(),
 };
 
-loadPolyfills(['fetch']).then(async () => {
+loadPolyfills(['fetch', 'crypto']).then(async () => {
   const backgroundUploadURLs = getBackgroundUploadURLs();
   const isAsyncForm = Object.keys(backgroundUploadURLs).length > 0;
 

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -53,7 +53,22 @@ const device = {
   isMobile: isCameraCapableMobile(),
 };
 
-loadPolyfills(['fetch']).then(() => {
+loadPolyfills(['fetch']).then(async () => {
+  const backgroundUploadURLs = getBackgroundUploadURLs();
+  const isAsyncForm = Object.keys(backgroundUploadURLs).length > 0;
+
+  let backgroundUploadEncryptKey;
+  if (isAsyncForm) {
+    backgroundUploadEncryptKey = await window.crypto.subtle.generateKey(
+      {
+        name: 'AES-GCM',
+        length: 256,
+      },
+      true,
+      ['encrypt', 'decrypt'],
+    );
+  }
+
   render(
     <AcuantProvider
       credentials={getMetaContent('acuant-sdk-initialization-creds')}
@@ -63,7 +78,8 @@ loadPolyfills(['fetch']).then(() => {
         endpoint={appRoot.getAttribute('data-endpoint')}
         csrf={getMetaContent('csrf-token')}
         isMockClient={isMockClient}
-        backgroundUploadURLs={getBackgroundUploadURLs()}
+        backgroundUploadURLs={backgroundUploadURLs}
+        backgroundUploadEncryptKey={backgroundUploadEncryptKey}
         formData={{
           document_capture_session_uuid: appRoot.getAttribute('data-document-capture-session-uuid'),
           locale: i18n.currentLocale(),

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@babel/register": "^7.12.1",
+    "@peculiar/webcrypto": "^1.1.3",
     "@rails/webpacker": "^5.2.1",
     "@testing-library/dom": "^7.21.8",
     "@testing-library/react": "^10.4.8",

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -8,10 +8,13 @@ import defaultUpload from '@18f/identity-document-capture/services/upload';
 describe('document-capture/context/upload', () => {
   it('defaults to the default upload service', () => {
     const { result } = renderHook(() => useContext(UploadContext));
-    const { upload, isMockClient } = result.current;
 
-    expect(upload).to.equal(defaultUpload);
-    expect(isMockClient).to.equal(false);
+    expect(result.current).to.deep.equal({
+      upload: defaultUpload,
+      isMockClient: false,
+      backgroundUploadURLs: {},
+      backgroundUploadEncryptKey: undefined,
+    });
   });
 
   it('can be overridden with custom upload behavior', async () => {
@@ -37,6 +40,37 @@ describe('document-capture/context/upload', () => {
     });
 
     expect(result.current.isMockClient).to.be.true();
+  });
+
+  it('can be overridden with background upload URLs', () => {
+    const backgroundUploadURLs = { foo: '/' };
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider backgroundUploadURLs={backgroundUploadURLs}>
+          {children}
+        </UploadContextProvider>
+      ),
+    });
+
+    expect(result.current.backgroundUploadURLs).to.deep.equal(backgroundUploadURLs);
+  });
+
+  it('can be overridden with background upload encrypt key', async () => {
+    const key = await window.crypto.subtle.generateKey(
+      {
+        name: 'AES-GCM',
+        length: 256,
+      },
+      true,
+      ['encrypt', 'decrypt'],
+    );
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider backgroundUploadEncryptKey={key}>{children}</UploadContextProvider>
+      ),
+    });
+
+    expect(result.current.backgroundUploadEncryptKey).to.equal(key);
   });
 
   it('can provide endpoint and csrf to make available to uploader', async () => {

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -77,35 +77,11 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
         );
         const iv = new Uint8Array(12);
         const data = 'Hello world';
-        const expected = new Uint8Array([
-          134,
-          194,
-          44,
-          81,
-          34,
-          64,
-          28,
-          1,
-          117,
-          34,
-          161,
-          11,
-          192,
-          7,
-          169,
-          19,
-          140,
-          29,
-          89,
-          104,
-          50,
-          208,
-          250,
-          152,
-          208,
-          214,
-          65,
-        ]).buffer;
+        const expected = new Uint8Array(
+          '134,194,44,81,34,64,28,1,117,34,161,11,192,7,169,19,140,29,89,104,50,208,250,152,208,214,65'.split(
+            ',',
+          ),
+        ).buffer;
 
         const encrypted = await encrypt(key, iv, data);
         expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
@@ -121,35 +97,11 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
         );
         const iv = new Uint8Array(12);
         const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
-        const expected = new Uint8Array([
-          134,
-          194,
-          44,
-          81,
-          34,
-          64,
-          28,
-          1,
-          117,
-          34,
-          161,
-          11,
-          192,
-          7,
-          169,
-          19,
-          140,
-          29,
-          89,
-          104,
-          50,
-          208,
-          250,
-          152,
-          208,
-          214,
-          65,
-        ]).buffer;
+        const expected = new Uint8Array(
+          '134,194,44,81,34,64,28,1,117,34,161,11,192,7,169,19,140,29,89,104,50,208,250,152,208,214,65'.split(
+            ',',
+          ),
+        ).buffer;
 
         const encrypted = await encrypt(key, iv, data);
         expect(isArrayBufferEqual(encrypted, expected)).to.be.true();

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -1,9 +1,44 @@
 import React, { useEffect } from 'react';
 import sinon from 'sinon';
 import { UploadContextProvider } from '@18f/identity-document-capture';
-import withBackgroundEncryptedUpload from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
+import withBackgroundEncryptedUpload, {
+  blobToDataView,
+  encrypt,
+} from '@18f/identity-document-capture/higher-order/with-background-encrypted-upload';
 import { useSandbox } from '../../../support/sinon';
 import render from '../../../support/render';
+
+/**
+ * @param {ArrayBuffer} a
+ * @param {ArrayBuffer} b
+ *
+ * @return {boolean}
+ */
+function isArrayBufferEqual(a, b) {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+
+  const aView = new DataView(a);
+  const bView = new DataView(b);
+  for (let i = 0; i < a.byteLength; i++) {
+    if (aView.getUint8(i) !== bView.getUint8(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+describe('blobToDataView', () => {
+  it('converts blob to data view', async () => {
+    const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
+    const expected = new Uint8Array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]).buffer;
+
+    const dataView = await blobToDataView(data);
+    expect(isArrayBufferEqual(dataView.buffer, expected)).to.be.true();
+  });
+});
 
 describe('withBackgroundEncryptedUpload', () => {
   const sandbox = useSandbox();
@@ -16,29 +51,128 @@ describe('withBackgroundEncryptedUpload', () => {
     return null;
   });
 
+  describe('encrypt', () => {
+    it('resolves to AES-GCM encrypted data from string value', async () => {
+      const key = await window.crypto.subtle.importKey(
+        'raw',
+        new Uint8Array(32).buffer,
+        'AES-GCM',
+        false,
+        ['encrypt', 'decrypt'],
+      );
+      const iv = new Uint8Array(12);
+      const data = 'Hello world';
+      const expected = new Uint8Array([
+        134,
+        194,
+        44,
+        81,
+        34,
+        64,
+        28,
+        1,
+        117,
+        34,
+        161,
+        11,
+        192,
+        7,
+        169,
+        19,
+        140,
+        29,
+        89,
+        104,
+        50,
+        208,
+        250,
+        152,
+        208,
+        214,
+        65,
+      ]).buffer;
+
+      const encrypted = await encrypt(key, iv, data);
+      expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
+    });
+
+    it('resolves to AES-GCM encrypted data from blob', async () => {
+      const key = await window.crypto.subtle.importKey(
+        'raw',
+        new Uint8Array(32).buffer,
+        'AES-GCM',
+        false,
+        ['encrypt', 'decrypt'],
+      );
+      const iv = new Uint8Array(12);
+      const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
+      const expected = new Uint8Array([
+        134,
+        194,
+        44,
+        81,
+        34,
+        64,
+        28,
+        1,
+        117,
+        34,
+        161,
+        11,
+        192,
+        7,
+        169,
+        19,
+        140,
+        29,
+        89,
+        104,
+        50,
+        208,
+        250,
+        152,
+        208,
+        214,
+        65,
+      ]).buffer;
+
+      const encrypted = await encrypt(key, iv, data);
+      expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
+    });
+  });
+
   it('intercepts onChange to include background uploads', async () => {
     const onChange = sinon.spy();
+    const key = await window.crypto.subtle.generateKey(
+      {
+        name: 'AES-GCM',
+        length: 256,
+      },
+      true,
+      ['encrypt', 'decrypt'],
+    );
     sandbox.stub(window, 'fetch').callsFake(() => Promise.resolve({}));
     render(
-      <UploadContextProvider backgroundUploadURLs={{ foo: 'about:blank' }}>
+      <UploadContextProvider
+        backgroundUploadURLs={{ foo: 'about:blank' }}
+        backgroundUploadEncryptKey={key}
+      >
         <Component onChange={onChange} />)
       </UploadContextProvider>,
     );
 
     expect(onChange.calledOnce).to.be.true();
     const patch = onChange.getCall(0).args[0];
-    expect(patch).to.have.keys(['foo', 'baz', 'fooBackgroundUpload']);
+    expect(patch).to.have.keys(['foo', 'baz', 'foo_image_iv', 'foo_image_url']);
     expect(patch.foo).to.equal('bar');
     expect(patch.baz).to.equal('quux');
-    expect(patch.fooBackgroundUpload).to.be.an.instanceOf(Promise);
-    expect(window.fetch.calledOnce).to.be.true();
-    expect(window.fetch.getCall(0).args).to.deep.equal([
-      'about:blank',
-      {
-        method: 'POST',
-        body: 'bar',
-      },
-    ]);
-    expect(await patch.fooBackgroundUpload).to.be.undefined();
+    expect(patch.foo_image_url).to.be.an.instanceOf(Promise);
+    expect(await patch.foo_image_url).to.equal('about:blank');
+    const [url, params] = window.fetch.getCall(0).args;
+    expect(url).to.equal('about:blank');
+    expect(params.method).to.equal('POST');
+    expect(params.body).to.be.instanceOf(ArrayBuffer);
+    const bodyAsString = String.fromCharCode.apply(null, new Uint8Array(params.body));
+    expect(bodyAsString).to.not.equal('bar');
   });
 });

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -30,149 +30,151 @@ function isArrayBufferEqual(a, b) {
   return true;
 }
 
-describe('blobToDataView', () => {
-  it('converts blob to data view', async () => {
-    const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
-    const expected = new Uint8Array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]).buffer;
-
-    const dataView = await blobToDataView(data);
-    expect(isArrayBufferEqual(dataView.buffer, expected)).to.be.true();
-  });
-});
-
-describe('withBackgroundEncryptedUpload', () => {
-  const sandbox = useSandbox();
-
-  const Component = withBackgroundEncryptedUpload(({ onChange }) => {
-    useEffect(() => {
-      onChange({ foo: 'bar', baz: 'quux' });
-    }, []);
-
-    return null;
-  });
-
-  describe('encrypt', () => {
-    it('resolves to AES-GCM encrypted data from string value', async () => {
-      const key = await window.crypto.subtle.importKey(
-        'raw',
-        new Uint8Array(32).buffer,
-        'AES-GCM',
-        false,
-        ['encrypt', 'decrypt'],
-      );
-      const iv = new Uint8Array(12);
-      const data = 'Hello world';
-      const expected = new Uint8Array([
-        134,
-        194,
-        44,
-        81,
-        34,
-        64,
-        28,
-        1,
-        117,
-        34,
-        161,
-        11,
-        192,
-        7,
-        169,
-        19,
-        140,
-        29,
-        89,
-        104,
-        50,
-        208,
-        250,
-        152,
-        208,
-        214,
-        65,
-      ]).buffer;
-
-      const encrypted = await encrypt(key, iv, data);
-      expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
-    });
-
-    it('resolves to AES-GCM encrypted data from blob', async () => {
-      const key = await window.crypto.subtle.importKey(
-        'raw',
-        new Uint8Array(32).buffer,
-        'AES-GCM',
-        false,
-        ['encrypt', 'decrypt'],
-      );
-      const iv = new Uint8Array(12);
+describe('document-capture/higher-order/with-background-encrypted-upload', () => {
+  describe('blobToDataView', () => {
+    it('converts blob to data view', async () => {
       const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
-      const expected = new Uint8Array([
-        134,
-        194,
-        44,
-        81,
-        34,
-        64,
-        28,
-        1,
-        117,
-        34,
-        161,
-        11,
-        192,
-        7,
-        169,
-        19,
-        140,
-        29,
-        89,
-        104,
-        50,
-        208,
-        250,
-        152,
-        208,
-        214,
-        65,
-      ]).buffer;
+      const expected = new Uint8Array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]).buffer;
 
-      const encrypted = await encrypt(key, iv, data);
-      expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
+      const dataView = await blobToDataView(data);
+      expect(isArrayBufferEqual(dataView.buffer, expected)).to.be.true();
     });
   });
 
-  it('intercepts onChange to include background uploads', async () => {
-    const onChange = sinon.spy();
-    const key = await window.crypto.subtle.generateKey(
-      {
-        name: 'AES-GCM',
-        length: 256,
-      },
-      true,
-      ['encrypt', 'decrypt'],
-    );
-    sandbox.stub(window, 'fetch').callsFake(() => Promise.resolve({}));
-    render(
-      <UploadContextProvider
-        backgroundUploadURLs={{ foo: 'about:blank' }}
-        backgroundUploadEncryptKey={key}
-      >
-        <Component onChange={onChange} />)
-      </UploadContextProvider>,
-    );
+  describe('withBackgroundEncryptedUpload', () => {
+    const sandbox = useSandbox();
 
-    expect(onChange.calledOnce).to.be.true();
-    const patch = onChange.getCall(0).args[0];
-    expect(patch).to.have.keys(['foo', 'baz', 'foo_image_iv', 'foo_image_url']);
-    expect(patch.foo).to.equal('bar');
-    expect(patch.baz).to.equal('quux');
-    expect(patch.foo_image_url).to.be.an.instanceOf(Promise);
-    expect(await patch.foo_image_url).to.equal('about:blank');
-    const [url, params] = window.fetch.getCall(0).args;
-    expect(url).to.equal('about:blank');
-    expect(params.method).to.equal('POST');
-    expect(params.body).to.be.instanceOf(ArrayBuffer);
-    const bodyAsString = String.fromCharCode.apply(null, new Uint8Array(params.body));
-    expect(bodyAsString).to.not.equal('bar');
+    const Component = withBackgroundEncryptedUpload(({ onChange }) => {
+      useEffect(() => {
+        onChange({ foo: 'bar', baz: 'quux' });
+      }, []);
+
+      return null;
+    });
+
+    describe('encrypt', () => {
+      it('resolves to AES-GCM encrypted data from string value', async () => {
+        const key = await window.crypto.subtle.importKey(
+          'raw',
+          new Uint8Array(32).buffer,
+          'AES-GCM',
+          false,
+          ['encrypt', 'decrypt'],
+        );
+        const iv = new Uint8Array(12);
+        const data = 'Hello world';
+        const expected = new Uint8Array([
+          134,
+          194,
+          44,
+          81,
+          34,
+          64,
+          28,
+          1,
+          117,
+          34,
+          161,
+          11,
+          192,
+          7,
+          169,
+          19,
+          140,
+          29,
+          89,
+          104,
+          50,
+          208,
+          250,
+          152,
+          208,
+          214,
+          65,
+        ]).buffer;
+
+        const encrypted = await encrypt(key, iv, data);
+        expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
+      });
+
+      it('resolves to AES-GCM encrypted data from blob', async () => {
+        const key = await window.crypto.subtle.importKey(
+          'raw',
+          new Uint8Array(32).buffer,
+          'AES-GCM',
+          false,
+          ['encrypt', 'decrypt'],
+        );
+        const iv = new Uint8Array(12);
+        const data = new window.File(['Hello world'], 'demo.text', { type: 'text/plain' });
+        const expected = new Uint8Array([
+          134,
+          194,
+          44,
+          81,
+          34,
+          64,
+          28,
+          1,
+          117,
+          34,
+          161,
+          11,
+          192,
+          7,
+          169,
+          19,
+          140,
+          29,
+          89,
+          104,
+          50,
+          208,
+          250,
+          152,
+          208,
+          214,
+          65,
+        ]).buffer;
+
+        const encrypted = await encrypt(key, iv, data);
+        expect(isArrayBufferEqual(encrypted, expected)).to.be.true();
+      });
+    });
+
+    it('intercepts onChange to include background uploads', async () => {
+      const onChange = sinon.spy();
+      const key = await window.crypto.subtle.generateKey(
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt'],
+      );
+      sandbox.stub(window, 'fetch').callsFake(() => Promise.resolve({}));
+      render(
+        <UploadContextProvider
+          backgroundUploadURLs={{ foo: 'about:blank' }}
+          backgroundUploadEncryptKey={key}
+        >
+          <Component onChange={onChange} />)
+        </UploadContextProvider>,
+      );
+
+      expect(onChange.calledOnce).to.be.true();
+      const patch = onChange.getCall(0).args[0];
+      expect(patch).to.have.keys(['foo', 'baz', 'foo_image_iv', 'foo_image_url']);
+      expect(patch.foo).to.equal('bar');
+      expect(patch.baz).to.equal('quux');
+      expect(patch.foo_image_url).to.be.an.instanceOf(Promise);
+      expect(await patch.foo_image_url).to.equal('about:blank');
+      const [url, params] = window.fetch.getCall(0).args;
+      expect(url).to.equal('about:blank');
+      expect(params.method).to.equal('POST');
+      expect(params.body).to.be.instanceOf(ArrayBuffer);
+      const bodyAsString = String.fromCharCode.apply(null, new Uint8Array(params.body));
+      expect(bodyAsString).to.not.equal('bar');
+    });
   });
 });

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,3 +1,4 @@
+import { Crypto } from '@peculiar/webcrypto';
 import chai from 'chai';
 import dirtyChai from 'dirty-chai';
 import { createDOM, useCleanDOM } from './support/dom';
@@ -13,6 +14,7 @@ global.expect = chai.expect;
 const dom = createDOM();
 global.window = dom.window;
 global.window.fetch = () => Promise.reject(new Error('Fetch must be stubbed'));
+global.window.crypto = new Crypto(); // In the future (Node >=15), use native webcrypto: https://nodejs.org/api/webcrypto.html
 global.navigator = window.navigator;
 global.document = window.document;
 global.Document = window.Document;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9449,6 +9449,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webcrypto-shim@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/webcrypto-shim/-/webcrypto-shim-0.1.6.tgz#b4554d95c0a63637226c9732440dc674bf96f5cb"
+  integrity sha512-0o612s3S5z3IkDSRghIwd3Ul4X8NRmmZDpt6PWGI9gSM+nygVvrfzGjhIh4vwzlOJxYxS0fcFD1wh3yznuVzFg==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,34 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@peculiar/asn1-schema@^2.0.12", "@peculiar/asn1-schema@^2.0.13":
+  version "2.0.23"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.0.23.tgz#653937fbff1e6b67da2a9935fb3d8b965c0bdfd6"
+  integrity sha512-dV1xQJiWTzwyjfAbvwTT+RTrS4UN9kPJuy92B6oGv572wPZxaoA8R+nxLX92jLz23L43CnLvxiBo+Rip59SWfw==
+  dependencies:
+    "@types/asn1js" "^0.0.2"
+    asn1js "^2.0.26"
+    pvtsutils "^1.0.14"
+    tslib "^2.0.2"
+
+"@peculiar/json-schema@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
+  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
+  dependencies:
+    tslib "^2.0.0"
+
+"@peculiar/webcrypto@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.3.tgz#54301b4cfa22e9d879fd8d460528fa44a1548119"
+  integrity sha512-M1mipPJkWzIf92w3T1Vx5ir3kV9c0oWCcLkeh4vNa/3XDEtQ7xxj5NRKyq67NuVNKLH2/0JD1crlLJyqfYbfBA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.13"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.0.11"
+    tslib "^2.0.1"
+    webcrypto-core "^1.1.6"
+
 "@rails/webpacker@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.2.1.tgz#87cdbd4af2090ae2d74bdc51f6f04717d907c5b3"
@@ -1117,6 +1145,13 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
   integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
+"@types/asn1js@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/asn1js/-/asn1js-0.0.2.tgz#f278a8af81861813d4fc9cd0a86c8b1ac5f16db3"
+  integrity sha512-xtLPq140WhPqvDZDpY70rTx4qTezHs+8htbhWQGuevBRQko8FRjFSO5WVTwXOwd3W5tQRxJ7eni30fDUP2q4wQ==
+  dependencies:
+    "@types/pvutils" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1179,6 +1214,11 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/pvutils@*":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pvutils/-/pvutils-0.0.2.tgz#e21684962cfa58ac920fd576d90556032dc86009"
+  integrity sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w==
 
 "@types/q@^1.5.1":
   version "1.5.4"
@@ -1660,6 +1700,13 @@ asn1@~0.2.3:
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
+
+asn1js@^2.0.26:
+  version "2.0.26"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-2.0.26.tgz#0a6d435000f556a96c6012969d9704d981b71251"
+  integrity sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==
+  dependencies:
+    pvutils latest
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -7662,6 +7709,18 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pvtsutils@^1.0.11, pvtsutils@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.0.14.tgz#002a07d5a47b00aa9191889e450493390ebffefc"
+  integrity sha512-X9SBWQ9ceNAEEgLweoE7m7P6LDnZ3pZADBq7utQQV4pQ1vj7uQIAXaAQRCz/4nKLKQRT9ZrHOuxailKqBiztrg==
+  dependencies:
+    tslib "^2.0.1"
+
+pvutils@latest:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.0.17.tgz#ade3c74dfe7178944fe44806626bd2e249d996bf"
+  integrity sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -9138,6 +9197,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -9448,6 +9512,17 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+webcrypto-core@^1.1.6:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.1.8.tgz#91720c07f4f2edd181111b436647ea5a282af0a9"
+  integrity sha512-hKnFXsqh0VloojNeTfrwFoRM4MnaWzH6vtXcaFcGjPEu+8HmBdQZnps3/2ikOFqS8bJN1RYr6mI2P/FJzyZnXg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.12"
+    "@peculiar/json-schema" "^1.1.12"
+    asn1js "^2.0.26"
+    pvtsutils "^1.0.11"
+    tslib "^2.0.1"
 
 webcrypto-shim@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
Extracted from #4335 (see https://github.com/18F/identity-idp/pull/4335#issuecomment-717296103)

**Why**: As a user, I want the client to encrypt images and upload them to S3, so that they can be processed privately and async.

**Testing Procedure:**

See notes at #4335.