### PR TITLE
Update identity-idp-functions, remove warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: b05d49b3c463124d0e49265c0c79f22a8102d910
-  ref: b05d49b3c463124d0e49265c0c79f22a8102d910
+  revision: 44f46a7fe2afa7894c665b09fd015fe41fd86450
+  ref: 44f46a7fe2afa7894c665b09fd015fe41fd86450
   specs:
     identity-idp-functions (0.6.0)
       aws-sdk-s3 (>= 1.73)

--- a/app/services/lambda_jobs/git_ref.rb
+++ b/app/services/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = 'b05d49b3c463124d0e49265c0c79f22a8102d910'
+  GIT_REF = '44f46a7fe2afa7894c665b09fd015fe41fd86450'
 end


### PR DESCRIPTION
Just a small bump, fixes HTTP_PROXY variable warnings

https://github.com/18f/identity-idp-functions/compare/b05d49b3c463124d0e49265c0c79f22a8102d910...44f46a7fe2afa7894c665b09fd015fe41fd86450
