### PR TITLE
Temporarily disable voice OTP delivery for confirmation

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -204,9 +204,13 @@ module Users
     end
 
     def delivery_params
-      params.require(:otp_delivery_selection_form).permit(:otp_delivery_preference,
-                                                          :otp_make_default_number,
-                                                          :resend)
+      form_params = params.require(:otp_delivery_selection_form).permit(
+        :otp_delivery_preference,
+        :otp_make_default_number,
+        :resend,
+      ).to_h
+      form_params[:otp_delivery_preference] = 'sms' if confirmation_context?
+      form_params
     end
 
     def phone_to_deliver_to

--- a/app/views/users/shared/_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.erb
@@ -1,9 +1,8 @@
 <%= render 'shared/alert', type: 'warning', class: 'margin-bottom-2' do %>
   <p>
-    We are having trouble making phone calls to confirm phone numbers.
+    <%= t('two_factor_authentication.temp_disabled.p_1') %>
   </p>
   <p class='margin-bottom-0'>
-    Phones can still be confirmed with an SMS message. If you are unable to
-    receive SMS messages please choose a different authentication method.
+    <%= t('two_factor_authentication.temp_disabled.p_2') %>
   </p>
 <% end %>

--- a/app/views/users/shared/_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_otp_delivery_preference_selection.html.erb
@@ -1,41 +1,9 @@
-<%
-  form_name = form_obj.class.name.underscore.to_s
-  form_name_label = form_name + "[otp_delivery_preference]"
-  form_name_tag_sms = form_name + "_otp_delivery_preference_sms"
-  form_name_tag_voice = form_name + "_otp_delivery_preference_voice"
-%>
-
-<div class="mb3">
-  <fieldset class="m0 p0 border-none">
-    <legend class="mb1 h4 serif bold">
-      <%= t('two_factor_authentication.otp_delivery_preference.title') %>
-    </legend>
-    <p class="mt0 mb2" id="otp_delivery_preference_instruction">
-      <%= t('two_factor_authentication.otp_delivery_preference.instruction') %>
-    </p>
-    <label
-      class="btn-border col-12 sm-col-5 sm-mr2 mb2 sm-mb0"
-      for= <%= form_name_tag_sms %>
-    >
-      <div class="radio">
-        <%= radio_button_tag form_name_label,
-          :sms, form_obj.delivery_preference_sms?,
-          class: :otp_delivery_preference_sms %>
-        <span class="indicator"></span>
-        <%= t('two_factor_authentication.otp_delivery_preference.sms') %>
-      </div>
-    </label>
-    <label
-      class="btn-border col-12 sm-col-5 mb0"
-      for=<%= form_name_tag_voice %>
-    >
-      <div class="radio">
-        <%= radio_button_tag form_name_label,
-            :voice, form_obj.delivery_preference_voice?,
-            class: :otp_delivery_preference_voice %>
-        <span class="indicator"></span>
-        <%= t('two_factor_authentication.otp_delivery_preference.voice') %>
-      </div>
-    </label>
-  </fieldset>
-</div>
+<%= render 'shared/alert', type: 'warning', class: 'margin-bottom-2' do %>
+  <p>
+    We are having trouble making phone calls to confirm phone numbers.
+  </p>
+  <p class='margin-bottom-0'>
+    Phones can still be confirmed with an SMS message. If you are unable to
+    receive SMS messages please choose a different authentication method.
+  </p>
+<% end %>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -320,7 +320,7 @@ production:
   no_sp_campaigns_whitelist: '[]'
   nonessential_email_banlist: '[]'
   otp_delivery_blocklist_findtime: '5'
-  otp_delivery_blocklist_maxretry: '10'
+  otp_delivery_blocklist_maxretry: '5'
   participate_in_dap: 'false'
   password_pepper:
   piv_cac_service_url:

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -182,8 +182,8 @@ CG:
 CH:
   country_code: '41'
   name: Switzerland
-  supports_sms: false
-  supports_voice: false
+  supports_sms: true
+  supports_voice: true
 CI:
   country_code: '225'
   name: Ivory Coast
