### PR TITLE
LG-3764, LG-3716: Use identity-style-guide@3 to deduplicate zxcvbn dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '~> 6.0.0'
 
 gem 'ahoy_matey', '~> 3.0'
 gem 'american_date'
+gem 'autoprefixer-rails', '~> 10.0'
 gem 'aws-sdk-kms', '~> 1.4'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-ses', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     american_date (1.1.1)
     android_key_attestation (0.3.0)
     ast (2.4.1)
+    autoprefixer-rails (10.0.3.0)
+      execjs
     awrence (1.1.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.400.0)
@@ -695,6 +697,7 @@ DEPENDENCIES
   aamva!
   ahoy_matey (~> 3.0)
   american_date
+  autoprefixer-rails (~> 10.0)
   aws-sdk-cloudwatchlogs
   aws-sdk-kms (~> 1.4)
   aws-sdk-lambda

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -4,11 +4,3 @@
 @import 'identity-style-guide/dist/assets/scss/styles';
 @import 'components/all';
 @import 'print';
-
-// This import is temporary and scoped to the new Document Capture screen. The File Input component
-// is part of a USWDS version newer than what's currently shipped with Login Design System. Follow-
-// up work should upgrade to use a newer USWDS, at which time this should be removed altogether.
-#document-capture-form { // scss-lint:disable IdSelector
-  @import 'uswds/dist/scss/elements/form-controls/file-input';
-  @import 'components/file-input';
-}

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,34 +1,14 @@
-.site .site-wrap .usa-banner {
-  background-color: #fff;
+.usa-banner,
+.usa-banner__button[aria-expanded='true']::before {
+  background-color: color('white');
+}
+
+.usa-banner {
   box-shadow: inset 0 -1px 0 0 #ccc;
 }
 
 .usa-banner__inner {
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.usa-banner__header {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
-  + .usa-banner__content.usa-accordion__content {
-    position: relative;
-  }
-}
-
-@media #{$mobile} {
-  .usa-banner__header--expanded .usa-banner__inner {
-    margin-left: auto;
-  }
-}
-
-.usa-banner__button[aria-expanded="true"]::after {
-  @include at-media-max('tablet') {
-    background-color: transparent;
-    right: 0;
-    top: 100%;
-    z-index: 10;
+  @include at-media('tablet') {
+    justify-content: center;
   }
 }

--- a/app/assets/stylesheets/components/_external-link.scss
+++ b/app/assets/stylesheets/components/_external-link.scss
@@ -8,4 +8,9 @@
   &.usa-link--alt {
     @include external-link(external-link-alt, external-link-alt);
   }
+
+  &::after {
+    // The icon is displayed inline, which has no implicit height when included in a flex context.
+    align-self: stretch;
+  }
 }

--- a/app/assets/stylesheets/components/_file-input.scss
+++ b/app/assets/stylesheets/components/_file-input.scss
@@ -67,7 +67,7 @@
     padding: 0;
   }
 
