### PR TITLE
remove two_factor_authentication gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ gem 'stringex', require: false
 gem 'strong_migrations', '>= 0.4.2'
 gem 'subprocess', require: false
 gem 'twilio-ruby'
-gem 'two_factor_authentication', '>= 2.1.1'
 gem 'uglifier', '~> 3.2'
 gem 'user_agent_parser'
 gem 'valid_email', '>= 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,6 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    encryptor (3.0.0)
     enumerable-statistics (2.0.1)
     equalizer (0.0.11)
     errbase (0.2.0)
@@ -503,7 +502,6 @@ GEM
     rainbow (3.0.0)
     raise-if-root (0.0.2)
     rake (13.0.1)
-    randexp (0.1.7)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -653,12 +651,6 @@ GEM
       faraday (>= 0.9, < 2.0)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)
-    two_factor_authentication (2.1.1)
-      devise
-      encryptor
-      rails (>= 3.1.1)
-      randexp
-      rotp (>= 3.2.0)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -821,7 +813,6 @@ DEPENDENCIES
   subprocess
   timecop
   twilio-ruby
-  two_factor_authentication (>= 2.1.1)
   uglifier (~> 3.2)
   user_agent_parser
   valid_email (>= 0.1.3)

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -4,6 +4,7 @@ module TwoFactorAuthenticatable
 
   NEED_AUTHENTICATION = 'need_two_factor_authentication'.freeze
   OTP_LENGTH = 6
+  DIRECT_OTP_LENGTH = 6
   ALLOWED_OTP_DRIFT_SECONDS = 30
   DIRECT_OTP_VALID_FOR_MINUTES = AppConfig.env.otp_valid_for.to_i
   DIRECT_OTP_VALID_FOR_SECONDS = DIRECT_OTP_VALID_FOR_MINUTES * 60
@@ -17,22 +18,6 @@ module TwoFactorAuthenticatable
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
     before_action :apply_secure_headers_override, only: %i[show create]
     # rubocop:enable Rails/LexicallyScopedActionFilter
-  end
-
-  def self.direct_otp_length
-    OTP_LENGTH
-  end
-
-  def self.otp_length
-    OTP_LENGTH
-  end
-
-  def self.direct_otp_valid_for_minutes
-    DIRECT_OTP_VALID_FOR_MINUTES
-  end
-
-  def self.direct_otp_valid_for_seconds
-    DIRECT_OTP_VALID_FOR_SECONDS
   end
 
   def self.allowed_otp_drift_seconds

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -2,6 +2,12 @@ module TwoFactorAuthenticatable
   extend ActiveSupport::Concern
   include TwoFactorAuthenticatableMethods
 
+  NEED_AUTHENTICATION = 'need_two_factor_authentication'.freeze
+  OTP_LENGTH = 6
+  ALLOWED_OTP_DRIFT_SECONDS = 30
+  DIRECT_OTP_VALID_FOR_SECONDS = AppConfig.env.otp_valid_for.to_i.minutes
+  REMEMBER_TFA_COOKIE = 'remember_tfa'.freeze
+
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter
     before_action :authenticate_user
@@ -10,5 +16,21 @@ module TwoFactorAuthenticatable
     before_action :reset_attempt_count_if_user_no_longer_locked_out, only: :create
     before_action :apply_secure_headers_override, only: %i[show create]
     # rubocop:enable Rails/LexicallyScopedActionFilter
+  end
+
+  def self.direct_otp_length
+    OTP_LENGTH
+  end
+
+  def self.otp_length
+    OTP_LENGTH
+  end
+
+  def self.direct_otp_valid_for_seconds
+    DIRECT_OTP_VALID_FOR_SECONDS
+  end
+
+  def self.allowed_otp_drift_seconds
+    ALLOWED_OTP_DRIFT_SECONDS
   end
 end

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -5,7 +5,8 @@ module TwoFactorAuthenticatable
   NEED_AUTHENTICATION = 'need_two_factor_authentication'.freeze
   OTP_LENGTH = 6
   ALLOWED_OTP_DRIFT_SECONDS = 30
-  DIRECT_OTP_VALID_FOR_SECONDS = AppConfig.env.otp_valid_for.to_i.minutes
+  DIRECT_OTP_VALID_FOR_MINUTES = AppConfig.env.otp_valid_for.to_i
+  DIRECT_OTP_VALID_FOR_SECONDS = DIRECT_OTP_VALID_FOR_MINUTES * 60
   REMEMBER_2FA_COOKIE = 'remember_tfa'.freeze
 
   included do
@@ -24,6 +25,10 @@ module TwoFactorAuthenticatable
 
   def self.otp_length
     OTP_LENGTH
