### PR TITLE
Fix SAML RelayState on post authn requests

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -142,8 +142,12 @@ module SamlIdpAuthConcern
     url = URI.parse request.original_url
     query_params = Rack::Utils.parse_nested_query url.query
     unless query_params['SAMLRequest']
-      orig_request = saml_request.options[:get_params][:SAMLRequest]
-      query_params['SAMLRequest'] = orig_request
+      orig_saml_request = saml_request.options[:get_params][:SAMLRequest]
+      query_params['SAMLRequest'] = orig_saml_request
+    end
+    unless query_params['RelayState']
+      orig_relay_state = saml_request.options[:get_params][:RelayState]
+      query_params['RelayState'] = orig_relay_state if orig_relay_state
     end
 
     url.query = Rack::Utils.build_query(query_params).presence

--- a/spec/features/saml/saml_relay_state_spec.rb
+++ b/spec/features/saml/saml_relay_state_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+feature 'SAML RelayState' do
+  include SamlAuthHelper
+
+  context 'when RelayState is passed in authn request' do
+    let(:user) { create(:user, :signed_up) }
+    let(:relay_state_value) { '8431d690-2ed1-11eb-adc1-0242ac120002' }
+    let(:params) { { RelayState: relay_state_value } }
+
+    it 'returns RelayState on GET authn request' do
+      get_saml_authn_request(sp1_saml_settings, params)
+
+      login_and_confirm_sp(user)
+
+      expect(find_field('SAMLResponse', type: :hidden).value).not_to be_blank
+      expect(find_field('RelayState', type: :hidden).value).to eq(relay_state_value)
+    end
+
+    it 'returns RelayState on POST authn request' do
+      post_saml_authn_request(sp1_saml_settings, params)
+
+      login_and_confirm_sp(user)
+
+      expect(find_field('SAMLResponse', type: :hidden).value).not_to be_blank
+      expect(find_field('RelayState', type: :hidden).value).to eq(relay_state_value)
+    end
+  end
+
+  context 'when RelayState is NOT passed in authn request' do
+    let(:user) { create(:user, :signed_up) }
+
+    it 'does not return RelayState on GET authn request' do
+      get_saml_authn_request(sp1_saml_settings)
+
+      login_and_confirm_sp(user)
+
+      expect(find_field('SAMLResponse', type: :hidden).value).not_to be_blank
+      expect do
+        find_field('RelayState', type: :hidden)
+      end.to raise_error(/Unable to find field "RelayState"/)
+    end
+
+    it 'does not return RelayState on POST authn request' do
+      post_saml_authn_request(sp1_saml_settings)
+
+      login_and_confirm_sp(user)
+
+      expect(find_field('SAMLResponse', type: :hidden).value).not_to be_blank
+      expect do
+        find_field('RelayState', type: :hidden)
+      end.to raise_error(/Unable to find field "RelayState"/)
+    end
+  end
+end


### PR DESCRIPTION
WHY:
RelayState is not returned after authn POST to /api/saml/auth2020 endpoint. 

COTS systems (Like MS D365) follow the first SingleSignOnService option provided in our metadata which is HTTP-POST:
https://secure.login.gov/api/saml/metadata2020