@@ -317,8 +317,8 @@ GA:
 GB:
   country_code: '44'
   name: United Kingdom
-  supports_sms: false
-  supports_voice: false
+  supports_sms: true
+  supports_voice: true
 GD:
   country_code: '1473'
   name: Grenada
@@ -457,8 +457,8 @@ IT:
 JM:
   country_code: '1'
   name: Jamaica
-  supports_sms: false
-  supports_voice: false
+  supports_sms: true
+  supports_voice: true
 JO:
   country_code: '962'
   name: Jordan
@@ -697,8 +697,8 @@ NG:
 NI:
   country_code: '505'
   name: Nicaragua
-  supports_sms: false
-  supports_voice: false
+  supports_sms: true
+  supports_voice: true
 NL:
   country_code: '31'
   name: Netherlands

--- a/config/country_dialing_codes.yml
+++ b/config/country_dialing_codes.yml
@@ -43,17 +43,17 @@ AR:
   country_code: '54'
   name: Argentina
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 AT:
   country_code: '43'
   name: Austria
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 AU:
   country_code: '61'
   name: Australia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 AW:
   country_code: '297'
   name: Aruba
@@ -73,7 +73,7 @@ BB:
   country_code: '1246'
   name: Barbados
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 BD:
   country_code: '880'
   name: Bangladesh
@@ -88,17 +88,17 @@ BF:
   country_code: '226'
   name: Burkina Faso
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 BG:
   country_code: '359'
   name: Bulgaria
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 BH:
   country_code: '973'
   name: Bahrain
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 BI:
   country_code: '257'
   name: Burundi
@@ -133,7 +133,7 @@ BR:
   country_code: '55'
   name: Brazil
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 BS:
   country_code: '1242'
   name: Bahamas
@@ -163,7 +163,7 @@ CA:
   country_code: '1'
   name: Canada
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 CD:
   country_code: '243'
   name: Democratic Republic of the Congo
@@ -198,7 +198,7 @@ CL:
   country_code: '56'
   name: Chile
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 CM:
   country_code: '237'
   name: Cameroon
@@ -213,7 +213,7 @@ CO:
   country_code: '57'
   name: Colombia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 CR:
   country_code: '506'
   name: Costa Rica
@@ -228,7 +228,7 @@ CY:
   country_code: '357'
   name: Cyprus
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 CZ:
   country_code: '420'
   name: Czechia
@@ -238,7 +238,7 @@ DE:
   country_code: '49'
   name: Germany
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 DJ:
   country_code: '253'
   name: Djibouti
@@ -258,7 +258,7 @@ DO:
   country_code: '1'
   name: Dominican Republic
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 DZ:
   country_code: '213'
   name: Algeria
@@ -268,7 +268,7 @@ EC:
   country_code: '593'
   name: Ecuador
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 EE:
   country_code: '372'
   name: Estonia
@@ -293,7 +293,7 @@ FI:
   country_code: '358'
   name: Finland
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 FJ:
   country_code: '679'
   name: Fiji
@@ -323,7 +323,7 @@ GD:
   country_code: '1473'
   name: Grenada
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 GE:
   country_code: '995'
   name: Georgia
@@ -373,12 +373,12 @@ GR:
   country_code: '30'
   name: Greece
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 GT:
   country_code: '502'
   name: Guatemala
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 GU:
   country_code: '1671'
   name: Guam
@@ -408,7 +408,7 @@ HR:
   country_code: '385'
   name: Croatia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 HT:
   country_code: '509'
   name: Haiti
@@ -418,22 +418,22 @@ HU:
   country_code: '36'
   name: Hungary
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 ID:
   country_code: '62'
   name: Indonesia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 IE:
   country_code: '353'
   name: Ireland
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 IL:
   country_code: '972'
   name: Israel
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 IN:
   country_code: '91'
   name: India
@@ -448,12 +448,12 @@ IS:
   country_code: '354'
   name: Iceland
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 IT:
   country_code: '39'
   name: Italy
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 JM:
   country_code: '1'
   name: Jamaica