+  end
+
+  def self.direct_otp_valid_for_minutes
+    DIRECT_OTP_VALID_FOR_MINUTES
   end
 
   def self.direct_otp_valid_for_seconds

--- a/app/controllers/concerns/two_factor_authenticatable.rb
+++ b/app/controllers/concerns/two_factor_authenticatable.rb
@@ -6,7 +6,7 @@ module TwoFactorAuthenticatable
   OTP_LENGTH = 6
   ALLOWED_OTP_DRIFT_SECONDS = 30
   DIRECT_OTP_VALID_FOR_SECONDS = AppConfig.env.otp_valid_for.to_i.minutes
-  REMEMBER_TFA_COOKIE = 'remember_tfa'.freeze
+  REMEMBER_2FA_COOKIE = 'remember_tfa'.freeze
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -203,7 +203,7 @@ module TwoFactorAuthenticatableMethods # rubocop:disable Metrics/ModuleLength
   end
 
   def mark_user_session_authenticated(authentication_type)
-    user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+    user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
     user_session[:authn_at] = Time.zone.now
     mark_user_session_authenticated_analytics(authentication_type)
   end

--- a/app/controllers/mfa_confirmation_controller.rb
+++ b/app/controllers/mfa_confirmation_controller.rb
@@ -20,7 +20,7 @@ class MfaConfirmationController < ApplicationController
   end
 
   def handle_valid_password
-    if current_user.totp_enabled?
+    if current_user.auth_app_configurations.any?
       redirect_to login_two_factor_authenticator_url(reauthn: true)
     else
       redirect_to user_two_factor_authentication_url(reauthn: true)

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -26,7 +26,7 @@ module TwoFactorAuthentication
     private
 
     def confirm_totp_enabled
-      return if current_user.totp_enabled? || current_user.auth_app_configurations.any?
+      return if current_user.auth_app_configurations.any?
 
       redirect_to user_two_factor_authentication_url
     end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -73,7 +73,7 @@ module Users
     end
 
     def mark_user_as_fully_authenticated
-      user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
       user_session[:authn_at] = Time.zone.now
     end
 

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -111,7 +111,7 @@ module Users
     end
 
     def mark_user_session_authenticated(authentication_type)
