### PR TITLE
LG-3587 LG-3609 One small fix, two bugs. 

### DIFF
--- a/app/javascript/packages/document-capture/components/selfie-capture.jsx
+++ b/app/javascript/packages/document-capture/components/selfie-capture.jsx
@@ -66,7 +66,7 @@ function SelfieCapture({ value, onChange, errorMessage, className }, ref) {
 
   function startCapture() {
     navigator.mediaDevices
-      .getUserMedia({ video: true })
+      .getUserMedia({ video: { width: 1920, height: 1080 } })
       .then(
         ifStillMounted((/** @type {MediaStream} */ stream) => {
           if (!videoRef.current) {


### PR DESCRIPTION
Force the camera to capture in higher resolution if supported. This causes the face to be larger in resolution, meaning no more "FaceTooSmall" errors from Acuant and actual results from LN TrueID.

By default the browser captures images from the webcam at 480p for whatever reason. If you want it to go higher you have to set the constraints higher and it'll choose the closest to the specified size that the camera supports. A setting of 1920x1080 seemed like a reasonable middle ground where anyone with a camera with a higher resolution will prefer 1080p which is plenty of data for these purposes, anyone with a camera with a lower resolution will get the highest that their camera supports.

This does open up some additional issues that need be addressed but I will be opening new tickets for those since they are larger pieces of work and decisions outside of just getting these things working.

