### PR TITLE
Email language selection: default to browser language

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -22,7 +22,7 @@ class UserDecorator
       # i18n-tasks-use t('account.email_language.name.fr')
       I18n.t("account.email_language.name.#{user.email_language}")
     else
-      I18n.t('account.email_language.name.default')
+      I18n.t('account.email_language.name.en')
     end
   end
 

--- a/app/views/shared/_email_languages.html.erb
+++ b/app/views/shared/_email_languages.html.erb
@@ -17,9 +17,9 @@ locals:
                           class: 'usa-radio__input',
                           id: item_id) %>
         <%= f.label(:email_language,
-                    locale == I18n.default_locale ?
-                      t("account.email_language.name.default") :
-                      t("account.email_language.name.#{locale}"),
+                    locale == I18n.locale ?
+                      t("account.email_language.default", language: t("i18n.locale.#{locale}")) :
+                      t("i18n.locale.#{locale}"),
                     for: item_id,
                     class: 'usa-radio__label usa-radio-bordered') %>
       </li>

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -7,10 +7,10 @@ en:
         government accounts online. Below is a list of all the accounts you currently
         have connected.
     email_language:
+      default: "%{language} (default)"
       edit_title: Edit email language preference
       languages_list: "%{app_name} allows you to receive your email communication
         in %{list}."
-      default: "%{language} (default)"
       name:
         en: English
         es: Spanish

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -10,8 +10,8 @@ en:
       edit_title: Edit email language preference
       languages_list: "%{app_name} allows you to receive your email communication
         in %{list}."
+      default: "%{language} (default)"
       name:
-        default: English (default)
         en: English
         es: Spanish
         fr: French

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -10,8 +10,8 @@ es:
       edit_title: Editar la preferencia de idioma del correo electrónico
       languages_list: "%{app_name} le permite recibir su comunicación por correo electrónico
         en %{list}"
+      default: "%{language} (predeterminado)"
       name:
-        default: Inglés (predeterminado)
         en: Inglés
         es: Español
         fr: Francés

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -7,10 +7,10 @@ es:
         cuentas gubernamentales en línea. A continuación se muestra una lista de todas
         las cuentas que tiene actualmente conectadas.
     email_language:
+      default: "%{language} (predeterminado)"
       edit_title: Editar la preferencia de idioma del correo electrónico
       languages_list: "%{app_name} le permite recibir su comunicación por correo electrónico
         en %{list}"
-      default: "%{language} (predeterminado)"
       name:
         en: Inglés
         es: Español

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -10,8 +10,8 @@ fr:
       edit_title: Modifier la préférence de langue des e-mails
       languages_list: "%{app_name} vous permet de recevoir votre communication par
         e-mail dans %{list}."
+      default: "%{language} (par défaut)"
       name:
-        default: Anglais (par défaut)
         en: Anglais
         es: l'Espagnol
         fr: langue française

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -7,10 +7,10 @@ fr:
         sécurité à plusieurs comptes gouvernementaux en ligne. Vous trouverez ci-dessous
         une liste de tous les comptes actuellement connectés.
     email_language:
+      default: "%{language} (par défaut)"
       edit_title: Modifier la préférence de langue des e-mails
       languages_list: "%{app_name} vous permet de recevoir votre communication par
         e-mail dans %{list}."
-      default: "%{language} (par défaut)"
       name:
         en: Anglais
         es: l'Espagnol

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -53,7 +53,7 @@ describe UserDecorator do
       let(:email_language) { nil }
 
       it 'is the default language' do
-        expect(description).to eq(I18n.t('account.email_language.name.default'))
+        expect(description).to eq(I18n.t('account.email_language.name.en'))
       end
     end
 
@@ -61,7 +61,7 @@ describe UserDecorator do
       let(:email_language) { 'zz' }
 
       it 'is the default language' do
-        expect(description).to eq(I18n.t('account.email_language.name.default'))
+        expect(description).to eq(I18n.t('account.email_language.name.en'))
       end
     end
   end

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Account email language' do
           click_link('Edit')
         end
 
-        choose 'French'
+        choose 'Français'
         click_button 'Submit'
       end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -40,7 +40,7 @@ feature 'Sign Up' do
     it 'allows a user to pick a language when entering email' do
       visit sign_up_email_path
       fill_in 'Email', with: email
-      choose 'Spanish'
+      choose 'Español'
       click_button t('forms.buttons.submit.default')
 
       user = User.find_with_email(email)

--- a/spec/views/shared/_email_languages.html.erb_spec.rb
+++ b/spec/views/shared/_email_languages.html.erb_spec.rb
@@ -51,4 +51,38 @@ RSpec.describe 'shared/_email_languages.html.erb' do
       expect(radio[:value]).to eq(selection)
     end
   end
+
+  it 'marks the current locale as the default' do
+    render_partial
+
+    doc = Nokogiri::HTML(rendered)
+    english_input = doc.css('input[type=radio][value=en]').first
+    english_label = doc.css("label[for=#{english_input[:id]}]").first
+    expect(english_label.text).to eq('English (default)')
+
+    others = doc.css('input[type=radio]:not([value=en])')
+    others.each do |radio|
+      label = doc.css("label[for=#{radio[:id]}]")
+      expect(label.text).to_not include('(default)')
+    end
+  end
+
+  context 'in french' do
+    before { I18n.locale = :fr }
+
+    it 'marks the current locale as the default' do
+      render_partial
+
+      doc = Nokogiri::HTML(rendered)
+      french_input = doc.css('input[type=radio][value=fr]').first
+      french_label = doc.css("label[for=#{french_input[:id]}]").first
+      expect(french_label.text).to eq('Français (par défaut)')
+
+      others = doc.css('input[type=radio]:not([value=fr])')
+      others.each do |radio|
+        label = doc.css("label[for=#{radio[:id]}]")
+        expect(label.text).to_not include('(par défaut)')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some design feedback from @juliaelman 

Two changes:
1. List each language in that language (similar to the language picker)
2. List the current (browser) language as the default language


| Before | After |
| --- | --- |
|  <img width="526" alt="Screen Shot 2020-11-05 at 2 55 42 PM" src="https://user-images.githubusercontent.com/458784/98306005-c0bb4600-1f77-11eb-98b7-99da63bd1ce5.png"> |  <img width="566" alt="Screen Shot 2020-11-05 at 2 59 03 PM" src="https://user-images.githubusercontent.com/458784/98306018-c6b12700-1f77-11eb-9ab1-1effc8658af3.png"> |