### PR TITLE
LG-3644: Update 2FA "Add" links to be contextualized

### DIFF
--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -1,10 +1,10 @@
 <div>
   <div class="grid-row mb1 mt0">
-    <h2 class="grid-col-6 m0">
+    <h2 class="grid-col-fill margin-y-0 padding-right-2">
       <%= t('headings.account.authentication_apps') %>
     </h2>
     <% if current_user.auth_app_configurations.count < AppConfig.env.max_auth_apps_per_account.to_i %>
-      <div class="right-align grid-col-6">
+      <div class="grid-col-auto">
         <%= link_to(
           prefix_with_plus(t('account.index.auth_app_add')),
           authenticator_setup_url,

--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -6,7 +6,7 @@
     <% if current_user.auth_app_configurations.count < AppConfig.env.max_auth_apps_per_account.to_i %>
       <div class="right-align grid-col-6">
         <%= link_to(
-          prefix_with_plus(t('forms.buttons.enable')),
+          prefix_with_plus(t('account.index.auth_app_add')),
           authenticator_setup_url,
           class: 'btn btn-account-action rounded-lg bg-light-blue',
         ) %>

--- a/app/views/accounts/_backup_codes.html.erb
+++ b/app/views/accounts/_backup_codes.html.erb
@@ -1,8 +1,8 @@
 <div class="grid-row mb1 mt0">
-  <h2 class="grid-col-6 m0">
+  <h2 class="grid-col-fill margin-y-0 padding-right-2">
     <%= t('forms.backup_code.title') %>
   </h2>
-  <div class="right-align grid-col-6">
+  <div class="grid-col-auto">
     <%= render @view_model.backup_codes_partial %>
   </div>
 </div>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -1,9 +1,9 @@
 <div>
   <div class="grid-row mb1 mt0">
-    <h2 class="grid-col-6 m0">
+    <h2 class="grid-col-fill margin-y-0 padding-right-2">
       <%= t('account.index.phone') %>
     </h2>
-    <div class="right-align grid-col-6">
+    <div class="grid-col-auto">
       <% if EmailPolicy.new(current_user).can_add_email? %>
         <%= link_to(
           prefix_with_plus(t('account.index.phone_add')),

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -6,7 +6,7 @@
     <% if current_user.piv_cac_configurations.count < AppConfig.env.max_piv_cac_per_account.to_i %>
       <div class="right-align grid-col-6">
         <%= link_to(
-          prefix_with_plus(t('forms.buttons.enable')),
+          prefix_with_plus(t('account.index.piv_cac_add')),
           setup_piv_cac_url,
           class: 'btn btn-account-action rounded-lg bg-light-blue',
         ) %>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -1,10 +1,10 @@
 <div>
   <div class="grid-row mb1 mt0">
-    <h2 class="grid-col-6 m0">
+    <h2 class="grid-col-fill margin-y-0 padding-right-2">
       <%= t('headings.account.federal_employee_id') %>
     </h2>
     <% if current_user.piv_cac_configurations.count < AppConfig.env.max_piv_cac_per_account.to_i %>
-      <div class="right-align grid-col-6">
+      <div class="grid-col-auto">
         <%= link_to(
           prefix_with_plus(t('account.index.piv_cac_add')),
           setup_piv_cac_url,

--- a/app/views/accounts/_webauthn.html.erb
+++ b/app/views/accounts/_webauthn.html.erb
@@ -1,9 +1,9 @@
 <div>
   <div class="grid-row mb1 mt0">
-    <h2 class="grid-col-6 m0">
+    <h2 class="grid-col-fill margin-y-0 padding-right-1">
       <%= t('account.index.webauthn') %>
     </h2>
-    <div class="right-align grid-col-6">
+    <div class="grid-col-auto">
       <%= link_to(
         prefix_with_plus(t('account.index.webauthn_add')),
         webauthn_setup_path,

--- a/config/locales/account/en.yml
+++ b/config/locales/account/en.yml
@@ -25,6 +25,7 @@ en:
         key) each time you want to access your account.
     index:
       address: Current address
+      auth_app_add: Add app
       auth_app_disabled: not enabled
       auth_app_enabled: enabled
       backup_code_confirm_delete: Yes, delete codes
@@ -42,6 +43,7 @@ en:
       password: Password
       phone: Phone numbers
       phone_add: Add phone
+      piv_cac_add: Add ID
       piv_cac_card: PIV/CAC Cards
       piv_cac_confirm_delete: Yes, remove card
       piv_cac_disabled: not enabled

--- a/config/locales/account/es.yml
+++ b/config/locales/account/es.yml
@@ -26,6 +26,7 @@ es:
         a su cuenta.
     index:
       address: Dirección actual
+      auth_app_add: Agregar aplicación
       auth_app_disabled: no permitido
       auth_app_enabled: permitido
       backup_code_confirm_delete: Sí, borrar códigos
@@ -43,6 +44,7 @@ es:
       password: Contraseña
       phone: Teléfono
       phone_add: Añadir teléfono
+      piv_cac_add: Agregar ID
       piv_cac_card: Tarjetas PIV/CAC
       piv_cac_confirm_delete: Sí, retire la tarjeta
       piv_cac_disabled: desactivada

--- a/config/locales/account/fr.yml
+++ b/config/locales/account/fr.yml
@@ -26,6 +26,7 @@ fr:
         chaque fois que vous souhaitez accéder à votre compte.
     index:
       address: Adresse actuelle
+      auth_app_add: Ajouter une application
       auth_app_disabled: non activée
       auth_app_enabled: activée
       backup_code_confirm_delete: Oui, supprimer les codes
@@ -43,6 +44,7 @@ fr:
       password: Mot de passe
       phone: Numéro de téléphone
       phone_add: Ajouter un téléphone
+      piv_cac_add: Ajouter un identifiant
       piv_cac_card: Cartes PIV/CAC
       piv_cac_confirm_delete: Oui, retirer la carte
       piv_cac_disabled: désactivée


### PR DESCRIPTION
**Why**: As a user, I expect that I can understand the purpose of a link based on its text or the text of the immediately surrounding context, so that I can understand where I will navigate when activating the link.

Related Slack discussion: https://gsa-tts.slack.com/archives/CNCGEHG1G/p1606226864304500

**Implementation Notes:**

In the course of implementing this, it became clearer that the labels may have been abbreviated to better fit within mobile viewports, where the button and heading share the same horizontal space. After some back-and-forth with @anniehirshman-gsa , the current proposal is to use [USWDS auto layout grid columns](https://designsystem.digital.gov/utilities/layout-grid/#auto-layout-columns) to try to allow the title and button to share the space, but allow wrapping when absolutely necessary (specifically, non-English locales).

**Screenshots:**

_Desktop:_

Locale|Before|After
---|---|---
English|![image](https://user-images.githubusercontent.com/1779930/100120537-09af3d80-2e46-11eb-85bb-5d50ecd9c33d.png)|![image](https://user-images.githubusercontent.com/1779930/100120253-c228b180-2e45-11eb-9ba7-fb6096218561.png)
French|![image](https://user-images.githubusercontent.com/1779930/100120514-01570280-2e46-11eb-91cf-b33591c738e5.png)|![image](https://user-images.githubusercontent.com/1779930/100120304-ce147380-2e45-11eb-9b14-d319fe16f9c2.png)
Spanish|![image](https://user-images.githubusercontent.com/1779930/100120489-f8fec780-2e45-11eb-939e-1ad32c98c28d.png)|![image](https://user-images.githubusercontent.com/1779930/100120336-d8367200-2e45-11eb-958e-996c635d3060.png)

_Mobile:_

Locale|Before|After
---|---|---
English|![image](https://user-images.githubusercontent.com/1779930/100120568-12a00f00-2e46-11eb-8742-58bb5534b24c.png)|![image](https://user-images.githubusercontent.com/1779930/100120719-4844f800-2e46-11eb-9f67-0d84a87025b1.png)
French|![image](https://user-images.githubusercontent.com/1779930/100120593-1a5fb380-2e46-11eb-8a65-c6b5b27fbd4e.png)|![image](https://user-images.githubusercontent.com/1779930/100120687-3d8a6300-2e46-11eb-97fc-53b5789b6be0.png)
Spanish|![image](https://user-images.githubusercontent.com/1779930/100120627-28adcf80-2e46-11eb-9176-ed4bc00c54e5.png)|![image](https://user-images.githubusercontent.com/1779930/100120667-34999180-2e46-11eb-9aa0-bba5c95d406e.png)