-      user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
       user_session[:authn_at] = Time.zone.now
       analytics.track_event(
         Analytics::USER_MARKED_AUTHED,

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -102,7 +102,7 @@ module Users
     end
 
     def mark_user_as_fully_authenticated
-      user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
       user_session[:authn_at] = Time.zone.now
     end
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -181,7 +181,7 @@ module Users
       params = {
         to: phone_to_deliver_to,
         otp: current_user.direct_otp,
-        expiration: Devise.direct_otp_valid_for.to_i / 60,
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60,
         channel: method.to_sym,
       }
       Telephony.send(send_otp_method_name, params)

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -181,7 +181,7 @@ module Users
       params = {
         to: phone_to_deliver_to,
         otp: current_user.direct_otp,
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         channel: method.to_sym,
       }
       Telephony.send(send_otp_method_name, params)

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -181,7 +181,7 @@ module Users
       params = {
         to: phone_to_deliver_to,
         otp: current_user.direct_otp,
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60,
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
         channel: method.to_sym,
       }
       Telephony.send(send_otp_method_name, params)

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -115,7 +115,7 @@ module Users
     end
 
     def mark_user_as_fully_authenticated
-      user_session[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
       user_session[:authn_at] = Time.zone.now
     end
 

--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -29,7 +29,7 @@ module Voice
     end
 
     def message
-      expiration = TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60
+      expiration = TwoFactorAuthenticatable.direct_otp_valid_for_minutes
       t('voice.otp.message', code: code_with_pauses, expiration: expiration)
     end
 

--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -29,7 +29,7 @@ module Voice
     end
 
     def message
-      expiration = TwoFactorAuthenticatable.direct_otp_valid_for_minutes
+      expiration = TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES
       t('voice.otp.message', code: code_with_pauses, expiration: expiration)
     end
 

--- a/app/controllers/voice/otp_controller.rb
+++ b/app/controllers/voice/otp_controller.rb
@@ -29,7 +29,7 @@ module Voice
     end
 
     def message
-      expiration = Devise.direct_otp_valid_for.to_i / 60
+      expiration = TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60
       t('voice.otp.message', code: code_with_pauses, expiration: expiration)
     end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -111,7 +111,7 @@ class UserDecorator
     options = {
       issuer: 'Login.gov',
       otp_secret_key: otp_secret_key,
-      digits: TwoFactorAuthenticatable.direct_otp_length,
+      digits: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
     }
     url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(email)
     qrcode = RQRCode::QRCode.new(url)

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -111,8 +111,9 @@ class UserDecorator
     options = {
       issuer: 'Login.gov',
       otp_secret_key: otp_secret_key,
+      digits: TwoFactorAuthenticatable.direct_otp_length,
     }
-    url = user.provisioning_uri(nil, options)
+    url = ROTP::TOTP.new(otp_secret_key, options).provisioning_uri(email)
     qrcode = RQRCode::QRCode.new(url)
     qrcode.as_png(size: 240).to_data_url
   end

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -26,7 +26,7 @@ class OtpVerificationForm
   end
 
   def otp_code_length
-    Devise.direct_otp_length
+    TwoFactorAuthenticatable.direct_otp_length
   end
 
   def extra_analytics_attributes

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -26,7 +26,7 @@ class OtpVerificationForm
   end
 
   def otp_code_length
-    TwoFactorAuthenticatable.direct_otp_length
+    TwoFactorAuthenticatable::DIRECT_OTP_LENGTH
   end
 
   def extra_analytics_attributes

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -26,7 +26,7 @@ class TotpVerificationForm
   end
 
   def totp_code_length
-    Devise.otp_length
+    TwoFactorAuthenticatable.otp_length
   end
 
   def extra_analytics_attributes

--- a/app/forms/totp_verification_form.rb
+++ b/app/forms/totp_verification_form.rb
@@ -26,7 +26,7 @@ class TotpVerificationForm
   end
 
   def totp_code_length
-    TwoFactorAuthenticatable.otp_length
+    TwoFactorAuthenticatable::OTP_LENGTH
   end
 
   def extra_analytics_attributes

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -1,0 +1,40 @@
+require 'otp_code_generator'
+
+module UserOtpMethods
+  extend ActiveSupport::Concern
+
+  def max_login_attempts?
+    second_factor_attempts_count.to_i >= max_login_attempts
+  end
+
+  def create_direct_otp
+    update(
+      direct_otp: OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable.direct_otp_length),
+      direct_otp_sent_at: Time.zone.now,
+    )
+  end
+
+  def generate_totp_secret
+    ROTP::Base32.random_base32
+  end
+
+  def authenticate_direct_otp(code)
+    return false if direct_otp.nil? || direct_otp != code || direct_otp_expired?
+    clear_direct_otp
+    true
+  end
+
+  def direct_otp_expired?
+    Time.zone.now > direct_otp_sent_at + TwoFactorAuthenticatable.direct_otp_valid_for_seconds
+  end
+
+  private
+
+  def clear_direct_otp
+    update(direct_otp: nil, direct_otp_sent_at: nil)
+  end
+
+  def max_login_attempts
+    3
+  end
+end

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -9,7 +9,7 @@ module UserOtpMethods
 
   def create_direct_otp
     update(
-      direct_otp: OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable.direct_otp_length),
+      direct_otp: OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable::DIRECT_OTP_LENGTH),
       direct_otp_sent_at: Time.zone.now,
     )
   end
@@ -25,7 +25,7 @@ module UserOtpMethods
   end
 
   def direct_otp_expired?
-    Time.zone.now > direct_otp_sent_at + TwoFactorAuthenticatable.direct_otp_valid_for_seconds
+    Time.zone.now > direct_otp_sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,7 +123,7 @@ class User < ApplicationRecord
   end
 
   def direct_otp_expired?
-    Time.zone.now.utc > direct_otp_sent_at + AppConfig.env.otp_valid_for.to_i.minutes
+    Time.zone.now > direct_otp_sent_at + TwoFactorAuthenticatable.direct_otp_valid_for_seconds
   end
 
   def random_base10(digits)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,7 +104,7 @@ class User < ApplicationRecord
   def create_direct_otp
     update(
       direct_otp: random_base10(TwoFactorAuthenticatable.direct_otp_length),
-      direct_otp_sent_at: Time.zone.now.utc,
+      direct_otp_sent_at: Time.zone.now,
     )
   end
 

--- a/app/presenters/idv/otp_verification_presenter.rb
+++ b/app/presenters/idv/otp_verification_presenter.rb
@@ -13,7 +13,7 @@ module Idv
     def phone_number_message
       t("instructions.mfa.#{otp_delivery_preference}.number_message_html",
         number: content_tag(:strong, phone_number),
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES)
     end
 
     def update_phone_link

