### PR TITLE
Fix lambda proofing document callback

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/identity-idp-functions.git
-  revision: 67f44016ca8c58ebaf46c969401da941a06eefd6
-  ref: 67f44016ca8c58ebaf46c969401da941a06eefd6
+  revision: 94c96472a5948f3dd97bddcb00401f181ccbfd36
+  ref: 94c96472a5948f3dd97bddcb00401f181ccbfd36
   specs:
-    identity-idp-functions (0.7.6)
+    identity-idp-functions (0.7.7)
       aws-sdk-s3 (>= 1.73)
       aws-sdk-ssm (>= 1.55)
       retries (>= 0.0.5)

--- a/app/controllers/lambda_callback/document_proof_result_controller.rb
+++ b/app/controllers/lambda_callback/document_proof_result_controller.rb
@@ -1,9 +1,14 @@
 module LambdaCallback
   class DocumentProofResultController < AuthTokenController
     def create
-      dcs = DocumentCaptureSession.new
-      dcs.result_id = result_id_parameter
-      dcs.store_proofing_result(document_result_parameter)
+      EncryptedRedisStructStorage.store(
+        ProofingDocumentCaptureSessionResult.new(
+          id: result_id_parameter,
+          pii: document_result_parameter[:pii_from_doc],
+          result: document_result_parameter.except(:pii_from_doc),
+        ),
+        expires_in: AppConfig.env.async_wait_timeout_seconds.to_i,
+      )
 
       track_exception_in_result(document_result_parameter)
     end

--- a/lib/lambda_jobs/git_ref.rb
+++ b/lib/lambda_jobs/git_ref.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaJobs
-  GIT_REF = '67f44016ca8c58ebaf46c969401da941a06eefd6'
+  GIT_REF = '94c96472a5948f3dd97bddcb00401f181ccbfd36'
 end


### PR DESCRIPTION
Problem: we were not storing PII from the doc auth callback in the PII field, this fixes that

Going to leave some comments on particular changes