### PR TITLE
Define Sprockets dependencies for JS i18n strings

### DIFF
--- a/app/assets/javascripts/i18n-strings.en.js.erb
+++ b/app/assets/javascripts/i18n-strings.en.js.erb
@@ -1,3 +1,5 @@
+<% depend_on(Rails.root.join('config', 'js_locale_strings.yml').to_s) %>
+<% Dir.glob(Rails.root.join('config/locales/**/en.yml')).each { |file| depend_on(file) } %>
 <% keys = YAML.load_file Rails.root.join('config', 'js_locale_strings.yml') %>
 
 window.LoginGov.I18n.strings = <%= keys.map { |key| [key, I18n.t(key, locale: 'en')] }.to_h.to_json %>;

--- a/app/assets/javascripts/i18n-strings.es.js.erb
+++ b/app/assets/javascripts/i18n-strings.es.js.erb
@@ -1,3 +1,5 @@
+<% depend_on(Rails.root.join('config', 'js_locale_strings.yml').to_s) %>
+<% Dir.glob(Rails.root.join('config/locales/**/es.yml')).each { |file| depend_on(file) } %>
 <% keys = YAML.load_file Rails.root.join('config', 'js_locale_strings.yml') %>
 
 window.LoginGov.I18n.strings = <%= keys.map { |key| [key, I18n.t(key, locale: 'es')] }.to_h.to_json %>;

--- a/app/assets/javascripts/i18n-strings.fr.js.erb
+++ b/app/assets/javascripts/i18n-strings.fr.js.erb
@@ -1,3 +1,5 @@
+<% depend_on(Rails.root.join('config', 'js_locale_strings.yml').to_s) %>
+<% Dir.glob(Rails.root.join('config/locales/**/fr.yml')).each { |file| depend_on(file) } %>
 <% keys = YAML.load_file Rails.root.join('config', 'js_locale_strings.yml') %>
 
 window.LoginGov.I18n.strings = <%= keys.map { |key| [key, I18n.t(key, locale: 'fr')] }.to_h.to_json %>;


### PR DESCRIPTION
**Why**: As a developer, I expect that if I make a change to a locale file or to the list of JS locale strings, I will see that change immediately, so that I'm no left confused that the text is not updated, and that I'm not forced to recall `rake tmp:clear` or `Rails.cache.clear`

**Open Questions:**

- Would this have a negative performance impact? It seems correct to define these dependencies, though since there are quite a few locale files, I'd worry if the overhead in determining in performing the cache lookup could be too costly. I'd considered a few alternatives, including to only define dependencies in development environment, or to try to find some way to hook to the underlying I18n cache digests ([[1]](https://github.com/ruby-i18n/i18n/blob/df7062f5903146ea231a18260ddf1f5083580e34/lib/i18n/backend/cache.rb#L46), [[2]](https://github.com/rails/sprockets/blob/0cb3314368f9f9e84343ebedcc09c7137e920bc4/lib/sprockets/context.rb#L53))