### PR TITLE
Add test case to find untranslated locale keys

### DIFF
--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -60,7 +60,7 @@ es:
         instructions: Su cuenta requiere un código de confirmación para ser verificado.
         reactivate_button: Ingrese el código que recibió por correo postal.
         success: Su cuenta ha sido verificada.
-        update_address: Please update your address to be verified.
+        update_address: Actualice su dirección para ser verificada.
       webauthn: Clave de seguridad
       webauthn_add: Añadir clave de seguridad
       webauthn_confirm_delete: Si quitar la llave

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -61,7 +61,7 @@ fr:
         instructions: Votre compte nécessite un code de confirmation pour être vérifié.
         reactivate_button: Entrez le code que vous avez reçu par la poste
         success: Votre compte a été vérifié.
-        update_address: Please update your address to be verified.
+        update_address: Veuillez mettre à jour votre adresse pour être vérifiée.
       webauthn: Clé de sécurité
       webauthn_add: Ajouter une clé de sécurité
       webauthn_confirm_delete: Oui, supprimer la clé

--- a/config/locales/cac_proofing/es.yml
+++ b/config/locales/cac_proofing/es.yml
@@ -2,7 +2,7 @@
 es:
   cac_proofing:
     buttons:
-      get_started: Get started
+      get_started: Empezar
       use_cac: Usa su PIV o CAC
       use_doc_auth: Usa su identificación del estado
     errors:
@@ -13,35 +13,35 @@ es:
       state_id: identificación emitida por el estado
     headings:
       choose_method: "¿Cómo le gustaría verificar su identidad?"
-      enter_info: Enter in your information
-      present_cac: Present your PIV/CAC card to verify your account
-      success: We've verified your information and PIV/CAC card.
-      verify: Verify your information
-      welcome: We need to verify your identity
+      enter_info: Ingrese su información
+      present_cac: Presente su tarjeta PIV / CAC para verificar su cuenta
+      success: Hemos verificado su información y su tarjeta PIV / CAC.
+      verify: Verifica tu información
+      welcome: Nosotros necesitamos verificar tu identidad
     info:
       choose_method: Recabaremos información sobre usted al leer su identificación.
       disclaimer: No almacenamos las imágenes que sube. Solo verificamos su identidad.
       piv_cac_description: Utilice una identificación de empleado del gobierno federal
         o militar (PIV o CAC) como una forma rápida y segura de verificar su identidad.
-      present_cac: After clicking "Present PIV/CAC" your browser will prompt you for
-        your PIV/CAC PIN and have you select a certificate.
+      present_cac: Después de hacer clic en "Presentar PIV / CAC", su navegador le
+        pedirá su PIN de PIV / CAC y le pedirá que seleccione un certificado.
       state_id_description: Si no tiene un PIV o CAC, pude usar una identificación
         emitida por el estado para verificar su identidad.
-      welcome: We verify your identity to make sure you are you—not someone pretending
-        to be you.  Verifying your identity also allows you to access services that
-        handle Personal Identifiable Information.
+      welcome: Verificamos su identidad para asegurarnos de que es usted, no alguien
+        que finge ser usted. La verificación de su identidad también le permite acceder
+        a los servicios que manejan información de identificación personal.
     instructions:
-      bullet1: Present your PIV/CAC card
-      bullet2: Enter your information
-      bullet3: Confirm your address
-      bullet4: Secure your account
-      bullet5: Account recovery
-      text1: your government issued ID card
-      text2: Social Security Number, date of birth, and address
-      text3: using a phone number or mailing address
-      text4: by re-entering your login.gov password
-      text5: make sure you always have access
-      welcome: 'What you''ll need to do:'
-    step: Verify your identity with PIV/CAC card - Step %{step} of 5
+      bullet1: Presenta tu tarjeta PIV / CAC
+      bullet2: Ingrese su informacion
+      bullet3: Confirma tu dirección
+      bullet4: Asegure su cuenta
+      bullet5: Recuperación de Cuenta
+      text1: su tarjeta de identificación emitida por el gobierno
+      text2: Número de seguro social, fecha de nacimiento y dirección
+      text3: usando un número de teléfono o dirección postal
+      text4: volviendo a ingresar su contraseña de login.gov
+      text5: asegúrese de tener siempre acceso
+      welcome: 'Lo que deberás hacer:'
+    step: Verifique su identidad con la tarjeta PIV / CAC - Paso %{step} de 5
     titles:
-      cac_proofing: Verify your identity with a PIV/CAC card
+      cac_proofing: Verifique su identidad con una tarjeta PIV / CAC

--- a/config/locales/cac_proofing/fr.yml
+++ b/config/locales/cac_proofing/fr.yml
@@ -2,7 +2,7 @@
 fr:
   cac_proofing:
     buttons:
-      get_started: Get started
+      get_started: Commencer
       use_cac: Utilisez votre PIV ou CAC
       use_doc_auth: Utilisez votre pièce d'identité officielle
     errors:
@@ -15,11 +15,11 @@ fr:
       state_id: identifiant émis par l'état
     headings:
       choose_method: Comment souhaitez-vous vérifier votre identité?
-      enter_info: Enter in your information
-      present_cac: Present your PIV/CAC card to verify your account
-      success: We've verified your information and PIV/CAC card.
-      verify: Verify your information
-      welcome: We need to verify your identity
+      enter_info: Entrez vos informations
+      present_cac: Presente su tarjeta PIV / CAC para verificar su cuenta
+      success: Nous avons vérifié vos informations et votre carte PIV / CAC.
+      verify: Vérifiez vos informations
+      welcome: Nous devons vérifier votre identité
     info:
       choose_method: Nous collecterons des informations qui vous concernent en lisant
         votre pièce d'identité.
@@ -28,25 +28,27 @@ fr:
       piv_cac_description: Utilisez une carte d'identité d'employé du gouvernement
         fédéral ou une carte d'identité militaire (PIV ou CAC) pour vérifier votre
         identité de façon rapide et sécurisée.
-      present_cac: After clicking "Present PIV/CAC" your browser will prompt you for
-        your PIV/CAC PIN and have you select a certificate.
+      present_cac: Après avoir cliqué sur "Présenter PIV / CAC", votre navigateur
+        vous demandera votre code PIN PIV / CAC et vous demandera de sélectionner
+        un certificat.
       state_id_description: Si vous n'avez pas de PIV ou de CAC, vous pouvez utiliser
         un identifiant émis par l'État pour vérifier votre identité.
-      welcome: We verify your identity to make sure you are you—not someone pretending
-        to be you.  Verifying your identity also allows you to access services that
-        handle Personal Identifiable Information.
+      welcome: Nous vérifions votre identité pour nous assurer que vous êtes bien
+        vous, et non quelqu'un qui se fait passer pour vous. La vérification de votre
+        identité vous permet également d'accéder aux services qui traitent les informations
+        personnelles identifiables.
     instructions:
-      bullet1: Present your PIV/CAC card
-      bullet2: Enter your information
-      bullet3: Confirm your address
-      bullet4: Secure your account
-      bullet5: Account recovery
-      text1: your government issued ID card
-      text2: Social Security Number, date of birth, and address
-      text3: using a phone number or mailing address
-      text4: by re-entering your login.gov password
-      text5: make sure you always have access
-      welcome: 'What you''ll need to do:'
-    step: Verify your identity with PIV/CAC card - Step %{step} of 5
+      bullet1: Présentez votre carte PIV / CAC
+      bullet2: Entrez vos informations
+      bullet3: Confirmez votre adresse
+      bullet4: Sécurise ton compte
+      bullet5: Récupération du compte
+      text1: votre carte d'identité émise par le gouvernement
+      text2: Numéro de sécurité sociale, date de naissance et adresse
+      text3: en utilisant un numéro de téléphone ou une adresse postale
+      text4: en saisissant à nouveau votre mot de passe login.gov
+      text5: assurez-vous d'avoir toujours accès
+      welcome: 'Ce que vous devez faire:'
+    step: Vérifiez votre identité avec la carte PIV / CAC - Étape %{step} sur 5
     titles:
-      cac_proofing: Verify your identity with a PIV/CAC card
+      cac_proofing: Vérifiez votre identité avec une carte PIV / CAC

--- a/config/locales/doc_auth/es.yml
+++ b/config/locales/doc_auth/es.yml
@@ -68,7 +68,7 @@ es:
           identidad expedido por el estado. Luego, se tomará una foto para confirmar
           que es el propietario de la identificación.
         heading: Necesita una cámara para verificar su identidad
-        title: Camera needed
+        title: Necesita cámara
       not_a_file: La selección no era un archivo válido.
     forms:
       address1: Dirección

--- a/config/locales/doc_auth/fr.yml
+++ b/config/locales/doc_auth/fr.yml
@@ -74,7 +74,7 @@ fr:
           vous-même pour confirmer que vous êtes bien le propriétaire de la carte
           d'identité.
         heading: Vous avez besoin d'une caméra pour vérifier votre identité
-        title: Camera needed
+        title: Appareil photo nécessaire
       not_a_file: La sélection n'était pas un fichier valide.
     forms:
       address1: Adresse

--- a/config/locales/event_types/fr.yml
+++ b/config/locales/event_types/fr.yml
@@ -8,7 +8,7 @@ fr:
     authenticator_disabled: Application d'authentification supprimée
     authenticator_enabled: Application authenticator ajoutée
     backup_codes_added: Codes de sauvegarde ajoutés
-    eastern_timestamp: "%{timestamp} (Eastern)"
+    eastern_timestamp: "%{timestamp} (est)"
     email_changed: Adresse courriel modifiée
     email_deleted: Adresse e-mail supprimée
     new_personal_key: Clé personnelle modifié

--- a/config/locales/forms/es.yml
+++ b/config/locales/forms/es.yml
@@ -40,7 +40,7 @@ es:
         seguridad?"
     buttons:
       back: Atrás
-      cac: Present PIV/CAC card
+      cac: Presentar tarjeta PIV/CAC
       cancel: Sí, cancelar
       confirm: Confirmar
       continue: Continuar

--- a/config/locales/forms/fr.yml
+++ b/config/locales/forms/fr.yml
@@ -39,7 +39,7 @@ fr:
       confirm: Êtes-vous sûr de vouloir régénérer vos codes de sauvegarde?
     buttons:
       back: Retour
-      cac: Present PIV/CAC card
+      cac: Insérez votre PIV/CAC
       cancel: Oui, annuler
       confirm: Confirmer
       continue: Continuer

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -140,8 +140,8 @@ es:
       usps:
         address_on_file: Le enviaremos una carta con un código de confirmación a su
           dirección verificada en el archivo.
-        new_address: We will mail a letter with a confirmation code to the address
-          you specify.
+        new_address: Le enviaremos una carta con un código de confirmación a la dirección
+          que especifique.
         resend: Envíeme otra carta
         success: Debe llegar en 5 a 10 días laborales.
     review:

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -153,8 +153,8 @@ fr:
       usps:
         address_on_file: Nous posterons une lettre à l'adresse vérifiée dans nos dossiers.
           Celle-ci contient un code de confirmation.
-        new_address: We will mail a letter with a confirmation code to the address
-          you specify.
+        new_address: Nous vous enverrons une lettre avec un code de confirmation à
+          l'adresse que vous spécifiez.
         resend: Envoyez-moi une autre lettre
         success: Elle devrait arriver dans 5 à 10 jours ouvrables.
     review:

--- a/config/locales/in_person_proofing/es.yml
+++ b/config/locales/in_person_proofing/es.yml
@@ -2,51 +2,52 @@
 es:
   in_person_proofing:
     buttons:
-      change_address: change
-      change_ssn: change
-      get_started: Get started
-    enrollment_form: Enrollment form
+      change_address: cambio
+      change_ssn: cambio
+      get_started: Empezar
+    enrollment_form: Formulario de inscripción
     forms:
