### PR TITLE
Hide USWDS banner immediately in JavaScript contexts

### DIFF
--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -22,6 +22,9 @@
         </div>
       </header>
       <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+        <%= nonced_javascript_tag do %>
+          document.getElementById('gov-banner').setAttribute('hidden', '');
+        <% end %>
         <div class="grid-row grid-gap-lg">
           <div class="usa-banner__guidance tablet:grid-col-6">
             <%= image_tag(

--- a/spec/features/visitors/js_disabled_spec.rb
+++ b/spec/features/visitors/js_disabled_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'JavaScript progressive enhancement' do
+  describe 'banner' do
+    context 'javascript disabled' do
+      it 'displays content visibly' do
+        visit root_path
+
+        expect(page).to have_css('#gov-banner', visible: true)
+      end
+    end
+
+    context 'javascript enabled', js: true do
+      it 'toggles content hidden' do
+        visit root_path
+
+        expect(page).to have_css('#gov-banner', visible: :hidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that there's not a distracting flickering of the banner disappearing from view once the JavaScript assets have loaded.

See: https://github.com/uswds/uswds/issues/3092

**Additional Notes:**

Because the toggled banner content should be available to users who opt to disable JavaScript in their browsers, it is shown by default, then hidden by JavaScript. Because there can be a brief delay in loading the JavaScript, this toggling may not be instantaneous. And because the content is the first in the page, the shift in page content can be quite jarring.

The approach here aims to resolve this by leveraging the fact that inline script tags typically block continued page rendering. Placing the script tag immediately following the toggled banner container provides some assurance that the expanded banner content will not be perceivable by a user where JavaScript is enabled.

The content of the script corresponds to and is idempotent with what would expect to be run when USWDS component JavaScript loads:

1. https://github.com/uswds/uswds/blob/70e64dd/src/js/components/accordion.js#L86-L91
   - https://github.com/18F/identity-idp/blob/42159b7be43a706aaa700c6eb012f49f4abda1e4/app/views/shared/_banner.html.erb#L19
2. https://github.com/uswds/uswds/blob/70e64dd/src/js/components/accordion.js#L42
3. https://github.com/uswds/uswds/blob/70e64dd/src/js/utils/toggle.js#L23