### PR TITLE
Allow users to select a preferred email language (LG-3647)

### DIFF
--- a/app/controllers/account_reset/recover_controller.rb
+++ b/app/controllers/account_reset/recover_controller.rb
@@ -20,7 +20,8 @@ module AccountReset
 
     def send_notifications
       current_user.confirmed_email_addresses.each do |email_address|
-        UserMailer.confirm_email_and_reverify(email_address,
+        UserMailer.confirm_email_and_reverify(current_user,
+                                              email_address,
                                               current_user.account_recovery_request).deliver_later
       end
     end

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -177,7 +177,8 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   def send_phone_added_email
     event = create_user_event_with_disavowal(:phone_added, current_user)
     current_user.confirmed_email_addresses.each do |email_address|
-      UserMailer.phone_added(email_address, disavowal_token: event.disavowal_token).deliver_later
+      UserMailer.phone_added(current_user, email_address, disavowal_token: event.disavowal_token).
+        deliver_later
     end
   end
 

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -175,7 +175,7 @@ module Idv
 
     def send_reminder
       current_user.confirmed_email_addresses.each do |email_address|
-        UserMailer.letter_reminder(email_address.email).deliver_later
+        UserMailer.letter_reminder(current_user, email_address.email).deliver_later
       end
     end
 

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -36,7 +36,7 @@ module SignUp
     end
 
     def permitted_params
-      params.require(:user).permit(:email, :request_id)
+      params.require(:user).permit(:email, :email_language, :request_id)
     end
 
     def process_successful_creation

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -40,7 +40,7 @@ module Users
     def confirm_and_notify_user(email_address)
       email_address.update!(confirmed_at: Time.zone.now)
       email_address.user.confirmed_email_addresses.each do |confirmed_email_address|
-        UserMailer.email_added(confirmed_email_address.email).deliver_later
+        UserMailer.email_added(email_address.user, confirmed_email_address.email).deliver_later
       end
     end
 

--- a/app/controllers/users/email_language_controller.rb
+++ b/app/controllers/users/email_language_controller.rb
@@ -1,0 +1,24 @@
+module Users
+  class EmailLanguageController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    def show
+      analytics.track_event(Analytics::EMAIL_LANGUAGE_VISITED)
+    end
+
+    def update
+      form_response = UpdateEmailLanguageForm.new(current_user).submit(update_email_params)
+      analytics.track_event(Analytics::EMAIL_LANGUAGE_UPDATED, form_response.to_h)
+
+      flash[:success] = I18n.t('account.email_language.updated') if form_response.success?
+
+      redirect_to account_path
+    end
+
+    private
+
+    def update_email_params
+      params.require(:user).permit(:email_language)
+    end
+  end
+end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -100,7 +100,7 @@ module Users
 
     def send_delete_email_notification
       @current_confirmed_emails.each do |confirmed_email|
-        UserMailer.email_deleted(confirmed_email).deliver_later
+        UserMailer.email_deleted(current_user, confirmed_email).deliver_later
       end
     end
   end

--- a/app/controllers/users/personal_keys_controller.rb
+++ b/app/controllers/users/personal_keys_controller.rb
@@ -51,7 +51,7 @@ module Users
     # @return [FormResponse]
     def send_new_personal_key_notifications
       emails = current_user.confirmed_email_addresses.map do |email_address|
-        UserMailer.personal_key_regenerated(email_address.email).deliver_now
+        UserMailer.personal_key_regenerated(current_user, email_address.email).deliver_now
       end
 
       telephony_responses = MfaContext.new(current_user).

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -16,8 +16,7 @@ class UserDecorator
   end
 
   def email_language_preference_description
-    case user.email_language.to_s
-    when *I18n.available_locales.map(&:to_s)
+    if I18n.locale_available?(user.email_language)
       # i18n-tasks-use t('account.email_language.name.en')
       # i18n-tasks-use t('account.email_language.name.es')
       # i18n-tasks-use t('account.email_language.name.fr')

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -15,6 +15,18 @@ class UserDecorator
     user.email_addresses.take&.email
   end
 
+  def email_language_preference_description
+    case user.email_language.to_s
+    when *I18n.available_locales.map(&:to_s)
+      # i18n-tasks-use t('account.email_language.name.en')
+      # i18n-tasks-use t('account.email_language.name.es')
+      # i18n-tasks-use t('account.email_language.name.fr')
+      I18n.t("account.email_language.name.#{user.email_language}")
+    else
+      I18n.t('account.email_language.name.default')
+    end
+  end
+
   def visible_email_addresses
     user.email_addresses.filter do |email_address|
       email_address.confirmed? || !email_address.confirmation_period_expired?

--- a/app/forms/update_email_language_form.rb
+++ b/app/forms/update_email_language_form.rb
@@ -1,0 +1,22 @@
+class UpdateEmailLanguageForm
+  include ActiveModel::Model
+
+  attr_reader :user, :email_language
+
+  validates_inclusion_of :email_language, in: I18n.available_locales.map(&:to_s)
+
+  def initialize(user)
+    @user = user
+  end
+
+  def submit(params)
+    @email_language = params[:email_language]
+
+    UpdateUser.new(user: user, attributes: { email_language: email_language }).call if valid?
+
+    FormResponse.new(
+      success: valid?,
+      errors: errors.messages,
+    )
+  end
+end

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -5,14 +5,14 @@ module LocaleHelper
   end
 
   def with_user_locale(user, &block)
-    email_language = user.email_language
+    locale = user.email_language
 
-    if email_language.present?
-      return I18n.with_locale(email_language, &block) if I18n.locale_available?(email_language)
+    if I18n.locale_available?(locale)
+      I18n.with_locale(locale, &block)
+    else
+      Rails.logger.warn("user_id=#{user.uuid} has bad email_language=#{locale}") if locale.present?
 
-      Rails.logger.warn("user_id=#{user.uuid} has bad email_language=#{email_language}")
+      yield
     end
-
-    yield
   end
 end

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -5,10 +5,14 @@ module LocaleHelper
   end
 
   def with_user_locale(user, &block)
-    if user.email_language.present?
-      I18n.with_locale(user.email_language, &block)
-    else
-      yield
+    email_language = user.email_language
+
+    if email_language.present?
+      return I18n.with_locale(email_language, &block) if I18n.locale_available?(email_language)
+
+      Rails.logger.warn("user_id=#{user.uuid} has bad email_language=#{email_language}")
     end
+
+    yield
   end
 end

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -3,4 +3,12 @@ module LocaleHelper
     active_locale = I18n.locale
     active_locale == I18n.default_locale ? nil : active_locale
   end
+
+  def with_user_locale(user, &block)
+    if user.email_language.present?
+      I18n.with_locale(user.email_language, &block)
+    else
+      yield
+    end
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -76,7 +76,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def new_device_sign_in(user, email_address, date, location, disavowal_token)
+  def new_device_sign_in(user:, email_address:, date:, location:, disavowal_token:)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
     with_user_locale(user) do

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,48 +6,60 @@ class UserMailer < ActionMailer::Base
           reply_to: email_with_name(Figaro.env.email_from, Figaro.env.email_from_display_name)
 
   def email_confirmation_instructions(user, email, token, request_id:, instructions:)
-    presenter = ConfirmationEmailPresenter.new(user, view_context)
-    @first_sentence = instructions || presenter.first_sentence
-    @confirmation_period = presenter.confirmation_period
-    @request_id = request_id
-    @locale = locale_url_param
-    @token = token
-    mail(to: email, subject: t('user_mailer.email_confirmation_instructions.subject'))
+    with_user_locale(user) do
+      presenter = ConfirmationEmailPresenter.new(user, view_context)
+      @first_sentence = instructions || presenter.first_sentence
+      @confirmation_period = presenter.confirmation_period
+      @request_id = request_id
+      @locale = locale_url_param
+      @token = token
+      mail(to: email, subject: t('user_mailer.email_confirmation_instructions.subject'))
+    end
   end
 
   def unconfirmed_email_instructions(user, email, token, request_id:, instructions:)
-    presenter = ConfirmationEmailPresenter.new(user, view_context)
-    @first_sentence = instructions || presenter.first_sentence
-    @confirmation_period = presenter.confirmation_period
-    @request_id = request_id
-    @locale = locale_url_param
-    @token = token
-    mail(to: email, subject: t('user_mailer.email_confirmation_instructions.email_not_found'))
+    with_user_locale(user) do
+      presenter = ConfirmationEmailPresenter.new(user, view_context)
+      @first_sentence = instructions || presenter.first_sentence
+      @confirmation_period = presenter.confirmation_period
+      @request_id = request_id
+      @locale = locale_url_param
+      @token = token
+      mail(to: email, subject: t('user_mailer.email_confirmation_instructions.email_not_found'))
+    end
   end
 
-  def signup_with_your_email(email)
-    @root_url = root_url(locale: locale_url_param)
-    mail(to: email, subject: t('mailer.email_reuse_notice.subject'))
+  def signup_with_your_email(user, email)
+    with_user_locale(user) do
+      @root_url = root_url(locale: locale_url_param)
+      mail(to: email, subject: t('mailer.email_reuse_notice.subject'))
+    end
   end
 
-  def reset_password_instructions(email, token:)
-    @locale = locale_url_param
-    @token = token
-    mail(to: email, subject: t('user_mailer.reset_password_instructions.subject'))
+  def reset_password_instructions(user, email, token:)
+    with_user_locale(user) do
+      @locale = locale_url_param
+      @token = token
+      mail(to: email, subject: t('user_mailer.reset_password_instructions.subject'))
+    end
   end
 
-  def password_changed(email_address, disavowal_token:)
+  def password_changed(user, email_address, disavowal_token:)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
-    @disavowal_token = disavowal_token
-    mail(to: email_address.email, subject: t('devise.mailer.password_updated.subject'))
+    with_user_locale(user) do
+      @disavowal_token = disavowal_token
+      mail(to: email_address.email, subject: t('devise.mailer.password_updated.subject'))
+    end
   end
 
-  def phone_added(email_address, disavowal_token:)
+  def phone_added(user, email_address, disavowal_token:)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
-    @disavowal_token = disavowal_token
-    mail(to: email_address.email, subject: t('user_mailer.phone_added.subject'))
+    with_user_locale(user) do
+      @disavowal_token = disavowal_token
+      mail(to: email_address.email, subject: t('user_mailer.phone_added.subject'))
+    end
   end
 
   def account_does_not_exist(email, request_id)
@@ -55,100 +67,132 @@ class UserMailer < ActionMailer::Base
     mail(to: email, subject: t('user_mailer.account_does_not_exist.subject'))
   end
 
-  def personal_key_sign_in(email, disavowal_token:)
+  def personal_key_sign_in(user, email, disavowal_token:)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    @disavowal_token = disavowal_token
-    mail(to: email, subject: t('user_mailer.personal_key_sign_in.subject'))
+    with_user_locale(user) do
+      @disavowal_token = disavowal_token
+      mail(to: email, subject: t('user_mailer.personal_key_sign_in.subject'))
+    end
   end
 
-  def new_device_sign_in(email_address, date, location, disavowal_token)
+  def new_device_sign_in(user, email_address, date, location, disavowal_token)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
-    @login_date = date
-    @login_location = location
-    @disavowal_token = disavowal_token
-    mail(to: email_address.email, subject: t('user_mailer.new_device_sign_in.subject'))
+    with_user_locale(user) do
+      @login_date = date
+      @login_location = location
+      @disavowal_token = disavowal_token
+      mail(to: email_address.email, subject: t('user_mailer.new_device_sign_in.subject'))
+    end
   end
 
-  def personal_key_regenerated(email)
+  def personal_key_regenerated(user, email)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    mail(to: email, subject: t('user_mailer.personal_key_regenerated.subject'))
+    with_user_locale(user) do
+      mail(to: email, subject: t('user_mailer.personal_key_regenerated.subject'))
+    end
   end
 
-  def account_reset_request(email_address, account_reset)
-    @token = account_reset&.request_token
-    @header = t('user_mailer.account_reset_request.header')
-    mail(to: email_address.email, subject: t('user_mailer.account_reset_request.subject'))
+  def account_reset_request(user, email_address, account_reset)
+    with_user_locale(user) do
+      @token = account_reset&.request_token
+      @header = t('user_mailer.account_reset_request.header')
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_request.subject'))
+    end
   end
 
-  def account_reset_granted(email_address, account_reset)
-    @token = account_reset&.request_token
-    @granted_token = account_reset&.granted_token
-    mail(to: email_address.email, subject: t('user_mailer.account_reset_granted.subject'))
+  def account_reset_granted(user, email_address, account_reset)
+    with_user_locale(user) do
+      @token = account_reset&.request_token
+      @granted_token = account_reset&.granted_token
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_granted.subject'))
+    end
   end
 
-  def account_reset_complete(email_address)
-    mail(to: email_address.email, subject: t('user_mailer.account_reset_complete.subject'))
+  def account_reset_complete(user, email_address)
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_complete.subject'))
+    end
   end
 
-  def account_reset_cancel(email_address)
-    mail(to: email_address.email, subject: t('user_mailer.account_reset_cancel.subject'))
+  def account_reset_cancel(user, email_address)
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reset_cancel.subject'))
+    end
   end
 
-  def please_reset_password(email_address)
-    mail(to: email_address, subject: t('user_mailer.please_reset_password.subject'))
+  def please_reset_password(user, email_address)
+    with_user_locale(user) do
+      mail(to: email_address, subject: t('user_mailer.please_reset_password.subject'))
+    end
   end
 
-  def undeliverable_address(email_address)
+  def undeliverable_address(user, email_address)
     return unless email_should_receive_nonessential_notifications?(email_address.email)
 
-    mail(to: email_address.email, subject: t('user_mailer.undeliverable_address.subject'))
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.undeliverable_address.subject'))
+    end
   end
 
-  def doc_auth_desktop_link_to_sp(email_address, application, link)
-    @link = link
-    @application = application
-    mail(to: email_address, subject: t('user_mailer.doc_auth_link.subject'))
+  def doc_auth_desktop_link_to_sp(user, email_address, application, link)
+    with_user_locale(user) do
+      @link = link
+      @application = application
+      mail(to: email_address, subject: t('user_mailer.doc_auth_link.subject'))
+    end
   end
 
-  def letter_reminder(email)
+  def letter_reminder(user, email)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    mail(to: email, subject: t('user_mailer.letter_reminder.subject'))
+    with_user_locale(user) do
+      mail(to: email, subject: t('user_mailer.letter_reminder.subject'))
+    end
   end
 
-  def letter_expired(email)
+  def letter_expired(user, email)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    mail(to: email, subject: t('user_mailer.letter_expired.subject'))
+    with_user_locale(user) do
+      mail(to: email, subject: t('user_mailer.letter_expired.subject'))
+    end
   end
 
-  def confirm_email_and_reverify(email, account_recovery_request)
-    @token = account_recovery_request.request_token
-    mail(to: email.email, subject: t('recover.email.confirm'))
+  def confirm_email_and_reverify(user, email, account_recovery_request)
+    with_user_locale(user) do
+      @token = account_recovery_request.request_token
+      mail(to: email.email, subject: t('recover.email.confirm'))
+    end
   end
 
   def add_email(user, email, token)
-    presenter = ConfirmationEmailPresenter.new(user, view_context)
-    @first_sentence = presenter.first_sentence
-    @confirmation_period = presenter.confirmation_period
-    @locale = locale_url_param
-    @token = token
-    mail(to: email, subject: t('user_mailer.add_email.subject'))
+    with_user_locale(user) do
+      presenter = ConfirmationEmailPresenter.new(user, view_context)
+      @first_sentence = presenter.first_sentence
+      @confirmation_period = presenter.confirmation_period
+      @locale = locale_url_param
+      @token = token
+      mail(to: email, subject: t('user_mailer.add_email.subject'))
+    end
   end
 
-  def email_added(email)
+  def email_added(user, email)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    mail(to: email, subject: t('user_mailer.email_added.subject'))
+    with_user_locale(user) do
+      mail(to: email, subject: t('user_mailer.email_added.subject'))
+    end
   end
 
-  def email_deleted(email)
+  def email_deleted(user, email)
     return unless email_should_receive_nonessential_notifications?(email)
 
-    mail(to: email, subject: t('user_mailer.email_deleted.subject'))
+    with_user_locale(user) do
+      mail(to: email, subject: t('user_mailer.email_deleted.subject'))
+    end
   end
 
   def add_email_associated_with_another_account(email)

--- a/app/models/usps_confirmation_code.rb
+++ b/app/models/usps_confirmation_code.rb
@@ -29,7 +29,7 @@ class UspsConfirmationCode < ApplicationRecord
 
   def self.send_email(user)
     user.confirmed_email_addresses.each do |email_address|
-      UserMailer.undeliverable_address(email_address).deliver_later
+      UserMailer.undeliverable_address(user, email_address).deliver_later
     end
   end
 end

--- a/app/services/account_reset/cancel.rb
+++ b/app/services/account_reset/cancel.rb
@@ -25,7 +25,7 @@ module AccountReset
 
     def notify_user_via_email_of_account_reset_cancellation
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.account_reset_cancel(email_address).deliver_later
+        UserMailer.account_reset_cancel(user, email_address).deliver_later
       end
     end
 

--- a/app/services/account_reset/create_request.rb
+++ b/app/services/account_reset/create_request.rb
@@ -34,7 +34,7 @@ module AccountReset
 
     def notify_user_by_email(request)
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.account_reset_request(email_address, request).deliver_later
+        UserMailer.account_reset_request(user, email_address, request).deliver_later
       end
     end
 

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -54,7 +54,7 @@ module AccountReset
 
     def notify_user_via_email_of_deletion
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.account_reset_complete(email_address).deliver_later
+        UserMailer.account_reset_complete(user, email_address).deliver_later
       end
     end
 

--- a/app/services/account_reset/grant_requests_and_send_emails.rb
+++ b/app/services/account_reset/grant_requests_and_send_emails.rb
@@ -37,7 +37,7 @@ module AccountReset
 
       arr = arr.reload
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.account_reset_granted(email_address, arr).deliver_later
+        UserMailer.account_reset_granted(user, email_address, arr).deliver_later
       end
       true
     end

--- a/app/services/account_reset/notify_user_of_request_cancellation.rb
+++ b/app/services/account_reset/notify_user_of_request_cancellation.rb
@@ -15,7 +15,7 @@ module AccountReset
 
     def notify_user_via_email_of_account_reset_cancellation
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.account_reset_cancel(email_address).deliver_later
+        UserMailer.account_reset_cancel(user, email_address).deliver_later
       end
     end
 

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -90,6 +90,8 @@ class Analytics
   IN_PERSON_PROOFING = 'In Person Proofing'.freeze # visited or submitted is appended
   EMAIL_AND_PASSWORD_AUTH = 'Email and Password Authentication'.freeze
   EMAIL_DELETION_REQUEST = 'Email Deletion Requested'.freeze
+  EMAIL_LANGUAGE_VISITED = 'Email Language: Visited'.freeze
+  EMAIL_LANGUAGE_UPDATED = 'Email Language: Updated'.freeze
   EVENT_DISAVOWAL = 'Event disavowal visited'.freeze
   EVENT_DISAVOWAL_PASSWORD_RESET = 'Event disavowal password reset'.freeze
   EVENT_DISAVOWAL_TOKEN_INVALID = 'Event disavowal token invalid'.freeze

--- a/app/services/idv/steps/upload_step.rb
+++ b/app/services/idv/steps/upload_step.rb
@@ -27,7 +27,9 @@ module Idv
       def mobile_to_desktop
         mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
-        UserMailer.doc_auth_desktop_link_to_sp(current_user.email, application, link).deliver_later
+        UserMailer.doc_auth_desktop_link_to_sp(
+          current_user, current_user.email, application, link
+        ).deliver_later
       end
 
       def desktop

--- a/app/services/locale_validator.rb
+++ b/app/services/locale_validator.rb
@@ -4,7 +4,7 @@ class LocaleValidator
   end
 
   def success?
-    locale.present? && I18n.available_locales.include?(locale.to_sym)
+    locale.present? && I18n.locale_available?(locale)
   end
 
   private

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -16,7 +16,7 @@ RequestPasswordReset = Struct.new(:email, :request_id) do
     throttled = Throttler::IsThrottledElseIncrement.call(user.id, :reset_password_email)
     return if throttled
     token = user.set_reset_password_token
-    UserMailer.reset_password_instructions(email, token: token).deliver_now
+    UserMailer.reset_password_instructions(user, email, token: token).deliver_now
   end
 
   def instructions

--- a/app/services/reset_user_password.rb
+++ b/app/services/reset_user_password.rb
@@ -33,7 +33,7 @@ class ResetUserPassword
 
   def notify_user
     user.email_addresses.each do |email_address|
-      UserMailer.please_reset_password(email_address.email).deliver_now
+      UserMailer.please_reset_password(user, email_address.email).deliver_now
     end
   end
 end

--- a/app/services/send_expired_letter_notifications.rb
+++ b/app/services/send_expired_letter_notifications.rb
@@ -17,7 +17,7 @@ class SendExpiredLetterNotifications
     user = usps_confirmation_code.profile.user
     mark_sent(usps_confirmation_code)
     user.confirmed_email_addresses.each do |email_address|
-      UserMailer.letter_expired(email_address.email).deliver_later
+      UserMailer.letter_expired(user, email_address.email).deliver_later
     end
   end
 

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -4,12 +4,12 @@ module UserAlerts
       login_location = DeviceDecorator.new(device).last_sign_in_location_and_ip
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.new_device_sign_in(
-          user,
-          email_address,
-          device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
+          user: user,
+          email_address: email_address,
+          date: device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),
-          login_location,
-          disavowal_token,
+          location: login_location,
+          disavowal_token: disavowal_token,
         ).deliver_now
       end
     end

