### PR TITLE
refactor async doc auth

### DIFF
--- a/app/controllers/lambda_callback/document_proof_result_controller.rb
+++ b/app/controllers/lambda_callback/document_proof_result_controller.rb
@@ -1,16 +1,19 @@
 module LambdaCallback
   class DocumentProofResultController < AuthTokenController
     def create
-      EncryptedRedisStructStorage.store(
-        ProofingDocumentCaptureSessionResult.new(
-          id: result_id_parameter,
-          pii: document_result_parameter[:pii_from_doc],
-          result: document_result_parameter.except(:pii_from_doc),
-        ),
-        expires_in: AppConfig.env.async_wait_timeout_seconds.to_i,
-      )
+      dcs = DocumentCaptureSession.find_by(result_id: result_id_parameter)
 
-      track_exception_in_result(document_result_parameter)
+      if dcs
+        dcs.store_doc_auth_result(
+          result: document_result_parameter.except(:pii_from_doc),
+          pii: document_result_parameter[:pii_from_doc],
+        )
+
+        track_exception_in_result(document_result_parameter)
+      else
+        NewRelic::Agent.notice_error('DocumentProofResult result_id not found')
+        head :not_found
+      end
     end
 
     private

--- a/app/forms/idv/api_document_verification_status_form.rb
+++ b/app/forms/idv/api_document_verification_status_form.rb
@@ -27,12 +27,12 @@ module Idv
     end
 
     def timeout_error
-      return unless @async_state.status == :timed_out
+      return unless @async_state.timed_out?
       errors.add(:timeout, t('errors.doc_auth.document_verification_timeout'))
     end
 
     def failed_result
-      return if @async_state.status != :done || @async_state.result[:success]
+      return if !@async_state.done? || @async_state.result[:success]
       @async_state.result[:errors].each { |key, error| errors.add(key, error) }
     end
   end

--- a/app/services/document_capture_session_async_result.rb
+++ b/app/services/document_capture_session_async_result.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Used in async document capture flow by LambdaJobs::Runner/Idv::Proofer.document_job_class
+DocumentCaptureSessionAsyncResult = Struct.new(:id, :status, :result, :pii, keyword_init: true) do
+  self::IN_PROGRESS = 'in_progress'
+  self::DONE = 'done'
+  self::TIMED_OUT = 'timed_out'
+
+  def self.redis_key_prefix
+    'dcs-async:result'
+  end
+
+  def self.timed_out
+    new(status: DocumentCaptureSessionAsyncResult::TIMED_OUT)
+  end
+
+  def timed_out?
+    status == DocumentCaptureSessionAsyncResult::TIMED_OUT
+  end
+
+  def done?
+    status == DocumentCaptureSessionAsyncResult::DONE
+  end
+
+  def in_progress?
+    status == DocumentCaptureSessionAsyncResult::IN_PROGRESS
+  end
+
+  alias_method :pii_from_doc, :pii
+end

--- a/db/migrate/20201207191837_document_capture_sessions_result_id_index.rb
+++ b/db/migrate/20201207191837_document_capture_sessions_result_id_index.rb
@@ -1,0 +1,7 @@
+class DocumentCaptureSessionsResultIdIndex < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :document_capture_sessions, ["result_id"], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_115231) do
+ActiveRecord::Schema.define(version: 2020_12_07_191837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 2020_11_18_115231) do
     t.datetime "requested_at"
     t.boolean "ial2_strict"
     t.string "issuer"
+    t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["user_id"], name: "index_document_capture_sessions_on_user_id"
     t.index ["uuid"], name: "index_document_capture_sessions_on_uuid"
   end

--- a/spec/controllers/idv/doc_auth_controller_spec.rb
+++ b/spec/controllers/idv/doc_auth_controller_spec.rb
@@ -278,6 +278,7 @@ describe Idv::DocAuthController do
         success: true,
         errors: {},
         messages: ['message'],
+        pii_from_doc: good_pii,
       }
     end
     let(:bad_pii) do
@@ -294,6 +295,14 @@ describe Idv::DocAuthController do
         state_id_jurisdiction: 'WI',
       }
     end
