### PR TITLE
Use separate logic for "Demo" vs "No PII" banners in lower envs (LG-3677)

### DIFF
--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,5 +1,5 @@
 <div aria-label="banner" role="banner">
-  <%= render 'shared/no_pii_banner' if FeatureManagement.fake_banner_mode? %>
+  <%= render 'shared/no_pii_banner' if FeatureManagement.show_no_pii_banner? %>
   <section class="usa-banner" aria-label="Official government website">
     <div class="usa-accordion">
       <header class="usa-banner__header">
@@ -11,9 +11,9 @@
             class: 'mr1'
           ) %>
           <div class="grid-col-fill tablet:grid-col-auto">
-            <p class="usa-banner__header-text"><%= FeatureManagement.fake_banner_mode? ?
-              t('shared.banner.fake_site') : t('shared.banner.official_site')
-            %></p>
+            <p class="usa-banner__header-text">
+              <%= FeatureManagement.show_demo_banner? ? t('shared.banner.fake_site') : t('shared.banner.official_site') %>
+            </p>
             <p class="usa-banner__header-action" aria-hidden="true"><%= t('shared.banner.how') %></p>
           </div>
           <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -69,8 +69,12 @@ class FeatureManagement
     ENVS_WHERE_PREFILLING_USPS_CODE_ALLOWED.include?(Figaro.env.domain_name)
   end
 
-  def self.fake_banner_mode?
-    Rails.env.production? && LoginGov::Hostdata.domain != 'login.gov'
+  def self.show_demo_banner?
+    LoginGov::Hostdata.in_datacenter? && LoginGov::Hostdata.env != 'prod'
+  end
+
+  def self.show_no_pii_banner?
+    LoginGov::Hostdata.in_datacenter? && LoginGov::Hostdata.domain != 'login.gov'
   end
 
   def self.enable_saml_cert_rotation?

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -136,8 +136,6 @@ describe 'FeatureManagement', type: :feature do
     subject(:show_demo_banner?) { FeatureManagement.show_demo_banner? }
 
     context 'in local development' do
-      # before { expect(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(false) }
-
       it 'is false' do
         expect(show_demo_banner?).to be_falsey
       end

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -132,28 +132,64 @@ describe 'FeatureManagement', type: :feature do
     end
   end
 
-  describe '.fake_banner_mode?' do
-    context 'when in the production environment: secure.login.gov, idp.staging.login.gov' do
-      it 'does not display the fake banner' do
-        allow(LoginGov::Hostdata).to receive(:domain).and_return('login.gov')
-        allow(Rails.env).to receive(:production?).and_return(true)
-        expect(FeatureManagement.fake_banner_mode?).to eq(false)
+  describe '.show_demo_banner?' do
+    subject(:show_demo_banner?) { FeatureManagement.show_demo_banner? }
+
+    context 'in local development' do
+      # before { expect(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(false) }
+
+      it 'is false' do
+        expect(show_demo_banner?).to be_falsey
       end
     end
 
-    context 'when the in the sandbox environment: identitysandbox.gov' do
-      it 'displays the fake banner' do
-        allow(LoginGov::Hostdata).to receive(:domain).and_return('identitysandbox.gov')
-        allow(Rails.env).to receive(:production?).and_return(true)
-        expect(FeatureManagement.fake_banner_mode?).to eq(true)
+    context 'in a deployed environment' do
+      before { expect(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(true) }
+
+      context 'in a non-prod env' do
+        before { expect(LoginGov::Hostdata).to receive(:env).and_return('staging') }
+
+        it 'is true' do
+          expect(show_demo_banner?).to be_truthy
+        end
+      end
+
+      context 'in production' do
+        before { expect(LoginGov::Hostdata).to receive(:env).and_return('prod') }
+
+        it 'is false' do
+          expect(show_demo_banner?).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe '.show_no_pii_banner?' do
+    subject(:show_no_pii_banner?) { FeatureManagement.show_no_pii_banner? }
+
+    context 'in local development' do
+      it 'is false' do
+        expect(show_no_pii_banner?).to eq(false)
       end
     end
 
-    context 'when the host is not secure.login.gov and the Rails env is not in production' do
-      it 'does not display the fake banner' do
-        allow(LoginGov::Hostdata).to receive(:domain).and_return(nil)
-        allow(Rails.env).to receive(:production?).and_return(false)
-        expect(FeatureManagement.fake_banner_mode?).to eq(false)
+    context 'in a deployed environment' do
+      before { expect(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(true) }
+
+      context 'in the sandbox domain' do
+        before { expect(LoginGov::Hostdata).to receive(:domain).and_return('identitysandbox.gov') }
+
+        it 'is true' do
+          expect(show_no_pii_banner?).to eq(true)
+        end
+      end
+
+      context 'in the prod domain' do
+        before { expect(LoginGov::Hostdata).to receive(:domain).and_return('login.gov') }
+
+        it 'is false' do
+          expect(show_no_pii_banner?).to eq(false)
+        end
       end
     end
   end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -29,21 +29,39 @@ describe 'layouts/application.html.erb' do
     end
   end
 
-  context 'when FeatureManagement.fake_banner_mode? is true' do
-    it 'displays the fake banner' do
-      allow(FeatureManagement).to receive(:fake_banner_mode?).and_return(true)
+  context 'when FeatureManagement.show_demo_banner? is true' do
+    it 'displays the demo banner' do
+      allow(FeatureManagement).to receive(:show_demo_banner?).and_return(true)
       render
 
       expect(rendered).to have_content('DEMO')
     end
   end
 
-  context 'when FeatureManagement.fake_banner_mode? is false' do
-    it 'does not display the fake banner' do
-      allow(FeatureManagement).to receive(:fake_banner_mode?).and_return(false)
+  context 'when FeatureManagement.show_demo_banner? is false' do
+    it 'does not display the demo banner' do
+      allow(FeatureManagement).to receive(:show_demo_banner?).and_return(false)
       render
 
       expect(rendered).to_not have_content('DEMO')
+    end
+  end
+
+  context 'when FeatureManagement.show_no_pii_banner? is true' do
+    it 'displays the no PII banner' do
+      allow(FeatureManagement).to receive(:show_no_pii_banner?).and_return(true)
+      render
+
+      expect(rendered).to have_content('Do not use real personal information')
+    end
+  end
+
+  context 'when FeatureManagement.show_no_pii_banner? is false' do
+    it 'does not display the no PII banner' do
+      allow(FeatureManagement).to receive(:show_no_pii_banner?).and_return(false)
+      render
+
+      expect(rendered).to_not have_content('Do not use real personal information')
     end
   end
 


### PR DESCRIPTION
Now with this logic:

| environment | screenshot |
| --- | --- |
| prod | <img width="704" alt="prod" src="https://user-images.githubusercontent.com/458784/98612268-aac7c100-22a8-11eb-973c-4af121306029.png"> |
| staging | <img width="700" alt="staging" src="https://user-images.githubusercontent.com/458784/98612272-ac918480-22a8-11eb-8501-3de1aa4ee635.png"> |
| dev/int/personal envs | <img width="736" alt="int-dev" src="https://user-images.githubusercontent.com/458784/98612273-adc2b180-22a8-11eb-8ef3-adabe1d2158d.png"> |
