### PR TITLE
Update flashes to use design system alert

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   include LocaleHelper
   include VerifySPAttributesConcern
 
-  FLASH_KEYS = %w[alert error notice success warning].freeze
+  FLASH_KEYS = %w[error info success warning other].freeze
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   include VerifySPAttributesConcern
 
   FLASH_KEYS = %w[error info success warning other].freeze
+  FLASH_KEY_MAP = { 'notice' => 'info', 'alert' => 'error' }.freeze
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,7 +113,7 @@ class ApplicationController < ActionController::Base
     return unless params[:timeout]
 
     unless current_user
-      flash[:notice] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
+      flash[:info] = t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
     end
     begin
       redirect_to url_for(permitted_timeout_params)

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -26,7 +26,7 @@ module PersonalKeyConcern
       user_signed_in: user_signed_in?,
     )
     sign_out
-    flash[:alert] = t('errors.invalid_authenticity_token')
+    flash[:error] = t('errors.invalid_authenticity_token')
     redirect_to new_user_session_url
   end
 end

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -46,7 +46,7 @@ class EventDisavowalController < ApplicationController
 
   def handle_successful_password_reset
     EventDisavowal::DisavowEvent.new(disavowed_event).call
-    flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
+    flash[:info] = t('devise.passwords.updated_not_active') if is_flashing_format?
     redirect_to new_user_session_url
   end
 

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -18,7 +18,7 @@ module Idv
       when :in_progress
         render :wait
       when :timed_out
-        flash[:notice] = I18n.t('idv.failure.timeout')
+        flash[:info] = I18n.t('idv.failure.timeout')
         render :new
       when :done
         async_state_done(async_state)

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -237,7 +237,7 @@ module Idv
     end
 
     def timed_out
-      flash[:notice] = I18n.t('idv.failure.timeout')
+      flash[:info] = I18n.t('idv.failure.timeout')
       delete_async
       ProofingDocumentCaptureSessionResult.timed_out
     end

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -43,6 +43,6 @@ class MfaConfirmationController < ApplicationController
   def handle_max_password_attempts_reached
     analytics.track_event(Analytics::PASSWORD_MAX_ATTEMPTS)
     sign_out
-    redirect_to root_url, alert: t('errors.max_password_attempts_reached')
+    redirect_to root_url, flash: { error: t('errors.max_password_attempts_reached') }
   end
 end

--- a/app/controllers/password_capture_controller.rb
+++ b/app/controllers/password_capture_controller.rb
@@ -45,6 +45,6 @@ class PasswordCaptureController < ApplicationController
   def handle_max_password_attempts_reached
     analytics.track_event(Analytics::PASSWORD_MAX_ATTEMPTS)
     sign_out
-    redirect_to root_url, alert: t('errors.max_password_attempts_reached')
+    redirect_to root_url, flash: { error: t('errors.max_password_attempts_reached') }
   end
 end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -70,7 +70,7 @@ module SignUp
 
     def sign_user_out_and_instruct_to_go_back_to_mobile_app
       sign_out