--- a/app/services/user_alerts/alert_user_about_new_device.rb
+++ b/app/services/user_alerts/alert_user_about_new_device.rb
@@ -4,6 +4,7 @@ module UserAlerts
       login_location = DeviceDecorator.new(device).last_sign_in_location_and_ip
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.new_device_sign_in(
+          user,
           email_address,
           device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),

--- a/app/services/user_alerts/alert_user_about_password_change.rb
+++ b/app/services/user_alerts/alert_user_about_password_change.rb
@@ -2,7 +2,8 @@ module UserAlerts
   class AlertUserAboutPasswordChange
     def self.call(user, disavowal_token)
       user.confirmed_email_addresses.each do |email_address|
-        UserMailer.password_changed(email_address, disavowal_token: disavowal_token).deliver_later
+        UserMailer.password_changed(user, email_address, disavowal_token: disavowal_token).
+          deliver_later
       end
     end
   end

--- a/app/services/user_alerts/alert_user_about_personal_key_sign_in.rb
+++ b/app/services/user_alerts/alert_user_about_personal_key_sign_in.rb
@@ -4,7 +4,7 @@ module UserAlerts
     def self.call(user, disavowal_token)
       emails = user.confirmed_email_addresses.map do |email_address|
         UserMailer.personal_key_sign_in(
-          email_address.email, disavowal_token: disavowal_token
+          user, email_address.email, disavowal_token: disavowal_token
         ).deliver_now
       end
       telephony_responses = MfaContext.new(user).phone_configurations.map do |phone_configuration|

