### PR TITLE
Upload document capture images to S3 as PUT request

### DIFF
--- a/app/controllers/test/fake_s3_controller.rb
+++ b/app/controllers/test/fake_s3_controller.rb
@@ -20,7 +20,7 @@ module Test
       end
     end
 
-    def create
+    def update
       key = params[:key]
 
       self.class.data[key] = request.body.read

--- a/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
+++ b/app/javascript/packages/document-capture/higher-order/with-background-encrypted-upload.jsx
@@ -63,7 +63,7 @@ const withBackgroundEncryptedUpload = (Component) => ({ onChange, ...props }) =>
         )
           .then((encryptedValue) =>
             window.fetch(url, {
-              method: 'POST',
+              method: 'PUT',
               body: encryptedValue,
               headers: { 'Content-Type': 'application/octet-stream' },
             }),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
         delete '/telephony' => 'telephony#destroy'
 
         get '/s3/:key' => 'fake_s3#show', as: :fake_s3
-        post '/s3/:key' => 'fake_s3#create'
+        put '/s3/:key' => 'fake_s3#update'
       end
     end
 

--- a/spec/controllers/fake_s3_controller_spec.rb
+++ b/spec/controllers/fake_s3_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Test::FakeS3Controller do
     end
   end
 
-  describe '#create' do
+  describe '#update' do
     subject(:action) do
-      post :create, body: data, params: { key: key }
+      post :update, body: data, params: { key: key }
     end
 
     it 'stores the data in memory' do

--- a/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
+++ b/spec/javascripts/packages/document-capture/higher-order/with-background-encrypted-upload-spec.jsx
@@ -137,7 +137,7 @@ describe('document-capture/higher-order/with-background-encrypted-upload', () =>
       expect(await patch.foo_image_url).to.equal('about:blank');
       const [url, params] = window.fetch.getCall(0).args;
       expect(url).to.equal('about:blank');
-      expect(params.method).to.equal('POST');
+      expect(params.method).to.equal('PUT');
       expect(params.body).to.be.instanceOf(ArrayBuffer);
       const bodyAsString = String.fromCharCode.apply(null, new Uint8Array(params.body));
       expect(bodyAsString).to.not.equal('bar');


### PR DESCRIPTION
**Why**: Corrresponding to how the presigned URLs are configured, since it's expected that the user could need to change (replace) their selected image.

See: https://github.com/18F/identity-idp/blob/e1e8983/app/helpers/aws_s3_helper.rb#L8
Discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1605187899258500?thread_ts=1605046986.258200&cid=CNCGEHG1G