@@ -468,12 +468,12 @@ JP:
   country_code: '81'
   name: Japan
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 KE:
   country_code: '254'
   name: Kenya
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 KG:
   country_code: '996'
   name: Kyrgyzstan
@@ -483,7 +483,7 @@ KH:
   country_code: '855'
   name: Cambodia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 KI:
   country_code: '686'
   name: Kiribati
@@ -513,12 +513,12 @@ KY:
   country_code: '1345'
   name: Cayman Islands
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 KZ:
   country_code: '7'
   name: Kazakhstan
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 LA:
   country_code: '856'
   name: Laos
@@ -558,17 +558,17 @@ LT:
   country_code: '370'
   name: Lithuania
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 LU:
   country_code: '352'
   name: Luxembourg
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 LV:
   country_code: '371'
   name: Latvia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 LY:
   country_code: '218'
   name: Libya
@@ -588,7 +588,7 @@ MD:
   country_code: '373'
   name: Moldova
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 ME:
   country_code: '382'
   name: Montenegro
@@ -608,7 +608,7 @@ ML:
   country_code: '223'
   name: Mali
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 MM:
   country_code: '95'
   name: Myanmar
@@ -663,12 +663,12 @@ MX:
   country_code: '52'
   name: Mexico
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 MY:
   country_code: '60'
   name: Malaysia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 MZ:
   country_code: '258'
   name: Mozambique
@@ -708,7 +708,7 @@ NL:
   country_code: '47'
   name: Norway
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 NP:
   country_code: '977'
   name: Nepal
@@ -718,7 +718,7 @@ NZ:
   country_code: '64'
   name: New Zealand
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 OM:
   country_code: '968'
   name: Oman
@@ -728,12 +728,12 @@ PA:
   country_code: '507'
   name: Panama
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 PE:
   country_code: '51'
   name: Peru
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 PG:
   country_code: '675'
   name: Papua New Guinea
@@ -743,22 +743,22 @@ PH:
   country_code: '63'
   name: Philippines
   supports_sms: false
-  supports_voice: false
+  supports_voice: true
 PK:
   country_code: '92'
   name: Pakistan
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 PL:
   country_code: '48'
   name: Poland
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 PR:
   country_code: '1'
   name: Puerto Rico
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 PS:
   country_code: '970'
   name: Palestinian Territories
@@ -793,7 +793,7 @@ RO:
   country_code: '40'
   name: Romania
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 RS:
   country_code: '381'
   name: Serbia
@@ -838,12 +838,12 @@ SI:
   country_code: '386'
   name: Slovenia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 SK:
   country_code: '421'
   name: Slovakia
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 SL:
   country_code: '232'
   name: Sierra Leone
@@ -878,7 +878,7 @@ SV:
   country_code: '503'
   name: El Salvador
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 SZ:
   country_code: '268'
   name: Swaziland
@@ -903,12 +903,12 @@ TH:
   country_code: '66'
   name: Thailand
   supports_sms: false
-  supports_voice: false
+  supports_voice: true
 TJ:
   country_code: '992'
   name: Tajikistan
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 TL:
   country_code: '670'
   name: Timor-Leste
@@ -938,12 +938,12 @@ TT:
   country_code: '1868'
   name: Trinidad and Tobago
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 TW:
   country_code: '886'
   name: Taiwan
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 TZ:
   country_code: '255'
   name: Tanzania
@@ -968,7 +968,7 @@ UY:
   country_code: '598'
   name: Uruguay
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 UZ:
   country_code: '998'
   name: Uzbekistan
@@ -983,7 +983,7 @@ VE:
   country_code: '58'
   name: Venezuela
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 VG:
   country_code: '1284'
   name: Virgin Islands, British
@@ -998,7 +998,7 @@ VN:
   country_code: '84'
   name: Vietnam
   supports_sms: false
-  supports_voice: false
+  supports_voice: true
 VU:
   country_code: '678'
   name: Vanuatu
@@ -1018,7 +1018,7 @@ ZA:
   country_code: '27'
   name: South Africa
   supports_sms: true
-  supports_voice: false
+  supports_voice: true
 ZM:
   country_code: '260'
   name: Zambia