--- a/app/views/accounts/_emails.html.erb
+++ b/app/views/accounts/_emails.html.erb
@@ -1,8 +1,8 @@
 <div class="clearfix border-bottom border-light-blue">
   <div class="col col-12 mb1 mt0">
-    <h2 class="col col-6 m0">
+    <h3 class="h2 col col-6 m0">
       <%= t('account.index.email_addresses') %>
-    </h2>
+    </h3>
     <div class="right-align col col-6">
       <% if EmailPolicy.new(current_user).can_add_email? %>
         <%= link_to(

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -9,8 +9,20 @@
 <%= render @view_model.pending_profile_partial, view_model: @view_model %>
 <%= render 'accounts/header', view_model: @view_model %>
 
+<h2><%= t('account.index.email_preferences') %></h2>
+
 <div class="mb3 card profile-info-box">
   <%= render 'emails' %>
+
+  <h2><%= t('i18n.language') %></h2>
+  <div class="grid-row p1 border border-light-blue">
+    <div class="grid-col-8">
+      <%= @view_model.decorated_user.email_language_preference_description %>
+    </div>
+    <div class="grid-col-4 right-align">
+      <%= link_to(t('forms.buttons.edit'), account_email_language_path) %>
+    </div>
+  </div>
 </div>
 
 <div class="mb3 card profile-info-box">

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -14,7 +14,7 @@
 <div class="mb3 card profile-info-box">
   <%= render 'emails' %>
 
-  <h2><%= t('i18n.language') %></h2>
+  <h3 class="h2"><%= t('i18n.language') %></h3>
   <div class="grid-row p1 border border-light-blue">
     <div class="grid-col-8">
       <%= @view_model.decorated_user.email_language_preference_description %>

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -1,12 +1,14 @@
 <%#
 locals:
-* selection: the current language selection
 * f: from validated_form_for
+* labelledby: id of element that radio boxes are labelled by
+* selection: the current language selection
 %>
 <div class="margin-bottom-4">
   <ul class="usa-input-list">
     <% I18n.available_locales.each do |locale| %>
       <% item_id = "email-locale-#{locale}" %>
+      <% label_id = SecureRandom.hex %>
       <li class="col-6">
         <%= f.input_field(:email_language,
                           type: :radio,
@@ -15,12 +17,14 @@ locals:
                             selection.to_s == locale.to_s :
                             (I18n.locale.to_s == locale.to_s),
                           class: 'usa-radio__input',
-                          id: item_id) %>
+                          id: item_id,
+                          aria: { labelledby: "#{labelledby} #{label_id}" }) %>
         <%= f.label(:email_language,
                     locale == I18n.default_locale ?
                       t("account.email_language.name.default") :
                       t("account.email_language.name.#{locale}"),
                     for: item_id,
+                    id: label_id,
                     class: 'usa-radio__label usa-radio-bordered') %>
       </li>
     <% end %>

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -1,14 +1,12 @@
 <%#
 locals:
 * f: from validated_form_for
-* labelledby: id of element that radio boxes are labelled by
 * selection: the current language selection
 %>
 <div class="margin-bottom-4">
   <ul class="usa-input-list">
     <% I18n.available_locales.each do |locale| %>
       <% item_id = "email-locale-#{locale}" %>
-      <% label_id = SecureRandom.hex %>
       <li class="col-6">
         <%= f.input_field(:email_language,
                           type: :radio,
@@ -17,14 +15,12 @@ locals:
                             selection.to_s == locale.to_s :
                             (I18n.locale.to_s == locale.to_s),
                           class: 'usa-radio__input',
-                          id: item_id,
-                          aria: { labelledby: "#{labelledby} #{label_id}" }) %>
+                          id: item_id) %>
         <%= f.label(:email_language,
                     locale == I18n.default_locale ?
                       t("account.email_language.name.default") :
                       t("account.email_language.name.#{locale}"),
                     for: item_id,
-                    id: label_id,
                     class: 'usa-radio__label usa-radio-bordered') %>
       </li>
     <% end %>

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -7,7 +7,7 @@ locals:
   <ul class="usa-input-list">
     <% I18n.available_locales.each do |locale| %>
       <% item_id = "email-locale-#{locale}" %>
