### PR TITLE
Update async poll verification interval from 10s to 3s

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -107,7 +107,7 @@ pinpoint_sms_shortcode:
 pinpoint_voice_credential_role_arn:
 pinpoint_voice_longcode_pool:
 pinpoint_voice_region:
-poll_rate_for_verify_in_seconds: '10'
+poll_rate_for_verify_in_seconds: '3'
 proofer_mock_fallback: 'true'
 push_notifications_enabled:
 reauthn_window: '120'


### PR DESCRIPTION
**Why**: Per feedback in acceptance for configurable document capture status polling.