### PR TITLE
Add feature test for JS-enabled document capture async upload

### DIFF
--- a/app/jobs/vendor_document_verification_job.rb
+++ b/app/jobs/vendor_document_verification_job.rb
@@ -1,14 +1,16 @@
 class VendorDocumentVerificationJob
-  def self.perform(_document_capture_session_result_id:,
-                   _encryption_key:,
-                   _front_image_iv:,
-                   _back_image_iv:,
-                   _selfie_image_iv:,
-                   _front_image_url:,
-                   _back_image_url:,
-                   _selfie_image_url:,
-                   _liveness_checking_enabled:)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def self.perform(document_capture_session_result_id:,
+                   encryption_key:,
+                   front_image_iv:,
+                   back_image_iv:,
+                   selfie_image_iv:,
+                   front_image_url:,
+                   back_image_url:,
+                   selfie_image_url:,
+                   liveness_checking_enabled:)
 
     FormResponse.new(success: true, errors: {})
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/app/services/idv/actions/verify_document_action.rb
+++ b/app/services/idv/actions/verify_document_action.rb
@@ -36,15 +36,15 @@ module Idv
         document_capture_session.store_proofing_pii_from_doc({})
 
         VendorDocumentVerificationJob.perform(
-          _document_capture_session_result_id: document_capture_session.result_id,
-          _encryption_key: params[:encryption_key],
-          _front_image_iv: params[:front_image_iv],
-          _back_image_iv: params[:back_image_iv],
-          _selfie_image_iv: params[:selfie_image_iv],
-          _front_image_url: params[:front_image_url],
-          _back_image_url: params[:back_image_url],
-          _selfie_image_url: params[:selfie_image_url],
-          _liveness_checking_enabled: params[:liveness_checking_enabled],
+          document_capture_session_result_id: document_capture_session.result_id,
+          encryption_key: params[:encryption_key],
+          front_image_iv: params[:front_image_iv],
+          back_image_iv: params[:back_image_iv],
+          selfie_image_iv: params[:selfie_image_iv],
+          front_image_url: params[:front_image_url],
+          back_image_url: params[:back_image_url],
+          selfie_image_url: params[:selfie_image_url],
+          liveness_checking_enabled: params[:liveness_checking_enabled],
         )
       end
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -438,6 +438,7 @@ test:
   piv_cac_service_url: https://localhost:8443/
   piv_cac_verify_token_secret: 3ac13bfa23e22adae321194c083e783faf89469f6f85dcc0802b27475c94b5c3891b5657bd87d0c1ad65de459166440512f2311018db90d57b15d8ab6660748f
   piv_cac_verify_token_url: https://localhost:8443/
