### PR TITLE
Change SMS content to autofill properly (LG-3691)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'identity-doc-auth', github: '18F/identity-doc-auth', tag: 'v0.3.0'
 gem 'identity-hostdata', github: '18F/identity-hostdata', tag: 'v0.4.1'
 require File.join(__dir__, 'app', 'services', 'lambda_jobs', 'git_ref.rb')
 gem 'identity-idp-functions', github: '18F/identity-idp-functions', ref: LambdaJobs::GIT_REF
-gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.5'
+gem 'identity-telephony', github: '18f/identity-telephony', tag: 'v0.1.6'
 gem 'identity_validations', github: '18F/identity-validations', branch: 'master'
 gem 'json-jwt', '>= 1.11.0'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-telephony.git
-  revision: 656d5cd779217b8be02bdb82ef747cd0fe0680e1
-  tag: v0.1.5
+  revision: 08839be0e7608bd9fe78a576276ad4762495bced
+  tag: v0.1.6
   specs:
-    identity-telephony (0.1.5)
+    identity-telephony (0.1.6)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n

--- a/spec/support/monitor/monitor_helper.rb
+++ b/spec/support/monitor/monitor_helper.rb
@@ -88,7 +88,7 @@ class MonitorHelper
   end
 
   def check_for_otp
-    otp_regex = /Enter (?<code>\d{6}) in login\.gov/
+    otp_regex = /Your security code is (?<code>\d{6})/
 
     if local?
       match_data = Telephony::Test::Message.messages.last.body.match(otp_regex)


### PR DESCRIPTION
Updates telephony gem to use the new content, depends on https://github.com/18F/identity-telephony/pull/33