### PR TITLE
LG-3704: Make document capture status polling interval configurable

### DIFF
--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -86,7 +86,9 @@ loadPolyfills(['fetch', 'crypto']).then(async () => {
       <UploadContextProvider
         endpoint={appRoot.getAttribute('data-endpoint')}
         statusEndpoint={appRoot.getAttribute('data-status-endpoint')}
-        statusPollInterval={Number(appRoot.getAttribute('data-status-poll-interval'))}
+        statusPollInterval={
+          Number(appRoot.getAttribute('data-status-poll-interval-ms')) || undefined
+        }
         method={isAsyncForm ? 'PUT' : 'POST'}
         csrf={getMetaContent('csrf-token')}
         isMockClient={isMockClient}

--- a/app/javascript/packs/document-capture.jsx
+++ b/app/javascript/packs/document-capture.jsx
@@ -86,6 +86,7 @@ loadPolyfills(['fetch', 'crypto']).then(async () => {
       <UploadContextProvider
         endpoint={appRoot.getAttribute('data-endpoint')}
         statusEndpoint={appRoot.getAttribute('data-status-endpoint')}
+        statusPollInterval={Number(appRoot.getAttribute('data-status-poll-interval'))}
         method={isAsyncForm ? 'PUT' : 'POST'}
         csrf={getMetaContent('csrf-token')}
         isMockClient={isMockClient}

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -13,7 +13,7 @@
   status_endpoint: FeatureManagement.document_capture_async_uploads_enabled? ?
     idv_doc_auth_step_path(step: :verify_document_status) :
     nil,
-  status_poll_interval: Figaro.env.poll_rate_for_verify_in_seconds.to_i * 1000,
+  status_poll_interval_ms: Figaro.env.poll_rate_for_verify_in_seconds.to_i * 1000,
   sp_name: sp_name,
   failure_to_proof_url: failure_to_proof_url,
   front_image_upload_url: front_image_upload_url,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -13,6 +13,7 @@
   status_endpoint: FeatureManagement.document_capture_async_uploads_enabled? ?
     idv_doc_auth_step_path(step: :verify_document_status) :
     nil,
+  status_poll_interval: Figaro.env.poll_rate_for_verify_in_seconds.to_i * 1000,
   sp_name: sp_name,
   failure_to_proof_url: failure_to_proof_url,
   front_image_upload_url: front_image_upload_url,

--- a/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/document-capture-spec.jsx
@@ -331,6 +331,7 @@ describe('document-capture/components/document-capture', () => {
       <UploadContextProvider
         endpoint="about:blank#upload"
         statusEndpoint="about:blank#status"
+        statusPollInterval={0}
         backgroundUploadURLs={{
           front: 'about:blank#front',
           back: 'about:blank#back',

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -11,12 +11,16 @@ import { render, useDocumentCaptureForm } from '../../../support/document-captur
 describe('document-capture/components/submission-complete-step', () => {
   const onSubmit = useDocumentCaptureForm();
 
-  let response = { success: true };
+  let response;
 
   function TestComponent() {
     const resource = useAsync(() => Promise.resolve(response));
     return <SubmissionComplete resource={resource} />;
   }
+
+  beforeEach(() => {
+    response = { success: true };
+  });
 
   it('renders fallback while loading', () => {
     const { getByText } = render(

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { waitFor } from '@testing-library/dom';
 import useAsync from '@18f/identity-document-capture/hooks/use-async';
+import { UploadContextProvider } from '@18f/identity-document-capture';
 import SubmissionComplete, {
   RetrySubmissionError,
 } from '@18f/identity-document-capture/components/submission-complete';
@@ -42,20 +43,41 @@ describe('document-capture/components/submission-complete-step', () => {
     await waitFor(() => expect(onSubmit.calledOnce).to.be.true());
   });
 
-  it('retries on pending success', async () => {
+  it('retries on pending success as configured by upload context poll interval', async () => {
     const onError = sinon.spy();
     response = { success: true, isPending: true };
 
-    render(
-      <SuspenseErrorBoundary fallback={null} onError={onError}>
-        <TestComponent />
-      </SuspenseErrorBoundary>,
+    const { findByText } = render(
+      <UploadContextProvider statusPollInterval={0}>
+        <SuspenseErrorBoundary fallback={null} onError={onError}>
+          <TestComponent />
+        </SuspenseErrorBoundary>
+      </UploadContextProvider>,
     );
 
     expect(onError.called).to.be.false();
-    await waitFor(() => expect(onError.calledOnce).to.be.true());
+    await findByText('doc_auth.headings.interstitial');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onError.calledOnce).to.be.true();
     expect(onError.getCall(0).args[0]).to.be.instanceOf(RetrySubmissionError);
     expect(console).to.have.loggedError(/^Error: Uncaught/);
     expect(console).to.have.loggedError(/React will try to recreate this component/);
+  });
+
+  it('does not retry on pending success if poll interval is not configured', async () => {
+    const onError = sinon.spy();
+
+    const { findByText } = render(
+      <UploadContextProvider>
+        <SuspenseErrorBoundary fallback={null} onError={onError}>
+          <TestComponent />
+        </SuspenseErrorBoundary>
+      </UploadContextProvider>,
+    );
+
+    expect(onError.called).to.be.false();
+    await findByText('doc_auth.headings.interstitial');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onError.called).to.be.false();
   });
 });

--- a/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
+++ b/spec/javascripts/packages/document-capture/components/submission-complete-spec.jsx
@@ -7,11 +7,9 @@ import SubmissionComplete, {
 } from '@18f/identity-document-capture/components/submission-complete';
 import SuspenseErrorBoundary from '@18f/identity-document-capture/components/suspense-error-boundary';
 import { render, useDocumentCaptureForm } from '../../../support/document-capture';
-import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/components/submission-complete-step', () => {
   const onSubmit = useDocumentCaptureForm();
-  const sandbox = useSandbox();
 
   let response = { success: true };
 
@@ -42,8 +40,6 @@ describe('document-capture/components/submission-complete-step', () => {
 
   it('retries on pending success', async () => {
     const onError = sinon.spy();
-    sandbox.spy(window, 'setTimeout');
-
     response = { success: true, isPending: true };
 
     render(

--- a/spec/javascripts/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/context/upload-spec.jsx
@@ -4,23 +4,29 @@ import UploadContext, {
   Provider as UploadContextProvider,
 } from '@18f/identity-document-capture/context/upload';
 import defaultUpload from '@18f/identity-document-capture/services/upload';
+import { useSandbox } from '../../../support/sinon';
 
 describe('document-capture/context/upload', () => {
-  it('defaults to the default upload service', () => {
+  const sandbox = useSandbox();
+
+  it('defaults to the default upload service', async () => {
     const { result } = renderHook(() => useContext(UploadContext));
 
     expect(result.current).to.have.keys([
       'upload',
       'isMockClient',
+      'statusPollInterval',
       'getStatus',
       'backgroundUploadURLs',
       'backgroundUploadEncryptKey',
     ]);
     expect(result.current.upload).to.equal(defaultUpload);
     expect(result.current.getStatus).to.be.instanceOf(Function);
+    expect(result.current.statusPollInterval).to.be.undefined();
     expect(result.current.isMockClient).to.be.false();
     expect(result.current.backgroundUploadURLs).to.deep.equal({});
     expect(result.current.backgroundUploadEncryptKey).to.be.undefined();
+    await new Promise((resolve) => result.current.getStatus().catch(resolve));
   });
 
   it('can be overridden with custom upload behavior', async () => {
@@ -46,6 +52,24 @@ describe('document-capture/context/upload', () => {
     });
 
     expect(result.current.isMockClient).to.be.true();
+  });
+
+  it('can be overridden with status endpoint', async () => {
+    const { result } = renderHook(() => useContext(UploadContext), {
+      wrapper: ({ children }) => (
+        <UploadContextProvider statusEndpoint="about:blank" statusPollInterval={1000}>
+          {children}
+        </UploadContextProvider>
+      ),
+    });
+
+    sandbox
+      .stub(window, 'fetch')
+      .withArgs('about:blank')
+      .resolves({ ok: true, json: () => Promise.resolve({ success: true }) });
+
+    await result.current.getStatus();
+    expect(result.current.statusPollInterval).to.equal(1000);
   });
 
   it('can be overridden with background upload URLs', () => {

--- a/spec/javascripts/support/document-capture.jsx
+++ b/spec/javascripts/support/document-capture.jsx
@@ -45,7 +45,7 @@ export function render(element, options = {}) {
   return baseRender(element, {
     ...baseRenderOptions,
     wrapper: ({ children }) => (
-      <UploadContextProvider upload={upload} isMockClient={isMockClient}>
+      <UploadContextProvider upload={upload} isMockClient={isMockClient} statusPollInterval={0}>
         {baseWrapper({ children })}
       </UploadContextProvider>
     ),

--- a/spec/javascripts/support/document-capture.jsx
+++ b/spec/javascripts/support/document-capture.jsx
@@ -45,7 +45,7 @@ export function render(element, options = {}) {
   return baseRender(element, {
     ...baseRenderOptions,
     wrapper: ({ children }) => (
-      <UploadContextProvider upload={upload} isMockClient={isMockClient} statusPollInterval={0}>
+      <UploadContextProvider upload={upload} isMockClient={isMockClient}>
         {baseWrapper({ children })}
       </UploadContextProvider>
     ),


### PR DESCRIPTION
**Why**: In order to have better control over scaling in response to server load for document capture async upload status requests, the interval at which status polling occurs should be configurable in application.yml.