+  poll_rate_for_verify_in_seconds: '1'
   rack_mini_profiler:
   recurring_jobs_disabled_names: '["disabled job"]'
   redis_throttle_url: redis://localhost:6379/1

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -237,20 +237,7 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
-    let(:good_result) do
-      { pii_from_doc: {
-        first_name: Faker::Name.first_name,
-        last_name: Faker::Name.last_name,
-        dob: Time.zone.today.to_s,
-        address1: Faker::Address.street_address,
-        city: Faker::Address.city,
-        state: Faker::Address.state_abbr,
-        zipcode: Faker::Address.zip_code,
-        state_id_type: 'drivers_license',
-        state_id_number: '111',
-        state_id_jurisdiction: 'WI',
-      }, success: true, errors: {}, messages: ['message'] }
-    end
+    let(:good_result) { nil }
     let(:bad_pii_result) do
       { pii_from_doc: {
         first_name: Faker::Name.first_name,
@@ -326,15 +313,6 @@ describe Idv::DocAuthController do
 
   def mock_next_step(step)
     allow_any_instance_of(Idv::Flows::DocAuthFlow).to receive(:next_step).and_return(step)
-  end
-
-  def mock_document_capture_result(idv_result)
-    id = SecureRandom.uuid
-    pii = { 'first_name' => 'Testy', 'last_name' => 'Testerson' }
-
-    result = ProofingDocumentCaptureSessionResult.new(id: id, pii: pii, result: idv_result)
-    allow_any_instance_of(DocumentCaptureSession).to receive(:load_proofing_result).
-      and_return(result)
   end
 
   def mock_document_capture_step

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -237,7 +237,20 @@ describe Idv::DocAuthController do
     before do
       mock_document_capture_step
     end
-    let(:good_result) { nil }
+    let(:good_result) do
+      { pii_from_doc: {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        dob: Time.zone.today.to_s,
+        address1: Faker::Address.street_address,
+        city: Faker::Address.city,
+        state: Faker::Address.state_abbr,
+        zipcode: Faker::Address.zip_code,
+        state_id_type: 'drivers_license',
+        state_id_number: '111',
+        state_id_jurisdiction: 'WI',
+      }, success: true, errors: {}, messages: ['message'] }
+    end
     let(:bad_pii_result) do
       { pii_from_doc: {
         first_name: Faker::Name.first_name,

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -330,7 +330,18 @@ feature 'doc auth document capture step' do
       end
 
       it 'proceeds to the next page with valid info' do
-        mock_document_capture_result
+        mock_document_capture_result pii_from_doc: {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          dob: Time.zone.today.to_s,
+          address1: Faker::Address.street_address,
+          city: Faker::Address.city,
+          state: Faker::Address.state_abbr,
+          zipcode: Faker::Address.zip_code,
+          state_id_type: 'drivers_license',
+          state_id_number: '111',
+          state_id_jurisdiction: 'WI',
+        }, success: true, errors: {}, messages: ['message']
         attach_images(liveness_enabled: false)
         form = page.find('#document-capture-form')
         front_url = form['data-front-image-upload-url']

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -9,11 +9,17 @@ feature 'doc auth document capture step' do
   let(:user) { user_with_2fa }
   let(:liveness_enabled) { 'false' }
   let(:fake_analytics) { FakeAnalytics.new }
+  let(:document_capture_async_uploads_enabled) { false }
+  let(:doc_auth_enable_presigned_s3_urls) { false }
   before do
     allow(Figaro.env).to receive(:document_capture_step_enabled).
       and_return(document_capture_step_enabled)
     allow(Figaro.env).to receive(:liveness_checking_enabled).
       and_return(liveness_enabled)
+    allow(FeatureManagement).to receive(:doc_auth_enable_presigned_s3_urls).
+      and_return(doc_auth_enable_presigned_s3_urls)
+    allow(FeatureManagement).to receive(:document_capture_async_uploads_enabled).
+      and_return(document_capture_async_uploads_enabled)
     allow(LoginGov::Hostdata::EC2).to receive(:load).
       and_return(OpenStruct.new(region: 'us-west-2', account_id: '123456789'))
     sign_in_and_2fa_user(user)
@@ -312,6 +318,19 @@ feature 'doc auth document capture step' do
         click_idv_continue
 
         expect(page).to have_current_path(next_step)
+      end
+    end
+
+    context 'when using async uploads', :js do
+      let(:document_capture_async_uploads_enabled) { true }
+      let(:doc_auth_enable_presigned_s3_urls) { true }
+
+      it 'proceeds to the next page with valid info' do
+        mock_document_capture_result
+        attach_images(liveness_enabled: false)
+        click_on 'Submit'
+
+        expect(page).to have_current_path(next_step, wait: 20)
       end
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -343,13 +343,13 @@ feature 'doc auth document capture step' do
 
           decipher = OpenSSL::Cipher.new('aes-256-gcm')
           decipher.decrypt
-          decipher.key = Base64.decode64(params[:_encryption_key])
+          decipher.key = Base64.decode64(params[:encryption_key])
 
           Capybara.current_driver = :rack_test # ChromeDriver doesn't support `page.status_code`
 
           page.driver.get front_url
           expect(page).to have_http_status(200)
-          decipher.iv = Base64.decode64(params[:_front_image_iv])
+          decipher.iv = Base64.decode64(params[:front_image_iv])
           decipher.auth_tag = page.body[-16..-1]
           decipher.auth_data = ''
           front_plain = decipher.update(page.body[0..-17]) + decipher.final
@@ -357,7 +357,7 @@ feature 'doc auth document capture step' do
 
           page.driver.get back_url
           expect(page).to have_http_status(200)
-          decipher.iv = Base64.decode64(params[:_back_image_iv])
+          decipher.iv = Base64.decode64(params[:back_image_iv])
           decipher.auth_tag = page.body[-16..-1]
           decipher.auth_data = ''
           back_plain = decipher.update(page.body[0..-17]) + decipher.final

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -328,9 +328,17 @@ feature 'doc auth document capture step' do
       it 'proceeds to the next page with valid info' do
         mock_document_capture_result
         attach_images(liveness_enabled: false)
+        form = page.find('#document-capture-form')
+        front_url = form['data-front-image-upload-url']
+        back_url = form['data-back-image-upload-url']
         click_on 'Submit'
 
         expect(page).to have_current_path(next_step, wait: 20)
+        Capybara.current_driver = :rack_test # ChromeDriver doesn't support `page.status_code`
+        visit front_url
+        expect(page).to have_http_status(200)
+        visit back_url
+        expect(page).to have_http_status(200)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,9 @@ RSpec.configure do |config|
   config.before(:each, js: true) do
     allow(Figaro.env).to receive(:domain_name).and_return('127.0.0.1')
     server = Capybara.current_session.server
-    Rails.application.routes.default_url_options[:host] = "#{server.host}:#{server.port}"
+    allow(Rails.application.routes).to receive(:default_url_options).and_return(
+      Rails.application.routes.default_url_options.merge(host: "#{server.host}:#{server.port}"),
+    )
   end
 
   config.before(:each, type: :controller) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |config|
 
   config.before(:each, js: true) do
     allow(Figaro.env).to receive(:domain_name).and_return('127.0.0.1')
+    server = Capybara.current_session.server
+    Rails.application.routes.default_url_options[:host] = "#{server.host}:#{server.port}"
   end
 
   config.before(:each, type: :controller) do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -223,21 +223,9 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     )
   end
 
-  def mock_document_capture_result(idv_result = nil)
+  def mock_document_capture_result(idv_result)
     id = SecureRandom.uuid
     pii = { 'first_name' => 'Testy', 'last_name' => 'Testerson' }
-    idv_result ||= { pii_from_doc: {
-      first_name: Faker::Name.first_name,
-      last_name: Faker::Name.last_name,
-      dob: Time.zone.today.to_s,
-      address1: Faker::Address.street_address,
-      city: Faker::Address.city,
-      state: Faker::Address.state_abbr,
-      zipcode: Faker::Address.zip_code,
-      state_id_type: 'drivers_license',
-      state_id_number: '111',
-      state_id_jurisdiction: 'WI',
-    }, success: true, errors: {}, messages: ['message'] }
 
     result = ProofingDocumentCaptureSessionResult.new(id: id, pii: pii, result: idv_result)
     allow_any_instance_of(DocumentCaptureSession).to receive(:load_proofing_result).

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -223,10 +223,37 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     )
   end
 
+  def mock_document_capture_result(idv_result = nil)
+    id = SecureRandom.uuid
+    pii = { 'first_name' => 'Testy', 'last_name' => 'Testerson' }
+    idv_result ||= { pii_from_doc: {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      dob: Time.zone.today.to_s,
+      address1: Faker::Address.street_address,
+      city: Faker::Address.city,
+      state: Faker::Address.state_abbr,
+      zipcode: Faker::Address.zip_code,
+      state_id_type: 'drivers_license',
+      state_id_number: '111',
+      state_id_jurisdiction: 'WI',
+    }, success: true, errors: {}, messages: ['message'] }
+
+    result = ProofingDocumentCaptureSessionResult.new(id: id, pii: pii, result: idv_result)
+    allow_any_instance_of(DocumentCaptureSession).to receive(:load_proofing_result).
+      and_return(result)
+  end
+
   def attach_images(liveness_enabled: true)
-    attach_file 'doc_auth_front_image', 'app/assets/images/logo.png'
-    attach_file 'doc_auth_back_image', 'app/assets/images/logo.png'
-    attach_file 'doc_auth_selfie_image', 'app/assets/images/logo.png' if liveness_enabled
+    if Capybara.current_driver == Capybara.javascript_driver
+      attach_file 'Front of your ID', 'app/assets/images/logo.png'
+      attach_file 'Back of your ID', 'app/assets/images/logo.png'
+      raise ArgumentError, 'liveness not currently supported in JS tests' if liveness_enabled
+    else
+      attach_file 'doc_auth_front_image', 'app/assets/images/logo.png'
+      attach_file 'doc_auth_back_image', 'app/assets/images/logo.png'
+      attach_file 'doc_auth_selfie_image', 'app/assets/images/logo.png' if liveness_enabled
+    end
   end
 
   def attach_front_image_data_url


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4401#issuecomment-726858602

**Why**: So we have some integration tests running through document capture in a real headless browser.

**Implementation Notes:**

The biggest hurdle here was overcoming "Failed to fetch" errors in the browser, related to the fact that without the changes here, the presigned URLs were [generated](https://github.com/18F/identity-idp/blob/11b601f07b0936febf59a915e9efd8af097b449d/app/services/image_upload_presigned_url_generator.rb#L10) with a host of `example.com`, which `window.fetch` would not connect with, since the test runs on localhost with a randomly-generated port. There may have been many alternative approaches here (e.g. avoiding `example.com` and instead setting a fixed host/port for tests), but in this case I addressed it by overriding the default URL options for the URL helper in tests using the JavaScript test driver.