### PR TITLE
Convert data request scripts into rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'xmlenc', '~> 0.7', '>= 0.7.1'
 gem 'zxcvbn-js'
 
 group :development do
+  gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'better_errors', '>= 2.5.1'
   gem 'binding_of_caller'
   gem 'brakeman', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ gem 'xmlenc', '~> 0.7', '>= 0.7.1'
 gem 'zxcvbn-js'
 
 group :development do
-  gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'better_errors', '>= 2.5.1'
   gem 'binding_of_caller'
   gem 'brakeman', require: false
@@ -88,6 +87,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'aws-sdk-cloudwatchlogs', require: false
   gem 'bootsnap', '~> 1.4.7', require: false
   gem 'bullet', '>= 6.0.2'
   gem 'i18n-tasks', '>= 0.9.31'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
     awrence (1.1.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.388.0)
+    aws-sdk-cloudwatchlogs (1.38.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.109.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -724,6 +727,7 @@ DEPENDENCIES
   aamva!
   ahoy_matey (~> 2.2, >= 2.2.1)
   american_date
+  aws-sdk-cloudwatchlogs
   aws-sdk-kms (~> 1.4)
   aws-sdk-lambda
   aws-sdk-ses (~> 1.6)

--- a/app/services/data_requests/create_email_addresses_report.rb
+++ b/app/services/data_requests/create_email_addresses_report.rb
@@ -1,0 +1,19 @@
+module DataRequests
+  class CreateEmailAddressesReport
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      user.email_addresses.map do |email_address|
+        {
+          email: email_address.email,
+          created_at: email_address.created_at,
+          confirmed_at: email_address.confirmed_at,
+        }
+      end
+    end
+  end
+end

--- a/app/services/data_requests/create_mfa_configurations_report.rb
+++ b/app/services/data_requests/create_mfa_configurations_report.rb
@@ -1,0 +1,67 @@
+module DataRequests
+  class CreateMfaConfigurationsReport
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      {
+        phone_configurations: phone_configurations_report,
+        auth_app_configurations: auth_app_configurations_report,
+        webauthn_configurations: webauthn_configurations_report,
+        piv_cac_configurations: piv_cac_configurations_report,
+        backup_code_configurations: backup_code_configurations_report,
+      }
+    end
+
+    private
+
+    def auth_app_configurations_report
+      user.auth_app_configurations.map do |auth_app_configuration|
+        {
+          name: auth_app_configuration.name,
+          created_at: auth_app_configuration.created_at,
+        }
+      end
+    end
+
+    def backup_code_configurations_report
+      user.backup_code_configurations.map do |backup_code_configuration|
+        {
+          created_at: backup_code_configuration.created_at,
+          used_at: backup_code_configuration.used_at,
+        }
+      end
+    end
+
+    def phone_configurations_report
+      user.phone_configurations.map do |phone_configuration|
+        {
+          phone: phone_configuration.phone,
+          created_at: phone_configuration.created_at,
+          confirmed_at: phone_configuration.confirmed_at,
+        }
+      end
+    end
+
+    def piv_cac_configurations_report
+      user.piv_cac_configurations.map do |piv_cac_configuration|
+        {
+          name: piv_cac_configuration.name,
+          created_at: piv_cac_configuration.created_at,
+        }
+      end
+    end
+
+    def webauthn_configurations_report
+      user.webauthn_configurations.map do |webauthn_configuration|
+        {
+          name: webauthn_configuration.name,
+          created_at: webauthn_configuration.created_at,
+        }
+      end
+    end
+  end
+end

--- a/app/services/data_requests/create_user_events_report.rb
+++ b/app/services/data_requests/create_user_events_report.rb
@@ -1,0 +1,22 @@
+module DataRequests
+  class CreateUserEventsReport
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      user.events.order(created_at: :asc).map do |event|
+        {
+          event_name: event.event_type,
+          date_time: event.created_at,
+          ip: event.ip,
+          disavowed_at: event.disavowed_at,
+          user_agent: event.device&.user_agent,
+          device_cookie: event.device&.cookie_uuid,
+        }
+      end
+    end
+  end
+end

--- a/app/services/data_requests/create_user_report.rb
+++ b/app/services/data_requests/create_user_report.rb
@@ -1,0 +1,41 @@
+module DataRequests
+  class CreateUserReport
+    attr_reader :user, :requesting_issuers
+
+    def initialize(user, requesting_issuers = nil)
+      @user = user
+      @requesting_issuers = requesting_issuers
+    end
+
+    def call
+      {
+        user_id: user.id,
+        login_uuid: user.uuid,
+        requesting_issuer_uuid: requesting_issuer_uuid,
+        email_addresses: email_addresses_report,
+        mfa_configurations: mfa_configurations_report,
+        user_events: user_events_report,
+      }
+    end
+
+    private
+
+    def email_addresses_report
+      CreateEmailAddressesReport.new(user).call
+    end
+
+    def mfa_configurations_report
+      CreateMfaConfigurationsReport.new(user).call
+    end
+
+    def requesting_issuer_uuid
+      return user.uuid if requesting_issuers.blank?
+      user.identities.where(service_provider: requesting_issuers).first&.uuid ||
+        "NonSPUser##{user.id}"
+    end
+
+    def user_events_report
+      CreateUserEventsReport.new(user).call
+    end
+  end
+end

--- a/app/services/data_requests/fetch_cloudwatch_logs.rb
+++ b/app/services/data_requests/fetch_cloudwatch_logs.rb
@@ -1,0 +1,79 @@
+require 'aws-sdk-cloudwatchlogs'
+
+module DataRequests
+  # This class depends on the AWS cloudwatch SDK gem. That gem is only available
+  # in development. The IDP role is not able to query cloudwatch logs. As a
+  # result this code can only run in dev with a role that can query cloudwatch
+  # logs
+  class FetchCloudwatchLogs
+    ResultRow = Struct.new(:timestamp, :message)
+
+    attr_reader :uuid, :dates
+
+    def initialize(uuid, dates)
+      @uuid = uuid
+      @dates = dates
+    end
+
+    def call
+      query_ids = start_queries
+      wait_for_query_results(query_ids).flatten.uniq.sort_by(&:timestamp)
+    end
+
+    private
+
+    def build_result_rows_from_aws_result(aws_results)
+      aws_results.map do |aws_result|
+        ResultRow.new(aws_result.first.value, aws_result.second.value)
+      end
+    end
+
+    def cloudwatch_client
+      @cloudwatch_client ||= Aws::CloudWatchLogs::Client.new
+    end
+
+    def query_string
+      <<~QUERY
+        fields @timestamp, @message
+        | filter @message like /#{uuid}/
+      QUERY
+    end
+
+    def start_queries
+      dates.map do |date|
+        warn "Downloading logs for #{date}"
+        query_start = (date - 12.hours).to_i
+        query_end = (date + 36.hours).to_i
+
+        cloudwatch_client.start_query(
+          log_group_name: 'prod_/srv/idp/shared/log/events.log',
+          start_time: query_start,
+          end_time: query_end,
+          query_string: query_string,
+        ).query_id
+      end
+    end
+
+    def wait_for_query_results(query_ids)
+      results = []
+
+      query_ids.map do |query_id|
+        Thread.new do
+          results.push(wait_for_query_result(query_id))
+        end
+      end.each(&:join)
+
+      results
+    end
+
+    def wait_for_query_result(query_id)
+      sleep 3
+      response = cloudwatch_client.get_query_results(query_id: query_id)
+      if response.status == 'Complete'
+        aws_results = response.results
+        return build_result_rows_from_aws_result(aws_results)
+      end
+      wait_for_query_result(query_id)
+    end
+  end
+end

--- a/app/services/data_requests/fetch_cloudwatch_logs.rb
+++ b/app/services/data_requests/fetch_cloudwatch_logs.rb
@@ -16,6 +16,8 @@ module DataRequests
     end
 
     def call
+      raise "Only run #{self.class.name} locally" if LoginGov::Hostdata.in_datacenter?
+
       query_ids = start_queries
       wait_for_query_results(query_ids).flatten.uniq.sort_by(&:timestamp)
     end

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -1,0 +1,71 @@
+module DataRequests
+  ##
+  # This class recursively looks up networks of users who are sharing devices.
+  # It does this by first looking up the devices for a set of users.
+  # Then it looks at all of the users who have signed in from those devices.
+  # If a user who has not had their devices looked up is present, it looks up
+  # the devices for that user.
+  # This process is done recuresively until all devices and users within a
+  # network are found.
+  #
+  class LookupSharedDeviceUsers
+    attr_reader :initial_users
+
+    def initialize(initial_users)
+      @initial_users = initial_users
+    end
+
+    def call
+      lookup_users(initial_users)
+      user_uuids_by_device
+    end
+
+    private
+
+    def lookup_device(device)
+      cookie_uuid = device.cookie_uuid
+      return if user_uuids_by_device.keys.include?(cookie_uuid)
+
+      warn "Searching for new devices matching #{cookie_uuid}"
+      matching_device_records = Device.includes(:user).where(cookie_uuid: cookie_uuid).all
+      user_uuids_by_device[cookie_uuid] = matching_device_records.map(&:user).compact.map(&:uuid)
+    end
+
+    def lookup_users(users)
+      users.each do |user|
+        lookup_user(user)
+      end
+      return if user_uuids_to_lookup.empty?
+      lookup_users(users_to_lookup)
+    end
+
+    def lookup_user(user)
+      warn "Looking up devices for user: #{user.uuid}"
+      devices = user.devices
+      devices.each { |device| lookup_device(device) }
+      looked_up_user_uuids.add(user.uuid)
+    end
+
+    def looked_up_user_uuids
+      @looked_up_users ||= Set.new
+    end
+
+    def users_to_lookup
+      user_uuids_to_lookup.map do |uuid|
+        User.find_by(uuid: uuid)
+      end
+    end
+
+    ##
+    # A hash where the key is a cookie UUID and the values are the UUIDs for the
+    # users associated with that device
+    #
+    def user_uuids_by_device
+      @user_uuids_by_device ||= {}
+    end
+
+    def user_uuids_to_lookup
+      Set.new(user_uuids_by_device.values.flatten) - looked_up_user_uuids
+    end
+  end
+end

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -27,7 +27,7 @@ module DataRequests
       return if user_uuids_by_device.keys.include?(cookie_uuid)
 
       warn "Searching for new devices matching #{cookie_uuid}"
-      user_uuids = Device.joins(:user).where(cookie_uuid: cookie_uuid).pluck(:uuid)
+      user_uuids = User.joins(:devices).where(devices: { cookie_uuid: cookie_uuid }).pluck(:uuid)
       user_uuids_by_device[cookie_uuid] = user_uuids
     end
 

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -27,8 +27,8 @@ module DataRequests
       return if user_uuids_by_device.keys.include?(cookie_uuid)
 
       warn "Searching for new devices matching #{cookie_uuid}"
-      matching_device_records = Device.includes(:user).where(cookie_uuid: cookie_uuid).all
-      user_uuids_by_device[cookie_uuid] = matching_device_records.map(&:user).compact.map(&:uuid)
+      user_uuids = matching_device_records.map(&:user).compact.map(&:uuid)
+      user_uuids_by_device[cookie_uuid] = user_uuids
     end
 
     def lookup_users(users)

--- a/app/services/data_requests/lookup_shared_device_users.rb
+++ b/app/services/data_requests/lookup_shared_device_users.rb
@@ -27,7 +27,7 @@ module DataRequests
       return if user_uuids_by_device.keys.include?(cookie_uuid)
 
       warn "Searching for new devices matching #{cookie_uuid}"
-      user_uuids = matching_device_records.map(&:user).compact.map(&:uuid)
+      user_uuids = Device.joins(:user).where(cookie_uuid: cookie_uuid).pluck(:uuid)
       user_uuids_by_device[cookie_uuid] = user_uuids
     end
 

--- a/app/services/data_requests/lookup_user_by_uuid.rb
+++ b/app/services/data_requests/lookup_user_by_uuid.rb
@@ -1,0 +1,14 @@
+module DataRequests
+  class LookupUserByUuid
+    attr_reader :uuid
+
+    def initialize(uuid)
+      @uuid = uuid
+    end
+
+    def call
+      User.find_by(uuid: uuid) ||
+        Identity.find_by(uuid: uuid)&.user
+    end
+  end
+end

--- a/app/services/data_requests/write_cloudwatch_logs.rb
+++ b/app/services/data_requests/write_cloudwatch_logs.rb
@@ -40,7 +40,9 @@ module DataRequests
       timestamp = data.dig('time')
       event_name = data.dig('name')
       success = data.dig('properties', 'event_properties', 'success')
-      multi_factor_auth_method = data.dig('properties', 'event_properties', 'multi_factor_auth_method')
+      multi_factor_auth_method = data.dig(
+        'properties', 'event_properties', 'multi_factor_auth_method'
+      )
       service_provider = data.dig('properties', 'service_provider')
       ip_address = data.dig('properties', 'user_ip')
       user_agent = data.dig('properties', 'user_agent')

--- a/app/services/data_requests/write_cloudwatch_logs.rb
+++ b/app/services/data_requests/write_cloudwatch_logs.rb
@@ -1,0 +1,58 @@
+module DataRequests
+  class WriteCloudwatchLogs
+    HEADERS = %w[
+      timestamp
+      event_name
+      success
+      multi_factor_auth_method
+      service_provider
+      ip_address
+      user_agent
+    ].freeze
+
+    attr_reader :cloudwatch_results, :output_dir
+
+    def initialize(cloudwatch_results, output_dir)
+      @cloudwatch_results = cloudwatch_results
+      @output_dir = output_dir
+    end
+
+    def call
+      output_file.puts(HEADERS.join(','))
+      cloudwatch_results.each do |row|
+        write_row(row)
+      end
+      output_file.close
+    end
+
+    private
+
+    def output_file
+      @output_file ||= begin
+        output_path = File.join(output_dir, 'logs.csv')
+        File.open(output_path, 'w')
+      end
+    end
+
+    def write_row(row)
+      data = JSON.parse(row.message)
+
+      timestamp = data.dig('time')
+      event_name = data.dig('name')
+      success = data.dig('properties', 'event_properties', 'success')
+      multi_factor_auth_method = data.dig('properties', 'event_properties', 'multi_factor_auth_method')
+      service_provider = data.dig('properties', 'service_provider')
+      ip_address = data.dig('properties', 'user_ip')
+      user_agent = data.dig('properties', 'user_agent')
+
+      output_file.puts(
+        CSV.generate_line(
+          [
+            timestamp, event_name, success, multi_factor_auth_method,
+            service_provider, ip_address, user_agent
+          ],
+        ),
+      )
+    end
+  end
+end

--- a/app/services/data_requests/write_user_events.rb
+++ b/app/services/data_requests/write_user_events.rb
@@ -1,0 +1,30 @@
+module DataRequests
+  class WriteUserEvents
+    attr_reader :user_report, :output_dir
+
+    def initialize(user_report, output_dir)
+      @user_report = user_report
+      @output_dir = output_dir
+    end
+
+    def call
+      File.open(File.join(output_dir, 'events.csv'), 'w') do |file|
+        file.puts('event_name,date_time,ip,disavowed_at,user_agent,device_cookie')
+        user_report[:user_events].each do |row|
+          file.puts(
+            CSV.generate_line(
+              row.values_at(
+                :event_name,
+                :date_time,
+                :ip,
+                :disavowed_at,
+                :user_agent,
+                :device_cookie,
+              ),
+            ),
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/data_requests/write_user_info.rb
+++ b/app/services/data_requests/write_user_info.rb
@@ -1,0 +1,85 @@
+module DataRequests
+  class WriteUserInfo
+    attr_reader :user_report, :output_dir
+
+    def initialize(user_report, output_dir)
+      @user_report = user_report
+      @output_dir = output_dir
+    end
+
+    def call
+      write_emails
+      write_phone_configurations
+      write_auth_app_configurations
+      write_webauthn_configurations
+      write_piv_cac_configurations
+      write_backup_code_configurations
+      output_file.close
+    end
+
+    private
+
+    def output_file
+      @output_file ||= begin
+        output_path = File.join(output_dir, 'user.csv')
+        File.open(output_path, 'w')
+      end
+    end
+
+    def write_rows_to_csv(rows, *columns)
+      output_file.puts(columns.join(','))
+
+      return output_file.puts("No data\n\n") if rows.empty?
+
+      rows.each do |row|
+        output_file.puts CSV.generate_line(row.values_at(*columns))
+      end
+      output_file.puts("\n")
+    end
+
+    def write_auth_app_configurations
+      output_file.puts('Auth app configurations:')
+      write_rows_to_csv(
+        user_report[:mfa_configurations][:auth_app_configurations],
+        :name, :created_at
+      )
+    end
+
+    def write_backup_code_configurations
+      output_file.puts('Backup code configurations:')
+      write_rows_to_csv(
+        user_report[:mfa_configurations][:backup_code_configurations],
+        :created_at, :used_at
+      )
+    end
+
+    def write_emails
+      output_file.puts('Emails:')
+      write_rows_to_csv(user_report[:email_addresses], :email, :created_at, :confirmed_at)
+    end
+
+    def write_phone_configurations
+      output_file.puts('Phone configurations:')
+      write_rows_to_csv(
+        user_report[:mfa_configurations][:phone_configurations],
+        :phone, :created_at, :confirmed_at
+      )
+    end
+
+    def write_piv_cac_configurations
+      output_file.puts('PIV/CAC configurations:')
+      write_rows_to_csv(
+        user_report[:mfa_configurations][:piv_cac_configurations],
+        :name, :created_at
+      )
+    end
+
+    def write_webauthn_configurations
+      output_file.puts('WebAuthn configurations:')
+      write_rows_to_csv(
+        user_report[:mfa_configurations][:webauthn_configurations],
+        :name, :created_at
+      )
+    end
+  end
+end

--- a/lib/tasks/data_requests.rake
+++ b/lib/tasks/data_requests.rake
@@ -1,0 +1,56 @@
+namespace :data_requests do
+  desc 'Recursively lookup users using a network of shared devices'
+  task lookup_users_by_device: :environment do
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 0')
+
+    uuids = ENV.fetch('UUIDS', '').split(',')
+    users = uuids.map { |uuid| DataRequests::LookupUserByUuid.new(uuid).call }.compact
+
+    result = DataRequests::LookupSharedDeviceUsers.new(users).call
+    puts JSON.pretty_generate(result)
+    puts "UUIDS: #{result.values.flatten.uniq.join(',')}"
+  end
+  # UUIDS=123abc,456def rake data_requests:lookup_users_by_device
+
+  desc 'Create a JSON report with data for the specified users'
+  task create_users_report: :environment do
+    uuids = ENV.fetch('UUIDS', '').split(',')
+    requesting_issuers = ENV.fetch('REQESTING_ISSUER', nil)&.split(',')
+
+    output = uuids.map do |uuid|
+      user = DataRequests::LookupUserByUuid.new(uuid).call
+      next warn("No record for uuid #{uuid}") if user.nil?
+      DataRequests::CreateUserReport.new(user, requesting_issuers).call
+    end.compact.to_json
+    puts output
+  end
+  # UUIDS=123abc,456def REQUESTING_ISSUER=sample:app:issuer rake data_requests:create_users_report
+
+  desc 'Take a JSON user report, download logs from cloud watch, and write user data'
+  task process_users_report: :environment do
+    users_report = JSON.parse(File.read(ENV['USERS_REPORT']), symbolize_names: true)
+    output_dir = ENV['OUTPUT_DIR']
+
+    users_report.each do |user_report|
+      puts "Processing user: #{user_report[:requesting_issuer_uuid]}"
+      user_output_dir = File.join(output_dir, user_report[:requesting_issuer_uuid])
+      FileUtils.mkdir_p(user_output_dir)
+
+      DataRequests::WriteUserInfo.new(user_report, user_output_dir).call
+      DataRequests::WriteUserEvents.new(user_report, user_output_dir).call
+
+      cloudwatch_dates = user_report[:user_events].map { |row| row[:date_time] }.map do |date_time|
+        Time.zone.parse(date_time).to_date
+      end.uniq
+      cloudwatch_results = DataRequests::FetchCloudwatchLogs.new(
+        user_report[:login_uuid],
+        cloudwatch_dates,
+      ).call
+
+      DataRequests::WriteCloudwatchLogs.new(cloudwatch_results, user_output_dir).call
+    end
+    # export USERS_REPORT=/tmp/query-2020-11-17/user_report.json
+    # export OUTPUT_DIR=/tmp/query-2020-11-17/results/
+    # rake data_requests:process_users_report
+  end
+end

--- a/lib/tasks/data_requests.rake
+++ b/lib/tasks/data_requests.rake
@@ -1,4 +1,5 @@
 namespace :data_requests do
+  # UUIDS=123abc,456def rake data_requests:lookup_users_by_device
   desc 'Recursively lookup users using a network of shared devices'
   task lookup_users_by_device: :environment do
     ActiveRecord::Base.connection.execute('SET statement_timeout = 0')
@@ -10,8 +11,8 @@ namespace :data_requests do
     puts JSON.pretty_generate(result)
     puts "UUIDS: #{result.values.flatten.uniq.join(',')}"
   end
-  # UUIDS=123abc,456def rake data_requests:lookup_users_by_device
 
+  # UUIDS=123abc,456def REQUESTING_ISSUER=sample:app:issuer rake data_requests:create_users_report
   desc 'Create a JSON report with data for the specified users'
   task create_users_report: :environment do
     uuids = ENV.fetch('UUIDS', '').split(',')
@@ -24,8 +25,10 @@ namespace :data_requests do
     end.compact.to_json
     puts output
   end
-  # UUIDS=123abc,456def REQUESTING_ISSUER=sample:app:issuer rake data_requests:create_users_report
 
+  # export USERS_REPORT=/tmp/query-2020-11-17/user_report.json
+  # export OUTPUT_DIR=/tmp/query-2020-11-17/results/
+  # rake data_requests:process_users_report
   desc 'Take a JSON user report, download logs from cloud watch, and write user data'
   task process_users_report: :environment do
     users_report = JSON.parse(File.read(ENV['USERS_REPORT']), symbolize_names: true)
@@ -49,8 +52,5 @@ namespace :data_requests do
 
       DataRequests::WriteCloudwatchLogs.new(cloudwatch_results, user_output_dir).call
     end
-    # export USERS_REPORT=/tmp/query-2020-11-17/user_report.json
-    # export OUTPUT_DIR=/tmp/query-2020-11-17/results/
-    # rake data_requests:process_users_report
   end
 end

--- a/spec/factories/auth_app_configurations.rb
+++ b/spec/factories/auth_app_configurations.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  Faker::Config.locale = :en
+
+  factory :auth_app_configuration do
+    name { Faker::Lorem.word }
+    encrypted_otp_secret_key { SecureRandom.hex(16) }
+    user
+  end
+end

--- a/spec/factories/piv_cac_configurations.rb
+++ b/spec/factories/piv_cac_configurations.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  Faker::Config.locale = :en
+
+  factory :piv_cac_configuration do
+    name { Faker::Lorem.word }
+    x509_dn_uuid { 'helloworld' }
+    user
+  end
+end

--- a/spec/services/data_requests/create_email_addresses_report_spec.rb
+++ b/spec/services/data_requests/create_email_addresses_report_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe DataRequests::CreateEmailAddressesReport do
+  describe '#call' do
+    it 'returns an array with hashes representing the users email addresses' do
+      user = create(:user)
+      email_address = user.email_addresses.first
+
+      result = described_class.new(user).call
+
+      expect(result.length).to eq(1)
+
+      expect(result.first[:email]).to eq(email_address.email)
+      expect(result.first[:created_at]).to be_within(1.second).of(
+        email_address.created_at,
+      )
+      expect(result.first[:confirmed_at]).to be_within(1.second).of(
+        email_address.confirmed_at,
+      )
+    end
+  end
+end

--- a/spec/services/data_requests/create_mfa_configurations_report_spec.rb
+++ b/spec/services/data_requests/create_mfa_configurations_report_spec.rb
@@ -60,7 +60,7 @@ describe DataRequests::CreateMfaConfigurationsReport do
     it 'includes an array with backup codes' do
       user = create(:user)
       backup_code_configuration = create(
-        :backup_code_configuration, user: user, used_at: Time.zone.now,
+        :backup_code_configuration, user: user, used_at: Time.zone.now
       )
 
       result = described_class.new(user).call

--- a/spec/services/data_requests/create_mfa_configurations_report_spec.rb
+++ b/spec/services/data_requests/create_mfa_configurations_report_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe DataRequests::CreateMfaConfigurationsReport do
+  describe '#call' do
+    it 'includes an array for phone numbers' do
+      user = create(:user)
+      phone_configuration = create(:phone_configuration, user: user)
+
+      result = described_class.new(user).call
+      phone_data = result[:phone_configurations]
+
+      expect(phone_data.first[:phone]).to eq(phone_configuration.phone)
+      expect(phone_data.first[:created_at]).to be_within(1.second).of(
+        phone_configuration.created_at,
+      )
+      expect(phone_data.first[:confirmed_at]).to be_within(1.second).of(
+        phone_configuration.confirmed_at,
+      )
+    end
+
+    it 'includes an array for authentication apps' do
+      user = create(:user)
+      auth_app_configuration = create(:auth_app_configuration, user: user)
+
+      result = described_class.new(user).call
+      auth_app_data = result[:auth_app_configurations]
+
+      expect(auth_app_data.first[:name]).to eq(auth_app_configuration.name)
+      expect(auth_app_data.first[:created_at]).to be_within(1.second).of(
+        auth_app_configuration.created_at,
+      )
+    end
+
+    it 'includes an array for security keys' do
+      user = create(:user)
+      webauthn_configuration = create(:webauthn_configuration, user: user)
+
+      result = described_class.new(user).call
+      webauthn_data = result[:webauthn_configurations]
+
+      expect(webauthn_data.first[:name]).to eq(webauthn_configuration.name)
+      expect(webauthn_data.first[:created_at]).to be_within(1.second).of(
+        webauthn_configuration.created_at,
+      )
+    end
+
+    it 'includes an array for piv/cac cards' do
+      user = create(:user)
+      piv_cac_configuration = create(:piv_cac_configuration, user: user)
+
+      result = described_class.new(user).call
+      piv_cac_data = result[:piv_cac_configurations]
+
+      expect(piv_cac_data.first[:name]).to eq(piv_cac_configuration.name)
+      expect(piv_cac_data.first[:created_at]).to be_within(1.second).of(
+        piv_cac_configuration.created_at,
+      )
+    end
+
+    it 'includes an array with backup codes' do
+      user = create(:user)
+      backup_code_configuration = create(
+        :backup_code_configuration, user: user, used_at: Time.zone.now,
+      )
+
+      result = described_class.new(user).call
+      backup_code_data = result[:backup_code_configurations]
+
+      expect(backup_code_data.first[:created_at]).to be_within(1.second).of(
+        backup_code_configuration.created_at,
+      )
+      expect(backup_code_data.first[:used_at]).to be_within(1.second).of(
+        backup_code_configuration.used_at,
+      )
+    end
+  end
+end

--- a/spec/services/data_requests/create_user_events_report_spec.rb
+++ b/spec/services/data_requests/create_user_events_report_spec.rb
@@ -7,7 +7,7 @@ describe DataRequests::CreateUserEventsReport do
       event1 = create(:event, created_at: 1.day.ago, disavowed_at: 12.hours.ago, user: user)
       device = create(:device)
       _event2 = create(
-        :event, event_type: :webauthn_key_added, device: device, ip: '1.2.3.4', user: user,
+        :event, event_type: :webauthn_key_added, device: device, ip: '1.2.3.4', user: user
       )
 
       result = described_class.new(user).call

--- a/spec/services/data_requests/create_user_events_report_spec.rb
+++ b/spec/services/data_requests/create_user_events_report_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe DataRequests::CreateUserEventsReport do
+  describe '#call' do
+    it 'returns an array of hashes representing the users events' do
+      user = create(:user)
+      event1 = create(:event, created_at: 1.day.ago, disavowed_at: 12.hours.ago, user: user)
+      device = create(:device)
+      _event2 = create(
+        :event, event_type: :webauthn_key_added, device: device, ip: '1.2.3.4', user: user,
+      )
+
+      result = described_class.new(user).call
+
+      expect(result.length).to eq(2)
+
+      expect(result.first[:event_name]).to eq(event1.event_type)
+      expect(result.first[:date_time]).to be_within(1.second).of(event1.created_at)
+      expect(result.first[:disavowed_at]).to be_within(1.second).of(event1.disavowed_at)
+
+      expect(result.last[:event_name]).to eq('webauthn_key_added')
+      expect(result.last[:ip]).to eq('1.2.3.4')
+      expect(result.last[:user_agent]).to eq(device.user_agent)
+      expect(result.last[:device_cookie]).to eq(device.cookie_uuid)
+    end
+  end
+end

--- a/spec/services/data_requests/create_user_report_spec.rb
+++ b/spec/services/data_requests/create_user_report_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe DataRequests::CreateUserReport do
+  it 'returns a report containing information about' do
+    user = create(:user)
+
+    result = described_class.new(user).call
+
+    expect(result[:user_id]).to eq(user.id)
+    expect(result[:login_uuid]).to eq(user.uuid)
+    expect(result[:requesting_issuer_uuid]).to eq(user.uuid)
+    expect(result[:email_addresses]).to be_a(Array)
+    expect(result[:mfa_configurations]).to be_a(Hash)
+    expect(result[:user_events]).to be_a(Array)
+  end
+
+  context 'with a requesting SP issuer provided' do
+    it 'includes the UUID for a SP if one exists' do
+      user = create(:user)
+      identity = create(:identity, user: user, service_provider: 'test123')
+
+      result = described_class.new(user, 'test123').call
+
+      expect(result[:user_id]).to eq(user.id)
+      expect(result[:login_uuid]).to eq(user.uuid)
+      expect(result[:requesting_issuer_uuid]).to eq(identity.uuid)
+    end
+
+    it 'includes the ID of the user if the user is not associated with the SP' do
+      user = create(:user)
+
+      result = described_class.new(user, 'test123').call
+
+      expect(result[:user_id]).to eq(user.id)
+      expect(result[:login_uuid]).to eq(user.uuid)
+      expect(result[:requesting_issuer_uuid]).to eq("NonSPUser##{user.id}")
+    end
+  end
+end

--- a/spec/services/data_requests/fetch_cloudwatch_logs_spec.rb
+++ b/spec/services/data_requests/fetch_cloudwatch_logs_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe DataRequests::FetchCloudwatchLogs do
+  it 'starts queries for each date and returns processed results' do
+    uuid = 'super-fun-but-fake-uuid'
+    dates = [
+      Date.new(2020, 3, 18),
+      Date.new(2020, 8, 7),
+    ]
+
+    mock_cloudwatch_client = Aws::CloudWatchLogs::Client.new(stub_responses: true)
+    mock_cloudwatch_client.stub_responses(
+      :start_query,
+      { query_id: '123abc' },
+      { query_id: '456def' },
+    )
+    mock_cloudwatch_client.stub_responses(
+      :get_query_results,
+      { status: 'Running' },
+      { status: 'Running' },
+      {
+        status: 'Complete',
+        results: [
+          [
+            { field: '@timestamp', value: 'timestamp-1' },
+            { field: '@message', value: 'message-1' },
+          ],
+        ],
+      },
+      {
+        status: 'Complete',
+        results: [
+          [
+            { field: '@timestamp', value: 'timestamp-2' },
+            { field: '@message', value: 'message-2' },
+          ],
+        ],
+      },
+    )
+    allow(Aws::CloudWatchLogs::Client).to receive(:new).and_return(mock_cloudwatch_client)
+
+    subject = described_class.new(uuid, dates)
+
+    allow(subject).to receive(:sleep)
+    allow(subject).to receive(:warn)
+
+    results = subject.call
+
+    expect(results.length).to eq(2)
+    expect(results.first.timestamp).to eq('timestamp-1')
+    expect(results.first.message).to eq('message-1')
+    expect(results.second.timestamp).to eq('timestamp-2')
+    expect(results.second.message).to eq('message-2')
+  end
+
+  it 'fails if run in a deployed environment' do
+    allow(LoginGov::Hostdata).to receive(:in_datacenter?).and_return(true)
+
+    expect do
+      described_class.new('fake-uuid', []).call
+    end.to raise_error('Only run DataRequests::FetchCloudwatchLogs locally')
+  end
+end

--- a/spec/services/data_requests/lookup_shared_device_users_spec.rb
+++ b/spec/services/data_requests/lookup_shared_device_users_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe DataRequests::LookupSharedDeviceUsers do
+  describe '#call' do
+    it 'recursively looks up users sharing devices' do
+      user1 = create(:user)
+      user2 = create(:user)
+      user3 = create(:user)
+
+      cookie_uuid1 = '123abc'
+      cookie_uuid2 = '456def'
+
+      create(:device, user: user1, cookie_uuid: cookie_uuid1)
+      create(:device, user: user2, cookie_uuid: cookie_uuid1)
+      create(:device, user: user2, cookie_uuid: cookie_uuid2)
+      create(:device, user: user3, cookie_uuid: cookie_uuid2)
+
+      subject = described_class.new([user1])
+
+      allow(subject).to receive(:warn)
+
+      result = subject.call
+
+      expect(result.keys.length).to eq(2)
+      expect(result[cookie_uuid1]).to match_array([user1, user2].map(&:uuid))
+      expect(result[cookie_uuid2]).to match_array([user2, user3].map(&:uuid))
+    end
+  end
+end

--- a/spec/services/data_requests/lookup_user_by_uuid_spec.rb
+++ b/spec/services/data_requests/lookup_user_by_uuid_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe DataRequests::LookupUserByUuid do
+  describe '#call' do
+    context 'when a user exists with the UUID' do
+      it 'returns the user' do
+        user = create(:user)
+        uuid = user.uuid
+
+        expect(described_class.new(uuid).call).to eq(user)
+      end
+    end
+
+    context 'when an identity exists with the UUID' do
+      it 'returns the user for the identity' do
+        identity = create(:identity)
+        uuid = identity.uuid
+
+        expect(described_class.new(uuid).call).to eq(identity.user)
+      end
+    end
+
+    context 'when nothing exists for the UUID' do
+      it 'returns nil' do
+        expect(described_class.new('123abc').call).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So we can track the code that we use to respond to data requests in source control and make it available to other members of the team

I will add documentation on how to use these to either the handbook or secops wiki once the user report rake task is available in prod.