### PR TITLE
maintain redirect for remembered device unless reauthenticating (LG-3424)

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -66,6 +66,7 @@ module RememberDeviceConcern
     mark_user_session_authenticated(:device_remembered)
     handle_valid_remember_device_analytics
     bypass_sign_in current_user
+    redirect_to after_otp_verification_confirmation_url unless reauthn?
     reset_otp_session_data
   end
 


### PR DESCRIPTION
Follow up to a bug introduced by #4425 in which users receive SMS for a remembered device but are never asked to enter it

Still working on a way to confirm this fix with tests, but opening a draft so I can get CI going