--- a/app/presenters/idv/otp_verification_presenter.rb
+++ b/app/presenters/idv/otp_verification_presenter.rb
@@ -13,7 +13,7 @@ module Idv
     def phone_number_message
       t("instructions.mfa.#{otp_delivery_preference}.number_message_html",
         number: content_tag(:strong, phone_number),
-        expiration: AppConfig.env.otp_valid_for)
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
     end
 
     def update_phone_link

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -11,7 +11,7 @@ module TwoFactorAuthCode
     def phone_number_message
       t("instructions.mfa.#{otp_delivery_preference}.number_message_html",
         number: content_tag(:strong, phone_number),
-        expiration: AppConfig.env.otp_valid_for)
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
     end
 
     def fallback_question

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -11,7 +11,7 @@ module TwoFactorAuthCode
     def phone_number_message
       t("instructions.mfa.#{otp_delivery_preference}.number_message_html",
         number: content_tag(:strong, phone_number),
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES)
     end
 
     def fallback_question

--- a/app/services/db/auth_app_configuration/authenticate.rb
+++ b/app/services/db/auth_app_configuration/authenticate.rb
@@ -3,10 +3,12 @@ module Db
     class Authenticate
       def self.call(user, code)
         user.auth_app_configurations.each do |cfg|
-          totp = ROTP::TOTP.new(cfg.otp_secret_key, digits: Devise.otp_length)
-          new_timestamp = totp.verify_with_drift_and_prior(code,
-                                                           Devise.allowed_otp_drift_seconds,
-                                                           cfg.totp_timestamp)
+          totp = ROTP::TOTP.new(cfg.otp_secret_key, digits: TwoFactorAuthenticatable.otp_length)
+          new_timestamp = totp.verify_with_drift_and_prior(
+            code,
+            TwoFactorAuthenticatable.allowed_otp_drift_seconds,
+            cfg.totp_timestamp,
+          )
           return true if update_timestamp(cfg, new_timestamp)
         end
         false

--- a/app/services/db/auth_app_configuration/authenticate.rb
+++ b/app/services/db/auth_app_configuration/authenticate.rb
@@ -3,10 +3,10 @@ module Db
     class Authenticate
       def self.call(user, code)
         user.auth_app_configurations.each do |cfg|
-          totp = ROTP::TOTP.new(cfg.otp_secret_key, digits: TwoFactorAuthenticatable.otp_length)
+          totp = ROTP::TOTP.new(cfg.otp_secret_key, digits: TwoFactorAuthenticatable::OTP_LENGTH)
           new_timestamp = totp.verify_with_drift_and_prior(
             code,
-            TwoFactorAuthenticatable.allowed_otp_drift_seconds,
+            TwoFactorAuthenticatable::ALLOWED_OTP_DRIFT_SECONDS,
             cfg.totp_timestamp,
           )
           return true if update_timestamp(cfg, new_timestamp)

--- a/app/services/db/auth_app_configuration/confirm.rb
+++ b/app/services/db/auth_app_configuration/confirm.rb
@@ -2,8 +2,8 @@ module Db
   module AuthAppConfiguration
     class Confirm
       def self.call(secret, code)
-        totp = ROTP::TOTP.new(secret, digits: Devise.otp_length)
-        totp.verify_with_drift_and_prior(code, Devise.allowed_otp_drift_seconds)
+        totp = ROTP::TOTP.new(secret, digits: TwoFactorAuthenticatable.direct_otp_length)
+        totp.verify_with_drift_and_prior(code, TwoFactorAuthenticatable.allowed_otp_drift_seconds)
       end
     end
   end

--- a/app/services/db/auth_app_configuration/confirm.rb
+++ b/app/services/db/auth_app_configuration/confirm.rb
@@ -2,8 +2,8 @@ module Db
   module AuthAppConfiguration
     class Confirm
       def self.call(secret, code)
-        totp = ROTP::TOTP.new(secret, digits: TwoFactorAuthenticatable.direct_otp_length)
-        totp.verify_with_drift_and_prior(code, TwoFactorAuthenticatable.allowed_otp_drift_seconds)
+        totp = ROTP::TOTP.new(secret, digits: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH)
+        totp.verify_with_drift_and_prior(code, TwoFactorAuthenticatable::ALLOWED_OTP_DRIFT_SECONDS)
       end
     end
   end

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -57,7 +57,7 @@ module Idv
       @telephony_response = Telephony.send_confirmation_otp(
         otp: code,
         to: phone,
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60,
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
         channel: delivery_method,
       )
       add_cost

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -57,7 +57,7 @@ module Idv
       @telephony_response = Telephony.send_confirmation_otp(
         otp: code,
         to: phone,
-        expiration: Devise.direct_otp_valid_for.to_i / 60,
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_seconds / 60,
         channel: delivery_method,
       )
       add_cost

--- a/app/services/idv/send_phone_confirmation_otp.rb
+++ b/app/services/idv/send_phone_confirmation_otp.rb
@@ -57,7 +57,7 @@ module Idv
       @telephony_response = Telephony.send_confirmation_otp(
         otp: code,
         to: phone,
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         channel: delivery_method,
       )
       add_cost