-      address1: Address
-      address2: Address (optional)
-      city: City
-      dob: Date of birth
-      first_name: First name
-      last_name: Last Name
-      ssn: Social security number
-      state: State
-      zip_code: Zip code
+      address1: Dirección
+      address2: Dirección (opcional)
+      city: Ciudad
+      dob: Fecha de nacimiento
+      first_name: Nombre de pila
+      last_name: Apellido
+      ssn: Número de seguridad social
+      state: Estado
+      zip_code: Código postal
     headings:
-      enrollment_form: Bring this form to your post office
-      enter_info: Enter in your information
-      usps_list: Choose a post office
-      welcome: Verify your identity in person
-      zip_code: Find a post office
+      enrollment_form: Traiga este formulario a su oficina de correos
+      enter_info: Ingrese su información
+      usps_list: Elija una oficina de correos
+      welcome: Verifica tu identidad en persona
+      zip_code: Encuentra una oficina de correos
     info:
-      enrollment_form: Please print or save this form and take it to the post office
-        you chose.
-      welcome: We can verify your identity at your local post office.
+      enrollment_form: Imprima o guarde este formulario y llévelo a la oficina de
+        correos que elija.
+      welcome: Podemos verificar su identidad en su oficina de correos local.
     instructions:
-      bullet1: Choose a nearby post office
-      bullet2: Enter your information
-      bullet3: Print or save your enrollment form
-      bullet4: Visit the post office to get verified
-      bullet5: Come back to login.gov
+      bullet1: Elija una oficina de correos cercana
+      bullet2: ingrese su informacion
+      bullet3: Imprime o guarda tu formulario de inscripción
+      bullet4: Visita la oficina de correos para ser verificado
+      bullet5: Regrese a login.gov
       encrypt: Cuando vuelva a ingresar su contraseña, login.gov protegerá la información
         que nos ha proporcionado, de modo que solo usted pueda acceder a ella.
-      enrollment_form: 'Bring this code to the following post office along with a
-        government-issued ID:'
+      enrollment_form: 'Lleve este código a la siguiente oficina postal junto con
+        una identificación emitida por el gobierno:'
       read_more_encrypt: Lea más sobre cómo login.gov protege su información personal
-      text1: by entering your ZIP code
-      text2: name, date of birth, address, and social security number
-      text3: a bar code that you need to take to the post office with you
-      text4: bring your enrollment code and a government-issued ID
-      text5: sign in and finish the process
-      welcome: 'What you''ll need to do:'
-    opt_in_link: Verify your identity in person at a local post office instead
-    step: Verify your identity in person - Step %{step} of 5
+      text1: ingresando su código postal
+      text2: nombre, fecha de nacimiento, dirección y número de seguro social
+      text3: un código de barras que debe llevar a la oficina de correos
+      text4: traiga su código de inscripción y una identificación emitida por el gobierno
+      text5: iniciar sesión y finalizar el proceso
+      welcome: 'Lo que deberás hacer:'
+    opt_in_link: En cambio, verifique su identidad en persona en una oficina de correos
+      local
+    step: Verifique su identidad en persona - Paso %{step} de 5
     titles:
-      in_person_proofing: Verify your identity in person
+      in_person_proofing: Verifica tu identidad en persona
     warning:
-      enrollment_form: Download, print, or save your enrollment form.  A copy has
-        also been sent to your email.
+      enrollment_form: Descargue, imprima o guarde su formulario de inscripción. También
+        se ha enviado una copia a su correo electrónico.

--- a/config/locales/in_person_proofing/fr.yml
+++ b/config/locales/in_person_proofing/fr.yml
@@ -2,52 +2,53 @@
 fr:
   in_person_proofing:
     buttons:
-      change_address: change
-      change_ssn: change
-      get_started: Get started
-    enrollment_form: Enrollment form
+      change_address: changement
+      change_ssn: changement
+      get_started: Commencer
+    enrollment_form: Formulaire d'engagement
     forms:
