### PR TITLE
do not raise exception on missing asset

### DIFF
--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -30,11 +30,7 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_logo
-    if sp.logo.present?
-      sp.logo
-    else
-      DEFAULT_LOGO
-    end
+    sp.logo.presence || DEFAULT_LOGO
   end
 
   def sp_logo_url

--- a/app/decorators/service_provider_session_decorator.rb
+++ b/app/decorators/service_provider_session_decorator.rb
@@ -30,7 +30,11 @@ class ServiceProviderSessionDecorator
   end
 
   def sp_logo
-    sp.logo || DEFAULT_LOGO
+    if sp.logo.present?
+      sp.logo
+    else
+      DEFAULT_LOGO
+    end
   end
 
   def sp_logo_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module Upaya
 
     config.load_defaults '5.2'
     config.active_record.belongs_to_required_by_default = false
+    config.assets.unknown_asset_fallback = true
 
     config.active_job.queue_adapter = 'inline'
     config.time_zone = 'UTC'

--- a/spec/decorators/service_provider_session_decorator_spec.rb
+++ b/spec/decorators/service_provider_session_decorator_spec.rb
@@ -172,6 +172,21 @@ RSpec.describe ServiceProviderSessionDecorator do
         expect(subject.sp_logo_url).to eq(logo)
       end
     end
+
+    context 'service provider has a poorly configured logo' do
+      it 'does not raise an exception' do
+        sp = build_stubbed(:service_provider, logo: 'abc')
+
+        subject = ServiceProviderSessionDecorator.new(
+          sp: sp,
+          view_context: view_context,
+          sp_session: {},
+          service_provider_request: ServiceProviderRequestProxy.new,
+        )
+
+        expect(subject.sp_logo_url).is_a? String
+      end
+    end
   end
 
   describe '#cancel_link_url' do


### PR DESCRIPTION
#4451 introduced a default config that causes an exception to be raised if a url/path helper is called with an asset that doesn't exist in the pipeline

This did reveal an edge case with some SPs that have a blank string as a logo instead of nil, so the switch to `.present?` should now give them the default logo.