--- a/app/services/phone_confirmation/code_generator.rb
+++ b/app/services/phone_confirmation/code_generator.rb
@@ -1,8 +1,10 @@
+require 'otp_code_generator'
+
 module PhoneConfirmation
   class CodeGenerator
     def self.call
       digits = TwoFactorAuthenticatable.direct_otp_length
-      SecureRandom.random_number(10**digits).to_s.rjust(digits, '0')
+      OtpCodeGenerator.generate_digits(digits)
     end
   end
 end

--- a/app/services/phone_confirmation/code_generator.rb
+++ b/app/services/phone_confirmation/code_generator.rb
@@ -3,8 +3,7 @@ require 'otp_code_generator'
 module PhoneConfirmation
   class CodeGenerator
     def self.call
-      digits = TwoFactorAuthenticatable.direct_otp_length
-      OtpCodeGenerator.generate_digits(digits)
+      OtpCodeGenerator.generate_digits(TwoFactorAuthenticatable::DIRECT_OTP_LENGTH)
     end
   end
 end

--- a/app/services/phone_confirmation/code_generator.rb
+++ b/app/services/phone_confirmation/code_generator.rb
@@ -1,7 +1,7 @@
 module PhoneConfirmation
   class CodeGenerator
     def self.call
-      digits = Devise.direct_otp_length
+      digits = TwoFactorAuthenticatable.direct_otp_length
       SecureRandom.random_number(10**digits).to_s.rjust(digits, '0')
     end
   end

--- a/app/services/phone_confirmation/confirmation_session.rb
+++ b/app/services/phone_confirmation/confirmation_session.rb
@@ -32,7 +32,7 @@ module PhoneConfirmation
     end
 
     def expired?
-      expiration_time = sent_at + TwoFactorAuthenticatable.direct_otp_valid_for_seconds
+      expiration_time = sent_at + TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
       Time.zone.now > expiration_time
     end
 

--- a/app/services/phone_confirmation/confirmation_session.rb
+++ b/app/services/phone_confirmation/confirmation_session.rb
@@ -32,7 +32,7 @@ module PhoneConfirmation
     end
 
     def expired?
-      expiration_time = sent_at + AppConfig.env.otp_valid_for.to_i.minutes
+      expiration_time = sent_at + TwoFactorAuthenticatable.direct_otp_valid_for_seconds
       Time.zone.now > expiration_time
     end
 

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -15,7 +15,7 @@
     <%= text_field_tag(:code, '', value: @code, required: true,
                        aria: { invalid: false, describedby: 'code-instructs' }, autofocus: true,
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       maxlength: TwoFactorAuthenticatable.direct_otp_length, autocomplete: 'one-time-code', type: 'tel') %>
+                       maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH, autocomplete: 'one-time-code', type: 'tel') %>
   </div>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>
   <br/>

--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -15,7 +15,7 @@
     <%= text_field_tag(:code, '', value: @code, required: true,
                        aria: { invalid: false, describedby: 'code-instructs' }, autofocus: true,
                        pattern: '[0-9]*', class: 'col-12 field monospace mfa',
-                       maxlength: Devise.direct_otp_length, autocomplete: 'one-time-code', type: 'tel') %>
+                       maxlength: TwoFactorAuthenticatable.direct_otp_length, autocomplete: 'one-time-code', type: 'tel') %>
   </div>
   <%= submit_tag t('forms.buttons.submit.default'), class: 'btn btn-primary align-top sm-col-6 col-12' %>
   <br/>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -21,7 +21,7 @@
                        pattern: '[0-9]*',
                        class: 'col-12 field monospace mfa',
                        aria: { invalid: false, describedby: 'code-instructs' },
-                       maxlength: TwoFactorAuthenticatable.direct_otp_length,
+                       maxlength: TwoFactorAuthenticatable::DIRECT_OTP_LENGTH,
                        autocomplete: 'one-time-code', type: 'tel') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number',

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -21,7 +21,7 @@
                        pattern: '[0-9]*',
                        class: 'col-12 field monospace mfa',
                        aria: { invalid: false, describedby: 'code-instructs' },
-                       maxlength: Devise.direct_otp_length,
+                       maxlength: TwoFactorAuthenticatable.direct_otp_length,
                        autocomplete: 'one-time-code', type: 'tel') %>
   </div>
   <%= hidden_field_tag 'otp_make_default_number',

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -16,7 +16,7 @@
                        pattern: '[0-9]*',
                        class: 'col-12 field monospace mfa',
                        type: 'tel',