-  .usa-file-input__preview__image {
+  .usa-file-input__preview-image {
     height: auto;
     margin-left: auto;
     margin-right: 0;

--- a/app/assets/stylesheets/components/all.scss
+++ b/app/assets/stylesheets/components/all.scss
@@ -8,6 +8,7 @@
 @import 'color';
 @import 'container';
 @import 'external-link';
+@import 'file-input';
 @import 'footer';
 @import 'form';
 @import 'icon';

--- a/app/javascript/app/components/index.js
+++ b/app/javascript/app/components/index.js
@@ -1,4 +1,9 @@
+import { accordion, accordionCloseButton, banner, navigation } from 'identity-style-guide';
+import domready from 'domready';
 import Modal from './modal';
 
 window.LoginGov = window.LoginGov || {};
 window.LoginGov.Modal = Modal;
+
+const components = [accordion, accordionCloseButton, banner, navigation];
+domready(() => components.forEach((component) => component.on()));

--- a/app/javascript/app/utils/index.js
+++ b/app/javascript/app/utils/index.js
@@ -1,4 +1,3 @@
-import 'identity-style-guide/dist/assets/js/main';
 import autoLogout from './auto-logout';
 import countdownTimer from './countdown-timer';
 import msFormatter from './ms-formatter';

--- a/app/javascript/packages/document-capture/components/acuant-capture.scss
+++ b/app/javascript/packages/document-capture/components/acuant-capture.scss
@@ -1,5 +1,4 @@
-// Note: ID specifier necessary only until USWDS upgraded.
-#document-capture-form .document-capture-acuant-capture { // scss-lint:disable IdSelector
+.document-capture-acuant-capture {
   max-width: 375px;
 
   %pad-common-id-card {

--- a/app/javascript/packages/document-capture/components/file-input.jsx
+++ b/app/javascript/packages/document-capture/components/file-input.jsx
@@ -210,9 +210,9 @@ const FileInput = forwardRef((props, ref) => {
           {value && isImage(value) && (
             <div className="usa-file-input__preview" aria-hidden="true">
               {value instanceof window.Blob ? (
-                <FileImage file={value} alt="" className="usa-file-input__preview__image" />
+                <FileImage file={value} alt="" className="usa-file-input__preview-image" />
               ) : (
-                <img src={value} alt="" className="usa-file-input__preview__image" />
+                <img src={value} alt="" className="usa-file-input__preview-image" />
               )}
             </div>
           )}

--- a/app/javascript/packages/document-capture/components/selfie-capture.scss
+++ b/app/javascript/packages/document-capture/components/selfie-capture.scss
@@ -84,9 +84,7 @@ div.selfie-capture__label[tabindex="-1"]:focus { // scss-lint:disable Qualifying
   }
 }
 
-// Disable reason: The ID selector is temporary, and is only needed as long as Login Design System
-// has yet to be upgraded to USWDS 2.7+.
-#document-capture-form .selfie-capture__consent-prompt-banner.usa-file-input__banner-text { // scss-lint:disable IdSelector
+.selfie-capture__consent-prompt-banner.usa-file-input__banner-text {
   @include u-margin-bottom(4);
   text-transform: none;
 }
@@ -160,9 +158,7 @@ div.selfie-capture__label[tabindex="-1"]:focus { // scss-lint:disable Qualifying
   width: 2rem;
 }
 
-// Disable reason: The ID selector is temporary, and is only needed as long as Login Design System
-// has yet to be upgraded to USWDS 2.7+.
-#document-capture-form .selfie-capture__preview-heading.usa-file-input__preview-heading { // scss-lint:disable IdSelector
+.selfie-capture__preview-heading.usa-file-input__preview-heading {
   pointer-events: all;
   width: 100%;
 }

--- a/app/views/shared/_banner-lock-icon.html.erb
+++ b/app/views/shared/_banner-lock-icon.html.erb
@@ -1,0 +1,19 @@
+<span class="icon-lock">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="52"
+    height="64"
+    viewBox="0 0 52 64"
+    class="usa-banner__lock-image"
+    role="img"
+    aria-labelledby="banner-lock-title banner-lock-description"
+  >
+    <title id="banner-lock-title">Lock</title>
+    <desc id="banner-lock-description">A locked padlock</desc>
+    <path
+      fill="#000000"
+      fill-rule="evenodd"
+      d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+    />
+  </svg>
+</span>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -29,26 +29,28 @@
           <div class="usa-banner__guidance tablet:grid-col-6">
             <%= image_tag(
               asset_url('icon-dot-gov.svg'),
+              role: 'img',
               alt: 'Dot gov',
               class: 'usa-banner__icon usa-media-block__img'
             ) %>
             <div class="usa-media-block__body">
               <p>
                 <strong><%= t('shared.banner.gov_heading') %></strong>
-                <br> <%= t('shared.banner.gov_description') %>
+                <br> <%= t('shared.banner.gov_description_html') %>
               </p>
             </div>
           </div>
           <div class="usa-banner__guidance tablet:grid-col-6">
             <%= image_tag(
               asset_url('icon-https.svg'),
+              role: 'img',
               alt: 'Https',
               class: 'usa-banner__icon usa-media-block__img'
             ) %>
             <div class="usa-media-block__body">
               <p>
                 <strong><%= t('shared.banner.secure_heading') %></strong>
-                <br> <%= t('shared.banner.secure_description_html') %>
+                <br> <%= t('shared.banner.secure_description_html', lock_icon: render('shared/banner-lock-icon')) %>
               </p>
             </div>
           </div>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -71,21 +71,28 @@
         <% end %>
 
         <div class="sm-hide">
-          <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
-                                 class: 'caps h6 blue text-decoration-none mr2') %>
-          <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
-                                 class: 'caps h6 blue text-decoration-none mr2') %>
-          <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                                 class: 'caps h6 blue text-decoration-none mr2') %>
+          <div class="display-flex">
+            <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
+                                  class: 'caps h6 blue text-decoration-none mr2') %>
+            <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
+                                  class: 'caps h6 blue text-decoration-none mr2') %>
+            <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
+                                  class: 'caps h6 blue text-decoration-none mr2') %>
+          </div>
         </div>
 
         <div class="sm-show">