-      flash[:notice] = t(
+      flash[:info] = t(
         'instructions.go_back_to_mobile_app',
         friendly_name: view_model.decorated_session.sp_name,
       )

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -34,7 +34,7 @@ module Users
       bypass_sign_in current_user
 
       flash[:personal_key] = @update_user_password_form.personal_key
-      redirect_to account_url, notice: t('notices.password_changed')
+      redirect_to account_url, flash: { info: t('notices.password_changed') }
     end
 
     def create_event_and_notify_user_about_password_change

--- a/app/controllers/users/phones_controller.rb
+++ b/app/controllers/users/phones_controller.rb
@@ -32,7 +32,7 @@ module Users
     end
 
     def confirm_phone
-      flash[:notice] = t('devise.registrations.phone_update_needs_confirmation')
+      flash[:info] = t('devise.registrations.phone_update_needs_confirmation')
       prompt_to_confirm_phone(id: user_session[:phone_id], phone: @new_phone_form.phone,
                               selected_delivery_method: @new_phone_form.otp_delivery_preference,
                               selected_default_number: @new_phone_form.otp_make_default_number)

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -109,7 +109,7 @@ module Users
 
     def handle_successful_password_reset
       create_reset_event_and_send_notification
-      flash[:notice] = t('devise.passwords.updated_not_active') if is_flashing_format?
+      flash[:info] = t('devise.passwords.updated_not_active') if is_flashing_format?
       redirect_to new_user_session_url
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,7 @@ module Users
     def new
       analytics.track_event(
         Analytics::SIGN_IN_PAGE_VISIT,
-        flash: flash[:alert],
+        flash: flash[:error],
         stored_location: session['user_return_to'],
       )
 
@@ -59,7 +59,7 @@ module Users
       analytics.track_event(Analytics::SESSION_TIMED_OUT)
       request_id = sp_session[:request_id]
       sign_out
-      flash[:notice] = t(
+      flash[:info] = t(
         'notices.session_timedout',
         app: APP_NAME,
         minutes: Figaro.env.session_timeout_in_minutes,
@@ -77,7 +77,7 @@ module Users
       controller_info = 'users/sessions#create'
       analytics.track_event(Analytics::INVALID_AUTHENTICITY_TOKEN, controller: controller_info)
       sign_out
-      flash[:alert] = t('errors.invalid_authenticity_token')
+      flash[:error] = t('errors.invalid_authenticity_token')
       redirect_back fallback_location: new_user_session_url
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,7 @@ module Users
     def new
       analytics.track_event(
         Analytics::SIGN_IN_PAGE_VISIT,
-        flash: flash[:error],
+        flash: flash[:alert],
         stored_location: session['user_return_to'],
       )
 

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -29,7 +29,7 @@ module Users
     def init_account_reactivation
       return if reactivate_account_session.started?
 
-      flash.now[:notice] = t('notices.account_reactivation')
+      flash.now[:info] = t('notices.account_reactivation')
       reactivate_account_session.start
     end
 

--- a/app/services/idv/steps/cac/verify_wait_step_show.rb
+++ b/app/services/idv/steps/cac/verify_wait_step_show.rb
@@ -17,7 +17,7 @@ module Idv
           when :in_progress
             nil
           when :timed_out
-            flash[:notice] = I18n.t('idv.failure.timeout')
+            flash[:info] = I18n.t('idv.failure.timeout')
             delete_async
             mark_step_incomplete(:verify)
           when :done

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -16,7 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
-          flash[:notice] = I18n.t('idv.failure.timeout')
+          flash[:info] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         when :done

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -16,7 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
-          flash[:notice] = I18n.t('idv.failure.timeout')
+          flash[:info] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         when :done

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,3 +1,10 @@
+<%#
+locals:
+* type: One of: "info", "success", "warning", "error", "other". Defaults to "info".
+* text_tag: Optional override HTML tag for text content. Defaults to `p`.
+* class: Additional class names to add to alert wrapper.
+* message: Text to display in alert. Text can also be provided through block.
+%>
 <%
   type = local_assigns.fetch(:type, 'info')
   type = 'error' if type === 'alert'

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -7,8 +7,7 @@ locals:
 %>
 <%
   type = local_assigns.fetch(:type, 'info')
-  type = 'error' if type === 'alert'
-  type = 'info' unless ['info', 'success', 'warning', 'error', 'other'].include?(type)
+  raise "unknown alert type=#{type}" unless %w[info success warning error other].include?(type)
   role = type === 'error' ? 'alert' : 'status'
   text_tag = local_assigns.fetch(:text_tag, 'p')
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,5 +1,7 @@
 <%
   type = local_assigns.fetch(:type, 'info')
+  type = 'error' if type === 'alert'
+  type = 'info' if type === 'notice'
   role = type === 'error' ? 'alert' : 'status'
   text_tag = local_assigns.fetch(:text_tag, 'p')
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -8,7 +8,7 @@
     "usa-alert--#{type}",
   ]
   classes << local_assigns[:class] if local_assigns[:class]
-  message = yield.presence || local_assigns.fetch(:message)
+  message = local_assigns.fetch(:message, yield.presence)
 %>
 
 <%= tag.div class: classes, role: role do %>

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,5 +1,5 @@
 <%
-  type = local_assigns.fetch(:type, 'other')
+  type = local_assigns.fetch(:type, 'info')
   role = type === 'error' ? 'alert' : 'status'
   text_tag = local_assigns.fetch(:text_tag, 'p')
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -8,7 +8,7 @@ locals:
 <%
   type = local_assigns.fetch(:type, 'info')
   type = 'error' if type === 'alert'
-  type = 'info' if type === 'notice'
+  type = 'info' unless ['info', 'success', 'warning', 'error', 'other'].include?(type)
   role = type === 'error' ? 'alert' : 'status'
   text_tag = local_assigns.fetch(:text_tag, 'p')
 

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,7 +1,9 @@
 <% flash.to_hash.slice(*ApplicationController::FLASH_KEYS).each do |type, message| %>
   <% if message.present? %>
-    <div class='alert <%= "alert-#{type}" %>' role='alert'>
-      <%= safe_join([message.html_safe]) %>
-    </div>
+    <%= render 'shared/alert', {
+      type: type,
+      message: safe_join([message.html_safe]),
+      class: 'margin-bottom-4',
+    } %>
   <% end %>
 <% end %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,7 +1,11 @@
-<% flash.to_hash.slice(*ApplicationController::FLASH_KEYS).each do |type, message| %>
+<%
+flash.
+  to_hash.
+  slice(*ApplicationController::FLASH_KEYS + ApplicationController::FLASH_KEY_MAP.keys).
+  each do |type, message| %>
   <% if message.present? %>
     <%= render 'shared/alert', {
-      type: type,
+      type: ApplicationController::FLASH_KEY_MAP.fetch(type, type),
       message: safe_join([message.html_safe]),
       class: 'margin-bottom-4',
     } %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -6,7 +6,7 @@ flash.
   <% if message.present? %>
     <%= render 'shared/alert', {
       type: ApplicationController::FLASH_KEY_MAP.fetch(type, type),
-      message: safe_join([message.html_safe]),
+      message: message.html_safe,
       class: 'margin-bottom-4',
     } %>
   <% end %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -275,7 +275,7 @@ describe ApplicationController do
 
         get :index, params: { timeout: true, request_id: '123' }
 
-        expect(flash[:notice]).to be_nil
+        expect(flash[:info]).to be_nil
       end
     end
 
@@ -295,7 +295,7 @@ describe ApplicationController do
 
         get :index, params: { timeout: true, request_id: '123' }
 
-        expect(flash[:notice]).
+        expect(flash[:info]).
           to eq t('notices.session_cleared', minutes: Figaro.env.session_timeout_in_minutes)
       end
     end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -71,7 +71,7 @@ describe Idv::PhoneController do
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
 
       get :new
-      expect(flash[:notice]).to include t('idv.failure.timeout')
+      expect(flash[:info]).to include t('idv.failure.timeout')
       expect(response).to render_template :new
       put :create, params: { idv_phone_form: { phone: good_phone } }
       get :new

--- a/spec/controllers/mfa_confirmation_controller_spec.rb
+++ b/spec/controllers/mfa_confirmation_controller_spec.rb
@@ -75,7 +75,7 @@ describe MfaConfirmationController do
 
         expect(response).to redirect_to(root_path)
         expect(controller.current_user).to be_nil
-        expect(flash[:alert]).to eq t('errors.max_password_attempts_reached')
+        expect(flash[:error]).to eq t('errors.max_password_attempts_reached')
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PASSWORD_MAX_ATTEMPTS)
       end

--- a/spec/controllers/sign_up/personal_keys_controller_spec.rb
+++ b/spec/controllers/sign_up/personal_keys_controller_spec.rb
@@ -69,7 +69,7 @@ describe SignUp::PersonalKeysController do
       patch :update
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
     end
 
     it 'deletes the personal key from the session' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -16,7 +16,7 @@ describe Users::PasswordsController do
         expect(@analytics).to have_received(:track_event).
           with(Analytics::PASSWORD_CHANGED, success: true, errors: {})
         expect(response).to redirect_to account_url
-        expect(flash[:notice]).to eq t('notices.password_changed')
+        expect(flash[:info]).to eq t('notices.password_changed')
         expect(flash[:personal_key]).to be_nil
       end
 

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -121,7 +121,7 @@ describe Users::PersonalKeysController do
       post :update
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
     end
   end
 
@@ -161,7 +161,7 @@ describe Users::PersonalKeysController do
       post :create
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
     end
   end
 end

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -202,7 +202,7 @@ describe Users::ResetPasswordsController, devise: true do
           expect(user.events.password_changed.size).to be 1
 
           expect(response).to redirect_to new_user_session_path
-          expect(flash[:notice]).to eq t('devise.passwords.updated_not_active')
+          expect(flash[:info]).to eq t('devise.passwords.updated_not_active')
           expect(user.reload.confirmed_at).to eq old_confirmed_at
         end
       end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -138,7 +138,7 @@ describe Users::SessionsController, devise: true do
 
       get :timeout
 
-      expect(flash[:notice]).to eq t(
+      expect(flash[:info]).to eq t(
         'notices.session_timedout',
         app: APP_NAME,
         minutes: Figaro.env.session_timeout_in_minutes,
@@ -356,7 +356,7 @@ describe Users::SessionsController, devise: true do
       post :create, params: { user: { email: user.email, password: user.password } }
 
       expect(response).to redirect_to new_user_session_url
-      expect(flash[:alert]).to eq t('errors.invalid_authenticity_token')
+      expect(flash[:error]).to eq t('errors.invalid_authenticity_token')
     end
 
     it 'returns to sign in page if email is a Hash' do

--- a/spec/controllers/users/verify_personal_key_controller_spec.rb
+++ b/spec/controllers/users/verify_personal_key_controller_spec.rb
@@ -33,7 +33,7 @@ describe Users::VerifyPersonalKeyController do
       it 'displays a flash message to the user' do
         get :new
 
-        expect(subject.flash[:notice]).to eq(t('notices.account_reactivation'))
+        expect(subject.flash[:info]).to eq(t('notices.account_reactivation'))
       end
     end
   end

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -73,4 +73,10 @@ describe 'shared/_alert.html.erb' do
 
     expect(rendered).to have_selector('.usa-alert.usa-alert--info[role="status"]')
   end
+
+  it 'coerces unknown types to info' do
+    render 'shared/alert', { type: 'nonsense', message: 'FYI' }
+
+    expect(rendered).to have_selector('.usa-alert.usa-alert--info')
+  end
 end

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -62,21 +62,9 @@ describe 'shared/_alert.html.erb' do
     expect(rendered).to have_selector('.usa-alert[role="alert"]')
   end
 
-  it 'normalizes "alert" type as "error"' do
-    render 'shared/alert', { type: 'alert', message: 'Attention!' }
-
-    expect(rendered).to have_selector('.usa-alert.usa-alert--error[role="alert"]')
-  end
-
-  it 'normalizes "notice" type as "info"' do
-    render 'shared/alert', { type: 'notice', message: 'FYI' }
-
-    expect(rendered).to have_selector('.usa-alert.usa-alert--info[role="status"]')
-  end
-
-  it 'coerces unknown types to info' do
-    render 'shared/alert', { type: 'nonsense', message: 'FYI' }
-
-    expect(rendered).to have_selector('.usa-alert.usa-alert--info')
+  it 'raises error for unknown type' do
+    expect do
+      render 'shared/alert', { type: 'alert', message: 'Attention!' }
+    end.to raise_error('unknown alert type=alert')
   end
 end

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -61,4 +61,16 @@ describe 'shared/_alert.html.erb' do
 
     expect(rendered).to have_selector('.usa-alert[role="alert"]')
   end
+
+  it 'normalizes "alert" type as "error"' do
+    render 'shared/alert', { type: 'alert', message: 'Attention!' }
+
+    expect(rendered).to have_selector('.usa-alert.usa-alert--error[role="alert"]')
+  end
+
+  it 'normalizes "notice" type as "info"' do
+    render 'shared/alert', { type: 'notice', message: 'FYI' }
+
+    expect(rendered).to have_selector('.usa-alert.usa-alert--info[role="status"]')
+  end
 end

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'shared/_alert.html.erb' do
-  it 'renders message from param' do
+  it 'renders message from locals' do
     render 'shared/alert', { message: 'FYI' }
 
     expect(rendered).to have_content('FYI')
@@ -11,6 +11,12 @@ describe 'shared/_alert.html.erb' do
     render('shared/alert') { 'FYI' }
 
     expect(rendered).to have_content('FYI')
+  end
+
+  it 'prefers message from locals' do
+    render('shared/alert', { message: 'locals' }) { 'block' }
+
+    expect(rendered).to have_content('locals')
   end
 
   it 'defaults to type "info"' do

--- a/spec/views/shared/_alert.html.erb_spec.rb
+++ b/spec/views/shared/_alert.html.erb_spec.rb
@@ -13,10 +13,10 @@ describe 'shared/_alert.html.erb' do
     expect(rendered).to have_content('FYI')
   end
 
-  it 'defaults to type "other"' do
+  it 'defaults to type "info"' do
     render 'shared/alert', { message: 'FYI' }
 
-    expect(rendered).to have_selector('.usa-alert.usa-alert--other')
+    expect(rendered).to have_selector('.usa-alert.usa-alert--info')
   end
 
   it 'accepts alert type param' do

--- a/spec/views/shared/_flashes.html.erb_spec.rb
+++ b/spec/views/shared/_flashes.html.erb_spec.rb
@@ -14,4 +14,18 @@ describe 'shared/_flashes.html.erb' do
 
     expect(rendered).to have_selector('div[role="alert"]')
   end
+
+  it 'renders normalized flash keys' do
+    allow(view).to receive(:flash).and_return('alert' => 'an error')
+    render
+
+    expect(rendered).to have_selector('div[role="alert"]')
+  end
+
+  it 'ignores unknown flash keys' do
+    allow(view).to receive(:flash).and_return('nonsense' => 'an error')
+    render
+
+    expect(rendered).not_to have_selector('div[role="alert"]')
+  end
 end


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4368#issuecomment-720721576

**Why**:

- Consistency of alerts across IdP
- Shared benefit of feature additions in alert partial for standalone usage
- Improved accessibility of role usage between role=alert and role=status
- Toward a goal of eliminating redundant CSS (duplicated custom alert and USWDS alert CSS)

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/98009464-9032ab00-1dc3-11eb-84d1-16560054abb9.png)|![after](https://user-images.githubusercontent.com/1779930/98009474-91fc6e80-1dc3-11eb-944e-6fc607a4ceca.png)
