### PR TITLE
Raise an exception if the piv_cac_verify_token_url is not configured with https in production (LG-3490)

### DIFF
--- a/app/services/piv_cac/check_config.rb
+++ b/app/services/piv_cac/check_config.rb
@@ -6,8 +6,11 @@ module PivCac
       url = URI.parse(Figaro.env.piv_cac_verify_token_url)
       return if url.scheme == 'https'
 
-      message = "PIV/CAC configured without SSL: #{Figaro.env.piv_cac_verify_token_url}"
+      # rubocop:disable Layout/LineLength
+      message = "piv_cac_verify_token_url configured without SSL: #{Figaro.env.piv_cac_verify_token_url}"
+      # rubocop:enable Layout/LineLength
       Rails.logger.error { "#{message} - EXITING" }
+      NewRelic::Agent.notice_error("#{message} - EXITING")
       raise message
     end
   end

--- a/app/services/piv_cac/check_config.rb
+++ b/app/services/piv_cac/check_config.rb
@@ -1,0 +1,14 @@
+module PivCac
+  class CheckConfig
+    def self.call
+      return unless Rails.env.production?
+
+      url = URI.parse(Figaro.env.piv_cac_verify_token_url)
+      return if url.scheme == 'https'
+
+      message = "PIV/CAC configured without SSL: #{Figaro.env.piv_cac_verify_token_url}"
+      Rails.logger.error { "#{message} - EXITING" }
+      raise message
+    end
+  end
+end

--- a/config/initializers/piv_cac_initializer.rb
+++ b/config/initializers/piv_cac_initializer.rb
@@ -1,0 +1,1 @@
+PivCac::CheckConfig.call

--- a/spec/services/piv_cac/check_config_spec.rb
+++ b/spec/services/piv_cac/check_config_spec.rb
@@ -23,7 +23,7 @@ describe PivCac::CheckConfig do
     context 'non-https config' do
       it 'does raise an error' do
         expect { PivCac::CheckConfig.call }.
-          to raise_error(RuntimeError, "PIV/CAC configured without SSL: #{url}")
+          to raise_error(RuntimeError, "piv_cac_verify_token_url configured without SSL: #{url}")
       end
     end
 

--- a/spec/services/piv_cac/check_config_spec.rb
+++ b/spec/services/piv_cac/check_config_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+# Covers app/services/piv_cac/check_config.rb, which raises an error if the
+# piv_cac_verify_token_url is not configured with https in production environments.
+describe PivCac::CheckConfig do
+  let(:is_production) { false }
+  let(:url) { 'http://non-secure.example.com/' }
+
+  before do
+    allow(Rails.env).to receive(:production?).and_return(is_production)
+    allow(Figaro.env).to receive(:piv_cac_verify_token_url).and_return(url)
+  end
+
+  context 'non-production environments' do
+    it 'does not raise an error' do
+      expect { PivCac::CheckConfig.call }.not_to raise_error
+    end
+  end
+
+  context 'production environments' do
+    let(:is_production) { true }
+
+    context 'non-https config' do
+      it 'does raise an error' do
+        expect { PivCac::CheckConfig.call }.
+          to raise_error(RuntimeError, "PIV/CAC configured without SSL: #{url}")
+      end
+    end
+
+    context 'https config' do
+      let(:url) { 'https://secure.example.com' }
+
+      it 'does not raise an error' do
+        expect { PivCac::CheckConfig.call }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
I confirmed that none of our current environments are incorrectly configured, but this check ensures that we never mistakenly mis-configure them in the future.