### PR TITLE
Compile bundles for production in ES5 safety test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
             yarn run typecheck
             bundle exec rubocop
             make check_asset_strings
-            ./bin/webpack && yarn es5-safe
+            NODE_ENV=production ./bin/webpack && yarn es5-safe
   build-release-container:
     working_directory: ~/identity-idp
     docker:


### PR DESCRIPTION
Previously: #4296

**Why**: Since development bundles are currently configured to use `eval-source-map` in development mode, ES5-incompatible syntax can hide in eval strings. Also ensures tested code is closer aligned to that which is run by real users.