### PR TITLE
LG-3697: Allow S3 presigned upload URLs through CSP connect-src

### DIFF
--- a/app/services/image_upload_presigned_url_generator.rb
+++ b/app/services/image_upload_presigned_url_generator.rb
@@ -17,7 +17,7 @@ class ImageUploadPresignedUrlGenerator
   end
 
   def bucket_url
-    s3_resource.bucket(bucket(prefix: bucket_prefix))&.url
+    s3_resource&.bucket(bucket(prefix: bucket_prefix))&.url
   end
 
   def bucket_prefix

--- a/app/services/image_upload_presigned_url_generator.rb
+++ b/app/services/image_upload_presigned_url_generator.rb
@@ -16,6 +16,10 @@ class ImageUploadPresignedUrlGenerator
     end
   end
 
+  def bucket
+    super(prefix: bucket_prefix)
+  end
+
   def bucket_prefix
     'login-gov-idp-doc-capture'.freeze
   end

--- a/app/services/image_upload_presigned_url_generator.rb
+++ b/app/services/image_upload_presigned_url_generator.rb
@@ -16,8 +16,8 @@ class ImageUploadPresignedUrlGenerator
     end
   end
 
-  def bucket
-    super(prefix: bucket_prefix)
+  def bucket_url
+    s3_resource.bucket(bucket(prefix: bucket_prefix))&.url
   end
 
   def bucket_prefix

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,7 +10,7 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
-  connect_src << "#{image_upload_bucket_url.gsub(/\/$/, '')}/*" if image_upload_bucket_url
+  connect_src << "#{image_upload_bucket_url.chomp('/')}/*" if image_upload_bucket_url
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,6 +9,10 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
+  if LoginGov::Hostdata.in_datacenter? && Figaro.env.aws_region
+    image_upload_bucket = ImageUploadPresignedUrlGenerator.new.bucket
+    connect_src << "https://s3.#{Figaro.env.aws_region}.amazonaws.com/#{image_upload_bucket}/*"
+  end
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,8 +10,8 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
   if LoginGov::Hostdata.in_datacenter? && Figaro.env.aws_region
-    image_upload_bucket = ImageUploadPresignedUrlGenerator.new.bucket
-    connect_src << "https://s3.#{Figaro.env.aws_region}.amazonaws.com/#{image_upload_bucket}/*"
+    image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
+    connect_src << "#{image_upload_bucket_url.gsub(/\/$/, '')}/*"
   end
   default_csp_config = {
     default_src: ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,10 +9,8 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
-  if LoginGov::Hostdata.in_datacenter? && Figaro.env.aws_region
-    image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
-    connect_src << "#{image_upload_bucket_url.gsub(/\/$/, '')}/*"
-  end
+  image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
+  connect_src << "#{image_upload_bucket_url.gsub(/\/$/, '')}/*" if image_upload_bucket_url
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src

--- a/spec/services/image_upload_presigned_url_generator_spec.rb
+++ b/spec/services/image_upload_presigned_url_generator_spec.rb
@@ -59,16 +59,21 @@ RSpec.describe ImageUploadPresignedUrlGenerator do
     end
   end
 
-  describe '#bucket' do
+  describe '#bucket_url' do
     before do
       allow(LoginGov::Hostdata).to receive(:env).and_return('test')
       allow(LoginGov::Hostdata::EC2).to receive(:load).and_return(
         OpenStruct.new(account_id: '123456789', region: 'us-west-2'),
       )
+      client_stub = Aws::S3::Client.new(region: 'us-west-2', stub_responses: true)
+      resource_stub = Aws::S3::Resource.new(client: client_stub)
+      allow(generator).to receive(:s3_resource).and_return(resource_stub)
     end
 
-    it 'is S3 bucket name' do
-      expect(generator.bucket).to eq('login-gov-idp-doc-capture-test.123456789-us-west-2')
+    it 'is S3 bucket url' do
+      expect(generator.bucket_url).to eq(
+        'https://s3.us-west-2.amazonaws.com/login-gov-idp-doc-capture-test.123456789-us-west-2',
+      )
     end
   end
 end

--- a/spec/services/image_upload_presigned_url_generator_spec.rb
+++ b/spec/services/image_upload_presigned_url_generator_spec.rb
@@ -58,4 +58,17 @@ RSpec.describe ImageUploadPresignedUrlGenerator do
       end
     end
   end
+
+  describe '#bucket' do
+    before do
+      allow(LoginGov::Hostdata).to receive(:env).and_return('test')
+      allow(LoginGov::Hostdata::EC2).to receive(:load).and_return(
+        OpenStruct.new(account_id: '123456789', region: 'us-west-2'),
+      )
+    end
+
+    it 'is S3 bucket name' do
+      expect(generator.bucket).to eq('login-gov-idp-doc-capture-test.123456789-us-west-2')
+    end
+  end
 end

--- a/spec/services/image_upload_presigned_url_generator_spec.rb
+++ b/spec/services/image_upload_presigned_url_generator_spec.rb
@@ -61,19 +61,37 @@ RSpec.describe ImageUploadPresignedUrlGenerator do
 
   describe '#bucket_url' do
     before do
-      allow(LoginGov::Hostdata).to receive(:env).and_return('test')
-      allow(LoginGov::Hostdata::EC2).to receive(:load).and_return(
-        OpenStruct.new(account_id: '123456789', region: 'us-west-2'),
-      )
-      client_stub = Aws::S3::Client.new(region: 'us-west-2', stub_responses: true)
-      resource_stub = Aws::S3::Resource.new(client: client_stub)
-      allow(generator).to receive(:s3_resource).and_return(resource_stub)
     end
 
-    it 'is S3 bucket url' do
-      expect(generator.bucket_url).to eq(
-        'https://s3.us-west-2.amazonaws.com/login-gov-idp-doc-capture-test.123456789-us-west-2',
-      )
+    context 'AWS credentials are not set' do
+      before do
+        allow(LoginGov::Hostdata::EC2).to receive(:load).
+          and_raise(Net::OpenTimeout)
+        allow(Aws::S3::Resource).to receive(:new).
+          and_raise(Aws::Sigv4::Errors::MissingCredentialsError, 'Credentials not set')
+      end
+
+      it 'returns nil' do
+        expect(generator.bucket_url).to be_nil
+      end
+    end
+
+    context 'AWS credentials are set' do
+      before do
+        allow(LoginGov::Hostdata).to receive(:env).and_return('test')
+        allow(LoginGov::Hostdata::EC2).to receive(:load).and_return(
+          OpenStruct.new(account_id: '123456789', region: 'us-west-2'),
+        )
+        client_stub = Aws::S3::Client.new(region: 'us-west-2', stub_responses: true)
+        resource_stub = Aws::S3::Resource.new(client: client_stub)
+        allow(generator).to receive(:s3_resource).and_return(resource_stub)
+      end
+
+      it 'returns S3 bucket url' do
+        expect(generator.bucket_url).to eq(
+          'https://s3.us-west-2.amazonaws.com/login-gov-idp-doc-capture-test.123456789-us-west-2',
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
**Why**: As a user, I want to ensure my image upload works so that I can continue the process.

In order for images to be uploaded to S3 in async upload, we must allow fetch connections to connect to the S3 server. This is currently restricted by the IdP's content security policy.