### PR TITLE
Use app config to conditionally add S3 CSP connect-src

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,8 +9,10 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
-  image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
-  connect_src << "#{image_upload_bucket_url.chomp('/')}/*" if image_upload_bucket_url
+  if AppConfig.env.doc_auth_enable_presigned_s3_urls == 'true'
+    image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
+    connect_src << "#{image_upload_bucket_url.chomp('/')}/*" if image_upload_bucket_url
+  end
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src


### PR DESCRIPTION
Previously: #4409

**Why**: We should only want to include the directive URL pattern in environments where we're expecting to generate S3 URLs.

See: https://github.com/18F/identity-idp/blob/6c3157d3bc238070aea7fc2c1f9e0db6225c3480/app/services/image_upload_presigned_url_generator.rb#L7