### PR TITLE
Async timeout fixes

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -18,6 +18,7 @@ module Idv
       when :in_progress
         render :wait
       when :timed_out
+        flash[:notice] = I18n.t('idv.failure.timeout')
         render :new
       when :done
         async_state_done(async_state)

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -200,10 +200,10 @@ module Idv
       dcs_uuid = idv_session.idv_usps_document_capture_session_uuid
       dcs = DocumentCaptureSession.find_by(uuid: dcs_uuid)
       return ProofingDocumentCaptureSessionResult.none if dcs_uuid.nil?
-      return ProofingDocumentCaptureSessionResult.timed_out if dcs.nil?
+      return timed_out if dcs.nil?
 
       proofing_job_result = dcs.load_proofing_result
-      return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+      return timed_out if proofing_job_result.nil?
 
       if proofing_job_result.result
         proofing_job_result.done
@@ -220,7 +220,7 @@ module Idv
       result = form_response(idv_result, success)
 
       pii = async_state.pii
-      idv_session.idv_usps_document_capture_session_uuid = nil
+      delete_async
 
       async_state_done_analytics(result)
       result.success? ? resolution_success(pii) : failure
@@ -230,6 +230,15 @@ module Idv
       analytics.track_event(Analytics::IDV_USPS_ADDRESS_SUBMITTED, result.to_h)
       Db::SpCost::AddSpCost.call(sp_session[:issuer].to_s, 2, :lexis_nexis_resolution)
       Db::ProofingCost::AddUserProofingCost.call(current_user.id, :lexis_nexis_resolution)
+    end
+
+    def delete_async
+      idv_session.idv_usps_document_capture_session_uuid = nil
+    end
+
+    def timed_out
+      delete_async
+      ProofingDocumentCaptureSessionResult.timed_out
     end
   end
 end

--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -237,6 +237,7 @@ module Idv
     end
 
     def timed_out
+      flash[:notice] = I18n.t('idv.failure.timeout')
       delete_async
       ProofingDocumentCaptureSessionResult.timed_out
     end

--- a/app/services/idv/actions/verify_document_status_action.rb
+++ b/app/services/idv/actions/verify_document_status_action.rb
@@ -62,16 +62,21 @@ module Idv
       end
 
       def async_state
-        return ProofingDocumentCaptureSessionResult.timed_out if document_capture_session.nil?
+        return timed_out if document_capture_session.nil?
 
         proofing_job_result = document_capture_session.load_proofing_result
-        return ProofingDocumentCaptureSessionResult.timed_out if proofing_job_result.nil?
+        return timed_out if proofing_job_result.nil?
 
         if proofing_job_result.result
           proofing_job_result.done
         elsif proofing_job_result.pii
           ProofingDocumentCaptureSessionResult.in_progress
         end
+      end
+
+      def timed_out
+        delete_async
+        ProofingDocumentCaptureSessionResult.timed_out
       end
 
       def delete_async

--- a/app/services/idv/steps/cac/verify_wait_step_show.rb
+++ b/app/services/idv/steps/cac/verify_wait_step_show.rb
@@ -17,6 +17,7 @@ module Idv
           when :in_progress
             nil
           when :timed_out
+            delete_async
             mark_step_incomplete(:verify)
           when :done
             async_state_done(current_async_state)

--- a/app/services/idv/steps/cac/verify_wait_step_show.rb
+++ b/app/services/idv/steps/cac/verify_wait_step_show.rb
@@ -17,6 +17,7 @@ module Idv
           when :in_progress
             nil
           when :timed_out
+            flash[:notice] = I18n.t('idv.failure.timeout')
             delete_async
             mark_step_incomplete(:verify)
           when :done

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -16,6 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
+          delete_async
           mark_step_incomplete(:verify)
         when :done
           async_state_done(current_async_state)

--- a/app/services/idv/steps/recover_verify_wait_step_show.rb
+++ b/app/services/idv/steps/recover_verify_wait_step_show.rb
@@ -16,6 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
+          flash[:notice] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         when :done

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -16,6 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
+          delete_async
           mark_step_incomplete(:verify)
         when :done
           async_state_done(current_async_state)

--- a/app/services/idv/steps/verify_wait_step_show.rb
+++ b/app/services/idv/steps/verify_wait_step_show.rb
@@ -16,6 +16,7 @@ module Idv
         when :in_progress
           nil
         when :timed_out
+          flash[:notice] = I18n.t('idv.failure.timeout')
           delete_async
           mark_step_incomplete(:verify)
         when :done

--- a/config/locales/idv/en.yml
+++ b/config/locales/idv/en.yml
@@ -58,6 +58,7 @@ en:
         heading: We could not find records matching your personal information.
         warning: Please check the information you entered. Common mistakes are an
           incorrect Social Security Number, ZIP Code, or date of birth.
+      timeout: We are having technical difficulties. Please try again.
     forgot_password:
       link_html: Forgot password? %{link}
       link_text: Follow these instructions

--- a/config/locales/idv/es.yml
+++ b/config/locales/idv/es.yml
@@ -61,6 +61,7 @@ es:
           personal.
         warning: Compruebe la información que ingresó. Los errores comunes son números
           incorrectos de Seguro Social, código postal o fecha de nacimiento.