-                       maxlength: Devise.otp_length,
+                       maxlength: TwoFactorAuthenticatable.otp_length,
                        autocomplete: 'one-time-code' %>
   </div>
   <div class="border border-light-blue rounded-lg py1 mt2 mb4 sm-my2 col-12 sm-col-7">

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -16,7 +16,7 @@
                        pattern: '[0-9]*',
                        class: 'col-12 field monospace mfa',
                        type: 'tel',
-                       maxlength: TwoFactorAuthenticatable.otp_length,
+                       maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
                        autocomplete: 'one-time-code' %>
   </div>
   <div class="border border-light-blue rounded-lg py1 mt2 mb4 sm-my2 col-12 sm-col-7">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -55,7 +55,7 @@
         <div class="clearfix mxn1">
           <div class="col col-6 sm-col-7 px1">
             <%= text_field_tag :code, '', required: true, aria: { invalid: false }, pattern: '[0-9]*', type: 'tel',
-                class: 'block col-12 field monospace mfa', maxlength: TwoFactorAuthenticatable.otp_length,
+                class: 'block col-12 field monospace mfa', maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
                 'aria-labelledby': 'totp-label' %>
           </div>
           <div class="col col-6 sm-col-5 px1">

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -55,7 +55,7 @@
         <div class="clearfix mxn1">
           <div class="col col-6 sm-col-7 px1">
             <%= text_field_tag :code, '', required: true, aria: { invalid: false }, pattern: '[0-9]*', type: 'tel',
-                class: 'block col-12 field monospace mfa', maxlength: Devise.otp_length,
+                class: 'block col-12 field monospace mfa', maxlength: TwoFactorAuthenticatable.otp_length,
                 'aria-labelledby': 'totp-label' %>
           </div>
           <div class="col col-6 sm-col-5 px1">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,7 +1,5 @@
 require 'saml_idp_constants'
 require 'custom_devise_failure_app'
-
-# rubocop:disable Metrics/BlockLength
 Devise.setup do |config|
   include Mailable
   require 'devise/orm/active_record'
@@ -24,15 +22,21 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 12
   config.timeout_in = AppConfig.env.session_timeout_in_minutes.to_i.minutes
 
-  # ==> Two Factor Authentication
-  config.allowed_otp_drift_seconds = 30
-  config.direct_otp_length = 6
-  config.direct_otp_valid_for = AppConfig.env.otp_valid_for.to_i.minutes
-  config.max_login_attempts = 3 # max OTP login attempts, not devise strategies (e.g. pw auth)
-  config.otp_length = 6
-
   config.warden do |manager|
     manager.failure_app = CustomDeviseFailureApp
   end
 end
-# rubocop:enable Metrics/BlockLength
+
+Warden::Manager.after_authentication do |user, auth, options|
+  if auth.env['action_dispatch.cookies']
+    expected_cookie_value = "#{user.class}-#{user.id}"
+    actual_cookie_value = auth.env['action_dispatch.cookies'].
+                          signed[TwoFactorAuthenticatable::REMEMBER_TFA_COOKIE]
+    bypass_by_cookie = actual_cookie_value == expected_cookie_value
+  end
+
+  unless bypass_by_cookie
+    auth.session(options[:scope])[TwoFactorAuthenticatable::NEED_AUTHENTICATION] =
+      user.need_two_factor_authentication?(auth.request)
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -31,7 +31,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   if auth.env['action_dispatch.cookies']
     expected_cookie_value = "#{user.class}-#{user.id}"
     actual_cookie_value = auth.env['action_dispatch.cookies'].
-                          signed[TwoFactorAuthenticatable::REMEMBER_TFA_COOKIE]
+                          signed[TwoFactorAuthenticatable::REMEMBER_2FA_COOKIE]
     bypass_by_cookie = actual_cookie_value == expected_cookie_value
   end
 

--- a/lib/otp_code_generator.rb
+++ b/lib/otp_code_generator.rb
@@ -1,0 +1,7 @@
+require 'securerandom'
+
+class OtpCodeGenerator
+  def self.generate_digits(digits)
+    SecureRandom.random_number(10**digits).to_s.rjust(digits, '0')
+  end
+end

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe Voice::OtpController do
       end
 
       it 'includes the otp expiration in the message' do
-        allow(Devise).to receive(:direct_otp_valid_for).and_return(4.minutes)
+        allow(TwoFactorAuthenticatable).to receive(:direct_otp_valid_for_seconds).
+          and_return(4.minutes)
 
         action
         expect(response.body).to include('4 minutes')

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -142,8 +142,8 @@ RSpec.describe Voice::OtpController do
       end
 
       it 'includes the otp expiration in the message' do
