### PR TITLE
Add new relic config in test and development

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,3 +1,5 @@
+development:
+  monitor_mode: false
 production:
   agent_enabled: true
   app_name: <%= LoginGov::Hostdata.env %>.<%= LoginGov::Hostdata.domain %>
@@ -21,3 +23,5 @@ production:
     transaction_threshold: apdex_f
   proxy_host:
   proxy_port:
+test:
+  monitor_mode: false


### PR DESCRIPTION
`** [NewRelic] FATAL : Config file at /Users/mitchellehenke/projects/identity-idp/config/newrelic.yml doesn't include a 'test' section!` sounds scarier than it is, but new relic should be disabled in these environments anyway

Partially copied from the default config here: https://github.com/newrelic/newrelic-ruby-agent/blob/dev/newrelic.yml#L33-L36
