### PR TITLE
LG-3697: Define connect-src S3 presigned URLs by full path

### DIFF
--- a/app/services/image_upload_presigned_url_generator.rb
+++ b/app/services/image_upload_presigned_url_generator.rb
@@ -16,10 +16,6 @@ class ImageUploadPresignedUrlGenerator
     end
   end
 
-  def bucket_url
-    s3_resource&.bucket(bucket(prefix: bucket_prefix))&.url
-  end
-
   def bucket_prefix
     'login-gov-idp-doc-capture'.freeze
   end

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -3,6 +3,10 @@
   <%= tag :meta, name: 'acuant-sdk-initialization-endpoint', content: AppConfig.env.acuant_sdk_initialization_endpoint %>
   <%= tag :meta, name: 'acuant-sdk-initialization-creds', content: AppConfig.env.acuant_sdk_initialization_creds %>
 <% end %>
+<% SecureHeaders.append_content_security_policy_directives(
+  request,
+  connect_src: [front_image_upload_url, back_image_upload_url, selfie_image_upload_url].compact
+) %>
 <%= tag.div id: 'document-capture-form', data: {
   liveness_required: liveness_checking_enabled?.presence,
   mock_client: (DocAuthRouter.doc_auth_vendor == 'mock').presence,

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,10 +9,6 @@ SecureHeaders::Configuration.default do |config| # rubocop:disable Metrics/Block
   connect_src = ["'self'", '*.newrelic.com', '*.nr-data.net', '*.google-analytics.com',
                  'services.assureid.net']
   connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
-  if AppConfig.env.doc_auth_enable_presigned_s3_urls == 'true'
-    image_upload_bucket_url = ImageUploadPresignedUrlGenerator.new.bucket_url
-    connect_src << "#{image_upload_bucket_url.chomp('/')}/*" if image_upload_bucket_url
-  end
   default_csp_config = {
     default_src: ["'self'"],
     child_src: ["'self'", 'www.google.com'], # CSP 2.0 only; replaces frame_src

--- a/spec/services/image_upload_presigned_url_generator_spec.rb
+++ b/spec/services/image_upload_presigned_url_generator_spec.rb
@@ -58,40 +58,4 @@ RSpec.describe ImageUploadPresignedUrlGenerator do
       end
     end
   end
-
-  describe '#bucket_url' do
-    before do
-    end
-
-    context 'AWS credentials are not set' do
-      before do
-        allow(LoginGov::Hostdata::EC2).to receive(:load).
-          and_raise(Net::OpenTimeout)
-        allow(Aws::S3::Resource).to receive(:new).
-          and_raise(Aws::Sigv4::Errors::MissingCredentialsError, 'Credentials not set')
-      end
-
-      it 'returns nil' do
-        expect(generator.bucket_url).to be_nil
-      end
-    end
-
-    context 'AWS credentials are set' do
-      before do
-        allow(LoginGov::Hostdata).to receive(:env).and_return('test')
-        allow(LoginGov::Hostdata::EC2).to receive(:load).and_return(
-          OpenStruct.new(account_id: '123456789', region: 'us-west-2'),
-        )
-        client_stub = Aws::S3::Client.new(region: 'us-west-2', stub_responses: true)
-        resource_stub = Aws::S3::Resource.new(client: client_stub)
-        allow(generator).to receive(:s3_resource).and_return(resource_stub)
-      end
-
-      it 'returns S3 bucket url' do
-        expect(generator.bucket_url).to eq(
-          'https://s3.us-west-2.amazonaws.com/login-gov-idp-doc-capture-test.123456789-us-west-2',
-        )
-      end
-    end
-  end
 end


### PR DESCRIPTION
**Why**: So that the browser will allow connect to upload images to S3.

The work in #4409 assumes that a wildcard `*` can be used in the path fragment of a `connect-src` source list, which is not correct ([see specification](https://www.w3.org/TR/CSP3/#match-paths)). Thus, connection attempts would still be rejected.

This largely reverts the prior effort, instead appending to the CSP header in the view itself. This may not be ideal, though it has a few upsides:

- Closer association to where the CSP URLs are relevant (as opposed to application-wide configuration)
- [There is prior art](https://github.com/18F/identity-idp/blob/86981809d5e2d4a19e31b2ad89149b6737674402/app/views/shared/_recaptcha.html.erb#L2-L3)

Alternatives explored:

- Append at [point in code](https://github.com/18F/identity-idp/blob/86981809d5e2d4a19e31b2ad89149b6737674402/app/services/idv/steps/document_capture_step.rb#L18-L33) where URLs are assigned into view variables. This felt like an unexpected side-effect of what should be expected to be a pure function.
- Some other pre-render hook of the document capture step. Unfortunately most existing behavior of a step appears to be tailored for a step's submission, not its initial rendering.

Possible follow-on: Ideally the feature tests added in #4407 could exercise these headers. Unfortunately, it's made challenging by the fact that our fake endpoints are served by the local server, which is allowed by default in the CSP headers. This would also be contingent upon LG-3785.