### PR TITLE
Add controller to mock S3 upload functionality in local development (LG-3724)

### DIFF
--- a/app/controllers/test/fake_s3_controller.rb
+++ b/app/controllers/test/fake_s3_controller.rb
@@ -1,0 +1,31 @@
+module Test
+  class FakeS3Controller < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    cattr_accessor :data
+    self.data ||= {}
+
+    # Intended for use in tests to clear stored data
+    def self.clear!
+      self.data.clear
+    end
+
+    def show
+      key = params[:key]
+
+      if self.class.data.key?(key)
+        send_data self.class.data[key], type: 'application/octet-stream', filename: key
+      else
+        render_not_found
+      end
+    end
+
+    def create
+      key = params[:key]
+
+      self.class.data[key] = request.body.read
+
+      render json: {}
+    end
+  end
+end

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -61,11 +61,13 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
           iv,
           value,
         )
-          .then((encryptedValue) => window.fetch(url, {
-            method: 'POST',
-            body: encryptedValue,
-            headers: { 'Content-Type': 'application/octet-stream' }
-          }))
+          .then((encryptedValue) =>
+            window.fetch(url, {
+              method: 'POST',
+              body: encryptedValue,
+              headers: { 'Content-Type': 'application/octet-stream' },
+            }),
+          )
           .then(() => url);
       }
     }

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -61,7 +61,11 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
           iv,
           value,
         )
-          .then((encryptedValue) => window.fetch(url, { method: 'POST', body: encryptedValue }))
+          .then((encryptedValue) => window.fetch(url, {
+            method: 'POST',
+            body: encryptedValue,
+            headers: { 'Content-Type': 'application/octet-stream' }
+          }))
           .then(() => url);
       }
     }

--- a/app/services/image_upload_presigned_url_generator.rb
+++ b/app/services/image_upload_presigned_url_generator.rb
@@ -2,12 +2,18 @@ class ImageUploadPresignedUrlGenerator
   include AwsS3Helper
 
   def presigned_image_upload_url(image_type:, transaction_id:)
-    return nil unless Figaro.env.doc_auth_enable_presigned_s3_urls == 'true'
+    keyname = "#{transaction_id}-#{image_type}"
 
-    s3_presigned_url(
-      bucket_prefix: bucket_prefix,
-      keyname: "#{transaction_id}-#{image_type}",
-    ).to_s
+    if Figaro.env.doc_auth_enable_presigned_s3_urls != 'true'
+      nil
+    elsif !LoginGov::Hostdata.in_datacenter?
+      Rails.application.routes.url_helpers.test_fake_s3_url(key: keyname)
+    else
+      s3_presigned_url(
+        bucket_prefix: bucket_prefix,
+        keyname: keyname,
+      ).to_s
+    end
   end
 
   def bucket_prefix

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,9 @@ Rails.application.routes.draw do
 
         get '/telephony' => 'telephony#index'
         delete '/telephony' => 'telephony#destroy'
+
+        get '/s3/:key' => 'fake_s3#show', as: :fake_s3
+        post '/s3/:key' => 'fake_s3#create'
       end
     end
 

--- a/spec/controllers/fake_s3_controller_spec.rb
+++ b/spec/controllers/fake_s3_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Test::FakeS3Controller do
+  before do
+    Test::FakeS3Controller.clear!
+  end
+
+  let(:key) { SecureRandom.uuid }
+  let(:data) { SecureRandom.random_bytes }
+
+  describe '#show' do
+    subject(:action) { get :show, params: { key: key } }
+
+    context 'with a valid key' do
+      before { Test::FakeS3Controller.data[key] = data }
+
+      it 'is that data' do
+        action
+
+        expect(response.body).to eq(data)
+      end
+    end
+
+    context 'with an unknown key' do
+      it '404s' do
+        action
+
+        expect(response).to be_not_found
+      end
+    end
+  end
+
+  describe '#create' do
+    subject(:action) do
+      post :create, body: data, params: { key: key }
+    end
+
+    it 'stores the data in memory' do
+      expect { action }.
+        to(change { Test::FakeS3Controller.data[key] }.to(data))
+    end
+  end
+end

--- a/spec/services/image_upload_presigned_url_generator_spec.rb
+++ b/spec/services/image_upload_presigned_url_generator_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe ImageUploadPresignedUrlGenerator do
+  include Rails.application.routes.url_helpers
+
+  subject(:generator) { ImageUploadPresignedUrlGenerator.new }
+
+  describe '#presigned_image_upload_url' do
+    subject(:presigned_image_upload_url) do
+      generator.presigned_image_upload_url(image_type: image_type, transaction_id: transaction_id)
+    end
+
+    let(:image_type) { 'front' }
+    let(:transaction_id) { SecureRandom.uuid }
+
+    before do
+      expect(Figaro.env).
+        to receive(:doc_auth_enable_presigned_s3_urls).and_return(doc_auth_enable_presigned_s3_urls)
+    end
+
+    context 'when doc_auth_enable_presigned_s3_urls is disabled' do
+      let(:doc_auth_enable_presigned_s3_urls) { 'false' }
+
+      it 'is nil' do
+        expect(presigned_image_upload_url).to eq(nil)
+      end
+    end
+
+    context 'when doc_auth_enable_presigned_s3_urls is enabled' do
+      let(:doc_auth_enable_presigned_s3_urls) { 'true' }
+
+      before do
+        expect(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(in_datacenter)
+      end
+
+      context 'when run locally' do
+        let(:in_datacenter) { false }
+
+        it 'is a local fake S3 URL' do
+          expect(presigned_image_upload_url).
+            to eq(test_fake_s3_url(key: "#{transaction_id}-#{image_type}"))
+        end
+      end
+
+      context 'when run in the datacenter' do
+        let(:in_datacenter) { true }
+
+        let(:real_s3_url) { 'https://s3.example.com/key/id/1234' }
+
+        it 'is a real S3 url' do
+          # from aws_s3_helper
+          expect(generator).to receive(:s3_presigned_url).
+            with(hash_including(keyname: "#{transaction_id}-#{image_type}")).
+            and_return(real_s3_url)
+
+          expect(presigned_image_upload_url).to eq(real_s3_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a fake S3 controller

- I enabled `doc_auth_enable_presigned_s3_urls` locally and got this to work with the async S3 uploads in our JS (once I added a content-type)

- Next steps, I think the only code we have to download from S3 is here: https://github.com/18F/identity-idp-functions/pull/26, so I will see about making a patch to that code in the mock document proofer that reads from these local URLs