### PR TITLE
Update lambda function name, derive from job class

### DIFF
--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -12,7 +12,7 @@ module Idv
       LambdaJobs::Runner.new(
         job_class: Idv::Proofer.resolution_job_class,
         args: { applicant_pii: @applicant, callback_url: callback_url,
-                should_proof_state_id: should_proof_state_id }
+                should_proof_state_id: should_proof_state_id },
       ).run do |idv_result|
         document_capture_session.store_proofing_result(idv_result[:resolution_result])
 
@@ -27,7 +27,7 @@ module Idv
 
       LambdaJobs::Runner.new(
         job_class: Idv::Proofer.address_job_class,
-        args: { applicant_pii: @applicant, callback_url: callback_url }
+        args: { applicant_pii: @applicant, callback_url: callback_url },
       ).run do |idv_result|
         document_capture_session.store_proofing_result(idv_result[:address_result])
 

--- a/app/services/idv/agent.rb
+++ b/app/services/idv/agent.rb
@@ -10,7 +10,7 @@ module Idv
       )
 
       LambdaJobs::Runner.new(
-        job_name: nil, job_class: Idv::Proofer.resolution_job_class,
+        job_class: Idv::Proofer.resolution_job_class,
         args: { applicant_pii: @applicant, callback_url: callback_url,
                 should_proof_state_id: should_proof_state_id }
       ).run do |idv_result|
@@ -26,7 +26,7 @@ module Idv
       )
 
       LambdaJobs::Runner.new(
-        job_name: nil, job_class: Idv::Proofer.address_job_class,
+        job_class: Idv::Proofer.address_job_class,
         args: { applicant_pii: @applicant, callback_url: callback_url }
       ).run do |idv_result|
         document_capture_session.store_proofing_result(idv_result[:address_result])

--- a/app/services/lambda_jobs/runner.rb
+++ b/app/services/lambda_jobs/runner.rb
@@ -1,6 +1,6 @@
 module LambdaJobs
   class Runner
-    attr_reader :job_name, :job_class, :args
+    attr_reader :job_class, :args
 
     def initialize(job_class:, args:)
       @job_class = job_class

--- a/app/services/lambda_jobs/runner.rb
+++ b/app/services/lambda_jobs/runner.rb
@@ -2,8 +2,7 @@ module LambdaJobs
   class Runner
     attr_reader :job_name, :job_class, :args
 
-    def initialize(job_name:, job_class:, args:)
-      @job_name = job_name
+    def initialize(job_class:, args:)
       @job_class = job_class
       @args = args
     end
@@ -31,7 +30,15 @@ module LambdaJobs
 
     # Due to length limits, we can only use the first 10 characters of a git SHA
     def function_name
-      "#{job_name}:#{LambdaJobs::GIT_REF[0...10]}"
+      "#{LoginGov::Hostdata.env}-idp-functions-#{job_name}Function:#{LambdaJobs::GIT_REF[0...10]}"
+    end
+
+    # @example
+    #   new(job_class: IdentityIdpFunctions::ProofResolutionMock).job_name
+    #   => "ProofResolutionMock"
+    # @return [String]
+    def job_name
+      job_class.name.split('::').last
     end
   end
 end

--- a/spec/services/lambda_jobs/runner_spec.rb
+++ b/spec/services/lambda_jobs/runner_spec.rb
@@ -2,22 +2,23 @@ require 'rails_helper'
 
 RSpec.describe LambdaJobs::Runner do
   subject(:runner) do
-    LambdaJobs::Runner.new(job_name: job_name, args: args, job_class: job_class)
+    LambdaJobs::Runner.new(args: args, job_class: job_class)
   end
 
-  let(:job_name) { 'my-job' }
   let(:args) { { foo: 'bar' } }
-  let(:job_class) { double('JobClass') }
+  let(:job_class) { double('JobClass', name: 'SomeModule::OtherModule::JobClass') }
   let(:aws_lambda_proofing_enabled) { 'true' }
 
+  let(:env) { 'dev' }
   let(:git_ref) { '1234567890abcdefghijklmnop' }
   before do
     stub_const('LambdaJobs::GIT_REF', git_ref)
+    allow(LoginGov::Hostdata).to receive(:env).and_return(env)
   end
 
   describe '#function_name' do
-    it 'adds the first 10 characters of the GIT_REF' do
-      expect(runner.function_name).to eq('my-job:1234567890')
+    it 'has the env, job class and first 10 characters of the GIT_REF' do
+      expect(runner.function_name).to eq('dev-idp-functions-JobClassFunction:1234567890')
     end
   end
 
@@ -41,7 +42,7 @@ RSpec.describe LambdaJobs::Runner do
 
         it 'involves a lambda in AWS' do
           expect(aws_lambda_client).to receive(:invoke).with(
-            function_name: 'my-job:1234567890',
+            function_name: 'dev-idp-functions-JobClassFunction:1234567890',
             invocation_type: 'Event',
             log_type: 'None',
             payload: args.to_json,


### PR DESCRIPTION
By convention, our job class classes match the Ruby classes in identity-idp-functions so this takes advantage of that

The Ruby class `IdentityIdpFunctions::ProofAddressMock` corresponds to the function `ProofAddressMockFunction` which then is named for the environment, repo and git sha:

```
dev-idp-functions-ProofAddressMockFunction:f067ac9a6c
```