+    let(:bad_pii_result) do
+      {
+        success: true,
+        errors: {},
+        messages: ['message'],
+        pii_from_doc: bad_pii,
+      }
+    end
     let(:fail_result) do
       {
         pii_from_doc: {},
@@ -307,7 +316,6 @@ describe Idv::DocAuthController do
       set_up_document_capture_result(
         uuid: verify_document_action_session_uuid,
         idv_result: good_result,
-        pii: good_pii,
       )
       put :update, params: { step: 'verify_document_status' }
 
@@ -319,7 +327,6 @@ describe Idv::DocAuthController do
       set_up_document_capture_result(
         uuid: verify_document_action_session_uuid,
         idv_result: nil,
-        pii: {},
       )
       put :update, params: { step: 'verify_document_status' }
 
@@ -331,7 +338,6 @@ describe Idv::DocAuthController do
       set_up_document_capture_result(
         uuid: verify_document_action_session_uuid,
         idv_result: fail_result,
-        pii: {},
       )
       put :update, params: { step: 'verify_document_status' }
 
@@ -346,8 +352,7 @@ describe Idv::DocAuthController do
     it 'returns status of fail with incomplete PII from doc auth' do
       set_up_document_capture_result(
         uuid: verify_document_action_session_uuid,
-        idv_result: good_result,
-        pii: bad_pii,
+        idv_result: bad_pii_result,
       )
       put :update, params: { step: 'verify_document_status' }
 

--- a/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
@@ -32,7 +32,7 @@ describe LambdaCallback::DocumentProofResultController do
           },
         }, as: :json
 
-        proofing_result = document_capture_session.load_proofing_result
+        proofing_result = document_capture_session.load_doc_auth_async_result
         expect(proofing_result.result).to include(
           exception: '',
           success: true,
@@ -44,7 +44,7 @@ describe LambdaCallback::DocumentProofResultController do
         post :create, params: { result_id: document_capture_session.result_id,
                                 document_result: { success: false, exception: '' } }
 
-        proofing_result = document_capture_session.load_proofing_result
+        proofing_result = document_capture_session.load_doc_auth_async_result
         expect(proofing_result.result[:success]).to eq 'false'
       end
 
@@ -53,8 +53,24 @@ describe LambdaCallback::DocumentProofResultController do
                                 document_result: { success: false,
                                                    exception: '#<Proofer::TimeoutError: ' } }
 
-        proofing_result = document_capture_session.load_proofing_result
+        proofing_result = document_capture_session.load_doc_auth_async_result
         expect(proofing_result.result[:exception]).to start_with('#<Proofer::TimeoutError: ')
+      end
+    end
+
+    context 'with invalid result_id' do
+      before do
+        request.headers['X-API-AUTH-TOKEN'] = AppConfig.env.document_proof_result_lambda_token
+      end
+
+      it 'returns 404' do
+        post :create, params: {
+          result_id: '0000',
+          document_result: {
+          },
+        }, as: :json
+
+        expect(response.status).to eq 404
       end
     end
 

--- a/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
@@ -19,7 +19,7 @@ describe LambdaCallback::DocumentProofResultController do
     context 'with valid API token' do
       before do
         request.headers['X-API-AUTH-TOKEN'] = AppConfig.env.document_proof_result_lambda_token
-        document_capture_session.store_proofing_pii_from_doc({}) # generates a result_id
+        document_capture_session.create_doc_auth_session
       end
 
       it 'accepts and stores pii and successful document proofing results' do

--- a/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
@@ -80,8 +80,7 @@ describe LambdaCallback::DocumentProofResultController do
 
         post :create, params: {
           result_id: '0000',
-          document_result: {
-          },
+          document_result: {},
         }, as: :json
       end
     end

--- a/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
+++ b/spec/controllers/lambda_callback/document_proof_result_controller_spec.rb
@@ -72,6 +72,18 @@ describe LambdaCallback::DocumentProofResultController do
 
         expect(response.status).to eq 404
       end
+
+      it 'sends exception to new relic' do
+        expect(NewRelic::Agent).to receive(:notice_error).with(
+          'DocumentProofResult result_id not found',
+        )
+
+        post :create, params: {
+          result_id: '0000',
+          document_result: {
+          },
+        }, as: :json
+      end
     end
 
     context 'with invalid API token' do

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -326,7 +326,9 @@ feature 'doc auth document capture step' do
         set_up_document_capture_result(
           uuid: DocumentCaptureSession.last.uuid,
           idv_result: {
-            success: true, errors: {}, messages: ['message'],
+            success: true,
+            errors: {},
+            messages: ['message'],
             pii_from_doc: {
             first_name: Faker::Name.first_name,
             last_name: Faker::Name.last_name,

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -340,7 +340,7 @@ feature 'doc auth document capture step' do
             state_id_type: 'drivers_license',
             state_id_number: '111',
             state_id_jurisdiction: 'WI',
-            }
+            },
           },
         )
 

