### PR TITLE
Create count_in_batches to avoid long-running COUNT(*) queries

### DIFF
--- a/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
+++ b/app/services/db/doc_auth_log/doc_auth_funnel_summary_stats.rb
@@ -6,7 +6,7 @@ module Db
            last_document_error].freeze
 
       def call
-        total_count = ::DocAuthLog.count
+        total_count = Reports::CountHelper.count_in_batches(::DocAuthLog)
         return {} if total_count.zero?
         convert_percentages(total_count)
         results['total_verified_users_count'] = ::DocAuthLog.verified_users_count

--- a/app/services/db/proofing_component/proofing_component_summary.rb
+++ b/app/services/db/proofing_component/proofing_component_summary.rb
@@ -4,7 +4,7 @@ module Db
       SKIP_FIELDS = %w[id user_id created_at updated_at].freeze
 
       def call
-        total_count = ::ProofingComponent.count
+        total_count = Reports::CountHelper.count_in_batches(::ProofingComponent)
         return {} if total_count.zero?
         results.each do |key, value|
           results[key] = (value.to_f / total_count).round(2)

--- a/app/services/db/proofing_cost/proofing_costs_summary.rb
+++ b/app/services/db/proofing_cost/proofing_costs_summary.rb
@@ -4,7 +4,7 @@ module Db
       SKIP_FIELDS = %w[id user_id created_at updated_at].freeze
 
       def call
-        total_count = ::ProofingCost.count
+        total_count = Reports::CountHelper.count_in_batches(::ProofingCost)
         return {} if total_count.zero?
         results.each do |key, value|
           results[key] = (value.to_f / total_count).round(2)

--- a/app/services/funnel/registration/range_registered_count.rb
+++ b/app/services/funnel/registration/range_registered_count.rb
@@ -2,7 +2,7 @@ module Funnel
   module Registration
     class RangeRegisteredCount
       def self.call(start, finish)
-        RegistrationLog.where('? < registered_at AND registered_at < ?', start, finish).count
+        Reports::CountHelper.count_in_batches(RegistrationLog.where(registered_at: (start..finish)))
       end
     end
   end

--- a/app/services/funnel/registration/range_submitted_count.rb
+++ b/app/services/funnel/registration/range_submitted_count.rb
@@ -2,7 +2,7 @@ module Funnel
   module Registration
     class RangeSubmittedCount
       def self.call(start, finish)
-        RegistrationLog.where('? < submitted_at AND submitted_at < ?', start, finish).count
+        Reports::CountHelper.count_in_batches(RegistrationLog.where(submitted_at: (start..finish)))
       end
     end
   end

--- a/app/services/funnel/registration/total_registered_count.rb
+++ b/app/services/funnel/registration/total_registered_count.rb
@@ -2,7 +2,7 @@ module Funnel
   module Registration
     class TotalRegisteredCount
       def self.call
-        RegistrationLog.where.not(registered_at: nil).count
+        Reports::CountHelper.count_in_batches(RegistrationLog.where.not(registered_at: nil))
       end
     end
   end

--- a/app/services/funnel/registration/total_submitted_count.rb
+++ b/app/services/funnel/registration/total_submitted_count.rb
@@ -2,7 +2,7 @@ module Funnel
   module Registration
     class TotalSubmittedCount
       def self.call
-        RegistrationLog.count
+        Reports::CountHelper.count_in_batches(RegistrationLog)
       end
     end
   end

--- a/app/services/reports/count_helper.rb
+++ b/app/services/reports/count_helper.rb
@@ -6,12 +6,17 @@ module Reports
     # Similar to ActiveRecord#find_in_batches, but uses #pluck to minimize allocations
     def count_in_batches(activerecord_relation, batch_size: 10_000)
       count = 0
-      min_id = 0
+      min_id = nil
       id_col = activerecord_relation.arel_table[:id]
 
       loop do
-        ids = activerecord_relation.
-              where(id_col.gt(min_id)).
+        scoped_relation = if min_id
+                            activerecord_relation.where(id_col.gt(min_id))
+                          else
+                            activerecord_relation
+                          end
+
+        ids = scoped_relation.
               limit(batch_size).
               order(:id).
               pluck(:id)

