### PR TITLE
LG-3663: Log NewRelic page action for Acuant capture result

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -179,13 +179,21 @@ function AcuantCapture(
         <FullScreen onRequestClose={() => setIsCapturingEnvironment(false)}>
           <AcuantCaptureCanvas
             onImageCaptureSuccess={(nextCapture) => {
+              let result;
               if (nextCapture.glare < ACCEPTABLE_GLARE_SCORE) {
                 setOwnErrorMessage(t('errors.doc_auth.photo_glare'));
+                result = 'glare';
               } else if (nextCapture.sharpness < ACCEPTABLE_SHARPNESS_SCORE) {
                 setOwnErrorMessage(t('errors.doc_auth.photo_blurry'));
+                result = 'blurry';
               } else {
                 onChangeAndResetError(nextCapture.image.data);
+                result = 'success';
               }
+
+              /** @type {{addPageAction(name: string, attributes: object): void}=} */
+              const agent = window.newrelic;
+              agent?.addPageAction('documentCapture.acuantResult', { result });
 
               setIsCapturingEnvironment(false);
             }}

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -208,7 +208,7 @@ function AcuantCapture(
               }
 
               const agent = /** @type {NewRelicGlobal} */ (window).newrelic;
-              agent?.addPageAction('documentCapture.acuantResult', { result });
+              agent?.addPageAction('documentCapture.acuantWebSDKResult', { result });
 
               setIsCapturingEnvironment(false);
             }}

--- a/app/javascript/packages/document-capture/components/acuant-capture.jsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.jsx
@@ -21,6 +21,12 @@ import './acuant-capture.scss';
 /** @typedef {import('react').ReactNode} ReactNode */
 
 /**
+ * @typedef NewRelicAgent
+ *
+ * @prop {(name: string, attributes: object) => void} addPageAction Log page action to New Relic.
+ */
+
+/**
  * @typedef AcuantPassiveLiveness
  *
  * @prop {(callback:(nextImageData:string)=>void)=>void} startSelfieCapture Start liveness capture.
@@ -33,7 +39,17 @@ import './acuant-capture.scss';
  */
 
 /**
+ * @typedef NewRelicGlobals
+ *
+ * @prop {NewRelicAgent=} newrelic New Relic agent.
+ */
+
+/**
  * @typedef {typeof window & AcuantGlobals} AcuantGlobal
+ */
+
+/**
+ * @typedef {typeof window & NewRelicGlobals} NewRelicGlobal
  */
 
 /**
@@ -191,8 +207,7 @@ function AcuantCapture(
                 result = 'success';
               }
 
-              /** @type {{addPageAction(name: string, attributes: object): void}=} */
-              const agent = window.newrelic;
+              const agent = /** @type {NewRelicGlobal} */ (window).newrelic;
               agent?.addPageAction('documentCapture.acuantResult', { result });
 
               setIsCapturingEnvironment(false);

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -279,7 +279,7 @@ describe('document-capture/components/acuant-capture', () => {
 
       const error = await findByText('errors.doc_auth.photo_glare');
       expect(
-        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
           result: 'glare',
         }),
       ).to.be.true();
@@ -316,7 +316,7 @@ describe('document-capture/components/acuant-capture', () => {
 
       const error = await findByText('errors.doc_auth.photo_blurry');
       expect(
-        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
           result: 'blurry',
         }),
       ).to.be.true();
@@ -411,7 +411,7 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
       await waitForElementToBeRemoved(error);
       expect(
-        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantWebSDKResult', {
           result: 'success',
         }),
       ).to.be.true();

--- a/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import sinon from 'sinon';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
-import sinon from 'sinon';
 import AcuantCapture from '@18f/identity-document-capture/components/acuant-capture';
 import { Provider as AcuantContextProvider } from '@18f/identity-document-capture/context/acuant';
 import DeviceContext from '@18f/identity-document-capture/context/device';
@@ -11,6 +11,16 @@ import { render, useAcuant } from '../../../support/document-capture';
 
 describe('document-capture/components/acuant-capture', () => {
   const { initialize } = useAcuant();
+
+  let originalNewRelic;
+  before(() => {
+    originalNewRelic = window.newrelic;
+    window.newrelic = { addPageAction: sinon.spy() };
+  });
+
+  after(() => {
+    window.newrelic = originalNewRelic;
+  });
 
   context('mobile', () => {
     it('renders with assumed capture button support while acuant is not ready and on mobile', () => {
@@ -268,6 +278,11 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
 
       const error = await findByText('errors.doc_auth.photo_glare');
+      expect(
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+          result: 'glare',
+        }),
+      ).to.be.true();
 
       expect(error).to.be.ok();
     });
@@ -300,6 +315,11 @@ describe('document-capture/components/acuant-capture', () => {
       fireEvent.click(button);
 
       const error = await findByText('errors.doc_auth.photo_blurry');
+      expect(
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+          result: 'blurry',
+        }),
+      ).to.be.true();
 
       expect(error).to.be.ok();
     });
@@ -390,6 +410,11 @@ describe('document-capture/components/acuant-capture', () => {
 
       fireEvent.click(button);
       await waitForElementToBeRemoved(error);
+      expect(
+        window.newrelic.addPageAction.calledWith('documentCapture.acuantResult', {
+          result: 'success',
+        }),
+      ).to.be.true();
     });
 
     it('triggers forced upload', () => {


### PR DESCRIPTION
**Why**:

As a user, I want a smooth experience and the ability of the login team to identify when I have issues, so that the experience can continue to improve. 

As a member of the Login team, I expect that errors which the user experiences in the new React-based document capture flow are logged, so that I can effectively assess where users are getting stuck.

**Implementation Notes:**

- Re: @amathews-fs 's note on the original ticket, user flow progress can be associated with a session by the [`session` attribute](https://docs.newrelic.com/attribute-dictionary/pageview/session) on a NewRelic `PageAction` event.
- For the time being, I've resisted the urge to avoid such direct references to window globals, where if we repeat this pattern in the future, we might want to consider better alternatives such as a [React context or at least TypeScript-defined shared globals](https://gist.github.com/aduth/c6104072d2ce3612f3d02ccfec3b3b76).