-          <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
-                                 class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
-          <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
-                                 class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
-          <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
-                                 class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
+          <%# Note: Once BassCSS is removed, absorb this wrapper into the parent and use class
+              `display-none tablet:display-flex`. This is not currently possible because BassCSS's
+              `display-none` applies using `!important`. %>
+          <div class="display-flex">
+            <%= new_window_link_to(t('links.help'), MarketingSite.help_url,
+                                  class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
+            <%= new_window_link_to(t('links.contact'), MarketingSite.contact_url,
+                                  class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
+            <%= new_window_link_to(t('links.privacy_policy'), MarketingSite.security_and_privacy_practices_url,
+                                  class: 'caps h6 white text-decoration-none mr2 usa-link--alt') %>
+          </div>
         </div>
       </div>
     </div>

--- a/babel.config.js
+++ b/babel.config.js
@@ -50,5 +50,13 @@ module.exports = function (api) {
         },
       ],
     ],
+    // For third-party dependencies compiled using Babel, don't assume module source type. Use
+    // "unambiguous" for best-effort attempt to identify source type by patterns.
+    overrides: [
+      {
+        test: /node_modules\/(?!@18f\/identity-)/,
+        sourceType: 'unambiguous',
+      },
+    ],
   };
 };

--- a/config/locales/shared/en.yml
+++ b/config/locales/shared/en.yml
@@ -2,15 +2,15 @@
 en:
   shared:
     banner:
-      fake_site: A DEMO website of the United States government.
-      gov_description: Federal government websites often end in .gov or .mil. Before
-        sharing sensitive information, make sure you’re on a federal government site.
-      gov_heading: The .gov means it’s official.
+      fake_site: A DEMO website of the United States government
+      gov_description_html: A <strong>.gov</strong> website belongs to an official
+        government organization in the United States.
+      gov_heading: Official websites use .gov
       how: Here’s how you know
-      official_site: An official website of the United States government.
-      secure_description_html: The <strong>https://</strong> ensures that you are
-        connecting to the official website and that any information you provide is
-        encrypted and transmitted securely.
-      secure_heading: The site is secure.
+      official_site: An official website of the United States government
+      secure_description_html: A <strong>lock</strong> (%{lock_icon}) or <strong>https://</strong>
+        means you’ve safely connected to the .gov website. Share sensitive information
+        only on official, secure websites.
+      secure_heading: Secure .gov websites use HTTPS
     footer_lite:
       gsa: US General Services Administration

