### PR TITLE
Prompt on doc auth navigate using window.onbeforeunload global

### DIFF
--- a/app/javascript/packages/document-capture/components/prompt-on-navigate.jsx
+++ b/app/javascript/packages/document-capture/components/prompt-on-navigate.jsx
@@ -13,8 +13,10 @@ function PromptOnNavigate() {
       event.returnValue = '';
     }
 
-    window.addEventListener('beforeunload', onBeforeUnload);
-    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+    window.onbeforeunload = onBeforeUnload;
+    return () => {
+      window.onbeforeunload = null;
+    };
   });
 
   return null;


### PR DESCRIPTION
**Why**: As a user, I expect that if my session times out while filling out the doc auth document capture step, I am redirected without a prompt, so that when I return my computer I'm not left confused by the prompt, and the fact that clicking "Cancel" to stay on the page does not prevent the inescapable fact that my progress has been lost.

The session timeout implementation already accounts for `onbeforeunload`:

https://github.com/18F/identity-idp/blob/bc1a2240899b7400e9e460c5b1611c6133e32105/app/javascript/app/utils/auto-logout.js#L1-L5

But this only captures prompts added using `window.beforeunload`, not `window.addEventListener('beforeunload', ...);`. The changes here simply update to use the former. There's no significant difference, other than the fact that `addEventListener` allows for multiple event handlers to be bound to the same event, not something we're expecting to need for our usage.

**Testing Procedure:**

1. Log in
2. Navigate to `/verify`
3. Proceed to document capture step
4. Add a value for Front image
5. Try refreshing, verifying prompt still shows as expected
6. Wait for session timeout
7. Verify prompt doesn't show when redirecting on timeout

It can help to alter the value of `session_timeout_in_minutes` in `config/application.yml` to something like `1` to expedite the testing process.

You can also force the timeout redirect by calling `window.LoginGov.autoLogout()` in your browser's devtools console.

Related discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1604349112206700