### PR TITLE
Move cloudwatch sdk require outside of the "autoload" path

### DIFF
--- a/app/services/data_requests/fetch_cloudwatch_logs.rb
+++ b/app/services/data_requests/fetch_cloudwatch_logs.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk-cloudwatchlogs'
-
 module DataRequests
   # This class depends on the AWS cloudwatch SDK gem. That gem is only available
   # in development. The IDP role is not able to query cloudwatch logs. As a
@@ -30,6 +28,7 @@ module DataRequests
     end
 
     def cloudwatch_client
+      require 'aws-sdk-cloudwatchlogs'
       @cloudwatch_client ||= Aws::CloudWatchLogs::Client.new region: 'us-west-2'
     end
 

--- a/spec/services/data_requests/fetch_cloudwatch_logs_spec.rb
+++ b/spec/services/data_requests/fetch_cloudwatch_logs_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'aws-sdk-cloudwatchlogs'
 
 describe DataRequests::FetchCloudwatchLogs do
   it 'starts queries for each date and returns processed results' do


### PR DESCRIPTION
**Why**: We explicitly don't load this gem in deployed environments,
so the require fails on app launch