-      <li class="col-6">
+      <li class="grid-col-8 mobile-lg:grid-col-6">
         <%= f.input_field(:email_language,
                           type: :radio,
                           value: locale,

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -1,0 +1,28 @@
+<%#
+locals:
+* selection: the current language selection
+* f: from validated_form_for
+%>
+<div class="margin-bottom-4">
+  <ul class="usa-input-list">
+    <% I18n.available_locales.each do |locale| %>
+      <% item_id = "email-locale-#{locale}" %>
+      <li class="col-6">
+        <%= f.input_field(:email_language,
+                          type: :radio,
+                          value: locale,
+                          checked: selection ?
+                            selection.to_s == locale.to_s :
+                            (I18n.locale.to_s == locale.to_s),
+                          class: 'usa-radio__input',
+                          id: item_id) %>
+        <%= f.label(:email_language,
+                    locale == I18n.default_locale ?
+                      t("account.email_language.name.default") :
+                      t("account.email_language.name.#{locale}"),
+                    for: item_id,
+                    class: 'usa-radio__label usa-radio-bordered') %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -19,10 +19,9 @@
     <%= f.input :email, label: t('forms.registration.labels.email'), required: true, input_html: { aria: { invalid: false } } %>
 
     <fieldset class="usa-fieldset">
-      <% email_language_label = SecureRandom.hex %>
-      <%= content_tag :label, id: email_language_label, class: 'margin-bottom-1' do %>
-        <strong><%= t('forms.registration.labels.email_language') %></strong>
-      <% end %>
+      <legend class="sans-serif margin-bottom-1">
+        <%= t('forms.registration.labels.email_language') %>
+      </legend>
 
       <p class="margin-bottom-4">
         <%= t('account.email_language.languages_list',
@@ -33,7 +32,7 @@
       </p>
 
       <%= render partial: 'shared/email_languages',
-                 locals: { f: f, labelledby: email_language_label, selection: @register_user_email_form.email_language } %>
+                 locals: { f: f, selection: @register_user_email_form.email_language } %>
     </fieldset>
 
     <span class='email-invalid-alert-inline usa-error-message margin-top-neg-3 margin-bottom-3 hide' role='alert' hidden='true'>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -19,9 +19,9 @@
     <%= f.input :email, label: t('forms.registration.labels.email'), required: true, input_html: { aria: { invalid: false } } %>
 
     <fieldset class="usa-fieldset">
-      <div class="margin-bottom-1">
+      <legend class="margin-bottom-1">
         <strong><%= t('forms.registration.labels.email_language') %></strong>
-      </div>
+      </legend>
 
       <p class="margin-bottom-4">
         <%= t('account.email_language.languages_list',

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -17,12 +17,30 @@
       html: { autocomplete: 'off', role: 'form' },
       url: sign_up_register_path) do |f| %>
     <%= f.input :email, label: t('forms.registration.labels.email'), required: true, input_html: { aria: { invalid: false } } %>
+
+    <fieldset class="usa-fieldset">
+      <div class="margin-bottom-1">
+        <strong><%= t('forms.registration.labels.email_language') %></strong>
+      </div>
+
+      <p class="margin-bottom-4">
+        <%= t('account.email_language.languages_list',
+              app_name: APP_NAME,
+              list: I18n.available_locales.
+                map { |locale| t("account.email_language.name.#{locale}") }.
+                to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} ")) %>
+      </p>
+
+      <%= render partial: 'shared/email_languages',
+                 locals: { f: f, selection: @register_user_email_form.email_language } %>
+    </fieldset>
+
     <span class='email-invalid-alert-inline usa-error-message margin-top-neg-3 margin-bottom-3 hide' role='alert' hidden='true'>
       <%= t('sign_up.email.invalid_email_alert_inline') %>
     </span>
     <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
     <%= render 'shared/recaptcha' %>
-    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide' %>
+    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide col-6' %>
   <% end %>
 </div>
 

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -40,7 +40,7 @@
     </span>
     <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
     <%= render 'shared/recaptcha' %>
-    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide col-6' %>
+    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide grid-col-8 mobile-lg:grid-col-6' %>
   <% end %>
 </div>
 

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -19,9 +19,10 @@
     <%= f.input :email, label: t('forms.registration.labels.email'), required: true, input_html: { aria: { invalid: false } } %>
 
     <fieldset class="usa-fieldset">
-      <legend class="margin-bottom-1">
+      <% email_language_label = SecureRandom.hex %>
+      <%= content_tag :label, id: email_language_label, class: 'margin-bottom-1' do %>
         <strong><%= t('forms.registration.labels.email_language') %></strong>
-      </legend>
+      <% end %>
 
       <p class="margin-bottom-4">
         <%= t('account.email_language.languages_list',
@@ -32,7 +33,7 @@
       </p>
 
       <%= render partial: 'shared/email_languages',
-                 locals: { f: f, selection: @register_user_email_form.email_language } %>
+                 locals: { f: f, labelledby: email_language_label, selection: @register_user_email_form.email_language } %>
     </fieldset>
 
     <span class='email-invalid-alert-inline usa-error-message margin-top-neg-3 margin-bottom-3 hide' role='alert' hidden='true'>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('account.email_language.edit_title') %></h2>
+<h1 class="h2"><%= t('account.email_language.edit_title') %></h1>
 
 <p class="margin-bottom-4">
   <%= t('account.email_language.languages_list',
@@ -8,13 +8,14 @@
           to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} ")) %>
 </p>
 
-<p><%= t('account.email_language.please_select') %></p>
-
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
-  <%= render partial: 'shared/email_languages',
-             locals: {
-               selection: current_user.email_language,
-               f: f
-             } %>
+  <fieldset class="usa-fieldset">
+    <legend><%= t('account.email_language.please_select') %></legend>
+    <%= render partial: 'shared/email_languages',
+               locals: {
+                 selection: current_user.email_language,
+                 f: f
+               } %>
+  </fieldset>
   <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide col-6' %>
 <% end %>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -10,12 +10,12 @@
 
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
   <fieldset class="usa-fieldset">
-    <% label_id = SecureRandom.hex %>
-    <%= content_tag :label, t('account.email_language.please_select'), id: label_id %>
+    <legend class="sans-serif margin-bottom-1">
+      <%= t('account.email_language.please_select') %>
+    </legend>
     <%= render partial: 'shared/email_languages',
                locals: {
                  selection: current_user.email_language,
-                 labelledby: label_id,
                  f: f
                } %>
   </fieldset>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -11,7 +11,6 @@
 <p><%= t('account.email_language.please_select') %></p>
 
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
-
   <%= render partial: 'shared/email_languages',
              locals: {
                selection: current_user.email_language,

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -1,0 +1,21 @@
+<h2><%= t('account.email_language.edit_title') %></h2>
+
+<p class="margin-bottom-4">
+  <%= t('account.email_language.languages_list',
+        app_name: APP_NAME,
+        list: I18n.available_locales.
+          map { |locale| t("account.email_language.name.#{locale}") }.
+          to_sentence(last_word_connector: " #{t('account.email_language.sentence_connector')} ")) %>
+</p>
+
+<p><%= t('account.email_language.please_select') %></p>
+
+<%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
+
+  <%= render partial: 'shared/email_languages',
+             locals: {
+               selection: current_user.email_language,
+               f: f
+             } %>
+  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide col-6' %>
+<% end %>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -10,10 +10,12 @@
 
 <%= validated_form_for(current_user, url: account_email_language_path, method: 'PATCH') do |f| %>
   <fieldset class="usa-fieldset">
-    <legend><%= t('account.email_language.please_select') %></legend>
+    <% label_id = SecureRandom.hex %>
+    <%= content_tag :label, t('account.email_language.please_select'), id: label_id %>
     <%= render partial: 'shared/email_languages',
                locals: {
                  selection: current_user.email_language,
+                 labelledby: label_id,
                  f: f
                } %>
   </fieldset>

--- a/app/views/users/email_language/show.html.erb
+++ b/app/views/users/email_language/show.html.erb
@@ -19,5 +19,5 @@
                  f: f
                } %>
   </fieldset>
-  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide col-6' %>
+  <%= f.button :submit, t('forms.buttons.submit.default'), class: 'btn-wide grid-col-8 mobile-lg:grid-col-6' %>
 <% end %>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -6,6 +6,18 @@ en:
       description: With your login.gov account, you can securely connect to multiple
         government accounts online. Below is a list of all the accounts you currently
         have connected.
+    email_language:
+      edit_title: Edit email language preference
+      languages_list: "%{app_name} allows you to receive your email communication
+        in %{list}."
+      name:
+        default: English (default)
+        en: English
+        es: Spanish
+        fr: French
+      please_select: Please select your language preference below.
+      sentence_connector: or
+      updated: Your email language preference has been updated.
     forget_all_browsers:
       longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional
         information to know that it’s actually you signing in to your account. We’ll
@@ -25,6 +37,7 @@ en:
       email: Email address
       email_add: Add email
       email_addresses: Email addresses
+      email_preferences: Email preferences
       full_name: Full name
       password: Password
       phone: Phone numbers

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -9,7 +9,7 @@ es:
     email_language:
       edit_title: Editar la preferencia de idioma del correo electrónico
       languages_list: "%{app_name} le permite recibir su comunicación por correo electrónico
-         en %{list}"
+        en %{list}"
       name:
         default: Inglés (predeterminado)
         en: Inglés

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -6,6 +6,18 @@ es:
       description: Con su cuenta login.gov, puede conectarse de manera segura a múltiples
         cuentas gubernamentales en línea. A continuación se muestra una lista de todas
         las cuentas que tiene actualmente conectadas.
+    email_language:
+      edit_title: Editar la preferencia de idioma del correo electrónico
+      languages_list: "%{app_name} le permite recibir su comunicación por correo electrónico
+         en %{list}"
+      name:
+        default: Inglés (predeterminado)
+        en: Inglés
+        es: Español
+        fr: Francés
+      please_select: Seleccione su preferencia de idioma a continuación.
+      sentence_connector: o
+      updated: Se actualizó su preferencia de idioma de correo electrónico.
     forget_all_browsers:
       longer_description: Una vez que elija "olvidar todos los navegadores", necesitaremos
         información adicional para saber que en realidad está iniciando sesión en
@@ -26,6 +38,7 @@ es:
       email: Correo electrónico
       email_add: Agregar email
       email_addresses: Correos electrónicos
+      email_preferences: Preferencias de correo electrónico
       full_name: Nombre completo
       password: Contraseña
       phone: Teléfono

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -6,6 +6,18 @@ fr:
       description: Avec votre compte login.gov, vous pouvez vous connecter en toute
         sécurité à plusieurs comptes gouvernementaux en ligne. Vous trouverez ci-dessous
         une liste de tous les comptes actuellement connectés.
+    email_language:
+      edit_title: Modifier la préférence de langue des e-mails
+      languages_list: "%{app_name} vous permet de recevoir votre communication par e-mail
+         dans %{list}."
+      name:
+        default: Anglais (par défaut)
+        en: Anglais
+        es: l'Espagnol
+        fr: langue française
+      please_select: Veuillez sélectionner votre préférence de langue ci-dessous.
+      sentence_connector: ou
+      updated: Votre préférence de langue pour les e-mails a été mise à jour.
     forget_all_browsers:
       longer_description: Une fois que vous aurez choisi "d'oublier tous les navigateurs",
         nous aurons besoin d'informations supplémentaires pour savoir qu'il s'agit
@@ -26,6 +38,7 @@ fr:
       email: Adresse courriel
       email_add: Ajouter un email
       email_addresses: Adresses courriel
+      email_preferences: Préférences de messagerie
       full_name: Nom complet
       password: Mot de passe
       phone: Numéro de téléphone

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -8,8 +8,8 @@ fr:
         une liste de tous les comptes actuellement connectés.
     email_language:
       edit_title: Modifier la préférence de langue des e-mails
-      languages_list: "%{app_name} vous permet de recevoir votre communication par e-mail
-         dans %{list}."
+      languages_list: "%{app_name} vous permet de recevoir votre communication par
+        e-mail dans %{list}."
       name:
         default: Anglais (par défaut)
         en: Anglais

--- a/config/locales/forms/en.yml
+++ b/config/locales/forms/en.yml
@@ -120,6 +120,7 @@ en:
     registration:
       labels:
         email: Email address
+        email_language: Select email language preference
     ssn:
       show: Show Social Security Number
     totp_delete:

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -128,6 +128,7 @@ es:
     registration:
       labels:
         email: Email
+        email_language: Seleccionar preferencia de idioma de correo electrónico
     ssn:
       show: Mostrar Número de Seguro Social
     totp_delete:

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -133,6 +133,7 @@ fr:
     registration:
       labels:
         email: Adresse courriel
+        email_language: Sélectionnez la préférence de langue des e-mails
     ssn:
       show: Afficher le numéro de sécurité sociale
     totp_delete:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,8 @@ Rails.application.routes.draw do
     get '/account/devices/:id/events' => 'events#show', as: :account_events
     get '/account/delete' => 'users/delete#show', as: :account_delete
     post '/account/delete' => 'users/delete#delete'
+    get '/account/email_language' => 'users/email_language#show', as: :account_email_language
+    patch '/account/email_language' => 'users/email_language#update'
     get '/account/history' => 'accounts/history#show'
     get '/account/reactivate/start' => 'reactivate_account#index', as: :reactivate_account
     put '/account/reactivate/start' => 'reactivate_account#update'

--- a/db/migrate/20201029192324_add_email_language_to_users.rb
+++ b/db/migrate/20201029192324_add_email_language_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailLanguageToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email_language, :string, null: true, limit: 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_144755) do
+ActiveRecord::Schema.define(version: 2020_10_29_192324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -560,6 +560,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_144755) do
     t.string "encrypted_password_digest", default: ""
     t.string "encrypted_recovery_code_digest", default: ""
     t.datetime "remember_device_revoked_at"
+    t.string "email_language", limit: 10
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -85,6 +85,16 @@ describe SignUp::RegistrationsController, devise: true do
         expect(subject).to have_received(:create_user_event).with(:account_created, user)
       end
 
+      it 'sets the users preferred email locale and sends an email in that locale' do
+        post :create, params: { user: { email: 'test@test.com', email_language: 'es' } }
+
+        expect(User.find_with_email('test@test.com').email_language).to eq('es')
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).
+          to eq(I18n.t('user_mailer.email_confirmation_instructions.subject', locale: 'es'))
+      end
+
       it 'sets the email in the session and redirects to sign_up_verify_email_path' do
         post :create, params: { user: { email: 'test@test.com' } }
 

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -291,7 +291,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
         @mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
         subject.current_user.email_addresses.each do |email_address|
           allow(UserMailer).to receive(:phone_added).
-            with(email_address, disavowal_token: instance_of(String)).
+            with(subject.current_user, email_address, disavowal_token: instance_of(String)).
             and_return(@mailer)
         end
         @previous_phone = MfaContext.new(subject.current_user).phone_configurations.first&.phone
@@ -331,7 +331,7 @@ describe TwoFactorAuthentication::OtpVerificationController do
             expect(subject).to have_received(:create_user_event).exactly(:once)
             subject.current_user.email_addresses.each do |email_address|
               expect(UserMailer).to have_received(:phone_added).
-                with(email_address, disavowal_token: instance_of(String))
+                with(subject.current_user, email_address, disavowal_token: instance_of(String))
             end
             expect(@mailer).to have_received(:deliver_later)
           end

--- a/spec/controllers/users/email_language_controller_spec.rb
+++ b/spec/controllers/users/email_language_controller_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Users::EmailLanguageController do
+  describe 'before_actions' do
+    it 'includes appropriate before_actions' do
+      expect(subject).to have_actions(
+        :before,
+        :confirm_two_factor_authenticated,
+      )
+    end
+  end
+
+  let(:original_email_language) { nil }
+  let(:user) { create(:user, email_language: original_email_language) }
+
+  before do
+    stub_sign_in(user)
+  end
+
+  describe '#show' do
+    subject(:action) { get :show }
+
+    it 'renders' do
+      action
+      expect(response).to render_template(:show)
+    end
+
+    it 'logs an analytics event for visiting' do
+      stub_analytics
+      expect(@analytics).to receive(:track_event).with(Analytics::EMAIL_LANGUAGE_VISITED)
+
+      action
+    end
+  end
+
+  describe '#update' do
+    subject(:action) do
+      patch :update, params: { user: { email_language: email_language } }
+    end
+
+    context 'with a valid language selection' do
+      let(:email_language) { 'es' }
+
+      it 'updates the user email_language' do
+        expect { action }.
+          to(change { user.reload.email_language }.from(original_email_language).to(email_language))
+      end
+
+      it 'redirects to the account page with a success flash' do
+        action
+
+        expect(response).to redirect_to account_path
+        expect(flash[:success]).to be_present
+      end
+
+      it 'logs a successful analytics event' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::EMAIL_LANGUAGE_UPDATED, hash_including(success: true))
+
+        action
+      end
+    end
+
+    context 'with an invalid language selection' do
+      let(:email_language) { 'zz' }
+
+      it 'does not change the user email_language' do
+        expect { action }.to_not(change { user.reload.email_language })
+      end
+
+      it 'redirects to the account page, no success flash' do
+        action
+
+        expect(response).to redirect_to account_path
+        expect(flash[:success]).to be_blank
+      end
+
+      it 'logs an unsuccessful analytics event' do
+        stub_analytics
+        expect(@analytics).to receive(:track_event).
+          with(Analytics::EMAIL_LANGUAGE_UPDATED, hash_including(success: false))
+
+        action
+      end
+    end
+  end
+end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -52,7 +52,7 @@ describe Users::PasswordsController do
         mail = double
         expect(mail).to receive(:deliver_later)
         expect(UserMailer).to receive(:password_changed).
