### PR TITLE
ImageUploadController PII validation fix

### DIFF
--- a/app/controllers/idv/image_uploads_controller.rb
+++ b/app/controllers/idv/image_uploads_controller.rb
@@ -8,6 +8,7 @@ module Idv
 
     def create
       form_response = image_form.submit
+      client_response = nil
 
       if form_response.success?
         client_response = doc_auth_client.post_images(
@@ -30,7 +31,7 @@ module Idv
 
       presenter = ImageUploadResponsePresenter.new(
         form: image_form,
-        form_response: client_response || form_response,
+        form_response: presenter_response(form_response, client_response),
       )
 
       render json: presenter, status: presenter.status
@@ -82,6 +83,11 @@ module Idv
             issuer: sp_session[:issuer].to_s,
             liveness_checking_enabled: liveness_checking_enabled?).
         call(client_response)
+    end
+
+    def presenter_response(form_response, client_response)
+      return client_response if form_response.success? && client_response.present?
+      form_response
     end
   end
 end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -313,6 +313,25 @@ describe Idv::ImageUploadsController do
           expect_funnel_update_counts(user, 1)
         end
       end
+
+      context 'when required pii field is missing from doc response' do
+        before { params.merge!(back: DocAuthImageFixtures.error_yaml_no_db_multipart) }
+
+        it 'returns error' do
+          action
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(response.status).to eq(400)
+          expect(json[:success]).to eq(false)
+          expect(json[:remaining_attempts]).to be_a_kind_of(Numeric)
+          expect(json[:errors]).to eq [
+            {
+              field: 'pii',
+              message: I18n.t('doc_auth.errors.lexis_nexis.birth_date_checks'),
+            },
+          ]
+        end
+      end
     end
   end
 

--- a/spec/fixtures/ial2_test_credential_no_dob.yml
+++ b/spec/fixtures/ial2_test_credential_no_dob.yml
@@ -1,0 +1,10 @@
+document:
+  first_name: Jane
+  last_name: Doe
+  middle_name: Q
+  address1: 1800 F Street
+  address2: Apt 3
+  city: Bayside
+  state: NY
+  zipcode: '11364'
+  phone: +1 314-555-1212

--- a/spec/support/doc_auth_image_fixtures.rb
+++ b/spec/support/doc_auth_image_fixtures.rb
@@ -51,6 +51,14 @@ module DocAuthImageFixtures
     Rack::Test::UploadedFile.new(path, Mime[:yaml])
   end
 
+  def self.error_yaml_no_db_multipart
+    path = File.join(
+      File.dirname(__FILE__),
+      '../fixtures/ial2_test_credential_no_dob.yml',
+    )
+    Rack::Test::UploadedFile.new(path, Mime[:yaml])
+  end
+
   def self.fixture_path(filename)
     File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
Follow up to #4366 

Some of the later changes made to analytics caused errors to not be returned properly, and errors weren't being shown in the React app as expected.

We should return the form_response if it contains any errors, but we weren't due to how the merging and variable assignment worked.