### PR TITLE
Add missing closing tag to connected accounts content

### DIFF
--- a/app/views/accounts/connected_accounts/show.html.erb
+++ b/app/views/accounts/connected_accounts/show.html.erb
@@ -13,5 +13,6 @@
     <% @view_model.connected_apps.each do |identity| %>
       <%= render identity.connected_app_partial, identity: identity %>
     <% end %>
+  </div>
 </div>
 


### PR DESCRIPTION
Spotted while testing #4485

Fixes an issue where invalid markup causes browser correction to consider footer as part of body content instead of sibling content.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/101213185-fbcc9a00-3647-11eb-9dcb-9176ae51d449.png)|![after](https://user-images.githubusercontent.com/1779930/101213191-fd965d80-3647-11eb-8747-a7ee8d40731d.png)
