### PR TITLE
LG-3740: Polyfill custom events constructor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "browser": true,
     "commonjs": true,
     "es6": true,
-    "mocha": true,
+    "mocha": true
   },
   "globals": {
     "expect": true
@@ -28,7 +28,13 @@
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
     "no-plusplus": "off",
-    "no-restricted-syntax": "off",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "NewExpression[callee.name='Event']",
+        "message": "Use CustomEvent constructor with polyfill for Internet Explorer"
+      }
+    ],
     "no-unused-expressions": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",

--- a/app/javascript/app/phone-internationalization.js
+++ b/app/javascript/app/phone-internationalization.js
@@ -70,15 +70,8 @@ const internationalCodeFromPhone = (phone) => {
   return '1';
 };
 
-const updateInternationalCodeInPhone = (phone, newCode) => {
-  if (phone.match(/^\+[^d+]$/)) {
-    phone = phone.replace(/^\+[^d+]$/, '');
-  }
-  if (phone.match(INTERNATIONAL_CODE_REGEX)) {
-    return phone.replace(INTERNATIONAL_CODE_REGEX, `+${newCode} `);
-  }
-  return `+${newCode} ${phone}`;
-};
+const updateInternationalCodeInPhone = (phone, newCode) =>
+  phone.replace(new RegExp(`^\\+?(\\d+\\s+|${newCode})?`), `+${newCode} `);
 
 const updateInternationalCodeInput = () => {
   const phoneInput = document.querySelector('[data-international-phone-form] .phone');

--- a/app/javascript/app/phone-validation.js
+++ b/app/javascript/app/phone-validation.js
@@ -1,3 +1,5 @@
+import { loadPolyfills } from '@18f/identity-polyfill';
+import domready from 'domready';
 import { isValidNumber } from 'libphonenumber-js';
 
 const isPhoneValid = (phone, countryCode) => {
@@ -39,22 +41,24 @@ const checkPhoneValidity = () => {
     sendCodeButton.disabled = !phoneValid;
 
     if (!phoneValid) {
-      phoneInput.dispatchEvent(new Event('invalid'));
+      phoneInput.dispatchEvent(new CustomEvent('invalid'));
     }
   }
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  const intlPhoneInput =
-    document.querySelector('[data-international-phone-form] .phone') ||
-    document.querySelector('[data-international-phone-form] .new-phone');
-  const codeInput = document.querySelector('[data-international-phone-form] .international-code');
-  if (intlPhoneInput) {
-    intlPhoneInput.addEventListener('keyup', checkPhoneValidity);
-    intlPhoneInput.addEventListener('focus', checkPhoneValidity);
-  }
-  if (codeInput) {
-    codeInput.addEventListener('change', checkPhoneValidity);
-  }
-  checkPhoneValidity();
-});
+Promise.all([new Promise((resolve) => domready(resolve)), loadPolyfills(['custom-event'])]).then(
+  () => {
+    const intlPhoneInput =
+      document.querySelector('[data-international-phone-form] .phone') ||
+      document.querySelector('[data-international-phone-form] .new-phone');
+    const codeInput = document.querySelector('[data-international-phone-form] .international-code');
+    if (intlPhoneInput) {
+      intlPhoneInput.addEventListener('keyup', checkPhoneValidity);
+      intlPhoneInput.addEventListener('focus', checkPhoneValidity);
+    }
+    if (codeInput) {
+      codeInput.addEventListener('change', checkPhoneValidity);
+    }
+    checkPhoneValidity();
+  },
+);

--- a/app/javascript/packages/polyfill/index.js
+++ b/app/javascript/packages/polyfill/index.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {"fetch"|"element-closest"|"classlist"|"crypto"} SupportedPolyfills
+ * @typedef {"fetch"|"element-closest"|"classlist"|"crypto"|"custom-event"} SupportedPolyfills
  */
 
 /**
@@ -28,6 +28,18 @@ const POLYFILLS = {
   crypto: {
     test: () => 'crypto' in window,
     load: () => import(/* webpackChunkName: "webcrypto-shim" */ 'webcrypto-shim'),