-          with(user.email_addresses.first, hash_including(:disavowal_token)).
+          with(user, user.email_addresses.first, hash_including(:disavowal_token)).
           and_return(mail)
 
         stub_sign_in(user)

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -463,7 +463,7 @@ describe Users::ResetPasswordsController, devise: true do
     mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
     user.email_addresses.each do |email_address|
       allow(UserMailer).to receive(:password_changed).
-        with(email_address, disavowal_token: instance_of(String)).
+        with(user, email_address, disavowal_token: instance_of(String)).
         and_return(mailer)
     end
   end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -36,6 +36,36 @@ describe UserDecorator do
     end
   end
 
+  describe '#email_language_preference_description' do
+    let(:user) { build_stubbed(:user, email_language: email_language) }
+
+    subject(:description) { UserDecorator.new(user).email_language_preference_description }
+
+    context 'when the user has a supported email_language' do
+      let(:email_language) { 'es' }
+
+      it 'is the that language' do
+        expect(description).to eq(I18n.t('account.email_language.name.es'))
+      end
+    end
+
+    context 'when the user has a nil email_language' do
+      let(:email_language) { nil }
+
+      it 'is the default language' do
+        expect(description).to eq(I18n.t('account.email_language.name.default'))
+      end
+    end
+
+    context 'when the user has an unsupported email_language' do
+      let(:email_language) { 'zz' }
+
+      it 'is the default language' do
+        expect(description).to eq(I18n.t('account.email_language.name.default'))
+      end
+    end
+  end
+
   describe '#lockout_time_remaining' do
     it 'returns the difference in seconds between otp drift and second_factor_locked_at' do
       Timecop.freeze(Time.zone.now) do

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -119,6 +119,15 @@ feature 'Accessibility on pages that require authentication', :js do
     expect(page).to label_required_fields
   end
 