--- a/config/locales/shared/es.yml
+++ b/config/locales/shared/es.yml
@@ -2,16 +2,15 @@
 es:
   shared:
     banner:
-      fake_site: Un sitio web de DEMO del gobierno de Estados Unidos.
-      gov_description: Los sitios web del gobierno federal a menudo terminan en .gov
-        o .mil. Antes de compartir información confidencial, asegúrese de estar en
-        un sitio del gobierno federal.
-      gov_heading: La .gov significa que es oficial.
-      how: Así es como sabes
-      official_site: Un sitio oficial del Gobierno de Estados Unidos.
-      secure_description_html: El <strong>https://</strong> garantiza que se está
-        conectando al sitio web oficial y que toda la información que proporciona
-        está encriptada y transmitida de forma segura.
-      secure_heading: El sitio es seguro.
+      fake_site: Un sitio oficial del Gobierno de Estados Unidos
+      gov_description_html: Un sitio web <strong>.gov</strong> pertenece a una organización
+        oficial del Gobierno de Estados Unidos.
+      gov_heading: Los sitios web oficiales usan .gov
+      how: Así es como usted puede verificarlo
+      official_site: Un sitio oficial del Gobierno de Estados Unidos
+      secure_description_html: Un <strong>candado</strong> (%{lock_icon}) o <strong>https://</strong>
+        significa que usted se conectó de forma segura a un sitio web .gov. Comparta
+        información sensible sólo en sitios web oficiales y seguros.
+      secure_heading: Los sitios web seguros .gov usan HTTPS
     footer_lite:
       gsa: Administración General de Servicios de EE. UU.

--- a/config/locales/shared/fr.yml
+++ b/config/locales/shared/fr.yml
@@ -2,16 +2,15 @@
 fr:
   shared:
     banner:
-      fake_site: Un site de DEMO du gouvernement des États-Unis.
-      gov_description: Les sites Web du gouvernement fédéral se terminent souvent
-        par .gov ou .mil. Avant de partager des informations sensibles, assurez-vous
-        que vous êtes sur un site du gouvernement fédéral.
-      gov_heading: Le .gov signifie que c'est officiel.
+      fake_site: Un site de DEMO du gouvernement des États-Unis
+      gov_description_html: Un site Web <strong>.gov</strong> appartient à une organisation
+        gouvernementale officielle des États-Unis.
+      gov_heading: Les sites Web officiels utilisent .gov
       how: Voici comment vous savez
-      official_site: Un site web officiel du gouvernement des États-Unis.
-      secure_description_html: Le <strong>https://</strong> garantit que vous vous
-        connectez au site officiel et que toutes les informations que vous fournissez
-        sont cryptées et transmises en toute sécurité.
-      secure_heading: Le site est sécurisé.
+      official_site: Un site web officiel du gouvernement des États-Unis
+      secure_description_html: Un <strong>verrou</strong> (%{lock_icon}) ou <strong>https://</strong>
+        signifie que vous êtes connecté en toute sécurité au site Web .gov. Partagez
+        des informations sensibles uniquement sur des sites Web officiels et sécurisés.
+      secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
     footer_lite:
       gsa: Administration des services généraux des États-Unis

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,9 +11,9 @@ babelLoader.include.push(/node_modules\/@18f\/identity-/);
 babelLoader.exclude = /node_modules\/(?!@18f\/identity-)/;
 
 const sassLoader = environment.loaders.get('sass');
+// Prepend minimum required design system variables, mixins, and functions to make available to all
+// Webpack-imported SCSS files. Notably, this should _not_ include any actual CSS output on its own.
 // Note: This option is renamed `additionalData` in newer versions of `sass-loader`.
