### PR TITLE
Remove test-specific useCleanDOM

### DIFF
--- a/spec/javascripts/app/components/modal-spec.js
+++ b/spec/javascripts/app/components/modal-spec.js
@@ -1,10 +1,8 @@
 import { waitFor } from '@testing-library/dom';
 import BaseModal from '../../../../app/javascript/app/components/modal';
-import { useCleanDOM } from '../../support/dom';
 import { useSandbox } from '../../support/sinon';
 
 describe('components/modal', () => {
-  useCleanDOM();
   const sandbox = useSandbox();
 
   class Modal extends BaseModal {

--- a/spec/javascripts/packs/form-validation-spec.js
+++ b/spec/javascripts/packs/form-validation-spec.js
@@ -1,11 +1,9 @@
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
-import { useCleanDOM } from '../support/dom';
 import { useSandbox } from '../support/sinon';
 import { initialize } from '../../../app/javascript/packs/form-validation';
 
 describe('form-validation', () => {
-  useCleanDOM();
   const sandbox = useSandbox();
 
   const onSubmit = (event) => event.preventDefault();

--- a/spec/javascripts/packs/submit-with-spinner-spec.js
+++ b/spec/javascripts/packs/submit-with-spinner-spec.js
@@ -1,9 +1,6 @@
 import { screen } from '@testing-library/dom';
-import { useCleanDOM } from '../support/dom';
 
 describe('submit-with-spinner', () => {
-  useCleanDOM();
-
   async function initialize({ withForm = true } = {}) {
     const parent = withForm
       ? document.body.appendChild(document.createElement('form'))


### PR DESCRIPTION
**Why**: Redundant. useCleanDOM is initialized in global test setup, and applies to all test cases.

See:

https://github.com/18F/identity-idp/blob/fb558a203c8b26bf9ed383218919482a102481cb/spec/javascripts/spec_helper.js#L23