### PR TITLE
Allow Node.js >=12

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Identity Management System powering login.gov.
 - Ruby 2.6
 - [Postgresql](http://www.postgresql.org/download/)
 - [Redis 2.8+](http://redis.io/)
-- [Node.js v12.x.x](https://nodejs.org)
+- [Node.js v14.x.x](https://nodejs.org)
 - [Yarn](https://yarnpkg.com/en/)
 
 #### Running the app with Docker

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": "12.x.x",
-    "npm": "6.x.x"
+    "node": ">=12",
+    "npm": ">=6"
   },
   "workspaces": [
     "app/javascript/packages/*"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": "14.x.x",
+    "node": ">=12",
     "npm": "6.x.x"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=12",
-    "npm": ">=6"
+    "node": "14.x.x",
+    "npm": "6.x.x"
   },
   "workspaces": [
     "app/javascript/packages/*"


### PR DESCRIPTION
**Why**: Node 14 is now LTS as of 10/27/20. CircleCI has upgraded to use the latest LTS by default in `circleci/ruby:2.6.6-node-browsers` Docker image, which now causes errors in all builds.

See: https://nodejs.org/en/about/releases/

See: https://hub.docker.com/layers/circleci/ruby/2.6.6-node-browsers/images/sha256-1a3d0931fd7c55611f5b382c9dcb39ea58830858d276cddc284d51a4d7b8cee3?context=explore