### PR TITLE
Remove page-unload event handlers for error redirect

### DIFF
--- a/app/javascript/packages/document-capture/services/upload.js
+++ b/app/javascript/packages/document-capture/services/upload.js
@@ -68,6 +68,7 @@ async function upload(payload, { method = 'POST', endpoint, csrf }) {
     const errorResult = result;
 
     if (errorResult.redirect) {
+      window.onbeforeunload = null;
       window.location.href = errorResult.redirect;
 
       // Avoid settling the promise, allowing the redirect to complete.

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -138,12 +138,6 @@ describe('document-capture/services/upload', () => {
     await Promise.race([
       new Promise((resolve) => {
         window.onhashchange = () => {
-          // Verify that if the redirect were a full-page redirect (as opposed to hash change), a
-          // prompt would not be shown to the user.
-          const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
-          window.dispatchEvent(event);
-          expect(event.defaultPrevented).to.be.false();
-
           expect(window.location.hash).to.equal('#teapot');
           resolve();
         };

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -134,6 +134,7 @@ describe('document-capture/services/upload', () => {
       ),
     );
 
+    // `Promise.race` because the `upload` promise should never resolve in case of a redirect.
     await Promise.race([
       new Promise((resolve) => {
         window.onhashchange = () => {
@@ -153,7 +154,9 @@ describe('document-capture/services/upload', () => {
           endpoint: 'https://example.com',
           csrf: 'TYsqyyQ66Y',
         },
-      ),
+      ).then(() => {
+        throw new Error('Unexpected upload resolution during redirect.');
+      }),
     ]);
   });
 

--- a/spec/javascripts/packages/document-capture/services/upload-spec.js
+++ b/spec/javascripts/packages/document-capture/services/upload-spec.js
@@ -137,6 +137,12 @@ describe('document-capture/services/upload', () => {
     await Promise.race([
       new Promise((resolve) => {
         window.onhashchange = () => {
+          // Verify that if the redirect were a full-page redirect (as opposed to hash change), a
+          // prompt would not be shown to the user.
+          const event = new window.Event('beforeunload', { cancelable: true, bubbles: false });
+          window.dispatchEvent(event);
+          expect(event.defaultPrevented).to.be.false();
+
           expect(window.location.hash).to.equal('#teapot');
           resolve();
         };


### PR DESCRIPTION
**Why**: As a user, if I am being redirected due to a failure of my document capture (e.g. throttling) I expect not to be warned about unsaved changes, so that I am not left confused that I am leaving the current page.

**Implementation Notes:** Ideally there wouldn't be this sort of awareness of the implementation detail of page unload behavior, but (a) it's simplest, and (b) [it follows prior art](https://github.com/18F/identity-idp/blob/9a5db2cfa84e7d01ae0418f27da6882bdefab5f0/app/javascript/app/utils/auto-logout.js). An alternative (and more complex) implementation would allow the error result to flow through to the `<Submission />` component to handle the redirect.