-// Note: Import paths for USWDS required imports have improved in newer versions.
-//       See: https://github.com/uswds/uswds/blob/50f6ffd6/src/stylesheets/packages/_required.scss
 sassLoader.use.find(({ loader }) => loader === 'sass-loader').options.prependData = `
 $font-path: '~identity-style-guide/dist/assets/fonts';
 $image-path: '~identity-style-guide/dist/assets/img';
@@ -26,17 +26,7 @@ $image-path: '~identity-style-guide/dist/assets/img';
 @import '~identity-style-guide/dist/assets/scss/uswds-theme/color';
 @import '~identity-style-guide/dist/assets/scss/uswds-theme/utilities';
 @import '~identity-style-guide/dist/assets/scss/uswds-theme/components';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-general';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-typography';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-color';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-spacing';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-utilities';
-@import '~identity-style-guide/dist/assets/scss/uswds/settings/settings-components';
-@import '~identity-style-guide/dist/assets/scss/uswds/core/functions';
-@import '~identity-style-guide/dist/assets/scss/uswds/core/system-tokens';
-@import '~identity-style-guide/dist/assets/scss/uswds/core/variables';
-@import '~identity-style-guide/dist/assets/scss/uswds/core/properties';
-@import '~identity-style-guide/dist/assets/scss/uswds/core/mixins/all';
+@import '~identity-style-guide/dist/assets/scss/uswds/packages/required';
 @import '~identity-style-guide/dist/assets/scss/uswds/utilities/palettes/all';
 @import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/all';
 @import '~identity-style-guide/dist/assets/scss/uswds/utilities/rules/package';`;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -6,9 +6,14 @@ environment.loaders.delete('moduleSass');
 environment.loaders.delete('moduleCss');
 environment.loaders.delete('css');
 
+// Some files under `node_modules` should be compiled by Babel:
+// 1. Yarn workspace package symlinks, by package name starting with `@18f/identity-`.
+// 2. Specific dependencies that don't compile their own code to run safely in legacy browsers.
 const babelLoader = environment.loaders.get('babel');
-babelLoader.include.push(/node_modules\/@18f\/identity-/);
-babelLoader.exclude = /node_modules\/(?!@18f\/identity-)/;
+babelLoader.include.push(
+  /node_modules\/(@18f\/identity-|identity-style-guide|uswds|receptor|elem-dataset)/,
+);
+babelLoader.exclude = /node_modules\/(?!@18f\/identity-|identity-style-guide|uswds|receptor|elem-dataset)/;
 
 const sassLoader = environment.loaders.get('sass');
 // Prepend minimum required design system variables, mixins, and functions to make available to all

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc",
     "lint": "eslint app spec babel.config.js --ext .js,.jsx",
     "test": "mocha 'spec/javascripts/**/**spec.js?(x)' 'app/javascript/packages/**/*.spec.js?(x)'",
-    "es5-safe": "is-es5-safe public/packs/js/*.js",
+    "es5-safe": "is-es5-safe 'public/packs?(-test)/js/*.js'",
     "build": "true"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
     "domready": "^1.0.8",
     "focus-trap": "^6.1.3",
     "hint.css": "^2.3.2",
-    "identity-style-guide": "^2.1.5",
+    "identity-style-guide": "^3.0.0",
     "intl-tel-input": "^16.0.7",
     "libphonenumber-js": "^1.7.26",
     "normalize.css": "^4.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "uswds": "^2.8.0",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3499,10 +3499,10 @@ electron-to-chromium@^1.3.488:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.520.tgz#dfda0a14a4aed785cbddfdb505ea122f75978392"
   integrity sha512-q6H9E1sXDCjRHP+X06vcP+N0ki8ZvYoRPZfKnDuiRX10WWXxEHzKFVf4O9rBFMpuPtR3M+2KAdJnugJoBBp3Rw==
 
