### PR TITLE
Refactor document verification async steps to return image presenter

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -22,9 +22,6 @@ module Idv
         update_analytics(client_response)
 
         store_pii(client_response) if client_response.success?
-        status = :bad_request unless client_response.success?
-      else
-        status = image_form.status
       end
 
       presenter = ImageUploadResponsePresenter.new(
@@ -32,8 +29,7 @@ module Idv
         form_response: client_response || form_response,
       )
 
-      render json: presenter,
-             status: status || :ok
+      render json: presenter, status: presenter.status
     end
 
     private

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -29,12 +29,6 @@ module Idv
       )
     end
 
-    def status
-      return :ok if valid?
-      return :too_many_requests if errors.key?(:limit)
-      :bad_request
-    end
-
     def remaining_attempts
       return unless document_capture_session
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)

--- a/app/forms/idv/api_document_verification_form.rb
+++ b/app/forms/idv/api_document_verification_form.rb
@@ -15,7 +15,6 @@ module Idv
     def initialize(params, liveness_checking_enabled:)
       @params = params
       @liveness_checking_enabled = liveness_checking_enabled
-      @readable = {}
     end
 
     def submit

--- a/app/forms/idv/api_document_verification_status_form.rb
+++ b/app/forms/idv/api_document_verification_status_form.rb
@@ -1,0 +1,45 @@
+module Idv
+  class ApiDocumentVerificationStatusForm
+    include ActiveModel::Model
+    include ActionView::Helpers::TranslationHelper
+
+    validate :throttle_if_rate_limited
+    validate :timeout_error
+    validate :failed_result
+
+    def initialize(async_state:, document_capture_session:)
+      @async_state = async_state
+      @document_capture_session = document_capture_session
+    end
+
+    def submit
+      FormResponse.new(
+        success: valid?,
+        errors: errors.messages,
+        extra: {
+          remaining_attempts: remaining_attempts,
+        },
+      )
+    end
+
+    def remaining_attempts
+      return unless @document_capture_session
+      Throttler::RemainingCount.call(@document_capture_session.user_id, :idv_acuant)
+    end
+
+    def throttle_if_rate_limited
+      return unless remaining_attempts.zero?
+      errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
+    end
+
+    def timeout_error
+      return unless @async_state.status == :timeout
+      errors.add(:timeout, t('errors.doc_auth.document_verification_timeout'))
+    end
+
+    def failed_result
+      return unless @async_state.status == :done && !@async_state.result[:success]
+      @async_state.result[:errors].each { |key, error| errors.add(key, error) }
+    end
+  end
+end

--- a/app/forms/idv/api_document_verification_status_form.rb
+++ b/app/forms/idv/api_document_verification_status_form.rb
@@ -3,7 +3,6 @@ module Idv
     include ActiveModel::Model
     include ActionView::Helpers::TranslationHelper
 
-    validate :throttle_if_rate_limited
     validate :timeout_error
     validate :failed_result
 
@@ -25,11 +24,6 @@ module Idv
     def remaining_attempts
       return unless @document_capture_session
       Throttler::RemainingCount.call(@document_capture_session.user_id, :idv_acuant)
-    end
-
-    def throttle_if_rate_limited
-      return unless remaining_attempts.zero?
-      errors.add(:limit, t('errors.doc_auth.acuant_throttle'))
     end
 
     def timeout_error

--- a/app/forms/idv/api_document_verification_status_form.rb
+++ b/app/forms/idv/api_document_verification_status_form.rb
@@ -27,7 +27,7 @@ module Idv
     end
 
     def timeout_error
-      return unless @async_state.status == :timeout
+      return unless @async_state.status == :timed_out
       errors.add(:timeout, t('errors.doc_auth.document_verification_timeout'))
     end
 

--- a/app/forms/idv/api_document_verification_status_form.rb
+++ b/app/forms/idv/api_document_verification_status_form.rb
@@ -38,7 +38,7 @@ module Idv
     end
 
     def failed_result
-      return unless @async_state.status == :done && !@async_state.result[:success]
+      return if @async_state.status != :done || @async_state.result[:success]
       @async_state.result[:errors].each { |key, error| errors.add(key, error) }
     end
   end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -30,12 +30,6 @@ module Idv
       )
     end
 