-      address1: Address
-      address2: Address (optional)
-      city: City
-      dob: Date of birth
-      first_name: First name
-      last_name: Last Name
-      ssn: Social security number
-      state: State
-      zip_code: Zip code
+      address1: Adresse
+      address2: Adresse (facultatif)
+      city: Ville
+      dob: Date de naissance
+      first_name: Prénom
+      last_name: Nom de famille
+      ssn: Numéro de sécurité sociale
+      state: Etat
+      zip_code: Code postal
     headings:
-      enrollment_form: Bring this form to your post office
-      enter_info: Enter in your information
-      usps_list: Choose a post office
-      welcome: Verify your identity in person
-      zip_code: Find a post office
+      enrollment_form: Apportez ce formulaire à votre bureau de poste
+      enter_info: Entrez vos informations
+      usps_list: Choisissez un bureau de poste
+      welcome: Vérifiez votre identité en personne
+      zip_code: Trouver un bureau de poste
     info:
-      enrollment_form: Please print or save this form and take it to the post office
-        you chose.
-      welcome: We can verify your identity at your local post office.
+      enrollment_form: Veuillez imprimer ou enregistrer ce formulaire et l'apporter
+        au bureau de poste de votre choix.
+      welcome: Nous pouvons vérifier votre identité à votre bureau de poste local.
     instructions:
-      bullet1: Choose a nearby post office
-      bullet2: Enter your information
-      bullet3: Print or save your enrollment form
-      bullet4: Visit the post office to get verified
-      bullet5: Come back to login.gov
+      bullet1: Choisissez un bureau de poste à proximité
+      bullet2: Entrez vos informations
+      bullet3: Imprimez ou enregistrez votre formulaire d'inscription
+      bullet4: Visitez le bureau de poste pour être vérifié
+      bullet5: Revenez à login.gov
       encrypt: Lorsque vous ressaisissez votre mot de passe, login.gov protégera les
         informations que vous nous avez fournies, afin que vous seul puissiez y accéder.
-      enrollment_form: 'Bring this code to the following post office along with a
-        government-issued ID:'
+      enrollment_form: 'Apportez ce code au bureau de poste suivant avec une pièce
+        d''identité officielle:'
       read_more_encrypt: En savoir plus sur la façon dont login.gov protège vos informations
         personnelles
-      text1: by entering your ZIP code
-      text2: name, date of birth, address, and social security number
-      text3: a bar code that you need to take to the post office with you
-      text4: bring your enrollment code and a government-issued ID
-      text5: sign in and finish the process
-      welcome: 'What you''ll need to do:'
-    opt_in_link: Verify your identity in person at a local post office instead
-    step: Verify your identity in person - Step %{step} of 5
+      text1: en entrant votre code postal
+      text2: nom, date de naissance, adresse et numéro de sécurité sociale
+      text3: un code-barres que vous devez emporter au bureau de poste avec vous
+      text4: apportez votre code d'inscription et une pièce d'identité officielle
+      text5: connectez-vous et terminez le processus
+      welcome: 'Ce que vous devez faire:'
+    opt_in_link: Vérifiez plutôt votre identité en personne dans un bureau de poste
+      local
+    step: Vérifiez votre identité en personne - Étape %{step} sur 5
     titles:
-      in_person_proofing: Verify your identity in person
+      in_person_proofing: Vérifiez votre identité en personne
     warning:
-      enrollment_form: Download, print, or save your enrollment form.  A copy has
-        also been sent to your email.
+      enrollment_form: Téléchargez, imprimez ou enregistrez votre formulaire d'inscription.
+        Une copie a également été envoyée à votre adresse e-mail.

--- a/config/locales/notices/fr.yml
+++ b/config/locales/notices/fr.yml
@@ -60,6 +60,6 @@ fr:
     totp_disabled: Vous avez supprimé votre application d'authentification.
     use_diff_email:
       link: utilisez une adresse courriel différente
-      text_html: Or, %{link}
+      text_html: Ou %{link}
     webauthn_configured: Ha permitido una clé de sécurité.
     webauthn_deleted: Vous avez supprimé une clé de sécurité.

