### PR TITLE
Update identity-idp-functions calling syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,12 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: c922c736b9ad53a6723a90a21f5e2488da567c6e
-  ref: c922c736b9ad53a6723a90a21f5e2488da567c6e
+  revision: f91df2fb0d13368e01fe5e014f93fda06ead17d4
+  ref: f91df2fb0d13368e01fe5e014f93fda06ead17d4
   specs:
-    identity-idp-functions (0.3.3)
+    identity-idp-functions (0.5.0)
+      aws-sdk-s3 (>= 1.73)
+      aws-sdk-ssm (>= 1.55)
       retries (>= 0.0.5)
 
 GIT
@@ -143,15 +145,15 @@ GEM
     arel (9.0.0)
     ast (2.4.1)
     awrence (1.1.1)
-    aws-eventstream (1.0.3)
-    aws-partitions (1.235.0)
-    aws-sdk-core (3.75.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.228.0)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.388.0)
+    aws-sdk-core (3.109.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.25.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-kms (1.39.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-lambda (1.42.0)
       aws-sdk-core (~> 3, >= 3.71.0)
@@ -162,15 +164,18 @@ GEM
     aws-sdk-pinpointsmsvoice (1.16.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.53.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-s3 (1.83.1)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sdk-ses (1.27.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sdk-ssm (1.95.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     axe-matchers (2.6.1)
       dumb_delegator (~> 0.8)
       virtus (~> 1.0)

--- a/app/services/lambda_jobs/git_ref.rb
+++ b/app/services/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = 'c922c736b9ad53a6723a90a21f5e2488da567c6e'
+  GIT_REF = 'f91df2fb0d13368e01fe5e014f93fda06ead17d4'
 end

--- a/app/services/lambda_jobs/runner.rb
+++ b/app/services/lambda_jobs/runner.rb
@@ -17,7 +17,7 @@ module LambdaJobs
         )
       else
         job_class.handle(
-          event: { 'body' => args.to_json },
+          event: args,
           context: nil,
           &local_callback
         )

--- a/spec/services/lambda_jobs/runner_spec.rb
+++ b/spec/services/lambda_jobs/runner_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe LambdaJobs::Runner do
 
         it 'calls JobClass.handle' do
           expect(job_class).to receive(:handle).with(
-            event: { 'body' => args.to_json },
+            event: args,
             context: nil,
           )
 
@@ -71,7 +71,7 @@ RSpec.describe LambdaJobs::Runner do
 
       it 'calls JobClass.handle' do
         expect(job_class).to receive(:handle).with(
-          event: { 'body' => args.to_json },
+          event: args,
           context: nil,
         )
 
@@ -83,7 +83,7 @@ RSpec.describe LambdaJobs::Runner do
           result = Object.new
 
           expect(job_class).to receive(:handle).with(
-            event: { 'body' => args.to_json },
+            event: args,
             context: nil,
           ).and_yield(result)
 


### PR DESCRIPTION
- No longer need to JSONify payloads, it accepts hashes
- Bumps aws-sdk-s3, lambda has a newer dependency

Corresponds to https://github.com/18F/identity-idp-functions/pull/21