### PR TITLE
LG-3816 Fix doc auth SSN enter extra digits breaks continue

### DIFF
--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -59,8 +59,8 @@ function formatSSNFieldAndLimitLength() {
         }
       }
 
-      ssnBox.addEventListener('keydown', limitLength.bind(ssnBox));
       ssnBox.addEventListener('keyup', limitLength.bind(ssnBox));
+      ssnBox.addEventListener('keydown', limitLength.bind(ssnBox));
     });
   }
 }

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -23,6 +23,7 @@ function formatSSNField() {
       const toggle = document.getElementById(`ssn-toggle-${i}`);
 
       let cleave;
+      let maxlength;
 
       function sync() {
         const { value } = input;
@@ -34,12 +35,15 @@ function formatSSNField() {
             blocks: [3, 2, 4],
             delimiter: '-',
           });
+          maxlength = 11;
         } else {
           const nextValue = value.replace(/-/g, '');
           if (nextValue !== value) {
             input.value = nextValue;
           }
+          maxlength = 9;
         }
+        document.getElementById('doc_auth_ssn').maxLength = maxlength;
         const didFormat = input.value !== value;
         if (didFormat) {
           input.checkValidity();

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -28,7 +28,6 @@ function formatSSNFieldAndLimitLength() {
         const { value } = input;
         input.type = toggle.checked ? 'text' : 'password';
         cleave?.destroy();
-        alert(value.)
         if (toggle.checked) {
           cleave = new Cleave(input, {
             numericOnly: true,

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -3,7 +3,7 @@ import Cleave from 'cleave.js';
 const { I18n } = window.LoginGov;
 
 /* eslint-disable no-new */
-function formatSSNField() {
+function formatSSNFieldAndLimitLength() {
   const inputs = document.querySelectorAll('input.ssn-toggle[type="password"]');
 
   if (inputs) {
@@ -23,27 +23,24 @@ function formatSSNField() {
       const toggle = document.getElementById(`ssn-toggle-${i}`);
 
       let cleave;
-      let maxlength;
 
       function sync() {
         const { value } = input;
         input.type = toggle.checked ? 'text' : 'password';
         cleave?.destroy();
+        alert(value.)
         if (toggle.checked) {
           cleave = new Cleave(input, {
             numericOnly: true,
             blocks: [3, 2, 4],
             delimiter: '-',
           });
-          maxlength = 11;
         } else {
           const nextValue = value.replace(/-/g, '');
           if (nextValue !== value) {
             input.value = nextValue;
           }
-          maxlength = 9;
         }
-        document.getElementById('doc_auth_ssn').maxLength = maxlength;
         const didFormat = input.value !== value;
         if (didFormat) {
           input.checkValidity();
@@ -52,8 +49,20 @@ function formatSSNField() {
 
       sync();
       toggle.addEventListener('change', sync);
+
+      const ssnBox = document.getElementById('doc_auth_ssn');
+      const maxLength = 9;
+
+      function limitLength() {
+        if (this.value.length > maxLength) {
+          this.value = this.value.slice(0, maxLength);
+        }
+      }
+
+      ssnBox.addEventListener('keydown', limitLength.bind(ssnBox));
+      ssnBox.addEventListener('keyup', limitLength.bind(ssnBox));
     });
   }
 }
 
-document.addEventListener('DOMContentLoaded', formatSSNField);
+document.addEventListener('DOMContentLoaded', formatSSNFieldAndLimitLength);

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -50,15 +50,15 @@ function formatSSNFieldAndLimitLength() {
       toggle.addEventListener('change', sync);
 
       const ssnBox = document.getElementById('doc_auth_ssn');
-      const maxLength = 9;
 
       function limitLength() {
+        const maxLength = 9 + (this.value.match(/-/g) || []).length;
         if (this.value.length > maxLength) {
           this.value = this.value.slice(0, maxLength);
         }
       }
 
-      ssnBox.addEventListener('input', limitLength.bind(ssnBox));
+      input.addEventListener('input', limitLength.bind(input));
     });
   }
 }

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -49,8 +49,6 @@ function formatSSNFieldAndLimitLength() {
       sync();
       toggle.addEventListener('change', sync);
 
-      const ssnBox = document.getElementById('doc_auth_ssn');
-
       function limitLength() {
         const maxLength = 9 + (this.value.match(/-/g) || []).length;
         if (this.value.length > maxLength) {

--- a/app/javascript/app/ssn-field.js
+++ b/app/javascript/app/ssn-field.js
@@ -58,8 +58,7 @@ function formatSSNFieldAndLimitLength() {
         }
       }
 
-      ssnBox.addEventListener('keyup', limitLength.bind(ssnBox));
-      ssnBox.addEventListener('keydown', limitLength.bind(ssnBox));
+      ssnBox.addEventListener('input', limitLength.bind(ssnBox));
     });
   }
 }

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -26,7 +26,7 @@
         label: t('idv.form.ssn_label_html'),
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
-        maxlength: 9,
+        maxlength: 11,
         input_html: { aria: { invalid: false }, class: 'ssn ssn-toggle', value: '' }
       ) %>
     </div>

--- a/app/views/idv/doc_auth/ssn.html.erb
+++ b/app/views/idv/doc_auth/ssn.html.erb
@@ -26,7 +26,7 @@
         label: t('idv.form.ssn_label_html'),
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
-        maxlength: 11,
+        maxlength: 9,
         input_html: { aria: { invalid: false }, class: 'ssn ssn-toggle', value: '' }
       ) %>
     </div>

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -60,6 +60,20 @@ feature 'doc auth ssn step' do
         expect(page).to have_current_path(idv_doc_auth_verify_step)
       end
 
+      it 'proceeds to the next page if the user enters extra digits with dashes' do
+        fill_in 'doc_auth_ssn', with: '666-66-12345'
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+      end
+
+      it 'proceeds to the next page if the user enters extra digits with no dashes' do
+        fill_in 'doc_auth_ssn', with: '6666612345'
+        click_idv_continue
+
+        expect(page).to have_current_path(idv_doc_auth_verify_step)
+      end
+
       it 'does not proceed to the next page with invalid info' do
         fill_out_ssn_form_fail
         click_idv_continue

--- a/spec/features/idv/doc_auth/ssn_step_spec.rb
+++ b/spec/features/idv/doc_auth/ssn_step_spec.rb
@@ -60,15 +60,8 @@ feature 'doc auth ssn step' do
         expect(page).to have_current_path(idv_doc_auth_verify_step)
       end
 
-      it 'proceeds to the next page if the user enters extra digits with dashes' do
+      it 'proceeds to the next page if the user enters extra digits' do
         fill_in 'doc_auth_ssn', with: '666-66-12345'
-        click_idv_continue
-
-        expect(page).to have_current_path(idv_doc_auth_verify_step)
-      end
-
-      it 'proceeds to the next page if the user enters extra digits with no dashes' do
-        fill_in 'doc_auth_ssn', with: '6666612345'
         click_idv_continue
 
         expect(page).to have_current_path(idv_doc_auth_verify_step)


### PR DESCRIPTION
**How**: Maxlength needs to stay 11 due to cleave bug so just add a listener to the field and limit the length while accounting for dashes.