--- a/config/locales/openid_connect/es.yml
+++ b/config/locales/openid_connect/es.yml
@@ -3,7 +3,7 @@ es:
   openid_connect:
     authorization:
       errors:
-        bad_client_id: Bad client_id
+        bad_client_id: Client_id incorrecto
         invalid_verified_within_duration:
           one: el valor debe ser al menos %{count} día o más
           other: el valor debe tener al menos %{count} días o más

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -19,10 +19,10 @@ es:
       text_html: Si no puede usar ninguna de estas opciones de seguridad anteriores,
         puede restablecer tus preferencias por %{link}.
     backup_code_fallback:
-      question: Don't have your backup codes available?
-    backup_code_header_text: Enter your backup security code
-    backup_code_prompt: You can use this security code once. After you enter it, you'll
-      need to use a new key.
+      question: "¿No tienes tus códigos de seguridad disponibles?"
+    backup_code_header_text: Ingrese su código de seguridad de respaldo
+    backup_code_prompt: Puede utilizar este código de seguridad una vez. Después de
+      ingresarlo, deberá usar una nueva clave.
     choose_another_option: "‹ Elige otra opción"
     devices:
       auth_app: Aplicación de autenticación

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -19,10 +19,10 @@ fr:
       text_html: Si vous ne pouvez pas utiliser l'une de ces options de sécurité ci-dessus,
         vous pouvez réinitialiser vos préférences par %{link}.
     backup_code_fallback:
-      question: Don't have your backup codes available?
-    backup_code_header_text: Enter your backup security code
-    backup_code_prompt: You can use this security code once. After you enter it, you'll
-      need to use a new key.
+      question: Vous n'avez pas vos codes de secours disponibles?
+    backup_code_header_text: Entrez votre code de sécurité de secours
+    backup_code_prompt: Vous pouvez utiliser ce code de sécurité une fois. Après l'avoir
+      entré, vous devrez utiliser une nouvelle clé.
     choose_another_option: "‹ Choisissez une autre option"
     devices:
       auth_app: Application d'authentification

--- a/config/locales/user_mailer/es.yml
+++ b/config/locales/user_mailer/es.yml
@@ -56,9 +56,9 @@ es:
       reset_password: Si no recuerda su contraseña, vaya a %{app} para restablecerla.
     contact_link_text: Contáctenos
     doc_auth_link:
-      message: You've requested to verify your identity on a desktop computer.  Please
-        sign in to %{sp_link}
-      subject: Verify your identity on a desktop computer
+      message: Ha solicitado verificar su identidad en una computadora de escritorio.
+        Inicie sesión en %{sp_link}
+      subject: Verifique su identidad en una computadora de escritorio
     email_added:
       header: Se agregó una nueva dirección de correo electrónico a su perfil de login.gov.
       help: Si no realizó este cambio, inicie sesión en su perfil y administre sus

--- a/config/locales/user_mailer/fr.yml
+++ b/config/locales/user_mailer/fr.yml
@@ -57,9 +57,9 @@ fr:
         %{app} pour le réinitialiser.
     contact_link_text: communiquez avec nous
     doc_auth_link:
-      message: You've requested to verify your identity on a desktop computer.  Please
-        sign in to %{sp_link}
-      subject: Verify your identity on a desktop computer
+      message: Vous avez demandé à vérifier votre identité sur un ordinateur de bureau.
+        Veuillez vous connecter à %{sp_link}
+      subject: Vérifiez votre identité sur un ordinateur de bureau
     email_added:
       header: Une nouvelle adresse e-mail a été ajoutée à votre profil login.gov.
       help: Si vous n'avez pas apporté cette modification, connectez-vous à votre

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -5,7 +5,15 @@ require 'yaml_normalizer'
 
 ALLOWED_UNTRANSLATED_KEYS = [
   'account.navigation.menu', # "Menu" is "Menu" in French
+  'doc_auth.headings.photo', # "Photo" is "Photo" in French
   /^i18n\.locale\./, # Show locale options translated as that language, regardless of current locale
+  'links.contact', # "Contact" is "Contact" in French
+  'simple_form.no', # "No" is "No" in Spanish
+  'simple_form.required.html', # No text content
+  'simple_form.required.mark', # No text content
+  'time.am', # "AM" is "AM" in French and Spanish
+  'time.pm', # "PM" is "PM" in French and Spanish
+  'two_factor_authentication.devices.piv_cac', # "PIV/CAC" does not translate
 ]
 
 module I18n

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -3,6 +3,11 @@
 require 'i18n/tasks'
 require 'yaml_normalizer'
 
