### PR TITLE
Style File Input banner text as 1.5 line-height

### DIFF
--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -50,11 +50,15 @@
   font-size: 1.625rem;
   letter-spacing: .4px;
   line-height: 1.5;
+  // For content to appear as vertically centered, offset the larger line-height of the banner to
+  // match the space below the drag text.
+  margin-top: ((1.5rem - size('body', '2xs')) - ((1.625rem * 1.5) - 1.625rem)) / 2;
   text-transform: uppercase;
 
   + .usa-file-input__drag-text {
     @include u-display('block');
     @include u-margin-top(2);
+    line-height: 1.5rem;
   }
 }
 

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -49,7 +49,7 @@
   display: block;
   font-size: 1.625rem;
   letter-spacing: .4px;
-  line-height: 1.5rem;
+  line-height: 1.5;
   text-transform: uppercase;
 
   + .usa-file-input__drag-text {


### PR DESCRIPTION
In reviewing #4359, @anniehirshman-gsa had noticed that the line height of the placeholder text of the selfie capture did not match the design.

TBD: Should `line-height` be `1.5` for both file inputs and selfie capture? In the designs, it is `1.5rem` (`24px`) for file inputs and `1.5` (`39px`) for selfie capture.

**Screenshots:**

As implemented, using `line-height: 1.5` for both file input and selfie capture:

_File input:_

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/97914851-87d46480-1d1e-11eb-85bb-6e0265d34080.png)|![after](https://user-images.githubusercontent.com/1779930/97914863-8b67eb80-1d1e-11eb-9873-b7a29fe187d6.png)

_Selfie capture:_

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/97914942-a6d2f680-1d1e-11eb-9489-c302324234bb.png)|![after](https://user-images.githubusercontent.com/1779930/97914962-ae929b00-1d1e-11eb-9be1-5df46c11ae40.png)