### PR TITLE
Fix invalid SSN field on first load in Firefox

### DIFF
--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -2,27 +2,6 @@ import Cleave from 'cleave.js';
 
 const { I18n } = window.LoginGov;
 
-function sync(input, toggle, ssnCleave) {
-  input.type = toggle.checked ? 'text' : 'password';
-
-  ssnCleave?.destroy();
-
-  if (toggle.checked) {
-    return new Cleave(input, {
-      numericOnly: true,
-      blocks: [3, 2, 4],
-      delimiter: '-',
-    });
-  }
-
-  const nextValue = input.value.replace(/-/g, '');
-  if (input.value !== nextValue) {
-    input.value = nextValue;
-  }
-
-  return null;
-}
-
 /* eslint-disable no-new */
 function formatSSNField() {
   const inputs = document.querySelectorAll('input.ssn-toggle[type="password"]');
@@ -42,13 +21,33 @@ function formatSSNField() {
       input.insertAdjacentHTML('afterend', el);
 
       const toggle = document.getElementById(`ssn-toggle-${i}`);
-      let ssnCleave;
 
-      ssnCleave = sync(input, toggle, ssnCleave);
+      let cleave;
 
-      toggle.addEventListener('change', function () {
-        ssnCleave = sync(input, toggle, ssnCleave);
-      });
+      function sync() {
+        const { value } = input;
+        input.type = toggle.checked ? 'text' : 'password';
+        cleave?.destroy();
+        if (toggle.checked) {
+          cleave = new Cleave(input, {
+            numericOnly: true,
+            blocks: [3, 2, 4],
+            delimiter: '-',
+          });
+        } else {
+          const nextValue = value.replace(/-/g, '');
+          if (nextValue !== value) {
+            input.value = nextValue;
+          }
+        }
+        const didFormat = input.value !== value;
+        if (didFormat) {
+          input.checkValidity();
+        }
+      }
+
+      sync();
+      toggle.addEventListener('change', sync);
     });
   }
 }

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -14,7 +14,11 @@ function sync(input, toggle, ssnCleave) {
       delimiter: '-',
     });
   }
-  input.value = input.value.replace(/-/g, '');
+
+  const nextValue = input.value.replace(/-/g, '');
+  if (input.value !== nextValue) {
+    input.value = nextValue;
+  }
 
   return null;
 }


### PR DESCRIPTION
Followup to #4342 

The input value was always getting mutated on the first load, and Firefox added the invalid border since the field is required. Validation also doesn't always trigger when JS changes the input value, which causes some issues that required users to hit Continue twice.

This PR adds some checks to not manipulate the input value on load, and manually runs validations when we are changing the value.

Example of Firefox issue before this fix:
![image](https://user-images.githubusercontent.com/1430443/97498598-7d8b2280-193a-11eb-8fb3-fecf85a61276.png)