+  scenario 'edit email language page' do
+    sign_in_and_2fa_user
+
+    visit account_email_language_path
+
+    expect(page).to be_accessible.according_to :section508, :"best-practice"
+    expect(page).to label_required_fields
+  end
+
   scenario 'add phone page' do
     sign_in_and_2fa_user
 

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Account email language' do
+  let(:user) { user_with_2fa }
+
+  let(:original_email_language) { 'es' }
+
+  before do
+    user.email_language = original_email_language
+    user.save!
+  end
+
+  context 'for a user signed in to their account page' do
+    before do
+      sign_in_and_2fa_user(user)
+    end
+
+    it 'lets them view their current email language' do
+      within(page.find('.profile-info-box', text: 'Language')) do
+        expect(page).to have_content('Spanish')
+      end
+    end
+
+    context 'changing their email language' do
+      before do
+        within(page.find('.profile-info-box', text: 'Language')) do
+          click_link('Edit')
+        end
+
+        choose 'French'
+        click_button 'Submit'
+      end
+
+      it 'reflects the updated language preference' do
+        within(page.find('.profile-info-box', text: 'Language')) do
+          expect(page).to have_content('French')
+        end
+      end
+
+      it 'respects the language preference in emails, such as password reset emails' do
+        within(page.find('.profile-info-box', text: 'Password')) do
+          click_link('Edit')
+        end
+        fill_in 'update_user_password_form_password', with: Features::SessionHelper::VALID_PASSWORD
+        click_button 'Update'
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq(I18n.t('devise.mailer.password_updated.subject', locale: 'fr'))
+      end
+    end
+  end
+end

--- a/spec/features/multiple_emails/reset_password_spec.rb
+++ b/spec/features/multiple_emails/reset_password_spec.rb
@@ -8,7 +8,7 @@ describe 'reset password with multiple emails' do
     mail1 = double
     expect(mail1).to receive(:deliver_now)
     expect(UserMailer).to receive(:reset_password_instructions).
-      with(email1, hash_including(:token)).
+      with(user, email1, hash_including(:token)).
       and_return(mail1)
 
     visit root_path
@@ -21,7 +21,7 @@ describe 'reset password with multiple emails' do
     mail2 = double
     expect(mail2).to receive(:deliver_now)
     expect(UserMailer).to receive(:reset_password_instructions).
-      with(email2, hash_including(:token)).
+      with(user, email2, hash_including(:token)).
       and_return(mail2)
 
     visit root_path

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -19,11 +19,12 @@ describe 'New device tracking' do
 
       expect(UserMailer).to have_received(:new_device_sign_in).
         with(
-          user.email_addresses.first,
-          device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
+          user: user,
+          email_address: user.email_addresses.first,
+          date: device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),
-          'From 127.0.0.1 (IP address potentially located in United States)',
-          instance_of(String),
+          location: 'From 127.0.0.1 (IP address potentially located in United States)',
+          disavowal_token: instance_of(String),
         )
     end
   end
@@ -57,11 +58,12 @@ describe 'New device tracking' do
 
       expect(UserMailer).to have_received(:new_device_sign_in).
         with(
-          user.email_addresses.first,
-          device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
+          user: user,
+          email_address: user.email_addresses.first,
+          date: device.last_used_at.in_time_zone('Eastern Time (US & Canada)').
             strftime('%B %-d, %Y %H:%M Eastern Time'),
-          'From 127.0.0.1 (IP address potentially located in United States)',
-          instance_of(String),
+          location: 'From 127.0.0.1 (IP address potentially located in United States)',
+          disavowal_token: instance_of(String),
         )
     end
   end

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -23,7 +23,7 @@ describe 'Add a new phone number' do
     phone = '+1 (225) 278-1234'
 
     expect(UserMailer).to receive(:phone_added).
-      with(user.email_addresses.first, hash_including(:disavowal_token)).
+      with(user, user.email_addresses.first, hash_including(:disavowal_token)).
       and_call_original
 
     sign_in_and_2fa_user(user)

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -17,7 +17,7 @@ feature 'View personal key' do
         personal_key_sign_in_mail = double
         expect(personal_key_sign_in_mail).to receive(:deliver_now)
         expect(UserMailer).to receive(:personal_key_regenerated).
-          with(user.email).
+          with(user, user.email).
           and_return(personal_key_sign_in_mail)
         expect(Telephony).to receive(:send_personal_key_regeneration_notice).
           with(to: user.phone_configurations.first.phone)

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -34,6 +34,20 @@ feature 'Sign Up' do
     end
   end
 
+  context 'picking a preferred email language on signup' do
+    let(:email) { Faker::Internet.safe_email }
+
+    it 'allows a user to pick a language when entering email' do
+      visit sign_up_email_path
+      fill_in 'Email', with: email
+      choose 'Spanish'
+      click_button t('forms.buttons.submit.default')
+
+      user = User.find_with_email(email)
+      expect(user.email_language).to eq('es')
+    end
+  end
+
   context 'user cancels sign up on email screen' do
     before do
       visit sign_up_email_path

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -116,6 +116,26 @@ describe RegisterUserEmailForm do
         expect(submit_form).to eq result
       end
 
+      it 'saves the user email_language for a valid form' do
+        captcha_results = mock_captcha(enabled: true, present: true, valid: true)
+        form = RegisterUserEmailForm.new(recaptcha_results: captcha_results)
+
+        response = form.submit(email: 'not_taken@gmail.com', email_language: 'fr')
+        expect(response).to be_success
+
+        expect(User.find_with_email('not_taken@gmail.com').email_language).to eq('fr')
+      end
+
+      it 'does not save the user email_language for an invalid form' do
+        captcha_results = mock_captcha(enabled: true, present: true, valid: false)
+        form = RegisterUserEmailForm.new(recaptcha_results: captcha_results)
+
+        response = form.submit(email: 'not_taken@gmail.com', email_language: 'fr')
+        expect(response).to_not be_success
+
+        expect(User.find_with_email('not_taken@gmail.com')&.email_language).to be_nil
+      end
+
       it 'is invalid with invalid recaptcha' do
         result = instance_double(FormResponse)
         allow(FormResponse).to receive(:new).and_return(result)

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -12,7 +12,7 @@ describe RegisterUserEmailForm do
 
         mailer = instance_double(ActionMailer::MessageDelivery)
         allow(UserMailer).to receive(:signup_with_your_email).
