### PR TITLE
Handle submission completion as CallbackOnMount callback

### DIFF
--- a/app/javascript/packages/document-capture/components/callback-on-mount.jsx
+++ b/app/javascript/packages/document-capture/components/callback-on-mount.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * @typedef CallbackOnMountProps
+ *
+ * @prop {()=>void} onMount Callback to trigger on mount.
+ */
+
+/**
+ * @param {CallbackOnMountProps} props Props object.
+ */
+function CallbackOnMount({ onMount }) {
+  useEffect(() => {
+    onMount();
+  }, []);
+
+  return null;
+}
+
+export default CallbackOnMount;

--- a/app/javascript/packages/document-capture/components/submission-complete.jsx
+++ b/app/javascript/packages/document-capture/components/submission-complete.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import SubmissionInterstitial from './submission-interstitial';
+import CallbackOnMount from './callback-on-mount';
 
 /** @typedef {import('../context/upload').UploadSuccessResponse} UploadSuccessResponse */
 
@@ -34,7 +35,7 @@ function SubmissionComplete({ resource }) {
   const sleepTimeout = useRef(/** @type {number=} */ (undefined));
   const response = resource.read();
 
-  useEffect(() => {
+  function handleResponse() {
     if (response.isPending) {
       sleepTimeout.current = window.setTimeout(() => {
         setRetryError(() => {
@@ -48,9 +49,14 @@ function SubmissionComplete({ resource }) {
     }
 
     return () => window.clearTimeout(sleepTimeout.current);
-  }, []);
+  }
 
-  return <SubmissionInterstitial />;
+  return (
+    <>
+      <CallbackOnMount onMount={handleResponse} />
+      <SubmissionInterstitial />
+    </>
+  );
 }
 
 export default SubmissionComplete;

--- a/spec/javascripts/packages/document-capture/components/callback-on-mount-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/callback-on-mount-spec.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import CallbackOnMount from '@18f/identity-document-capture/components/callback-on-mount';
+
+describe('document-capture/components/callback-on-mount', () => {
+  it('calls callback once on mount', () => {
+    const callback = sinon.spy();
+
+    render(<CallbackOnMount onMount={callback} />);
+
+    expect(callback.calledOnce).to.be.true();
+  });
+});


### PR DESCRIPTION
**Why**: Rules of hooks requires that hooks be called deterministically in the same way for every render. Because it's expected that [`resource.read` can throw a promise or an error](https://github.com/18F/identity-idp/blob/b749766635c9a69a1440436db44210b52d5759a1/app/javascript/packages/document-capture/hooks/use-async.js#L49-L53) because it is a [React Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html) resource, the useEffect which follows cannot be guaranteed to be called in the same way for every render. This could lead to unexpected behavior.

See: https://reactjs.org/docs/hooks-rules.html

This restores a `CallbackOnMount` component which had existed previously and was removed as unused in #4335.

Note: I couldn't find much documentation about this in Rules of Hooks or Suspense documentation, nor is it covered by [`eslint-plugin-react-hook`](https://www.npmjs.com/package/eslint-plugin-react-hooks)'s `rules-of-hooks` rule.

**Testing Procedure:**

Document capture submission proceeds to next step when successful.