+      timeout: Estamos teniendo dificultades técnicas. Por favor inténtelo de nuevo.
     forgot_password:
       link_html: "¿Se te olvidó tu contraseña? %{link}"
       link_text: Siga estas instrucciones

--- a/config/locales/idv/fr.yml
+++ b/config/locales/idv/fr.yml
@@ -65,6 +65,7 @@ fr:
         warning: Veuillez vérifier l'information que vous avez fournie. Un numéro
           de sécurité sociale, un code ZIP ou une date de naissance mal écrits sont
           des erreurs communes.
+      timeout: Nous avons des difficultés techniques. Veuillez réessayer.
     forgot_password:
       link_html: Mot de passe oublié? %{link}
       link_text: Suivez ces instructions

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -71,6 +71,7 @@ describe Idv::PhoneController do
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
 
       get :new
+      expect(flash[:notice]).to include t('idv.failure.timeout')
       expect(response).to render_template :new
       put :create, params: { idv_phone_form: { phone: good_phone } }
       get :new

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -65,13 +65,16 @@ describe Idv::PhoneController do
       expect(response).to redirect_to idv_phone_errors_failure_url
     end
 
-    it 'shows phone form if async process times out' do
+    it 'shows phone form if async process times out and allows successful resubmission' do
       # setting the document capture session to a nonexistent uuid will trigger async
       # timed_out behavior
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
 
       get :new
       expect(response).to render_template :new
+      put :create, params: { idv_phone_form: { phone: good_phone } }
+      get :new
+      expect(response).to redirect_to idv_review_path
     end
 
     it 'shows waiting interstitial if async process is in progress' do

--- a/spec/features/idv/cac/verify_step_spec.rb
+++ b/spec/features/idv/cac/verify_step_spec.rb
@@ -50,6 +50,7 @@ feature 'cac proofing verify info step' do
       click_continue
 
       expect(page).to have_current_path(idv_cac_proofing_verify_step)
+      expect(page).to have_content t('idv.failure.timeout')
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
       click_continue
       expect(page).to have_current_path(idv_cac_proofing_success_step)

--- a/spec/features/idv/cac/verify_step_spec.rb
+++ b/spec/features/idv/cac/verify_step_spec.rb
@@ -37,4 +37,22 @@ feature 'cac proofing verify info step' do
       expect(page).to have_current_path(idv_cac_proofing_verify_wait_step)
     end
   end
+
+  context 'timed out' do
+    before do
+      sign_in_and_2fa_user
+      complete_cac_proofing_steps_before_verify_step
+    end
+
+    it 'allows resubmitting form' do
+      allow(DocumentCaptureSession).to receive(:find_by).
+        and_return(nil)
+      click_continue
+
+      expect(page).to have_current_path(idv_cac_proofing_verify_step)
+      allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+      click_continue
+      expect(page).to have_current_path(idv_cac_proofing_success_step)
+    end
+  end
 end

--- a/spec/features/idv/doc_auth/verify_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_step_spec.rb
@@ -197,4 +197,20 @@ feature 'doc auth verify step' do
       expect(agent).to have_received(:proof_resolution).with(anything, should_proof_state_id: false)
     end
   end
+
+  context 'async timed out' do
+    it 'allows resubmitting form' do
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_verify_step
+
+      allow(DocumentCaptureSession).to receive(:find_by).
+        and_return(nil)
+
+      click_continue
+      expect(page).to have_current_path(idv_doc_auth_verify_step)
+      allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+      click_continue
+      expect(page).to have_current_path(idv_phone_path)
+    end
+  end
 end

--- a/spec/features/idv/recovery/verify_step_spec.rb
+++ b/spec/features/idv/recovery/verify_step_spec.rb
@@ -106,6 +106,7 @@ feature 'recovery verify step' do
       click_continue
 
       expect(page).to have_current_path(idv_recovery_verify_step)
+      expect(page).to have_content t('idv.failure.timeout')
       allow(DocumentCaptureSession).to receive(:find_by).and_call_original
       click_continue
       expect(page).to have_current_path(account_path)

--- a/spec/features/idv/recovery/verify_step_spec.rb
+++ b/spec/features/idv/recovery/verify_step_spec.rb
@@ -94,4 +94,21 @@ feature 'recovery verify step' do
       expect(page).to have_current_path(idv_recovery_verify_wait_step)
     end
   end
+
+  context 'timed out' do
+    it 'allows resubmitting form' do
+      allow_any_instance_of(Idv::Steps::RecoverVerifyWaitStepShow).to receive(:saved_pii).
+        and_return(saved_pii.to_json)
+      allow(DocumentCaptureSession).to receive(:find_by).
+        and_return(nil)
+
+      complete_recovery_steps_before_verify_step
+      click_continue
+
+      expect(page).to have_current_path(idv_recovery_verify_step)
+      allow(DocumentCaptureSession).to receive(:find_by).and_call_original
+      click_continue
+      expect(page).to have_current_path(account_path)
+    end
+  end
 end


### PR DESCRIPTION
The time out state should delete the active document capture session from the session to allow users to submit again (or other behavior in the future)

The step was getting marked incomplete, taking users back to the form, but not allowing resubmission since having an existing async job prevents that.