+  },
+  'custom-event': {
+    test() {
+      try {
+        // eslint-disable-next-line no-new
+        new window.CustomEvent('test');
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    load: () => import(/* webpackChunkName: "custom-event-polyfill" */ 'custom-event-polyfill'),
   },
 };
 

--- a/app/javascript/packages/polyfill/package.json
+++ b/app/javascript/packages/polyfill/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "classlist-polyfill": "^1.2.0",
+    "custom-event-polyfill": "^1.0.7",
     "element-closest": "^3.0.2",
     "webcrypto-shim": "^0.1.6",
     "whatwg-fetch": "^3.4.0"

--- a/app/javascript/packs/intl-tel-input.js
+++ b/app/javascript/packs/intl-tel-input.js
@@ -3,7 +3,7 @@ import 'intl-tel-input/build/js/utils.js';
 import * as intlTelInput from 'intl-tel-input/build/js/intlTelInput';
 
 function intlTelInputNormalize() {
-  // remove duplacte items in the country list
+  // remove duplicate items in the country list
   const dupUsOption = document.querySelectorAll('#country-listbox #iti-item-us')[1];
   if (dupUsOption) {
     /** @type {HTMLElement} */ (dupUsOption.parentNode).removeChild(dupUsOption);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "classlist-polyfill": "^1.2.0",
     "cleave.js": "^1.5.3",
     "clipboard": "^1.6.1",
+    "domready": "^1.0.8",
     "focus-trap": "^6.1.3",
     "hint.css": "^2.3.2",
     "identity-style-guide": "^2.1.5",

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -34,6 +34,31 @@ describe 'Add a new phone number' do
     click_submit_default
   end
 
+  scenario 'adding a new phone number validates number', js: true do
+    user = create(:user, :signed_up)
+    sign_in_and_2fa_user(user)
+    click_on "+ #{t('account.index.phone_add')}"
+
+    hidden_select = page.find('[name="new_phone_form[international_code]"]', visible: :hidden)
+
+    find_button 'Continue', disabled: true
+    expect(hidden_select.value).to eq('US')
+
+    input = fill_in :new_phone_form_phone, with: '5135558410'
+    expect(input.value).to eq('5135558410')
+    find_button 'Continue', disabled: false
+    expect(hidden_select.value).to eq('US')
+
+    fill_in :new_phone_form_phone, with: 'abcd1234'
+    find_button 'Continue', disabled: true
+    expect(hidden_select.value).to eq('US')
+
+    input = fill_in :new_phone_form_phone, with: '+81543543643'
+    expect(input.value).to eq('+81 543543643')
+    find_button 'Continue', disabled: false
+    expect(hidden_select.value).to eq('JP')
+  end
+
   scenario 'adding a phone that is already on the user account does not add another phone config' do
     user = create(:user, :signed_up)
     phone = user.phone_configurations.first.phone

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "app/javascript/packages",
     "app/javascript/packs/document-capture.jsx",
     "app/javascript/packs/form-validation.js",
+    "app/javascript/packs/intl-tel-input.js",
     "app/javascript/packs/submit-with-spinner.js"
   ],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,6 +3143,11 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+custom-event-polyfill@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
+  integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"


### PR DESCRIPTION
**Why**: Event constructors are [not supported in Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event#Browser_compatibility).

**Notes:**

- Requires a bit of rearrangement of some initialization because polyfill load is asynchronous.
- In case of existing `DOMContentLoaded`, introduced `domready` to preempt a possible race condition where `DOMContentLoaded` won't fire if the event has already fired since the event was bound (see [`Document.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState)), in case `Promise.all` schedules each subtask for a future tick.
- Avoids custom `countryChange` event and instead leverages existing `change` behavior.
- In the course of writing a feature test, I discovered that the logic associated with formatting an international phone number is broken and throwing errors in production.
- USWDS [includes a `CustomEvent` polyfill](https://github.com/uswds/uswds/blob/develop/src/js/polyfills/custom-event.js). Technically we don't need to polyfill it ourselves, and it could have been enough to change from `Event` to `CustomEvent`. That being said, I don't think it's a strong assurance to depend on a polyfill from a third-party library (and to be frank, I don't think USWDS should be shipping polyfills).