-        allow(TwoFactorAuthenticatable).to receive(:direct_otp_valid_for_seconds).
-          and_return(4.minutes)
+        allow(TwoFactorAuthenticatable).to receive(:direct_otp_valid_for_minutes).
+          and_return(4)
 
         action
         expect(response.body).to include('4 minutes')

--- a/spec/controllers/voice/otp_controller_spec.rb
+++ b/spec/controllers/voice/otp_controller_spec.rb
@@ -142,8 +142,7 @@ RSpec.describe Voice::OtpController do
       end
 
       it 'includes the otp expiration in the message' do
-        allow(TwoFactorAuthenticatable).to receive(:direct_otp_valid_for_minutes).
-          and_return(4)
+        stub_const('TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES', 4)
 
         action
         expect(response.body).to include('4 minutes')

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -29,7 +29,7 @@ feature 'phone otp verification step spec' do
   end
 
   it 'rejects OTPs after they are expired' do
-    expiration_minutes = AppConfig.env.otp_valid_for.to_i + 1
+    expiration_minutes = TwoFactorAuthenticatable.direct_otp_valid_for_minutes + 1
 
     start_idv_from_sp
     complete_idv_steps_before_phone_otp_verification_step

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -29,7 +29,7 @@ feature 'phone otp verification step spec' do
   end
 
   it 'rejects OTPs after they are expired' do
-    expiration_minutes = TwoFactorAuthenticatable.direct_otp_valid_for_minutes + 1
+    expiration_minutes = TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES + 1
 
     start_idv_from_sp
     complete_idv_steps_before_phone_otp_verification_step

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -15,7 +15,7 @@ describe 'default phone selection' do
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
           number: '***-***-1212',
-          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+          expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
     end
@@ -31,7 +31,7 @@ describe 'default phone selection' do
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
           number: '+1 202-555-3434',
-          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+          expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
 
         submit_prefilled_otp_code(user, 'sms')
@@ -44,7 +44,7 @@ describe 'default phone selection' do
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
           number: '***-***-3434',
-          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+          expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
     end
@@ -83,7 +83,7 @@ describe 'default phone selection' do
         expect(page).to have_content t(
           'instructions.mfa.sms.number_message_html',
           number: '***-***-3111',
-          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+          expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
         )
       end
     end

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -12,9 +12,11 @@ describe 'default phone selection' do
     context 'when the user has not set a default phone number' do
       it 'uses the first phone created as the default' do
         sign_in_before_2fa(user)
-        expect(page).to have_content t('instructions.mfa.sms.number_message_html',
-                                       number: '***-***-1212',
-                                       expiration: AppConfig.env.otp_valid_for)
+        expect(page).to have_content t(
+          'instructions.mfa.sms.number_message_html',
+          number: '***-***-1212',
+          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        )
       end
     end
 
@@ -26,9 +28,11 @@ describe 'default phone selection' do
         check 'new_phone_form_otp_make_default_number'
         click_button t('forms.buttons.continue')
 
-        expect(page).to have_content t('instructions.mfa.sms.number_message_html',
-                                       number: '+1 202-555-3434',
-                                       expiration: AppConfig.env.otp_valid_for)
+        expect(page).to have_content t(
+          'instructions.mfa.sms.number_message_html',
+          number: '+1 202-555-3434',
+          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        )
 
         submit_prefilled_otp_code(user, 'sms')
 
@@ -37,9 +41,11 @@ describe 'default phone selection' do
 
         set_new_browser_session
         sign_in_before_2fa(user)
-        expect(page).to have_content t('instructions.mfa.sms.number_message_html',
-                                       number: '***-***-3434',
-                                       expiration: AppConfig.env.otp_valid_for)
+        expect(page).to have_content t(
+          'instructions.mfa.sms.number_message_html',
+          number: '***-***-3434',
+          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        )
       end
     end
 
@@ -74,9 +80,11 @@ describe 'default phone selection' do
 
         set_new_browser_session
         sign_in_before_2fa(user)
-        expect(page).to have_content t('instructions.mfa.sms.number_message_html',
-                                       number: '***-***-3111',
-                                       expiration: AppConfig.env.otp_valid_for)
+        expect(page).to have_content t(
+          'instructions.mfa.sms.number_message_html',
+          number: '***-***-3111',
+          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        )
       end
     end
   end
@@ -92,8 +100,7 @@ describe 'default phone selection' do
         click_button t('forms.buttons.continue')
 
         expect(page).to have_content t('instructions.mfa.voice.number_message_html',
-                                       number: '+1 202-555-3434',
-                                       expiration: AppConfig.env.otp_valid_for)
+                                       number: '+1 202-555-3434')
 
         submit_prefilled_otp_code(user, 'voice')
 