-          with(existing_user.email).and_return(mailer)
+          with(existing_user, existing_user.email).and_return(mailer)
         allow(mailer).to receive(:deliver_later)
 
         extra = {

--- a/spec/forms/update_email_language_form_spec.rb
+++ b/spec/forms/update_email_language_form_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe UpdateEmailLanguageForm do
+  let(:user) { build(:user) }
+
+  subject(:form) { UpdateEmailLanguageForm.new(user) }
+
+  describe '#submit' do
+    subject(:submit) { form.submit(email_language: email_language) }
+
+    context 'with a valid email_language' do
+      let(:email_language) { 'es' }
+
+      it 'is valid and has no errors' do
+        response = submit
+
+        expect(form).to be_valid
+        expect(form.errors).to be_blank
+        expect(response).to be_success
+        expect(response.errors).to be_blank
+      end
+
+      it 'updates the user email_language' do
+        expect { submit }.to(change { user.email_language }.to('es'))
+      end
+    end
+
+    context 'with an supported email_language' do
+      let(:email_language) { 'zz' }
+
+      it 'is invalid' do
+        response = submit
+
+        expect(form).to_not be_valid
+        expect(form.errors).to be_present
+        expect(response).to_not be_success
+        expect(response.errors).to be_present
+      end
+
+      it 'does not update the user email_language' do
+        expect { submit }.to_not(change { user.email_language })
+      end
+    end
+  end
+end

--- a/spec/helpers/locale_helper_spec.rb
+++ b/spec/helpers/locale_helper_spec.rb
@@ -28,4 +28,55 @@ RSpec.describe LocaleHelper do
       end
     end
   end
+
+  describe '#with_user_locale' do
+    let(:user) { build_stubbed(:user, email_language: email_language) }
+
+    subject do
+      with_user_locale(user) do
+        @locale_inside_block = I18n.locale
+        @did_yield = true
+      end
+    end
+
+    context 'when the user has no email_language' do
+      let(:email_language) { '' }
+
+      it 'yields the block and does not change the locale' do
+        subject
+
+        expect(@locale_inside_block).to eq(:en)
+        expect(@did_yield).to eq(true)
+      end
+    end
+
+    context 'when the user has an email_language' do
+      let(:email_language) { 'es' }
+
+      it 'sets the language inside the block and yields' do
+        subject
+
+        expect(@locale_inside_block).to eq(:es)
+        expect(@did_yield).to eq(true)
+      end
+    end
+
+    context 'when the user has an invalid email_language' do
+      let(:email_language) { 'zz' }
+
+      it 'yields the block and does not change the locale' do
+        subject
+
+        expect(@locale_inside_block).to eq(:en)
+        expect(@did_yield).to eq(true)
+      end
+
+      it 'warns about a bad email_language' do
+        expect(Rails.logger).to receive(:warn).
+          with("user_id=#{user.uuid} has bad email_language=#{user.email_language}")
+
+        subject
+      end
+    end
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,10 +5,11 @@ describe UserMailer, type: :mailer do
   let(:email_address) { user.email_addresses.first }
   let(:banned_email) { 'banned_email+123abc@gmail.com' }
 
-  describe 'email_deleted' do
-    let(:mail) { UserMailer.email_deleted('old@email.com') }
+  describe '#email_deleted' do
+    let(:mail) { UserMailer.email_deleted(user, 'old@email.com') }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the old email' do
       expect(mail.to).to eq ['old@email.com']
@@ -26,15 +27,16 @@ describe UserMailer, type: :mailer do
     end
 
     it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.email_deleted(banned_email)
+      mail = UserMailer.email_deleted(user, banned_email)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'password_changed' do
-    let(:mail) { UserMailer.password_changed(email_address, disavowal_token: '123abc') }
+  describe '#password_changed' do
+    let(:mail) { UserMailer.password_changed(user, email_address, disavowal_token: '123abc') }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -56,15 +58,16 @@ describe UserMailer, type: :mailer do
 
     it 'does not send mail to emails in nonessential email banlist' do
       email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.password_changed(email_address, disavowal_token: '123abc')
+      mail = UserMailer.password_changed(user, email_address, disavowal_token: '123abc')
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'personal_key_sign_in' do
-    let(:mail) { UserMailer.personal_key_sign_in(user.email, disavowal_token: 'asdf1234') }
+  describe '#personal_key_sign_in' do
+    let(:mail) { UserMailer.personal_key_sign_in(user, user.email, disavowal_token: 'asdf1234') }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [user.email]
@@ -84,12 +87,12 @@ describe UserMailer, type: :mailer do
     end
 
     it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.personal_key_sign_in(banned_email, disavowal_token: 'asdf1234')
+      mail = UserMailer.personal_key_sign_in(user, banned_email, disavowal_token: 'asdf1234')
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'email_confirmation_instructions' do
+  describe '#email_confirmation_instructions' do
     let(:instructions) { 'do the things' }
     let(:request_id) { '1234-abcd' }
     let(:token) { 'asdf123' }
@@ -105,13 +108,16 @@ describe UserMailer, type: :mailer do
     end
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
   end
 
-  describe 'sign in from new device' do
+  describe '#new_device_sign_in' do
     date = 'Washington, DC'
     location = 'February 25, 2019 15:02'
     disavowal_token = 'asdf1234'
-    let(:mail) { UserMailer.new_device_sign_in(email_address, date, location, disavowal_token) }
+    let(:mail) do
+      UserMailer.new_device_sign_in(user, email_address, date, location, disavowal_token)
+    end
 
     it_behaves_like 'a system email'
 
@@ -135,15 +141,16 @@ describe UserMailer, type: :mailer do
 
     it 'does not send mail to emails in nonessential email banlist' do
       email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.new_device_sign_in(email_address, date, location, disavowal_token)
+      mail = UserMailer.new_device_sign_in(user, email_address, date, location, disavowal_token)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'personal_key_regenerated' do
-    let(:mail) { UserMailer.personal_key_regenerated(user.email) }
+  describe '#personal_key_regenerated' do
+    let(:mail) { UserMailer.personal_key_regenerated(user, user.email) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [user.email]
@@ -160,15 +167,16 @@ describe UserMailer, type: :mailer do
     end
 
     it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.personal_key_regenerated(banned_email)
+      mail = UserMailer.personal_key_regenerated(user, banned_email)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'signup_with_your_email' do
-    let(:mail) { UserMailer.signup_with_your_email(user.email) }
+  describe '#signup_with_your_email' do
+    let(:mail) { UserMailer.signup_with_your_email(user, user.email) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [user.email]
@@ -197,11 +205,12 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'phone_added' do
+  describe '#phone_added' do
     disavowal_token = 'i_am_disavowal_token'
-    let(:mail) { UserMailer.phone_added(email_address, disavowal_token: disavowal_token) }
+    let(:mail) { UserMailer.phone_added(user, email_address, disavowal_token: disavowal_token) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -219,12 +228,12 @@ describe UserMailer, type: :mailer do
 
     it 'does not send mail to emails in nonessential email banlist' do
       email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.phone_added(email_address, disavowal_token: disavowal_token)
+      mail = UserMailer.phone_added(user, email_address, disavowal_token: disavowal_token)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'account_does_not_exist' do
+  describe '#account_does_not_exist' do
     let(:mail) { UserMailer.account_does_not_exist('test@test.com', 'request_id') }
 
     it_behaves_like 'a system email'
@@ -257,11 +266,12 @@ describe UserMailer, type: :mailer do
     )
   end
 
-  describe 'account_reset_request' do
-    let(:mail) { UserMailer.account_reset_request(email_address, account_reset) }
+  describe '#account_reset_request' do
+    let(:mail) { UserMailer.account_reset_request(user, email_address, account_reset) }
     let(:account_reset) { user.account_reset_request }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -297,10 +307,11 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'account_reset_granted' do
-    let(:mail) { UserMailer.account_reset_granted(email_address, user.account_reset_request) }
+  describe '#account_reset_granted' do
+    let(:mail) { UserMailer.account_reset_granted(user, email_address, user.account_reset_request) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -316,10 +327,11 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'account_reset_complete' do
-    let(:mail) { UserMailer.account_reset_complete(email_address) }
+  describe '#account_reset_complete' do
+    let(:mail) { UserMailer.account_reset_complete(user, email_address) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -335,10 +347,11 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'please_reset_password' do
-    let(:mail) { UserMailer.please_reset_password(email_address.email) }
+  describe '#please_reset_password' do
+    let(:mail) { UserMailer.please_reset_password(user, email_address.email) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -357,10 +370,11 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'undeliverable_address' do
-    let(:mail) { UserMailer.undeliverable_address(email_address) }
+  describe '#undeliverable_address' do
+    let(:mail) { UserMailer.undeliverable_address(user, email_address) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -377,17 +391,18 @@ describe UserMailer, type: :mailer do
 
     it 'does not send mail to emails in nonessential email banlist' do
       email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.undeliverable_address(email_address)
+      mail = UserMailer.undeliverable_address(user, email_address)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'doc_auth_desktop_link_to_sp' do
+  describe '#doc_auth_desktop_link_to_sp' do
     let(:app) { 'login.gov' }
     let(:link) { root_url }
-    let(:mail) { UserMailer.doc_auth_desktop_link_to_sp(email_address.email, app, link) }
+    let(:mail) { UserMailer.doc_auth_desktop_link_to_sp(user, email_address.email, app, link) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -405,10 +420,11 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'expired letter' do
-    let(:mail) { UserMailer.letter_expired(email_address.email) }
+  describe '#letter_expired' do
+    let(:mail) { UserMailer.letter_expired(user, email_address.email) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -424,15 +440,16 @@ describe UserMailer, type: :mailer do
     end
 
     it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.letter_expired(banned_email)
+      mail = UserMailer.letter_expired(user, banned_email)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'reminder letter' do
-    let(:mail) { UserMailer.letter_reminder(email_address.email) }
+  describe '#letter_reminder' do
+    let(:mail) { UserMailer.letter_reminder(user, email_address.email) }
 
     it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
 
     it 'sends to the current email' do
       expect(mail.to).to eq [email_address.email]
@@ -448,12 +465,12 @@ describe UserMailer, type: :mailer do
     end
 
     it 'does not send mail to emails in nonessential email banlist' do
-      mail = UserMailer.letter_reminder(banned_email)
+      mail = UserMailer.letter_reminder(user, banned_email)
       expect(mail.to).to eq(nil)
     end
   end
 
-  describe 'sps_over_quota_limit' do
+  describe '#sps_over_quota_limit' do
     let(:mail) { UserMailer.sps_over_quota_limit(email_address.email) }
 
     it_behaves_like 'a system email'

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -116,7 +116,13 @@ describe UserMailer, type: :mailer do
     location = 'February 25, 2019 15:02'
     disavowal_token = 'asdf1234'
     let(:mail) do
-      UserMailer.new_device_sign_in(user, email_address, date, location, disavowal_token)
+      UserMailer.new_device_sign_in(
+        user: user,
+        email_address: email_address,
+        date: date,
+        location: location,
+        disavowal_token: disavowal_token,
+      )
     end
 
     it_behaves_like 'a system email'
@@ -141,7 +147,13 @@ describe UserMailer, type: :mailer do
 
     it 'does not send mail to emails in nonessential email banlist' do
       email_address = EmailAddress.new(email: banned_email)
-      mail = UserMailer.new_device_sign_in(user, email_address, date, location, disavowal_token)
+      mail = UserMailer.new_device_sign_in(
+        user: user,
+        email_address: email_address,
+        date: date,
+        location: location,
+        disavowal_token: disavowal_token,
+      )
       expect(mail.to).to eq(nil)
     end
   end

--- a/spec/services/account_reset/cancel_spec.rb
+++ b/spec/services/account_reset/cancel_spec.rb
@@ -59,7 +59,7 @@ describe AccountReset::Cancel do
 
       @mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       user.email_addresses.each do |email_address|
-        expect(UserMailer).to receive(:account_reset_cancel).with(email_address).
+        expect(UserMailer).to receive(:account_reset_cancel).with(user, email_address).
           and_return(@mailer)
       end
 

--- a/spec/services/account_reset/notify_user_of_request_cancellation_spec.rb
+++ b/spec/services/account_reset/notify_user_of_request_cancellation_spec.rb
@@ -13,8 +13,10 @@ describe AccountReset::NotifyUserOfRequestCancellation do
       mail1 = double
       mail2 = double
 
-      expect(UserMailer).to receive(:account_reset_cancel).with(email_address1).and_return(mail1)
-      expect(UserMailer).to receive(:account_reset_cancel).with(email_address2).and_return(mail2)
+      expect(UserMailer).to receive(:account_reset_cancel).
+        with(user, email_address1).and_return(mail1)
+      expect(UserMailer).to receive(:account_reset_cancel).
+        with(user, email_address2).and_return(mail2)
 
       expect(mail1).to receive(:deliver_later)
       expect(mail2).to receive(:deliver_later)

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -38,7 +38,7 @@ describe RequestPasswordReset do
         mail = double
         expect(mail).to receive(:deliver_now)
         expect(UserMailer).to receive(:reset_password_instructions).
-          with(email, token: 'asdf1234').
+          with(user, email, token: 'asdf1234').
           and_return(mail)
 
         RequestPasswordReset.new(email).perform
@@ -58,7 +58,7 @@ describe RequestPasswordReset do
         mail = double
         expect(mail).to receive(:deliver_now)
         expect(UserMailer).to receive(:reset_password_instructions).
-          with(email, token: 'asdf1234').
+          with(user, email, token: 'asdf1234').
           and_return(mail)
 
         RequestPasswordReset.new(email).perform

--- a/spec/services/user_alerts/alert_user_about_new_device_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_new_device_spec.rb
@@ -17,15 +17,17 @@ describe UserAlerts::AlertUserAboutNewDevice do
 
       expect(UserMailer).to have_received(:new_device_sign_in).twice
       expect(UserMailer).to have_received(:new_device_sign_in).
-        with(confirmed_email_addresses[0],
-             instance_of(String),
-             instance_of(String),
-             disavowal_token)
+        with(user: user,
+             email_address: confirmed_email_addresses[0],
+             date: instance_of(String),
+             location: instance_of(String),
+             disavowal_token: disavowal_token)
       expect(UserMailer).to have_received(:new_device_sign_in).
-        with(confirmed_email_addresses[1],
-             instance_of(String),
-             instance_of(String),
-             disavowal_token)
+        with(user: user,
+             email_address: confirmed_email_addresses[1],
+             date: instance_of(String),
+             location: instance_of(String),
+             disavowal_token: disavowal_token)
     end
   end
 end

--- a/spec/services/user_alerts/alert_user_about_password_change_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_password_change_spec.rb
@@ -15,9 +15,9 @@ describe UserAlerts::AlertUserAboutPasswordChange do
 
       expect(UserMailer).to have_received(:password_changed).twice
       expect(UserMailer).to have_received(:password_changed).
-        with(confirmed_email_addresses[0], disavowal_token: disavowal_token)
+        with(user, confirmed_email_addresses[0], disavowal_token: disavowal_token)
       expect(UserMailer).to have_received(:password_changed).
-        with(confirmed_email_addresses[1], disavowal_token: disavowal_token)
+        with(user, confirmed_email_addresses[1], disavowal_token: disavowal_token)
     end
   end
 end

--- a/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_personal_key_sign_in_spec.rb
@@ -20,9 +20,9 @@ describe UserAlerts::AlertUserAboutPersonalKeySignIn do
 
       expect(UserMailer).to have_received(:personal_key_sign_in).twice
       expect(UserMailer).to have_received(:personal_key_sign_in).
-        with(confirmed_email_addresses[0].email, disavowal_token: disavowal_token)
+        with(user, confirmed_email_addresses[0].email, disavowal_token: disavowal_token)
       expect(UserMailer).to have_received(:personal_key_sign_in).
-        with(confirmed_email_addresses[1].email, disavowal_token: disavowal_token)
+        with(user, confirmed_email_addresses[1].email, disavowal_token: disavowal_token)
       expect(Telephony).to have_received(:send_personal_key_sign_in_notice).
         with(to: phone_configurations[0].phone)
       expect(Telephony).to have_received(:send_personal_key_sign_in_notice).

--- a/spec/support/shared_examples_for_mailer.rb
+++ b/spec/support/shared_examples_for_mailer.rb
@@ -4,3 +4,15 @@ shared_examples 'a system email' do
     expect(mail[:from].display_names).to eq [Figaro.env.email_from_display_name]
   end
 end
+
+# expects there to be a let(:user) in scope
+shared_examples 'an email that respects user email locale preference' do
+  before do
+    user.email_language = 'fr'
+    user.save!
+  end
+
+  it 'is in the correct locale' do
+    expect(mail.parts.first.body).to have_content(I18n.t('mailer.privacy_policy', locale: 'fr'))
+  end
+end

--- a/spec/views/layouts/user_mailer.html.erb_spec.rb
+++ b/spec/views/layouts/user_mailer.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe 'layouts/user_mailer.html.erb' do
+  let(:user) { build_stubbed(:user) }
+
   before do
-    @mail = UserMailer.email_added('foo@example.com')
+    @mail = UserMailer.email_added(user, 'foo@example.com')
     allow(view).to receive(:message).and_return(@mail)
     allow(view).to receive(:attachments).and_return(@mail.attachments)
 

--- a/spec/views/shared/_email_languages.html.erb_spec.rb
+++ b/spec/views/shared/_email_languages.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_email_languages.html.erb' do
+  include SimpleForm::ActionViewExtensions::FormHelper
+
+  subject(:render_partial) do
+    simple_form_for(:user, url: '/') do |f|
+      render partial: 'shared/email_languages', locals: { f: f, selection: selection }
+    end
+  end
+
+  let(:selection) { 'fr' }
+
+  it 'renders a checkbox per available locale' do
+    render_partial
+
+    doc = Nokogiri::HTML(rendered)
+    radios = doc.css('input[type=radio]')
+
+    expect(radios.map { |r| r['value'] }).to match_array(I18n.available_locales.map(&:to_s))
+  end
+
+  context 'with a nil selection' do
+    let(:selection) { nil }
+
+    it 'marks the default language as checked' do
+      render_partial
+
+      doc = Nokogiri::HTML(rendered)
+      checked = doc.css('input[type=radio][checked]')
+      expect(checked.length).to eq(1)
+
+      radio = checked.first
+      expect(radio[:value]).to eq(I18n.default_locale.to_s)
+    end
+  end
+
+  context 'with a language selection' do
+    let(:selection) { 'es' }
+
+    it 'marks the selection language as checked' do
+      render_partial
+
+      doc = Nokogiri::HTML(rendered)
+      checked = doc.css('input[type=radio][checked]')
+      expect(checked.length).to eq(1)
+
+      radio = checked.first
+      expect(radio[:value]).to eq(selection)
+    end
+  end
+end

--- a/spec/views/shared/_email_languages.html.erb_spec.rb
+++ b/spec/views/shared/_email_languages.html.erb_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'shared/_email_languages.html.erb' do
 
   subject(:render_partial) do
     simple_form_for(:user, url: '/') do |f|
-      render partial: 'shared/email_languages', locals: { f: f, selection: selection }
+      render partial: 'shared/email_languages',
+             locals: { f: f, selection: selection, labelledby: labelledby }
     end
   end
 
   let(:selection) { 'fr' }
+  let(:labelledby) { 'outer-label-id' }
 
   it 'renders a checkbox per available locale' do
     render_partial
@@ -18,6 +20,32 @@ RSpec.describe 'shared/_email_languages.html.erb' do
     radios = doc.css('input[type=radio]')
 
     expect(radios.map { |r| r['value'] }).to match_array(I18n.available_locales.map(&:to_s))
+  end
+
+  context 'accessibility' do
+    it 'marks all radio boxes as labelled by the outer label' do
+      render_partial
+
+      doc = Nokogiri::HTML(rendered)
+      radios = doc.css('input[type=radio]')
+
+      radios.each do |radio|
+        expect(radio['aria-labelledby']).to include(labelledby)
+      end
+    end
+
+    it 'marks each radio box as labelled by its unique label' do
+      render_partial
+
+      doc = Nokogiri::HTML(rendered)
+      radios = doc.css('input[type=radio]')
+
+      radios.each do |radio|
+        aria = radio['aria-labelledby']
+        unique_label = (aria.split(' ') - [labelledby]).first
+        expect(doc.css("label##{unique_label}").size).to eq(1)
+      end
+    end
   end
 
   context 'with a nil selection' do

--- a/spec/views/shared/_email_languages.html.erb_spec.rb
+++ b/spec/views/shared/_email_languages.html.erb_spec.rb
@@ -22,32 +22,6 @@ RSpec.describe 'shared/_email_languages.html.erb' do
     expect(radios.map { |r| r['value'] }).to match_array(I18n.available_locales.map(&:to_s))
   end
 
-  context 'accessibility' do
-    it 'marks all radio boxes as labelled by the outer label' do
-      render_partial
-
-      doc = Nokogiri::HTML(rendered)
-      radios = doc.css('input[type=radio]')
-
-      radios.each do |radio|
-        expect(radio['aria-labelledby']).to include(labelledby)
-      end
-    end
-
-    it 'marks each radio box as labelled by its unique label' do
-      render_partial
-
-      doc = Nokogiri::HTML(rendered)
-      radios = doc.css('input[type=radio]')
-
-      radios.each do |radio|
-        aria = radio['aria-labelledby']
-        unique_label = (aria.split(' ') - [labelledby]).first
-        expect(doc.css("label##{unique_label}").size).to eq(1)
-      end
-    end
-  end
-
   context 'with a nil selection' do
     let(:selection) { nil }
 


### PR DESCRIPTION
* Add email language selection to signup form
* Add email language preference to account page, editable
* Update existing emails to respect email language preference

Screenies!

| Signup page | Corresponding email |
| --- | --- |
| <img width="653" alt="Screen Shot 2020-10-30 at 2 48 50 PM" src="https://user-images.githubusercontent.com/458784/97760251-f10a6c80-1abf-11eb-99c7-874144a2d2dc.png"> | (if you selected Spanish) <img width="599" alt="Screen Shot 2020-10-30 at 2 49 23 PM" src="https://user-images.githubusercontent.com/458784/97760242-ee0f7c00-1abf-11eb-8de1-9cdd942b25a8.png"> |

| Account Page | Update Page | After Update |
| --- | --- | --- |
| <img width="950" alt="Screen Shot 2020-10-30 at 2 49 40 PM" src="https://user-images.githubusercontent.com/458784/97760244-efd93f80-1abf-11eb-8a61-f97a1bfebebb.png"> | <img width="647" alt="Screen Shot 2020-10-30 at 2 50 29 PM" src="https://user-images.githubusercontent.com/458784/97760246-f071d600-1abf-11eb-98f0-1d3a552dd618.png"> | (if you changed to Spanish) <img width="810" alt="Screen Shot 2020-10-30 at 2 50 44 PM" src="https://user-images.githubusercontent.com/458784/97760249-f10a6c80-1abf-11eb-9298-5e052a483d96.png"> |
