### PR TITLE
Update identity-idp-functions (LG-3683)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: d192473f2221e13c380bfb1403edc91913494279
-  ref: d192473f2221e13c380bfb1403edc91913494279
+  revision: 8b6b21b84e67327ebe77776d4d424b357e956f76
+  ref: 8b6b21b84e67327ebe77776d4d424b357e956f76
   specs:
-    identity-idp-functions (0.5.1)
+    identity-idp-functions (0.5.2)
       aws-sdk-s3 (>= 1.73)
       aws-sdk-ssm (>= 1.55)
       retries (>= 0.0.5)

--- a/app/services/lambda_jobs/git_ref.rb
+++ b/app/services/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = 'd192473f2221e13c380bfb1403edc91913494279'
+  GIT_REF = '8b6b21b84e67327ebe77776d4d424b357e956f76'
 end


### PR DESCRIPTION
Updates to use lambda version that errors if it is misconfigured (https://github.com/18F/identity-idp-functions/pull/29)