### PR TITLE
Update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,22 +15,12 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
   TargetRubyVersion: 2.6
-  TargetRailsVersion: 5.2
+  TargetRailsVersion: 6.0
   UseCache: true
+  DisabledByDefault: true
 
 Rails:
   Enabled: true
-
-Metrics/AbcSize:
-  Description: A calculated magnitude based on number of assignments, branches, and
-    conditions.
-  Enabled: false
-  Max: 15
-  Exclude:
-  - spec/**/*
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
 
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
@@ -45,12 +35,6 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'spec/**/*.rb'
 
-Metrics/ClassLength:
-  Description: Avoid classes longer than 100 lines of code.
-  Enabled: false
-  CountComments: false
-  Max: 100
-
 Layout/LineLength:
   Description: Limit lines to 100 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
@@ -62,16 +46,6 @@ Layout/LineLength:
   - https
   Exclude:
     - 'config/routes.rb'
-
-Metrics/MethodLength:
-  Description: Avoid methods longer than 15 lines of code.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
-  Enabled: false
-  CountComments: false
-  Max: 15
-  Exclude:
-  - 'db/migrate/*'
-  - spec/**/*
 
 Metrics/ModuleLength:
   CountComments: false
@@ -89,6 +63,9 @@ Naming/VariableName:
     - 'spec/services/pii/nist_encryption_spec.rb'
 
 Rails/FilePath:
+  Enabled: false
+
+Rails/ApplicationMailer:
   Enabled: false
 
 Rails/HttpPositionalArguments:
@@ -148,13 +125,6 @@ Style/AndOr:
   - always
   - conditionals
 
-Style/Documentation:
-  Description: Document classes and non-namespace modules.
-  Enabled: false
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-
 Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
@@ -162,9 +132,6 @@ Layout/DotPosition:
   SupportedStyles:
   - leading
   - trailing
-
-Style/DoubleNegation:
-  Enabled: false
 
 # Warn on empty else statements
 # empty - warn only on empty else
@@ -184,12 +151,6 @@ Layout/ExtraSpacing:
   AllowForAlignment: true
   # When true, forces the alignment of = in assignments on consecutive lines.
   ForceEqualSignAlignment: false
-
-Style/FrozenStringLiteralComment:
-  Description: >-
-                 Add the frozen_string_literal comment to the top of files
-                 to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Enabled: false
 
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
@@ -248,9 +209,6 @@ Style/StringLiterals:
   - double_quotes
   ConsistentQuotesInMultiline: true
 
-Style/RegexpLiteral:
-  Enabled: false
-
 Style/TrailingCommaInArguments:
   # If `comma`, the cop requires a comma after the last argument, but only for
   # parenthesized method calls where each argument is on its own line.
@@ -287,42 +245,6 @@ Style/TrailingCommaInHashLiteral:
 Naming/MethodParameterName:
   MinNameLength: 2
 
-Style/ExpandPathArguments:
-  Enabled: false
-
-Style/FormatStringToken:
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Enabled: false
-
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
-Naming/MemoizedInstanceVariableName:
-  Enabled: false
-
-Naming/RescuedExceptionsVariableName:
-  Enabled: false
-
-Style/HashEachMethods:
-  Enabled: false
-
-Style/HashTransformKeys:
-  Enabled: false
-
-Style/HashTransformValues:
-  Enabled: false
-
-Lint/SuppressedException:
-  Enabled: false
-
-Lint/SendWithMixinArgument:
-  Enabled: false
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
-
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
@@ -335,23 +257,8 @@ Lint/MixedRegexpCaptureTypes:
 Lint/RaiseException:
   Enabled: true
 
-Lint/StructNewOverride:
-  Enabled: false
-
-Style/ExponentialNotation:
-  Enabled: false
-
 Style/RedundantRegexpCharacterClass:
   Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: false
-
-Style/SlicingWithRange:
-  Enabled: false
-
-Rails/ApplicationMailer:
-  Enabled: false
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
@@ -364,9 +271,6 @@ Lint/DuplicateRescueException:
 
 Lint/FloatComparison:
   Enabled: true
-
-Lint/MissingSuper:
-  Enabled: false
 
 Lint/OutOfRangeRegexpRef:
   Enabled: true
@@ -386,9 +290,6 @@ Lint/SelfAssignment:
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 
-Style/GlobalStdStream:
-  Enabled: false
-
 Style/RedundantAssignment:
   Enabled: true
 
@@ -397,42 +298,6 @@ Style/RedundantFetchBlock:
 
 Style/RedundantFileExtensionInRequire:
   Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: false
-
-Lint/UnreachableLoop:
-  Enabled: false
-
-Style/AccessorGrouping:
-  Enabled: false
-
-Style/ArrayCoercion:
-  Enabled: false
-
-Style/BisectedAttrAccessor:
-  Enabled: false
-
-Style/CaseLikeIf:
-  Enabled: false
-
-Style/ExplicitBlockArgument:
-  Enabled: false
-
-Style/HashAsLastArrayItem:
-  Enabled: false
-
-Style/HashLikeCase:
-  Enabled: false
-
-Style/OptionalBooleanParameter:
-  Enabled: false
-
-Style/SingleArgumentDig:
-  Enabled: false
-
-Style/StringConcatenation:
-  Enabled: false
 
 Style/MultilineWhenThen:
   Enabled: true
@@ -446,29 +311,11 @@ Lint/DuplicateRequire:
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
-Lint/EmptyFile:
-  Enabled: false
-
-Lint/UselessMethodDefinition:
-  Enabled: false
-
-Style/CombinableLoops:
-  Enabled: false
-
-Style/RedundantSelfAssignment:
-  Enabled: false
-
-Style/SoleNestedConditional:
-  Enabled: false
-
 Lint/UselessTimes:
   Enabled: true
 
 Layout/BeginEndAlignment:
   Enabled: true
-
-Lint/ConstantDefinitionInBlock:
-  Enabled: false
 
 Lint/IdentityComparison:
   Enabled: true
@@ -477,4 +324,13 @@ Bundler/DuplicatedGem:
   Enabled: true
 
 Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
+Style/ArgumentsForwarding:
+  Enabled: true
+
+Style/NilLambda:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :development, :test do
   gem 'psych'
   gem 'puma'
   gem 'rspec-rails', '~> 4.0'
-  gem 'rubocop', '~> 0.91.0', require: false
+  gem 'rubocop', '~> 1.4.0', require: false
   gem 'rubocop-rails', '>= 2.5.2', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,17 +546,17 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
-    rubocop (0.91.0)
+    rubocop (1.4.2)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 0.4.0, < 1.0)
+      rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.4.1)
-      parser (>= 2.7.1.4)
+    rubocop-ast (1.3.0)
+      parser (>= 2.7.1.5)
     rubocop-rails (2.5.2)
       activesupport
       rack (>= 1.1)
@@ -767,7 +767,7 @@ DEPENDENCIES
   rotp (~> 6.1)
   rqrcode
   rspec-rails (~> 4.0)
-  rubocop (~> 0.91.0)
+  rubocop (~> 1.4.0)
   rubocop-rails (>= 2.5.2)
   ruby-progressbar
   ruby-saml


### PR DESCRIPTION
Updates to catch up with the many newly released versions. Guidance taken from standard for what rules to enable.

Significant changes:
- Disable all unspecified `rubocop` rules by default
- Remove all of the disabled `rubocop` rules from the YAML file
