### PR TITLE
Add 2 disposable emails to the banlist

### DIFF
--- a/config/valid_email.yml
+++ b/config/valid_email.yml
@@ -7,3 +7,5 @@ disposable_email_services:
   - speedstermail.com
   - sprintpostmail.com
   - usimmigrationemail.com
+  - firemailbox.club
+  - safemail.icu


### PR DESCRIPTION
**Why**: So they can't be used for OTP spam