-elem-dataset@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/elem-dataset/-/elem-dataset-1.1.1.tgz#18f07fa7fc71ebd49b0f9f63819cb03c8276577a"
-  integrity sha1-GPB/p/xx69SbD59jgZywPIJ2V3o=
+elem-dataset@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/elem-dataset/-/elem-dataset-2.0.0.tgz#4ed8b2b0217898bdf78c1a01b4eb722a1c89e799"
+  integrity sha512-e7gieGopWw5dMdEgythH3lUS7nMizutPDTtkzfQW/q2gCvFnACyNnK3ytCncAXKxdBXQWcXeKaYTTODiMnp8mw==
 
 element-closest@^2.0.1:
   version "2.0.2"
@@ -4824,11 +4824,12 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-identity-style-guide@^2.1.5:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-2.2.3.tgz#e6d6b6b10a65d0e97877d35e5e00f3850ed23a62"
-  integrity sha512-bAPgCic/ztIUOLyEofToecfhIiM8b1WNlRj0rOhYr1/zZHL4NPhLjQ2HBURTiGyxEhm/22n1gxprDuilxLLLBw==
+identity-style-guide@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-3.0.0.tgz#9f0d1331b3200dad63073c928dd195c1c50c9378"
+  integrity sha512-PFoNrTStU7uOFMXi8qEC1Yx+Vq4IZMxpK5+5mFRU5Ef6e/9S0U9wKaVzCv4+jK7Z4yUPlsMe8Xd/K9XWjnm6fQ==
   dependencies:
+    uswds "^2.9.0"
     zxcvbn "^4.4.2"
 
 ieee754@^1.1.4:
@@ -9401,15 +9402,15 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.8.0.tgz#635e829555a359562f28ab51e1b6c983f149f739"
-  integrity sha512-LI7ZNbh823ehtThvebwQ5eHNKGY791vcT5d3T9gJ+RY511HgstWLRSEEso7YO/ifjoV/FwuTAtDwQqt7zsXRvA==
+uswds@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.9.0.tgz#002089d74582960099b0ee836f89f043cdf6d0bc"
+  integrity sha512-5IMVgMCUUlgWVFrB7Wf1qTvv5L3oDDlSsAgvJ02+/sV2uh4JzO9YPm3493RTaMuHTc+feRCuYyEIloXsEQY0Pg==
   dependencies:
     classlist-polyfill "^1.0.3"
     del "^5.1.0"
     domready "^1.0.8"
-    elem-dataset "^1.1.1"
+    elem-dataset "^2.0.0"
     lodash.debounce "^4.0.7"
     object-assign "^4.1.1"
     receptor "^1.0.0"


### PR DESCRIPTION
**Why**: To use latest USWDS version consistently across all login products and services.

**Why**: The zxcvbn dependency is large and should not be included in JavaScript bundles where it is not used. Instead, bundles should use the minimum implementations necessary. This is made possible in the latest version 3.0 of identity-style-guide.

Related: https://github.com/18F/identity-style-guide/pull/165 (LG-3757)

**Impact:**

_Treemap:_

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/101171500-dd49ad00-360d-11eb-8a31-9ad1b9086581.png)|![after](https://user-images.githubusercontent.com/1779930/101171510-df137080-360d-11eb-8b9c-cb0e208a98d3.png)

Highlighted segments identify where `zxcvbn` is loaded. Previously `identity-style-guide` was prebundled, so it was not clearly labelled separate, but you can tell by the fact that `identity-style-guide` inflated bundle size significantly.

_Bundle Size:_

Before:

```
   js/application-3ab408e425de3e0bfa39.js    1.02 MiB    2, 3  [emitted] [immutable]  [big]  application
js/application-3ab408e425de3e0bfa39.js.br     406 KiB          [emitted]              [big]  
js/application-3ab408e425de3e0bfa39.js.gz     457 KiB          [emitted]              [big]  
```

After:

```
   js/application-95e84262cf8ef6113d8c.js     221 KiB    2, 3  [emitted] [immutable]         application
js/application-95e84262cf8ef6113d8c.js.br    53.8 KiB          [emitted]                     
js/application-95e84262cf8ef6113d8c.js.gz    63.3 KiB          [emitted]                     
```