### PR TITLE
LG-3738: Resolve parse error on password change screen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "indent": "off",
     "max-classes-per-file": "off",
     "newline-per-chained-call": "off",
+    "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-param-reassign": ["off", "never"],
     "no-confusing-arrow": "off",
     "no-plusplus": "off",

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -12,6 +12,7 @@ class EventDisavowalController < ApplicationController
         extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
       ).to_h,
     )
+    @forbidden_passwords = forbidden_passwords
   end
 
   def create
@@ -20,11 +21,18 @@ class EventDisavowalController < ApplicationController
     if result.success?
       handle_successful_password_reset
     else
+      @forbidden_passwords = forbidden_passwords
       render :new
     end
   end
 
   private
+
+  def forbidden_passwords
+    disavowed_event.user.email_addresses.flat_map do |email_address|
+      ForbiddenPasswords.new(email_address.email).call
+    end
+  end
 
   def password_reset_from_disavowal_form
     @password_reset_from_disavowal_form ||= EventDisavowal::PasswordResetFromDisavowalForm.new(

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -121,6 +121,7 @@ module Users
         return
       end
 
+      @forbidden_passwords = forbidden_passwords(resource.email_addresses)
       render :edit
     end
 

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -99,12 +99,14 @@ function disableSubmit(submitEl, length = 0, score = 0) {
 /**
  * @param {HTMLElement?} element
  *
- * @return {string[]|undefined}
+ * @return {string[]}
  */
 export function getForbiddenPasswords(element) {
   try {
     return JSON.parse(element.dataset.forbidden);
-  } catch {}
+  } catch {
+    return [];
+  }
 }
 
 function analyzePw() {

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -103,7 +103,7 @@ function disableSubmit(submitEl, length = 0, score = 0) {
  */
 export function getForbiddenPasswords(element) {
   try {
-    return JSON.parse(element.dataset.forbiddenPasswords);
+    return JSON.parse(element.dataset.forbidden);
   } catch {}
 }
 
@@ -116,7 +116,7 @@ function analyzePw() {
   const pwStrength = document.getElementById('pw-strength-txt');
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const submit = document.querySelector('input[type="submit"]');
-  const forbiddenPasswordsElement = document.querySelector('[data-forbidden-passwords]');
+  const forbiddenPasswordsElement = document.querySelector('[data-forbidden]');
   const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
 
   disableSubmit(submit);

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -112,7 +112,12 @@ export function getForbiddenPasswords(element) {
 function analyzePw() {
   const { userAgent } = window.navigator;
   const input = document.querySelector(
-    '#password_form_password, #reset_password_form_password, #update_user_password_form_password',
+    [
+      '#password_form_password',
+      '#password_reset_from_disavowal_form_password',
+      '#reset_password_form_password',
+      '#update_user_password_form_password',
+    ].join(','),
   );
   const pwCntnr = document.getElementById('pw-strength-cntnr');
   const pwStrength = document.getElementById('pw-strength-txt');

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -96,6 +96,17 @@ function disableSubmit(submitEl, length = 0, score = 0) {
   }
 }
 
+/**
+ * @param {HTMLElement?} element
+ *
+ * @return {string[]|undefined}
+ */
+export function getForbiddenPasswords(element) {
+  try {
+    return JSON.parse(element.dataset.forbiddenPasswords);
+  } catch {}
+}
+
 function analyzePw() {
   const { userAgent } = window.navigator;
   const input = document.querySelector(
@@ -106,7 +117,7 @@ function analyzePw() {
   const pwFeedback = document.getElementById('pw-strength-feedback');
   const submit = document.querySelector('input[type="submit"]');
   const forbiddenPasswordsElement = document.querySelector('[data-forbidden-passwords]');
-  const { forbiddenPasswords } = forbiddenPasswordsElement.dataset;
+  const forbiddenPasswords = getForbiddenPasswords(forbiddenPasswordsElement);
 
   disableSubmit(submit);
 
@@ -116,7 +127,7 @@ function analyzePw() {
   pwCntnr.className = '';
 
   function checkPasswordStrength(e) {
-    const z = zxcvbn(e.target.value, JSON.parse(forbiddenPasswords));
+    const z = zxcvbn(e.target.value, forbiddenPasswords);
     const [cls, strength] = getStrength(z);
     const feedback = getFeedback(z);
     pwCntnr.className = cls;

--- a/app/javascript/packs/pw-strength.js
+++ b/app/javascript/packs/pw-strength.js
@@ -114,7 +114,7 @@ function analyzePw() {
   const input = document.querySelector(
     [
       '#password_form_password',
-      '#password_reset_from_disavowal_form_password',
+      '#event_disavowal_password_reset_from_disavowal_form_password',
       '#reset_password_form_password',
       '#update_user_password_form_password',
     ].join(','),

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,7 +13,7 @@
   <%= f.full_error :reset_password_token %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
               input_html: { class: 'password-toggle' } %>
-  <%= render 'devise/shared/password_strength' %>
+  <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3' %>
 <% end %>
 

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -11,7 +11,7 @@
         <%= t('instructions.password.strength.intro') %>
       </span>
       <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
-        forbidden: @forbidden_passwords,
+        forbidden: forbidden_passwords,
       } %>
     </div>
     <div class='h6'>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -11,7 +11,7 @@
         <%= t('instructions.password.strength.intro') %>
       </span>
       <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
-        forbidden: forbidden_passwords,
+        forbidden: local_assigns[:forbidden_passwords].presence,
       } %>
     </div>
     <div class='h6'>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -11,7 +11,7 @@
         <%= t('instructions.password.strength.intro') %>
       </span>
       <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
-        'forbidden-passwords': @forbidden_passwords,
+        forbidden: @forbidden_passwords,
       } %>
     </div>
     <div class='h6'>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -10,9 +10,9 @@
       <span class='h6'>
         <%= t('instructions.password.strength.intro') %>
       </span>
-      <span id='pw-strength-txt' class='bold' data-forbidden-passwords='<%= @forbidden_passwords %>'>
-        ...
-      </span>
+      <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
+        'forbidden-passwords': @forbidden_passwords,
+      } %>
     </div>
     <div class='h6'>
       <div id='pw-strength-feedback' class='italic'>

--- a/app/views/devise/shared/_password_strength.html.erb
+++ b/app/views/devise/shared/_password_strength.html.erb
@@ -11,7 +11,7 @@
         <%= t('instructions.password.strength.intro') %>
       </span>
       <%= tag.span '...', id: 'pw-strength-txt', class: 'bold', data: {
-        forbidden: local_assigns[:forbidden_passwords].presence,
+        forbidden: local_assigns[:forbidden_passwords],
       } %>
     </div>
     <div class='h6'>

--- a/app/views/event_disavowal/new.html.erb
+++ b/app/views/event_disavowal/new.html.erb
@@ -13,7 +13,7 @@
                 input_html: { value: @disavowal_token, name: :disavowal_token } %>
     <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
                 input_html: { aria: { invalid: false }, class: 'password-toggle' } %>
-    <%= render 'devise/shared/password_strength' %>
+    <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
     <%= f.button :submit, t('forms.passwords.edit.buttons.submit'), class: 'mb3' %>
 <% end %>
 

--- a/app/views/sign_up/passwords/new.html.erb
+++ b/app/views/sign_up/passwords/new.html.erb
@@ -14,7 +14,7 @@
   <%= f.input :password, required: true,
               input_html: { aria: { invalid: false, describedby: 'password-description' },
                             class: 'password-toggle' } %>
-  <%= render 'devise/shared/password_strength' %>
+  <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= hidden_field_tag :confirmation_token, @confirmation_token, id: 'confirmation_token' %>
   <%= f.input :request_id, as: :hidden, input_html: { value: params[:request_id] || request_id } %>
   <div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -13,7 +13,7 @@
   <%= f.error_notification %>
   <%= f.input :password, label: t('forms.passwords.edit.labels.password'), required: true,
               input_html: { aria: { invalid: false, describedby: 'password-description' }, class: 'password-toggle' } %>
-  <%= render 'devise/shared/password_strength' %>
+  <%= render 'devise/shared/password_strength', forbidden_passwords: @forbidden_passwords %>
   <%= f.button :submit, t('forms.buttons.submit.update'), class: 'mt2 mb3' %>
 <% end %>
 

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -139,6 +139,7 @@ describe Users::ResetPasswordsController, devise: true do
 
         put :update, params: { reset_password_form: form_params }
 
+        expect(assigns(:forbidden_passwords)).to all(be_a(String))
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -1,0 +1,43 @@
+describe('pw-strength', () => {
+  let getForbiddenPasswords;
+  before(async () => {
+    window.LoginGov = { I18n: { t() {} } };
+    ({ getForbiddenPasswords } = await import('../../../app/javascript/packs/pw-strength'));
+  });
+
+  after(() => {
+    delete window.LoginGov;
+  });
+
+  describe('getForbiddenPasswords', () => {
+    it('returns undefined if given argument is null', () => {
+      const element = null;
+      const result = getForbiddenPasswords(element);
+
+      expect(result).to.be.undefined();
+    });
+
+    it('returns undefined if element has absent dataset value', () => {
+      const element = document.createElement('span');
+      const result = getForbiddenPasswords(element);
+
+      expect(result).to.be.undefined();
+    });
+
+    it('returns undefined if element has invalid dataset value', () => {
+      const element = document.createElement('span');
+      element.setAttribute('data-forbidden-passwords', 'nil');
+      const result = getForbiddenPasswords(element);
+
+      expect(result).to.be.undefined();
+    });
+
+    it('parsed array of forbidden passwords', () => {
+      const element = document.createElement('span');
+      element.setAttribute('data-forbidden-passwords', '["foo","bar","baz"]');
+      const result = getForbiddenPasswords(element);
+
+      expect(result).to.be.deep.equal(['foo', 'bar', 'baz']);
+    });
+  });
+});

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -26,7 +26,7 @@ describe('pw-strength', () => {
 
     it('returns undefined if element has invalid dataset value', () => {
       const element = document.createElement('span');
-      element.setAttribute('data-forbidden-passwords', 'nil');
+      element.setAttribute('data-forbidden', 'nil');
       const result = getForbiddenPasswords(element);
 
       expect(result).to.be.undefined();
@@ -34,7 +34,7 @@ describe('pw-strength', () => {
 
     it('parsed array of forbidden passwords', () => {
       const element = document.createElement('span');
-      element.setAttribute('data-forbidden-passwords', '["foo","bar","baz"]');
+      element.setAttribute('data-forbidden', '["foo","bar","baz"]');
       const result = getForbiddenPasswords(element);
 
       expect(result).to.be.deep.equal(['foo', 'bar', 'baz']);

--- a/spec/javascripts/packs/pw-strength-spec.js
+++ b/spec/javascripts/packs/pw-strength-spec.js
@@ -10,26 +10,26 @@ describe('pw-strength', () => {
   });
 
   describe('getForbiddenPasswords', () => {
-    it('returns undefined if given argument is null', () => {
+    it('returns empty array if given argument is null', () => {
       const element = null;
       const result = getForbiddenPasswords(element);
 
-      expect(result).to.be.undefined();
+      expect(result).to.deep.equal([]);
     });
 
-    it('returns undefined if element has absent dataset value', () => {
+    it('returns empty array if element has absent dataset value', () => {
       const element = document.createElement('span');
       const result = getForbiddenPasswords(element);
 
-      expect(result).to.be.undefined();
+      expect(result).to.deep.equal([]);
     });
 
-    it('returns undefined if element has invalid dataset value', () => {
+    it('returns empty array if element has invalid dataset value', () => {
       const element = document.createElement('span');
       element.setAttribute('data-forbidden', 'nil');
       const result = getForbiddenPasswords(element);
 
-      expect(result).to.be.undefined();
+      expect(result).to.deep.equal([]);
     });
 
     it('parsed array of forbidden passwords', () => {

--- a/spec/views/devise/shared/_password_strength.html.erb_spec.rb
+++ b/spec/views/devise/shared/_password_strength.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'devise/shared/_password_strength.html.erb' do
   let(:forbidden_passwords) { nil }
 
   before(:each) do
-    assign(:forbidden_passwords, forbidden_passwords)
+    allow(view).to receive(:forbidden_passwords).and_return(forbidden_passwords)
   end
 
   describe 'forbidden attributes' do

--- a/spec/views/devise/shared/_password_strength.html.erb_spec.rb
+++ b/spec/views/devise/shared/_password_strength.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'devise/shared/_password_strength.html.erb' do
+  let(:forbidden_passwords) { nil }
+
+  before(:each) do
+    assign(:forbidden_passwords, forbidden_passwords)
+  end
+
+  describe 'forbidden attributes' do
+    context 'when local is unassigned' do
+      let(:forbidden_passwords) { nil }
+
+      it 'omits data-forbidden attribute from strength text tag' do
+        render
+
+        expect(rendered).to have_selector('#pw-strength-txt:not([data-forbidden])')
+      end
+    end
+
+    context 'when local is assigned' do
+      let(:forbidden_passwords) { ['a', 'b', 'c'] }
+
+      it 'adds JSON-encoded data-forbidden to strength text tag' do
+        render
+
+        expect(rendered).to have_selector('#pw-strength-txt[data-forbidden="[\"a\",\"b\",\"c\"]"]')
+      end
+    end
+  end
+end

--- a/spec/views/devise/shared/_password_strength.html.erb_spec.rb
+++ b/spec/views/devise/shared/_password_strength.html.erb_spec.rb
@@ -1,29 +1,33 @@
 require 'rails_helper'
 
 describe 'devise/shared/_password_strength.html.erb' do
-  let(:forbidden_passwords) { nil }
-
-  before(:each) do
-    allow(view).to receive(:forbidden_passwords).and_return(forbidden_passwords)
-  end
-
   describe 'forbidden attributes' do
     context 'when local is unassigned' do
-      let(:forbidden_passwords) { nil }
+      before do
+        render
+      end
 
       it 'omits data-forbidden attribute from strength text tag' do
-        render
+        expect(rendered).to have_selector('#pw-strength-txt:not([data-forbidden])')
+      end
+    end
 
+    context 'when local is nil' do
+      before do
+        render 'devise/shared/password_strength', forbidden_passwords: nil
+      end
+
+      it 'omits data-forbidden attribute from strength text tag' do
         expect(rendered).to have_selector('#pw-strength-txt:not([data-forbidden])')
       end
     end
 
     context 'when local is assigned' do
-      let(:forbidden_passwords) { ['a', 'b', 'c'] }
+      before do
+        render 'devise/shared/password_strength', forbidden_passwords: ['a', 'b', 'c']
+      end
 
       it 'adds JSON-encoded data-forbidden to strength text tag' do
-        render
-
         expect(rendered).to have_selector('#pw-strength-txt[data-forbidden="[\"a\",\"b\",\"c\"]"]')
       end
     end


### PR DESCRIPTION
**Why**: User may be forbidden from choosing certain passwords which would be easily guessable. Specifically, the flow where a user enters an invalid password will not assign the expected view variable `forbidden_passwords`.

**Open Questions:** Is there a better way to ensure consistency of or consolidate how the password edit view is prepared? Similarly, there appear to be a few different variations of users (`token_user`, `build_user`, `resource`) within the `ResetPasswordsController` class, not all of which are available to reference in every method handler.