--- a/spec/features/idv/doc_auth/document_capture_step_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_step_spec.rb
@@ -325,8 +325,9 @@ feature 'doc auth document capture step' do
       it 'proceeds to the next page with valid info' do
         set_up_document_capture_result(
           uuid: DocumentCaptureSession.last.uuid,
-          idv_result: { success: true, errors: {}, messages: ['message'] },
-          pii: {
+          idv_result: {
+            success: true, errors: {}, messages: ['message'],
+            pii_from_doc: {
             first_name: Faker::Name.first_name,
             last_name: Faker::Name.last_name,
             dob: Time.zone.today.to_s,
@@ -337,6 +338,7 @@ feature 'doc auth document capture step' do
             state_id_type: 'drivers_license',
             state_id_number: '111',
             state_id_jurisdiction: 'WI',
+            }
           },
         )
 

--- a/spec/forms/idv/api_document_verification_status_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_status_form_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
     end
 
     context 'with pending result' do
-      let(:async_state) {
+      let(:async_state) do
         DocumentCaptureSessionAsyncResult.new(
           status: DocumentCaptureSessionAsyncResult::IN_PROGRESS,
         )
-      }
+      end
 
       it 'is valid' do
         expect(form.valid?).to eq(true)

--- a/spec/forms/idv/api_document_verification_status_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_status_form_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
 
   describe '#valid?' do
     context 'with timeout async state' do
-      let(:async_state) {
+      let(:async_state) do
         DocumentCaptureSessionAsyncResult.new(status: DocumentCaptureSessionAsyncResult::TIMED_OUT)
-      }
+      end
 
       it 'is invalid' do
         expect(form.valid?).to eq(false)

--- a/spec/forms/idv/api_document_verification_status_form_spec.rb
+++ b/spec/forms/idv/api_document_verification_status_form_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
     )
   end
 
-  let(:async_state) { ProofingDocumentCaptureSessionResult.none }
+  let(:async_state) { DocumentCaptureSessionAsyncResult.new }
   let(:document_capture_session) { DocumentCaptureSession.create! }
 
   describe '#valid?' do
     context 'with timeout async state' do
-      let(:async_state) { ProofingDocumentCaptureSessionResult.timed_out }
+      let(:async_state) {
+        DocumentCaptureSessionAsyncResult.new(status: DocumentCaptureSessionAsyncResult::TIMED_OUT)
+      }
 
       it 'is invalid' do
         expect(form.valid?).to eq(false)
@@ -22,7 +24,11 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
     end
 
     context 'with pending result' do
-      let(:async_state) { ProofingDocumentCaptureSessionResult.in_progress }
+      let(:async_state) {
+        DocumentCaptureSessionAsyncResult.new(
+          status: DocumentCaptureSessionAsyncResult::IN_PROGRESS,
+        )
+      }
 
       it 'is valid' do
         expect(form.valid?).to eq(true)
@@ -31,14 +37,14 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
 
     context 'with unsuccessful result' do
       let(:async_state) do
-        ProofingDocumentCaptureSessionResult.new(
+        DocumentCaptureSessionAsyncResult.new(
           id: nil,
           pii: nil,
           result: {
             success: false,
             errors: { front: 'Wrong document' },
           },
-          status: :done,
+          status: DocumentCaptureSessionAsyncResult::DONE,
         )
       end
 
@@ -50,13 +56,13 @@ RSpec.describe Idv::ApiDocumentVerificationStatusForm do
 
     context 'with successful result' do
       let(:async_state) do
-        ProofingDocumentCaptureSessionResult.new(
+        DocumentCaptureSessionAsyncResult.new(
           id: nil,
           pii: nil,
           result: {
             success: true,
           },
-          status: :done,
+          status: DocumentCaptureSessionAsyncResult::DONE,
         )
       end
 

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -223,10 +223,13 @@ AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
     )
   end
 
-  def set_up_document_capture_result(uuid:, idv_result:, pii:)
+  def set_up_document_capture_result(uuid:, idv_result:)
     dcs = DocumentCaptureSession.where(uuid: uuid).first_or_create
-    dcs.store_proofing_pii_from_doc(pii) # generates a result_id
-    dcs.store_proofing_result(idv_result)
+    dcs.create_doc_auth_session
+    if idv_result
+      dcs.store_doc_auth_result(result: idv_result.except(:pii_from_doc),
+                                pii: idv_result[:pii_from_doc])
+    end
   end
 
   def attach_images(liveness_enabled: true)


### PR DESCRIPTION
Refactors the Redis storage and classes so that the async doc auth uses its own data structure (with hopefully a more sensible interface)