@@ -103,8 +110,7 @@ describe 'default phone selection' do
         set_new_browser_session
         sign_in_before_2fa(user)
         expect(page).to have_content t('instructions.mfa.voice.number_message_html',
-                                       number: '***-***-3434',
-                                       expiration: AppConfig.env.otp_valid_for)
+                                       number: '***-***-3434')
       end
     end
   end

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -18,7 +18,7 @@ describe TotpSetupForm do
         expect(FormResponse).to receive(:new).
           with(success: true, errors: {}, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.reload.auth_app_configurations.any?).to eq true
+        expect(user.auth_app_configurations.any?).to eq true
       end
     end
 
@@ -34,7 +34,7 @@ describe TotpSetupForm do
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.reload.totp_enabled?).to eq false
+        expect(user.auth_app_configurations.any?).to eq false
       end
     end
 
@@ -52,7 +52,7 @@ describe TotpSetupForm do
         expect(FormResponse).to receive(:new).
           with(success: false, errors: {}, extra: extra).and_return(result)
         expect(form.submit).to eq result
-        expect(user.reload.totp_enabled?).to eq false
+        expect(user.auth_app_configurations.any?).to eq false
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -222,25 +222,17 @@ describe User do
   end
 
   describe 'OTP length' do
-    it 'uses Devise setting when set' do
-      allow(Devise).to receive(:direct_otp_length).and_return(10)
+    it 'uses TwoFactorAuthenticatable setting when set' do
+      allow(TwoFactorAuthenticatable).to receive(:direct_otp_length).and_return(10)
       user = build(:user)
-      user.send_new_otp
+      user.create_direct_otp
 
       expect(user.direct_otp.length).to eq 10
     end
 
-    it 'defaults to 6 when Devise setting is not set' do
-      allow(Devise).to receive(:direct_otp_length).and_return(nil)
-      user = build(:user)
-      user.send_new_otp
-
-      expect(user.direct_otp.length).to eq 6
-    end
-
     it 'is set to 6' do
       user = build(:user)
-      user.send_new_otp
+      user.create_direct_otp
 
       expect(user.direct_otp.length).to eq 6
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -223,7 +223,7 @@ describe User do
 
   describe 'OTP length' do
     it 'uses TwoFactorAuthenticatable setting when set' do
-      allow(TwoFactorAuthenticatable).to receive(:direct_otp_length).and_return(10)
+      stub_const('TwoFactorAuthenticatable::DIRECT_OTP_LENGTH', 10)
       user = build(:user)
       user.create_direct_otp
 

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -51,7 +51,7 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       text = t(
         'instructions.mfa.sms.number_message_html',
         number: "<strong>#{data[:phone_number]}</strong>",
-        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
+        expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES,
       )
       expect(presenter.phone_number_message).to eq text
     end

--- a/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
+++ b/spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb
@@ -51,7 +51,7 @@ describe TwoFactorAuthCode::PhoneDeliveryPresenter do
       text = t(
         'instructions.mfa.sms.number_message_html',
         number: "<strong>#{data[:phone_number]}</strong>",
-        expiration: AppConfig.env.otp_valid_for,
+        expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes,
       )
       expect(presenter.phone_number_message).to eq text
     end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -9,7 +9,7 @@ module ControllerHelper
 
   def sign_in_before_2fa(user = create(:user, :signed_up))
     sign_in_as_user(user)
-    controller.current_user.send_new_otp
+    controller.current_user.create_direct_otp
     allow(controller).to receive(:user_fully_authenticated?).and_return(false)
     allow(controller).to receive(:signed_in_url).and_return(account_url)
   end

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -49,7 +49,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
       let(:help_text) do
         t('instructions.mfa.sms.number_message_html',
           number: content_tag(:strong, presenter_data[:phone_number]),
-          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
+          expiration: TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_MINUTES)
       end
 
       it 'informs the user that an OTP has been sent to their number via #help_text' do

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -49,7 +49,7 @@ describe 'two_factor_authentication/otp_verification/show.html.erb' do
       let(:help_text) do
         t('instructions.mfa.sms.number_message_html',
           number: content_tag(:strong, presenter_data[:phone_number]),
-          expiration: AppConfig.env.otp_valid_for)
+          expiration: TwoFactorAuthenticatable.direct_otp_valid_for_minutes)
       end
 
       it 'informs the user that an OTP has been sent to their number via #help_text' do


### PR DESCRIPTION
We don't use much of the `totp` or `otp` parts of the gem because we send our own voice/sms OTP from the `TwoFactorAuthenticationController `, and the TOTP functionality from the gem doesn't allow multiple applications.

I've added the parts we use mostly to the User model, which feels weird for some of these so any guidance is appreciated 🙂 