+ALLOWED_UNTRANSLATED_KEYS = [
+  'account.navigation.menu', # "Menu" is "Menu" in French
+  /^i18n\.locale\./, # Show locale options translated as that language, regardless of current locale
+]
+
 module I18n
   module Tasks
     class BaseTask
@@ -45,9 +50,13 @@ RSpec.describe 'I18n' do
   end
 
   it 'does not have untranslated keys' do
-    expect(untranslated_keys).to(
+    unallowed_untranslated_keys = untranslated_keys.reject do |key|
+      ALLOWED_UNTRANSLATED_KEYS.any? { |pattern_or_key| key =~ Regexp.new(pattern_or_key) }
+    end
+
+    expect(unallowed_untranslated_keys).to(
       be_empty,
-      "untranslated i18n keys: #{untranslated_keys}",
+      "untranslated i18n keys: #{unallowed_untranslated_keys}",
     )
   end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -14,7 +14,7 @@ ALLOWED_UNTRANSLATED_KEYS = [
   'time.am', # "AM" is "AM" in French and Spanish
   'time.pm', # "PM" is "PM" in French and Spanish
   'two_factor_authentication.devices.piv_cac', # "PIV/CAC" does not translate
-]
+].freeze
 
 module I18n
   module Tasks

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -13,6 +13,7 @@ module I18n
           result << key if locales.any? do |current_locale|
             node = data[current_locale].first.children[key]
             next unless node&.value&.is_a?(String)
+            next if node.value.empty?
             node.value == value
           end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -9,7 +9,7 @@ module I18n
       ALLOWED_UNTRANSLATED_KEYS = [
         { key: 'account.navigation.menu', locales: %i[fr] }, # "Menu" is "Menu" in French
         { key: 'doc_auth.headings.photo', locales: %i[fr] }, # "Photo" is "Photo" in French
-        { key: /^i18n\.locale\./ }, # Show locale options translated as that language, regardless of current locale
+        { key: /^i18n\.locale\./ }, # Show locale options translated as that language
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'simple_form.required.html' }, # No text content
@@ -20,25 +20,28 @@ module I18n
       ].freeze
 
       def untranslated_keys
-        locales = self.locales - [base_locale]
         data[base_locale].key_values.each_with_object([]) do |key_value, result|
           key, value = key_value
-          result << key if locales.any? do |current_locale|
-            node = data[current_locale].first.children[key]
-            next unless node&.value&.is_a?(String)
-            next if node.value.empty?
-            next if allowed_untranslated_key?(current_locale, key)
-            node.value == value
-          end
-
+          result << key if untranslated_key?(key, value)
           result
+        end
+      end
+
+      def untranslated_key?(key, base_locale_value)
+        locales = self.locales - [base_locale]
+        locales.any? do |current_locale|
+          node = data[current_locale].first.children[key]
+          next unless node&.value&.is_a?(String)
+          next if node.value.empty?
+          next if allowed_untranslated_key?(current_locale, key)
+          node.value == base_locale_value
         end
       end
 
       def allowed_untranslated_key?(locale, key)
         ALLOWED_UNTRANSLATED_KEYS.any? do |entry|
           next unless key =~ Regexp.new(entry[:key])
-          !entry.has_key?(:locales) || entry[:locales].include?(locale.to_sym)
+          !entry.key?(:locales) || entry[:locales].include?(locale.to_sym)
         end
       end
     end


### PR DESCRIPTION
**Why**: As a developer, I want tests to fail if I forget to translate any localized string, so that users in non-English locales don't encounter text in English.

As a user, I want texts to show in my preferred locale, so that I can understand them.