### PR TITLE
Include app_id as UUID prefix when calling LexisNexis instant verify(LG-3652)

### DIFF
--- a/app/controllers/idv/usps_controller.rb
+++ b/app/controllers/idv/usps_controller.rb
@@ -74,6 +74,8 @@ module Idv
       %w[first_name middle_name last_name dob phone ssn].each do |key|
         hash[key] = pii_h[key]
       end
+
+      hash[:uuid_prefix] = ServiceProvider.from_issuer(sp_session[:issuer]).app_id
     end
 
     def pii_to_h

--- a/app/services/idv/steps/cac/verify_step.rb
+++ b/app/services/idv/steps/cac/verify_step.rb
@@ -11,6 +11,7 @@ module Idv
         def enqueue_job
           return if flow_session[cac_verify_document_capture_session_uuid_key]
           pii_from_doc = flow_session[:pii_from_doc]
+          pii_from_doc[:uuid_prefix] = ServiceProvider.from_issuer(sp_session[:issuer]).app_id
 
           document_capture_session = create_document_capture_session(
             cac_verify_document_capture_session_uuid_key,

--- a/app/services/idv/steps/recover_verify_step.rb
+++ b/app/services/idv/steps/recover_verify_step.rb
@@ -11,6 +11,7 @@ module Idv
         return if flow_session[recover_verify_document_capture_session_uuid_key]
 
         pii_from_doc = flow_session[:pii_from_doc]
+        pii_from_doc[:uuid_prefix] = ServiceProvider.from_issuer(sp_session[:issuer]).app_id
 
         document_capture_session = create_document_capture_session(
           recover_verify_document_capture_session_uuid_key,

--- a/app/services/idv/steps/verify_base_step.rb
+++ b/app/services/idv/steps/verify_base_step.rb
@@ -43,12 +43,6 @@ module Idv
         idv_session['resolution_successful'] = 'phone'
       end
 
-      def perform_resolution(pii_from_doc)
-        Idv::Agent.new(pii_from_doc).proof_resolution(
-          should_proof_state_id: should_use_aamva?(pii_from_doc),
-        )
-      end
-
       def idv_result_to_form_response(idv_result)
         FormResponse.new(
           success: idv_success(idv_result),

--- a/app/services/idv/steps/verify_step.rb
+++ b/app/services/idv/steps/verify_step.rb
@@ -11,6 +11,7 @@ module Idv
         return if flow_session[verify_step_document_capture_session_uuid_key]
 
         pii_from_doc = flow_session[:pii_from_doc]
+        pii_from_doc[:uuid_prefix] = ServiceProvider.from_issuer(sp_session[:issuer]).app_id
 
         document_capture_session = create_document_capture_session(
           verify_step_document_capture_session_uuid_key,

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Idv::Steps::VerifyStep do
+  let(:user) { build(:user) }
+  let(:service_provider) do
+    create(:service_provider,
+           issuer: 'http://sp.example.com',
+           app_id: '123')
+  end
+
+  describe '#call' do
+    it 'sets uuid_prefix on pii_from_doc' do
+      controller = instance_double('controller',
+                                   session: { sp: { issuer: service_provider.issuer } },
+                                   current_user: user)
+      flow = Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth')
+      flow.flow_session = { pii_from_doc: {} }
+      step = Idv::Steps::VerifyStep.new(flow)
+      step.call
+
+      expect(flow.flow_session[:pii_from_doc][:uuid_prefix]).to eq service_provider.app_id
+    end
+  end
+end

--- a/spec/services/idv/steps/verify_step_spec.rb
+++ b/spec/services/idv/steps/verify_step_spec.rb
@@ -13,6 +13,10 @@ describe Idv::Steps::VerifyStep do
       controller = instance_double('controller',
                                    session: { sp: { issuer: service_provider.issuer } },
                                    current_user: user)
+
+      expect(Idv::Agent).to receive(:new).
+        with(hash_including(uuid_prefix: service_provider.app_id)).and_call_original
+
       flow = Idv::Flows::DocAuthFlow.new(controller, {}, 'idv/doc_auth')
       flow.flow_session = { pii_from_doc: {} }
       step = Idv::Steps::VerifyStep.new(flow)


### PR DESCRIPTION
Follow up to #4087 

Adds uuid_prefix from `sp_session` when calling the resolution proofer (LN InstantVerify)