-    def status
-      return :ok if valid?
-      return :too_many_requests if errors.key?(:limit)
-      :bad_request
-    end
-
     def remaining_attempts
       Throttler::RemainingCount.call(document_capture_session.user_id, :idv_acuant)
     end

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -20,6 +20,16 @@ class ImageUploadResponsePresenter
     @form.remaining_attempts
   end
 
+  def status
+    if success
+      :ok
+    elsif @form_response.errors.key?(:limit)
+      :too_many_requests
+    else
+      :bad_request
+    end
+  end
+
   def as_json(*)
     if success
       { success: true }

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -6,7 +6,7 @@ class ImageUploadResponsePresenter
     @form_response = form_response
   end
 
-  def success
+  def success?
     @form_response.success?
   end
 
@@ -21,7 +21,7 @@ class ImageUploadResponsePresenter
   end
 
   def status
-    if success
+    if success?
       :ok
     elsif @form_response.errors.key?(:limit)
       :too_many_requests
@@ -31,7 +31,7 @@ class ImageUploadResponsePresenter
   end
 
   def as_json(*)
-    if success
+    if success?
       { success: true }
     elsif @form_response.errors.key?(:limit)
       { success: false, redirect: idv_session_errors_throttled_url }

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -8,9 +8,17 @@ module Idv
       private
 
       def form_submit
-        json = form.submit
-        render_json(json, status: form.status)
-        json
+        response = form.submit
+        presenter = ImageUploadResponsePresenter.new(
+          form: form,
+          form_response: response,
+        )
+        status = :accepted if response.success?
+        render_json(
+          presenter,
+          status: status || presenter.status,
+        )
+        response
       end
 
       def form

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -44,8 +44,9 @@ module Idv
       end
 
       def document_capture_session
+        return @document_capture_session if defined?(@document_capture_session)
         dcs_uuid = flow_session[verify_document_capture_session_uuid_key]
-        @document_capture_session ||= DocumentCaptureSession.find_by(uuid: dcs_uuid)
+        @document_capture_session = DocumentCaptureSession.find_by(uuid: dcs_uuid)
       end
 
       def async_state

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -46,6 +46,8 @@ en:
         <li>You are not wearing a hat or glasses, and your head is fully visible</li>
         </ul>
       document_capture_selfie_consent_blocked: Your camera is blocked
+      document_verification_timeout: The server took too long to respond. Please try
+        again.
       general_error: We could not read or verify your ID. Try to take and upload new
         images of both the front and back of your ID. Make sure everything can be
         easily read, including the barcode.

--- a/config/locales/errors/es.yml
+++ b/config/locales/errors/es.yml
@@ -46,6 +46,8 @@ es:
         <li>No lleva puesto un sombrero o anteojos, y su cabeza es completamente visible</li>
         </ul>
       document_capture_selfie_consent_blocked: El acceso a su cámara está bloqueado
+      document_verification_timeout: El servidor tardó demasiado en responder. Inténtalo
+        de nuevo.
       general_error: No pudimos leer ni verificar su identificación. Intenta tomar
         y subir nuevas imágenes de la parte delantera y trasera de tu ID. Asegúrese
         de que todo se pueda leer fácilmente, incluido el código de barras.

--- a/config/locales/errors/fr.yml
+++ b/config/locales/errors/fr.yml
@@ -46,6 +46,8 @@ fr:
         <li>Vous ne portez pas de chapeau ni de lunettes et votre tête est entièrement visible</li>
         </ul>
       document_capture_selfie_consent_blocked: L'accès à votre caméra est bloqué
+      document_verification_timeout: Le serveur a mis trop de temps à répondre. Veuillez
+        réessayer.
       general_error: Nous n'avons pas pu lire ni vérifier votre identité. Essayez
         de prendre et de télécharger de nouvelles images des deux côtés de votre ID.
         Assurez-vous que tout peut être facilement lu, y compris le code à barres.

--- a/spec/forms/idv/api_document_verification_status_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_status_form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
             success: false,
             errors: { front: 'Wrong document' },
           },
-          status: :done
+          status: :done,
         )
       end
 
@@ -56,7 +56,7 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
           result: {
             success: true,
           },
-          status: :done
+          status: :done,
         )
       end
 

