### PR TITLE
Show PII after re-authentication (LG-3424)

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -66,7 +66,6 @@ module RememberDeviceConcern
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user
-    redirect_to after_otp_verification_confirmation_url unless reauthn?
     reset_otp_session_data
   end
 

--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -66,7 +66,7 @@ module RememberDeviceConcern
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user
-    redirect_to after_otp_verification_confirmation_url
+    redirect_to after_otp_verification_confirmation_url unless reauthn?
     reset_otp_session_data
   end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -40,7 +40,7 @@ module Users
 
     def backup_code_redirect
       return unless TwoFactorAuthentication::BackupCodePolicy.new(current_user).configured?
-      redirect_to login_two_factor_backup_code_url
+      redirect_to login_two_factor_backup_code_url(reauthn_params)
     end
 
     def redirect_on_nothing_enabled
@@ -223,11 +223,19 @@ module Users
 
     def redirect_url
       if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled? && !mobile?
-        login_two_factor_piv_cac_url
+        login_two_factor_piv_cac_url(reauthn_params)
       elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
-        login_two_factor_webauthn_url
+        login_two_factor_webauthn_url(reauthn_params)
       elsif TwoFactorAuthentication::AuthAppPolicy.new(current_user).enabled?
-        login_two_factor_authenticator_url
+        login_two_factor_authenticator_url(reauthn_params)
+      end
+    end
+
+    def reauthn_params
+      if reauthn?
+        { reauthn: reauthn? }
+      else
+        {}
       end
     end
   end

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -83,30 +83,69 @@ describe Users::TwoFactorAuthenticationController do
     end
 
     context 'when user is TOTP enabled' do
-      it 'renders the :confirm_totp view' do
+      before do
         user = build(:user)
         stub_sign_in_before_2fa(user)
         allow_any_instance_of(
           TwoFactorAuthentication::AuthAppPolicy,
         ).to receive(:enabled?).and_return(true)
+      end
 
+      it 'renders the :confirm_totp view' do
         get :show
 
         expect(response).to redirect_to login_two_factor_authenticator_path
       end
+
+      it 'passes reauthn parameter on redirect' do
+        get :show, params: { reauthn: 'true' }
+
+        expect(response).to redirect_to login_two_factor_authenticator_path(reauthn: 'true')
+      end
+    end
+
+    context 'when user has backup codes' do
+      before do
+        user = build(:user)
+        stub_sign_in_before_2fa(user)
+
+        allow_any_instance_of(
+          TwoFactorAuthentication::BackupCodePolicy,
+        ).to receive(:configured?).and_return(true)
+      end
+
+      it 'renders the :backup_code view' do
+        get :show
+
+        expect(response).to redirect_to login_two_factor_backup_code_url
+      end
+
+      it 'passes reauthn parameter on redirect' do
+        get :show, params: { reauthn: 'true' }
+
+        expect(response).to redirect_to login_two_factor_backup_code_url(reauthn: 'true')
+      end
     end
 
     context 'when user is webauthn enabled' do
-      it 'renders the :webauthn view' do
+      before do
         stub_sign_in_before_2fa(build(:user, :with_webauthn))
 
         allow_any_instance_of(
           TwoFactorAuthentication::WebauthnPolicy,
         ).to receive(:enabled?).and_return(true)
+      end
 
+      it 'renders the :webauthn view' do
         get :show
 
         expect(response).to redirect_to login_two_factor_webauthn_path
+      end
+
+      it 'passes reauthn parameter on redirect' do
+        get :show, params: { reauthn: 'true' }
+
+        expect(response).to redirect_to login_two_factor_webauthn_path(reauthn: 'true')
       end
     end
 


### PR DESCRIPTION
This issue is caused by users authenticating in a remembered browser and clicking "reauthenticate" to view their PII. 
We want to force a full reauthentication despite a user being fully authenticated by the remembered browser as the second factor.

They are hitting a couple redirects before they can enter their second factor, one that was removed in `RememberDeviceConcern` and another in the `check_already_authenticated` method [here](https://github.com/18F/identity-idp/blob/master/app/controllers/concerns/two_factor_authenticatable_methods.rb#L46-L53).

The `reauthn` param has to be passed to disable the second redirect so users are not considered fully authenticated: https://github.com/18F/identity-idp/blob/master/app/controllers/application_controller.rb#L212-L215