### PR TITLE
Remove asset_host config in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,11 +2,6 @@ Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = true
 
-  config.action_controller.asset_host = proc do |_source, request|
-    # we want precompiled assets to have domain-agnostic URLs
-    # and request is nil during asset precompilation
-    AppConfig.env.domain_name if request
-  end
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true


### PR DESCRIPTION
[Config](https://github.com/18F/identity-idp/blob/master/config/application.yml.default#L188) sets the domain_name to `localhost:3000` in dev, but if you are using `127.0.0.1` you won't get any assets because Content Security Policy doesn't like the different hosts.

This change removes the host so assets have relative paths in development.

Before:

```
  <script src="http://localhost:3000/assets/i18n-strings.en.debug-279c7a1f98733e3aaf94f82d2065b3606658da2b97889c63c331435174397700.js"></script>
  <script src="http://localhost:3000/packs/js/application-4357b3360c459fd23ca1.js"></script>
```

After:

```
  <script src="/assets/i18n-strings.en.debug-279c7a1f98733e3aaf94f82d2065b3606658da2b97889c63c331435174397700.js"></script>
  <script src="/packs/js/application-4357b3360c459fd23ca1.js"></script>