--- a/config/locales/two_factor_authentication/en.yml
+++ b/config/locales/two_factor_authentication/en.yml
@@ -119,6 +119,10 @@ en:
     read_about_two_factor_authentication:
       link: read about two-factor authentication
       text_html: You can %{link} and why we use it at our Help page.
+    temp_disabled:
+      p_1: We are having trouble making phone calls to confirm phone numbers.
+      p_2: Phones can still be confirmed with an SMS message. If you are unable to
+        receive SMS messages please choose a different authentication method.
     totp_fallback:
       question: Don't have your authenticator app?
     totp_header_text: Enter your authentication app code

--- a/config/locales/two_factor_authentication/es.yml
+++ b/config/locales/two_factor_authentication/es.yml
@@ -128,6 +128,11 @@ es:
     read_about_two_factor_authentication:
       link: leer acerca de la autenticación de dos factores
       text_html: Puede %{link} y por qué la utilizamos en nuestra página de Ayuda.
+    temp_disabled:
+      p_1: Tenemos problemas para realizar llamadas telefónicas para confirmar números
+        de teléfono.
+      p_2: Los teléfonos aún se pueden confirmar con un mensaje SMS. Si no puede recibir
+        mensajes SMS, elija un método de autenticación diferente.
     totp_fallback:
       question: "¿No tiene su aplicación de autenticación?"
     totp_header_text: Ingrese su código de la app de autenticación

--- a/config/locales/two_factor_authentication/fr.yml
+++ b/config/locales/two_factor_authentication/fr.yml
@@ -127,6 +127,11 @@ fr:
     read_about_two_factor_authentication:
       link: lire sur l'authentification à deux facteurs
       text_html: Vous pouvez %{link} et pourquoi nous l'utilisons sur notre page d'aide.
+    temp_disabled:
+      p_1: Nous rencontrons des difficultés pour passer des appels téléphoniques pour
+        confirmer les numéros de téléphone.
+      p_2: Les téléphones peuvent toujours être confirmés par un message SMS. Si vous
+        ne pouvez pas recevoir de SMS, veuillez choisir une autre méthode d'authentification.
     totp_fallback:
       question: Vous n'avez pas votre application d'authentification?
     totp_header_text: Entrez votre code d'application d'authentification

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -43,7 +43,8 @@ feature 'disavowing an action' do
 
     fill_in 'new_phone_form[phone]', with: '202-555-3434'
 
-    choose 'new_phone_form_otp_delivery_preference_sms'
+    # Restore this line when voice confirmation is re-enabled
+    # choose 'new_phone_form_otp_delivery_preference_sms'
     check 'new_phone_form_otp_make_default_number'
     click_button t('forms.buttons.continue')
 

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -8,12 +8,14 @@ describe 'phone otp confirmation' do
     let!(:user) { sign_up_and_set_password }
 
     it_behaves_like 'phone otp confirmation', :sms
-    it_behaves_like 'phone otp confirmation', :voice
+    # Restore this line when voice confirmation is re-enabled
+    # it_behaves_like 'phone otp confirmation', :voice
 
-    def visit_otp_confirmation(delivery_method)
+    def visit_otp_confirmation(_delivery_method)
       select_2fa_option(:phone)
       fill_in :new_phone_form_phone, with: phone
-      select_phone_delivery_option(delivery_method)
+      # Restore this line when voice confirmation is re-enabled
+      # select_phone_delivery_option(delivery_method)
       click_send_security_code
     end
 
@@ -60,13 +62,15 @@ describe 'phone otp confirmation' do
     let(:user) { create(:user, :signed_up) }
 
     it_behaves_like 'phone otp confirmation', :sms
-    it_behaves_like 'phone otp confirmation', :voice
+    # Restore this line when voice confirmation is re-enabled
+    # it_behaves_like 'phone otp confirmation', :voice
 
-    def visit_otp_confirmation(delivery_method)
+    def visit_otp_confirmation(_delivery_method)
       sign_in_live_with_2fa(user)
       click_on "+ #{t('account.index.phone_add')}"
       fill_in :new_phone_form_phone, with: phone