--- a/app/services/reports/count_helper.rb
+++ b/app/services/reports/count_helper.rb
@@ -1,0 +1,28 @@
+module Reports
+  module CountHelper
+    module_function
+
+    # Run a COUNT(*), but in size-limited batches to minimize long-running queries
+    # Similar to ActiveRecord#find_in_batches, but uses #pluck to minimize allocations
+    def count_in_batches(activerecord_relation, batch_size: 10_000)
+      count = 0
+      min_id = 0
+      id_col = activerecord_relation.arel_table[:id]
+
+      loop do
+        ids = activerecord_relation.
+          where(id_col.gt(min_id)).
+          limit(batch_size).
+          order(:id).
+          pluck(:id)
+
+        break if ids.empty?
+
+        count += ids.size
+        min_id = ids.last
+      end
+
+      count
+    end
+  end
+end

--- a/app/services/reports/count_helper.rb
+++ b/app/services/reports/count_helper.rb
@@ -11,10 +11,10 @@ module Reports
 
       loop do
         ids = activerecord_relation.
-          where(id_col.gt(min_id)).
-          limit(batch_size).
-          order(:id).
-          pluck(:id)
+              where(id_col.gt(min_id)).
+              limit(batch_size).
+              order(:id).
+              pluck(:id)
 
         break if ids.empty?
 

--- a/spec/factories/registration_log.rb
+++ b/spec/factories/registration_log.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :registration_log do
+    user
+    submitted_at { Time.zone.now }
+  end
+end

--- a/spec/services/reports/count_helper_spec.rb
+++ b/spec/services/reports/count_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reports::CountHelper do
     end
 
     it 'adds up across multiple batches' do
-      expect(relation).to receive(:where).exactly(records_in_scope.size + 1).times.and_call_original
+      expect(relation).to receive(:where).exactly(records_in_scope.size).times.and_call_original
 
       expect(Reports::CountHelper.count_in_batches(relation, batch_size: 1)).
         to eq(records_in_scope.size)

--- a/spec/services/reports/count_helper_spec.rb
+++ b/spec/services/reports/count_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Reports::CountHelper do
+  describe '.count_in_batches' do
+    let!(:records_in_scope) do
+      10.times.map { create(:registration_log, registered_at: 3.days.ago) }
+    end
+    let!(:records_out_of_scope) do
+      5.times.map { create(:registration_log, registered_at: 10.years.ago) }
+    end
+
+    let(:relation) do
+      RegistrationLog.where(registered_at: (1.year.ago..Time.zone.now))
+    end
+
+    it 'counts the records in a relation' do
+      expect(Reports::CountHelper.count_in_batches(relation)).to eq(records_in_scope.size)
+    end
+
+    it 'adds up across multiple batches' do
+      expect(relation).to receive(:where).exactly(records_in_scope.size + 1).times.and_call_original
+
+      expect(Reports::CountHelper.count_in_batches(relation, batch_size: 1)).
+        to eq(records_in_scope.size)
+    end
+
+    it 'gets the correct count with missing intermediate ids' do
+      first, *middle, last = records_in_scope
+      middle.sample.destroy
+
+      expect(Reports::CountHelper.count_in_batches(relation)).
+          to eq(records_in_scope.count - 1)
+    end
+  end
+end

--- a/spec/services/reports/count_helper_spec.rb
+++ b/spec/services/reports/count_helper_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Reports::CountHelper do
     end
 
     it 'gets the correct count with missing intermediate ids' do
-      first, *middle, last = records_in_scope
+      _first, *middle, _last = records_in_scope
       middle.sample.destroy
 
       expect(Reports::CountHelper.count_in_batches(relation)).
-          to eq(records_in_scope.count - 1)
+        to eq(records_in_scope.count - 1)
     end
   end
 end


### PR DESCRIPTION
I know these reports are run against the read-replica, but it seems worthwhile to avoid long-running queries there if we can get similar results

Some informal benchmarking:


From INT environment:

```ruby
r = RegistrationLog.where(registered_at: (4.years.ago..Time.zone.now))

# plain COUNT(*) on a reasonable size data
[37] pry(main)> t = Time.now; r.count; Time.now.to_f - t.to_f
=> 0.016117095947265625

# code from this PR
[36] pry(main)> t = Time.now; count_in_batches(r); Time.now.to_f - t.to_f
=> 0.06184887886047363

# find_in_batches (allocates an ActiveRecord model for each row)
[38] pry(main)> t = Time.now; c = 0; r.find_in_batches(batch_size: 10_000) { |b| c += b.size }; Time.now.to_f - t.to_f
=> 1.0707452297210693
```