### PR TITLE
fix newrelic method tracers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
   include NonNullUuid
 
   include ::NewRelic::Agent::MethodTracer
-  add_method_tracer :send_devise_notification, "Custom/#{name}/send_devise_notification"
 
   devise(
     :database_authenticatable,
@@ -131,4 +130,6 @@ class User < ApplicationRecord
   def send_confirmation_instructions
     # no-op
   end
+
+  add_method_tracer :send_devise_notification, "Custom/#{name}/send_devise_notification"
 end

--- a/app/presenters/confirmation_email_presenter.rb
+++ b/app/presenters/confirmation_email_presenter.rb
@@ -1,8 +1,5 @@
 class ConfirmationEmailPresenter
   include ::NewRelic::Agent::MethodTracer
-  add_method_tracer :initialize, "Custom/#{name}/initialize"
-  add_method_tracer :first_sentence, "Custom/#{name}/first_sentence"
-  add_method_tracer :confirmation_period, "Custom/#{name}/confirmation_period"
 
   def initialize(user, view)
     @user = user
@@ -38,4 +35,8 @@ class ConfirmationEmailPresenter
   private
 
   attr_reader :user, :view
+
+  add_method_tracer :initialize, "Custom/#{name}/initialize"
+  add_method_tracer :first_sentence, "Custom/#{name}/first_sentence"
+  add_method_tracer :confirmation_period, "Custom/#{name}/confirmation_period"
 end

--- a/app/services/binary_search_sorted_hash_file.rb
+++ b/app/services/binary_search_sorted_hash_file.rb
@@ -1,6 +1,5 @@
 class BinarySearchSortedHashFile
   include ::NewRelic::Agent::MethodTracer
-  add_method_tracer :call, "Custom/#{name}/call"
 
   RECORD_SIZE = 41
 
@@ -30,4 +29,6 @@ class BinarySearchSortedHashFile
       end
     end
   end
+
+  add_method_tracer :call, "Custom/#{name}/call"
 end

--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -2,8 +2,6 @@ module Encryption
   class ContextlessKmsClient
     include Encodable
     include ::NewRelic::Agent::MethodTracer
-    add_method_tracer :decrypt, "Custom/#{name}/decrypt"
-    add_method_tracer :encrypt, "Custom/#{name}/encrypt"
 
     KEY_TYPE = {
       KMS: 'KMSx',
@@ -97,5 +95,8 @@ module Encryption
     def encryptor
       @encryptor ||= Encryptors::AesEncryptor.new
     end
+
+    add_method_tracer :decrypt, "Custom/#{name}/decrypt"
+    add_method_tracer :encrypt, "Custom/#{name}/encrypt"
   end
 end

--- a/app/services/encryption/encryptors/attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/attribute_encryptor.rb
@@ -3,8 +3,6 @@ module Encryption
     class AttributeEncryptor
       include Encodable
       include ::NewRelic::Agent::MethodTracer
-      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
-      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
 
       def initialize
         @aes_cipher = AesCipher.new
@@ -56,6 +54,9 @@ module Encryption
       def old_keys
         JSON.parse(AppConfig.env.attribute_encryption_key_queue)
       end
+
+      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
+      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
     end
   end
 end

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -2,8 +2,6 @@ module Encryption
   module Encryptors
     class PiiEncryptor
       include ::NewRelic::Agent::MethodTracer
-      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
-      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
 
       Ciphertext = Struct.new(:encrypted_data, :salt, :cost) do
         include Encodable
@@ -78,6 +76,9 @@ module Encryption
         scrypt_password_digest = SCrypt::Password.new(scrypted).digest
         [scrypt_password_digest].pack('H*')
       end
+
+      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
+      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
     end
   end
 end

--- a/app/services/encryption/encryptors/session_encryptor.rb
+++ b/app/services/encryption/encryptors/session_encryptor.rb
@@ -3,8 +3,6 @@ module Encryption
     class SessionEncryptor
       include Encodable
       include ::NewRelic::Agent::MethodTracer
-      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
-      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
 
       def encrypt(plaintext)
         aes_ciphertext = AesEncryptor.new.encrypt(plaintext, aes_encryption_key)
@@ -28,6 +26,9 @@ module Encryption
       def aes_encryption_key
         AppConfig.env.session_encryption_key[0...32]
       end
+
+      add_method_tracer :encrypt, "Custom/#{name}/encrypt"
+      add_method_tracer :decrypt, "Custom/#{name}/decrypt"
     end
   end
 end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -4,8 +4,6 @@ module Encryption
   class KmsClient
     include Encodable
     include ::NewRelic::Agent::MethodTracer
-    add_method_tracer :decrypt, "Custom/#{name}/decrypt"
-    add_method_tracer :encrypt, "Custom/#{name}/encrypt"
 
     KEY_TYPE = {
       KMS: 'KMSc',
@@ -124,5 +122,8 @@ module Encryption
     def multi_aws_client
       @multi_aws_client ||= MultiRegionKmsClient.new
     end
+
+    add_method_tracer :decrypt, "Custom/#{name}/decrypt"
+    add_method_tracer :encrypt, "Custom/#{name}/encrypt"
   end
 end

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -1,8 +1,6 @@
 module Encryption
   class PasswordVerifier
     include ::NewRelic::Agent::MethodTracer
-    add_method_tracer :digest, "Custom/#{name}/digest"
-    add_method_tracer :verify, "Custom/#{name}/verify"
 
     PasswordDigest = Struct.new(
       :encrypted_password,
@@ -108,5 +106,8 @@ module Encryption
     def verify_uak_digest(password, digest)
       UakPasswordVerifier.verify(password: password, digest: digest)
     end
+
+    add_method_tracer :digest, "Custom/#{name}/digest"
+    add_method_tracer :verify, "Custom/#{name}/verify"
   end
 end

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -11,7 +11,6 @@
 module Encryption
   class UserAccessKey
     include ::NewRelic::Agent::MethodTracer
-    add_method_tracer :initialize, "Custom/#{name}/build"
 
     attr_reader :cost, :salt, :z1, :z2, :random_r, :masked_ciphertext, :cek
 
@@ -101,5 +100,7 @@ module Encryption
         left_byte ^ right_byte
       end.pack('C*')
     end
+
+    add_method_tracer :initialize, "Custom/#{name}/build"
   end
 end

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -1,6 +1,5 @@
 class SendSignUpEmailConfirmation
   include ::NewRelic::Agent::MethodTracer
-  add_method_tracer(:call, "Custom/#{name}/call")
 
   attr_reader :user
 
@@ -83,4 +82,6 @@ class SendSignUpEmailConfirmation
   def handle_multiple_email_address_error
     raise 'sign up user has multiple email address records'
   end
+
+  add_method_tracer :call, "Custom/#{name}/call"
 end


### PR DESCRIPTION
#4462 broke custom new relic method tracers because it has to be added after the method has been defined ([docs](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation))

Example of tracing disappearing (though we are still encrypting/verifying correctly):
![image](https://user-images.githubusercontent.com/1430443/101201731-d337a680-362d-11eb-8e4f-6eeec66a47f5.png)