-      select_phone_delivery_option(delivery_method)
+      # Restore this line when voice confirmation is re-enabled
+      # select_phone_delivery_option(delivery_method)
       click_continue
     end
 

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -84,6 +84,8 @@ describe 'default phone selection' do
   describe 'voice delivery preference' do
     context 'when the user creates a new default phone number' do
       it 'displays the new default number for 2FA' do
+        pending 'disabled while voice OTP confirmation is disabled'
+
         sign_in_visit_add_phone_path(user, phone_config2)
 
         enter_phone_number('202-555-3434')

--- a/spec/features/phone/rate_limitting_spec.rb
+++ b/spec/features/phone/rate_limitting_spec.rb
@@ -10,7 +10,7 @@ describe 'phone rate limitting' do
     # Restore this line when voice confirmation is re-enabled
     # it_behaves_like 'phone rate limitting', :voice
 
-    def visit_otp_confirmation(delivery_method)
+    def visit_otp_confirmation(_delivery_method)
       select_2fa_option(:phone)
       # Restore this line when voice confirmation is re-enabled
       # select_phone_delivery_option(delivery_method)
@@ -26,7 +26,7 @@ describe 'phone rate limitting' do
     # Restore this line when voice confirmation is re-enabled
     # it_behaves_like 'phone rate limitting', :voice
 
-    def visit_otp_confirmation(delivery_method)
+    def visit_otp_confirmation(_delivery_method)
       sign_in_live_with_2fa(user)
       click_on "+ #{t('account.index.phone_add')}"
       fill_in :new_phone_form_phone, with: phone

--- a/spec/features/phone/rate_limitting_spec.rb
+++ b/spec/features/phone/rate_limitting_spec.rb
@@ -7,11 +7,13 @@ describe 'phone rate limitting' do
     let!(:user) { sign_up_and_set_password }
 
     it_behaves_like 'phone rate limitting', :sms
-    it_behaves_like 'phone rate limitting', :voice
+    # Restore this line when voice confirmation is re-enabled
+    # it_behaves_like 'phone rate limitting', :voice
 
     def visit_otp_confirmation(delivery_method)
       select_2fa_option(:phone)
-      select_phone_delivery_option(delivery_method)
+      # Restore this line when voice confirmation is re-enabled
+      # select_phone_delivery_option(delivery_method)
       fill_in :new_phone_form_phone, with: phone
       click_send_security_code
     end
@@ -21,13 +23,15 @@ describe 'phone rate limitting' do
     let(:user) { create(:user, :signed_up) }
 
     it_behaves_like 'phone rate limitting', :sms
-    it_behaves_like 'phone rate limitting', :voice
+    # Restore this line when voice confirmation is re-enabled
+    # it_behaves_like 'phone rate limitting', :voice
 
     def visit_otp_confirmation(delivery_method)
       sign_in_live_with_2fa(user)
       click_on "+ #{t('account.index.phone_add')}"
       fill_in :new_phone_form_phone, with: phone
-      select_phone_delivery_option(delivery_method)
+      # Restore this line when voice confirmation is re-enabled
+      # select_phone_delivery_option(delivery_method)
       click_continue
     end
   end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -40,6 +40,8 @@ feature 'Two Factor Authentication' do
       let(:unsupported_phone) { '242-327-0143' }
 
       scenario 'renders an error if a user submits with JS disabled' do
+        pending 'disabled while voice OTP confirmation is disabled'
+
         sign_in_before_2fa
         select_2fa_option(:phone)
         select_phone_delivery_option(:voice)
@@ -79,6 +81,8 @@ feature 'Two Factor Authentication' do
       end
 
       scenario 'allows a user to continue typing even if a number is invalid', :js do
+        pending 'disabled while voice OTP confirmation is disabled'
+
         sign_in_before_2fa
         select_2fa_option(:phone)
 


### PR DESCRIPTION
This change will only affect users who are attempting to add a phone. A message has been added to alert users they will receive an SMS. They are directed to choose a diferent option if they cannot receive SMS messages.