### PR TITLE
Validate PII doc contains necessary fields (LG-3643)

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -21,12 +21,15 @@ module Idv
 
         update_analytics(client_response)
 
-        store_pii(client_response) if client_response.success?
+        if client_response.success?
+          doc_pii_form_result = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
+          store_pii(client_response) if client_response.success? && doc_pii_form_result.success?
+        end
       end
 
       presenter = ImageUploadResponsePresenter.new(
         form: image_form,
-        form_response: client_response || form_response,
+        form_response: doc_pii_form_result || client_response || form_response,
       )
 
       render json: presenter, status: presenter.status

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -9,8 +9,6 @@ module Idv
     def create
       form_response = image_form.submit
 
-      analytics.track_event(Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM, form_response.to_h)
-
       if form_response.success?
         client_response = doc_auth_client.post_images(
           front_image: image_form.front.read,
@@ -27,6 +25,8 @@ module Idv
           store_pii(client_response) if client_response.success? && doc_pii_form_response.success?
         end
       end
+
+      analytics.track_event(Analytics::IDV_DOC_AUTH_SUBMITTED_IMAGE_UPLOAD_FORM, form_response.to_h)
 
       presenter = ImageUploadResponsePresenter.new(
         form: image_form,

--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -22,14 +22,15 @@ module Idv
         update_analytics(client_response)
 
         if client_response.success?
-          doc_pii_form_result = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
-          store_pii(client_response) if client_response.success? && doc_pii_form_result.success?
+          doc_pii_form_response = Idv::DocPiiForm.new(client_response.pii_from_doc).submit
+          form_response = form_response.merge(doc_pii_form_response)
+          store_pii(client_response) if client_response.success? && doc_pii_form_response.success?
         end
       end
 
       presenter = ImageUploadResponsePresenter.new(
         form: image_form,
-        form_response: doc_pii_form_result || client_response || form_response,
+        form_response: client_response || form_response,
       )
 
       render json: presenter, status: presenter.status

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -4,12 +4,13 @@ module Idv
 
     validate :validate_pii
 
-    attr_reader :first_name, :last_name, :dob
+    attr_reader :first_name, :last_name, :dob, :state
 
     def initialize(pii)
       @first_name = pii[:first_name]
       @last_name = pii[:last_name]
       @dob = pii[:dob]
+      @state = pii[:state]
     end
 
     def submit
@@ -22,16 +23,34 @@ module Idv
     private
 
     def validate_pii
-      if (first_name.blank? || last_name.blank?) && dob.blank?
-        errors.add(:pii, multiple_errors_message)
-      elsif dob.blank?
-        errors.add(:pii, dob_error)
-      elsif first_name.blank? || last_name.blank?
+      if error_count > 1
+        errors.add(:pii, generic_error)
+      elsif !name_valid?
         errors.add(:pii, name_error)
+      elsif !dob_valid?
+        errors.add(:pii, dob_error)
+      elsif !state_valid?
+        errors.add(:pii, generic_error)
       end
     end
 
-    def multiple_errors_message
+    def name_valid?
+      first_name.present? && last_name.present?
+    end
+
+    def dob_valid?
+      dob.present?
+    end
+
+    def state_valid?
+      state.present? && state.length == 2
+    end
+
+    def error_count
+      [name_valid?, dob_valid?, state_valid?].count(&:blank?)
+    end
+
+    def generic_error
       I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')
     end
 

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -1,0 +1,51 @@
+module Idv
+  class DocPiiForm
+    include ActiveModel::Model
+
+    validates_presence_of :first_name
+    validates_presence_of :last_name
+    validates_presence_of :dob
+
+    attr_reader :first_name, :last_name, :dob
+
+    def initialize(pii)
+      @first_name = pii[:first_name]
+      @last_name = pii[:last_name]
+      @dob = pii[:dob]
+    end
+
+    def submit
+      FormResponse.new(
+        success: valid?,
+        errors: error_hash,
+        extra: { original_errors: errors },
+      )
+    end
+
+    private
+
+    def error_hash
+      error_count = [name_error, dob_error].count(&:present?)
+
+      return {} if error_count.zero?
+      return { pii: multiple_errors_message } if error_count > 1
+      { pii: name_error || dob_error || state_id_error }
+    end
+
+    def multiple_errors_message
+      I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')
+    end
+
+    def name_error
+      if errors.include?(:first_name) || errors.include?(:last_name)
+        return I18n.t('doc_auth.errors.lexis_nexis.full_name_check')
+      end
+      nil
+    end
+
+    def dob_error
+      return I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks') if errors.include?(:dob)
+      nil
+    end
+  end
+end

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -39,9 +39,8 @@ module Idv
     end
 
     def name_error
-      if errors.include?(:first_name) || errors.include?(:last_name)
-        I18n.t('doc_auth.errors.lexis_nexis.full_name_check')
-      end
+      return unless errors.include?(:first_name) || errors.include?(:last_name)
+      I18n.t('doc_auth.errors.lexis_nexis.full_name_check')
     end
 
     def dob_error

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -26,7 +26,7 @@ module Idv
 
     def error_hash
       if name_error.present? && dob_error.present?
-        { pii: multiple_errors_message } 
+        { pii: multiple_errors_message }
       elsif name_error.present? || dob_error.present?
         { pii: name_error || dob_error }
       else

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -25,11 +25,13 @@ module Idv
     private
 
     def error_hash
-      error_count = [name_error, dob_error].count(&:present?)
-
-      return {} if error_count.zero?
-      return { pii: multiple_errors_message } if error_count > 1
-      { pii: name_error || dob_error || state_id_error }
+      if name_error.present? && dob_error.present?
+        { pii: multiple_errors_message } 
+      elsif name_error.present? || dob_error.present?
+        { pii: name_error || dob_error }
+      else
+        {}
+      end
     end
 
     def multiple_errors_message

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -40,9 +40,8 @@ module Idv
 
     def name_error
       if errors.include?(:first_name) || errors.include?(:last_name)
-        return I18n.t('doc_auth.errors.lexis_nexis.full_name_check')
+        I18n.t('doc_auth.errors.lexis_nexis.full_name_check')
       end
-      nil
     end
 
     def dob_error

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -44,8 +44,7 @@ module Idv
     end
 
     def dob_error
-      return I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks') if errors.include?(:dob)
-      nil
+      I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks') if errors.include?(:dob)
     end
   end
 end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -20,12 +20,13 @@ module Idv
 
           if form_response.success?
             async_result_response = async_state_done(current_async_state.result)
+            form_response = async_result_response.merge(form_response)
           end
         end
 
         presenter = ImageUploadResponsePresenter.new(
           form: form,
-          form_response: async_result_response || form_response,
+          form_response: form_response,
         )
 
         status = :accepted if current_async_state.status == :in_progress

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -35,6 +35,8 @@ module Idv
           presenter,
           status: status || presenter.status,
         )
+
+        form_response
       end
 
       def async_state_done(async_result)

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -37,14 +37,16 @@ module Idv
 
       def post_images_and_handle_result
         response = post_images
-        if response.success?
-          save_proofing_components
-          document_capture_session.store_result_from_response(response)
-          extract_pii_from_doc(response)
-          response
-        else
-          handle_document_verification_failure(response)
+        return handle_document_verification_failure(response) unless response.success?
+        doc_pii_form_result = Idv::DocPiiForm.new(response.pii_from_doc).submit
+        unless doc_pii_form_result.success?
+          return handle_document_verification_failure(doc_pii_form_result)
         end
+
+        save_proofing_components
+        document_capture_session.store_result_from_response(response)
+        extract_pii_from_doc(response)
+        response
       end
 
       def handle_document_verification_failure(response)

--- a/app/services/idv/steps/document_capture_step.rb
+++ b/app/services/idv/steps/document_capture_step.rb
@@ -40,7 +40,10 @@ module Idv
         return handle_document_verification_failure(response) unless response.success?
         doc_pii_form_result = Idv::DocPiiForm.new(response.pii_from_doc).submit
         unless doc_pii_form_result.success?
-          return handle_document_verification_failure(doc_pii_form_result)
+          doc_auth_form_result = IdentityDocAuth::Response.new(success: false,
+                                                               errors: doc_pii_form_result.errors)
+          doc_auth_form_result = doc_auth_form_result.merge(response)
+          return handle_document_verification_failure(doc_auth_form_result)
         end
 
         save_proofing_components

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -290,9 +290,18 @@ describe Idv::DocAuthController do
       expect(response.status).to eq(400)
       expect(response.body).to eq({
         success: false,
-        errors: [{ field: 'pii', message: I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')}],
+        errors: [{ field: 'pii',
+                   message: I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness') }],
         remaining_attempts: Figaro.env.acuant_max_attempts.to_i,
       }.to_json)
+      expect(@analytics).to have_received(:track_event).with(
+        Analytics::DOC_AUTH + ' submitted', {
+          errors: { pii: [I18n.t('doc_auth.errors.lexis_nexis.general_error_no_liveness')] },
+          success: false,
+          remaining_attempts: Figaro.env.acuant_max_attempts.to_i,
+          step: 'verify_document_status',
+        }
+      )
     end
   end
 

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -218,7 +218,20 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
-    let(:good_result) { { pii_from_doc: {}, success: true, errors: {}, messages: ['message'] } }
+    let(:good_result) do
+      { pii_from_doc: {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        dob: Time.zone.today.to_s,
+        address1: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zipcode: Faker::Address.zip_code,
+        state_id_type: 'drivers_license',
+        state_id_number: '111',
+        state_id_jurisdiction: 'WI',
+      }, success: true, errors: {}, messages: ['message'] }
+    end
     let(:fail_result) do
       {
         pii_from_doc: {},

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -102,6 +102,25 @@ feature 'doc auth document capture step' do
         expect(page).to have_current_path(idv_doc_auth_document_capture_step)
       end
 
+      it 'does not proceed to the next page with a successful doc auth but missing information' do
+        allow_any_instance_of(ApplicationController).
+          to receive(:analytics).and_return(fake_analytics)
+
+        mock_doc_auth_no_name_pii(:post_images)
+        attach_images
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_document_capture_step)
+
+        expect(fake_analytics).to have_logged_event(
+          Analytics::DOC_AUTH + ' submitted',
+          step: 'document_capture',
+          result: 'Passed',
+          billed: true,
+          success: false,
+        )
+      end
+
       it 'offers in person option on failure' do
         enable_in_person_proofing
 

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -30,7 +30,7 @@ describe Idv::DocPiiForm do
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(false)
-        expect(result.errors[:pii]).to eq t('doc_auth.errors.lexis_nexis.full_name_check')
+        expect(result.errors[:pii]).to eq [t('doc_auth.errors.lexis_nexis.full_name_check')]
       end
     end
 
@@ -40,7 +40,9 @@ describe Idv::DocPiiForm do
 
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(false)
-        expect(result.errors[:pii]).to eq t('doc_auth.errors.lexis_nexis.general_error_no_liveness')
+        expect(result.errors[:pii]).to eq [
+          t('doc_auth.errors.lexis_nexis.general_error_no_liveness'),
+        ]
       end
     end
   end

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -8,10 +8,17 @@ describe Idv::DocPiiForm do
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       dob: Time.zone.today.to_s,
+      state: Faker::Address.state_abbr,
     }
   end
-  let(:name_errors_pii) { { first_name: nil, last_name: nil, dob: Time.zone.today.to_s } }
-  let(:name_and_dob_errors_pii) { { first_name: nil, last_name: nil, dob: nil } }
+  let(:name_errors_pii) do
+    { first_name: nil, last_name: nil, dob: Time.zone.today.to_s,
+      state: Faker::Address.state_abbr }
+  end
+  let(:name_and_dob_errors_pii) do
+    { first_name: nil, last_name: nil, dob: nil,
+      state: Faker::Address.state_abbr }
+  end
 
   describe '#submit' do
     context 'when the form is valid' do

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Idv::DocPiiForm do
+  let(:user) { create(:user) }
+  let(:subject) { Idv::DocPiiForm }
+  let(:good_pii) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      dob: Time.zone.today.to_s,
+    }
+  end
+  let(:name_errors_pii) { { first_name: nil, last_name: nil, dob: Time.zone.today.to_s } }
+  let(:name_and_dob_errors_pii) { { first_name: nil, last_name: nil, dob: nil } }
+
+  describe '#submit' do
+    context 'when the form is valid' do
+      it 'returns a successful form response' do
+        result = subject.new(good_pii).submit
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context 'when there is an error with both name fields' do
+      it 'returns a single name-specific pii error' do
+        result = subject.new(name_errors_pii).submit
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors[:pii]).to eq t('doc_auth.errors.lexis_nexis.full_name_check')
+      end
+    end
+
+    context 'when there is an error with name fields and dob' do
+      it 'returns a single generic pii error' do
+        result = subject.new(name_and_dob_errors_pii).submit
+
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors[:pii]).to eq t('doc_auth.errors.lexis_nexis.general_error_no_liveness')
+      end
+    end
+  end
+end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -192,6 +192,23 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     click_idv_continue
   end
 
+  def mock_doc_auth_no_name_pii(method)
+    pii_with_no_name = IdentityDocAuth::Mock::ResultResponseBuilder::DEFAULT_PII_FROM_DOC.dup
+    pii_with_no_name[:last_name] = nil
+    IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
+      method: method,
+      response: IdentityDocAuth::Response.new(
+        pii_from_doc: pii_with_no_name,
+        extra: {
+          result: 'Passed',
+          billed: true,
+        },
+        success: true,
+        errors: {},
+      ),
+    )
+  end
+
   def mock_general_doc_auth_client_error(method)
     IdentityDocAuth::Mock::DocAuthMockClient.mock_response!(
       method: method,


### PR DESCRIPTION
This PR checks along both the React doc auth and no javascript paths to ensure that PII pulled from the doc contains the name and date of birth, which are required later for the address and resolution steps.

If there is an error with either or both of the name fields, the name error message is displayed. If there is an error with the DOB, the DOB error is displayed. If there's an error with both, a more generic error is shown.

React
![image](https://user-images.githubusercontent.com/1430443/97760464-34b9a200-1ad1-11eb-8565-f406dc4ef622.png)
![image](https://user-images.githubusercontent.com/1430443/97760804-07b9bf00-1ad2-11eb-88d9-8f7e3df9ab2b.png)
![image](https://user-images.githubusercontent.com/1430443/97760862-333ca980-1ad2-11eb-8c0f-4319bdce9689.png)

No javascript:
![image](https://user-images.githubusercontent.com/1430443/97760954-6d0db000-1ad2-11eb-92ae-533cc275f235.png)

