### PR TITLE
require password before editing password if user has PII that has not been decrypted (LG-3725)

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -27,10 +27,9 @@ module Users
     private
 
     def pii_requested_but_locked?
-      if current_user.decorate.identity_verified? && user_session[:decrypted_pii].blank?
-        store_location(request.url)
-        redirect_to capture_password_url
-      end
+      return unless current_user.decorate.identity_verified? && user_session[:decrypted_pii].blank?
+      user_session[:stored_location] = request.url
+      redirect_to capture_password_url
     end
 
     def user_params
@@ -60,10 +59,6 @@ module Users
         ForbiddenPasswords.new(email_address.email).call
       end
       render :edit
-    end
-
-    def store_location(url)
-      user_session[:stored_location] = url
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -27,9 +27,7 @@ module Users
     private
 
     def pii_requested_but_locked?
-      if UserDecorator.new(current_user).identity_verified? &&
-         user_session[:decrypted_pii].blank?
-
+      if current_user.decorate.identity_verified? && user_session[:decrypted_pii].blank?
         store_location(request.url)
         redirect_to capture_password_url
       end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class PasswordsController < ReauthnRequiredController
     before_action :confirm_two_factor_authenticated
-    before_action :pii_requested_but_locked?
+    before_action :capture_password_if_pii_requested_but_locked
 
     def edit
       @update_user_password_form = UpdateUserPasswordForm.new(current_user)
@@ -26,7 +26,7 @@ module Users
 
     private
 
-    def pii_requested_but_locked?
+    def capture_password_if_pii_requested_but_locked
       return unless current_user.decorate.identity_verified? && user_session[:decrypted_pii].blank?
       user_session[:stored_location] = request.url
       redirect_to capture_password_url

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -1,5 +1,9 @@
 <% title t('titles.visitors.index') %>
 
+<h1 class='h3 my0'>
+  <%= t('headings.passwords.confirm') %>
+</h1>
+
 <%= validated_form_for(current_user,
                        as: :user,
                        url: capture_password_url,

--- a/app/views/password_capture/new.html.erb
+++ b/app/views/password_capture/new.html.erb
@@ -12,7 +12,7 @@
   <%= f.input :password, label: t('account.index.password'), required: true,
               input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
   <div>
-    <%= f.button :submit, t('links.next'), class: 'sm-col-6 col-12 btn-wide mb3' %>
+    <%= f.button :submit, t('forms.buttons.submit.default'), class: 'sm-col-6 col-12 btn-wide mb3' %>
   </div>
 <% end %>
 

--- a/spec/controllers/password_capture_controller_spec.rb
+++ b/spec/controllers/password_capture_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe PasswordCaptureController do
+  describe '#update' do
+    let(:user) { create(:user, :signed_up, password: 'a really long sekrit') }
+
+    context 'form returns success' do
+      let(:pii) { { first_name: 'Jane', ssn: '111-11-1111' } }
+
+      it 'decrypts PII and redirects' do
+        create(:profile, :active, :verified, user: user, pii: pii)
+        stub_sign_in(user)
+
+        expect(controller.user_session[:decrypted_pii]).to be nil
+
+        params = { password: 'a really long sekrit' }
+        get :new
+        patch :create, params: { user: params }
+
+        expect(response).to redirect_to account_path
+        expect(controller.user_session[:decrypted_pii]).to_not be nil
+      end
+    end
+
+    context 'form errors' do
+      it 'increases password attempts' do
+        stub_sign_in(user)
+
+        params = { password: 'a wrong password' }
+        get :new
+        patch :create, params: { user: params }
+
+        expect(controller.session[:password_attempts]).to eq 1
+        expect(response).to redirect_to capture_password_path
+      end
+    end
+  end
+end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -93,4 +93,29 @@ describe Users::PasswordsController do
       end
     end
   end
+
+  describe '#edit' do
+    context 'user has a profile with PII' do
+      let(:pii) { { first_name: 'Jane' } }
+      before do
+        user = create(:user)
+        create(:profile, :active, :verified, user: user, pii: pii)
+        stub_sign_in(user)
+      end
+
+      it 'redirects to capture password if PII is not decrypted' do
+        get :edit
+
+        expect(response).to redirect_to capture_password_path
+      end
+
+      it 'renders form if PII is decrypted' do
+        controller.user_session[:decrypted_pii] = pii
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -121,7 +121,7 @@ module Features
 
     def fill_in_password_and_submit(password)
       fill_in 'user_password', with: password
-      click_button t('links.next')
+      click_button t('forms.buttons.submit.default')
     end
 
     def sign_up

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -287,11 +287,11 @@ def ial2_sign_in_with_piv_cac_gets_bad_password_error(sp)
   max_allowed_attempts = Figaro.env.password_max_attempts.to_i
   (max_allowed_attempts - 1).times do
     fill_in 'user_password', with: 'badpassword'
-    click_button t('links.next')
+    click_button t('forms.buttons.submit.default')
     expect(page).to have_content(t('errors.confirm_password_incorrect'))
   end
 
   fill_in 'user_password', with: 'badpassword'
-  click_button t('links.next')
+  click_button t('forms.buttons.submit.default')
   expect(page).to have_content(t('errors.max_password_attempts_reached'))
 end


### PR DESCRIPTION
This PR reuses some of the password capture controller to fix a bug where editing password fails while trying to re-encrypt PII because PII has not yet been decrypted due to logging in with PIV/CAC.  The password capture controller is currently used in a similar situation where an SP requests greater than IAL1 and a user has not yet decrypted PII.

Screenshot:
![image](https://user-images.githubusercontent.com/1430443/98691684-e8bdf700-2333-11eb-9652-2fbb11e00a85.png)