### PR TITLE
StrongMigrations check for integer columns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,7 +631,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stringex (2.8.5)
-    strong_migrations (0.6.8)
+    strong_migrations (0.7.2)
       activerecord (>= 5)
     subprocess (1.3.2)
     sysexits (1.2.0)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,24 @@
+# id columns are generated as bigint, and we sometimes use constraint-less integer columns
+# that reference another table. To ensure we use bigint for those columns, this check raises
+# if a column is added that uses :integer and the column_name ends with "_id".
+#
+# Some "_id" columns may not be references to other tables and may not need to be bigint.
+# To exclude a table/column from this check add a `[table, column]` item into excluded_columns:
+#
+# Ex: excluded_columns = [[:users, :my_new_id]]
+
+excluded_columns = []
+
+StrongMigrations.add_check do |method, args|
+  table, column, type, _options = args
+  excluded = excluded_columns.include?([table, column])
+  if !excluded && method == :add_column && column.to_s.ends_with?('_id') && type == :integer
+    stop! """
+    Columns referencing another table should use :bigint instead of integer.
+
+    add_column #{table.inspect}, #{column.inspect}, :bigint
+    OR
+    t.bigint #{column.inspect}
+    """
+  end
+end

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -6,12 +6,13 @@
 # To exclude a table/column from this check add a `[table, column]` item into excluded_columns:
 #
 # Ex: excluded_columns = [[:users, :my_new_id]]
-
-excluded_columns = []
+class IdpStrongMigrations
+  EXCLUDED_COLUMNS = [].freeze
+end
 
 StrongMigrations.add_check do |method, (table, column, type, _options)|
-  excluded = excluded_columns.include?([table, column])
-  if !excluded && method == :add_column && column.to_s.ends_with?('_id') && type == :integer
+  is_excluded = IdpStrongMigrations::EXCLUDED_COLUMNS.include?([table, column])
+  if !is_excluded && method == :add_column && column.to_s.ends_with?('_id') && type == :integer
     stop! """
     Columns referencing another table should use :bigint instead of integer.
 

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -9,8 +9,7 @@
 
 excluded_columns = []
 
-StrongMigrations.add_check do |method, args|
-  table, column, type, _options = args
+StrongMigrations.add_check do |method, (table, column, type, _options)|
   excluded = excluded_columns.include?([table, column])
   if !excluded && method == :add_column && column.to_s.ends_with?('_id') && type == :integer
     stop! """


### PR DESCRIPTION
Steve got me thinking at standup today, and this should catch some cases where we should use `bigint` for new columns referencing another table. The heuristic implemented is columns ending in "_id" of type `:integer` will fail, with the option to exclude specific columns. This PR is part of [LG-3648](https://cm-jira.usa.gov/browse/LG-3648).

The check runs for any added column, and I'm open to a better way of checking if anyone has ideas 🙂 

If you were to have a migration like:

```ruby
class BigInts < ActiveRecord::Migration[5.2]
  def change
    create_table :users do |t|
      t.integer :profile_id
    end

    # OR
    # add_column :users, :profile_id, :integer
  end
end

```

You'd get an error like:

```sh
== 20201028161952 BigInts: migrating ==========================================
-- create_table(:users)
   -> 0.0088s
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

=== Custom check #strong_migrations ===


    Columns referencing another table should use :bigint instead of integer.

    add_column :users, :profile_id, :bigint
    OR
    t.bigint :profile_id
```