### PR TITLE
LG-3325 Added a fallback error flow to doc auth

### DIFF
--- a/app/javascript/packs/document-capture-welcome.js
+++ b/app/javascript/packs/document-capture-welcome.js
@@ -1,8 +1,17 @@
-import { isCameraCapableMobile } from '@18f/identity-device';
+import { hasCamera, isCameraCapableMobile } from '@18f/identity-device';
 
 const form = document.querySelector('.js-consent-form');
 
 if (form && isCameraCapableMobile()) {
+  (async () => {
+    if (!(await hasCamera())) {
+      const ncInput = document.createElement('input');
+      ncInput.type = 'hidden';
+      ncInput.name = 'no_camera';
+      form.appendChild(ncInput);
+    }
+  })();
+
   const input = document.createElement('input');
   input.type = 'hidden';
   input.name = 'skip_upload';

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -7,7 +7,7 @@ module Idv
       end
 
       def form_submit
-        return no_camera_redirect if params[:no_camera] && FeatureManagement.document_capture_step_enabled?
+        return no_camera_redirect if params[:no_camera]
 
         skip_to_capture if params[:skip_upload] && FeatureManagement.document_capture_step_enabled?
 
@@ -34,7 +34,7 @@ module Idv
       def no_camera_redirect
         redirect_to idv_doc_auth_errors_no_camera_url
         exception = StandardError.new(
-          'Doc Auth error: Javascript could not detect camera on mobile device.'
+          'Doc Auth error: Javascript could not detect camera on mobile device.',
         )
 
         NewRelic::Agent.notice_error(exception)

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -7,6 +7,8 @@ module Idv
       end
 
       def form_submit
+        return no_camera_redirect if params[:no_camera] && FeatureManagement.document_capture_step_enabled?
+
         skip_to_capture if params[:skip_upload] && FeatureManagement.document_capture_step_enabled?
 
         Idv::ConsentForm.new.submit(consent_form_params)
@@ -27,6 +29,16 @@ module Idv
         mark_step_complete(:send_link)
         mark_step_complete(:link_sent)
         mark_step_complete(:email_sent)
+      end
+
+      def no_camera_redirect
+        redirect_to idv_doc_auth_errors_no_camera_url
+        exception = StandardError.new(
+          'Doc Auth error: Javascript could not detect camera on mobile device.'
+        )
+
+        NewRelic::Agent.notice_error(exception)
+        failure(exception)
       end
     end
   end

--- a/app/services/idv/steps/welcome_step.rb
+++ b/app/services/idv/steps/welcome_step.rb
@@ -7,9 +7,11 @@ module Idv
       end
 
       def form_submit
-        return no_camera_redirect if params[:no_camera]
+        if FeatureManagement.document_capture_step_enabled?
+          return no_camera_redirect if params[:no_camera]
 
-        skip_to_capture if params[:skip_upload] && FeatureManagement.document_capture_step_enabled?
+          skip_to_capture if params[:skip_upload]
+        end
 
         Idv::ConsentForm.new.submit(consent_form_params)
       end
@@ -33,12 +35,10 @@ module Idv
 
       def no_camera_redirect
         redirect_to idv_doc_auth_errors_no_camera_url
-        exception = StandardError.new(
-          'Doc Auth error: Javascript could not detect camera on mobile device.',
-        )
+        msg = 'Doc Auth error: Javascript could not detect camera on mobile device.'
 
-        NewRelic::Agent.notice_error(exception)
-        failure(exception)
+        NewRelic::Agent.notice_error(StandardError.new(msg))
+        failure(msg)
       end
     end
   end

--- a/app/views/idv/doc_auth/no_camera.html.erb
+++ b/app/views/idv/doc_auth/no_camera.html.erb
@@ -1,0 +1,35 @@
+<% title t('doc_auth.errors.no_camera.title') %>
+
+<%= image_tag(asset_url('alert/warning-lg'), width: 54, alt: '') %>
+
+<h1 class="h3 mb1 mt3 my0">
+  <%= t('doc_auth.errors.no_camera.heading') %>
+</h1>
+
+<p>
+  <% if liveness_checking_enabled? %>
+    <%= t('doc_auth.info.upload_liveness_enabled') %>
+  <% else %>
+    <%= t('doc_auth.info.upload') %>
+  <% end %>
+</p>
+
+<p class="text-bold">
+  <%= t('doc_auth.errors.no_camera.explanation') %>
+</p>
+
+<p>
+  <%= t('doc_auth.info.id_worn_html') %>
+</p>
+
+<% if decorated_session.sp_name %>
+  <p>
+    <%= t(
+            'doc_auth.info.no_other_id_help_bold_html',
+            failure_to_proof_url: decorated_session.failure_to_proof_url,
+            sp_name: decorated_session.sp_name,
+        ) %>
+  </p>
+<% end %>
+
+<%= render 'idv/doc_auth/start_over_or_cancel' %>

--- a/config/locales/doc_auth/en.yml
+++ b/config/locales/doc_auth/en.yml
@@ -57,6 +57,11 @@ en:
           in brighter lighting.
         visible_photo_check: We couldn't verify the photo on your ID. Try taking new
           pictures.
+      no_camera:
+        explanation: To continue, sign in to your login.gov account on any device
+          that has a camera, like a mobile phone, tablet or computer with a webcam.
+        heading: You need a camera to verify your identity
+        title: Camera needed
       not_a_file: The selection was not a valid file
     forms:
       address1: Address

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -62,6 +62,12 @@ es:
           Intente tomar nuevas fotografías con una iluminación más brillante.
         visible_photo_check: No pudimos verificar la foto de su identificación. Intente
           tomar nuevas fotografías.
+      no_camera:
+        explanation: Recopilaremos información sobre usted leyendo su documento de
+          identidad expedido por el estado. Luego, se tomará una foto para confirmar
+          que es el propietario de la identificación.
+        heading: Necesita una cámara para verificar su identidad
+        title: Camera needed
       not_a_file: La selección no era un archivo válido
     forms:
       address1: Dirección

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -63,6 +63,13 @@ fr:
           Essayez de prendre de nouvelles photos avec un éclairage plus lumineux.
         visible_photo_check: Nous n'avons pas pu vérifier la photo sur votre pièce
           d'identité. Essayez de prendre de nouvelles photos.
+      no_camera:
+        explanation: Nous recueillons des informations vous concernant en lisant
+          votre carte d'identité délivrée par l'État. Ensuite, vous prendrez une photo
+          de vous-même pour confirmer que vous êtes bien le propriétaire de la carte
+          d'identité.
+        heading: Vous avez besoin d'une caméra pour vérifier votre identité
+        title: Camera needed
       not_a_file: La sélection n'était pas un fichier valide
     forms:
       address1: Adresse

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -64,9 +64,9 @@ fr:
         visible_photo_check: Nous n'avons pas pu vérifier la photo sur votre pièce
           d'identité. Essayez de prendre de nouvelles photos.
       no_camera:
-        explanation: Nous recueillons des informations vous concernant en lisant
-          votre carte d'identité délivrée par l'État. Ensuite, vous prendrez une photo
-          de vous-même pour confirmer que vous êtes bien le propriétaire de la carte
+        explanation: Nous recueillons des informations vous concernant en lisant votre
+          carte d'identité délivrée par l'État. Ensuite, vous prendrez une photo de
+          vous-même pour confirmer que vous êtes bien le propriétaire de la carte
           d'identité.
         heading: Vous avez besoin d'une caméra pour vérifier votre identité
         title: Camera needed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,7 @@ Rails.application.routes.draw do
       get '/doc_auth/:step' => 'doc_auth#show', as: :doc_auth_step
       put '/doc_auth/:step' => 'doc_auth#update'
       get '/doc_auth/link_sent/poll' => 'capture_doc_status#show'
+      get '/doc_auth/errors/no_camera' => 'doc_auth#no_camera'
       get '/capture_doc' => 'capture_doc#index'
       get '/capture-doc' => 'capture_doc#index',
           # sometimes underscores get messed up when linked to via SMS

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -145,7 +145,7 @@ describe Idv::DocAuthController do
         result = {
           success: false,
           errors: {
-            message: 'Doc Auth error: Javascript could not detect camera on mobile device.'
+            message: 'Doc Auth error: Javascript could not detect camera on mobile device.',
           },
           step: 'welcome',
         }

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -140,6 +140,25 @@ describe Idv::DocAuthController do
 
         expect(response).to redirect_to idv_doc_auth_step_url(step: :document_capture)
       end
+
+      it 'redirects from welcome to no camera error' do
+        result = {
+          success: false,
+          errors: {
+            message: 'Doc Auth error: Javascript could not detect camera on mobile device.'
+          },
+          step: 'welcome',
+        }
+
+        expect(NewRelic::Agent).to receive(:notice_error)
+
+        put :update, params: { step: 'welcome', ial2_consent_given: true, no_camera: true }
+
+        expect(response).to redirect_to idv_doc_auth_errors_no_camera_url
+        expect(@analytics).to have_received(:track_event).with(
+          Analytics::DOC_AUTH + ' submitted', result
+        )
+      end
     end
 
     describe 'when document capture is disabled' do


### PR DESCRIPTION
LG-3325 Added a fallback error flow to doc auth if javascript cannot detect a camera on a mobile device.