--- a/spec/forms/idv/api_document_verification_status_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_status_form_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Idv::ApiDocumentVerificationStatusForm do
+  subject(:form) do
+    Idv::ApiDocumentVerificationStatusForm.new(
+      async_state: async_state,
+      document_capture_session: document_capture_session,
+    )
+  end
+
+  let(:async_state) { ProofingDocumentCaptureSessionResult.none }
+  let(:document_capture_session) { DocumentCaptureSession.create! }
+
+  describe '#valid?' do
+    context 'with timeout async state' do
+      let(:async_state) { ProofingDocumentCaptureSessionResult.timed_out }
+
+      it 'is invalid' do
+        expect(form.valid?).to eq(false)
+        expect(form.errors[:timeout]).to eq([t('errors.doc_auth.document_verification_timeout')])
+      end
+    end
+
+    context 'with pending result' do
+      let(:async_state) { ProofingDocumentCaptureSessionResult.in_progress }
+
+      it 'is valid' do
+        expect(form.valid?).to eq(true)
+      end
+    end
+
+    context 'with unsuccessful result' do
+      let(:async_state) do
+        ProofingDocumentCaptureSessionResult.new(
+          id: nil,
+          pii: nil,
+          result: {
+            success: false,
+            errors: { front: 'Wrong document' },
+          },
+          status: :done
+        )
+      end
+
+      it 'is invalid' do
+        expect(form.valid?).to eq(false)
+        expect(form.errors[:front]).to eq(['Wrong document'])
+      end
+    end
+
+    context 'with successful result' do
+      let(:async_state) do
+        ProofingDocumentCaptureSessionResult.new(
+          id: nil,
+          pii: nil,
+          result: {
+            success: true,
+          },
+          status: :done
+        )
+      end
+
+      it 'is valid' do
+        expect(form.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe '#submit' do
+    it 'includes remaining_attempts' do
+      response = form.submit
+      expect(response.extra[:remaining_attempts]).to be_a_kind_of(Numeric)
+    end
+  end
+end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -60,6 +60,44 @@ describe ImageUploadResponsePresenter do
     end
   end
 
+  describe '#status' do
+    context 'limit error' do
+      let(:form_response) do
+        FormResponse.new(
+          success: false,
+          errors: {
+            limit: t('errors.doc_auth.acuant_throttle'),
+          },
+        )
+      end
+
+      it 'returns bad request' do
+        expect(presenter.status).to eq :too_many_requests
+      end
+    end
+
+    context 'failure' do
+      let(:form_response) do
+        FormResponse.new(
+          success: false,
+          errors: {
+            front: t('doc_auth.errors.not_a_file'),
+          },
+        )
+      end
+
+      it 'returns bad request' do
+        expect(presenter.status).to eq :bad_request
+      end
+    end
+
+    context 'success' do
+      it 'returns ok' do
+        expect(presenter.status).to eq :ok
+      end
+    end
+  end
+
   describe '#as_json' do
     context 'success' do
       it 'returns hash of properties' do

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -14,18 +14,18 @@ describe ImageUploadResponsePresenter do
     )
   end
 
-  describe '#success' do
+  describe '#success?' do
     context 'failure' do
       let(:form_response) { FormResponse.new(success: false, errors: {}, extra: {}) }
 
       it 'returns false' do
-        expect(presenter.success).to eq false
+        expect(presenter.success?).to eq false
       end
     end
 
     context 'success' do
       it 'returns true' do
-        expect(presenter.success).to eq true
+        expect(presenter.success?).to eq true
       end
     end
   end

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -71,7 +71,7 @@ describe ImageUploadResponsePresenter do
         )
       end
 
-      it 'returns bad request' do
+      it 'returns 429 too many requests' do
         expect(presenter.status).to eq :too_many_requests
       end
     end
@@ -86,7 +86,7 @@ describe ImageUploadResponsePresenter do
         )
       end
 
-      it 'returns bad request' do
+      it 'returns 400 bad request' do
         expect(presenter.status).to eq :bad_request
       end
     end


### PR DESCRIPTION
Extracted from #4335
Previously: #4313 (https://github.com/18F/identity-idp/pull/4313#discussion_r510907870)

**Why**: To simplify React client handling of sync and async (submission and status) responses, generate all responses through `ImageUploadResponsePresenter` presenter.